### PR TITLE
Added no unused fragments validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Console.Writeline(result);
 - [x] Lone anonymous operations
 - [ ] No fragment cycle
 - [x] No undefined variables
-- [ ] No unused fragments
+- [x] No unused fragments
 - [x] No unused variables
 - [ ] Overlapping fields can be merged
 - [ ] Possible fragment spreads

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Types\FloatGraphTypeTests.cs" />
     <Compile Include="Types\QueryArgumentTests.cs" />
     <Compile Include="Utilities\AstPrinterTests.cs" />
+    <Compile Include="Validation\NoUnusedFragmentsTests.cs" />
     <Compile Include="Utilities\SchemaPrinterTests.cs" />
     <Compile Include="CustomConvention.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/GraphQL.Tests/Validation/NoUnusedFragmentsTests.cs
+++ b/src/GraphQL.Tests/Validation/NoUnusedFragmentsTests.cs
@@ -1,0 +1,170 @@
+﻿using GraphQL.Validation.Rules;
+
+namespace GraphQL.Tests.Validation
+{
+  public class NoUnusedFragmentsTests : ValidationTestBase<NoUnusedFragments, ValidationSchema>
+  {
+    [Fact]
+    public void all_fragment_names_are_used()
+    {
+      ShouldPassRule(@"
+        {
+          human(id: 4) {
+            ...HumanFields1
+            ... on Human {
+              ...HumanFields2
+            }
+          }
+        }
+        fragment HumanFields1 on Human {
+          name
+          ...HumanFields3
+        }
+        fragment HumanFields2 on Human {
+          name
+        }
+        fragment HumanFields3 on Human {
+          name
+        }
+      ");
+    }
+
+    [Fact]
+    public void all_fragment_names_are_used_by_multiple_operations()
+    {
+      ShouldPassRule(@"
+        query Foo {
+          human(id: 4) {
+            ...HumanFields1
+          }
+        }
+        query Bar {
+          human(id: 4) {
+            ...HumanFields2
+          }
+        }
+        fragment HumanFields1 on Human {
+          name
+          ...HumanFields3
+        }
+        fragment HumanFields2 on Human {
+          name
+        }
+        fragment HumanFields3 on Human {
+          name
+        }
+      ");
+    }
+
+    [Fact]
+    public void contains_unknown_fragments()
+    {
+      ShouldFailRule(_ =>
+      {
+        _.Query = @"
+          query Foo {
+            human(id: 4) {
+              ...HumanFields1
+            }
+          }
+          query Bar {
+            human(id: 4) {
+              ...HumanFields2
+            }
+          }
+          fragment HumanFields1 on Human {
+            name
+            ...HumanFields3
+          }
+          fragment HumanFields2 on Human {
+            name
+          }
+          fragment HumanFields3 on Human {
+            name
+          }
+          fragment Unused1 on Human {
+            name
+          }
+          fragment Unused2 on Human {
+            name
+          }
+        ";
+        unusedFrag(_, "Unused1", 22, 11);
+        unusedFrag(_, "Unused2", 25, 11);
+      });
+    }
+
+    [Fact]
+    public void contains_unknown_fragments_with_ref_cycle()
+    {
+      ShouldFailRule(_ =>
+      {
+        _.Query = @"
+          query Foo {
+            human(id: 4) {
+              ...HumanFields1
+            }
+          }
+          query Bar {
+            human(id: 4) {
+              ...HumanFields2
+            }
+          }
+          fragment HumanFields1 on Human {
+            name
+            ...HumanFields3
+          }
+          fragment HumanFields2 on Human {
+            name
+          }
+          fragment HumanFields3 on Human {
+            name
+          }
+          fragment Unused1 on Human {
+            name
+            ...Unused2
+          }
+          fragment Unused2 on Human {
+            name
+            ...Unused1
+          }
+        ";
+        unusedFrag(_, "Unused1", 22, 11);
+        unusedFrag(_, "Unused2", 26, 11);
+      });
+    }
+
+    [Fact]
+    public void contains_unknown_and_undef_fragments()
+    {
+      ShouldFailRule(_ =>
+      {
+        _.Query = @"
+          query Foo {
+            human(id: 4) {
+              ...bar
+            }
+          }
+          fragment foo on Human {
+            name
+          }
+        ";
+        unusedFrag(_, "foo", 7, 11);
+      });
+    }
+
+    private void unusedFrag(
+      ValidationTestConfig _,
+      string varName,
+      int line,
+      int column
+      )
+    {
+      _.Error(err =>
+      {
+        err.Message = Rule.UnusedFragMessage(varName);
+        err.Loc(line, column);
+      });
+    }
+  }
+}

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Validation\Rules\LoneAnonymousOperation.cs" />
     <Compile Include="Validation\EnterLeaveListener.cs" />
     <Compile Include="Validation\Rules\NoUndefinedVariables.cs" />
+    <Compile Include="Validation\Rules\NoUnusedFragments.cs" />
     <Compile Include="Validation\Rules\NoUnusedVariables.cs" />
     <Compile Include="Validation\Rules\ScalarLeafs.cs" />
     <Compile Include="Validation\Rules\UniqueArgumentNames.cs" />

--- a/src/GraphQL/Language/InlineFragment.cs
+++ b/src/GraphQL/Language/InlineFragment.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQL.Language
 {
-    public class InlineFragment : AbstractNode, IFragment
+    public class InlineFragment : AbstractNode, IFragment, IHaveSelectionSet
     {
         public NamedType Type { get; set; }
 

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -60,6 +60,7 @@ namespace GraphQL.Validation
                 new ScalarLeafs(),
                 new UniqueFragmentNames(),
                 new KnownFragmentNames(),
+                new NoUnusedFragments(),
                 new NoUndefinedVariables(),
                 new NoUnusedVariables(),
                 new UniqueVariableNames(),

--- a/src/GraphQL/Validation/Rules/NoUnusedFragments.cs
+++ b/src/GraphQL/Validation/Rules/NoUnusedFragments.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using GraphQL.Language;
+
+namespace GraphQL.Validation.Rules
+{
+  /// <summary>
+  /// No unused fragments
+  /// 
+  /// A GraphQL document is only valid if all fragment definitions are spread
+  /// within operations, or spread within other fragments spread within operations.
+  /// </summary>
+  public class NoUnusedFragments : IValidationRule
+  {
+    public string UnusedFragMessage(string fragName)
+    {
+      return $"Fragment \"{fragName}\" is never used.";
+    }
+
+    public INodeVisitor Validate(ValidationContext context)
+    {
+      var operationDefs = new List<Operation>();
+      var fragmentDefs = new List<FragmentDefinition>();
+
+      return new EnterLeaveListener(_ =>
+      {
+        _.Match<Operation>(node => operationDefs.Add(node));
+        _.Match<FragmentDefinition>(node => fragmentDefs.Add(node));
+        _.Match<Document>(
+          leave: document =>
+          {
+            var fragmentNameUsed = new List<string>();
+            operationDefs.Apply(operation =>
+            {
+              context.GetRecursivelyReferencedFragments(operation).Apply(fragment =>
+              {
+                fragmentNameUsed.Add(fragment.Name);
+              });
+            });
+
+            fragmentDefs.Apply(fragmentDef =>
+            {
+              var fragName = fragmentDef.Name;
+              if (!fragmentNameUsed.Contains(fragName))
+              {
+                var error = new ValidationError("5.4.1.4", UnusedFragMessage(fragName), fragmentDef);
+                context.ReportError(error);
+              }
+            });
+          });
+      });
+    }
+  }
+}


### PR DESCRIPTION
Issue #10 

Added `IHaveSelectionSet` to `InlineFragment`, which was required for the first test to pass, and matches the semantics of graphql-js.