### PR TITLE
Fix for "Location of errors is always line:0, column:0"

### DIFF
--- a/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using GraphQL.Language;
-using GraphQL.Language.AST;
 using GraphQL.Types;
-using GraphQLParser;
-using GraphQLParser.AST;
 using Shouldly;
 using Xunit;
 
@@ -13,17 +9,16 @@ namespace GraphQL.Tests.Errors
 {
     public class ErrorLocationTests : QueryTestBase<ErrorLocationTests.TestSchema>
     {
-        [Fact]
-        public async Task should_show_location_when_exception_thrown()
+        [Theory]
+        [InlineData("{\n    test\n}", 2, 5)]
+        [InlineData("{  test\n}", 1, 4)]
+        [InlineData("{\n    test\n  cat\n}", 3, 3)]
+        public async Task should_show_location_when_exception_thrown(string body, int line, int column)
         {
-            const string query = @"{
-    test
-}";
-
-            var result =  await Executer.ExecuteAsync(
+            var result = await Executer.ExecuteAsync(
                 Schema,
                 null,
-                query,
+                body,
                 null
                 );
 
@@ -31,32 +26,8 @@ namespace GraphQL.Tests.Errors
             var error = result.Errors.First();
             error.Locations.Count().ShouldBe(1);
             var location = error.Locations.First();
-            location.Line.ShouldBe(2);
-            location.Column.ShouldBe(5);
-        }
-
-        [Theory]
-        [InlineData("{\n    test\n}", 6, 12, 2, 5)]
-        [InlineData("{  test\n}", 3, 9, 1, 4)]
-        public void should_calculate_line_and_column(string body, int start, int end, int line, int column)
-        {
-            var node = new TestNode();
-            node.Location = new GraphQLLocation() { Start = start, End = end };
-            var source = new TestSource() { Body = body };
-            var field = new Field().WithLocation(node, source);
-            field.SourceLocation.ShouldBe(new SourceLocation(line, column, start, end));
-        }
-
-        public class TestSource : ISource
-        {
-            public string Body { get; set; }
-
-            public string Name { get; set; }
-        }
-
-        public class TestNode : ASTNode
-        {
-            public override ASTNodeKind Kind { get { return ASTNodeKind.Field; } }
+            location.Line.ShouldBe(line);
+            location.Column.ShouldBe(column);
         }
 
         public class TestQuery : ObjectGraphType

--- a/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Errors
+{
+    public class ErrorLocationTests : QueryTestBase<ErrorLocationTests.TestSchema>
+    {
+        [Fact]
+        public async Task should_show_location_when_exception_thrown()
+        {
+            const string query = @"{
+    test
+}";
+
+            var result =  await Executer.ExecuteAsync(
+                Schema,
+                null,
+                query,
+                null
+                );
+
+            result.Errors.Count.ShouldBe(1);
+            var error = result.Errors.First();
+            error.Locations.Count().ShouldBe(1);
+            var location = error.Locations.First();
+            location.Line.ShouldBe(1);
+            location.Column.ShouldBe(4);
+        }
+
+        public class TestQuery : ObjectGraphType
+        {
+            public TestQuery()
+            {
+                Name = "Query";
+
+                Field<StringGraphType>()
+                    .Name("test")
+                    .Resolve(_ => { throw new Exception("wat"); });
+            }
+        }
+
+        public class TestSchema : Schema
+        {
+            public TestSchema()
+            {
+                Query = new TestQuery();
+            }
+        }
+    }
+}

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -12,6 +12,8 @@ namespace GraphQL.Execution
             Errors = new ExecutionErrors();
         }
 
+        public Document Document { get; set; }
+
         public ISchema Schema { get; set; }
 
         public object RootValue { get; set; }

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using GraphQL.Language.AST;
+using GraphQLParser;
 
 namespace GraphQL
 {
@@ -27,7 +28,7 @@ namespace GraphQL
                 _errorLocations = new List<ErrorLocation>();
             }
 
-            _errorLocations.Add(new ErrorLocation {Line = line, Column = column});
+            _errorLocations.Add(new ErrorLocation { Line = line, Column = column });
         }
     }
 
