### PR TITLE
Easier implementation of custom ComplexityAnalyzer

### DIFF
--- a/src/GraphQL.Tests/Complexity/CustomComplexityAnalyzerTest.cs
+++ b/src/GraphQL.Tests/Complexity/CustomComplexityAnalyzerTest.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using GraphQL.Tests.Complexity.CustomComplexityAnalyzer;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Complexity
+{
+    public class CustomComplexityAnalyzerTest : CustomComplexityAnalyzerTestBase
+    {
+
+        [Fact]
+        public void should_work_when_complexity_within_params()
+        {
+            var query = @"
+                query HeroNameQuery {
+                  hero {
+                    name
+                  }
+                }
+            ";
+
+            var complexityConfiguration = new ExtendedComplexityConfig { MaxComplexity = 105, complexityMap = new Dictionary<string, double>() { { "hero", 100f } } };
+            var res = Execute(complexityConfiguration, query);
+
+            res.Result.Errors.ShouldBe(null);
+        }
+
+        [Fact]
+        public void should_not_work_when_complexity_within_params()
+        {
+            var query = @"
+                query HeroNameQuery {
+                  hero {
+                    name
+                  }
+                }
+            ";
+
+            var complexityConfiguration = new ExtendedComplexityConfig
+            {
+                MaxComplexity = 100,
+                complexityMap = new Dictionary<string, double>() { { "hero", 100f }, { "droid", 5f } }
+            };
+            var res = Execute(complexityConfiguration, query);
+
+            res.Result.Errors.ShouldNotBe(null);
+        }
+    }
+}

--- a/src/GraphQL.Tests/Complexity/CustomComplexityAnalyzerTestBase.cs
+++ b/src/GraphQL.Tests/Complexity/CustomComplexityAnalyzerTestBase.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using GraphQL.Language.AST;
+using GraphQL.Tests.StarWars;
+using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
+
+namespace GraphQL.Tests.Complexity.CustomComplexityAnalyzer
+{
+    public class CustomComplexityAnalyzerTestBase
+    {
+        public IComplexityAnalyzer Analyzer { get; } = new CustomComplexityAnalyzerDefinition();
+
+        public async Task<ExecutionResult> Execute(ExtendedComplexityConfig complexityConfig, string query) =>
+            await new DocumentExecuter(new GraphQLDocumentBuilder(), new DocumentValidator(), Analyzer).ExecuteAsync(
+                options =>
+                {
+                    options.Schema = new StarWarsTestBase().Schema;
+                    options.Query = query;
+                    options.ComplexityConfiguration = complexityConfig;
+                });
+    }
+
+
+    public class CustomComplexityAnalyzerDefinition : IComplexityAnalyzer
+    {
+        private readonly ComplexityResult _result = new ComplexityResult();
+
+        public void Validate(Document document, IComplexityConfiguration parameters)
+        {
+            if (!(parameters is ExtendedComplexityConfig)) throw new ArgumentException();
+            var extendedConfig = (ExtendedComplexityConfig)parameters;
+
+            TreeIterator(document, _result, extendedConfig.complexityMap);
+            if (extendedConfig.MaxComplexity.HasValue &&
+                _result.Complexity > extendedConfig.MaxComplexity.Value)
+                throw new InvalidOperationException("Query is too complex to execute.");
+
+        }
+
+        private void TreeIterator(INode node, ComplexityResult result, Dictionary<string, double> map)
+        {
+            if (node is Field)
+            {
+                result.Complexity += map.ContainsKey(((Field)node).Name) ? map[((Field)node).Name] : 1;
+                foreach (var nodeChild in node.Children.Where(n => n is SelectionSet))
+                    TreeIterator(nodeChild, result, map);
+            }
+
+            if (node.Children.Any(n => n is Field || n is SelectionSet && ((SelectionSet)n).Children.Any() || n is Operation))
+            {
+                foreach (var nodeChild in node.Children)
+                    TreeIterator(nodeChild, result, map);
+            }
+        }
+    }
+    public class ExtendedComplexityConfig : IComplexityConfiguration
+    {
+        public double? FieldImpact { get; set; }
+        public int? MaxComplexity { get; set; }
+        public int? MaxDepth { get; set; }
+        public Dictionary<string, double> complexityMap { get; set; }
+    }
+}

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -22,7 +22,7 @@ namespace GraphQL
         public IEnumerable<IValidationRule> ValidationRules { get; set; }
         public object UserContext { get; set; }
         public IFieldMiddlewareBuilder FieldMiddleware { get; set; } = new FieldMiddlewareBuilder();
