### PR TITLE
support variables for types that return custom objects

### DIFF
--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -1,8 +1,10 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.Linq;
 using GraphQL.Language.AST;
 using GraphQL.Types;
 using GraphQL.Validation;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Shouldly;
 using Xunit;
 
@@ -47,6 +49,44 @@ namespace GraphQL.Tests.Execution
 
             return null;
         }
+    }
+
+    public class TestJsonScalarReturningObject : ScalarGraphType
+    {
+        public TestJsonScalarReturningObject()
+        {
+            Name = "JsonScalarReturningObject";
+        }
+
+        public override object Serialize(object value)
+        {
+            return value;
+        }
+
+        public override object ParseValue(object value)
+        {
+            var stringValue = value as string;
+            if (stringValue == null)
+                return null;
+            return JsonConvert.DeserializeObject<TestJsonScalarObject>(stringValue);
+        }
+
+        public override object ParseLiteral(IValue value)
+        {
+            var stringValue = value as StringValue;
+            if (stringValue == null)
+                return null;
+            return JsonConvert.DeserializeObject<TestJsonScalarObject>(stringValue.Value);
+        }
+    }
+
+    public class TestJsonScalarObject
+    {
+        [JsonProperty("stringProperty")]
+        public string StringProperty { get; set; }
+
+        [JsonProperty("arrayProperty")]
+        public string[] ArrayProperty { get; set; }
     }
 
     public class TestInputObject : InputObjectGraphType
@@ -110,6 +150,19 @@ namespace GraphQL.Tests.Execution
                 {
                     var result = JsonConvert.SerializeObject(context.GetArgument<object>("input"));
                     return result;
+                });
+
+            Field<StringGraphType>(
+                "fieldWithCustomScalarInput",
+                arguments: new QueryArguments(
+                    new QueryArgument<TestJsonScalarReturningObject> { Name = "input" }
+                ),
+                resolve: context =>
+                {
+                    var val = context.GetArgument<TestJsonScalarObject>("input");
+                    var stringProperty = val.StringProperty;
+                    var arrayProperty = string.Join(", ", val.ArrayProperty);
+                    return $"{stringProperty}-{arrayProperty}";
                 });
         }
     }
@@ -498,6 +551,34 @@ namespace GraphQL.Tests.Execution
             ";
 
             AssertQuerySuccess(query, expected);
+        }
+
+        [Fact]
+        public void allows_custom_scalar_that_resolves_to_an_object()
+        {
+            var query = @"
+            query SetsCustomScalarInput($input: JsonScalarReturningObject) {
+              fieldWithCustomScalarInput(input: $input)
+            }
+            ";
+
+            var expected = @"
+            {
+              'fieldWithCustomScalarInput': ""bear-cat, dog, bird""
+            }
+            ";
+
+            var jsonString = new JObject
+            {
+                ["stringProperty"] = "bear",
+                ["arrayProperty"] = new JArray {"cat", "dog", "bird"}
+            }.ToString();
+
+            var inputs = new Inputs(new Dictionary<string, object>
+            {
+                ["input"] = jsonString
+            });
+            AssertQuerySuccess(query, expected, inputs);
         }
     }
 

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -574,10 +574,8 @@ namespace GraphQL.Tests.Execution
                 ["arrayProperty"] = new JArray {"cat", "dog", "bird"}
             }.ToString();
 
-            var inputs = new Inputs(new Dictionary<string, object>
-            {
-                ["input"] = jsonString
-            });
+            var inputs = $"{{ 'input': '{jsonString}' }}".ToInputs();
+            
             AssertQuerySuccess(query, expected, inputs);
         }
     }

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -37,6 +37,12 @@ namespace GraphQL
 
         public static object GetPropertyValue(this object propertyValue, Type fieldType)
         {
+            // Short-circuit conversion if the property value already 
+            if (fieldType.IsInstanceOfType(propertyValue))
+            {
+                return propertyValue;
+            }
+
             if (fieldType.FullName == "System.Object")
             {
                 return propertyValue;
@@ -102,9 +108,7 @@ namespace GraphQL
                 value = Enum.Parse(fieldType, str, true);
             }
 
-            if (_conversions.Value.Has(fieldType))
-                return ConvertValue(value, fieldType);
-            return value;
+            return ConvertValue(value, fieldType);
         }
 
         public static object GetProperyValue(this object obj, string propertyName)

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -102,7 +102,9 @@ namespace GraphQL
                 value = Enum.Parse(fieldType, str, true);
             }
 
-            return ConvertValue(value, fieldType);
+            if (_conversions.Value.Has(fieldType))
+                return ConvertValue(value, fieldType);
+            return value;
         }
 
         public static object GetProperyValue(this object obj, string propertyName)


### PR DESCRIPTION
I've been trying to create a custom ScalarGraphType that would accept a JSON-encoded string, and output a deserialized object corresponding to that string, using JSON.NET. I was getting an error due to the fact that the `Conversions` class was trying to convert the value returned from the ScalarGraphType, even though there was no IConversionProvider registered for my custom type. I solved it by bypassing the attempt to convert when no provider is registered for the type.