### PR TITLE
Retain Utc/Local information in provided DateTime argument values.

### DIFF
--- a/src/GraphQL.Tests/Types/DateGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DateGraphTypeTests.cs
@@ -39,5 +39,12 @@ namespace GraphQL.Tests.Types
             type.ParseValue("2015-11-21T19:59:32.987+0200").ShouldEqual(
                 new DateTime(2015, 11, 21, 17, 59, 32) + TimeSpan.FromMilliseconds(987));
         }
+
+        [Fact]
+        public void coerces_datetimes_to_utc()
+        {
+            ((DateTime)type.ParseValue("2015-11-21T19:59:32.987+0200")).Kind.ShouldEqual(
+                DateTimeKind.Utc);
+        }
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -456,6 +456,11 @@ namespace GraphQL
                 return new FloatValue((double)value);
             }
 
+            if (value is DateTime)
+            {
+                return new DateTimeValue((DateTime)value);
+            }
+
             return new StringValue(value?.ToString());
         }
 

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.props" Condition="Exists('..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.props')" />
+  <Import Project="C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.props" Condition="Exists('C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -34,11 +34,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=e9931a4108ef2354, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Antlr4.Runtime.4.5-alpha002\lib\net45\Antlr4.Runtime.dll</HintPath>
+      <HintPath>C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.Runtime.4.5-alpha002\lib\net45\Antlr4.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>C:\projects\alex\Platform\trunk\Nuget\Repository\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -191,10 +191,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.props'))" />
-    <Error Condition="!Exists('..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets'))" />
+    <Error Condition="!Exists('C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.props')" Text="$([System.String]::Format('$(ErrorText)', 'C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.props'))" />
+    <Error Condition="!Exists('C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.targets')" Text="$([System.String]::Format('$(ErrorText)', 'C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets" Condition="Exists('..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets')" />
+  <Import Project="C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.targets" Condition="Exists('C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.props" Condition="Exists('C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.props')" />
+  <Import Project="..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.props" Condition="Exists('..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -34,11 +34,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=e9931a4108ef2354, processorArchitecture=MSIL">
-      <HintPath>C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.Runtime.4.5-alpha002\lib\net45\Antlr4.Runtime.dll</HintPath>
+      <HintPath>..\..\packages\Antlr4.Runtime.4.5-alpha002\lib\net45\Antlr4.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>C:\projects\alex\Platform\trunk\Nuget\Repository\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -191,10 +191,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.props')" Text="$([System.String]::Format('$(ErrorText)', 'C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.props'))" />
-    <Error Condition="!Exists('C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.targets')" Text="$([System.String]::Format('$(ErrorText)', 'C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.props'))" />
+    <Error Condition="!Exists('..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets'))" />
   </Target>
-  <Import Project="C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.targets" Condition="Exists('C:\projects\alex\Platform\trunk\Nuget\Repository\Antlr4.4.5-alpha002\build\Antlr4.targets')" />
+  <Import Project="..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets" Condition="Exists('..\..\packages\Antlr4.4.5-alpha002\build\Antlr4.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/GraphQL/Language/IntValue.cs
+++ b/src/GraphQL/Language/IntValue.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GraphQL.Language
@@ -142,6 +143,35 @@ namespace GraphQL.Language
             if (obj.GetType() != this.GetType()) return false;
 
             return Equals((BooleanValue)obj);
+        }
+    }
+
+    public class DateTimeValue : AbstractNode, IValue
+    {
+        public DateTimeValue(DateTime value)
+        {
+            Value = value;
+        }
+
+        public DateTime Value { get; }
+
+        public override string ToString()
+        {
+            return "DateTimeValue{{value={0}}}".ToFormat(Value.ToString("o"));
+        }
+
+        protected bool Equals(DateTimeValue other)
+        {
+            return DateTime.Equals(Value, other.Value);
+        }
+
+        public override bool IsEqualTo(INode obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+
+            return Equals((DateTimeValue)obj);
         }
     }
 

