### PR TITLE
Wrong error message while referencing a unknown fragment

### DIFF
--- a/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 
 namespace GraphQL.Tests.StarWars
 {
@@ -76,6 +76,25 @@ namespace GraphQL.Tests.StarWars
             }";
 
             AssertQuerySuccess(query, expected);
+        }
+
+        [Fact]
+        public void use_undefined_fragment()
+        {
+            var query = @"
+                query someDroids {
+                    r2d2: droid(id: ""3"") {
+                        ...unknown_fragment
+                        name
+                    }
+               }
+            ";
+            var errors = new ExecutionErrors();
+            var error = new ExecutionError(@"Unknown fragment ""unknown_fragment"".");
+            error.AddLocation(4, 25);
+            errors.Add(error);
+
+            AssertQuery(query, CreateQueryResult(null, errors), null, null);
         }
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -172,12 +172,6 @@ namespace GraphQL
                     throw new ExecutionError("Unable to determine operation from query.");
                 }
 
-                if (config.ComplexityConfiguration != null)
-                {
-                    using (metrics.Subject("document", "Analyzing complexity"))
-                        _complexityAnalyzer.Validate(document, config.ComplexityConfiguration);
-                }
-
                 IValidationResult validationResult;
                 using (metrics.Subject("document", "Validating document"))
                 {
@@ -187,6 +181,12 @@ namespace GraphQL
                         document,
                         config.ValidationRules,
                         config.UserContext);
+                }
+
+                if (config.ComplexityConfiguration != null && validationResult.IsValid)
+                {
+                    using (metrics.Subject("document", "Analyzing complexity"))
+                        _complexityAnalyzer.Validate(document, config.ComplexityConfiguration);
                 }
 
                 foreach (var listener in config.Listeners)

--- a/src/GraphQL/Validation/Rules/PossibleFragmentSpreads.cs
+++ b/src/GraphQL/Validation/Rules/PossibleFragmentSpreads.cs
@@ -62,7 +62,7 @@ namespace GraphQL.Validation.Rules
         private IGraphType getFragmentType(ValidationContext context, string name)
         {
             var frag = context.GetFragment(name);
-            return frag.Type.GraphTypeFromType(context.Schema);
+            return frag?.Type?.GraphTypeFromType(context.Schema);
         }
     }
 }


### PR DESCRIPTION
The message was Key Object reference not set to an instance of an object."
Now it is "Unknown fragment \"unknown_fragment\"