### PR TITLE
Allow generic InputObjectGraphType for strongly-typed field definition

### DIFF
--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -678,7 +678,7 @@ namespace GraphQL
                 return;
             }
 
-            if (type is IObjectGraphType || type is InputObjectGraphType)
+            if (type is IObjectGraphType || type is IInputObjectGraphType)
             {
                 var dict = input as Dictionary<string, object>;
                 var complexType = (IComplexGraphType)type;
@@ -690,7 +690,7 @@ namespace GraphQL
                 }
 
                 // ensure every provided field is defined
-                var unknownFields = type is InputObjectGraphType
+                var unknownFields = type is IInputObjectGraphType
                     ? dict.Keys.Where(key => complexType.Fields.All(field => field.Name != key)).ToArray()
                     : null;
 
@@ -751,7 +751,7 @@ namespace GraphQL
                     : new[] { CoerceValue(schema, listItemType, input, variables) };
             }
 
-            if (type is IObjectGraphType || type is InputObjectGraphType)
+            if (type is IObjectGraphType || type is IInputObjectGraphType)
             {
                 var complexType = type as IComplexGraphType;
                 var obj = new Dictionary<string, object>();

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -154,14 +154,14 @@ namespace GraphQL
                 return IsValidLiteralValue(ofType, valueAst, schema);
             }
 
-            if (type is InputObjectGraphType)
+            if (type is IComplexGraphType)
             {
                 if (!(valueAst is ObjectValue))
                 {
                     return new[] {$"Expected \"{type.Name}\", found not an object."};
                 }
 
-                var inputType = (InputObjectGraphType) type;
+                var inputType = (IComplexGraphType) type;
 
                 var fields = inputType.Fields.ToList();
                 var fieldAsts = ((ObjectValue) valueAst).ObjectFields.ToList();

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -154,14 +154,14 @@ namespace GraphQL
                 return IsValidLiteralValue(ofType, valueAst, schema);
             }
 
-            if (type is IComplexGraphType)
+            if (type is InputObjectGraphType)
             {
                 if (!(valueAst is ObjectValue))
                 {
                     return new[] {$"Expected \"{type.Name}\", found not an object."};
                 }
 
-                var inputType = (IComplexGraphType) type;
+                var inputType = (InputObjectGraphType) type;
 
                 var fields = inputType.Fields.ToList();
                 var fieldAsts = ((ObjectValue) valueAst).ObjectFields.ToList();

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -36,7 +36,7 @@ namespace GraphQL
             var namedType = type.GetNamedType();
             return namedType is ScalarGraphType ||
                    namedType is EnumerationGraphType ||
-                   namedType is InputObjectGraphType;
+                   namedType is IInputObjectGraphType;
         }
 
         public static IGraphType GetNamedType(this IGraphType type)
@@ -154,14 +154,14 @@ namespace GraphQL
                 return IsValidLiteralValue(ofType, valueAst, schema);
             }
 
