### PR TITLE
Introduced IInputObjectGraphType and ObjectMutationTests

### DIFF
--- a/src/GraphQL.Tests/Execution/MutationTests.cs
+++ b/src/GraphQL.Tests/Execution/MutationTests.cs
@@ -12,11 +12,27 @@ namespace GraphQL.Tests.Execution
         public int TheNumber { get; set; }
     }
 
+    public class MyObject
+    {
+        public string Prop1 { get; set; }
+        public int Prop2 { get; set; }
+    }
+
+    public class MyObjectHolder
+    {
+        public MyObject TheObject { get; set; }
+
+        public MyObjectHolder()
+        {
+            TheObject = new MyObject();
+        }
+    }
+
     public class Root
     {
         public Root(int number)
         {
-            NumberHolder = new NumberHolder {TheNumber = number};
+            NumberHolder = new NumberHolder { TheNumber = number };
         }
 
         public NumberHolder NumberHolder { get; private set; }
@@ -45,12 +61,56 @@ namespace GraphQL.Tests.Execution
         }
     }
 
+    public class ObjectRoot
+    {
+        public ObjectRoot(MyObjectHolder obj)
+        {
+            ObjectHolder = new MyObjectHolder { TheObject = { Prop1 = "", Prop2 = 0 } };
+        }
+
+        public MyObjectHolder ObjectHolder { get; private set; }
+
+        public MyObjectHolder ImmediatelyChangeTheObject(MyObject change)
+        {
+            ObjectHolder.TheObject.Prop1 = change.Prop1;
+            ObjectHolder.TheObject.Prop2 = change.Prop2;
+            return ObjectHolder;
+        }
+
+        public Task<MyObjectHolder> PromiseToChangeTheObjectAsync(MyObject change)
+        {
+            ObjectHolder.TheObject.Prop1 = change.Prop1;
+            ObjectHolder.TheObject.Prop2 = change.Prop2;
+            return Task.FromResult(ObjectHolder);
+        }
+
+        public MyObjectHolder FailToChangeTheObject(MyObject change)
+        {
+            throw new InvalidOperationException("Cannot change the object");
+        }
+
+        public async Task<MyObjectHolder> PromiseAndFailToChangeTheObjectAsync(MyObject change)
+        {
+            await Task.Delay(100).ConfigureAwait(false);
+            throw new InvalidOperationException("Cannot change the object");
+        }
+    }
+
     public class MutationSchema : Schema
     {
         public MutationSchema()
         {
             Query = new MutationQuery();
             Mutation = new MutationChange();
+        }
+    }
+
+    public class ObjectMutationSchema : Schema
+    {
+        public ObjectMutationSchema()
+        {
+            Query = new ObjectMutationQuery();
+            Mutation = new ObjectMutationChange();
         }
     }
 
@@ -63,12 +123,40 @@ namespace GraphQL.Tests.Execution
         }
     }
 
+    public class MyObjectType : ObjectGraphType<MyObject>, IInputObjectGraphType
+    {
+        public MyObjectType()
+        {
+            Name = "MyObject";
+            Field(_ => _.Prop1);
+            Field(_ => _.Prop2);
+        }
+    }
+
+    public class ObjectHolderType : ObjectGraphType<MyObjectHolder>, IInputObjectGraphType
+    {
+        public ObjectHolderType()
+        {
+            Name = "ObjectHolder";
+            Field(_ => _.TheObject, false, typeof(MyObjectType));
+        }
+    }
+
     public class MutationQuery : ObjectGraphType
     {
         public MutationQuery()
         {
             Name = "Query";
             Field<NumberHolderType>("numberHolder");
+        }
+    }
+
+    public class ObjectMutationQuery : ObjectGraphType
+    {
+        public ObjectMutationQuery()
+        {
+            Name = "ObjectQuery";
+            Field<ObjectHolderType>("objectHolder");
         }
     }
 
@@ -143,6 +231,82 @@ namespace GraphQL.Tests.Execution
                     var root = context.Source as Root;
                     var change = context.GetArgument<int>("newNumber");
                     return root.PromiseAndFailToChangeTheNumberAsync(change);
