### PR TITLE
Catch faulty tasks and rethrow exception on field resolution

### DIFF
--- a/src/GraphQL/Instrumentation/MiddlewareResolver.cs
+++ b/src/GraphQL/Instrumentation/MiddlewareResolver.cs
@@ -20,6 +20,10 @@ namespace GraphQL.Instrumentation
             if (result is Task)
             {
                 var task = result as Task;
+                if (task.IsFaulted)
+                {
+                    throw task.Exception;
+                }
                 await task.ConfigureAwait(false);
                 result = task.GetProperyValue("Result");
             }


### PR DESCRIPTION
When the middleware resolver sees a faulted task, awaiting it would enter a loop and not report the underlying exception. This branch gets around that issue by re-throwing the reported task exception.