### PR TITLE
Connection builder improvements

### DIFF
--- a/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
@@ -1,0 +1,6 @@
+﻿namespace GraphQL.Tests.Builders
+{
+    public class ConnectionBuilderTests
+    {
+    }
+}

--- a/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
@@ -1,6 +1,187 @@
-﻿namespace GraphQL.Tests.Builders
+﻿using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Types;
+using Should;
+
+namespace GraphQL.Tests.Builders
 {
-    public class ConnectionBuilderTests
+    public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestSchema>
     {
+        public class ParentType : ObjectGraphType
+        {
+            public ParentType()
+            {
+                Name = "Parent";
+
+                Connection<ChildType, Child>()
+                    .Name("connection1")
+                    .WithObject<Parent>()
+                    .Unidirectional()
+                    .Resolve(context => context.Object.Connection1);
+
+                Connection<ChildType, Child>()
+                    .Name("connection2")
+                    .Description("RandomDescription")
+                    .WithObject<Parent>()
+                    .Bidirectional()
+                    .Resolve(context => context.Object.Connection2);
+            }
+        }
+
+        public class ChildType : ObjectGraphType
+        {
+            public ChildType()
+            {
+                Name = "Child";
+
+                Field<StringGraphType>()
+                    .Name("field1");
+
+                Field<IntGraphType>()
+                    .Name("field2");
+            }
+        }
+
+        public class Parent
+        {
+            public Parent()
+            {
+                Connection1 = new List<Child>
+                {
+                    new Child { Field1 = "one", Field2 = 1 },
+                    new Child { Field1 = "two", Field2 = 2 },
+                    new Child { Field1 = "three", Field2 = 3 },
+                };
+                Connection2 = new List<Child>
+                {
+                    new Child { Field1 = "ONE", Field2 = 11 },
+                    new Child { Field1 = "TWO", Field2 = 22 },
+                    new Child { Field1 = "THREE", Field2 = 33 },
+                };
+            }
+
+            public List<Child> Connection1 { get; set; }
+
+            public List<Child> Connection2 { get; set; }
+        }
+
+        public class Child
+        {
+            public string Field1 { get; set; }
+
+            public int Field2 { get; set; }
+        }
+
+        public class TestQuery : ObjectGraphType
+        {
+            public TestQuery()
+            {
+                Name = "Query";
+
+                Field<ParentType>()
+                    .Name("parent")
+                    .Returns<Parent>()
+                    .Resolve(_ => new Parent());
+            }
+        }
+
+        public class TestSchema : Schema
+        {
+            public TestSchema()
+            {
+                Query = new TestQuery();
+            }
+        }
+
+        [Test]
+        public void ConnectionWithName()
+        {
+            var objectType = new ParentType();
+            objectType.Fields.First().Name.ShouldEqual("connection1");
+        }
+
+        [Test]
+        public void ConnectionWithDescription()
+        {
+            var objectType = new ParentType();
+            objectType.Fields.ElementAt(0).Description.ShouldEqual(null);
+            objectType.Fields.ElementAt(1).Description.ShouldEqual("RandomDescription");
+        }
+
+        [Test]
+        public void ConnectionMetaData()
+        {
+            var connectionType = new ConnectionType<ChildType>();
+            connectionType.Name.ShouldEqual("ChildConnection");
+            connectionType.Description.ShouldEqual("A connection from an object to a list of objects of type `Child`.");
+        }
+
+        [Test]
+        public void ConnectionsInSchema()
+        {
+            AssertQuerySuccess(
+                "{ parent {" +
+                "   connection1 { totalCount edges { cursor node { field1 field2 } } items { field1 field2 } }" +
+                "   connection2 { totalCount edges { cursor node { field1 field2 } } items { field1 field2 } }" +
+                "}",
+                "{ parent: {" +
+                "connection1: {" +
+                "  totalCount: 3," +
+                "  edges: [" +
+                "    { cursor: '00000001', node: { field1: 'one', field2: 1 } }," +
+                "    { cursor: '00000002', node: { field1: 'two', field2: 2 } }," +
+                "    { cursor: '00000003', node: { field1: 'three', field2: 3 } }" +
+                "  ]," +
+                "  items: [" +
+                "    { field1: 'one', field2: 1 }," +
+                "    { field1: 'two', field2: 2 }," +
+                "    { field1: 'three', field2: 3 }" +
+                "  ]" +
+                "}," +
+                "connection2: {" +
+                "  totalCount: 3," +
+                "  edges: [" +
+                "    { cursor: '00000001', node: { field1: 'ONE', field2: 11 } }," +
+                "    { cursor: '00000002', node: { field1: 'TWO', field2: 22 } }," +
+                "    { cursor: '00000003', node: { field1: 'THREE', field2: 33 } }" +
+                "  ]," +
+                "  items: [" +
+                "    { field1: 'ONE', field2: 11 }," +
+                "    { field1: 'TWO', field2: 22 }," +
+                "    { field1: 'THREE', field2: 33 }" +
+                "  ]" +
+                "}" +
+                "} }");
+        }
+
+        [Test]
+        public void ConnectionsInSchemaWithPagination()
+        {
+            AssertQuerySuccess(
+                "{ parent {" +
+                "   connection1(first: 1, after: \"00000001\") { totalCount edges { cursor node { field1 field2 } } items { field1 field2 } }" +
+                "   connection2(last: 1) { totalCount edges { cursor node { field1 field2 } } items { field1 field2 } }" +
+                "}",
+                "{ parent: {" +
+                "connection1: {" +
+                "  totalCount: 3," +
+                "  edges: [" +
+                "    { cursor: '00000002', node: { field1: 'two', field2: 2 } }" +
+                "  ]," +
+                "  items: [" +
+                "    { field1: 'two', field2: 2 }" +
+                "  ]" +
+                "}," +
+                "connection2: {" +
+                "  totalCount: 3," +
+                "  edges: [" +
+                "    { cursor: '00000003', node: { field1: 'THREE', field2: 33 } }" +
+                "  ]," +
+                "  items: [" +
+                "    { field1: 'THREE', field2: 33 }" +
+                "  ]" +
+                "}" +
+                "} }");
+        }
     }
 }