+                }
+            );
+        }
+    }
+
+    public class ObjectMutationChange : ObjectGraphType
+    {
+        public ObjectMutationChange()
+        {
+            Name = "Mutation";
+
+            Field<ObjectHolderType>(
+                "immediatelyChangeTheObject",
+                arguments: new QueryArguments(
+                    new QueryArgument<MyObjectType>
+                    {
+                        Name = "newObject",
+                        DefaultValue = new MyObjectType()
+                    }
+                ),
+                resolve: context =>
+                {
+                    var root = context.Source as ObjectRoot;
+                    var change = context.GetArgument<MyObject>("newObject");
+                    return root.ImmediatelyChangeTheObject(change);
+                }
+            );
+
+            Field<ObjectHolderType>(
+                "promiseToChangeTheObject",
+                arguments: new QueryArguments(
+                    new QueryArgument<MyObjectType>
+                    {
+                        Name = "newObject",
+                        DefaultValue = new MyObject()
+                    }
+                ),
+                resolve: context =>
+                {
+                    var root = context.Source as ObjectRoot;
+                    var change = context.GetArgument<MyObject>("newObject");
+                    return root.PromiseToChangeTheObjectAsync(change);
+                }
+            );
+
+            Field<ObjectHolderType>(
+                "failToChangeTheObject",
+                arguments: new QueryArguments(
+                    new QueryArgument<MyObjectType>
+                    {
+                        Name = "newObject",
+                        DefaultValue = new MyObject()
+                    }
+                ),
+                resolve: context =>
+                {
+                    var root = context.Source as ObjectRoot;
+                    var change = context.GetArgument<MyObject>("newObject");
+                    return root.FailToChangeTheObject(change);
+                }
+            );
+
+            Field<ObjectHolderType>(
+                "promiseAndFailToChangeTheObject",
+                arguments: new QueryArguments(
+                    new QueryArgument<MyObjectType>
+                    {
+                        Name = "newObject",
+                        DefaultValue = new MyObject()
+                    }
+                ),
+                resolve: context =>
+                {
+                    var root = context.Source as ObjectRoot;
+                    var change = context.GetArgument<MyObject>("newObject");
+                    return root.PromiseAndFailToChangeTheObjectAsync(change);
                 }
             );
         }
@@ -243,6 +407,160 @@ namespace GraphQL.Tests.Execution
             result.Errors.First().InnerException.Message.ShouldBe("Cannot change the number");
             var last = result.Errors.Last();
             last.InnerException.GetBaseException().Message.ShouldBe("Cannot change the number");
+        }
+    }
+
+    public class ObjectMutationTests : QueryTestBase<ObjectMutationSchema>
+    {
+        [Fact]
+        public void evaluates_object_mutations_serially()
+        {
+            var query = @"
+                mutation M {
+                  first: immediatelyChangeTheObject(newObject:  { prop1: ""Mod1"", prop2: 1 }) 
+                    {
+                        theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                    }
+                  second: immediatelyChangeTheObject(newObject:  { prop1: ""Mod2"", prop2: 2 }) 
+                    {
+                        theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                    }
+                  third: immediatelyChangeTheObject(newObject:  { prop1: ""Mod3"", prop2: 3 }) 
+                    {
+                        theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                    }
+                  fourth: immediatelyChangeTheObject(newObject:  { prop1: ""Mod4"", prop2: 4 }) 
+                    {
+                        theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                    }
+                  fifth: immediatelyChangeTheObject(newObject:  { prop1: ""Mod5"", prop2: 5 }) 
+                    {
+                        theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"
+                {
+                    'first': {
+                        'theObject': { ""prop1"": ""Mod1"", ""prop2"": 1 }
+                    },
+                    'second': {
+                        'theObject': { ""prop1"": ""Mod2"", ""prop2"": 2 }
+                    },
+                    'third': {
+                        'theObject': { ""prop1"": ""Mod3"", ""prop2"": 3 }
+                    },
+                    'fourth': {
+                        'theObject': { ""prop1"": ""Mod4"", ""prop2"": 4 }
+                    },
+                    'fifth': {
+                        'theObject': { ""prop1"": ""Mod5"", ""prop2"": 5 }
+                    },
+                }";
+
+            AssertQuerySuccess(query, expected, root: new ObjectRoot(new MyObjectHolder()));
+        }
+
+        [Fact]
+        public void evaluates_mutations_correctly_in_the_presense_of_a_failed_mutation()
+        {
+            var query = @"
+                mutation M {
+                  first: immediatelyChangeTheObject(newObject:  { prop1: ""Mod1"", prop2: 1 }) {
+                    theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                  }
+                  second: promiseToChangeTheObject(newObject:  { prop1: ""Mod2"", prop2: 2 }) {
+                    theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                  }
+                  third: failToChangeTheObject(newObject:  { prop1: ""Mod3"", prop2: 3 }) {
+                    theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                  }
+                  fourth: promiseToChangeTheObject(newObject:  { prop1: ""Mod4"", prop2: 4 }) {
+                    theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                  }
+                  fifth: immediatelyChangeTheObject(newObject:  { prop1: ""Mod5"", prop2: 5 }) {
+                    theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                  }
+                  sixth: promiseAndFailToChangeTheObject(newObject:  { prop1: ""Mod6"", prop2: 6 }) {
+                    theObject
+                        {
+                            prop1
+                            prop2
+                        }
+                  }
+                }
+            ";
+
+            var expected = @"
+                {
+                  'first': {
+                        'theObject': { ""prop1"": ""Mod1"", ""prop2"": 1 }
+                    },
+                  'second': {
+                        'theObject': { ""prop1"": ""Mod2"", ""prop2"": 2 }
+                    },
+                  'third': null,
+                  'fourth': {
+                    'theObject': { ""prop1"": ""Mod4"", ""prop2"": 4 }
+                  },
+                  'fifth': {
+                    'theObject': { ""prop1"": ""Mod5"", ""prop2"": 5 }
+                  },
+                  'sixth': null
+                }";
+
+            var result = AssertQueryWithErrors(query, expected, root: new ObjectRoot(new MyObjectHolder()
+            {
+                TheObject = new MyObject()
+                {
+                    Prop1 = "Mod6",
+                    Prop2 = 6
+                }
+            }), expectedErrorCount: 2);
+            result.Errors.First().InnerException.Message.ShouldBe("Cannot change the object");
+            var last = result.Errors.Last();
+            last.InnerException.GetBaseException().Message.ShouldBe("Cannot change the object");
         }
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -661,7 +661,7 @@ namespace GraphQL
                 return;
             }
 
-            if (type is IObjectGraphType || type is InputObjectGraphType)
+            if (type is IObjectGraphType || type is IInputObjectGraphType)
             {
                 var dict = input as Dictionary<string, object>;
                 var complexType = (IComplexGraphType)type;
@@ -673,7 +673,7 @@ namespace GraphQL
                 }
 
                 // ensure every provided field is defined
-                var unknownFields = type is InputObjectGraphType
+                var unknownFields = type is IInputObjectGraphType
                     ? dict.Keys.Where(key => complexType.Fields.All(field => field.Name != key)).ToArray()
                     : null;
 
@@ -736,7 +736,7 @@ namespace GraphQL
                     : new[] { CoerceValue(schema, listItemType, input, variables) };
             }
 
-            if (type is IObjectGraphType || type is InputObjectGraphType)
+            if (type is IObjectGraphType || type is IInputObjectGraphType)
             {
                 var complexType = type as IComplexGraphType;
                 var obj = new Dictionary<string, object>();

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -36,7 +36,7 @@ namespace GraphQL
             var namedType = type.GetNamedType();
             return namedType is ScalarGraphType ||
                    namedType is EnumerationGraphType ||
-                   namedType is InputObjectGraphType;
+                   namedType is IInputObjectGraphType;
         }
 
         public static IGraphType GetNamedType(this IGraphType type)
@@ -149,14 +149,14 @@ namespace GraphQL
                 return IsValidLiteralValue(ofType, valueAst, schema);
             }
 
