### PR TITLE
Fix recursive type lookup

### DIFF
--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -62,6 +62,14 @@ namespace GraphQL.Types
             AddType = addType;
         }
 
+        public TypeCollectionContext(
+            Func<Type, GraphType> resolver,
+            Action<string, GraphType, TypeCollectionContext> addType)
+        {
+            ResolveType = resolver;
+            AddType = ( name, type ) => addType( name, type, this );
+        }
+
         public Func<Type, GraphType> ResolveType { get; private set; }
         public Action<string, GraphType> AddType { get; private set; }
     }

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -92,12 +92,21 @@ namespace GraphQL.Types
 
         public void AddType(GraphType type, TypeCollectionContext context)
         {
+            AddType(null, type, context);
+        }
+
+        public void AddType( string name, GraphType type, TypeCollectionContext context )
+        {
             if (type == null)
             {
                 return;
             }
 
-            var name = type.CollectTypes(context);
+            if (name == null)
+            {
+              name = type.CollectTypes(context);
+            }
+            
             _types[name] = type;
 
             type.Fields.Apply(field =>

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -66,9 +66,9 @@ namespace GraphQL.Types
 
         private GraphType AddType(Type type)
         {
-            var ctx = new TypeCollectionContext(ResolveType, (name, graphType) =>
+            var ctx = new TypeCollectionContext(ResolveType, (name, graphType, context) =>
             {
-                _lookup[name] = graphType;
+              _lookup.AddType( name, graphType, context );
             });
 
             var instance = ResolveType(type);
@@ -82,9 +82,9 @@ namespace GraphQL.Types
             {
                 _lookup = new GraphTypesLookup();
 
-                var ctx = new TypeCollectionContext(ResolveType, (name, graphType) =>
+                var ctx = new TypeCollectionContext(ResolveType, (name, graphType, context) =>
                 {
-                    _lookup[name] = graphType;
+                    _lookup.AddType( name, graphType, context );
                 });
 
                 _lookup.AddType(Query, ctx);


### PR DESCRIPTION
I was having a problem where types that were only contained on sub-types and not the root level were not being included in the Schema.

e.g.

```
{
  root {
    children {
      child1 {
         child2 {
           id
         }
      }
    }
  }
}
```

`child1` and `child2` weren't being included in the schema. 

Not sure if this is the best way of fixing it so any feedback would be great.