### PR TITLE
Add ArgumentsOfCorrectType, bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,30 @@ Console.Writeline(result);
 - [x] Async execution
 
 ### Validation
-- In progress
-- [x] Unique operation names
+- [x] Arguments of correct type - *additional test coverage needed*
+- [ ] Default values of correct type
+- [ ] Fields on correct type
+- [ ] Fragments on composite type
+- [ ] Known argument names
+- [ ] Known directives
+- [ ] Known fragment names
+- [ ] Known type names
 - [x] Lone anonymous operations
-- [x] Scalar leafs
+- [ ] No fragment cycle
+- [ ] No undefined variables
+- [ ] No unused fragments
+- [ ] No unused variables
+- [ ] Overlapping fields can be merged
+- [ ] Possible fragment spreads
+- [ ] Provide non-null arguments
+- [x] Scalar leafs - *additional test coverage needed*
+- [ ] Unique argument names
+- [ ] Unique fragment names
+- [ ] Unique input field names
+- [x] Unique operation names
+- [ ] Unique variable names
+- [ ] Variables are input types
+- [ ] Variables in allowed position
 
 ### Schema Introspection
 - [x] __typename
@@ -164,4 +184,5 @@ Console.Writeline(result);
   - [x] types
   - [x] queryType
   - [x] mutationType
+  - [ ] subscriptionType
   - [x] directives

--- a/src/GraphQL.Tests/Execution/EnumAsInputsTests.cs
+++ b/src/GraphQL.Tests/Execution/EnumAsInputsTests.cs
@@ -28,6 +28,30 @@ namespace GraphQL.Tests.Execution
                  }
                 }");
         }
+
+        [Test]
+        public void mutation_input_from_variables()
+        {
+            var inputs = @"{ 'userInput': { 'profileImage': 'myimage.png', 'gender': 'Female' } }".ToInputs();
+
+            AssertQuerySuccess(
+                @"
+                mutation createUser($userInput: UserInput!) {
+                  createUser(userInput: $userInput){
+                    id
+                    gender
+                    profileImage
+                  }
+                }
+                ",
+                @"{
+                'createUser': {
+                  'id': 1,
+                  'gender': 'Female',
+                  'profileImage': 'myimage.png'
+                 }
+                }", inputs);
+        }
     }
 
     public class EnumMutationSchema : Schema
@@ -70,13 +94,10 @@ namespace GraphQL.Tests.Execution
 
             Field<UserType>("createUser", "create user api",
                 new QueryArguments(
-                    new QueryArgument[]
+                    new QueryArgument<NonNullGraphType<UserInputType>>
                     {
-                        new QueryArgument<NonNullGraphType<UserInputType>>
-                        {
-                            Name = "userInput",
-                            Description = "user info details"
-                        }
+                        Name = "userInput",
+                        Description = "user info details"
                     }
                 ),
                 context =>

--- a/src/GraphQL.Tests/Execution/InputConversionTests.cs
+++ b/src/GraphQL.Tests/Execution/InputConversionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Should;
 
@@ -11,6 +12,30 @@ namespace GraphQL.Tests.Execution
             public int A { get; set; }
             public string B { get; set; }
             public List<string> C { get; set; }
+            public int? D { get; set; }
+            public Guid E { get; set; }
+            public List<int?> F { get; set; }
+            public List<List<int?>> G { get; set; }
+        }
+
+        public class EnumInput
+        {
+            public Numbers A { get; set; }
+            public Numbers2? B { get; set; }
+        }
+
+        public enum Numbers
+        {
+            One,
+            Two,
+            Three
+        }
+
+        public enum Numbers2 : long
+        {
+            One,
+            Two,
+            Three
         }
 
         [Test]
@@ -51,6 +76,130 @@ namespace GraphQL.Tests.Execution
             myInput.C.ShouldNotBeNull();
             myInput.C.Count.ShouldEqual(1);
             myInput.C.First().ShouldEqual("foo");
+        }
+
+        [Test]
+        public void can_convert_json_to_nullable_array()
+        {
+            var json = @"{'a': 1, 'b': '2', 'c': ['foo'], 'f': [1,null]}";
+
+            var inputs = json.ToInputs();
+
+            inputs.ShouldNotBeNull();
+            inputs["f"].ShouldBeType<List<object>>();
+
+            var myInput = inputs.ToObject<MyInput>();
+            myInput.ShouldNotBeNull();
+            myInput.F.ShouldNotBeNull();
+            myInput.F.Count.ShouldEqual(2);
+            myInput.F[0].ShouldEqual(1);
+            myInput.F[1].ShouldEqual(null);
+        }
+
+        [Test]
+        public void can_convert_json_to_nested_nullable_array()
+        {
+            var json = @"{'a': 1, 'b': '2', 'c': ['foo'], 'g': [[1,null], [null, 1]]}";
+
+            var inputs = json.ToInputs();
+
+            inputs.ShouldNotBeNull();
+            inputs["g"].ShouldBeType<List<object>>();
+
+            var myInput = inputs.ToObject<MyInput>();
+            myInput.ShouldNotBeNull();
+            myInput.G.ShouldNotBeNull();
+            myInput.G.Count.ShouldEqual(2);
+
+            myInput.G[0].Count.ShouldEqual(2);
+            myInput.G[0][0].ShouldEqual(1);
+            myInput.G[0][1].ShouldBeNull();
+
+            myInput.G[1].Count.ShouldEqual(2);
+            myInput.G[1][0].ShouldBeNull();
+            myInput.G[1][1].ShouldEqual(1);
+        }
+
+        [Test]
+        public void can_convert_json_to_input_object_with_nullable_int()
+        {
+            var json = @"{'a': 1, 'b': '2', 'd': '5'}";
+            var inputs = json.ToInputs();
+            inputs.ShouldNotBeNull();
+            var myInput = inputs.ToObject<MyInput>();
+            myInput.ShouldNotBeNull();
+            myInput.D.ShouldEqual(5);
+        }
+
+        [Test]
+        public void can_convert_json_to_input_object_with_guid()
+        {
+            var json = @"{'a': 1, 'b': '2', 'e': '920a1b6d-f75a-4594-8567-e2c457b29cc0'}";
+            var inputs = json.ToInputs();
+            inputs.ShouldNotBeNull();
+            var myInput = inputs.ToObject<MyInput>();
+            myInput.ShouldNotBeNull();
+            myInput.E.ShouldEqual(new Guid("920a1b6d-f75a-4594-8567-e2c457b29cc0"));
+        }
+
+        [Test]
+        public void can_convert_json_to_input_object_with_enum_string()
+        {
+            var json = @"{'a': 'three'}";
+
+            var inputs = json.ToInputs();
+
+            inputs.ShouldNotBeNull();
+
+            var myInput = inputs.ToObject<EnumInput>();
+
+            myInput.ShouldNotBeNull();
+            myInput.A.ShouldEqual(Numbers.Three);
+            myInput.B.ShouldBeNull();
+        }
+
+        [Test]
+        public void can_convert_json_to_input_object_with_enum_string_exact()
+        {
+            var json = @"{'a': 'Two'}";
+
+            var inputs = json.ToInputs();
+
+            inputs.ShouldNotBeNull();
+
+            var myInput = inputs.ToObject<EnumInput>();
+
+            myInput.ShouldNotBeNull();
+            myInput.A.ShouldEqual(Numbers.Two);
+        }
+
+        [Test]
+        public void can_convert_json_to_input_object_with_enum_number()
+        {
+            var json = @"{'a': '2'}";
+
+            var inputs = json.ToInputs();
+
+            inputs.ShouldNotBeNull();
+
+            var myInput = inputs.ToObject<EnumInput>();
+
+            myInput.ShouldNotBeNull();
+            myInput.A.ShouldEqual(Numbers.Three);
+            myInput.B.ShouldBeNull();
+        }
+
+        [Test]
+        public void can_convert_json_to_input_object_with_enum_long_number()
+        {
+            var json = @"{'a': 2, 'b': 2}";
+
+            var inputs = json.ToInputs();
+
+            var myInput = inputs.ToObject<EnumInput>();
+
+            myInput.ShouldNotBeNull();
+            myInput.B.Value.ShouldEqual(Numbers2.Three);
         }
     }
 }