-            if (type is InputObjectGraphType)
+            if (type is IInputObjectGraphType)
             {
                 if (!(valueAst is ObjectValue))
                 {
                     return new[] {$"Expected \"{type.Name}\", found not an object."};
                 }
 
-                var inputType = (InputObjectGraphType) type;
+                var inputType = (IInputObjectGraphType) type;
 
                 var fields = inputType.Fields.ToList();
                 var fieldAsts = ((ObjectValue) valueAst).ObjectFields.ToList();
@@ -330,14 +330,14 @@ namespace GraphQL
 
             // Populate the fields of the input object by creating ASTs from each value
             // in the dictionary according to the fields in the input type.
-            if (type is InputObjectGraphType)
+            if (type is IInputObjectGraphType)
             {
                 if (!(value is Dictionary<string, object>))
                 {
                     return null;
                 }
 
-                var input = (InputObjectGraphType) type;
+                var input = (IInputObjectGraphType) type;
                 var dict = (Dictionary<string, object>)value;
 
                 var fields = dict

--- a/src/GraphQL/Introspection/__Type.cs
+++ b/src/GraphQL/Introspection/__Type.cs
@@ -93,7 +93,7 @@ namespace GraphQL.Introspection
                 });
             Field<ListGraphType<NonNullGraphType<__InputValue>>>("inputFields", resolve: context =>
             {
-                var type = context.Source as InputObjectGraphType;
+                var type = context.Source as IInputObjectGraphType;
                 return type?.Fields;
             });
             Field<__Type>("ofType", resolve: context =>
@@ -136,7 +136,7 @@ namespace GraphQL.Introspection
             {
                 return TypeKind.UNION;
             }
-            if (type is InputObjectGraphType)
+            if (type is IInputObjectGraphType)
             {
                 return TypeKind.INPUT_OBJECT;
             }
@@ -174,7 +174,7 @@ namespace GraphQL.Introspection
             {
                 return TypeKind.UNION;
             }
-            if (typeof (InputObjectGraphType).IsAssignableFrom(type))
+            if (typeof (IInputObjectGraphType).IsAssignableFrom(type))
             {
                 return TypeKind.INPUT_OBJECT;
             }

--- a/src/GraphQL/Types/IInputObjectGraphType.cs
+++ b/src/GraphQL/Types/IInputObjectGraphType.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace GraphQL.Types
+{
+    public interface IInputObjectGraphType : IInputGraphType
+    {
+        IEnumerable<FieldType> Fields { get; }
+    }
+}

--- a/src/GraphQL/Types/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/InputObjectGraphType.cs
@@ -1,6 +1,6 @@
 ﻿namespace GraphQL.Types
 {
-    public class InputObjectGraphType : ComplexGraphType<object>
+    public class InputObjectGraphType : ComplexGraphType<object>, IInputObjectGraphType
     {
     }
 }

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -187,12 +187,12 @@ namespace GraphQL.Utilities
                 return PrintDirective((DirectiveGraphType)type);
             }
 
