### PR TITLE
added new error type in order to have a different behavior for developer triggered errors

### DIFF
--- a/src/GraphQL.Tests/Errors/CustomExecutionErrorTests.cs
+++ b/src/GraphQL.Tests/Errors/CustomExecutionErrorTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Errors
+{
+    public class CustomExecutionErrorTests : QueryTestBase<CustomExecutionErrorTests.TestSchema>
+    {
+        [Fact]
+        public async Task should_show_custom_error_when_manual_ExecutionError_is_thrown()
+        {
+            var body = "{\n    test\n}";
+            var result = await Executer.ExecuteAsync(
+                Schema,
+                null,
+                body,
+                null
+                );
+
+            result.Errors.Count.ShouldBe(1);
+            var error = result.Errors.First();
+            error.Locations.Count().ShouldBe(1);
+            error.Message.ShouldBe("Custom Error");
+        }
+
+        public class TestQuery : ObjectGraphType
+        {
+            public TestQuery()
+            {
+                Name = "Query";
+
+                Field<StringGraphType>()
+                    .Name("test")
+                    .Resolve(_ => { throw new ExternalExecutionError("Custom Error"); });
+            }
+        }
+
+        public class TestSchema : Schema
+        {
+            public TestSchema()
+            {
+                Query = new TestQuery();
+            }
+        }
+    }
+}

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -337,7 +337,7 @@ namespace GraphQL
 
         private ResolveFieldResult<object> GenerateError(ResolveFieldResult<object> resolveResult, Field field, ExecutionContext context, Exception exc)
         {
-            var error = new ExecutionError("Error trying to resolve {0}.".ToFormat(field.Name), exc);
+            var error = exc is ExternalExecutionError ? new ExecutionError(exc.Message) : new ExecutionError("Error trying to resolve {0}.".ToFormat(field.Name), exc);
             error.AddLocation(field, context.Document);
             context.Errors.Add(error);
             resolveResult.Skip = false;

--- a/src/GraphQL/Execution/ExternalExecutionError.cs
+++ b/src/GraphQL/Execution/ExternalExecutionError.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GraphQL.Execution
+{
+    public class ExternalExecutionError : Exception
+    {
+        public ExternalExecutionError(string message) : base(message)
+        {
+            
+        }
+    }
+}


### PR DESCRIPTION
Hello,

I'am facing an issue with the error handling:
My API always return a generic error `error trying to resolve X` if external components go wrong (DB, validation error, etc).

The actual error that was raised is put in the inner exception of that generic error, but when the results are serialized in the response, we lose the inner exception.

Is there a reason to have this generic error "hiding" the orginal error? 
Because I use graphql in a nodejs app as well, and when I throw an error, it is directly sent in the response.

I added a new type of Execution error `ExternalExecutionError`. When this particular type of error is raised, it will not go in the `error trying to resolve X` scenario, it will instead take the triggered error's message.

In the end, everything functions as before, and if I throw an `ExternalExecutionError` in my code I get the behavior that I want. I also added a unit test for this.

What do you think?

Thanks,

