### PR TITLE
backslash bug fix

### DIFF
--- a/src/GraphQL.Tests/Types/StringGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/StringGraphTypeTests.cs
@@ -29,5 +29,20 @@ namespace GraphQL.Tests.Types
         {
             _type.ParseValue("\"").ShouldEqual("\"");
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Fact]
+        public void parses_backslash()
+        {
+            _type.ParseValue(@"\\").ShouldEqual(@"\");
+        }
+
+        [Fact]
+        public void keeps_backslash_in_string()
+        {
+            _type.ParseValue(@"c:\\\\windows\\test").ShouldEqual(@"c:\\windows\test");
+        }
     }
 }

--- a/src/GraphQL/Types/StringGraphType.cs
+++ b/src/GraphQL/Types/StringGraphType.cs
@@ -29,6 +29,7 @@ namespace GraphQL.Types
 
         private string ProcessString(string value)
         {
+            value = value.Replace("\\\\", "\\");
             value = value.Replace("\\\"", "\"");
             if (value.StartsWith("\"") && value.EndsWith("\"") && value.Length > 1)
             {


### PR DESCRIPTION
Fixed an issue where a backslash isn't properly handled. The case would be 

{
    query(path:"c:\\\\windows\\test"){ files }
}

would not be propertly handled. See http://stackoverflow.com/questions/37709250/sending-double-quotes-and-backslash-in-graphql-request