--- a/src/GraphQL.Tests/Execution/MutationTests.cs
+++ b/src/GraphQL.Tests/Execution/MutationTests.cs
@@ -80,14 +80,12 @@ namespace GraphQL.Tests.Execution
             Field<NumberHolderType>(
                 "immediatelyChangeTheNumber",
                 arguments: new QueryArguments(
-                    new QueryArgument[]
+                    new QueryArgument<IntGraphType>
                     {
-                        new QueryArgument<IntGraphType>
-                        {
-                            Name = "newNumber",
-                            DefaultValue = 0
-                        }
-                    }),
+                        Name = "newNumber",
+                        DefaultValue = 0
+                    }
+                ),
                 resolve: context =>
                 {
                     var root = context.Source as Root;
@@ -99,14 +97,12 @@ namespace GraphQL.Tests.Execution
             Field<NumberHolderType>(
                 "promiseToChangeTheNumber",
                 arguments: new QueryArguments(
-                    new QueryArgument[]
+                    new QueryArgument<IntGraphType>
                     {
-                        new QueryArgument<IntGraphType>
-                        {
-                            Name = "newNumber",
-                            DefaultValue = 0
-                        }
-                    }),
+                        Name = "newNumber",
+                        DefaultValue = 0
+                    }
+                ),
                 resolve: context =>
                 {
                     var root = context.Source as Root;
@@ -118,14 +114,12 @@ namespace GraphQL.Tests.Execution
             Field<NumberHolderType>(
                 "failToChangeTheNumber",
                 arguments: new QueryArguments(
-                    new QueryArgument[]
+                    new QueryArgument<IntGraphType>
                     {
-                        new QueryArgument<IntGraphType>
-                        {
-                            Name = "newNumber",
-                            DefaultValue = 0
-                        }
-                    }),
+                        Name = "newNumber",
+                        DefaultValue = 0
+                    }
+                ),
                 resolve: context =>
                 {
                     var root = context.Source as Root;
@@ -137,14 +131,12 @@ namespace GraphQL.Tests.Execution
             Field<NumberHolderType>(
                 "promiseAndFailToChangeTheNumber",
                 arguments: new QueryArguments(
-                    new QueryArgument[]
+                    new QueryArgument<IntGraphType>
                     {
-                        new QueryArgument<IntGraphType>
-                        {
-                            Name = "newNumber",
-                            DefaultValue = 0
-                        }
-                    }),
+                        Name = "newNumber",
+                        DefaultValue = 0
+                    }
+                ),
                 resolve: context =>
                 {
                     var root = context.Source as Root;

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using GraphQL.Language;
 using GraphQL.Types;
+using GraphQL.Validation;
 using Newtonsoft.Json;
 using Should;
 
@@ -162,7 +163,7 @@ namespace GraphQL.Tests.Execution
             ";
             var expected = "{ \"fieldWithObjectInput\": \"null\" }";
 
-            AssertQuerySuccess(query, expected);
+            AssertQuerySuccess(query, expected, rules: Enumerable.Empty<IValidationRule>());
         }
     }
 
@@ -545,7 +546,7 @@ namespace GraphQL.Tests.Execution
             }
             ";
 
-            AssertQuerySuccess(query, expected);
+            AssertQuerySuccess(query, expected, rules:Enumerable.Empty<IValidationRule>());
         }
     }
 }

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Introspection\SchemaIntrospectionTests.cs" />
     <Compile Include="Types\FloatGraphTypeTests.cs" />
     <Compile Include="Types\QueryArgumentTests.cs" />
+    <Compile Include="Utilities\AstPrinterTests.cs" />
     <Compile Include="Utilities\SchemaPrinterTests.cs" />
     <Compile Include="SimpleContainer.cs" />
     <Compile Include="StarWars\EpisodeEnum.cs" />
@@ -95,6 +96,7 @@
     <Compile Include="Types\Relay\EdgeTypeTests.cs" />
     <Compile Include="Types\Relay\ConnectionTypeTests.cs" />
     <Compile Include="Types\SchemaTests.cs" />
