### PR TITLE
explicit ConfigureAwait calls

### DIFF
--- a/src/GraphQL.GraphiQL/Controllers/GraphQLController.cs
+++ b/src/GraphQL.GraphiQL/Controllers/GraphQLController.cs
@@ -33,9 +33,9 @@ namespace GraphQL.GraphiQL.Controllers
         }
 
         // This will display an example error
-        public async Task<HttpResponseMessage> Get(HttpRequestMessage request)
+        public Task<HttpResponseMessage> Get(HttpRequestMessage request)
         {
-            return await Post(request, new GraphQLQuery { Query = "query foo { hero }", Variables = "" }).ConfigureAwait(true);
+            return Post(request, new GraphQLQuery { Query = "query foo { hero }", Variables = "" });
         }
 
         public async Task<HttpResponseMessage> Post(HttpRequestMessage request, GraphQLQuery query)
@@ -48,7 +48,7 @@ namespace GraphQL.GraphiQL.Controllers
                 queryToExecute = _namedQueries[query.NamedQuery];
             }
 
-            var result = await Execute(_schema, null, queryToExecute, query.OperationName, inputs).ConfigureAwait(true);
+            var result = await ExecuteAsync(_schema, null, queryToExecute, query.OperationName, inputs).ConfigureAwait(true);
 
             var httpResult = result.Errors?.Count > 0
                 ? HttpStatusCode.BadRequest
@@ -62,14 +62,14 @@ namespace GraphQL.GraphiQL.Controllers
             return response;
         }
 
-        public async Task<ExecutionResult> Execute(
+        public Task<ExecutionResult> ExecuteAsync(
           ISchema schema,
           object rootObject,
           string query,
           string operationName = null,
           Inputs inputs = null)
         {
-            return await _executer.ExecuteAsync(schema, rootObject, query, operationName, inputs).ConfigureAwait(false);
+            return _executer.ExecuteAsync(schema, rootObject, query, operationName, inputs);
         }
     }
 

--- a/src/GraphQL.GraphiQL/Controllers/GraphQLController.cs
+++ b/src/GraphQL.GraphiQL/Controllers/GraphQLController.cs
@@ -33,12 +33,14 @@ namespace GraphQL.GraphiQL.Controllers
         }
 
         // This will display an example error
-        public Task<HttpResponseMessage> Get(HttpRequestMessage request)
+        [HttpGet]
+        public Task<HttpResponseMessage> GetAsync(HttpRequestMessage request)
         {
-            return Post(request, new GraphQLQuery { Query = "query foo { hero }", Variables = "" });
+            return PostAsync(request, new GraphQLQuery { Query = "query foo { hero }", Variables = "" });
         }
 
-        public async Task<HttpResponseMessage> Post(HttpRequestMessage request, GraphQLQuery query)
+        [HttpPost]
+        public async Task<HttpResponseMessage> PostAsync(HttpRequestMessage request, GraphQLQuery query)
         {
             var inputs = query.Variables.ToInputs();
             var queryToExecute = query.Query;

--- a/src/GraphQL.GraphiQL/Controllers/GraphQLController.cs
+++ b/src/GraphQL.GraphiQL/Controllers/GraphQLController.cs
@@ -35,7 +35,7 @@ namespace GraphQL.GraphiQL.Controllers
         // This will display an example error
         public async Task<HttpResponseMessage> Get(HttpRequestMessage request)
         {
-            return await Post(request, new GraphQLQuery { Query = "query foo { hero }", Variables = "" });
+            return await Post(request, new GraphQLQuery { Query = "query foo { hero }", Variables = "" }).ConfigureAwait(true);
         }
 
         public async Task<HttpResponseMessage> Post(HttpRequestMessage request, GraphQLQuery query)
@@ -48,7 +48,7 @@ namespace GraphQL.GraphiQL.Controllers
                 queryToExecute = _namedQueries[query.NamedQuery];
             }
 