--- a/src/GraphQL/Types/DateGraphType.cs
+++ b/src/GraphQL/Types/DateGraphType.cs
@@ -21,31 +21,30 @@ namespace GraphQL.Types
 
         public override object ParseValue(object value)
         {
-            string inputValue;
-            DateTime dateTime;
-
             if (value is DateTime)
             {
-                inputValue = ((DateTime)value).ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF'Z'");
-            }
-            else
-            {
-                inputValue = value != null ? value.ToString().Trim('"') : string.Empty;
+                return value;
             }
 
-            if (DateTime.TryParse(inputValue, CultureInfo.CurrentCulture, DateTimeStyles.AdjustToUniversal,
-                out dateTime))
-            {
-                return dateTime;
+            string inputValue = (string)value;
+            DateTime outputValue;
+            if (DateTime.TryParse(
+                inputValue,
+                CultureInfo.CurrentCulture,
+                DateTimeStyles.AdjustToUniversal,
+                out outputValue))
+            { 
+                return outputValue;
             }
+
             return null;
         }
 
         public override object ParseLiteral(IValue value)
         {
-            if (value is StringValue)
+            if (value is DateTimeValue)
             {
-                return ParseValue(((StringValue)value).Value);
+                return ((DateTimeValue)value).Value.ToString("o");
             }
 
             return null;

--- a/src/GraphQL/Types/DateGraphType.cs
+++ b/src/GraphQL/Types/DateGraphType.cs
@@ -23,10 +23,11 @@ namespace GraphQL.Types
         {
             if (value is DateTime)
             {
-                return value;
+                DateTime dateTime = (DateTime)value;
+                return dateTime.Kind == DateTimeKind.Utc ? value : dateTime.ToUniversalTime();
             }
             
-            string inputValue = value.ToString();
+            string inputValue = value?.ToString();
 
             DateTime outputValue;
             if (DateTime.TryParse(
@@ -45,7 +46,12 @@ namespace GraphQL.Types
         {
             if (value is DateTimeValue)
             {
-                return ((DateTimeValue)value).Value.ToString("o");
+                return ((DateTimeValue)value).Value;
+            }
+
+            if (value is StringValue)
+            {
+                return ParseValue(((StringValue)value).Value.Trim('"'));
             }
 
             return null;

--- a/src/GraphQL/Types/DateGraphType.cs
+++ b/src/GraphQL/Types/DateGraphType.cs
@@ -46,7 +46,7 @@ namespace GraphQL.Types
         {
             if (value is DateTimeValue)
             {
-                return ((DateTimeValue)value).Value;
+                return ParseValue(((DateTimeValue)value).Value);
             }
 
             if (value is StringValue)

--- a/src/GraphQL/Types/DateGraphType.cs
+++ b/src/GraphQL/Types/DateGraphType.cs
@@ -24,7 +24,7 @@ namespace GraphQL.Types
             if (value is DateTime)
             {
                 DateTime dateTime = (DateTime)value;
-                return dateTime.Kind == DateTimeKind.Utc ? value : dateTime.ToUniversalTime();
+                return dateTime.Kind == DateTimeKind.Utc ? dateTime : dateTime.ToUniversalTime();
             }
             
             string inputValue = value?.ToString();

--- a/src/GraphQL/Types/DateGraphType.cs
+++ b/src/GraphQL/Types/DateGraphType.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Types
                 return dateTime.Kind == DateTimeKind.Utc ? dateTime : dateTime.ToUniversalTime();
             }
             
-            string inputValue = value?.ToString();
+            string inputValue = value?.ToString().Trim('"');
 
             DateTime outputValue;
             if (DateTime.TryParse(
@@ -51,7 +51,7 @@ namespace GraphQL.Types
 
             if (value is StringValue)
             {
-                return ParseValue(((StringValue)value).Value.Trim('"'));
+                return ParseValue(((StringValue)value).Value);
             }
 
             return null;

--- a/src/GraphQL/Types/DateGraphType.cs
+++ b/src/GraphQL/Types/DateGraphType.cs
@@ -25,8 +25,9 @@ namespace GraphQL.Types
             {
                 return value;
             }
+            
+            string inputValue = value.ToString();
 
-            string inputValue = (string)value;
             DateTime outputValue;
             if (DateTime.TryParse(
                 inputValue,


### PR DESCRIPTION
This is done by introducing a `Language\DateTimeValue` class, avoiding the need to `.ToString()` DateTime objects in `DocumentExecuter.AstFromValue()`.

Also prevents round-tripping of DateTime objects in `DateGraphType`.

Fixes #139 