### PR TITLE
Subscription Executer

### DIFF
--- a/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using GraphQL.Resolvers;
+using GraphQL.Subscription;
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Subscription
+{
+    public class ChatSchema : Schema
+    {
+        public ChatSchema(IChat chat)
+        {
+            Query = new ChatQuery(chat);
+            Mutation = new ChatMutation(chat);
+            Subscription = new ChatSubscriptions(chat);
+        }
+    }
+
+    public class ChatSubscriptions : ObjectGraphType<object>
+    {
+        private readonly IChat _chat;
+
+        public ChatSubscriptions(IChat chat)
+        {
+            _chat = chat;
+            AddField(new EventStreamFieldType
+            {
+                Name = "messageAdded",
+                Type = typeof(MessageType),
+                Resolver = new FuncFieldResolver<Message>(ResolveMessage),
+                Subscriber = new EventStreamResolver<Message>(Subscribe)
+            });
+
+            AddField(new EventStreamFieldType
+            {
+                Name = "messageAddedByUser",
+                Arguments = new QueryArguments(
+                    new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id" }
+                ),
+                Type = typeof(MessageType),
+                Resolver = new FuncFieldResolver<Message>(ResolveMessage),
+                Subscriber = new EventStreamResolver<Message>(SubscribeById)
+            });
+        }
+
+        private IObservable<Message> SubscribeById(ResolveEventStreamContext context)
+        {
+            var id = context.GetArgument<string>("id");
+
+            var messages = _chat.Messages();
+
+            return messages.Where(message => message.From.Id == id);
+        }
+
+        private Message ResolveMessage(ResolveFieldContext context)
+        {
+            var message = context.Source as Message;
+
+            return message;
+        }
+
+        private IObservable<Message> Subscribe(ResolveEventStreamContext context)
+        {
+            return _chat.Messages();
+        }
+    }
+
+    public class ChatMutation : ObjectGraphType<object>
+    {
+        public ChatMutation(IChat chat)
+        {
+            Field<MessageType>("addMessage",
+                arguments: new QueryArguments(
+                    new QueryArgument<MessageInputType> { Name = "message" }
+                ),
+                resolve: context =>
+                {
+                    var receivedMessage = context.GetArgument<ReceivedMessage>("message");
+                    var message = chat.AddMessage(receivedMessage);
+                    return message;
+                });
+        }
+    }
+
+    public class ChatQuery : ObjectGraphType
+    {
+        public ChatQuery(IChat chat)
+        {
+            Field<ListGraphType<MessageType>>("messages", resolve: context => chat.AllMessages.Take(100));
+        }
+    }
+
+    public class MessageType : ObjectGraphType<Message>
+    {
+        public MessageType()
+        {
+            Field(o => o.Content);
+            Field(o => o.SentAt);
+            Field(o => o.From, false, typeof(MessageFromType)).Resolve(ResolveFrom);
+        }
+
+        private MessageFrom ResolveFrom(ResolveFieldContext<Message> context)
+        {
+            var message = context.Source;
+            return message.From;
+        }
+    }
+
+    public class MessageInputType : InputObjectGraphType
+    {
+        public MessageInputType()
+        {
+            Field<StringGraphType>("fromId");
+            Field<StringGraphType>("content");
+            Field<DateGraphType>("sentAt");
+        }
+    }
+
+    public class MessageFromType : ObjectGraphType<MessageFrom>
+    {
+        public MessageFromType()
+        {
+            Field(o => o.Id);
+            Field(o => o.DisplayName);
+        }
+    }
+
+    public class Message
+    {
+        public MessageFrom From { get; set; }
+
+        public string Content { get; set; }
+
+        public DateTime SentAt { get; set; }
+    }
+
+    public class MessageFrom
+    {
+        public string Id { get; set; }
+
+        public string DisplayName { get; set; }
+    }
+
+    public class ReceivedMessage
+    {
+        public string FromId { get; set; }
+
+        public string Content { get; set; }
+
+        public DateTime SentAt { get; set; }
+    }
+
+    public interface IChat
+    {
+        ConcurrentStack<Message> AllMessages { get; }
+
+        Message AddMessage(Message message);
+
+        IObservable<Message> Messages();
+
+        Message AddMessage(ReceivedMessage message);
+    }
+
+    public class Chat : IChat
+    {
+        private readonly ISubject<Message> _messageStream = new ReplaySubject<Message>(1);
+
+
+        public Chat()
+        {
+            AllMessages = new ConcurrentStack<Message>();
+            Users = new ConcurrentDictionary<string, string>
+            {
+                ["1"] = "developer",
+                ["2"] = "tester"
+            };
+        }
+
+        public ConcurrentDictionary<string, string> Users { get; set; }
+
+        public ConcurrentStack<Message> AllMessages { get; }
+
+        public Message AddMessage(ReceivedMessage message)
+        {
+            if (!Users.TryGetValue(message.FromId, out var displayName))
+            {
+                displayName = "(unknown)";
+            }
+
+            return AddMessage(new Message
+            {
+                Content = message.Content,
+                SentAt = message.SentAt,
+                From = new MessageFrom
+                {
+                    DisplayName = displayName,
+                    Id = message.FromId
+                }
+            });
+        }
+
+        public Message AddMessage(Message message)
+        {
+            AllMessages.Push(message);
+            _messageStream.OnNext(message);
+            return message;
+        }
+
+        public IObservable<Message> Messages()
+        {
+            return _messageStream.AsObservable();
+        }
+
+        public void AddError(Exception exception)
+        {
+            _messageStream.OnError(exception);
+        }
+    }
+}

