### PR TITLE
FIX: Unable to recognise interface using `IsSubclassOf()`

### DIFF
--- a/src/GraphQL.Tests/Types/ObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ObjectGraphTypeTests.cs
@@ -1,0 +1,23 @@
+using GraphQL.Types;
+using Shouldly;
+using System.Linq;
+using Xunit;
+
+namespace GraphQL.Tests.Types
+{
+    public class ObjectGraphTypeTests
+    {
+        private ObjectGraphType type = new ObjectGraphType();
+
+        private class TestInterface : InterfaceGraphType
+        {
+        }
+
+        [Fact]
+        public void can_implement_interfaces()
+        {
+            type.Interface<TestInterface>();
+            type.Interfaces.Count().ShouldBe(1);
+        }
+    }
+}

--- a/src/GraphQL/Types/ObjectGraphType.cs
+++ b/src/GraphQL/Types/ObjectGraphType.cs
@@ -1,5 +1,6 @@
 using GraphQL.Builders;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -38,7 +39,7 @@ namespace GraphQL.Types
             {
                 throw new ArgumentNullException(nameof(type));
             }
-            if (!type.GetTypeInfo().IsSubclassOf(typeof(IInterfaceGraphType)))
+            if (!type.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IInterfaceGraphType)))
             {
                 throw new ArgumentException("Interface must implement IInterfaceGraphType", nameof(type));
             }


### PR DESCRIPTION
Using `IsSubclassOf()` will cause `Interface()` to throw an `ArgumentException` regardless of whether `type` implements the `IInterfaceGraphType` interface or not. Changed it to check for implemented interfaces instead.