@@ -39,11 +40,20 @@ namespace GraphQL
 
     public static class ExecutionErrorExtensions
     {
-        public static void AddLocation(this ExecutionError error, Field field)
+        public static void AddLocation(this ExecutionError error, AbstractNode abstractNode, Document document)
         {
-            if (field != null)
+
+            if (abstractNode != null)
             {
-                error.AddLocation(field.SourceLocation.Line, field.SourceLocation.Column);
+                if (document != null)
+                {
+                    var location = new Location(new Source(document.OriginalQuery), abstractNode.SourceLocation.Start);
+                    error.AddLocation(location.Line, location.Column);
+                }
+                else if (abstractNode.SourceLocation.Line > 0 && abstractNode.SourceLocation.Column > 0)
+                {
+                    error.AddLocation(abstractNode.SourceLocation.Line, abstractNode.SourceLocation.Column);
+                }
             }
         }
     }

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Language.AST;
 using GraphQLParser;
 using GraphQLParser.AST;
-using OperationType = GraphQL.Language.AST.OperationType;
 using OperationTypeParser = GraphQLParser.AST.OperationType;
+using OperationType = GraphQL.Language.AST.OperationType;
 
 namespace GraphQL.Language
 {
@@ -118,17 +117,17 @@ namespace GraphQL.Language
             switch (source.Kind)
             {
                 case ASTNodeKind.Field:
-                    {
-                        return Field((GraphQLFieldSelection)source);
-                    }
+                {
+                    return Field((GraphQLFieldSelection) source);
+                }
                 case ASTNodeKind.FragmentSpread:
-                    {
-                        return FragmentSpread((GraphQLFragmentSpread)source);
-                    }
+                {
+                    return FragmentSpread((GraphQLFragmentSpread) source);
+                }
                 case ASTNodeKind.InlineFragment:
-                    {
-                        return InlineFragment((GraphQLInlineFragment)source);
-                    }
+                {
+                    return InlineFragment((GraphQLInlineFragment) source);
+                }
             }
 
             throw new ExecutionError($"Unmapped selection {source.Kind}");
@@ -175,63 +174,63 @@ namespace GraphQL.Language
             switch (source.Kind)
             {
                 case ASTNodeKind.StringValue:
-                    {
-                        var str = source as GraphQLScalarValue;
-                        return new StringValue($"{str.Value}").WithLocation(str, _body);
-                    }
+                {
+                    var str = source as GraphQLScalarValue;
+                    return new StringValue($"{str.Value}").WithLocation(str, _body);
+                }
                 case ASTNodeKind.IntValue:
+                {
+                    var str = source as GraphQLScalarValue;
+
+                    int intResult;
+                    if (int.TryParse(str.Value, out intResult))
                     {
-                        var str = source as GraphQLScalarValue;
-
-                        int intResult;
-                        if (int.TryParse(str.Value, out intResult))
-                        {
-                            var val = new IntValue(intResult).WithLocation(str, _body);
-                            return val;
-                        }
-
-                        // If the value doesn't fit in an integer, revert to using long...
-                        long longResult;
-                        if (long.TryParse(str.Value, out longResult))
-                        {
-                            var val = new LongValue(longResult).WithLocation(str, _body);
-                            return val;
-                        }
-
-                        throw new ExecutionError($"Invalid number {str.Value}");
+                        var val = new IntValue(intResult).WithLocation(str, _body);
+                        return val;
                     }
+
+                    // If the value doesn't fit in an integer, revert to using long...
+                    long longResult;
+                    if (long.TryParse(str.Value, out longResult))
+                    {
+                        var val = new LongValue(longResult).WithLocation(str, _body);
+                        return val;
+                    }
+
+                    throw new ExecutionError($"Invalid number {str.Value}");
+                }
                 case ASTNodeKind.FloatValue:
-                    {
-                        var str = source as GraphQLScalarValue;
-                        return new FloatValue(double.Parse(str.Value)).WithLocation(str, _body);
-                    }
+                {
+                    var str = source as GraphQLScalarValue;
+                    return new FloatValue(double.Parse(str.Value)).WithLocation(str, _body);
+                }
                 case ASTNodeKind.BooleanValue:
-                    {
-                        var str = source as GraphQLScalarValue;
-                        return new BooleanValue(bool.Parse(str.Value)).WithLocation(str, _body);
-                    }
+                {
+                    var str = source as GraphQLScalarValue;
+                    return new BooleanValue(bool.Parse(str.Value)).WithLocation(str, _body);
+                }
                 case ASTNodeKind.EnumValue:
-                    {
-                        var str = source as GraphQLScalarValue;
-                        return new EnumValue(str.Value).WithLocation(str, _body);
-                    }
+                {
+                    var str = source as GraphQLScalarValue;
+                    return new EnumValue(str.Value).WithLocation(str, _body);
+                }
                 case ASTNodeKind.Variable:
-                    {
-                        var vari = source as GraphQLVariable;
-                        return new VariableReference(Name(vari.Name)).WithLocation(vari, _body);
-                    }
+                {
+                    var vari = source as GraphQLVariable;
+                    return new VariableReference(Name(vari.Name)).WithLocation(vari, _body);
+                }
                 case ASTNodeKind.ObjectValue:
-                    {
-                        var obj = source as GraphQLObjectValue;
-                        var fields = obj.Fields.Select(ObjectField);
-                        return new ObjectValue(fields).WithLocation(obj, _body);
-                    }
+                {
+                    var obj = source as GraphQLObjectValue;
+                    var fields = obj.Fields.Select(ObjectField);
+                    return new ObjectValue(fields).WithLocation(obj, _body);
+                }
                 case ASTNodeKind.ListValue:
-                    {
-                        var list = source as GraphQLListValue;
-                        var values = list.Values.Select(Value);
-                        return new ListValue(values).WithLocation(list, _body);
-                    }
+                {
+                    var list = source as GraphQLListValue;
+                    var values = list.Values.Select(Value);
+                    return new ListValue(values).WithLocation(list, _body);
+                }
             }
 
             throw new ExecutionError($"Unmapped value type {source.Kind}");
@@ -254,22 +253,22 @@ namespace GraphQL.Language
             switch (type.Kind)
             {
                 case ASTNodeKind.NamedType:
-                    {
-                        var name = (GraphQLNamedType)type;
-                        return new NamedType(Name(name.Name)).WithLocation(name, _body);
-                    }
+                {
+                    var name = (GraphQLNamedType) type;
+                    return new NamedType(Name(name.Name)).WithLocation(name, _body);
+                }
 
                 case ASTNodeKind.NonNullType:
-                    {
-                        var nonNull = (GraphQLNonNullType)type;
-                        return new NonNullType(Type(nonNull.Type)).WithLocation(nonNull, _body);
-                    }
+                {
+                    var nonNull = (GraphQLNonNullType) type;
+                    return new NonNullType(Type(nonNull.Type)).WithLocation(nonNull, _body);
+                }
 
                 case ASTNodeKind.ListType:
-                    {
-                        var list = (GraphQLListType)type;
-                        return new ListType(Type(list.Type)).WithLocation(list, _body);
-                    }
+                {
+                    var list = (GraphQLListType) type;
+                    return new ListType(Type(list.Type)).WithLocation(list, _body);
+                }
             }
 
             throw new ExecutionError($"Unmapped type {type.Kind}");

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -118,17 +118,17 @@ namespace GraphQL.Language
             switch (source.Kind)
             {
                 case ASTNodeKind.Field:
-                {
-                    return Field((GraphQLFieldSelection) source);
-                }
+                    {
+                        return Field((GraphQLFieldSelection)source);
+                    }
                 case ASTNodeKind.FragmentSpread:
-                {
-                    return FragmentSpread((GraphQLFragmentSpread) source);
-                }
+                    {
+                        return FragmentSpread((GraphQLFragmentSpread)source);
+                    }
                 case ASTNodeKind.InlineFragment:
-                {
-                    return InlineFragment((GraphQLInlineFragment) source);
-                }
+                    {
+                        return InlineFragment((GraphQLInlineFragment)source);
+                    }
             }
 
             throw new ExecutionError($"Unmapped selection {source.Kind}");
@@ -175,63 +175,63 @@ namespace GraphQL.Language
             switch (source.Kind)
             {
                 case ASTNodeKind.StringValue:
-                {
-                    var str = source as GraphQLScalarValue;
-                    return new StringValue($"{str.Value}").WithLocation(str, _body);
-                }
+                    {
+                        var str = source as GraphQLScalarValue;
+                        return new StringValue($"{str.Value}").WithLocation(str, _body);
+                    }
                 case ASTNodeKind.IntValue:
-                {
-                    var str = source as GraphQLScalarValue;
-
-                    int intResult;
-                    if (int.TryParse(str.Value, out intResult))
                     {
-                        var val = new IntValue(intResult).WithLocation(str, _body);
-                        return val;
-                    }
+                        var str = source as GraphQLScalarValue;
 
-                    // If the value doesn't fit in an integer, revert to using long...
-                    long longResult;
-                    if (long.TryParse(str.Value, out longResult))
-                    {
-                        var val = new LongValue(longResult).WithLocation(str, _body);
-                        return val;
-                    }
+                        int intResult;
+                        if (int.TryParse(str.Value, out intResult))
+                        {
+                            var val = new IntValue(intResult).WithLocation(str, _body);
+                            return val;
+                        }
 
-                    throw new ExecutionError($"Invalid number {str.Value}");
-                }
+                        // If the value doesn't fit in an integer, revert to using long...
+                        long longResult;
+                        if (long.TryParse(str.Value, out longResult))
+                        {
+                            var val = new LongValue(longResult).WithLocation(str, _body);
+                            return val;
+                        }
+
+                        throw new ExecutionError($"Invalid number {str.Value}");
+                    }
                 case ASTNodeKind.FloatValue:
-                {
-                    var str = source as GraphQLScalarValue;
-                    return new FloatValue(double.Parse(str.Value)).WithLocation(str, _body);
-                }
+                    {
+                        var str = source as GraphQLScalarValue;
+                        return new FloatValue(double.Parse(str.Value)).WithLocation(str, _body);
+                    }
                 case ASTNodeKind.BooleanValue:
-                {
-                    var str = source as GraphQLScalarValue;
-                    return new BooleanValue(bool.Parse(str.Value)).WithLocation(str, _body);
-                }
+                    {
+                        var str = source as GraphQLScalarValue;
+                        return new BooleanValue(bool.Parse(str.Value)).WithLocation(str, _body);
+                    }
                 case ASTNodeKind.EnumValue:
-                {
-                    var str = source as GraphQLScalarValue;
-                    return new EnumValue(str.Value).WithLocation(str, _body);
-                }
+                    {
+                        var str = source as GraphQLScalarValue;
+                        return new EnumValue(str.Value).WithLocation(str, _body);
+                    }
                 case ASTNodeKind.Variable:
-                {
-                    var vari = source as GraphQLVariable;
-                    return new VariableReference(Name(vari.Name)).WithLocation(vari, _body);
-                }
+                    {
+                        var vari = source as GraphQLVariable;
+                        return new VariableReference(Name(vari.Name)).WithLocation(vari, _body);
+                    }
                 case ASTNodeKind.ObjectValue:
-                {
-                    var obj = source as GraphQLObjectValue;
-                    var fields = obj.Fields.Select(ObjectField);
-                    return new ObjectValue(fields).WithLocation(obj, _body);
-                }
+                    {
+                        var obj = source as GraphQLObjectValue;
+                        var fields = obj.Fields.Select(ObjectField);
+                        return new ObjectValue(fields).WithLocation(obj, _body);
+                    }
                 case ASTNodeKind.ListValue:
-                {
-                    var list = source as GraphQLListValue;
-                    var values = list.Values.Select(Value);
-                    return new ListValue(values).WithLocation(list, _body);
-                }
+                    {
+                        var list = source as GraphQLListValue;
+                        var values = list.Values.Select(Value);
+                        return new ListValue(values).WithLocation(list, _body);
+                    }
             }
 
             throw new ExecutionError($"Unmapped value type {source.Kind}");