--- a/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
@@ -45,6 +45,7 @@ namespace GraphQL.Tests.Subscription
             message.ShouldNotBeNull();
             message.ShouldBeOfType<ExecutionResult>();
             message.Data.ShouldNotBeNull();
+            message.Data.ShouldNotBeAssignableTo<Task>();
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using GraphQL.Subscription;
-using Newtonsoft.Json.Linq;
+using Shouldly;
 using Xunit;
 
 namespace GraphQL.Tests.Subscription
@@ -41,8 +41,10 @@ namespace GraphQL.Tests.Subscription
             /* Then */
             var stream = result.Streams.Values.FirstOrDefault();
             var message = await stream.FirstOrDefaultAsync();
-            Assert.NotNull(message);
-            Assert.IsType<ExecutionResult>(message);
+
+            message.ShouldNotBeNull();
+            message.ShouldBeOfType<ExecutionResult>();
+            message.Data.ShouldNotBeNull();
         }
 
         [Fact]
@@ -79,8 +81,10 @@ namespace GraphQL.Tests.Subscription
             /* Then */
             var stream = result.Streams.Values.FirstOrDefault();
             var message = await stream.FirstOrDefaultAsync();
-            Assert.NotNull(message);
-            Assert.IsType<ExecutionResult>(message);
+
+            message.ShouldNotBeNull();
+            message.ShouldBeOfType<ExecutionResult>();
+            message.Data.ShouldNotBeNull();
         }
 
         [Fact]
@@ -103,10 +107,11 @@ namespace GraphQL.Tests.Subscription
             /* Then */
             var stream = result.Streams.Values.FirstOrDefault();
             var message = await stream.FirstOrDefaultAsync();
-            Assert.NotNull(message);
-            Assert.IsType<ExecutionResult>(message);
-            Assert.Null(message.Data);
-            Assert.Contains("test", message.Errors.Select(e => e.InnerException.Message));
+
+            message.ShouldNotBeNull();
+            message.ShouldBeOfType<ExecutionResult>();
+            message.Data.ShouldBeNull();
+            message.Errors.ShouldContain(error => error.InnerException.Message == "test");
         }
     }
 }

