### PR TITLE
Fix issues with boxed value casting in Arguments

### DIFF
--- a/src/GraphQL.Tests/Execution/EnumAsInputsTests.cs
+++ b/src/GraphQL.Tests/Execution/EnumAsInputsTests.cs
@@ -66,6 +66,46 @@ namespace GraphQL.Tests.Execution
                   }
                 }");
         }
+
+        [Test]
+        public void query_can_get_long_variable()
+        {
+            var inputs = "{ 'userId': 1000000000000000001 }".ToInputs();
+
+            AssertQuerySuccess(
+                @"query aQuery($userId: Int!) { getLongUser(userId: $userId) { idLong }}",
+                @"{
+                  'getLongUser': {
+                    'idLong': 1000000000000000001
+                  }
+                }", inputs);
+        }
+
+        [Test]
+        public void query_can_get_long_inline()
+        {
+            AssertQuerySuccess(
+                @"query aQuery { getLongUser(userId: 1000000000000000001) { idLong }}",
+                @"{
+                  'getLongUser': {
+                    'idLong': 1000000000000000001
+                  }
+                }");
+        }
+
+        [Test]
+        public void query_can_get_int_variable()
+        {
+            var inputs = "{ 'userId': 3 }".ToInputs();
+
+            AssertQuerySuccess(
+                @"query aQuery($userId: Int!) { getIntUser(userId: $userId) { id }}",
+                @"{
+                  'getIntUser': {
+                    'id': 3
+                  }
+                }", inputs);
+        }
     }
 
     public class EnumMutationSchema : Schema
@@ -89,6 +129,41 @@ namespace GraphQL.Tests.Execution
                     Gender = Gender.Male,
                     ProfileImage = "hello.png"
                 });
+            Field<UserType>("getIntUser", "get user api",
+                new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
+                    {
+                        Name = "userId",
+                        Description = "user id"
+                    }
+                ),
+                context =>
+                {
+                    var id = context.Argument<int>("userId");
+                    return new User
+                    {
+                        Id = id
+                    };
+                }
+            );
+
+            Field<UserType>("getLongUser", "get user api",
+                new QueryArguments(
+                    new QueryArgument<NonNullGraphType<IntGraphType>>
+                    {
+                        Name = "userId",
+                        Description = "user id"
+                    }
+                ),
+                context =>
+                {
+                    var id = context.Argument<long>("userId");
+                    return new User
+                    {
+                        IdLong = id
+                    };
+                }
+            );
         }
     }
 