+    <Compile Include="Validation\ArgumentsOfCorrectTypeTests.cs" />
     <Compile Include="Validation\ScalarLeafTests.cs" />
     <Compile Include="Validation\ValidationErrorAssertion.cs" />
     <Compile Include="Validation\ValidationTestBase.cs" />

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using GraphQL.Execution;
@@ -42,10 +43,11 @@ namespace GraphQL.Tests
             string expected,
             Inputs inputs = null,
             object root = null,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default(CancellationToken),
+            IEnumerable<IValidationRule> rules = null)
         {
             var queryResult = CreateQueryResult(expected);
-            return AssertQuery(query, queryResult, inputs, root, cancellationToken);
+            return AssertQuery(query, queryResult, inputs, root, cancellationToken, rules);
         }
 
         public ExecutionResult AssertQueryWithErrors(
@@ -84,9 +86,23 @@ namespace GraphQL.Tests
             return runResult;
         }
 
-        public ExecutionResult AssertQuery(string query, ExecutionResult expectedExecutionResult, Inputs inputs, object root, CancellationToken cancellationToken = default(CancellationToken))
+        public ExecutionResult AssertQuery(
+            string query,
+            ExecutionResult expectedExecutionResult,
+            Inputs inputs,
+            object root,
+            CancellationToken cancellationToken = default(CancellationToken),
+            IEnumerable<IValidationRule> rules = null)
         {
-            var runResult = Executer.ExecuteAsync(Schema, root, query, null, inputs, cancellationToken).Result;
+            var runResult = Executer.ExecuteAsync(
+                Schema,
+                root, 
+                query,
+                null,
+                inputs,
+                cancellationToken,
+                rules
+                ).Result;
 
             var writtenResult = Writer.Write(runResult);
             var expectedResult = Writer.Write(expectedExecutionResult);

--- a/src/GraphQL.Tests/StarWars/StarWarsQuery.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsQuery.cs
@@ -12,19 +12,15 @@ namespace GraphQL.Tests
             Field<HumanType>(
                 "human",
                 arguments: new QueryArguments(
-                    new []
-                    {
-                        new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the human" }
-                    }),
+                    new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the human" }
+                ),
                 resolve: context => data.GetHumanByIdAsync(context.Argument<string>("id"))
             );
             Field<DroidType>(
                 "droid",
                 arguments: new QueryArguments(
-                    new []
-                    {
-                        new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the droid" }
-                    }),
+                    new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the droid" }
+                ),
                 resolve: context => data.GetDroidByIdAsync(context.Argument<string>("id"))
             );
         }

--- a/src/GraphQL.Tests/Utilities/AstPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/AstPrinterTests.cs
@@ -1,0 +1,75 @@
+﻿using GraphQL.Execution;
+using GraphQL.Language;
+using GraphQL.Utilities;
+using Should;
+
+namespace GraphQL.Tests.Utilities
+{
+    public class AstPrinterTests
+    {
+        private readonly AstPrintVisitor _printer = new AstPrintVisitor();
+
+        [Test]
+        public void prints_ast()
+        {
+            var query = @"{
+              complicatedArgs {
+                intArgField(intArg: 2)
+              }
+            }";
+            var builder = new AntlrDocumentBuilder();
+            var document = builder.Build(query);
+
+            var result = _printer.Visit(document);
+            result.ShouldNotBeNull();
+        }
+
+        [Test]
+        public void prints_variables()
+        {
+            var query = @"
+            mutation createUser($userInput: UserInput!) {
+              createUser(userInput: $userInput){
+                id
+                gender
+                profileImage
+              }
+            }
+            ";
+
+            var builder = new AntlrDocumentBuilder();
+            var document = builder.Build(query);
+
+            var result = _printer.Visit(document);
+            result.ShouldNotBeNull();
+        }
+
+        [Test]
+        public void prints_int_value()
+        {
+            int value = 3;
+            var val = new IntValue(value);
+            var result = _printer.Visit(val);
+            result.ShouldEqual(value);
+        }
+
+        [Test]
+        public void prints_long_value()
+        {
+            long value = 3;
+            var val = new LongValue(value);
+            var result = _printer.Visit(val);
+            result.ShouldEqual(value);
+        }
+
+        [Test]
+        public void prints_float_value()
+        {
+            double value = 3.33;
+
+            var val = new FloatValue(value);
+            var result = _printer.Visit(val);
+            result.ShouldEqual($"{value, 0:0.0##}");
+        }
+    }
+}

--- a/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
+++ b/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using GraphQL.Validation.Rules;
+
+namespace GraphQL.Tests.Validation
+{
+    public class ArgumentsOfCorrectTypeTests : ValidationTestBase<ValidationSchema>
+    {
+        private readonly ArgumentsOfCorrectType _rule = new ArgumentsOfCorrectType();
+
+        [Test]
+        public void good_int_value()
+        {
+            var query = @"{
+  complicatedArgs {
+    intArgField(intArg: 2)
+  }
+}";
+
+            ShouldPassRule(_ =>
+            {
+                _.Query = query;
+                _.Rule(_rule);
+            });
+        }
+
+        [Test]
+        public void string_into_int_value()
+        {
+            var query = @"{
+              complicatedArgs {
+                intArgField(intArg: ""3"")
+              }
+            }";
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = query;
+                _.Rule(_rule);
+                badValue(_, "intArg", "Int", "\"3\"", 3, 29);
+            });
+        }
+
+        [Test]
+        public void unquoted_string_into_int()
+        {
+            var query = @"{
+              complicatedArgs {
+                intArgField(intArg: FOO)
+              }
+            }";
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = query;
+                _.Rule(_rule);
+                badValue(_, "intArg", "Int", "FOO", 3, 29);
+            });
+        }
+
+        [Test]
+        public void simple_float_into_int()
+        {
+            var query = @"{
+              complicatedArgs {
+                intArgField(intArg: 3.0)
+              }
+            }";
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = query;
+                _.Rule(_rule);
+                badValue(_, "intArg", "Int", "3.0", 3, 29);
+            });
+        }
+
+        [Test]
+        public void float_into_int()
+        {
+            var query = @"{
+              complicatedArgs {
+                intArgField(intArg: 3.333)
+              }
+            }";
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = query;
+                _.Rule(_rule);
+                badValue(_, "intArg", "Int", "3.333", 3, 29);
+            });
+        }
+
+        private void badValue(
+            ValidationTestConfig _,
+            string argName,
+            string typeName,
+            string value,
+            int? line = null,
+            int? column = null,
+            IEnumerable<string> errors = null)
+        {
+            if (errors == null)
+            {
+                errors = new [] {$"Expected type \"{typeName}\", found {value}."};
+            }
+
+            _.Error(
+                _rule.BadValueMessage(argName, null, value, errors),
+                line,
+                column);
+        }
+    }
+}