-            if (!(type is InputObjectGraphType))
+            if (!(type is IInputObjectGraphType))
             {
                 throw new InvalidOperationException("Unknown GraphType {0}".ToFormat(type.GetType().Name));
             }
 
-            return PrintInputObject((InputObjectGraphType)type);
+            return PrintInputObject((IInputObjectGraphType)type);
         }
 
         public string PrintScalar(ScalarGraphType type)
@@ -233,7 +233,7 @@ namespace GraphQL.Utilities
             return description + "enum {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, values);
         }
 
-        public string PrintInputObject(InputObjectGraphType type)
+        public string PrintInputObject(IInputObjectGraphType type)
         {
             var description = PrintDescription(type.Description);
             var fields = type.Fields.Select(x => "  " + PrintInputValue(x));

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -157,7 +157,7 @@ namespace GraphQL.Validation
                 var objectType = GetInputType().GetNamedType();
                 IGraphType fieldType = null;
 
-                if (objectType is InputObjectGraphType)
+                if (objectType is IInputObjectGraphType)
                 {
                     var complexType = objectType as IComplexGraphType;
                     var inputField = complexType.Fields.FirstOrDefault(x => x.Name == ((ObjectField) node).Name);


### PR DESCRIPTION
Hi,
We had a problem here doing Mutations straight on objects, which could be easily solved by checking  for IInputObjectGraphType (which derives from the original IInputGraphType interface) instead of InputObjectGraphType. That way mutations are possible on objects as well as scalar types and you can now do mutations like "immediatelyChangeTheObject(newObject:  { prop1: ""Mod1"", prop2: 1 })".

I also put some tests in  src/GraphQL.Tests/Execution/MutationTests.cs, of similar fashion as the original mutation tests.

Thanks,
Christos