### PR TITLE
Make GraphQLFloat type correspond to double

### DIFF
--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Execution\VariablesTests.cs" />
     <Compile Include="Introspection\IntrospectionResult.cs" />
     <Compile Include="Introspection\SchemaIntrospectionTests.cs" />
+    <Compile Include="Types\FloatGraphTypeTests.cs" />
     <Compile Include="Utilities\SchemaPrinterTests.cs" />
     <Compile Include="SimpleContainer.cs" />
     <Compile Include="StarWars\EpisodeEnum.cs" />

--- a/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Should;
+
+namespace GraphQL.Tests.Types
+{
+    public class FloatGraphTypeTests
+    {
+        private FloatGraphType type = new FloatGraphType();
+
+        [Test]
+        public void coerces_null_to_null()
+        {
+            type.Coerce(null).ShouldEqual(null);
+        }
+
+        [Test]
+        public void coerces_invalid_string_to_null()
+        {
+            type.Coerce("abcd").ShouldEqual(null);
+        }
+
+        [Test]
+        public void coerces_double_to_value()
+        {
+            type.Coerce(1.79769313486231e308).ShouldEqual((double)1.79769313486231e308);
+        }
+    }
+}

--- a/src/GraphQL/Types/FloatGraphType.cs
+++ b/src/GraphQL/Types/FloatGraphType.cs
@@ -9,8 +9,8 @@ namespace GraphQL.Types
 
         public override object Coerce(object value)
         {
-            float result;
-            if (float.TryParse(value.ToString(), out result))
+            double result;
+            if (double.TryParse(value?.ToString() ?? string.Empty, out result))
             {
                 return result;
             }


### PR DESCRIPTION
According to the GraphQL specification a Float type is a double precision floating point, so use a double to support the full range of values. Fixes #66.