@@ -254,22 +254,22 @@ namespace GraphQL.Language
             switch (type.Kind)
             {
                 case ASTNodeKind.NamedType:
-                {
-                    var name = (GraphQLNamedType) type;
-                    return new NamedType(Name(name.Name)).WithLocation(name, _body);
-                }
+                    {
+                        var name = (GraphQLNamedType)type;
+                        return new NamedType(Name(name.Name)).WithLocation(name, _body);
+                    }
 
                 case ASTNodeKind.NonNullType:
-                {
-                    var nonNull = (GraphQLNonNullType) type;
-                    return new NonNullType(Type(nonNull.Type)).WithLocation(nonNull, _body);
-                }
+                    {
+                        var nonNull = (GraphQLNonNullType)type;
+                        return new NonNullType(Type(nonNull.Type)).WithLocation(nonNull, _body);
+                    }
 
                 case ASTNodeKind.ListType:
-                {
-                    var list = (GraphQLListType) type;
-                    return new ListType(Type(list.Type)).WithLocation(list, _body);
-                }
+                    {
+                        var list = (GraphQLListType)type;
+                        return new ListType(Type(list.Type)).WithLocation(list, _body);
+                    }
             }
 
             throw new ExecutionError($"Unmapped type {type.Kind}");
@@ -303,23 +303,7 @@ namespace GraphQL.Language
         public static T WithLocation<T>(this T node, ASTNode astNode, ISource source)
             where T : AbstractNode
         {
-            if (astNode == null)
-            {
-                return node.WithLocation(0, 0);
-            }
-
-            var startText = source.Body.Substring(0, astNode.Location.Start);
-            var lastLine = startText.Split(new[] { "\n" }, StringSplitOptions.None).Last();
-
-            var line = startText.ToCharArray().Count(x => x == '\n') + 1;
-            var column = astNode.Location.Start - startText.Substring(0, startText.Length - lastLine.Length).Length + 1;
-
-            return node.WithLocation(line, column, astNode.Location.Start, astNode.Location.End);
-        }
-
-        public static Location Location(this ASTNode node, ISource source)
-        {
-            return new Location(source, node.Location.Start);
+            return node.WithLocation(0, 0, astNode?.Location.Start ?? -1, astNode?.Location.End ?? -1);
         }
     }
 }

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Language.AST;
 using GraphQLParser;
 using GraphQLParser.AST;
