### PR TITLE
Add unique fragment names validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Console.Writeline(result);
 - [ ] Provide non-null arguments
 - [x] Scalar leafs
 - [ ] Unique argument names
-- [ ] Unique fragment names
+- [x] Unique fragment names
 - [x] Unique input field names
 - [x] Unique operation names
 - [x] Unique variable names

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Validation\NoUndefinedVariablesTests.cs" />
     <Compile Include="Validation\NoUnusedVariablesTests.cs" />
     <Compile Include="Validation\ScalarLeafTests.cs" />
+    <Compile Include="Validation\UniqueFragmentNamesTests.cs" />
     <Compile Include="Validation\UniqueInputFieldNamesTests.cs" />
     <Compile Include="Validation\UniqueOperationNamesTests.cs" />
     <Compile Include="Validation\UniqueVariableNamesTests.cs" />

--- a/src/GraphQL.Tests/Validation/UniqueFragmentNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/UniqueFragmentNamesTests.cs
@@ -1,0 +1,135 @@
+﻿using GraphQL.Validation.Rules;
+
+namespace GraphQL.Tests.Validation
+{
+  public class UniqueFragmentNamesTests : ValidationTestBase<UniqueFragmentNames, ValidationSchema>
+  {
+    [Fact]
+    public void no_fragments()
+    {
+      ShouldPassRule(@"
+        {
+          field
+        }
+      ");
+    }
+
+    [Fact]
+    public void one_fragment()
+    {
+      ShouldPassRule(@"
+        {
+          ...fragA
+        }
+        fragment fragA on Type {
+          field
+        }
+      ");
+    }
+
+    [Fact]
+    public void many_fragments()
+    {
+      ShouldPassRule(@"
+        {
+          ...fragA
+          ...fragB
+          ...fragC
+        }
+        fragment fragA on Type {
+          fieldA
+        }
+        fragment fragB on Type {
+          fieldB
+        }
+        fragment fragC on Type {
+          fieldC
+        }
+      ");
+    }
+
+    [Fact]
+    public void inline_fragments_are_always_unique()
+    {
+      ShouldPassRule(@"
+        {
+          ...on Type {
+            fieldA
+          }
+          ...on Type {
+            fieldB
+          }
+        }
+      ");
+    }
+
+    [Fact]
+    public void fragment_and_operation_named_the_same()
+    {
+      ShouldPassRule(@"
+        query Foo {
+          ...Foo
+        }
+        fragment Foo on Type {
+          field
+        }
+      ");
+    }
+
+    [Fact]
+    public void fragments_named_the_same()
+    {
+      ShouldFailRule(_ =>
+      {
+        _.Query = @"
+          {
+            ...fragA
+          }
+          fragment fragA on Type {
+            fieldA
+          }
+          fragment fragA on Type {
+            fieldB
+          }
+        ";
+        // Note: this is failing on "fragment"; graphql-js fails on the fragment name.
+        duplicateFrag(_, "fragA", 5, 11, 8, 11);
+      });
+    }
+
+    [Fact]
+    public void fragments_named_the_same_without_being_referenced()
+    {
+      ShouldFailRule(_ =>
+      {
+        _.Query = @"
+          fragment fragA on Type {
+            fieldA
+          }
+          fragment fragA on Type {
+            fieldB
+          }
+        ";
+        // Note: this is failing on "fragment"; graphql-js fails on the fragment name.
+        duplicateFrag(_, "fragA", 2, 11, 5, 11);
+      });
+    }
+
+
+    private void duplicateFrag(
+      ValidationTestConfig _,
+      string fragName,
+      int line1,
+      int column1,
+      int line2,
+      int column2)
+    {
+      _.Error(err =>
+      {
+        err.Message = Rule.DuplicateFragmentNameMessage(fragName);
+        err.Loc(line1, column1);
+        err.Loc(line2, column2);
+      });
+    }
+  }
+}

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Validation\Rules\NoUndefinedVariables.cs" />
     <Compile Include="Validation\Rules\NoUnusedVariables.cs" />
     <Compile Include="Validation\Rules\ScalarLeafs.cs" />
+    <Compile Include="Validation\Rules\UniqueFragmentNames.cs" />
     <Compile Include="Validation\Rules\UniqueInputFieldNames.cs" />
     <Compile Include="Validation\Rules\UniqueVariableNames.cs" />
     <Compile Include="Validation\Rules\VariablesAreInputTypes.cs" />

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -58,6 +58,7 @@ namespace GraphQL.Validation
                 new KnownTypeNames(),
                 new VariablesAreInputTypes(),
                 new ScalarLeafs(),
+                new UniqueFragmentNames(),
                 new NoUndefinedVariables(),
                 new NoUnusedVariables(),
                 new UniqueVariableNames(),

--- a/src/GraphQL/Validation/Rules/UniqueFragmentNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueFragmentNames.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using GraphQL.Language;
+
+namespace GraphQL.Validation.Rules
+{
+  /// <summary>
+  /// Unique fragment names
+  /// 
+  /// A GraphQL document is only valid if all defined fragments have unique names.
+  /// </summary>
+  public class UniqueFragmentNames : IValidationRule
+  {
+    public string DuplicateFragmentNameMessage(string fragName)
+    {
+      return $"There can only be one fragment named \"${fragName}\"";
+    }
+
+    public INodeVisitor Validate(ValidationContext context)
+    {
+      var knownFragments = new Dictionary<string, FragmentDefinition>();
+
+      return new EnterLeaveListener(_ =>
+      {
+        _.Match<FragmentDefinition>(fragmentDefinition =>
+        {
+          var fragmentName = fragmentDefinition.Name;
+          if (knownFragments.ContainsKey(fragmentName))
+          {
+            var error = new ValidationError("5.4.1.1", DuplicateFragmentNameMessage(fragmentName),
+                                            knownFragments[fragmentName], fragmentDefinition);
+            context.ReportError(error);
+          }
+          else
+          {
+            knownFragments[fragmentName] = fragmentDefinition;
+          }
+        });
+      });
+    }
+  }
+}


### PR DESCRIPTION
Issue #10 

I noted this in the tests, but the column number is a bit different from qraphql-js. Their column number is the fragment name; the column number for this validation is "fragment". I wouldn't expect that to be a big deal for users, but it's a difference.