-            if (type is InputObjectGraphType)
+            if (type is IInputObjectGraphType)
             {
                 if (!(valueAst is ObjectValue))
                 {
                     return new[] {$"Expected \"{type.Name}\", found not an object."};
                 }
 
-                var inputType = (InputObjectGraphType) type;
+                var inputType = (IInputObjectGraphType) type;
 
                 var fields = inputType.Fields.ToList();
                 var fieldAsts = ((ObjectValue) valueAst).ObjectFields.ToList();
@@ -335,14 +335,14 @@ namespace GraphQL
 
             // Populate the fields of the input object by creating ASTs from each value
             // in the dictionary according to the fields in the input type.
-            if (type is InputObjectGraphType)
+            if (type is IInputObjectGraphType)
             {
                 if (!(value is Dictionary<string, object>))
                 {
                     return null;
                 }
 
-                var input = (InputObjectGraphType) type;
+                var input = (IInputObjectGraphType) type;
                 var dict = (Dictionary<string, object>)value;
 
                 var fields = dict

--- a/src/GraphQL/Introspection/__Type.cs
+++ b/src/GraphQL/Introspection/__Type.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using GraphQL.Types;
@@ -89,7 +89,7 @@ namespace GraphQL.Introspection
                 });
             Field<ListGraphType<NonNullGraphType<__InputValue>>>("inputFields", resolve: context =>
             {
-                var type = context.Source as InputObjectGraphType;
+                var type = context.Source as IInputObjectGraphType;
                 return type?.Fields;
             });
             Field<__Type>("ofType", resolve: context =>
@@ -132,7 +132,7 @@ namespace GraphQL.Introspection
             {
                 return TypeKind.UNION;
             }
-            if (type is InputObjectGraphType)
+            if (type is IInputObjectGraphType)
             {
                 return TypeKind.INPUT_OBJECT;
             }
@@ -170,7 +170,7 @@ namespace GraphQL.Introspection
             {
                 return TypeKind.UNION;
             }
-            if (typeof (InputObjectGraphType).IsAssignableFrom(type))
+            if (typeof (IInputObjectGraphType).IsAssignableFrom(type))
             {
                 return TypeKind.INPUT_OBJECT;
             }

--- a/src/GraphQL/Types/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/InputObjectGraphType.cs
@@ -1,6 +1,109 @@
-﻿namespace GraphQL.Types
+using GraphQL.Builders;
+using GraphQL.Resolvers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace GraphQL.Types
 {
     public class InputObjectGraphType : ComplexGraphType<object>
     {
     }
+
+
+
+    public class InputObjectGraphType<TSourceType> : InputObjectGraphType
+    {
+
+        public FieldType Field(
+            Type type,
+            string name,
+            string description = null,
+            QueryArguments arguments = null,
+            Func<ResolveFieldContext<TSourceType>, object> resolve = null,
+            string deprecationReason = null)
+        {
+            return AddField(new FieldType
+            {
+                Name = name,
+                Description = description,
+                DeprecationReason = deprecationReason,
+                Type = type,
+                Arguments = arguments,
+                Resolver = resolve != null
+                    ? new FuncFieldResolver<TSourceType, object>(resolve)
+                    : null,
+            });
+        }
+
+        public FieldType Field<TGraphType>(
+            string name,
+            string description = null,
+            QueryArguments arguments = null,
+            Func<ResolveFieldContext<TSourceType>, object> resolve = null,
+            string deprecationReason = null)
+            where TGraphType : IGraphType
+        {
+            return AddField(new FieldType
+            {
+                Name = name,
+                Description = description,
+                DeprecationReason = deprecationReason,
+                Type = typeof(TGraphType),
+                Arguments = arguments,
+                Resolver = resolve != null
+                    ? new FuncFieldResolver<TSourceType, object>(resolve)
+                    : null,
+            });
+        }
+
+        public FieldBuilder<TSourceType, TProperty> Field<TProperty>(
+            Expression<Func<TSourceType, TProperty>> expression,
+            bool nullable = false,
+            Type type = null)
+        {
+            string name;
+            try
+            {
+                name = expression.NameOf();
+            }
+            catch
+            {
+                throw new ArgumentException(
+                    $"Cannot infer a Field name from the expression: '{expression.Body.ToString()}' " +
+                    $"on parent GraphQL type: '{Name ?? GetType().Name}'.");
+            }
+            return Field(name, expression, nullable, type);
+        }
+
+        public FieldBuilder<TSourceType, TProperty> Field<TProperty>(
+           string name,
+           Expression<Func<TSourceType, TProperty>> expression,
+           bool nullable = false,
+           Type type = null)
+        {
+            try
+            {
+                if (type == null)
+                    type = typeof(TProperty).GetGraphTypeFromType(nullable);
+            }
+            catch (ArgumentOutOfRangeException exp)
+            {
+                throw new ArgumentException(
+                    $"The GraphQL type for Field: '{name}' on parent type: '{Name ?? GetType().Name}' could not be derived implicitly. \n",
+                    exp
+                 );
+            }
+
+            var builder = FieldBuilder.Create<TSourceType, TProperty>(type)
+                .Resolve(new ExpressionFieldResolver<TSourceType, TProperty>(expression))
+                .Name(name);
+
+            AddField(builder.FieldType);
+            return builder;
+        }
+
+    }
 }
+

--- a/src/GraphQL/Types/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/InputObjectGraphType.cs
@@ -7,102 +7,16 @@ using System.Linq.Expressions;
 
 namespace GraphQL.Types
 {
-    public class InputObjectGraphType : ComplexGraphType<object>
+    public interface IInputObjectGraphType : IComplexGraphType
     {
     }
 
-
-
-    public class InputObjectGraphType<TSourceType> : InputObjectGraphType
+    public class InputObjectGraphType : InputObjectGraphType<object>
     {
+    }
 
-        public FieldType Field(
-            Type type,
-            string name,
-            string description = null,
-            QueryArguments arguments = null,
-            Func<ResolveFieldContext<TSourceType>, object> resolve = null,
-            string deprecationReason = null)
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = type,
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, object>(resolve)
-                    : null,
-            });
-        }
-
-        public FieldType Field<TGraphType>(
-            string name,
-            string description = null,
-            QueryArguments arguments = null,
-            Func<ResolveFieldContext<TSourceType>, object> resolve = null,
-            string deprecationReason = null)
-            where TGraphType : IGraphType
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = typeof(TGraphType),
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, object>(resolve)
-                    : null,
-            });
-        }
-
-        public FieldBuilder<TSourceType, TProperty> Field<TProperty>(
-            Expression<Func<TSourceType, TProperty>> expression,
-            bool nullable = false,
-            Type type = null)
-        {
-            string name;
-            try
-            {
-                name = expression.NameOf();
-            }
-            catch
-            {
-                throw new ArgumentException(
-                    $"Cannot infer a Field name from the expression: '{expression.Body.ToString()}' " +
-                    $"on parent GraphQL type: '{Name ?? GetType().Name}'.");
-            }
-            return Field(name, expression, nullable, type);
-        }
-
-        public FieldBuilder<TSourceType, TProperty> Field<TProperty>(
-           string name,
-           Expression<Func<TSourceType, TProperty>> expression,
-           bool nullable = false,
-           Type type = null)
-        {
-            try
-            {
-                if (type == null)
-                    type = typeof(TProperty).GetGraphTypeFromType(nullable);
-            }
-            catch (ArgumentOutOfRangeException exp)
-            {
-                throw new ArgumentException(
-                    $"The GraphQL type for Field: '{name}' on parent type: '{Name ?? GetType().Name}' could not be derived implicitly. \n",
-                    exp
-                 );
-            }
-
-            var builder = FieldBuilder.Create<TSourceType, TProperty>(type)
-                .Resolve(new ExpressionFieldResolver<TSourceType, TProperty>(expression))
-                .Name(name);
-
-            AddField(builder.FieldType);
-            return builder;
-        }
+    public class InputObjectGraphType<TSourceType> : ComplexGraphType<TSourceType>, IInputObjectGraphType
+    {        
 
     }
 }

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -188,12 +188,12 @@ namespace GraphQL.Utilities
                 return PrintDirective((DirectiveGraphType)type);
             }
 