-using OperationTypeParser = GraphQLParser.AST.OperationType;
 using OperationType = GraphQL.Language.AST.OperationType;
+using OperationTypeParser = GraphQLParser.AST.OperationType;
 
 namespace GraphQL.Language
 {
@@ -302,7 +303,18 @@ namespace GraphQL.Language
         public static T WithLocation<T>(this T node, ASTNode astNode, ISource source)
             where T : AbstractNode
         {
-            return node.WithLocation(0, 0, astNode?.Location.Start ?? -1, astNode?.Location.End ?? -1);
+            if (astNode == null)
+            {
+                return node.WithLocation(0, 0);
+            }
+
+            var startText = source.Body.Substring(0, astNode.Location.Start);
+            var lastLine = startText.Split(new[] { "\n" }, StringSplitOptions.None).Last();
+
+            var line = startText.ToCharArray().Count(x => x == '\n') + 1;
+            var column = astNode.Location.Start - startText.Substring(0, startText.Length - lastLine.Length).Length + 1;
+
+            return node.WithLocation(line, column, astNode.Location.Start, astNode.Location.End);
         }
 
         public static Location Location(this ASTNode node, ISource source)


### PR DESCRIPTION
This crashes Relay in https://github.com/facebook/relay/blob/17096c3f22fbd98d0b4ace26762917e6c6a54832/src/network-layer/default/RelayDefaultNetworkLayer.js#L185 since the line number is 0. The line is then undefined and `substr` fails with an undefined error.

From what I can tell, [DocumentExecuter](https://github.com/graphql-dotnet/graphql-dotnet/blob/b35e118f2d9e2a6154bb39498a55bf17d94af16a/src/GraphQL/Execution/DocumentExecuter.cs#L58) never has line or column on `SourceLocation` (I inspected the object in the debugger).

It seems to always be zero because of [this](https://github.com/graphql-dotnet/graphql-dotnet/blob/b35e118f2d9e2a6154bb39498a55bf17d94af16a/src/GraphQL/Language/CoreToVanillaConverter.cs#L305).

Here is a first draft of a fix. Is this right? 

I think my `should_calculate_line_and_column` test should probably be elsewhere, but I'm not sure where it belongs!

Thanks again for the great library!

(I'll rebase everything into a neat commit once reviewed and approved!)