-            var result = await Execute(_schema, null, queryToExecute, query.OperationName, inputs);
+            var result = await Execute(_schema, null, queryToExecute, query.OperationName, inputs).ConfigureAwait(true);
 
             var httpResult = result.Errors?.Count > 0
                 ? HttpStatusCode.BadRequest
@@ -69,7 +69,7 @@ namespace GraphQL.GraphiQL.Controllers
           string operationName = null,
           Inputs inputs = null)
         {
-            return await _executer.ExecuteAsync(schema, rootObject, query, operationName, inputs);
+            return await _executer.ExecuteAsync(schema, rootObject, query, operationName, inputs).ConfigureAwait(false);
         }
     }
 

--- a/src/GraphQL.Tests/Execution/Cancellation/CancellationTests.cs
+++ b/src/GraphQL.Tests/Execution/Cancellation/CancellationTests.cs
@@ -23,11 +23,11 @@ namespace GraphQL.Tests.Execution.Cancellation
         {
             Name = "CancellationTestType";
 
-            Field<StringGraphType>("one", resolve: GetOne);
-            Field<StringGraphType>("two", resolve: GetTwo);
+            Field<StringGraphType>("one", resolve: GetOneAsync);
+            Field<StringGraphType>("two", resolve: GetTwoAsync);
         }
 
-        public Task<string> GetOne(ResolveFieldContext context)
+        public Task<string> GetOneAsync(ResolveFieldContext context)
         {
             if (!context.CancellationToken.CanBeCanceled)
             {
@@ -37,7 +37,7 @@ namespace GraphQL.Tests.Execution.Cancellation
             return Task.FromResult("one");
         }
 
-        public Task<string> GetTwo(ResolveFieldContext context)
+        public Task<string> GetTwoAsync(ResolveFieldContext context)
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/GraphQL.Tests/Execution/MutationTests.cs
+++ b/src/GraphQL.Tests/Execution/MutationTests.cs
@@ -39,7 +39,7 @@ namespace GraphQL.Tests.Execution
 
         public async Task<NumberHolder> PromiseAndFailToChangeTheNumber(int number)
         {
-            await Task.Delay(100);
+            await Task.Delay(100).ConfigureAwait(false);
             throw new InvalidOperationException("Cannot change the number");
         }
     }

--- a/src/GraphQL.Tests/Execution/MutationTests.cs
+++ b/src/GraphQL.Tests/Execution/MutationTests.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Tests.Execution
             return NumberHolder;
         }
 
-        public Task<NumberHolder> PromiseToChangeTheNumber(int number)
+        public Task<NumberHolder> PromiseToChangeTheNumberAsync(int number)
         {
             NumberHolder.TheNumber = number;
             return Task.FromResult(NumberHolder);
@@ -37,7 +37,7 @@ namespace GraphQL.Tests.Execution
             throw new InvalidOperationException("Cannot change the number");
         }
 
-        public async Task<NumberHolder> PromiseAndFailToChangeTheNumber(int number)
+        public async Task<NumberHolder> PromiseAndFailToChangeTheNumberAsync(int number)
         {
             await Task.Delay(100).ConfigureAwait(false);
             throw new InvalidOperationException("Cannot change the number");
@@ -107,7 +107,7 @@ namespace GraphQL.Tests.Execution
                 {
                     var root = context.Source as Root;
                     var change = context.Argument<int>("newNumber");
-                    return root.PromiseToChangeTheNumber(change);
+                    return root.PromiseToChangeTheNumberAsync(change);
                 }
             );
 
@@ -141,7 +141,7 @@ namespace GraphQL.Tests.Execution
                 {
                     var root = context.Source as Root;
                     var change = context.Argument<int>("newNumber");
-                    return root.PromiseAndFailToChangeTheNumber(change);
+                    return root.PromiseAndFailToChangeTheNumberAsync(change);
                 }
             );
         }

--- a/src/GraphQL.Tests/Execution/SchemaLifetimeTests.cs
+++ b/src/GraphQL.Tests/Execution/SchemaLifetimeTests.cs
@@ -22,7 +22,7 @@ namespace GraphQL.Tests.Execution
             var executer = new DocumentExecuter(new AntlrDocumentBuilder(), new DocumentValidator());
             var schema = new Schema();
 
