### PR TITLE
Add serialization strategy for ExecutionResult

### DIFF
--- a/src/GraphQL.GraphiQL/Controllers/GraphQLController.cs
+++ b/src/GraphQL.GraphiQL/Controllers/GraphQLController.cs
@@ -1,4 +1,6 @@
-﻿using GraphQL.Tests;
+﻿using System.Net;
+using System.Net.Http;
+using GraphQL.Tests;
 using GraphQL.Types;
 using System.Threading.Tasks;
 using System.Web.Http;
@@ -26,10 +28,16 @@ namespace GraphQL.GraphiQL.Controllers
             _schema = _container.Get<StarWarsSchema>();
         }
 
-        public async Task<ExecutionResult> Post(GraphQLQuery query)
+        public async Task<HttpResponseMessage> Post(HttpRequestMessage request, GraphQLQuery query)
         {
             var inputs = query.Variables.ToInputs();
-            return await Execute(_schema, null, query.Query, query.OperationName, inputs);
+            var result = await Execute(_schema, null, query.Query, query.OperationName, inputs);
+
+            var httpResult = result.Errors?.Count > 0
+                ? HttpStatusCode.BadRequest
+                : HttpStatusCode.OK;
+
+            return request.CreateResponse(httpResult, result);
         }
 
         public async Task<ExecutionResult> Execute(

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Introspection\IntrospectionResult.cs" />
     <Compile Include="Introspection\SchemaIntrospectionTests.cs" />
     <Compile Include="Types\FloatGraphTypeTests.cs" />
+    <Compile Include="Types\QueryArgumentTests.cs" />
     <Compile Include="Utilities\SchemaPrinterTests.cs" />
     <Compile Include="SimpleContainer.cs" />
     <Compile Include="StarWars\EpisodeEnum.cs" />

--- a/src/GraphQL.Tests/StarWars/StarWarsQuery.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsQuery.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Tests
                     {
                         new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the human" }
                     }),
-                resolve: context => data.GetHumanByIdAsync((string)context.Arguments["id"])
+                resolve: context => data.GetHumanByIdAsync(context.Argument<string>("id"))
             );
             Field<DroidType>(
                 "droid",
@@ -25,7 +25,7 @@ namespace GraphQL.Tests
                     {
                         new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the droid" }
                     }),
-                resolve: context => data.GetDroidByIdAsync((string)context.Arguments["id"])
+                resolve: context => data.GetDroidByIdAsync(context.Argument<string>("id"))
             );
         }
     }

--- a/src/GraphQL.Tests/Types/QueryArgumentTests.cs
+++ b/src/GraphQL.Tests/Types/QueryArgumentTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Types
+{
+    public class QueryArgumentTests
+    {
+        [Test]
+        public void throws_exception_with_null_type()
+        {
+            Expect.Throws<ArgumentOutOfRangeException>(() => new QueryArgument(null));
+        }
+
+        [Test]
+        public void throws_exception_with_invalid_type()
+        {
+            Expect.Throws<ArgumentOutOfRangeException>(() => new QueryArgument(typeof(string)));
+        }
+
+        [Test]
+        public void does_not_throw_with_valid_type()
+        {
+            new QueryArgument(typeof(GraphType));
+        }
+
+        [Test]
+        public void does_not_throw_with_object_type()
+        {
+            new QueryArgument(typeof(ObjectGraphType));
+        }
+    }
+}

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -175,6 +175,7 @@ namespace GraphQL.Builders
         }
 
         public ConnectionBuilder<TGraphType, TObjectType> Argument<TArgumentGraphType>(string name, string description)
