### PR TITLE
Compile and reuse resolver expression

### DIFF
--- a/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
+++ b/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
@@ -6,16 +6,16 @@ namespace GraphQL.Resolvers
 {
     public class ExpressionFieldResolver<TSourceType, TProperty> : IFieldResolver<TProperty>
     {
-        private readonly Expression<Func<TSourceType, TProperty>> _property;
+        private readonly Func<TSourceType, TProperty> _property;
 
         public ExpressionFieldResolver(Expression<Func<TSourceType, TProperty>> property)
         {
-            _property = property;
+            _property = property.Compile();
         }
 
         public TProperty Resolve(ResolveFieldContext context)
         {
-            return _property.Compile()(context.As<TSourceType>().Source);
+            return _property(context.As<TSourceType>().Source);
         }
 
         object IFieldResolver.Resolve(ResolveFieldContext context)


### PR DESCRIPTION
Expression compilation is apparently expensive - this change alone yielded a ~10x speed improvement on my machine (a 15" MacBook Pro 2016) while testing the [DataLoader.StarWars](https://github.com/dlukez/dataloader-dotnet/tree/master/sample/DataLoader.StarWars) sample app.