--- a/src/GraphQL.Tests/Validation/ScalarLeafTests.cs
+++ b/src/GraphQL.Tests/Validation/ScalarLeafTests.cs
@@ -119,14 +119,23 @@ fragment scalarSelectionsNotAllowedOnEnum on Cat {
         {
             Field<StringGraphType>(
                 "name",
-                arguments: new QueryArguments(new[]
-                {
-                    new QueryArgument<BooleanGraphType>
-                    {
-                        Name = "surname"
-                    }
-                }));
+                arguments: new QueryArguments(
+                    new QueryArgument<BooleanGraphType> {Name = "surname"}
+                ));
             Field<IntGraphType>("iq");
+        }
+    }
+
+    public class ComplicatedArgs : ObjectGraphType
+    {
+        public ComplicatedArgs()
+        {
+            Name = "ComplicatedArgs";
+            Field<StringGraphType>(
+                "intArgField",
+                arguments: new QueryArguments(
+                    new QueryArgument<IntGraphType> {Name = "intArg"}
+                ));
         }
     }
 
@@ -136,15 +145,15 @@ fragment scalarSelectionsNotAllowedOnEnum on Cat {
         {
             Field<Human>(
                 "human",
-                arguments: new QueryArguments(new[]
-                {
+                arguments: new QueryArguments(
                     new QueryArgument<IdGraphType>
                     {
                         Name = "id"
                     }
-                }));
+                ));
             Field<Dog>("dog");
             Field<Cat>("cat");
+            Field<ComplicatedArgs>("complicatedArgs");
         }
     }
 

--- a/src/GraphQL.Tests/Validation/ValidationTestBase.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestBase.cs
@@ -25,8 +25,6 @@ namespace GraphQL.Tests.Validation
 
             var result = Validate(config.Query, Schema, config.Rules);
 
-            result.IsValid.ShouldBeFalse();
-
             var count = 0;
 
             config.Assertions.Apply(assert =>
@@ -41,6 +39,8 @@ namespace GraphQL.Tests.Validation
                     location.Column.ShouldEqual(assert.Column.Value);
                 }
             });
+
+            result.IsValid.ShouldBeFalse();
         }
 
         protected void ShouldPassRule(Action<ValidationTestConfig> configure)

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -22,7 +22,8 @@ namespace GraphQL
             string query,
             string operationName,
             Inputs inputs = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default(CancellationToken),
+            IEnumerable<IValidationRule> rules = null);
     }
 
     public class DocumentExecuter : IDocumentExecuter
@@ -47,12 +48,13 @@ namespace GraphQL
             string query,
             string operationName,
             Inputs inputs = null,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default(CancellationToken),
+            IEnumerable<IValidationRule> rules = null)
         {
             var document = _documentBuilder.Build(query);
             var result = new ExecutionResult();
 
-            var validationResult = _documentValidator.Validate(schema, document);
+            var validationResult = _documentValidator.Validate(schema, document, rules);
 
             if (validationResult.IsValid)
             {

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -118,6 +118,7 @@
     <Compile Include="StringExtensions.cs" />
     <Compile Include="Types\TypeExtensions.cs" />
     <Compile Include="Types\UnionGraphType.cs" />
+    <Compile Include="Utilities\AstPrinter.cs" />
     <Compile Include="Utilities\SchemaPrinter.cs" />
     <Compile Include="Validation\DebugNodeVisitor.cs" />
     <Compile Include="Validation\DocumentValidator.cs" />
@@ -151,6 +152,7 @@
     <Compile Include="Validation\INodeVisitor.cs" />
     <Compile Include="Validation\BasicVisitor.cs" />
     <Compile Include="GraphQLExtensions.cs" />
+    <Compile Include="Validation\Rules\ArgumentsOfCorrectType.cs" />
     <Compile Include="Validation\Rules\LoneAnonymousOperationRule.cs" />
     <Compile Include="Validation\NodeVisitorMatchFuncListener.cs" />
     <Compile Include="Validation\Rules\ScalarLeafs.cs" />

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using GraphQL.Language;
 using GraphQL.Types;
+using GraphQL.Utilities;
 
 namespace GraphQL
 {
@@ -27,6 +33,112 @@ namespace GraphQL
             }
 
             return unmodifiedType;
+        }
+
+        public static IEnumerable<string> IsValidLiteralValue(this GraphType type, IValue valueAst, ISchema schema)
+        {
+            if (type is NonNullGraphType)
+            {
+                var nonNull = (NonNullGraphType) type;
+                var ofType = schema.FindType(nonNull.Type);
+
+                if (valueAst == null)
+                {
+                    if (ofType != null)
+                    {
+                        return new[] { $"Expected {ofType.Name}, found null"};
+                    }
+
+                    return new[] { "Expected non-null value, found null"};
+                }
+
+                return IsValidLiteralValue(ofType, valueAst, schema);
+            }
+
+            if (valueAst == null)
+            {
+                return new string[] {};
+            }
+
+            // This function only tests literals, and assumes variables will provide
+            // values of the correct type.
+            if (valueAst is VariableReference)
+            {
+                return new string[] {};
+            }
+
+            if (type is ListGraphType)
+            {
+                var list = (ListGraphType)type;
+                var ofType = schema.FindType(list.Type);
+
+                if (valueAst is ListValue)
+                {
+                    var index = 0;
+                    return ((ListValue) valueAst).Values.Aggregate(new string[] {}, (acc, value) =>
+                    {
+                        var errors = IsValidLiteralValue(ofType, value, schema);
+                        var result = acc.Concat(errors.Map(err => $"In element {index}: {err}")).ToArray();
+                        index++;
+                        return result;
+                    });
+                }
+
+                return IsValidLiteralValue(ofType, valueAst, schema);
+            }
+
+            if (type is InputObjectGraphType)
+            {
+                if (!(valueAst is ObjectValue))
+                {
+                    return new[] {$"Expected \"{type.Name}\", found not an object."};
+                }
+
+                var inputType = (InputObjectGraphType) type;
+
+                var fields = inputType.Fields.ToList();
+                var fieldAsts = ((ObjectValue) valueAst).ObjectFields.ToList();
+
+                var errors = new List<string>();
+
+                // ensure every provided field is defined
+                fieldAsts.Apply(providedFieldAst =>
+                {
+                    var found = fields.FirstOrDefault(x => x.Name == providedFieldAst.Name);
+                    if (found == null)
+                    {
+                        errors.Add($"In field \"{providedFieldAst.Name}\": Unknown field.");
+                    }
+                });
+
+                // ensure every defined field is valid
+                fields.Apply(field =>
+                {
+                    var fieldAst = fieldAsts.FirstOrDefault(x => x.Name == field.Name);
+                    var result = IsValidLiteralValue(schema.FindType(field.Type), fieldAst?.Value, schema);
+
+                    errors.AddRange(result.Map(err=> $"In field \"{field.Name}\": {err}"));
+                });
+
+                return errors;
+            }
+
+            var scalar = (ScalarGraphType) type;
+
+            var parseResult = scalar.ParseLiteral(valueAst);
+
+            if (parseResult == null)
+            {
+                return new [] {$"Expected type \"{type.Name}\", found {AstPrinter.Print(valueAst)}."};
+            }
+
+            return new string[] {};
+        }
+
+        public static string NameOf<T, P>(this Expression<Func<T, P>> expression)
+        {
+            var member = (MemberExpression) expression.Body;
+            return member.Member.Name;
         }
     }
 }

