### PR TITLE
Added support for custom scalar types such as byte or short.

### DIFF
--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -413,6 +413,12 @@ namespace GraphQL
                 return new StringValue(serialized.ToString());
             }
 
+            var converter = schema.FindValueConverter(serialized);
+            if (converter != null)
+            {
+                return converter.Convert(serialized);
+            }
+
             throw new ExecutionError($"Cannot convert value to AST: {serialized}");
         }
 
@@ -421,36 +427,6 @@ namespace GraphQL
             if (value == null)
             {
                 return null;
-            }
-
-            if (value is StringValue)
-            {
-                var str = (StringValue)value;
-                return str.Value;
-            }
-
-            if (value is IntValue)
-            {
-                var num = (IntValue)value;
-                return num.Value;
-            }
-
-            if (value is LongValue)
-            {
-                var num = (LongValue)value;
-                return num.Value;
-            }
-
-            if (value is FloatValue)
-            {
-                var num = (FloatValue)value;
-                return num.Value;
-            }
-
-            if (value is EnumValue)
-            {
-                var @enum = (EnumValue)value;
-                return @enum.Name;
             }
 
             if (value is ObjectValue)
@@ -467,7 +443,7 @@ namespace GraphQL
                 return list.Values.Select(ValueFromAst).ToList();
             }
 
-            return null;
+            return value.GetValue();
         }
     }
 }

--- a/src/GraphQL/Language/AST/IValue.cs
+++ b/src/GraphQL/Language/AST/IValue.cs
@@ -1,6 +1,7 @@
-﻿namespace GraphQL.Language.AST
+namespace GraphQL.Language.AST
 {
     public interface IValue : INode
     {
+        object GetValue();
     }
 }

--- a/src/GraphQL/Language/AST/IntValue.cs
+++ b/src/GraphQL/Language/AST/IntValue.cs
@@ -12,6 +12,11 @@ namespace GraphQL.Language.AST
             Value = value;
         }
 
+        public object GetValue()
+        {
+            return Value;
+        }
+
         public int Value { get; }
 
         public override string ToString()
@@ -38,6 +43,11 @@ namespace GraphQL.Language.AST
         public LongValue(long value)
         {
             Value = value;
+        }
+
+        public object GetValue()
+        {
+            return Value;
         }
 
         public long Value { get; }
@@ -68,6 +78,11 @@ namespace GraphQL.Language.AST
             Value = value;
         }
 
+        public object GetValue()
+        {
+            return Value;
+        }
+
         public decimal Value { get; }
 
         public override string ToString()
@@ -94,6 +109,11 @@ namespace GraphQL.Language.AST
         public FloatValue(double value)
         {
             Value = value;
+        }
+
+        public object GetValue()
+        {
+            return Value;
         }
 
         public double Value { get; }
@@ -126,6 +146,11 @@ namespace GraphQL.Language.AST
             Value = value;
         }
 
+        public object GetValue()
+        {
+            return Value;
+        }
+
         public string Value { get; }
 
         public override string ToString()
@@ -152,6 +177,11 @@ namespace GraphQL.Language.AST
         public BooleanValue(bool value)
         {
             Value = value;
+        }
+
+        public object GetValue()
+        {
+            return Value;
         }
 
         public bool Value { get; }
@@ -183,6 +213,11 @@ namespace GraphQL.Language.AST
             Value = value;
         }
 
+        public object GetValue()
+        {
+            return Value;
+        }
+
         public DateTime Value { get; }
 
         public override string ToString()
@@ -211,6 +246,11 @@ namespace GraphQL.Language.AST
         {
             Name = name.Name;
             NameNode = name;
+        }
+
+        public object GetValue()
+        {
+            return Name;
         }
 
         public EnumValue(string name)
@@ -248,6 +288,11 @@ namespace GraphQL.Language.AST
             Values = values;
         }
 
+        public object GetValue()
+        {
+            return Values;
+        }
+
         public IEnumerable<IValue> Values { get; }
 
         public override IEnumerable<INode> Children => Values;
@@ -272,6 +317,11 @@ namespace GraphQL.Language.AST
         public ObjectValue(IEnumerable<ObjectField> fields)
         {
             ObjectFields = fields;
+        }
+
+        public object GetValue()
+        {
+            return ObjectFields;
         }
 
         public IEnumerable<ObjectField> ObjectFields { get; }

--- a/src/GraphQL/Language/AST/NullValue.cs
+++ b/src/GraphQL/Language/AST/NullValue.cs
@@ -1,10 +1,15 @@
-﻿namespace GraphQL.Language.AST
+namespace GraphQL.Language.AST
 {
     public class NullValue : AbstractNode, IValue
     {
         public override string ToString()
         {
             return "null";
+        }
+
+        public object GetValue()
+        {
+            return null;
         }
 
         public override bool IsEqualTo(INode obj)

--- a/src/GraphQL/Language/AST/Variable.cs
+++ b/src/GraphQL/Language/AST/Variable.cs
@@ -67,6 +67,11 @@ namespace GraphQL.Language.AST
             NameNode = name;
         }
 
+        public object GetValue()
+        {
+            return NameNode;
+        }
+
         public string Name { get; }
         public NameNode NameNode { get; }
 

--- a/src/GraphQL/Types/IAstFromValueConverter.cs
+++ b/src/GraphQL/Types/IAstFromValueConverter.cs
@@ -1,0 +1,11 @@
+
+using GraphQL.Language.AST;
+
+namespace GraphQL.Types
+{
+    public interface IAstFromValueConverter
+    {
+        bool Matches(object value);
+        IValue Convert(object value);
+    }
+}

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -42,6 +42,10 @@ namespace GraphQL.Types
         void RegisterDirective(DirectiveGraphType directive);
 
         void RegisterDirectives(params DirectiveGraphType[] directives);
+
+        void RegisterValueConverter(IAstFromValueConverter converter);
+
+        IAstFromValueConverter FindValueConverter(object value);
     }
 
     public class Schema : ISchema
@@ -50,6 +54,7 @@ namespace GraphQL.Types
         private readonly List<Type> _additionalTypes;
         private readonly List<IGraphType> _additionalInstances;
         private readonly List<DirectiveGraphType> _directives;
+        private readonly List<IAstFromValueConverter> _converters;
 
         public Schema()
             : this(new DefaultDependencyResolver())
@@ -79,6 +84,7 @@ namespace GraphQL.Types
                 DirectiveGraphType.Skip,
                 DirectiveGraphType.Deprecated
             };
+            _converters = new List<IAstFromValueConverter>();
         }
 
         public static ISchema For(string[] typeDefinitions, Action<SchemaBuilder> configure = null)
@@ -177,6 +183,16 @@ namespace GraphQL.Types
         public DirectiveGraphType FindDirective(string name)
         {
             return _directives.FirstOrDefault(x => x.Name == name);
+        }
+
+        public void RegisterValueConverter(IAstFromValueConverter converter)
+        {
+            _converters.Add(converter);
+        }
+
+        public IAstFromValueConverter FindValueConverter(object value)
+        {
+            return _converters.FirstOrDefault(x => x.Matches(value));
         }
 
         public IGraphType FindType(string name)


### PR DESCRIPTION
Addresses issue [458](https://github.com/graphql-dotnet/graphql-dotnet/issues/458)

I've tested this change in my organization's GraphQL API and our short and byte custom types work great.