### PR TITLE
Add test and fix for weird description error on __type introspection.

### DIFF
--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -17,5 +17,64 @@ namespace GraphQL.Tests.Introspection
 
             json.ShouldBe(IntrospectionResult.Data);
         }
+
+        [Fact]
+        public void validate_non_null_schema()
+        {
+            var documentExecuter = new DocumentExecuter();
+            var executionResult = documentExecuter.ExecuteAsync(new TestSchema(), null, InputObjectBugQuery, null).Result;
+            var json = new DocumentWriter(true).Write(executionResult.Data);
+            executionResult.Errors.ShouldBeNull();
+
+            json.ShouldBe(InputObjectBugResult);
+        }
+
+        public static readonly string InputObjectBugQuery = @"
+query test {
+    __type(name:""SomeInput"") {
+        inputFields {
+            type {
+                name,
+                description
+                ofType {
+                    kind,
+                    name
+                }
+            }
+        }
+    }
+}";
+
+        public static readonly string InputObjectBugResult = "{\r\n  \"__type\": {\r\n    \"inputFields\": [\r\n      {\r\n        \"type\": {\r\n          \"name\": \"String\",\r\n          \"description\": null,\r\n          \"ofType\": null\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}";
+
+        public class SomeInputType : InputObjectGraphType
+        {
+            public SomeInputType()
+                : base()
+            {
+                Name = "SomeInput";
+                Description = "Input values for a patient's demographic information";
+
+                Field<StringGraphType>("address");
+            }
+        }
+
+        public class RootMutation : ObjectGraphType
+        {
+            public RootMutation()
+            {
+                Field<StringGraphType>(
+                    "test",
+                    arguments: new QueryArguments(new QueryArgument(typeof(SomeInputType)) { Name = "some" }));
+            }
+        }
+
+        public class TestSchema : Schema
+        {
+            public TestSchema()
+            {
+                Mutation = new RootMutation();
+            }
+        }
     }
 }

--- a/src/GraphQL/Introspection/__InputValue.cs
+++ b/src/GraphQL/Introspection/__InputValue.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Introspection
                 "and optionally a default value.";
             Field<NonNullGraphType<StringGraphType>>("name");
             Field<StringGraphType>("description");
-            Field<NonNullGraphType<__Type>>("type");
+            Field<NonNullGraphType<__Type>>("type", resolve: ctx => ctx.Schema.FindType(ctx.Source.Type));
             Field<StringGraphType>(
                 "defaultValue",
                 "A GraphQL-formatted string representing the default value for this input value.",

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -1,10 +1,6 @@
-﻿using GraphQL.Types;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
@@ -16,10 +12,21 @@ namespace GraphQL.Resolvers
         {
             var source = context.Source;
 
-            return source?.GetType()
+            if (source == null)
+            {
+                return null;
+            }
+
+            var prop = source.GetType()
                 .GetTypeInfo()
-                .GetProperty(context.FieldAst.Name, _flags)
-                .GetValue(source, null);
+                .GetProperty(context.FieldAst.Name, _flags);
+
+            if (prop == null)
+            {
+                throw new InvalidOperationException($"Expected to find property {context.FieldAst.Name} on {context.Source.GetType().Name} but it does not exist.");
+            }
+
+            return prop.GetValue(source, null);
         }
     }
 }


### PR DESCRIPTION
I was using introspection to get metadata on my input types so my React UI could change according to back-end specification and I encountered this bug.

The data is returned anyway (in the test), but there was an error in the `Errors` collection indicating a null reference exception when getting the description.

In `NameFieldResolver`, the `source` was the *type* `StringGraphType` and not an instance. I'm not too sure why or if it's normal, but it broke my use-case.

I'm not sure if the test is in the right place or my variables or the test schema, please comment and tell me what I can change!