@@ -149,6 +224,7 @@ namespace GraphQL.Tests.Execution
         {
             Name = "User";
             Field<IntGraphType>("id");
+            Field<IntGraphType>("idLong");
             Field<StringGraphType>("profileImage");
             Field<GenderEnum>("gender");
             Field<StringGraphType>(
@@ -165,6 +241,7 @@ namespace GraphQL.Tests.Execution
     public class User
     {
         public int Id { get; set; }
+        public long IdLong { get; set; }
         public string ProfileImage { get; set; }
         public Gender Gender { get; set; }
     }

--- a/src/GraphQL.Tests/Execution/InputConversionTests.cs
+++ b/src/GraphQL.Tests/Execution/InputConversionTests.cs
@@ -56,6 +56,24 @@ namespace GraphQL.Tests.Execution
         }
 
         [Test]
+        public void converts_small_numbers_to_int()
+        {
+            var json = @"{'a': 1}";
+            var inputs = json.ToInputs();
+            inputs["a"].ShouldEqual(1);
+            inputs["a"].GetType().ShouldEqual(typeof(int));
+        }
+
+        [Test]
+        public void converts_large_numbers_to_long()
+        {
+            var json = @"{'a': 1000000000000000001}";
+            var inputs = json.ToInputs();
+            inputs["a"].ShouldEqual(1000000000000000001);
+            inputs["a"].GetType().ShouldEqual(typeof(long));
+        }
+
+        [Test]
         public void can_convert_json_to_input_object_and_specific_object()
         {
             var json = @"{'a': 1, 'b': '2'}";
@@ -63,7 +81,7 @@ namespace GraphQL.Tests.Execution
             var inputs = json.ToInputs();
 
             inputs.ShouldNotBeNull();
-            inputs["a"].ShouldEqual((long)1);
+            inputs["a"].ShouldEqual((int)1);
             inputs["b"].ShouldEqual("2");
 
             var myInput = inputs.ToObject<MyInput>();
@@ -81,7 +99,7 @@ namespace GraphQL.Tests.Execution
             var inputs = json.ToInputs();
 
             inputs.ShouldNotBeNull();
-            inputs["a"].ShouldEqual((long)1);
+            inputs["a"].ShouldEqual((int)1);
             inputs["b"].ShouldEqual("2");
             inputs["c"].ShouldBeType<List<object>>();
 

--- a/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
+++ b/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using GraphQL.Types;
+using Should;
+
+namespace GraphQL.Tests.Execution
+{
+    public class ResolveFieldContextTests
+    {
+        private readonly ResolveFieldContext _context;
+
+        public ResolveFieldContextTests()
+        {
+            _context = new ResolveFieldContext();
+            _context.Arguments = new Dictionary<string, object>();
+        }
+
+        [Test]
+        public void argument_converts_int_to_long()
+        {
+            int val = 1;
+            _context.Arguments["a"] = val;
+            var result = _context.Argument<long>("a");
+            result.ShouldEqual(1);
+        }
+
+        [Test]
+        public void argument_converts_long_to_int()
+        {
+            long val = 1;
+            _context.Arguments["a"] = val;
+            var result = _context.Argument<int>("a");
+            result.ShouldEqual(1);
+        }
+
+        [Test]
+        public void argument_returns_boxed_string_uncast()
+        {
+            _context.Arguments["a"] = "one";
+            var result = _context.Argument<object>("a");
+            result.ShouldEqual("one");
+        }
+
+        [Test]
+        public void argument_returns_long()
+        {
+            long val = 1000000000000001;
+            _context.Arguments["a"] = val;
+            var result = _context.Argument<long>("a");
+            result.ShouldEqual(1000000000000001);
+        }
+
+        [Test]
+        public void argument_returns_enum()
+        {
+            _context.Arguments["a"] = SomeEnum.Two;
+            var result = _context.Argument<SomeEnum>("a");
+            result.ShouldEqual(SomeEnum.Two);
+        }
+
+        [Test]
+        public void argument_returns_enum_from_string()
+        {
+            _context.Arguments["a"] = "two";
+            var result = _context.Argument<SomeEnum>("a");
+            result.ShouldEqual(SomeEnum.Two);
+        }
+
+        [Test]
+        public void argument_returns_enum_from_number()
+        {
+            _context.Arguments["a"] = 1;
+            var result = _context.Argument<SomeEnum>("a");
+            result.ShouldEqual(SomeEnum.Two);
+        }
+
+        [Test]
+        public void throw_error_if_argument_doesnt_exist()
+        {
+            Expect.Throws<ExecutionError>(() => _context.Argument<string>("wat"));
+        }
+
+        enum SomeEnum
+        {
+            One,
+            Two
+        }
+    }
+}

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -69,10 +69,9 @@ namespace GraphQL.Tests.Execution
 
             Field<StringGraphType>(
                 "fieldWithObjectInput",
-                arguments: new QueryArguments(new []
-                {
+                arguments: new QueryArguments(
                     new QueryArgument<TestInputObject> { Name = "input"}
-                }),
+                ),
                 resolve: context =>
                 {
                     var result = JsonConvert.SerializeObject(context.Argument<object>("input"));
@@ -81,22 +80,21 @@ namespace GraphQL.Tests.Execution
 
             Field<StringGraphType>(
                 "fieldWithNullableStringInput",
-                arguments: new QueryArguments(new []
-                {
+                arguments: new QueryArguments(
                     new QueryArgument<StringGraphType> { Name = "input" }
-                }),
+                ),
                 resolve: context =>
                 {
-                    var result = JsonConvert.SerializeObject(context.Argument<object>("input"));
+                    var val = context.Argument<object>("input");
+                    var result = JsonConvert.SerializeObject(val);
                     return result;
                 });
 
             Field<StringGraphType>(
                 "fieldWithNonNullableStringInput",
-                arguments: new QueryArguments(new []
-                {
+                arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "input" }
-                }),
+                ),
                 resolve: context =>
                 {
                     var result = JsonConvert.SerializeObject(context.Argument<object>("input"));
@@ -105,10 +103,9 @@ namespace GraphQL.Tests.Execution
 
             Field<StringGraphType>(
                 "fieldWithDefaultArgumentValue",
-                arguments: new QueryArguments(new []
-                {
+                arguments: new QueryArguments(
                     new QueryArgument<StringGraphType> { Name = "input", DefaultValue = "Hello World"}
-                }),
+                ),
                 resolve: context =>
                 {
                     var result = JsonConvert.SerializeObject(context.Argument<object>("input"));

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Execution\Directives\DirectivesTests.cs" />
     <Compile Include="Execution\InputConversionTests.cs" />
     <Compile Include="Execution\MutationTests.cs" />
+    <Compile Include="Execution\ResolveFieldContextTests.cs" />
     <Compile Include="Execution\SchemaLifetimeTests.cs" />
     <Compile Include="Execution\UnionInterfaceTests.cs" />
     <Compile Include="Execution\VariablesTests.cs" />

--- a/src/GraphQL/Language/GraphQLVisitor.cs
+++ b/src/GraphQL/Language/GraphQLVisitor.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Language
                 long longResult;
                 if (long.TryParse(value, out longResult))
                 {
-                    var val = new LongValue(intResult);
+                    var val = new LongValue(longResult);
                     NewNode(val, context);
                     return val;
                 }
@@ -101,7 +101,7 @@ namespace GraphQL.Language
                 long longResult;
                 if (long.TryParse(value, out longResult))
                 {
-                    var val = new LongValue(intResult);
+                    var val = new LongValue(longResult);
                     NewNode(val, context);
                     return val;
                 }

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -35,6 +35,11 @@ namespace GraphQL
 
         public static object GetPropertyValue(object propertyValue, Type fieldType)
         {
+            if (fieldType.FullName == "System.Object")
+            {
+                return propertyValue;
+            }
+
             if (fieldType.Name != "String"
                 && fieldType.GetInterface("IEnumerable`1") != null)
             {
@@ -80,10 +85,10 @@ namespace GraphQL
                 value = Enum.Parse(fieldType, str, true);
             }
 
-            return GetValue(value, fieldType);
+            return ConvertValue(value, fieldType);
         }
 
-        public static object GetValue(object value, Type fieldType)
+        public static object ConvertValue(object value, Type fieldType)
         {
             if (value == null) return null;
 
@@ -91,6 +96,11 @@ namespace GraphQL
             return text != null
               ? TypeDescriptor.GetConverter(fieldType).ConvertFromInvariantString(text)
               : Convert.ChangeType(value, fieldType);
+        }
+
+        public static T GetPropertyValue<T>(this object value)
+        {
+            return (T)GetPropertyValue(value, typeof(T));
         }
 
         public static bool IsDefinedEnumValue(Type type, object value)

--- a/src/GraphQL/StringExtensions.cs
+++ b/src/GraphQL/StringExtensions.cs
@@ -61,7 +61,16 @@ namespace GraphQL
             var rawValue = value as JValue;
             if (rawValue != null)
             {
-                return rawValue.Value;
+                var val = rawValue.Value;
+                if (val is long)
+                {
+                    long l = (long) val;
+                    if (l >= int.MinValue && l <= int.MaxValue)
+                    {
+                        return (int) l;
+                    }
+                }
+                return val;
             }
 
             return value;


### PR DESCRIPTION
* Fix issues when trying to cast between int/long in Argument<T>
* Fixed an issue where long values were not initialized properly in the
  GraphQLVisitor
* Throw exception if argument doesn't exist

Github Issue: #103