### PR TITLE
[WIP ] Automatically extract and pass parameters from context to resolver

### DIFF
--- a/src/GraphQL.StarWars/StarWarsQuery.cs
+++ b/src/GraphQL.StarWars/StarWarsQuery.cs
@@ -1,4 +1,5 @@
-﻿using GraphQL.StarWars.Types;
+﻿using System;
+using GraphQL.StarWars.Types;
 using GraphQL.Types;
 
 namespace GraphQL.StarWars
@@ -17,12 +18,15 @@ namespace GraphQL.StarWars
                 ),
                 resolve: context => data.GetHumanByIdAsync(context.GetArgument<string>("id"))
             );
-            Field<DroidType>(
+
+            Func<ResolveFieldContext<object>, string, object> func = (context, id) => data.GetDroidByIdAsync(id);
+
+            FieldDelegate<DroidType>(
                 "droid",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the droid" }
                 ),
-                resolve: context => data.GetDroidByIdAsync(context.GetArgument<string>("id"))
+                resolve: func
             );
         }
     }

--- a/src/GraphQL/Resolvers/DelegateFieldModelBinderResolver.cs
+++ b/src/GraphQL/Resolvers/DelegateFieldModelBinderResolver.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -6,11 +6,11 @@ using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
-    public class FuncFieldModelBinderResolver<TSourceType, TReturnType> : IFieldResolver<Task<TReturnType>>
+    public class DelegateFieldModelBinderResolver<TSourceType, TReturnType> : IFieldResolver<Task<TReturnType>>
     {
         private readonly Delegate _resolver;
 
-        public FuncFieldModelBinderResolver(Delegate resolver)
+        public DelegateFieldModelBinderResolver(Delegate resolver)
         {
             if (resolver == null)
             {

--- a/src/GraphQL/Resolvers/DelegateFieldModelBinderResolver.cs
+++ b/src/GraphQL/Resolvers/DelegateFieldModelBinderResolver.cs
@@ -37,9 +37,9 @@ namespace GraphQL.Resolvers
 
                 foreach (var parameter in parameters.Skip(index))
                 {
-                    arguments[index] = context.GetArgument<object>(parameter.Name);
+                    arguments[index] = context.GetArgument(parameter.ParameterType, parameter.Name, null);
                     index++;
-                } 
+                }
             }
 
             var result = _resolver.DynamicInvoke(arguments);

--- a/src/GraphQL/Resolvers/FuncFieldModelBinderResolver.cs
+++ b/src/GraphQL/Resolvers/FuncFieldModelBinderResolver.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using GraphQL.Types;
+
+namespace GraphQL.Resolvers
+{
+    public class FuncFieldModelBinderResolver<TSourceType, TReturnType> : IFieldResolver<Task<TReturnType>>
+    {
+        private readonly Delegate _resolver;
+
+        public FuncFieldModelBinderResolver(Delegate resolver)
+        {
+            if (resolver == null)
+            {
+                throw new ArgumentNullException("A resolver function must be specified");
+            }
+            _resolver = resolver;
+        }
+
+        public async Task<TReturnType> Resolve(ResolveFieldContext context)
+        {
+            var parameters = RuntimeReflectionExtensions.GetMethodInfo(_resolver).GetParameters();
+
+            int index = 0;
+            var arguments = new object[parameters.Length];
+
+            if (context.As<TSourceType>().GetType() == parameters[0].ParameterType)
+            {
+                arguments[index] = context.As<TSourceType>();
+                index++;
+            }
+
+            foreach (var parameter in parameters.Skip(index))
+            {
+                arguments[index] = context.GetArgument<object>(parameter.Name);
+                index++;
+            }
+
+            var result = _resolver.DynamicInvoke(arguments);
+
+            if (result is Task)
+            {
+                var task = result as Task;
+                if (task.IsFaulted)
+                {
+                    throw task.Exception;
+                }
+                await task.ConfigureAwait(false);
+                result = task.GetProperyValue("Result");
+            }
+
+            return (TReturnType)result;
+        }
+
+        object IFieldResolver.Resolve(ResolveFieldContext context)
+        {
+            return Resolve(context);
+        }
+    }
+}

--- a/src/GraphQL/Resolvers/FuncFieldModelBinderResolver.cs
+++ b/src/GraphQL/Resolvers/FuncFieldModelBinderResolver.cs
@@ -21,21 +21,25 @@ namespace GraphQL.Resolvers
 
         public async Task<TReturnType> Resolve(ResolveFieldContext context)
         {
-            var parameters = RuntimeReflectionExtensions.GetMethodInfo(_resolver).GetParameters();
+            var parameters = _resolver.GetMethodInfo().GetParameters();
 
             int index = 0;
-            var arguments = new object[parameters.Length];
+            object[] arguments = null;
 
-            if (context.As<TSourceType>().GetType() == parameters[0].ParameterType)
+            if (parameters.Any())
             {
-                arguments[index] = context.As<TSourceType>();
-                index++;
-            }
+                arguments = new object[parameters.Length];
+                if (context.As<TSourceType>().GetType() == parameters[0].ParameterType)
+                {
+                    arguments[index] = context.As<TSourceType>();
+                    index++;
+                }
 
-            foreach (var parameter in parameters.Skip(index))
-            {
-                arguments[index] = context.GetArgument<object>(parameter.Name);
-                index++;
+                foreach (var parameter in parameters.Skip(index))
+                {
+                    arguments[index] = context.GetArgument<object>(parameter.Name);
+                    index++;
+                } 
             }
 
             var result = _resolver.DynamicInvoke(arguments);

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -113,7 +113,7 @@ namespace GraphQL.Types
                 Type = typeof(TGraphType),
                 Arguments = arguments,
                 Resolver = resolve != null
-                    ? new FuncFieldModelBinderResolver<TSourceType, object>(resolve)
+                    ? new DelegateFieldModelBinderResolver<TSourceType, object>(resolve)
                     : null,
             });
         }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -113,7 +113,7 @@ namespace GraphQL.Types
                 Type = typeof(TGraphType),
                 Arguments = arguments,
                 Resolver = resolve != null
