### PR TITLE
Cancellation Support

### DIFF
--- a/src/GraphQL.Tests/Execution/Cancellation/CancellationTests.cs
+++ b/src/GraphQL.Tests/Execution/Cancellation/CancellationTests.cs
@@ -1,0 +1,79 @@
+﻿using GraphQL.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Should;
+
+namespace GraphQL.Tests.Execution.Cancellation
+{
+    public class CancellationSchema : Schema
+    {
+        public CancellationSchema()
+        {
+            Query = new CancellationTestType();
+        }
+    }
+
+    public class CancellationTestType : ObjectGraphType
+    {
+        public CancellationTestType()
+        {
+            Name = "CancellationTestType";
+
+            Field<StringGraphType>("one", resolve: GetOne);
+            Field<StringGraphType>("two", resolve: GetTwo);
+        }
+
+        public Task<string> GetOne(ResolveFieldContext context)
+        {
+            if (!context.CancellationToken.CanBeCanceled)
+            {
+                throw new Exception("Should have token!");
+            }
+
+            return Task.FromResult("one");
+        }
+
+        public Task<string> GetTwo(ResolveFieldContext context)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult("two");
+        }
+    }
+
+    public class CancellationTests : QueryTestBase<CancellationSchema>
+    {
+        [Test]
+        public void cancellation_token_in_context()
+        {
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                AssertQuerySuccess("{one}", "{one: 'one'}", cancellationToken: tokenSource.Token);
+            }
+        }
+
+        [Test]
+        public void cancellation_is_propagated()
+        {
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                try
+                {
+                    tokenSource.Cancel();
+                    AssertQuerySuccess("{two}", "{two: 'two'}", cancellationToken: tokenSource.Token);
+                }
+                catch(AggregateException aggExc)
+                {
+                    aggExc.InnerException.ShouldBeType<TaskCanceledException>();
+                    return;
+                }
+            }
+
+            throw new Exception("Cancellation did not propagate!");
+        }
+    }
+}

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Execution\Cancellation\CancellationTests.cs" />
     <Compile Include="Execution\Directives\DirectivesTests.cs" />
     <Compile Include="StarWars\EpisodeEnum.cs" />
     <Compile Include="StarWars\StarWarsIntrospectionTests.cs" />

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -6,6 +6,8 @@ using GraphQL.Validation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Should;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace GraphQL.Tests
 {
@@ -31,15 +33,15 @@ namespace GraphQL.Tests
 
         public IDocumentWriter Writer { get; private set; }
 
-        public void AssertQuerySuccess(string query, string expected, Inputs inputs = null, object root = null)
+        public void AssertQuerySuccess(string query, string expected, Inputs inputs = null, object root = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var queryResult = CreateQueryResult(expected);
-            AssertQuery(query, queryResult, inputs, root);
+            AssertQuery(query, queryResult, inputs, root, cancellationToken);
         }
 
-        public void AssertQuery(string query, ExecutionResult executionResult, Inputs inputs, object root)
+        public void AssertQuery(string query, ExecutionResult executionResult, Inputs inputs, object root, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var runResult = Executer.ExecuteAsync(Schema, root, query, null, inputs).Result;
+            var runResult = Executer.ExecuteAsync(Schema, root, query, null, inputs, cancellationToken).Result;
 
             var writtenResult = Writer.Write(runResult);
             var expectedResult = Writer.Write(executionResult);

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -150,6 +150,7 @@ namespace GraphQL
                 resolveContext.ParentType = parentType;
                 resolveContext.Arguments = arguments;
                 resolveContext.Source = source;
+                resolveContext.CancellationToken = context.CancellationToken;
                 var resolve = fieldDefinition.Resolve ?? defaultResolve;
                 var result = resolve(resolveContext);
 

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -8,13 +8,22 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
+
+using ExecutionContext = GraphQL.Execution.ExecutionContext;
 
 namespace GraphQL
 {
     public interface IDocumentExecuter
     {
-        Task<ExecutionResult> ExecuteAsync(Schema schema, object root, string query, string operationName, Inputs inputs = null);
+        Task<ExecutionResult> ExecuteAsync(
+            Schema schema, 
+            object root, 
+            string query, 
+            string operationName, 
+            Inputs inputs = null, 
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 
     public class DocumentExecuter : IDocumentExecuter
@@ -33,7 +42,13 @@ namespace GraphQL
             _documentValidator = documentValidator;
         }
 
-        public async Task<ExecutionResult> ExecuteAsync(Schema schema, object root, string query, string operationName, Inputs inputs = null)
+        public async Task<ExecutionResult> ExecuteAsync(
+            Schema schema, 
+            object root, 
+            string query, 
+            string operationName, 
+            Inputs inputs = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             var document = _documentBuilder.Build(query);
             var result = new ExecutionResult();
@@ -42,7 +57,7 @@ namespace GraphQL
 
             if (validationResult.IsValid)
             {
-                var context = BuildExecutionContext(schema, root, document, operationName, inputs);
+                var context = BuildExecutionContext(schema, root, document, operationName, inputs, cancellationToken);
 
                 if (context.Errors.Any())
                 {
@@ -67,7 +82,8 @@ namespace GraphQL
             object root,
             Document document,
             string operationName,
-            Inputs inputs)
+            Inputs inputs,
+            CancellationToken cancellationToken)
         {
             var context = new ExecutionContext();
             context.Schema = schema;
@@ -86,6 +102,7 @@ namespace GraphQL
             context.Operation = operation;
             context.Variables = GetVariableValues(schema, operation.Variables, inputs);
             context.Fragments = document.Fragments;
+            context.CancellationToken = cancellationToken;
 
             return context;
         }
@@ -107,6 +124,8 @@ namespace GraphQL
 
         public async Task<object> ResolveField(ExecutionContext context, ObjectGraphType parentType, object source, Fields fields)
         {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             var field = fields.First();
 
             var fieldDefinition = GetFieldDefinition(context.Schema, parentType, field);

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -1,5 +1,6 @@
 ﻿using GraphQL.Language;
 using GraphQL.Types;
+using System.Threading;
 
 namespace GraphQL.Execution
 {
@@ -22,5 +23,7 @@ namespace GraphQL.Execution
         public Variables Variables { get; set; }
 
         public ExecutionErrors Errors { get; set; }
+
+        public CancellationToken CancellationToken { get; set; }
     }
 }

--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using GraphQL.Language;
+using System.Threading;
 
 namespace GraphQL.Types
 {
@@ -16,5 +17,7 @@ namespace GraphQL.Types
         public object Source { get; set; }
 
         public Schema Schema { get; set; }
+
+        public CancellationToken CancellationToken { get; set; }
     }
 }


### PR DESCRIPTION
This is an initial take on supporting cancellation, to address #16. 

It doesn't seem to be a big change at all, I felt that the `CancellationToken` only needed to be passed to the field resolvers for optional use and to `DocumentExecuter.ResolveField` to be checked. My reasoning is that they are the only points at which a long running async action may occur and all other  work takes a trivial amount of time.

I'm still working on tests around this.