--- a/src/GraphQL.Tests/Builders/ConnectionTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionTests.cs
@@ -1,0 +1,421 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Should;
+
+namespace GraphQL.Tests.Builders
+{
+    public class ConnectionTests
+    {
+        [Test]
+        public void SimpleConnection()
+        {
+            var connection = GenerateConnection(5);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(false);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(false);
+            connection.PageInfo.StartCursor.ShouldEqual("00000001");
+            connection.PageInfo.EndCursor.ShouldEqual("00000005");
+            connection.Edges.Count.ShouldEqual(5);
+            connection.Items.Count.ShouldEqual(5);
+
+            for (var i = 1; i <= 5; i++)
+            {
+                connection.Edges[i - 1].Cursor.ShouldEqual($"{i:D8}");
+                connection.Edges[i - 1].Node.Value.ShouldEqual(i);
+                connection.Items[i - 1].Value.ShouldEqual(i);
+            }
+        }
+
+        [Test]
+        public void First3()
+        {
+            var connection = GenerateConnection(5, first: 3);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(false);
+            connection.PageInfo.StartCursor.ShouldEqual("00000001");
+            connection.PageInfo.EndCursor.ShouldEqual("00000003");
+            connection.Edges.Count.ShouldEqual(3);
+            connection.Items.Count.ShouldEqual(3);
+
+            for (var i = 1; i <= 3; i++)
+            {
+                connection.Edges[i - 1].Cursor.ShouldEqual($"{i:D8}");
+                connection.Edges[i - 1].Node.Value.ShouldEqual(i);
+                connection.Items[i - 1].Value.ShouldEqual(i);
+            }
+        }
+
+        [Test]
+        public void Last3()
+        {
+            var connection = GenerateConnection(5, last: 3);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(false);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000003");
+            connection.PageInfo.EndCursor.ShouldEqual("00000005");
+            connection.Edges.Count.ShouldEqual(3);
+            connection.Items.Count.ShouldEqual(3);
+
+            for (var i = 1; i <= 3; i++)
+            {
+                connection.Edges[i - 1].Cursor.ShouldEqual($"{i + 2:D8}");
+                connection.Edges[i - 1].Node.Value.ShouldEqual(i + 2);
+                connection.Items[i - 1].Value.ShouldEqual(i + 2);
+            }
+        }
+
+        [Test]
+        public void First3After1()
+        {
+            var connection = GenerateConnection(5, after: "00000001", first: 3);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000002");
+            connection.PageInfo.EndCursor.ShouldEqual("00000004");
+            connection.Edges.Count.ShouldEqual(3);
+            connection.Items.Count.ShouldEqual(3);
+
+            for (var i = 1; i <= 3; i++)
+            {
+                connection.Edges[i - 1].Cursor.ShouldEqual($"{i + 1:D8}");
+                connection.Edges[i - 1].Node.Value.ShouldEqual(i + 1);
+                connection.Items[i - 1].Value.ShouldEqual(i + 1);
+            }
+        }
+
+        [Test]
+        public void Last3Before5()
+        {
+            var connection = GenerateConnection(5, before: "00000005", last: 3);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000002");
+            connection.PageInfo.EndCursor.ShouldEqual("00000004");
+            connection.Edges.Count.ShouldEqual(3);
+            connection.Items.Count.ShouldEqual(3);
+
+            for (var i = 1; i <= 3; i++)
+            {
+                connection.Edges[i - 1].Cursor.ShouldEqual($"{i + 1:D8}");
+                connection.Edges[i - 1].Node.Value.ShouldEqual(i + 1);
+                connection.Items[i - 1].Value.ShouldEqual(i + 1);
+            }
+        }
+
+        [Test]
+        public void AfterBounds()
+        {
+            var connection = GenerateConnection(5, after: "00000005", first: 2);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(false);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000006");
+            connection.PageInfo.EndCursor.ShouldEqual("00000006");
+            connection.Edges.Count.ShouldEqual(0);
+            connection.Items.Count.ShouldEqual(0);
+        }
+
+
+        [Test]
+        public void BeforeBounds()
+        {
+            var connection = GenerateConnection(5, before: "00000001", last: 2);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(false);
+            connection.PageInfo.StartCursor.ShouldEqual("00000000");
+            connection.PageInfo.EndCursor.ShouldEqual("00000000");
+            connection.Edges.Count.ShouldEqual(0);
+            connection.Items.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public void First0()
+        {
+            var connection = GenerateConnection(5, first: 0);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(false);
+            connection.PageInfo.StartCursor.ShouldEqual("00000000");
+            connection.PageInfo.EndCursor.ShouldEqual("00000000");
+            connection.Edges.Count.ShouldEqual(0);
+            connection.Items.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public void First0After2()
+        {
+            var connection = GenerateConnection(5, after: "00000002", first: 0);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000003");
+            connection.PageInfo.EndCursor.ShouldEqual("00000003");
+            connection.Edges.Count.ShouldEqual(0);
+            connection.Items.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public void First1After2()
+        {
+            var connection = GenerateConnection(5, after: "00000002", first: 1);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000003");
+            connection.PageInfo.EndCursor.ShouldEqual("00000003");
+            connection.Edges.Count.ShouldEqual(1);
+            connection.Items.Count.ShouldEqual(1);
+        }
+
+        [Test]
+        public void AfterLast()
+        {
+            var connection = GenerateConnection(5, after: "00000005");
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(false);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000006");
+            connection.PageInfo.EndCursor.ShouldEqual("00000006");
+            connection.Edges.Count.ShouldEqual(0);
+            connection.Items.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public void Last0()
+        {
+            var connection = GenerateConnection(5, last: 0);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(false);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000006");
+            connection.PageInfo.EndCursor.ShouldEqual("00000006");
+            connection.Edges.Count.ShouldEqual(0);
+            connection.Items.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public void Last0Before3()
+        {
+            var connection = GenerateConnection(5, before: "00000003", last: 0);
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000002");
+            connection.PageInfo.EndCursor.ShouldEqual("00000002");
+            connection.Edges.Count.ShouldEqual(0);
+            connection.Items.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public void BeforeFirst()
+        {
+            var connection = GenerateConnection(5, before: "00000001");
+
+            connection.TotalCount.ShouldEqual(5);
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(false);
+            connection.PageInfo.StartCursor.ShouldEqual("00000000");
+            connection.PageInfo.EndCursor.ShouldEqual("00000000");
+            connection.Edges.Count.ShouldEqual(0);
+            connection.Items.Count.ShouldEqual(0);
+        }
+
+        [Test]
+        public void CombineBeforeAndAfter()
+        {
+            ArgumentException argEx = null;
+            try
+            {
+                GenerateConnection(5, before: "00000001", after: "00000001");
+            }
+            catch (ArgumentException ex)
+            {
+                argEx = ex;
+            }
+            argEx.ShouldNotBeNull();
+            argEx?.Message.ShouldEqual("Cannot use `after` in conjunction with `before`.");
+        }
+
+        [Test]
+        public void CombineFirstAndLast()
+        {
+            ArgumentException argEx = null;
+            try
+            {
+                GenerateConnection(5, first: 1, last: 1);
+            }
+            catch (ArgumentException ex)
+            {
+                argEx = ex;
+            }
+            argEx.ShouldNotBeNull();
+            argEx?.Message.ShouldEqual("Cannot use `first` in conjunction with `last`.");
+        }
+
+        [Test]
+        public void CombineFirstAndBefore()
+        {
+            ArgumentException argEx = null;
+            try
+            {
+                GenerateConnection(5, first: 1, before: "00000003");
+            }
+            catch (ArgumentException ex)
+            {
+                argEx = ex;
+            }
+            argEx.ShouldNotBeNull();
+            argEx?.Message.ShouldEqual("Cannot use `first` in conjunction with `before`.");
+        }
+
+        [Test]
+        public void CombineLastAndAfter()
+        {
+            ArgumentException argEx = null;
+            try
+            {
+                GenerateConnection(5, last: 1, after: "00000001");
+            }
+            catch (ArgumentException ex)
+            {
+                argEx = ex;
+            }
+            argEx.ShouldNotBeNull();
+            argEx?.Message.ShouldEqual("Cannot use `last` in conjunction with `after`.");
+        }
+
+        [Test]
+        public void First3OfInfiniteCollection()
+        {
+            var connection = GenerateInfiniteConnection(5, 6, first: 3);
+
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(false);
+            connection.PageInfo.StartCursor.ShouldEqual("00000001");
+            connection.PageInfo.EndCursor.ShouldEqual("00000003");
+            connection.Edges.Count.ShouldEqual(3);
+            connection.Items.Count.ShouldEqual(3);
+
+            for (var i = 1; i <= 3; i++)
+            {
+                connection.Edges[i - 1].Cursor.ShouldEqual($"{i:D8}");
+                connection.Edges[i - 1].Node.ShouldEqual(i);
+            }
+        }
+
+        [Test]
+        public void First3After2OfInfiniteCollection()
+        {
+            var connection = GenerateInfiniteConnection(5, 6, first: 3, after: "00000002");
+
+            connection.PageInfo.HasNextPage.ShouldEqual(true);
+            connection.PageInfo.HasPreviousPage.ShouldEqual(true);
+            connection.PageInfo.StartCursor.ShouldEqual("00000003");
+            connection.PageInfo.EndCursor.ShouldEqual("00000005");
+            connection.Edges.Count.ShouldEqual(3);
+            connection.Items.Count.ShouldEqual(3);
+
+            for (var i = 1; i <= 3; i++)
+            {
+                connection.Edges[i - 1].Cursor.ShouldEqual($"{i + 2:D8}");
+                connection.Edges[i - 1].Node.ShouldEqual(i + 2);
+            }
+        }
+
+        [Test]
+        public void Last3OfInfiniteCollectionThrowsException()
+        {
+            try
+            {
+                GenerateInfiniteConnection(5, 6, last: 3);
+                true.ShouldBeFalse("Getting the last entries of an infinite collection should fail.");
+            }
+            catch (Exception ex)
+            {
+                ex.Message.ShouldEqual("Enumerated too many entries");
+            }
+        }
+
+        [Test]
+        public void TotalCountOfInfiniteCollectionThrowsException()
+        {
+            try
+            {
+                var connection = GenerateInfiniteConnection(5, 6, first: 3);
+                connection.TotalCount.ShouldBeNull();
+                true.ShouldBeFalse("Getting the total count of an infinite collection should fail.");
+            }
+            catch (Exception ex)
+            {
+                ex.Message.ShouldEqual("Enumerated too many entries");
+            }
+        }
+
+        private Connection<Foo> GenerateConnection(
+            int count, int? first = null, int? last = null, string after = null, string before = null)
+        {
+            var items = new List<Foo>();
+            for (var i = 1; i <= count; i++)
+            {
+                items.Add(new Foo { Value = i });
+            }
+
+            return new Connection<Foo>()
+                .FromCollection(items)
+                .Paginate(first, last, after, before);
+        }
+
+        private IEnumerable<int> InfiniteCollection(int throwAboveThisNumber = -1)
+        {
+            for (var i = 1; ; i++)
+            {
+                if (throwAboveThisNumber >= 0 && i > throwAboveThisNumber)
+                {
+                    throw new Exception("Enumerated too many entries");
+                }
+                yield return i;
+            }
+        }
+
+        private Connection<int> GenerateInfiniteConnection(
+            int count, int throwExceptionAboveThisNumber,
+            int? first = null, int? last = null, string after = null, string before = null)
+        {
+            return new Connection<int>()
+                .FromCollection(InfiniteCollection(throwExceptionAboveThisNumber))
+                .Paginate(first, last, after, before);
+        }
+
+        class Foo
+        {
+            public int Value { get; set; }
+        }
+
+        class Bar
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/GraphQL.Tests/Builders/ConnectionTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using GraphQL.Types;
 using Should;
 

--- a/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
@@ -1,0 +1,269 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Types;
+using Should;
+
+namespace GraphQL.Tests.Builders
+{
+    public class FieldBuilderTests
+    {
+        [Test]
+        public void FieldWithName()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .Name("TheName");
+
+            var fields = objectType.Fields.ToList();
+            fields.Count.ShouldEqual(1);
+            fields[0].Name.ShouldEqual("TheName");
+            fields[0].Description.ShouldEqual(null);
+            fields[0].Type.ShouldEqual(typeof(StringGraphType));
+        }
+
+        [Test]
+        public void FieldWithNameAndDescription()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .Name("TheName")
+                .Description("TheDescription");
+
+            var fields = objectType.Fields.ToList();
+            fields.Count.ShouldEqual(1);
+            fields[0].Name.ShouldEqual("TheName");
+            fields[0].Description.ShouldEqual("TheDescription");
+            fields[0].Type.ShouldEqual(typeof(StringGraphType));
+        }
+
+        [Test]
+        public void FieldReturns()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .Name("TheName")
+                .Returns<string>()
+                .Resolve(_ => "SomeString");
+
+            var fields = objectType.Fields.ToList();
+            fields.Count.ShouldEqual(1);
+            fields[0].Name.ShouldEqual("TheName");
+            fields[0].Type.ShouldEqual(typeof(StringGraphType));
+
+            var context = new ResolveFieldContext();
+            fields[0].Resolve(context).GetType().ShouldEqual(typeof(string));
+            fields[0].Resolve(context).ShouldEqual("SomeString");
+        }
+
+        [Test]
+        public void MultipleFields()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<IntGraphType>()
+                .Name("Field1");
+            objectType.Field<FloatGraphType>()
+                .Name("Field2");
+            objectType.Field<DateGraphType>()
+                .Name("Field3");
+
+            var fields = objectType.Fields.ToList();
+            fields.Count.ShouldEqual(3);
+            fields[0].Name.ShouldEqual("Field1");
+            fields[0].Type.ShouldEqual(typeof(IntGraphType));
+            fields[1].Name.ShouldEqual("Field2");
+            fields[1].Type.ShouldEqual(typeof(FloatGraphType));
+            fields[2].Name.ShouldEqual("Field3");
+            fields[2].Type.ShouldEqual(typeof(DateGraphType));
+        }
+
+        [Test]
+        public void FieldWithDefaultValue()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<IntGraphType>()
+                .Returns<int>()
+                .DefaultValue(15);
+
+            objectType.Fields.First().DefaultValue.ShouldEqual(15);
+        }
+
+        [Test]
+        public void FieldWithArguments()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<IntGraphType>()
+                .Argument<StringGraphType, string>("arg1", "desc1", "12345")
+                .Argument<IntGraphType, int>("arg2", "desc2", 9)
+                .Argument<IntGraphType>("arg3", "desc3");
+
+            var field = objectType.Fields.First();
+            field.Arguments.Count.ShouldEqual(3);
+
+            field.Arguments[0].Name.ShouldEqual("arg1");
+            field.Arguments[0].Description.ShouldEqual("desc1");
+            field.Arguments[0].Type.ShouldEqual(typeof(StringGraphType));
+            field.Arguments[0].DefaultValue.ShouldEqual("12345");
+
+            field.Arguments[1].Name.ShouldEqual("arg2");
+            field.Arguments[1].Description.ShouldEqual("desc2");
+            field.Arguments[1].Type.ShouldEqual(typeof(IntGraphType));
+            field.Arguments[1].DefaultValue.ShouldEqual(9);
+
+            field.Arguments[2].Name.ShouldEqual("arg3");
+            field.Arguments[2].Description.ShouldEqual("desc3");
+            field.Arguments[2].Type.ShouldEqual(typeof(IntGraphType));
+            field.Arguments[2].DefaultValue.ShouldEqual(null);
+        }
+
+        [Test]
+        public void FieldResolveHasArgument()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<IntGraphType>()
+                .Argument<StringGraphType, string>("arg1", "desc1", "12345")
+                .Returns<int>()
+                .Resolve(context =>
+                {
+                    context.HasArgument("arg1").ShouldEqual(true);
+                    context.HasArgument("arg0").ShouldEqual(false);
+                    return 0;
+                });
+
+            var field = objectType.Fields.First();
+            field.Arguments.Count.ShouldEqual(1);
+
+            field.Arguments[0].Name.ShouldEqual("arg1");
+            field.Arguments[0].Description.ShouldEqual("desc1");
+            field.Arguments[0].Type.ShouldEqual(typeof(StringGraphType));
+            field.Arguments[0].DefaultValue.ShouldEqual("12345");
+            field.Resolve(new ResolveFieldContext
+            {
+                Arguments = new Dictionary<string, object>
+                {
+                    { "arg1", "abc" }
+                }
+            });
+        }
+
+        [Test]
+        public void FieldResolveGetNonExistentArgument()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .Argument<StringGraphType, string>("arg1", "desc1")
+                .Resolve(context =>
+                {
+                    context.GetArgument<string>("arg1").ShouldEqual(null);
+                    return null;
+                });
+
+            var field = objectType.Fields.First();
+            field.Resolve(new ResolveFieldContext
+            {
+                Arguments = new Dictionary<string, object>(),
+                FieldDefinition = field,
+            });
+        }
+
+        [Test]
+        public void FieldResolveGetNonExistentArgumentWithDefault()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .Argument<StringGraphType, string>("arg1", "desc1", "default")
+                .Resolve(context =>
+                {
+                    context.GetArgument<string>("arg1").ShouldEqual("default");
+                    return null;
+                });
+
+            var field = objectType.Fields.First();
+            field.Resolve(new ResolveFieldContext
+            {
+                Arguments = new Dictionary<string, object>(),
+                FieldDefinition = field,
+            });
+        }
+
+        [Test]
+        public void FieldResolveGetNonExistentArgumentWithOverriddenDefault()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .Argument<StringGraphType, string>("arg1", "desc1", "default")
+                .Resolve(context =>
+                {
+                    context.GetArgument("arg1", "default2").ShouldEqual("default2");
+                    return null;
+                });
+
+            var field = objectType.Fields.First();
+            field.Resolve(new ResolveFieldContext
+            {
+                Arguments = new Dictionary<string, object>(),
+                FieldDefinition = field,
+            });
+        }
+
+        [Test]
+        public void FieldResolveGetExistentArgumentWithDefault()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .Argument<StringGraphType, string>("arg1", "desc1", "default")
+                .Resolve(context =>
+                {
+                    context.GetArgument("arg1", "default2").ShouldEqual("arg1value");
+                    return null;
+                });
+
+            var field = objectType.Fields.First();
+            field.Resolve(new ResolveFieldContext
+            {
+                Arguments = new Dictionary<string, object>
+                {
+                    { "arg1", "arg1value" }
+                },
+                FieldDefinition = field,
+            });
+        }
+
+        [Test]
+        public void FieldResolveGetObject()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .WithObject<int>()
+                .Resolve(context =>
+                {
+                    context.Object.ShouldEqual(12345);
+                    return null;
+                });
+
+            var field = objectType.Fields.First();
+            field.Resolve(new ResolveFieldContext
+            {
+                Source = 12345,
+            });
+        }
+
+        [Test]
+        public void FieldResolveGetObjectWithCustomResolver()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .WithObject(obj => (int)obj + 1)
+                .Resolve(context =>
+                {
+                    context.Object.ShouldEqual(12346);
+                    return null;
+                });
+
+            var field = objectType.Fields.First();
+            field.Resolve(new ResolveFieldContext
+            {
+                Source = 12345,
+            });
+        }
+    }
+}

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -52,6 +52,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Builders\ConnectionBuilderTests.cs" />
+    <Compile Include="Builders\FieldBuilderTests.cs" />
     <Compile Include="Execution\Cancellation\CancellationTests.cs" />
     <Compile Include="Execution\Directives\DirectivesTests.cs" />
     <Compile Include="Execution\InputConversionTests.cs" />

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Builders\ConnectionBuilderTests.cs" />
+    <Compile Include="Builders\ConnectionTests.cs" />
     <Compile Include="Builders\FieldBuilderTests.cs" />
     <Compile Include="Execution\Cancellation\CancellationTests.cs" />
     <Compile Include="Execution\Directives\DirectivesTests.cs" />

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -8,19 +8,17 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
-        public static ConnectionBuilder<TParentType, TGraphType, object> Create<TParentType, TGraphType>()
-            where TParentType : GraphType
+        public static ConnectionBuilder<TGraphType, object, TDataObject> Create<TGraphType, TDataObject>()
             where TGraphType : ObjectGraphType, new()
         {
-            return ConnectionBuilder<TParentType, TGraphType, object>.Create();
+            return ConnectionBuilder<TGraphType, object, TDataObject>.Create();
         }
     }
 
