### PR TITLE
Wrap inner exception during resolving

### DIFF
--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -58,7 +58,7 @@ namespace GraphQL.Instrumentation
                         }
                         catch (AggregateException ex)
                         {
-                            throw new Exception($"GraphQL - Error resolving field {context.FieldName}", ex.InnerException);
+                            throw new Exception(String.Format("GraphQL - error resolving field {0}", context.FieldName), ex.InnerException);
                         }
                     });
                 });

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -58,7 +58,7 @@ namespace GraphQL.Instrumentation
                         }
                         catch (AggregateException ex)
                         {
-                            throw new Exception(String.Format("GraphQL - error resolving field {0}", context.FieldName), ex.InnerException);
+                            throw new Exception(ex.InnerException.Message, ex.InnerException);
                         }
                     });
                 });

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -58,7 +58,7 @@ namespace GraphQL.Instrumentation
                         }
                         catch (AggregateException ex)
                         {
-                            throw ex.InnerException;
+                            throw new Exception($"GraphQL - Error resolving field {context.FieldName}", ex.InnerException);
                         }
                     });
                 });


### PR DESCRIPTION
If inner exception is thrown at this point - the original stack trace is lost.
![image](https://user-images.githubusercontent.com/10229823/33197899-7ac4f1f4-d101-11e7-9bbd-dde5d779350e.png)

By wrapping it into new exception the original stack trace is preserved