--- a/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using GraphQL.Subscription;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GraphQL.Tests.Subscription
+{
+    public class SubscriptionTests
+    {
+        [Fact]
+        public async Task Subscribe()
+        {
+            /* Given */
+            var addedMessage = new Message
+            {
+                Content = "test",
+                From = new MessageFrom()
+                {
+                    DisplayName = "test",
+                    Id = "1"
+                },
+                SentAt = DateTime.Now
+            };
+            var chat = new Chat();
+            var schema = new ChatSchema(chat);
+            var sut = new SubscriptionExecuter();
+
+            /* When */
+            var result = await sut.SubscribeAsync(new ExecutionOptions
+            {
+                Query = "subscription MessageAdded { messageAdded { from { id displayName } content sentAt } }",
+                Schema = schema
+            });
+
+            chat.AddMessage(addedMessage);
+
+            /* Then */
+            var stream = result.Streams.Values.FirstOrDefault();
+            var message = await stream.FirstOrDefaultAsync();
+            Assert.NotNull(message);
+            Assert.IsType<ExecutionResult>(message);
+        }
+
+        [Fact]
+        public async Task SubscribeWithArgument()
+        {
+            /* Given */
+            var addedMessage = new Message
+            {
+                Content = "test",
+                From = new MessageFrom()
+                {
+                    DisplayName = "test",
+                    Id = "1"
+                },
+                SentAt = DateTime.Now
+            };
+            var chat = new Chat();
+            var schema = new ChatSchema(chat);
+            var sut = new SubscriptionExecuter();
+
+            /* When */
+            var result = await sut.SubscribeAsync(new ExecutionOptions
+            {
+                Query = "subscription MessageAddedByUser($id:String!) { messageAddedByUser(id: $id) { from { id displayName } content sentAt } }",
+                Schema = schema,
+                Inputs = new Inputs(new Dictionary<string, object>()
+                {
+                    ["id"] = "1"
+                })
+            });
+
+            chat.AddMessage(addedMessage);
+
+            /* Then */
+            var stream = result.Streams.Values.FirstOrDefault();
+            var message = await stream.FirstOrDefaultAsync();
+            Assert.NotNull(message);
+            Assert.IsType<ExecutionResult>(message);
+        }
+
+        [Fact]
+        public async Task OnError()
+        {
+            /* Given */
+            var chat = new Chat();
+            var schema = new ChatSchema(chat);
+            var sut = new SubscriptionExecuter();
+
+            /* When */
+            var result = await sut.SubscribeAsync(new ExecutionOptions
+            {
+                Query = "subscription MessageAdded { messageAdded { from { id displayName } content sentAt } }",
+                Schema = schema
+            });
+
+            chat.AddError(new Exception("test"));
+
+            /* Then */
+            var stream = result.Streams.Values.FirstOrDefault();
+            var message = await stream.FirstOrDefaultAsync();
+            Assert.NotNull(message);
+            Assert.IsType<ExecutionResult>(message);
+            Assert.Null(message.Data);
+            Assert.Contains("test", message.Errors.Select(e => e.InnerException.Message));
+        }
+    }
+}

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -237,7 +237,7 @@ namespace GraphQL
             return context;
         }
 
