### PR TITLE
Switch to double.Parse for FloatValue

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
@@ -1,0 +1,46 @@
+﻿using GraphQL.Types;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class Bug138DecimalPrecisionTests : QueryTestBase<DecimalSchema>
+    {
+        [Fact]
+        public void double_to_decimal_does_not_lose_precision()
+        {
+            var query = @"
+                mutation SetState{
+                    set(request:24.15)
+                }
+            ";
+
+            var expected = @"{
+              set: 24.15
+            }";
+
+            AssertQuerySuccess(query, expected);
+        }
+    }
+
+    public class DecimalSchema : Schema
+    {
+        public DecimalSchema()
+        {
+            Mutation = new DecimalMutation();
+        }
+    }
+
+    public class DecimalMutation : ObjectGraphType
+    {
+        public DecimalMutation()
+        {
+            Field<DecimalGraphType>(
+                "set",
+                arguments: new QueryArguments(new QueryArgument<DecimalGraphType> { Name = "request"}),
+                resolve: context =>
+                {
+                    var val = context.Argument<decimal>("request");
+                    return val;
+                });
+        }
+    }
+}

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bugs\Bug118SpacesInTypeNameTests.cs" />
+    <Compile Include="Bugs\Bug138DecimalPrecisionTests.cs" />
     <Compile Include="Bugs\Bug68NonNullEnumGraphTypeTests.cs" />
     <Compile Include="Builders\ConnectionBuilderTests.cs" />
     <Compile Include="Builders\FieldBuilderTests.cs" />

--- a/src/GraphQL/Language/GraphQLVisitor.cs
+++ b/src/GraphQL/Language/GraphQLVisitor.cs
@@ -45,7 +45,7 @@ namespace GraphQL.Language
 
             if (context.FloatValue() != null)
             {
-                var val = new FloatValue(float.Parse(context.FloatValue().GetText()));
+                var val = new FloatValue(double.Parse(context.FloatValue().GetText()));
                 NewNode(val, context);
                 return val;
             }
@@ -109,7 +109,7 @@ namespace GraphQL.Language
 
             if (context.FloatValue() != null)
             {
-                var val = new FloatValue(float.Parse(context.FloatValue().GetText()));
+                var val = new FloatValue(double.Parse(context.FloatValue().GetText()));
                 NewNode(val, context);
                 return val;
             }


### PR DESCRIPTION
* When FloatValue was updated to use double the GraphQLVisitor was
  not updated to match.

Fixes #138 