--- a/src/GraphQL/Language/Arguments.cs
+++ b/src/GraphQL/Language/Arguments.cs
@@ -4,9 +4,11 @@ using System.Linq;
 
 namespace GraphQL.Language
 {
-    public class Arguments : IEnumerable<Argument>
+    public class Arguments : AbstractNode, IEnumerable<Argument>
     {
         private readonly List<Argument> _arguments = new List<Argument>();
+
+        public override IEnumerable<INode> Children => _arguments;
 
         public void Add(Argument arg)
         {
@@ -17,6 +19,19 @@ namespace GraphQL.Language
         {
             var arg = _arguments.FirstOrDefault(x => x.Name == name);
             return arg != null ? arg.Value : null;
+        }
+
+        protected bool Equals(Arguments args)
+        {
+            return false;
+        }
+
+        public override bool IsEqualTo(INode obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Arguments) obj);
         }
 
         public IEnumerator<Argument> GetEnumerator()

--- a/src/GraphQL/Language/Directive.cs
+++ b/src/GraphQL/Language/Directive.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace GraphQL.Language
 {
     public class Directive : AbstractNode
@@ -5,6 +7,11 @@ namespace GraphQL.Language
         public string Name { get; set; }
 
         public Arguments Arguments { get; set; }
+
+        public override IEnumerable<INode> Children
+        {
+            get { yield return Arguments; }
+        }
 
         public override string ToString()
         {

--- a/src/GraphQL/Language/Directives.cs
+++ b/src/GraphQL/Language/Directives.cs
@@ -4,9 +4,11 @@ using System.Linq;
 
 namespace GraphQL.Language
 {
-    public class Directives : IEnumerable<Directive>
+    public class Directives : AbstractNode, IEnumerable<Directive>
     {
         private readonly List<Directive> _directives = new List<Directive>();
+
+        public override IEnumerable<INode> Children => _directives;
 
         public void Add(Directive directive)
         {
@@ -26,6 +28,19 @@ namespace GraphQL.Language
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        protected bool Equals(Directives directives)
+        {
+            return false;
+        }
+
+        public override bool IsEqualTo(INode obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Directives) obj);
         }
     }
 }

--- a/src/GraphQL/Language/Field.cs
+++ b/src/GraphQL/Language/Field.cs
@@ -20,18 +20,12 @@ namespace GraphQL.Language
             {
                 if (Arguments != null)
                 {
-                    foreach (var argument in Arguments)
-                    {
-                        yield return argument;
-                    }
+                    yield return Arguments;
                 }
 
                 if (Directives != null)
                 {
-                    foreach (var directive in Directives)
-                    {
-                        yield return directive;
-                    }
+                    yield return Directives;
                 }
 
                 if (SelectionSet != null)

--- a/src/GraphQL/Language/GraphQLVisitor.cs
+++ b/src/GraphQL/Language/GraphQLVisitor.cs
@@ -107,6 +107,13 @@ namespace GraphQL.Language
                 }
             }
 
+            if (context.FloatValue() != null)
+            {
+                var val = new FloatValue(float.Parse(context.FloatValue().GetText()));
+                NewNode(val, context);
+                return val;
+            }
+
             if (context.BooleanValue() != null)
             {
                 var val = new BooleanValue(bool.Parse(context.BooleanValue().GetText()));
@@ -281,6 +288,7 @@ namespace GraphQL.Language
         public override object VisitArguments(GraphQLParser.ArgumentsContext context)
         {
             var arguments = new Arguments();
+            NewNode(arguments, context);
 
             foreach (var arg in context.argument())
             {
@@ -308,6 +316,7 @@ namespace GraphQL.Language
         public override object VisitDirectives(GraphQLParser.DirectivesContext context)
         {
             var directives = new Directives();
+            NewNode(directives, context);
 
             foreach (var dir in context.directive())
             {

--- a/src/GraphQL/Language/Variables.cs
+++ b/src/GraphQL/Language/Variables.cs
@@ -40,17 +40,6 @@ namespace GraphQL.Language
             _variables.Add(variable);
         }
 
-        public object ValueFor(string name)
-        {
-            throw new NotImplementedException();
-//            var variable = _variables.FirstOrDefault(v => v.Name == name);
-//            if (variable == null)
-//            {
-//                return null;
-//            }
-//            return variable.Value ?? variable.DefaultValue;
-        }
-
         public IEnumerator<VariableDefinition> GetEnumerator()
         {
             return _variables.GetEnumerator();

--- a/src/GraphQL/Types/DirectiveGraphType.cs
+++ b/src/GraphQL/Types/DirectiveGraphType.cs
@@ -24,7 +24,7 @@
         {
             Name = "include";
             Description = "Directs the executor to include this field or fragment only when the 'if' argument is true.";
-            Arguments = new QueryArguments(new [] { new QueryArgument<NonNullGraphType<BooleanGraphType>> { Name = "if" } });
+            Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>> {Name = "if"});
             OnOperation = false;
             OnFragment = true;
             OnField = true;
@@ -37,7 +37,7 @@
         {
             Name = "skip";
             Description = "Directs the executor to skip this field or fragment when the 'if' argument is true.";
-            Arguments = new QueryArguments(new [] { new QueryArgument<NonNullGraphType<BooleanGraphType>>  { Name = "if" } });
+            Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>> {Name = "if"});
             OnOperation = false;
             OnFragment = true;
             OnField = true;

--- a/src/GraphQL/Types/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/EnumerationGraphType.cs
@@ -39,6 +39,11 @@ namespace GraphQL.Types
 
         public override object ParseValue(object value)
         {
+            if (value == null)
+            {
+                return null;
+            }
+
             var found = Values.FirstOrDefault(v =>
                 StringComparer.InvariantCultureIgnoreCase.Equals(v.Name, value.ToString()));
             return found?.Value;
@@ -46,8 +51,18 @@ namespace GraphQL.Types
 
         public override object ParseLiteral(IValue value)
         {
-            var enumVal = value as EnumValue;
-            return ParseValue(enumVal?.Name);
+            object val = null;
+
+            if (value is EnumValue)
+            {
+                val = ((EnumValue)value).Name;
+            }
+            else if (value is StringValue)
+            {
+                val = ((StringValue)value).Value;
+            }
+
+            return ParseValue(val);
         }
     }
 

--- a/src/GraphQL/Types/QueryArguments.cs
+++ b/src/GraphQL/Types/QueryArguments.cs
@@ -1,12 +1,23 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GraphQL.Types
 {
     public class QueryArguments : List<QueryArgument>
     {
+        public QueryArguments(params QueryArgument[] args)
+        {
+            AddRange(args);
+        }
+
         public QueryArguments(IEnumerable<QueryArgument> list)
             : base(list)
         {
+        }
+
+        public QueryArgument Find(string name)
+        {
+            return this.FirstOrDefault(x => x.Name == name);
         }
     }
 }

--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -46,7 +46,7 @@ namespace GraphQL.Types
                         return (TType)arg;
                     }
 
-                    return (TType)inputObject.ToObject(typeof(TType));
+                    return (TType)inputObject.ToObject(type);
                 }
 
                 return (TType) arg;

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -1,0 +1,429 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using GraphQL.Language;
+
+namespace GraphQL.Utilities
+{
+    public static class AstPrinter
+    {
+        public static string Print(INode node)
+        {
+            var printer = new AstPrintVisitor();
+            return printer.Visit(node)?.ToString() ?? "";
+        }
+    }
+
+    public class AstPrintConfig
+    {
+        private readonly List<AstPrintFieldDefinition> _fields = new List<AstPrintFieldDefinition>();
+
+        public IEnumerable<AstPrintFieldDefinition> Fields => _fields;
+        public Func<INode, bool> Matches { get; set; }
+        public Func<IDictionary<string, object>, object> PrintAst { get; set; }
+
+        public void Field(AstPrintFieldDefinition field)
+        {
+            if (_fields.Exists(x => x.Name == field.Name))
+            {
+                throw new ExecutionError($"A field with name \"{field.Name}\" aleady exists!");
+            }
+
+            _fields.Add(field);
+        }
+    }
+
+    public class PrintFormat<T>
+    {
+        private readonly IDictionary<string, object> _args;
+
+        public PrintFormat(IDictionary<string, object> args)
+        {
+            _args = args;
+        }
+
+        public object Arg(string key)
+        {
+            object arg;
+            _args.TryGetValue(key, out arg);
+            return arg;
+        }
+
+        public TVal Arg<TVal>(string key)
+        {
+            return (TVal) Arg(key);
+        }
+
+        public object Arg<TProperty>(Expression<Func<T, TProperty>> argument)
+        {
+            var name = argument.NameOf();
+            return Arg(name);
+        }
+
+        public IEnumerable<object> ArgArray<TProperty>(Expression<Func<T, TProperty>> argument)
+        {
+            var name = argument.NameOf();
+            return Arg<IEnumerable<object>>(name);
+        }
+    }
+
+    public class AstPrintConfig<T> : AstPrintConfig
+        where T : INode
+    {
+        public void Field<TProperty>(Expression<Func<T, TProperty>> resolve)
+        {
+            var name = resolve.NameOf();
+            var def = new AstPrintFieldDefinition
+            {
+                Name = name,
+                Resolver = new ExpressionValueResolver<T, TProperty>(resolve)
+            };
+
+            Field(def);
+        }
+
+        public void Print(Func<PrintFormat<T>, object> configure)
+        {
+            PrintAst = (args) =>
+            {
+                var f = new PrintFormat<T>(args);
+                return configure(f);
+            };
+        }
+    }
+
+    public class AstPrintFieldDefinition
+    {
+        public string Name { get; set; }
+        public IValueResolver Resolver { get; set; }
+    }
+
+    public class ResolveValueContext
+    {
+        public object Source { get; set; }
+
+        public TType SourceAs<TType>()
+        {
+            if (Source != null)
+            {
+                return (TType) Source;
+            }
+
+            return default(TType);
+        }
+    }
+
+    public interface IValueResolver
+    {
+        object Resolve(ResolveValueContext context);
+    }
+
+    public interface IValueResolver<T> : IValueResolver
+    {
+        new T Resolve(ResolveValueContext context);
+    }
+
+    public class ExpressionValueResolver<TObject, TProperty> : IValueResolver<TProperty>
+    {
+        private readonly Expression<Func<TObject, TProperty>> _property;
+
+        public ExpressionValueResolver(Expression<Func<TObject, TProperty>> property)
+        {
+            _property = property;
+        }
+
+        public TProperty Resolve(ResolveValueContext context)
+        {
+            return _property.Compile()(context.SourceAs<TObject>());
+        }
+
+        object IValueResolver.Resolve(ResolveValueContext context)
+        {
+            return Resolve(context);
+        }
+    }
+
+    public class AstPrintVisitor
+    {
+        private readonly List<AstPrintConfig> _configs = new List<AstPrintConfig>();
+
+        public AstPrintVisitor()
+        {
+            Config<Document>(c =>
+            {
+                c.Field(x => x.Operations);
+                c.Field(x => x.Fragments);
+                c.Print(p =>
+                {
+                    var ops = join(p.ArgArray(x => x.Operations), "\n\n");
+                    var frags = join(p.ArgArray(x => x.Fragments), "\n\n");
+
+                    var result = join(new[] {ops, frags}, "\n\n") + "\n";
+                    return result;
+                });
+            });
+
+            Config<Operation>(c =>
+            {
+                c.Field(x => x.OperationType);
+                c.Field(x => x.Name);
+                c.Field(x => x.Variables);
+                c.Field(x => x.Directives);
+                c.Field(x => x.SelectionSet);
+                c.Print(p =>
+                {
+                    var op = p.Arg(x => x.OperationType).ToString().ToLower();
+                    var name = p.Arg(x => x.Name)?.ToString();
+                    var variables = wrap("(", join(p.ArgArray(x => x.Variables), ", "), ")");
+                    var directives = join(p.ArgArray(x => x.Directives), " ");
+                    var selectionSet = p.Arg(x => x.SelectionSet);
+
+                    return string.IsNullOrWhiteSpace(name)
+                           && string.IsNullOrWhiteSpace(directives)
+                           && string.IsNullOrWhiteSpace(variables)
+                        ? selectionSet
+                        : join(new[] {op, join(new[] {name, variables}, ""), directives, selectionSet}, " ");
+                });
+            });
+
+            Config<VariableDefinition>(c =>
+            {
+                c.Field(x => x.Name);
+                c.Field(x => x.Type);
+                c.Field(x => x.DefaultValue);
+                c.Print(p =>
+                {
+                    return $"${p.Arg(x => x.Name)}: {p.Arg(x => x.Type)}";
+                });
+            });
+
+            Config<SelectionSet>(c =>
+            {
+                c.Field(x => x.Selections);
+                c.Print(p =>
+                {
+                    return block(p.ArgArray(x => x.Selections));
+                });
+            });
+
+            Config<Arguments>(c =>
+            {
+                c.Field(x => x.Children);
+                c.Print(p =>
+                {
+                    var result = p.Arg(x => x.Children);
+                    return result;
+                });
+            });
+
+            Config<Argument>(c =>
+            {
+                c.Field(x => x.Name);
+                c.Field(x => x.Value);
+                c.Print(p => $"{p.Arg(x => x.Name)}: {p.Arg(x => x.Value)}");
+            });
+
+            Config<Field>(c =>
+            {
+                c.Field(x => x.Alias);
+                c.Field(x => x.Name);
+                c.Field(x => x.Arguments);
+                c.Field(x => x.Directives);
+                c.Field(x => x.SelectionSet);
+                c.Print(n =>
+                {
+                    var alias = n.Arg(x => x.Alias);
+                    var name = n.Arg(x => x.Name);
+                    var args = join(n.ArgArray(x => x.Arguments), ", ");
+                    var directives = join(n.ArgArray(x => x.Directives), " ");
+                    var selectionSet = n.Arg(x => x.SelectionSet);
+
+                    var result = join(new []
+                    {
+                        wrap("", alias, ": ") + name + wrap("(", args, ")"),
+                        directives,
+                        selectionSet
+                    }, " ");
+                    return result;
+                });
+            });
+
+            // Value
+
+            Config<VariableReference>(c =>
+            {
+                c.Field(x => x.Name);
+                c.Print(p => $"${p.Arg(x => x.Name)}");
+            });
+
+            Config<IntValue>(c =>
+            {
+                c.Field(x => x.Value);
+                c.Print(f => f.Arg(x => x.Value));
+            });
+            Config<LongValue>(c =>
+            {
+                c.Field(x => x.Value);
+                c.Print(f => f.Arg(x => x.Value));
+            });
+            Config<FloatValue>(c =>
+            {
+                c.Field(x => x.Value);
+                c.Print(f => $"{f.Arg(x => x.Value), 0:0.0##}");
+            });
+            Config<StringValue>(c =>
+            {
+                c.Field(x => x.Value);
+                c.Print(f => f.Arg(x => x.Value));
+            });
+            Config<BooleanValue>(c =>
+            {
+                c.Field(x => x.Value);
+                c.Print(f => f.Arg(x => x.Value));
+            });
+            Config<EnumValue>(c =>
+            {
+                c.Field(x => x.Name);
+                c.Print(p => p.Arg(x => x.Name));
+            });
+            Config<ListValue>(c =>
+            {
+                c.Field(x => x.Values);
+                c.Print(p => $"[{join(p.ArgArray(x => x.Values), ", ")}]");
+            });
+            Config<ObjectValue>(c =>
+            {
+                c.Field(x => x.ObjectFields);
+                c.Print(p => $"{{{join(p.ArgArray(x=>x.ObjectFields), ", ")}}}");
+            });
+            Config<ObjectField>(c =>
+            {
+                c.Field(x => x.Name);
+                c.Field(x => x.Value);
+                c.Print(p => $"{p.Arg(x => x.Name)}: {p.Arg(x => x.Value)}");
+            });
+
+            // Directive
+
+            // Type
+            Config<NamedType>(c =>
+            {
+                c.Field(x => x.Name);
+                c.Print(p => p.Arg(x => x.Name));
+            });
+            Config<ListType>(c =>
+            {
+                c.Field(x => x.Type);
+                c.Print(p => $"[{p.Arg(x => x.Type)}]");
+            });
+            Config<NonNullType>(c =>
+            {
+                c.Field(x => x.Type);
+                c.Print(p => $"{p.Arg(x => x.Type)}!");
+            });
+
+            // Type System Definitions
+        }
+
+        public void Config<T>(Action<AstPrintConfig<T>> configure)
+            where T : INode
+        {
+            var config = new AstPrintConfig<T>();
+            config.Matches = n => n is T;
+            configure(config);
+            _configs.Add(config);
+        }
+
+        private string join(IEnumerable<object> nodes, string separator)
+        {
+            return nodes != null
+                ? string.Join(
+                    separator,
+                    nodes.Where(n => n != null)
+                        .Where(n => !string.IsNullOrWhiteSpace(n.ToString()))
+                        .Select(n => n.ToString()))
+                : "";
+        }
+
+        private string block(IEnumerable<object> nodes)
+        {
+            var list = nodes.ToList();
+            return list.Any()
+                ? indent($"{{\n{join(list, "\n")}") + "\n}"
+                : "";
+        }
+
+        private string wrap(string start, object middle, string end)
+        {
+            var m = middle?.ToString() ?? "";
+            return !string.IsNullOrWhiteSpace(m)
+                ? $"{start}{m}{end}"
+                : "";
+        }
+
+        private string indent(string str)
+        {
+            return Regex.Replace(str, "\n", "\n  ");
+        }
+
+        public object Visit(INode node)
+        {
+            return ApplyConfig(node);
+        }
+
+        public object ApplyConfig(INode node)
+        {
+            var config = _configs.SingleOrDefault(c => c.Matches(node));
+
+            if (config != null)
+            {
+                var vals = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+                config.Fields.Apply(f =>
+                {
+                    var ctx = new ResolveValueContext
+                    {
+                        Source = node
+                    };
+
+                    var result = f.Resolver.Resolve(ctx);
+
+                    if (result is INode)
+                    {
+                        result = ApplyConfig(result as INode);
+                    }
+                    else if (result is IEnumerable && !(result is string))
+                    {
+                        result = GetListResult(result as IEnumerable);
+                    }
+
+                    vals[f.Name] = result;
+                });
+
+                return config.PrintAst(vals);
+            }
+
+            return null;
+        }
+
+        private object GetListResult(IEnumerable enumerable)
+        {
+            var list = new List<object>();
+            foreach (var item in enumerable)
+            {
+                if (item is INode)
+                {
+                    var listResult = ApplyConfig(item as INode);
+                    if (listResult != null)
+                    {
+                        list.Add(listResult);
+                    }
+                }
+            }
+            return list;
+        }
+    }
+}

--- a/src/GraphQL/Validation/BasicVisitor.cs
+++ b/src/GraphQL/Validation/BasicVisitor.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Validation
     {
         private readonly IEnumerable<INodeVisitor> _visitors;
 
-        public BasicVisitor(IEnumerable<INodeVisitor> visitors)
+        public BasicVisitor(params INodeVisitor[] visitors)
         {
             _visitors = visitors;
         }

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Language;
 using GraphQL.Types;
+using GraphQL.Utilities;
 using GraphQL.Validation.Rules;
 
 namespace GraphQL.Validation
@@ -36,8 +37,11 @@ namespace GraphQL.Validation
             var visitors = rules.Select(x => x.Validate(context)).ToList();
 
             visitors.Insert(0, context.TypeInfo);
+#if DEBUG
+            visitors.Insert(1, new DebugNodeVisitor());
+#endif
 
-            var basic = new BasicVisitor(visitors);
+            var basic = new BasicVisitor(visitors.ToArray());
 
             basic.Visit(document);
 
@@ -50,6 +54,7 @@ namespace GraphQL.Validation
         {
             var rules = new List<IValidationRule>()
             {
+                new ArgumentsOfCorrectType(),
                 new UniqueOperationNames(),
                 new LoneAnonymousOperationRule(),
                 new ScalarLeafs()

--- a/src/GraphQL/Validation/Rules/ArgumentsOfCorrectType.cs
+++ b/src/GraphQL/Validation/Rules/ArgumentsOfCorrectType.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Language;
+using GraphQL.Types;
+
+namespace GraphQL.Validation.Rules
+{
+    public class ArgumentsOfCorrectType : IValidationRule
+    {
+        public INodeVisitor Validate(ValidationContext context)
+        {
+            return new NodeVisitorMatchFuncListener<Argument>(
+                n => n is Argument,
+                argAst =>
+                {
+                    var argDef = context.TypeInfo.GetArgument();
+
+                    if (argDef != null)
+                    {
+                        var type = context.Schema.FindType(argDef.Type);
+                        var errors = type.IsValidLiteralValue(argAst.Value, context.Schema).ToList();
+                        if (errors.Any())
+                        {
+                            var error = new ValidationError(
+                                "5.3.3.1",
+                                BadValueMessage(argAst.Name, type, context.Print(argAst.Value), errors));
+                            error.AddLocation(argAst.SourceLocation.Line, argAst.SourceLocation.Column);
+                            context.ReportError(error);
+                        }
+                    }
+                });
+        }
+
+        public string BadValueMessage(
+            string argName,
+            GraphType type,
+            string value,
+            IEnumerable<string> verboseErrors)
+        {
+            var message = verboseErrors != null ? $"\n{string.Join("\n", verboseErrors)}" : "";
+
+            return $"Argument \"{argName}\" has invalid value {value}.{message}";
+        }
+    }
+}

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using GraphQL.Language;
 using GraphQL.Types;
+using GraphQL.Utilities;
 
 namespace GraphQL.Validation
 {
@@ -22,6 +23,11 @@ namespace GraphQL.Validation
         public void ReportError(ValidationError error)
         {
             _errors.Add(error);
+        }
+
+        public string Print(INode node)
+        {
+            return AstPrinter.Print(node);
         }
     }
 }


### PR DESCRIPTION
* Fixes a bug with EnumerationGraphType and input variables
* Fixes a bug where float values would not be created
* Add ArgumentsOfCorrectType validation rule
* Add AstPrinter
* Add overload to DocumentExecutor where validation rules can be
  provided
* Refactor ToObject to support enums, guids, nullable lists, and
  nested lists
* Add overload to QueryArguments which takes params

Fixes: https://github.com/graphql-dotnet/graphql-dotnet/issues/59, https://github.com/graphql-dotnet/graphql-dotnet/issues/94, https://github.com/graphql-dotnet/graphql-dotnet/issues/95