-        private Operation GetOperation(string operationName, Document document)
+        protected Operation GetOperation(string operationName, Document document)
         {
             var operation = !string.IsNullOrWhiteSpace(operationName)
                 ? document.Operations.WithName(operationName)

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -28,6 +28,8 @@
   <ItemGroup>
     <PackageReference Include="GraphQL-Parser" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
+    <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">

--- a/src/GraphQL/Resolvers/EventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/EventStreamResolver.cs
@@ -1,0 +1,27 @@
+using System;
+using GraphQL.Execution;
+using GraphQL.Subscription;
+
+namespace GraphQL.Resolvers
+{
+    public class EventStreamResolver<T> : IEventStreamResolver<T>
+    {
+        private readonly Func<ResolveEventStreamContext, IObservable<T>> _subscriber;
+
+        public EventStreamResolver(
+            Func<ResolveEventStreamContext, IObservable<T>> subscriber)
+        {
+            _subscriber = subscriber ?? throw new ArgumentNullException(nameof(subscriber));
+        }
+
+        public IObservable<T> Subscribe(ResolveEventStreamContext context)
+        {
+            return _subscriber(context);
+        }
+
+        IObservable<object> IEventStreamResolver.Subscribe(ResolveEventStreamContext context)
+        {
+            return (IObservable<object>)Subscribe(context);
+        }
+    }
+}

--- a/src/GraphQL/Resolvers/IEventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/IEventStreamResolver.cs
@@ -1,0 +1,16 @@
+using System;
+using GraphQL.Execution;
+using GraphQL.Subscription;
+
+namespace GraphQL.Resolvers
+{
+    public interface IEventStreamResolver
+    {
+        IObservable<object> Subscribe(ResolveEventStreamContext context);
+    }
+
+    public interface IEventStreamResolver<out T> : IEventStreamResolver
+    {
+        new IObservable<T> Subscribe(ResolveEventStreamContext context);
+    }
+}

--- a/src/GraphQL/Subscription/ISubscriptionExecuter.cs
+++ b/src/GraphQL/Subscription/ISubscriptionExecuter.cs
@@ -1,9 +1,8 @@
 using System.Threading.Tasks;
-using GraphQL.Execution;
 
 namespace GraphQL.Subscription
 {
-    public interface ISubscriptionExecuter : IDocumentExecuter
+    public interface ISubscriptionExecuter
     {
         Task<SubscriptionExecutionResult> SubscribeAsync(ExecutionOptions config);
     }

--- a/src/GraphQL/Subscription/ISubscriptionExecuter.cs
+++ b/src/GraphQL/Subscription/ISubscriptionExecuter.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using GraphQL.Execution;
+
+namespace GraphQL.Subscription
+{
+    public interface ISubscriptionExecuter : IDocumentExecuter
+    {
+        Task<SubscriptionExecutionResult> SubscribeAsync(ExecutionOptions config);
+    }
+}

--- a/src/GraphQL/Subscription/ResolveEventStreamContext.cs
+++ b/src/GraphQL/Subscription/ResolveEventStreamContext.cs
@@ -1,0 +1,8 @@
+using GraphQL.Types;
+
+namespace GraphQL.Subscription
+{
+    public class ResolveEventStreamContext : ResolveFieldContext<object>
+    {
+    }
+}

--- a/src/GraphQL/Subscription/ResolveEventStreamResult.cs
+++ b/src/GraphQL/Subscription/ResolveEventStreamResult.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GraphQL.Subscription
+{
+    public class ResolveEventStreamResult
+    {
+        public IObservable<ExecutionResult> Value { get; set; }
+
+        public bool Skip { get; set; }
+    }
+}

--- a/src/GraphQL/Subscription/SubscriptionExecuter.cs
+++ b/src/GraphQL/Subscription/SubscriptionExecuter.cs
@@ -35,16 +35,6 @@ namespace GraphQL.Subscription
             _complexityAnalyzer = complexityAnalyzer;
         }
 
-        //todo: this is currently private in the DocumentExecuter
-        protected Operation GetOperation(string operationName, Document document)
-        {
-            var operation = !string.IsNullOrWhiteSpace(operationName)
-                ? document.Operations.WithName(operationName)
-                : document.Operations.FirstOrDefault();
-
-            return operation;
-        }
-
         public async Task<SubscriptionExecutionResult> SubscribeAsync(ExecutionOptions config)
         {
             var metrics = new Metrics();

--- a/src/GraphQL/Subscription/SubscriptionExecuter.cs
+++ b/src/GraphQL/Subscription/SubscriptionExecuter.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using GraphQL.Instrumentation;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
+using Field = GraphQL.Language.AST.Field;
+
+namespace GraphQL.Subscription
+{
+    public class SubscriptionExecuter : DocumentExecuter, ISubscriptionExecuter
+    {
+        private readonly IDocumentBuilder _documentBuilder;
+        private readonly IDocumentValidator _documentValidator;
+        private readonly IComplexityAnalyzer _complexityAnalyzer;
+
+        public SubscriptionExecuter()
+            : this(new GraphQLDocumentBuilder(), new DocumentValidator(), new ComplexityAnalyzer())
+        {
+        }
+
+        public SubscriptionExecuter(
+            IDocumentBuilder documentBuilder, 
+            IDocumentValidator documentValidator, 
+            IComplexityAnalyzer complexityAnalyzer) : base(documentBuilder, documentValidator, complexityAnalyzer)
+        {
+            _documentBuilder = documentBuilder;
+            _documentValidator = documentValidator;
+            _complexityAnalyzer = complexityAnalyzer;
+        }
+
+        //todo: this is currently private in the DocumentExecuter
+        protected Operation GetOperation(string operationName, Document document)
+        {
+            var operation = !string.IsNullOrWhiteSpace(operationName)
+                ? document.Operations.WithName(operationName)
+                : document.Operations.FirstOrDefault();
+
+            return operation;
+        }
+
+        public async Task<SubscriptionExecutionResult> SubscribeAsync(ExecutionOptions config)
+        {
+            var metrics = new Metrics();
+            metrics.Start(config.OperationName);
+
+            config.Schema.FieldNameConverter = config.FieldNameConverter;
+
+            var result = new SubscriptionExecutionResult
+            {
+                Query = config.Query,
+                ExposeExceptions = config.ExposeExceptions
+            };
+
+            try
+            {
+                if (!config.Schema.Initialized)
+                    using (metrics.Subject("schema", "Initializing schema"))
+                    {
+                        config.FieldMiddleware.ApplyTo(config.Schema);
+                        config.Schema.Initialize();
+                    }
+
+                var document = config.Document;
+                using (metrics.Subject("document", "Building document"))
+                {
+                    if (document == null)
+                        document = _documentBuilder.Build(config.Query);
+                }
+
+                result.Document = document;
+
+                var operation = GetOperation(config.OperationName, document);
+
+                // is this needed? 
+                if (operation.OperationType != OperationType.Subscription)
+                    throw new InvalidOperationException(
+                        $"Cannot subscribe to query '{config.Query}'. {nameof(SubscribeAsync)} only supports subscriptions");
+
+                result.Operation = operation;
+                metrics.SetOperationName(operation?.Name);
+
+                if (config.ComplexityConfiguration != null)
+                    using (metrics.Subject("document", "Analyzing complexity"))
+                    {
+                        _complexityAnalyzer.Validate(document, config.ComplexityConfiguration);
+                    }
+
+                IValidationResult validationResult;
+                using (metrics.Subject("document", "Validating document"))
+                {
+                    validationResult = _documentValidator.Validate(
+                        config.Query,
+                        config.Schema,
+                        document,
+                        config.ValidationRules,
+                        config.UserContext);
+                }
+
+                foreach (var listener in config.Listeners)
+                    await listener.AfterValidationAsync(
+                            config.UserContext,
+                            validationResult,
+                            config.CancellationToken)
+                        .ConfigureAwait(false);
+
+                if (validationResult.IsValid)
+                {
+                    var context = BuildExecutionContext(
+                        config.Schema,
+                        config.Root,
+                        document,
+                        operation,
+                        config.Inputs,
+                        config.UserContext,
+                        config.CancellationToken,
+                        metrics);
+
+                    if (context.Errors.Any())
+                    {
+                        result.Errors = context.Errors;
+                        return result;
+                    }
+
+                    using (metrics.Subject("execution", "Executing operation"))
+                    {
+                        foreach (var listener in config.Listeners)
+                            await listener.BeforeExecutionAsync(config.UserContext, config.CancellationToken)
+                                .ConfigureAwait(false);
+
+                        var streams = ExecuteSubscription(context);
+                        result.Streams = streams;
+
+                        foreach (var listener in config.Listeners)
+                            await listener.AfterExecutionAsync(config.UserContext, config.CancellationToken)
+                                .ConfigureAwait(false);
+                    }
+
+                    if (context.Errors.Any())
+                        result.Errors = context.Errors;
+                }
+                else
+                {
+                    result.Streams = null;
+                    result.Errors = validationResult.Errors;
+                }
+
+                return result;
+            }
+            catch (Exception exc)
+            {
+                if (result.Errors == null)
+                    result.Errors = new ExecutionErrors();
+
+                result.Streams = null;
+                result.Errors.Add(new ExecutionError(exc.Message, exc));
+                return result;
+            }
+            finally
+            {
+                result.Perf = metrics.Finish().ToArray();
+            }
+        }
+
+        public IDictionary<string, IObservable<ExecutionResult>> ExecuteSubscription(ExecutionContext context)
+        {
+            var rootType = GetOperationRootType(context.Document, context.Schema, context.Operation);
+            var fields = CollectFields(
+                context,
+                rootType,
+                context.Operation.SelectionSet,
+                new Dictionary<string, Fields>(),
+                new List<string>());
+
+            return ExecuteSubscriptionFields(context, rootType, context.RootValue, fields);
+        }
+
+        public IDictionary<string, IObservable<ExecutionResult>> ExecuteSubscriptionFields(
+           ExecutionContext context,
+           IObjectGraphType rootType,
+           object source,
+           Dictionary<string, Fields> fields)
+        {
+            var result = new ConcurrentDictionary<string, IObservable<ExecutionResult>>();
+
+            foreach (var field in fields)
+            {
+                var key = field.Key;
+
+                var fieldResult = ResolveEventStream(context, rootType, source, field.Value);
+
+                if (fieldResult.Skip)
+                    continue;
+
+                result[key] = fieldResult.Value;
+            }
+
+            return result;
+        }
+
+        public ResolveEventStreamResult ResolveEventStream(ExecutionContext context,
+            IObjectGraphType parentType, object source, Fields fields)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            var resolveResult = new ResolveEventStreamResult
+            {
+                Skip = false
+            };
+
+            var field = fields.First();
+
+            if (!(GetFieldDefinition(context.Schema, parentType, field) is EventStreamFieldType fieldDefinition))
+            {
+                resolveResult.Skip = true;
+                return resolveResult;
+            }
+
+            var arguments = GetArgumentValues(context.Schema, fieldDefinition.Arguments, field.Arguments,
+                context.Variables);
+
+            try
+            {
+                var resolveContext = new ResolveEventStreamContext();
+                resolveContext.FieldName = field.Name;
+                resolveContext.FieldAst = field;
+                resolveContext.FieldDefinition = fieldDefinition;
+                resolveContext.ReturnType = fieldDefinition.ResolvedType;
+                resolveContext.ParentType = parentType;
+                resolveContext.Arguments = arguments;
+                resolveContext.Source = source;
+                resolveContext.Schema = context.Schema;
+                resolveContext.Document = context.Document;
+                resolveContext.Fragments = context.Fragments;
+                resolveContext.RootValue = context.RootValue;
+                resolveContext.UserContext = context.UserContext;
+                resolveContext.Operation = context.Operation;
+                resolveContext.Variables = context.Variables;
+                resolveContext.CancellationToken = context.CancellationToken;
+                resolveContext.Metrics = context.Metrics;
+                resolveContext.Errors = context.Errors;
+
+                if (fieldDefinition.Subscriber == null)
+                    return GenerateError(resolveResult, field, context,
+                        new InvalidOperationException($"Subscriber not set for field {field.Name}"));
+
+                var result = fieldDefinition.Subscriber.Subscribe(resolveContext);
+
+                var valueTransformer = result
+                    .Select(value =>
+                    {
+                        var r = ResolveFieldAsync(context, parentType, value, fields).GetAwaiter().GetResult();
+
+                        return new ExecutionResult()
+                        {
+                            Data = r.Value
+                        };
+                    })
+                    .Catch<ExecutionResult, Exception>(exception => Observable.Return(
+                            new ExecutionResult
+                            {
+                                Errors = new ExecutionErrors
+                                {
+                                    new ExecutionError(
+                                        $"Error in subscription '{resolveContext.Document.OriginalQuery}'",
+                                        exception)
+                                }
+                            }));
+
+                resolveResult.Value = valueTransformer;
+                return resolveResult;
+            }
+            catch (Exception exc)
+            {
+                return GenerateError(resolveResult, field, context, exc);
+            }
+        }
+
+        private ResolveEventStreamResult GenerateError(ResolveEventStreamResult resolveResult, Field field,
+            ExecutionContext context, Exception exc)
+        {
+            var error = new ExecutionError("Error trying to resolve {0}.".ToFormat(field.Name), exc);
+            error.AddLocation(field, context.Document);
+            context.Errors.Add(error);
+            resolveResult.Skip = false;
+            return resolveResult;
+        }
+    }
+}

--- a/src/GraphQL/Subscription/SubscriptionExecutionResult.cs
+++ b/src/GraphQL/Subscription/SubscriptionExecutionResult.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using GraphQL.Instrumentation;
+using GraphQL.Language.AST;
+
+namespace GraphQL.Subscription
+{
+    public class SubscriptionExecutionResult
+    {
+        public string Query { get; set; }
+
+        public bool ExposeExceptions { get; set; }
+
+        public Document Document { get; set; }
+
+        public Operation Operation { get; set; }
+
+        public ExecutionErrors Errors { get; set; }
+
+        public IDictionary<string, IObservable<ExecutionResult>> Streams { get; set; }
+
+        public PerfRecord[] Perf { get; set; }
+    }
+}

--- a/src/GraphQL/Types/EventStreamFieldType.cs
+++ b/src/GraphQL/Types/EventStreamFieldType.cs
@@ -1,0 +1,9 @@
+using GraphQL.Resolvers;
+
+namespace GraphQL.Types
+{
+    public class EventStreamFieldType : FieldType
+    {
+        public IEventStreamResolver Subscriber { get; set; }
+    }
+}


### PR DESCRIPTION
# Description

Provides a `SubscriptionExecuter` which allows subscribing to a source stream provided by the `EventStreamFieldType`. Returned stream is of type `IObservable<object>` allowing easy manipulation.

## Examples

See the "unit tests": https://github.com/pekkah/graphql-dotnet/blob/features/subscription/src/GraphQL.Tests/Subscription/SubscriptionTests.cs


## Where is the transport?

I'll be pushing out a separate NuGet/repo with the transport layer for Apollo Client compatibility after this makes it into the official GraphQL NuGet so I can just add it as an dependency.