### PR TITLE
Inject list input variables from query to field

### DIFF
--- a/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
@@ -296,6 +296,29 @@ namespace GraphQL.Tests.Builders
         }
 
         [Fact]
+        public void can_get_list_argument()
+        {
+            var objectType = new ObjectGraphType();
+            objectType.Field<StringGraphType>()
+                .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>>("episodes", "episodes")
+                .Resolve(context =>
+                {
+                    context.GetArgument<IEnumerable<string>>("episodes").ShouldEqual(new List<string> { "JEDI", "EMPIRE" });
+                    return null;
+                });
+
+            var field = objectType.Fields.First();
+            field.Resolve(new ResolveFieldContext
+            {
+                Arguments = new Dictionary<string, object>
+                {
+                    {"episodes", new object[] {"JEDI", "EMPIRE" } }
+                },
+                FieldDefinition = field
+            });
+        }
+
+        [Fact]
         public void getting_specified_argument_in_resolver_overrides_default_value()
         {
             var objectType = new ObjectGraphType();

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Language;
 using GraphQL.Types;
@@ -193,6 +194,16 @@ namespace GraphQL.Tests.Execution
         }
 
         [Fact]
+        public void properly_parses_multiple_values_to_list()
+        {
+            var expected = "{ \"fieldWithObjectInput\": \"{\\\"a\\\":\\\"foo\\\",\\\"b\\\":[\\\"bar\\\",\\\"qux\\\"],\\\"c\\\":\\\"baz\\\"}\" }";
+
+            var inputs = "{'input': {'a':'foo', 'b':['bar', 'qux'], 'c': 'baz'} }".ToInputs();
+
+            AssertQuerySuccess(_query, expected, inputs);
+        }
+
+        [Fact]
         public void uses_default_value_when_not_provided()
         {
             var queryWithDefaults = @"
@@ -281,14 +292,14 @@ namespace GraphQL.Tests.Execution
         public void executes_with_injected_input_variables()
         {
             var query = @"
-                query q($argC: String!, $argD: ComplexScalar) {
-                  fieldWithObjectInput(input: { c: $argC, d: $argD })
+                query q($argB: [String!]!, $argC: String!, $argD: ComplexScalar) {
+                  fieldWithObjectInput(input: { b: $argB, c: $argC, d: $argD,  })
                 }
             ";
 
-            var expected = "{ \"fieldWithObjectInput\": \"{\\\"c\\\":\\\"foo\\\",\\\"d\\\":\\\"DeserializedValue\\\"}\" }";
+            var expected = "{ \"fieldWithObjectInput\": \"{\\\"b\\\":[\\\"bar\\\",\\\"qux\\\"],\\\"c\\\":\\\"foo\\\",\\\"d\\\":\\\"DeserializedValue\\\"}\" }";
 
-            var inputs = "{'argC': 'foo', 'argD': 'SerializedValue'}".ToInputs();
+            var inputs = "{'argB':['bar', 'qux'], 'argC': 'foo', 'argD': 'SerializedValue'}".ToInputs();
 
             AssertQuerySuccess(query, expected, inputs);
         }
@@ -427,7 +438,7 @@ namespace GraphQL.Tests.Execution
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
             caughtError.InnerException.ShouldNotBeNull();
-            caughtError.InnerException.Message.ShouldEqual("Variable '$value' of required type 'String' was not provided.");
+            caughtError.InnerException.Message.ShouldEqual("Variable '$value' of required type 'String!' was not provided.");
         }
 
         [Fact]
@@ -448,7 +459,7 @@ namespace GraphQL.Tests.Execution
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
             caughtError.InnerException.ShouldNotBeNull();
-            caughtError.InnerException.Message.ShouldEqual("Variable '$value' of required type 'String' was not provided.");
+            caughtError.InnerException.Message.ShouldEqual("Variable '$value' of required type 'String!' was not provided.");
         }
 
         [Fact]

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -465,7 +465,7 @@ namespace GraphQL
 
         public object GetVariableValue(ISchema schema, VariableDefinition variable, IValue input)
         {
-            var type = schema.FindType(variable.Type.Name());
+            var type = variable.Type.GraphTypeFromType(schema);
 
             var value = input ?? variable.DefaultValue;
             if (IsValidValue(schema, type, variable.Type, input))

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -40,10 +40,13 @@ namespace GraphQL
                 return propertyValue;
             }
 
+            var enumerableInterface = fieldType.Name == "IEnumerable`1"
+              ? fieldType
+              : fieldType.GetInterface("IEnumerable`1");
             if (fieldType.Name != "String"
-                && fieldType.GetInterface("IEnumerable`1") != null)
+                && enumerableInterface != null)
             {
-                var elementType = fieldType.GetGenericArguments()[0];
+                var elementType = enumerableInterface.GetGenericArguments()[0];
                 var underlyingType = Nullable.GetUnderlyingType(elementType) ?? elementType;
                 var genericListType = typeof(List<>).MakeGenericType(elementType);
                 var newArray = (IList) Activator.CreateInstance(genericListType);


### PR DESCRIPTION
In DocumentExecuter.GetVariableValue the variables type's name was
retrieved. This stripped list and non-nullable information and made the
IsValidValue check fail.

This change instead gets the type via the GraphTypeFromType method. The
test executes_with_injected_input_variables is extended to cover the
scenario. The properly_parses_multiple_values_to_list does not demonstrate
a bug but is there for completeness.

Additionally GetArgument on context did not support IEnumerable as generic
parameter. This is fixed in ObjectExtensions and tested in
can_get_list_argument.