### PR TITLE
Throw exception when resolve delegate return null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ npm-debug.log
 yarn-error.log
 bundle.js
 fixie-results.xml
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
 
 TestResults/
 [Oo]bj/

--- a/src/GraphQL.Tests/Extensions/GraphQLExtensionsTests.cs
+++ b/src/GraphQL.Tests/Extensions/GraphQLExtensionsTests.cs
@@ -1,0 +1,18 @@
+using System;
+using GraphQL.StarWars.Types;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Extensions
+{
+    public class GraphQLExtensionsTests
+    {
+        [Fact]
+        void BuildNamedType_ResolveReturnNull_Throws()
+        {
+            Should.Throw<InvalidOperationException>(
+                () => typeof(ListGraphType<ListGraphType<EpisodeEnum>>).BuildNamedType(_ => null));
+        }
+    }
+}

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -82,7 +82,9 @@ namespace GraphQL
                 }
             }
 
-            return resolve(type);
+            return resolve(type) ??
+                   throw new InvalidOperationException(
+                       $"Expected non-null value, {nameof(resolve)} delegate return null for \"${type}\"");
         }
 
         public static Type GetNamedType(this Type type)


### PR DESCRIPTION
I got an NRE in `GraphQL.Utilities.SchemaPrinter.ResolveName(IGraphType)` when *field of type [FieldType] must have a sub selection*. `resolve(type)` in `GraphQL.GraphQLExtensions.BuildNamedType` return `null`. In this case, I was expecting to see more relevan exception.
```
at GraphQL.Utilities.SchemaPrinter.ResolveName(IGraphType type) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Utilities\\SchemaPrinter.cs:line 344\r\n
   at GraphQL.Utilities.SchemaPrinter.ResolveName(IGraphType type) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Utilities\\SchemaPrinter.cs:line 341\r\n
   at GraphQL.Validation.ValidationContext.Print(IGraphType type) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\ValidationContext.cs:line 158\r\n
   at GraphQL.Validation.Rules.ScalarLeafs.Field(IGraphType type, Field field, ValidationContext context) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\Rules\\ScalarLeafs.cs:line 47\r\n
   at GraphQL.Validation.Rules.ScalarLeafs.<>c__DisplayClass2_0.<Validate>b__1(Field f) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\Rules\\ScalarLeafs.cs:line 26\r\n
   at GraphQL.Validation.EnterLeaveListener.<>c__DisplayClass4_0`1.<Match>b__1(INode n) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\EnterLeaveListener.cs:line 59\r\n
   at GraphQL.Validation.EnterLeaveListener.<>c__DisplayClass2_0.<GraphQL.Validation.INodeVisitor.Enter>b__1(MatchingNodeListener l) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\EnterLeaveListener.cs:line 30\r\n
   at GraphQL.EnumerableExtensions.Apply[T](IEnumerable`1 items, Action`1 action) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\EnumerableExtensions.cs:line 35\r\n
   at GraphQL.Validation.EnterLeaveListener.GraphQL.Validation.INodeVisitor.Enter(INode node) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\EnterLeaveListener.cs:line 28\r\n
   at GraphQL.Validation.BasicVisitor.<>c__DisplayClass2_0.<Visit>b__0(INodeVisitor l) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\BasicVisitor.cs:line 22\r\n
   at GraphQL.EnumerableExtensions.Apply[T](IEnumerable`1 items, Action`1 action) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\EnumerableExtensions.cs:line 35\r\n
   at GraphQL.Validation.BasicVisitor.Visit(INode node) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\BasicVisitor.cs:line 22\r\n
   at GraphQL.EnumerableExtensions.Apply[T](IEnumerable`1 items, Action`1 action) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\EnumerableExtensions.cs:line 35\r\n
   at GraphQL.Validation.BasicVisitor.Visit(INode node) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\BasicVisitor.cs:line 24\r\n
   at GraphQL.EnumerableExtensions.Apply[T](IEnumerable`1 items, Action`1 action) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\EnumerableExtensions.cs:line 35\r\n
   at GraphQL.Validation.BasicVisitor.Visit(INode node) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\BasicVisitor.cs:line 24\r\n
   at GraphQL.EnumerableExtensions.Apply[T](IEnumerable`1 items, Action`1 action) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\EnumerableExtensions.cs:line 35\r\n
   at GraphQL.Validation.BasicVisitor.Visit(INode node) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\BasicVisitor.cs:line 24\r\n
   at GraphQL.EnumerableExtensions.Apply[T](IEnumerable`1 items, Action`1 action) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\EnumerableExtensions.cs:line 35\r\n
   at GraphQL.Validation.BasicVisitor.Visit(INode node) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\BasicVisitor.cs:line 24\r\n
   at GraphQL.EnumerableExtensions.Apply[T](IEnumerable`1 items, Action`1 action) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\EnumerableExtensions.cs:line 35\r\n
   at GraphQL.Validation.BasicVisitor.Visit(INode node) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\BasicVisitor.cs:line 24\r\n
   at GraphQL.Validation.DocumentValidator.Validate(String originalQuery, ISchema schema, Document document, IEnumerable`1 rules, Object userContext) in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Validation\\DocumentValidator.cs:line 56\r\n
   at GraphQL.DocumentExecuter.<ExecuteAsync>d__7.MoveNext() in C:\\Projects\\graphql-dotnet\\src\\GraphQL\\Execution\\DocumentExecuter.cs:line 127
```