### PR TITLE
Bug 252 - reuse of schema causes stack overflow

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
+++ b/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
@@ -35,7 +35,7 @@ namespace GraphQL.Tests.Bugs
     public class Bug252ExecutorAppliesBuilderOnceTests
     {
         [Fact]
-        public void apply_to_called_once_after_execution()
+        public void apply_to_not_called_without_execute()
         {
             var docExec = new DocumentExecuter();
             var execOptions = new ExecutionOptions();

--- a/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
+++ b/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Instrumentation;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    /// <summary>
+    /// This class adds a variable to count the calls to ApplyTo()
+    /// in the FieldMiddlewareBuilder class
+    /// </summary>
+    public class ApplyCounterMiddlewareBuilder : GraphQL.Instrumentation.IFieldMiddlewareBuilder
+    {
+        public int AppliedCount;
+        IFieldMiddlewareBuilder overriddenBuilder = new FieldMiddlewareBuilder();
+        public void ApplyTo(ISchema schema)
+        {
+            AppliedCount++;
+            overriddenBuilder.ApplyTo(schema);
+        }
+
+        public FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start = null)
+        {
+            return overriddenBuilder.Build(start);
+        }
+
+        public IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
+        {
+            return overriddenBuilder.Use(middleware);
+        }
+    }
+    public class Bug252ExecutorAppliesBuilderOnceTests
+    {
+        [Fact]
+        public void apply_to_called_once_after_execution()
+        {
+            var docExec = new DocumentExecuter();
+            var execOptions = new ExecutionOptions();
+            execOptions.Schema = new Schema();
+            var mockMiddleware = new ApplyCounterMiddlewareBuilder();
+            execOptions.FieldMiddleware = mockMiddleware;
+
+            // no execute in this test
+            //docExec.ExecuteAsync(execOptions).Wait();
+
+            Assert.Equal(0, mockMiddleware.AppliedCount);
+        }
+        [Fact]
+        public void apply_to_called_once()
+        {
+            var docExec = new DocumentExecuter();
+            var execOptions = new ExecutionOptions();
+            execOptions.Schema = new Schema();
+            var mockMiddleware = new ApplyCounterMiddlewareBuilder();
+            execOptions.FieldMiddleware = mockMiddleware;
+
+            docExec.ExecuteAsync(execOptions).Wait();
+
+            Assert.Equal(1, mockMiddleware.AppliedCount);
+        }
+        [Fact]
+        public void apply_to_called_once_with_multiple_execute()
+        {
+            var docExec = new DocumentExecuter();
+            var execOptions = new ExecutionOptions();
+            execOptions.Schema = new Schema();
+            var mockMiddleware = new ApplyCounterMiddlewareBuilder();
+            execOptions.FieldMiddleware = mockMiddleware;
+
+            docExec.ExecuteAsync(execOptions).Wait();
+            docExec.ExecuteAsync(execOptions).Wait();
+
+            Assert.Equal(1, mockMiddleware.AppliedCount);
+        }
+    }
+}

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -86,7 +86,6 @@ namespace GraphQL
             var metrics = new Metrics();
             metrics.Start(config.OperationName);
 
-            config.FieldMiddleware.ApplyTo(config.Schema);
 
             var result = new ExecutionResult { Query = config.Query };
             try
@@ -95,6 +94,7 @@ namespace GraphQL
                 {
                     using (metrics.Subject("schema", "Initializing schema"))
                     {
+                        config.FieldMiddleware.ApplyTo(config.Schema);
                         config.Schema.Initialize();
                     }
                 }


### PR DESCRIPTION
As discussed in the thread, move ApplyTo call into the schema initialization section.  Simple tests to count the number of times FieldMiddlewareBuilders.ApplyTo() is called over the lifetime of an executor/schema/builder.