+            where TArgumentGraphType : GraphType
         {
             FieldType.Arguments.Add(new QueryArgument(typeof(TArgumentGraphType))
             {
@@ -186,6 +187,7 @@ namespace GraphQL.Builders
 
         public ConnectionBuilder<TGraphType, TObjectType> Argument<TArgumentGraphType, TArgumentType>(string name, string description,
             TArgumentType defaultValue = default(TArgumentType))
+            where TArgumentGraphType : GraphType
         {
             FieldType.Arguments.Add(new QueryArgument(typeof(TArgumentGraphType))
             {

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 
 namespace GraphQL
 {
     public class ExecutionError : Exception
     {
+        private List<ErrorLocation> _errorLocations;
+
         public ExecutionError(string message)
             : base(message)
         {
@@ -13,5 +16,23 @@ namespace GraphQL
             : base(message, innerException)
         {
         }
+
+        public IEnumerable<ErrorLocation> Locations => _errorLocations;
+
+        public void AddLocation(int line, int column)
+        {
+            if (_errorLocations == null)
+            {
+                _errorLocations = new List<ErrorLocation>();
+            }
+
+            _errorLocations.Add(new ErrorLocation {Line = line, Column = column});
+        }
+    }
+
+    public class ErrorLocation
+    {
+        public int Line { get; set; }
+        public int Column { get; set; }
     }
 }

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -2,11 +2,11 @@ using Newtonsoft.Json;
 
 namespace GraphQL
 {
+    [JsonConverter(typeof(ExecutionResultJsonConverter))]
     public class ExecutionResult
     {
         public object Data { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public ExecutionErrors Errors { get; set; }
     }
 }

--- a/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
@@ -1,0 +1,81 @@
+using System;
+using Newtonsoft.Json;
+
+namespace GraphQL
+{
+    public class ExecutionResultJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is ExecutionResult)
+            {
+                var result = (ExecutionResult) value;
+
+                writer.WriteStartObject();
+
+                writeData(result, writer, serializer);
+                writeErrors(result.Errors, writer, serializer);
+
+                writer.WriteEndObject();
+            }
+        }
+
+        private void writeData(ExecutionResult result, JsonWriter writer, JsonSerializer serializer)
+        {
+            var data = result.Data;
+
+            if (result.Errors?.Count > 0 && data == null)
+            {
+                return;
+            }
+
+            if (result.Errors?.Count > 0)
+            {
+                data = null;
+            }
+
+            writer.WritePropertyName("data");
+            serializer.Serialize(writer, data);
+        }
+
+        private void writeErrors(ExecutionErrors errors, JsonWriter writer, JsonSerializer serializer)
+        {
+            if (errors == null || errors.Count == 0)
+            {
+                return;
+            }
+
+            writer.WritePropertyName("errors");
+
+            writer.WriteStartArray();
+
+            errors.Apply(error =>
+            {
+                writer.WriteStartObject();
+
+                writer.WritePropertyName("message");
+                serializer.Serialize(writer, error.Message);
+
+                if (error.Locations != null)
+                {
+                    writer.WritePropertyName("locations");
+                    serializer.Serialize(writer, error.Locations);
+                }
+
+                writer.WriteEndObject();
+            });
+
+            writer.WriteEndArray();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(ExecutionResult);
+        }
+    }
+}

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Builders\ConnectionBuilder.cs" />
     <Compile Include="Builders\FieldBuilder.cs" />
     <Compile Include="Execution\AntlrDocumentBuilder.cs" />
+    <Compile Include="Execution\ExecutionResultJsonConverter.cs" />
     <Compile Include="Execution\ResolveFieldResult.cs" />
     <Compile Include="Introspection\SchemaIntrospection.cs" />
     <Compile Include="Introspection\SchemaMetaFieldType.cs" />

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -15,6 +15,11 @@ namespace GraphQL.Types
     {
         public QueryArgument(Type type)
         {
+            if (type == null || !typeof(GraphType).IsAssignableFrom(type))
+            {
+                throw new ArgumentOutOfRangeException(nameof(type), "QueryArgument type is required and must derive from GraphType.");
+            }
+
             Type = type;
         }
 


### PR DESCRIPTION
* Added a serialization strategy to ExecutionResult to conform to
  error spec
* Updated sample GraphQLController to return 400 status code on error
* Added GraphType constraint to ConnectionBuilder<,>.Argument

Issues: #73, #82