### PR TITLE
[Docs] Return Task and Wait on it

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,10 +37,10 @@ namespace ConsoleApplication
     {
         public static void Main(string[] args)
         {
-          Run();
+          Run().Wait();
         }
 
-        private static async void Run()
+        private static async Task Run()
         {
           Console.WriteLine("Hello GraphQL!");
 


### PR DESCRIPTION
Small doc change. Return `Task` and `Wait`ing on it. Otherwise, you have a chance to exit without finishing the entire execution, depending what `DocumentExecuter().ExecuteAsync` does.