-            if (!(type is InputObjectGraphType))
+            if (!(type is IInputObjectGraphType))
             {
                 throw new InvalidOperationException("Unknown GraphType {0}".ToFormat(type.GetType().Name));
             }
 
-            return PrintInputObject((InputObjectGraphType)type);
+            return PrintInputObject((IInputObjectGraphType)type);
         }
 
         public string PrintScalar(ScalarGraphType type)
@@ -234,7 +234,7 @@ namespace GraphQL.Utilities
             return description + "enum {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, values);
         }
 
-        public string PrintInputObject(InputObjectGraphType type)
+        public string PrintInputObject(IInputObjectGraphType type)
         {
             var description = PrintDescription(type.Description);
             var fields = type.Fields.Select(x => "  " + PrintInputValue(x));

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Introspection;
 using GraphQL.Language.AST;
@@ -157,7 +157,7 @@ namespace GraphQL.Validation
                 var objectType = GetInputType().GetNamedType();
                 IGraphType fieldType = null;
 
-                if (objectType is InputObjectGraphType)
+                if (objectType is IInputObjectGraphType)
                 {
                     var complexType = objectType as IComplexGraphType;
                     var inputField = complexType.Fields.FirstOrDefault(x => x.Name == ((ObjectField) node).Name);


### PR DESCRIPTION
This should allow strongly-typed classes to be used to define input types. It should continue to adhere to GraphQL spec as all added fields must be of ScalarGraphType or InputObjectGraphType.

Usage example:
```
public class MyClass
{
    public int Id { get; set; }
    public string RandomDescription { get; set; }
}

public class MyClassInputType : InputObjectGraphType<MyClass>
{
    Field(x => x.Id);
    Field(x => x.RandomDescription);
}
```