-                    ? new DelegateFieldModelBinderResolver<TSourceType, object>(resolve)
+                    ? new DelegateFieldModelBinderResolver(resolve)
                     : null,
             });
         }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -97,6 +97,27 @@ namespace GraphQL.Types
             });
         }
 
+        public FieldType FieldDelegate<TGraphType>(
+            string name,
+            string description = null,
+            QueryArguments arguments = null,
+            Delegate resolve = null,
+            string deprecationReason = null)
+            where TGraphType : IGraphType
+        {
+            return AddField(new FieldType
+            {
+                Name = name,
+                Description = description,
+                DeprecationReason = deprecationReason,
+                Type = typeof(TGraphType),
+                Arguments = arguments,
+                Resolver = resolve != null
+                    ? new FuncFieldModelBinderResolver<TSourceType, object>(resolve)
+                    : null,
+            });
+        }
+
         public FieldType FieldAsync<TGraphType>(
             string name,
             string description = null,

--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -67,6 +67,11 @@ namespace GraphQL.Types
 
         public TType GetArgument<TType>(string name, TType defaultValue = default(TType))
         {
+            return (TType) GetArgument(typeof(TType), name, defaultValue);
+        }
+
+        public object GetArgument(System.Type argumentType, string name, object defaultValue)
+        {
             if (!HasArgument(name))
             {
                 return defaultValue;
@@ -76,16 +81,16 @@ namespace GraphQL.Types
             var inputObject = arg as Dictionary<string, object>;
             if (inputObject != null)
             {
-                var type = typeof(TType);
+                var type = argumentType;
                 if (type.Namespace?.StartsWith("System") == true)
                 {
-                    return (TType)arg;
+                    return arg;
                 }
 
-                return (TType)inputObject.ToObject(type);
+                return inputObject.ToObject(type);
             }
 
-            return arg.GetPropertyValue<TType>();
+            return ObjectExtensions.GetPropertyValue(arg, argumentType);
         }
 
         public bool HasArgument(string argumentName)


### PR DESCRIPTION
Inspired by ASP.NET MVC model binder I added FuncFieldModelBinderResolver which inspects parameters of the resolver function, extracts them from the context arguments (by matching parameter name to argument name) and passes them to the resolver function. As a result instead of calling `context.GetArgument<string>("id")` you can just add a `string id` parameter to resolver function.

This is still work in progress but I wanted to get feedback from community before going too far with it. I find it useful because it allows to get rid of the magic strings in resolver function. The only downside is that you need to declare and intermediate variable for the resolver function before passing it as a resolver.

So what do you think ?