### PR TITLE
Add known fragment names validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Console.Writeline(result);
 - [ ] Fragments on composite type
 - [x] Known argument names
 - [ ] Known directives
-- [ ] Known fragment names
+- [x] Known fragment names
 - [x] Known type names
 - [x] Lone anonymous operations
 - [ ] No fragment cycle

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Validation\ArgumentsOfCorrectTypeTests.cs" />
     <Compile Include="Validation\DefaultValuesOfCorrectTypeTests.cs" />
     <Compile Include="Validation\KnownArgumentNamesTests.cs" />
+    <Compile Include="Validation\KnownFragmentNamesTests.cs" />
     <Compile Include="Validation\KnownTypeNamesTests.cs" />
     <Compile Include="Validation\LoneAnonymousOperationTests.cs" />
     <Compile Include="Validation\NoUndefinedVariablesTests.cs" />

--- a/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
@@ -53,5 +53,27 @@
 
             AssertQuerySuccess(query, expected);
         }
+
+        [Fact]
+        public void use_unnamed_inline_fragment_on_interface()
+        {
+            var query = @"
+               query SomeDroids {
+                  r2d2: droid(id: ""3"") {
+                    ... {
+                      name
+                    }
+                  }
+               }
+            ";
+
+            var expected = @"{
+              'r2d2': {
+                name: 'R2-D2'
+              },
+            }";
+
+            AssertQuerySuccess(query, expected);
+        }
     }
 }

