### PR TITLE
Fix Interface(Type) for generic ObjectGraphType<>

### DIFF
--- a/src/GraphQL.Tests/Types/ObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ObjectGraphTypeTests.cs
@@ -7,16 +7,23 @@ namespace GraphQL.Tests.Types
 {
     public class ObjectGraphTypeTests
     {
-        private ObjectGraphType type = new ObjectGraphType();
-
-        private class TestInterface : InterfaceGraphType
-        {
-        }
+        private class TestInterface : InterfaceGraphType { }
 
         [Fact]
         public void can_implement_interfaces()
         {
-            type.Interface<TestInterface>();
+            var type = new ObjectGraphType();
+            type.Interface(typeof(TestInterface));
+            type.Interfaces.Count().ShouldBe(1);
+        }
+
+        private class TestPoco { }
+
+        [Fact]
+        public void can_implement_interfaces_in_derived_generic()
+        {
+            var type = new ObjectGraphType<TestPoco>();
+            type.Interface(typeof(TestInterface));
             type.Interfaces.Count().ShouldBe(1);
         }
     }

--- a/src/GraphQL/Types/ObjectGraphType.cs
+++ b/src/GraphQL/Types/ObjectGraphType.cs
@@ -84,7 +84,7 @@ namespace GraphQL.Types
             {
                 throw new ArgumentNullException(nameof(type));
             }
-            if (!type.GetTypeInfo().IsSubclassOf(typeof(IInterfaceGraphType)))
+            if (!type.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IInterfaceGraphType)))
             {
                 throw new ArgumentException("Interface must implement IInterfaceGraphType", nameof(type));
             }


### PR DESCRIPTION
#212 fixed the non-generic version of `ObjectGraphType` but unfortunately there's some duplicated code.... Could the non-generic `ObjectGraphType` just derive from `ObjectGraphType<object>`?

Also fixed up the test, since the bug only gets hit when calling the `Interface(Type)` overload.