-        public ComplexityConfiguration ComplexityConfiguration { get; set; } = null;
+        public IComplexityConfiguration ComplexityConfiguration { get; set; } = null;
 
         public readonly IList<IDocumentExecutionListener> Listeners = new List<IDocumentExecutionListener>();
 

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalyzer.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalyzer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -30,7 +30,7 @@ namespace GraphQL.Validation.Complexity
             _maxRecursionCount = maxRecursionCount;
         }
 
-        public void Validate(Document document, ComplexityConfiguration complexityParameters)
+        public void Validate(Document document, IComplexityConfiguration complexityParameters)
         {
             if (complexityParameters == null) return;
             var complexityResult = Analyze(document, complexityParameters.FieldImpact ?? 2.0f);

--- a/src/GraphQL/Validation/Complexity/ComplexityConfiguration.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityConfiguration.cs
@@ -1,0 +1,14 @@
+﻿namespace GraphQL.Validation.Complexity
+{
+    public class ComplexityConfiguration : IComplexityConfiguration
+    {
+        public int? MaxDepth { get; set; }
+        public int? MaxComplexity { get; set; }
+
+        /// <summary>
+        /// Hardcoded maximum number of objects returned by each field.
+        /// If there is no hardcoded maximum then use the average number of rows/objects returned by each field.
+        /// </summary>
+        public double? FieldImpact { get; set; }
+    }
+}

--- a/src/GraphQL/Validation/Complexity/IComplexityAnalyzer.cs
+++ b/src/GraphQL/Validation/Complexity/IComplexityAnalyzer.cs
@@ -8,6 +8,6 @@ namespace GraphQL.Validation.Complexity
         /// <exception cref="InvalidOperationException">
         /// Thrown if complexity is not within the defiend range in parameters.
         /// </exception>
-        void Validate(Document document, ComplexityConfiguration parameters);
+        void Validate(Document document, IComplexityConfiguration parameters);
     }
 }

--- a/src/GraphQL/Validation/Complexity/IComplexityConfiguration.cs
+++ b/src/GraphQL/Validation/Complexity/IComplexityConfiguration.cs
@@ -1,14 +1,9 @@
 ﻿namespace GraphQL.Validation.Complexity
 {
-    public class ComplexityConfiguration
+    public interface IComplexityConfiguration
     {
-        public int? MaxDepth { get; set; }
-        public int? MaxComplexity { get; set; }
-
-        /// <summary>
-        /// Hardcoded maximum number of objects returned by each field.
-        /// If there is no hardcoded maximum then use the average number of rows/objects returned by each field.
-        /// </summary>
-        public double? FieldImpact { get; set; }
+        double? FieldImpact { get; set; }
+        int? MaxComplexity { get; set; }
+        int? MaxDepth { get; set; }
     }
 }


### PR DESCRIPTION
After discussion in #298 I tried to make it simpler to implement a custom analyzer.

Example usage is available in the test case.
In that example I implemented a **dummy** (the logic behind it is flawed for simplicity so don't use that in production) IComplexityAnalyzer type that goes through the AST and adds the value of all nodes together (values are passed through by a Dictionary object which maps field names to a value) and in absence of a value in the dictionary a default value of 1 is assumed.

You may use it as a template to build your own.