--- a/src/GraphQL.Tests/Validation/KnownFragmentNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/KnownFragmentNamesTests.cs
@@ -1,0 +1,73 @@
+﻿using GraphQL.Validation.Rules;
+
+namespace GraphQL.Tests.Validation
+{
+  public class KnownFragmentNamesTests : ValidationTestBase<KnownFragmentNames, ValidationSchema>
+  {
+    [Fact]
+    public void known_fragment_names_are_valid()
+    {
+      ShouldPassRule(@"
+        {
+          human(id: 4) {
+            ...HumanFields1
+            ... on Human {
+              ...HumanFields2
+            }
+            ... {
+              name
+            }
+          }
+        }
+        fragment HumanFields1 on Human {
+          name
+          ...HumanFields3
+        }
+        fragment HumanFields2 on Human {
+          name
+        }
+        fragment HumanFields3 on Human {
+          name
+        }
+      ");
+    }
+
+    [Fact]
+    public void unknown_fragment_names_are_invalid()
+    {
+      ShouldFailRule(_ =>
+      {
+        _.Query = @"
+          {
+            human(id: 4) {
+              ...UnknownFragment1
+              ... on Human {
+                ...UnknownFragment2
+              }
+            }
+          }
+          fragment HumanFields on Human {
+            name
+            ...UnknownFragment3
+          }
+        ";
+        undefFrag(_, "UnknownFragment1", 4, 15);
+        undefFrag(_, "UnknownFragment2", 6, 17);
+        undefFrag(_, "UnknownFragment3", 12, 13);
+      });
+    }
+
+    private void undefFrag(
+      ValidationTestConfig _,
+      string fragName,
+      int line,
+      int column)
+    {
+      _.Error(err =>
+      {
+        err.Message = Rule.UnknownFragmentMessage(fragName);
+        err.Loc(line, column);
+      });
+    }
+  }
+}

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -766,8 +766,10 @@ namespace GraphQL
                 {
                     var inline = (InlineFragment)selection;
 
+                    var name = inline.Type != null ? inline.Type.Name : specificType.Name;
+
                     if (!ShouldIncludeNode(context, inline.Directives)
-                      || !DoesFragmentConditionMatch(context, inline.Type.Name, specificType))
+                      || !DoesFragmentConditionMatch(context, name, specificType))
                     {
                         return;
                     }

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Validation\Rules\ArgumentsOfCorrectType.cs" />
     <Compile Include="Validation\Rules\DefaultValuesOfCorrectType.cs" />
     <Compile Include="Validation\Rules\KnownArgumentNames.cs" />
+    <Compile Include="Validation\Rules\KnownFragmentNames.cs" />
     <Compile Include="Validation\Rules\KnownTypeNames.cs" />
     <Compile Include="Validation\Rules\LoneAnonymousOperation.cs" />
     <Compile Include="Validation\EnterLeaveListener.cs" />

--- a/src/GraphQL/GraphQL.g4
+++ b/src/GraphQL/GraphQL.g4
@@ -54,13 +54,13 @@ argument : NAME ':' valueWithVariable;
 
 fragmentSpread : '...' fragmentName directives?;
 
-inlineFragment : '...' 'on' typeCondition directives? selectionSet;
+inlineFragment : '...' typeCondition? directives? selectionSet;
 
-fragmentDefinition : 'fragment' fragmentName 'on' typeCondition directives? selectionSet;
+fragmentDefinition : 'fragment' fragmentName typeCondition directives? selectionSet;
 
 fragmentName :  NAME;
 
-typeCondition : typeName;
+typeCondition : 'on' typeName;
 
 // Value
 

--- a/src/GraphQL/Language/GraphQLVisitor.cs
+++ b/src/GraphQL/Language/GraphQLVisitor.cs
@@ -361,7 +361,10 @@ namespace GraphQL.Language
             var fragment = new InlineFragment();
             NewNode(fragment, context);
 
-            fragment.Type = Visit(context.typeCondition().typeName()) as NamedType;
+            if (context.typeCondition() != null)
+            {
+                fragment.Type = Visit(context.typeCondition().typeName()) as NamedType;
+            }
 
             if (context.directives() != null)
             {

--- a/src/GraphQL/Language/InlineFragment.cs
+++ b/src/GraphQL/Language/InlineFragment.cs
@@ -14,7 +14,10 @@ namespace GraphQL.Language
         {
             get
             {
-                yield return Type;
+                if (Type != null)
+                {
+                    yield return Type;
+                }
 
                 if (Directives != null)
                 {

--- a/src/GraphQL/Language/SelectionSet.cs
+++ b/src/GraphQL/Language/SelectionSet.cs
@@ -30,7 +30,7 @@ namespace GraphQL.Language
 
         public override string ToString()
         {
-            var sel = string.Join(", ", _selections.Select(s => s.ToString()));
+            var sel = string.Join(", ", _selections.Select(s => s?.ToString() ?? "null"));
             return $"SelectionSet{{selections={sel}}}";
         }
     }

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -59,6 +59,7 @@ namespace GraphQL.Validation
                 new VariablesAreInputTypes(),
                 new ScalarLeafs(),
                 new UniqueFragmentNames(),
+                new KnownFragmentNames(),
                 new NoUndefinedVariables(),
                 new NoUnusedVariables(),
                 new UniqueVariableNames(),

--- a/src/GraphQL/Validation/Rules/KnownFragmentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownFragmentNames.cs
@@ -1,0 +1,35 @@
+﻿using GraphQL.Language;
+
+namespace GraphQL.Validation.Rules
+{
+  /// <summary>
+  /// Known fragment names
+  /// 
+  /// A GraphQL document is only valid if all <c>...Fragment</c> fragment spreads refer
+  /// to fragments defined in the same document.
+  /// </summary>
+  public class KnownFragmentNames : IValidationRule
+  {
+    public string UnknownFragmentMessage(string fragName)
+    {
+      return $"Unknown fragment \"{fragName}\".";
+    }
+
+    public INodeVisitor Validate(ValidationContext context)
+    {
+      return new EnterLeaveListener(_ =>
+      {
+        _.Match<FragmentSpread>(node =>
+        {
+          var fragmentName = node.Name;
+          var fragment = context.GetFragment(fragmentName);
+          if (fragment == null)
+          {
+            var error = new ValidationError("5.4.2.1", UnknownFragmentMessage(fragmentName), node);
+            context.ReportError(error);
+          }
+        });
+      });
+    }
+  }
+}

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -114,7 +114,7 @@ namespace GraphQL.Validation
             if (node is InlineFragment)
             {
                 var def = (InlineFragment) node;
-                var type = _schema.FindType(def.Type.Name);
+                var type = def.Type != null ? _schema.FindType(def.Type.Name) : GetLastType();
                 _typeStack.Push(type);
                 return;
             }


### PR DESCRIPTION
Issue #10 

The modification in `SelectionSet` was needed in order for `ShouldPassRule` in `known_fragment_names_are_valid` to not get an exception. There were several `null` selections for some reason.