-    public class ConnectionBuilder<TParentType, TGraphType, TObjectType>
-        where TParentType : GraphType
+    public class ConnectionBuilder<TGraphType, TObjectType, TDataObject>
         where TGraphType : ObjectGraphType, new()
     {
-        public class ResolutionArguments : FieldBuilder<TGraphType, TObjectType, IEnumerable<TGraphType>>.ResolutionArguments
+        public class ResolutionArguments : FieldBuilder<TGraphType, TObjectType, IEnumerable<TDataObject>>.ResolutionArguments
         {
             private readonly int? _defaultPageSize;
 
@@ -31,7 +29,7 @@ namespace GraphQL.Builders
                 _defaultPageSize = defaultPageSize;
             }
 
-            public bool IsUnidirectional { get; set; }
+            public bool IsUnidirectional { get; private set; }
 
             public int? First
             {
@@ -97,18 +95,18 @@ namespace GraphQL.Builders
             FieldType = fieldType;
         }
 
-        public static ConnectionBuilder<TParentType, TGraphType, TObjectType> Create()
+        public static ConnectionBuilder<TGraphType, TObjectType, TDataObject> Create()
         {
             var fieldType = new FieldType
             {
-                Type = typeof(ConnectionType<TParentType, TGraphType>),
+                Type = typeof(ConnectionType<TGraphType>),
                 Arguments = new QueryArguments(new QueryArgument[0]),
             };
-            return new ConnectionBuilder<TParentType, TGraphType, TObjectType>(fieldType, null, false, false, null)
+            return new ConnectionBuilder<TGraphType, TObjectType, TDataObject>(fieldType, null, false, false, null)
                 .Unidirectional();
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TObjectType> Unidirectional()
+        public ConnectionBuilder<TGraphType, TObjectType, TDataObject> Unidirectional()
         {
             if (_isUnidirectional)
             {
@@ -126,7 +124,7 @@ namespace GraphQL.Builders
             return this;
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TObjectType> Bidirectional()
+        public ConnectionBuilder<TGraphType, TObjectType, TDataObject> Bidirectional()
         {
             if (_isBidirectional)
             {
@@ -136,7 +134,7 @@ namespace GraphQL.Builders
             Argument<StringGraphType, string>("before",
                 "Only look at connected edges with cursors smaller than the value of `before`.");
             Argument<IntGraphType, int?>("last",
-                "Specifies the number of edges to return counting reversly from `before` or the last entry if `before` is not specified");
+                "Specifies the number of edges to return counting reversely from `before`, or the last entry if `before` is not specified.");
 
             _isUnidirectional = false;
             _isBidirectional = true;
@@ -144,33 +142,33 @@ namespace GraphQL.Builders
             return this;
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TObjectType> Name(string name)
+        public ConnectionBuilder<TGraphType, TObjectType, TDataObject> Name(string name)
         {
             FieldType.Name = name;
             return this;
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TObjectType> Description(string description)
+        public ConnectionBuilder<TGraphType, TObjectType, TDataObject> Description(string description)
         {
             FieldType.Description = description;
             return this;
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TObjectType> PageSize(int pageSize)
+        public ConnectionBuilder<TGraphType, TObjectType, TDataObject> PageSize(int pageSize)
         {
             _pageSize = pageSize;
             return this;
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TObjectType> ReturnAll()
+        public ConnectionBuilder<TGraphType, TObjectType, TDataObject> ReturnAll()
         {
             _pageSize = null;
             return this;
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TNewObjectType> WithObject<TNewObjectType>(Func<object, TNewObjectType> objectResolver = null)
+        public ConnectionBuilder<TGraphType, TNewObjectType, TDataObject> WithObject<TNewObjectType>(Func<object, TNewObjectType> objectResolver = null)
         {
-            return new ConnectionBuilder<TParentType, TGraphType, TNewObjectType>(
+            return new ConnectionBuilder<TGraphType, TNewObjectType, TDataObject>(
                 FieldType,
                 objectResolver ?? (obj => (TNewObjectType)obj),
                 _isUnidirectional,
@@ -178,7 +176,7 @@ namespace GraphQL.Builders
                 _pageSize);
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TObjectType> Argument<TArgumentGraphType>(string name, string description)
+        public ConnectionBuilder<TGraphType, TObjectType, TDataObject> Argument<TArgumentGraphType>(string name, string description)
         {
             FieldType.Arguments.Add(new QueryArgument(typeof(TArgumentGraphType))
             {
@@ -188,7 +186,7 @@ namespace GraphQL.Builders
             return this;
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, TObjectType> Argument<TArgumentGraphType, TArgumentType>(string name, string description,
+        public ConnectionBuilder<TGraphType, TObjectType, TDataObject> Argument<TArgumentGraphType, TArgumentType>(string name, string description,
             TArgumentType defaultValue = default(TArgumentType))
         {
             FieldType.Arguments.Add(new QueryArgument(typeof(TArgumentGraphType))
@@ -200,25 +198,25 @@ namespace GraphQL.Builders
             return this;
         }
 
-        public void Resolve(Func<ResolutionArguments, IEnumerable<TGraphType>> resolver)
+        public void Resolve(Func<ResolutionArguments, IEnumerable<TDataObject>> resolver)
         {
             FieldType.Resolve = context =>
             {
                 var args = new ResolutionArguments(context, _objectResolver, _isUnidirectional, _pageSize);
                 CheckForErrors(args);
                 var entries = resolver(args);
-                return ResolveCallback(args, entries != null ? entries.ToList() : new List<TGraphType>());
+                return ResolveCallback(args, entries != null ? entries.ToList() : new List<TDataObject>());
             };
         }
 
-        public void Resolve(Func<ResolutionArguments, Task<IEnumerable<TGraphType>>> resolver)
+        public void Resolve(Func<ResolutionArguments, Task<IEnumerable<TDataObject>>> resolver)
         {
             FieldType.Resolve = context =>
             {
                 var args = new ResolutionArguments(context, _objectResolver, _isUnidirectional, _pageSize);
                 CheckForErrors(args);
                 var entries = resolver(args).Result;
-                return ResolveCallback(args, entries != null ? entries.ToList() : new List<TGraphType>());
+                return ResolveCallback(args, entries != null ? entries.ToList() : new List<TDataObject>());
             };
         }
 
@@ -250,83 +248,21 @@ namespace GraphQL.Builders
             }
         }
 
-        private ConnectionType<TParentType, TGraphType> ResolveCallback(ResolutionArguments args, List<TGraphType> entries)
+        private Connection<TDataObject> ResolveCallback(ResolutionArguments args, List<TDataObject> entries)
         {
+
             var totalCount = args.IsPartial ? args.TotalCount : entries.Count;
-            var limit = args.PageSize ?? totalCount ?? 25;
-            var firstIndex = args.NumberOfSkippedEntries ?? 0;
-            var skip = 0;
 
             if (!args.IsUnidirectional && !totalCount.HasValue)
             {
                 throw new ArgumentException("`totalCount` is not set for partial bidirectional connection.");
             }
 
-            var after = ParseCursor(args.After);
-            var before = ParseCursor(args.Before);
+            var connection = new Connection<TDataObject>()
+                .FromCollection(entries)
+                .Paginate(args.First, args.Last, args.After, args.Before);
 
-            if (!args.IsPartial)
-            {
-                if (after.HasValue)
-                {
-                    skip = Math.Max(after.Value - firstIndex, 0);
-                }
-                else if (before.HasValue)
-                {
-                    var count = totalCount.GetValueOrDefault(0);
-                    var skipFromEnd = Math.Max(count - before.Value + 1, 0);
-                    skip = count - limit - skipFromEnd;
-                    if (skip < 0)
-                    {
-                        skip = 0;
-                        limit = 0;
-                    }
-                }
-                firstIndex = skip;
-            }
-
-            var cursor = firstIndex;
-            var edges = entries
-                .Skip(skip)
-                .Take(limit)
-                .Select(entry =>
-                    new EdgeType<TParentType, TGraphType>
-                    {
-                        Cursor = GetCursorFromIndex(++cursor),
-                        Node = entry,
-                    })
-                .ToList();
-            var takeCount = edges.Count;
-
-            var pageInfo = new PageInfoType
-            {
-                HasNextPage = takeCount < entries.Count - skip,
-                HasPreviousPage = firstIndex > 0,
-                StartCursor = GetCursorFromIndex(firstIndex + 1),
-                EndCursor = GetCursorFromIndex(firstIndex + Math.Max(1, takeCount)),
-            };
-
-            return new ConnectionType<TParentType, TGraphType>
-            {
-                TotalCount = totalCount,
-                Edges = edges,
-                PageInfo = pageInfo,
-            };
-        }
-
-        private static string GetCursorFromIndex(int index)
-        {
-            return index.ToString("D8");
-        }
-
-        private static int? ParseCursor(string cursor)
-        {
-            int cursorInt;
-            if (cursor != null && int.TryParse(cursor, out cursorInt))
-            {
-                return cursorInt;
-            }
-            return null;
+            return connection;
         }
     }
 }

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -9,14 +9,14 @@ namespace GraphQL.Builders
     public static class ConnectionBuilder
     {
         public static ConnectionBuilder<TGraphType, object, TDataObject> Create<TGraphType, TDataObject>()
-            where TGraphType : ObjectGraphType, new()
+            where TGraphType : ObjectGraphType
         {
             return ConnectionBuilder<TGraphType, object, TDataObject>.Create();
         }
     }
 
     public class ConnectionBuilder<TGraphType, TObjectType, TDataObject>
-        where TGraphType : ObjectGraphType, new()
+        where TGraphType : ObjectGraphType
     {
         public class ResolutionArguments : FieldBuilder<TGraphType, TObjectType, IEnumerable<TDataObject>>.ResolutionArguments
         {
@@ -250,7 +250,6 @@ namespace GraphQL.Builders
 
         private Connection<TDataObject> ResolveCallback(ResolutionArguments args, List<TDataObject> entries)
         {
-
             var totalCount = args.IsPartial ? args.TotalCount : entries.Count;
 
             if (!args.IsUnidirectional && !totalCount.HasValue)

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using GraphQL.Types;
 
 namespace GraphQL.Builders
@@ -39,7 +40,34 @@ namespace GraphQL.Builders
 
             public TObjectType Object { get; set; }
 
-            public T GetArgument<T>(string argumentName, T defaultValue = default(T))
+            public T GetArgument<T>(string argumentName)
+            {
+                object argument;
+                var defaultValue = default(T);
+
+                if (_context.FieldDefinition != null &&
+                    _context.FieldDefinition.Arguments != null)
+                {
+                    var arg = _context.FieldDefinition
+                        .Arguments
+                        .FirstOrDefault(a => a.Name == argumentName);
+                    if (arg != null)
+                    {
+                        defaultValue = arg.DefaultValue is T
+                            ? (T)arg.DefaultValue
+                            : default(T);
+                    }
+                }
+
+                if (_context.Arguments.TryGetValue(argumentName, out argument))
+                {
+                    return argument is T ? (T)argument : defaultValue;
+                }
+
+                return defaultValue;
+            }
+
+            public T GetArgument<T>(string argumentName, T defaultValue)
             {
                 object argument;
 

--- a/src/GraphQL/Types/ConnectionType.cs
+++ b/src/GraphQL/Types/ConnectionType.cs
@@ -1,16 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace GraphQL.Types
 {
-    public class ConnectionType<TFrom, TTo> : ObjectGraphType
+    public class ConnectionType<TTo> : ObjectGraphType
         where TTo : ObjectGraphType, new()
     {
         public ConnectionType()
         {
-            Name = string.Format("{0}{1}Connection", typeof(TFrom).GraphQLName(true), typeof(TTo).GraphQLName());
-            Description = string.Format("A connection from an object of type `{0}` to a list of objects of type `{1}`",
-                typeof(TFrom).GraphQLName(), typeof(TTo).GraphQLName());
+            Name = string.Format("{0}Connection", typeof(TTo).GraphQLName());
+            Description = string.Format("A connection from an object to a list of objects of type `{0}`.",
+                typeof(TTo).GraphQLName());
 
             Field<IntGraphType>()
                 .Name("totalCount")
@@ -25,7 +27,7 @@ namespace GraphQL.Types
                 .Name("pageInfo")
                 .Description("Information to aid in pagination.");
 
-            Field<ListGraphType<EdgeType<TFrom, TTo>>>()
+            Field<ListGraphType<EdgeType<TTo>>>()
                 .Name("edges")
                 .Description("Information to aid in pagination.");
 
@@ -38,20 +40,216 @@ namespace GraphQL.Types
                     "the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, " +
                     "and the full \"{ edges { node } } \" version should be used instead.");
         }
+    }
 
-        public int? TotalCount { get; set; }
+    public class Connection<T>
+    {
+        private IEnumerable<T> _collection;
+        private PageInfo _pageInfo;
+        private List<Edge<T>> _edges;
+        private int? _first;
+        private int? _last;
+        private string _after;
+        private string _before;
+        private int _fetchCount;
+        private bool _hasBeenPaginated;
 
-        public PageInfoType PageInfo { get; set; }
+        public int? TotalCount => _collection?.Count();
 
-        public List<EdgeType<TFrom, TTo>> Edges { get; set; }
-
-        public List<TTo> Items
+        public PageInfo PageInfo
         {
             get
             {
-                return Edges != null
-                    ? Edges.Select(e => e.Node).Where(n => n != null).ToList()
-                    : new List<TTo>();
+                if (_pageInfo == null)
+                {
+                    Paginate(_first, _last, _after, _before);
+                }
+                return _pageInfo;
+            }
+        }
+
+        public List<Edge<T>> Edges
+        {
+            get
+            {
+                if (_edges != null)
+                {
+                    return _edges;
+                }
+
+                if (_collection == null)
+                {
+                    _edges = new List<Edge<T>>();
+                    return _edges;
+                }
+
+                _fetchCount = -1;
+                var edges = _collection
+                    .Select((item, index) => new Edge<T>
+                    {
+                        Cursor = $"{index + 1:D8}",
+                        Node = item,
+                    });
+
+                if (!string.IsNullOrWhiteSpace(_after))
+                {
+                    int.TryParse(_after, NumberStyles.Any, CultureInfo.InvariantCulture, out _fetchCount);
+                    edges = edges.SkipWhile(edge => string.CompareOrdinal(edge.Cursor, _after) <= 0);
+                }
+
+                if (!string.IsNullOrWhiteSpace(_before))
+                {
+                    var beforeEdges = edges
+                        .TakeWhile(edge => string.CompareOrdinal(edge.Cursor, _before) <= 0)
+                        .ToList();
+
+                    _fetchCount = beforeEdges.Count;
+
+                    edges = beforeEdges
+                        .TakeWhile(edge => string.CompareOrdinal(edge.Cursor, _before) < 0);
+                }
+
+                if (_first.HasValue)
+                {
+                    var edgesList = edges.Take(_first.Value).ToList();
+                    edges = edgesList;
+                    _fetchCount = _fetchCount != -1
+                        ? edgesList.Count + 1 + _fetchCount
+                        : edgesList.Count + 1;
+                }
+
+                if (_last.HasValue)
+                {
+                    var edgesList = edges.ToList();
+                    var count = edgesList.Count;
+                    edges = _last.Value < count
+                        ? edgesList.Skip(count - _last.Value)
+                        : edgesList;
+                }
+
+                _edges = edges.ToList();
+
+                if (_fetchCount == -1)
+                {
+                    _fetchCount = _collection.Count();
+                }
+
+                return _edges;
+            }
+        }
+
+        public List<T> Items => Edges?.Select(edge => edge != null ? edge.Node : default(T)).ToList();
+
+        public Connection<T> FromCollection(IEnumerable<T> collection)
+        {
+            _collection = collection;
+            return this;
+        }
+
+        public Connection<T> Paginate(
+            int? first = null, int? last = null, string after = null, string before = null)
+        {
+            if (_hasBeenPaginated)
+            {
+                throw new Exception("Cannot paginate connection twice.");
+            }
+
+            _first = first;
+            _last = last;
+            _after = after;
+            _before = before;
+            ValidateParameters();
+
+            _edges = null;
+            var edges = Edges;
+            var minCursor = $"{0:D8}";
+            var maxCursor = $"{0:D8}";
+
+            if (_collection.Any())
+            {
+                minCursor = $"{1:D8}";
+                maxCursor = $"{_fetchCount:D8}";
+            }
+
+            if (edges.Any())
+            {
+                var minPageCursor = edges.Min(edge => edge.Cursor);
+                var maxPageCursor = edges.Max(edge => edge.Cursor);
+
+                _pageInfo = new PageInfo
+                {
+                    StartCursor = minPageCursor,
+                    EndCursor = maxPageCursor,
+                    HasNextPage = string.CompareOrdinal(maxPageCursor, maxCursor) < 0,
+                    HasPreviousPage = string.CompareOrdinal(minPageCursor, minCursor) > 0,
+                };
+            }
+            else
+            {
+                _pageInfo = new PageInfo
+                {
+                    StartCursor = after ?? before ?? minCursor,
+                    EndCursor = before ?? after ?? maxCursor,
+                };
+
+                int startValue, endValue;
+                int.TryParse(PageInfo.StartCursor, NumberStyles.Any, CultureInfo.InvariantCulture, out startValue);
+                int.TryParse(PageInfo.EndCursor, NumberStyles.Any, CultureInfo.InvariantCulture, out endValue);
+
+                if (!string.IsNullOrWhiteSpace(before))
+                {
+                    var cursorValue = Math.Min(startValue - 1, endValue - 1);
+                    PageInfo.StartCursor = PageInfo.EndCursor = $"{cursorValue:D8}";
+                }
+                else if (!string.IsNullOrWhiteSpace(after))
+                {
+                    var cursorValue = Math.Max(startValue + 1, endValue + 1);
+                    PageInfo.StartCursor = PageInfo.EndCursor = $"{cursorValue:D8}";
+                }
+                else if (first.HasValue)
+                {
+                    var cursorValue = Math.Min(startValue - 1, endValue - 1);
+                    PageInfo.StartCursor = PageInfo.EndCursor = $"{cursorValue:D8}";
+                }
+                else if (last.HasValue)
+                {
+                    var cursorValue = Math.Max(startValue + 1, endValue + 1);
+                    PageInfo.StartCursor = PageInfo.EndCursor = $"{cursorValue:D8}";
+                }
+
+                PageInfo.HasNextPage =
+                    (_first.GetValueOrDefault(-1) == 0)
+                        ? string.CompareOrdinal(PageInfo.EndCursor, maxCursor) <= 0
+                        : string.CompareOrdinal(PageInfo.EndCursor, maxCursor) < 0;
+
+                PageInfo.HasPreviousPage =
+                    string.CompareOrdinal(PageInfo.StartCursor, minCursor) > 0;
+            }
+
+            _hasBeenPaginated = true;
+            return this;
+        }
+
+        private void ValidateParameters()
+        {
+            if (_first.HasValue && _last.HasValue)
+            {
+                throw new ArgumentException("Cannot use `first` in conjunction with `last`.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(_after) && !string.IsNullOrWhiteSpace(_before))
+            {
+                throw new ArgumentException("Cannot use `after` in conjunction with `before`.");
+            }
+
+            if (_first.HasValue && !string.IsNullOrWhiteSpace(_before))
+            {
+                throw new ArgumentException("Cannot use `first` in conjunction with `before`.");
+            }
+
+            if (_last.HasValue && !string.IsNullOrWhiteSpace(_after))
+            {
+                throw new ArgumentException("Cannot use `last` in conjunction with `after`.");
             }
         }
     }

--- a/src/GraphQL/Types/ConnectionType.cs
+++ b/src/GraphQL/Types/ConnectionType.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace GraphQL.Types
 {
     public class ConnectionType<TTo> : ObjectGraphType
-        where TTo : ObjectGraphType, new()
+        where TTo : ObjectGraphType
     {
         public ConnectionType()
         {

--- a/src/GraphQL/Types/EdgeType.cs
+++ b/src/GraphQL/Types/EdgeType.cs
@@ -1,7 +1,7 @@
 ﻿namespace GraphQL.Types
 {
     public class EdgeType<TTo> : ObjectGraphType
-        where TTo : ObjectGraphType, new()
+        where TTo : ObjectGraphType
     {
         public EdgeType()
         {

--- a/src/GraphQL/Types/EdgeType.cs
+++ b/src/GraphQL/Types/EdgeType.cs
@@ -1,23 +1,27 @@
 ﻿namespace GraphQL.Types
 {
-    public class EdgeType<TFrom, TTo> : ObjectGraphType
+    public class EdgeType<TTo> : ObjectGraphType
         where TTo : ObjectGraphType, new()
     {
         public EdgeType()
         {
-            Name = string.Format("{0}{1}Edge",
-                typeof(TFrom).GraphQLName(true), typeof(TTo).GraphQLName());
+            Name = string.Format("{0}Edge", typeof(TTo).GraphQLName());
             Description = string.Format(
-                "An edge in a connection between objects of types `{0}` and `{1}`.",
-                typeof(TFrom).GraphQLName(), typeof(TTo).GraphQLName());
+                "An edge in a connection from an object to another object of type `{0}`.",
+                typeof(TTo).GraphQLName());
 
-            Field<NonNullGraphType<StringGraphType>>("cursor", "A cursor for use in pagination",
-                resolve: context => ((EdgeType<TFrom, TTo>)context.Source).Cursor);
+            Field<NonNullGraphType<StringGraphType>>()
+                .Name("cursor")
+                .Description("A cursor for use in pagination");
 
-            Field<TTo>("node", "The item at the end of the edge",
-                resolve: context => ((EdgeType<TFrom, TTo>)context.Source).Node);
+            Field<TTo>()
+                .Name("node")
+                .Description("The item at the end of the edge");
         }
+    }
 
+    public class Edge<TTo>
+    {
         public string Cursor { get; set; }
 
         public TTo Node { get; set; }

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -30,11 +30,10 @@ namespace GraphQL.Types
             return builder;
         }
 
-        public ConnectionBuilder<TParentType, TGraphType, object> Connection<TParentType, TGraphType>()
-            where TParentType : GraphType
+        public ConnectionBuilder<TGraphType, object, TDataObject> Connection<TGraphType, TDataObject>()
             where TGraphType : ObjectGraphType, new()
         {
-            var builder = ConnectionBuilder.Create<TParentType, TGraphType>();
+            var builder = ConnectionBuilder.Create<TGraphType, TDataObject>();
             _fields.Add(builder.FieldType);
             return builder;
         }

--- a/src/GraphQL/Types/PageInfoType.cs
+++ b/src/GraphQL/Types/PageInfoType.cs
@@ -12,7 +12,10 @@
             Field<StringGraphType>("startCursor", "When paginating backwards, the cursor to continue.");
             Field<StringGraphType>("endCursor", "When paginating forwards, the cursor to continue.");
         }
+    }
 
+    public class PageInfo
+    {
         public bool HasNextPage { get; set; }
 
         public bool HasPreviousPage { get; set; }


### PR DESCRIPTION
### Changes:
 * `GetArgument()` wasn't using the `FieldDefinition`'s default value for an argument correctly. Added method signature for using the `FieldDefinition` default, and one for overriding the value.
 * Added unit tests for the `FieldBuilder` helper class.
 * `ConnectionType<T>`, `EdgeType<T>` and `PageInfoType` implementations have been improved, and now use backing data objects. Previously, due to the defined type templates, it was only possible to use `ConnectionType` with an object deriving from `ObjectGraphType`; this has now been fixed.
 * Added a range of unit tests for `Connection<T>`, the underlying data type; and for `ConnectionBuilder<T>`.
 * Removed `new()` constraint on connections and edges.