-            await executer.ExecuteAsync(schema, null, "{noop}", null);
+            await executer.ExecuteAsync(schema, null, "{noop}", null).ConfigureAwait(false);
 
             Assert.DoesNotThrow(() => schema.Dispose());
         }

--- a/src/GraphQL/EnumerableExtensions.cs
+++ b/src/GraphQL/EnumerableExtensions.cs
@@ -27,7 +27,7 @@ namespace GraphQL
                 .Select(map)
                 .ToArray();
 
-            return await Task.WhenAll(tasks);
+            return await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
         public static void Apply<T>(this IEnumerable<T> items, Action<T> action)
@@ -56,11 +56,11 @@ namespace GraphQL
             var tasks = items
                 .Select(async item => new {
                     Key = keyFunc(item),
-                    Result = await valueFunc(item)
+                    Result = await valueFunc(item).ConfigureAwait(false)
                 })
                 .ToArray();
 
-            var keyValuePairs = await Task.WhenAll(tasks);
+            var keyValuePairs = await Task.WhenAll(tasks).ConfigureAwait(false);
             keyValuePairs = keyValuePairs.Where(x => !x.Result.Skip).ToArray();
 
             return keyValuePairs.ToDictionary(kvp => kvp.Key, kvp => kvp.Result.Value);

--- a/src/GraphQL/EnumerableExtensions.cs
+++ b/src/GraphQL/EnumerableExtensions.cs
@@ -20,14 +20,12 @@ namespace GraphQL
             return mappedItems.ToList();
         }
 
-        public static async Task<IEnumerable> MapAsync(this IEnumerable items, Func<object, Task<object>> map)
+        public static Task<object[]> MapAsync(this IEnumerable items, Func<object, Task<object>> map)
         {
             var tasks = items
                 .Cast<object>()
-                .Select(map)
-                .ToArray();
-
-            return await Task.WhenAll(tasks).ConfigureAwait(false);
+                .Select(map);
+            return Task.WhenAll(tasks);
         }
 
         public static void Apply<T>(this IEnumerable<T> items, Action<T> action)

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -124,7 +124,7 @@ namespace GraphQL
             return context;
         }
 
-        public Task<object> ExecuteOperationAsync(ExecutionContext context)
+        public Task<Dictionary<string, object>> ExecuteOperationAsync(ExecutionContext context)
         {
             var rootType = GetOperationRootType(context.Schema, context.Operation);
             var fields = CollectFields(
@@ -137,11 +137,10 @@ namespace GraphQL
             return ExecuteFields(context, rootType, context.RootValue, fields);
         }
 
-        public async Task<object> ExecuteFields(ExecutionContext context, ObjectGraphType rootType, object source, Dictionary<string, Fields> fields)
-        {
-            return await fields.ToDictionaryAsync<KeyValuePair<string, Fields>,string, ResolveFieldResult<object>, object>(
+        public Task<Dictionary<string, object>> ExecuteFields(ExecutionContext context, ObjectGraphType rootType, object source, Dictionary<string, Fields> fields) {
+            return fields.ToDictionaryAsync<KeyValuePair<string, Fields>, string, ResolveFieldResult<object>, object>(
                 pair => pair.Key,
-                pair => ResolveField(context, rootType, source, pair.Value)).ConfigureAwait(false);
+                pair => ResolveField(context, rootType, source, pair.Value));
         }
 
         public async Task<ResolveFieldResult<object>> ResolveField(ExecutionContext context, ObjectGraphType parentType, object source, Fields fields)


### PR DESCRIPTION
Explicitly call ConfigureAwait, in most cases the synchronization context is not needed.

I suggest installing something like [ConfigureAwaitFixer](https://visualstudiogallery.msdn.microsoft.com/07d8d8a4-f2cd-4350-aad8-751c33879d52).
