### PR TITLE
Allow Unsigned Integers

### DIFF
--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -88,12 +88,7 @@ namespace GraphQL
             }
 
   
-            if (type == typeof(int))
-            {
-                graphType = typeof(IntGraphType);
-            }
-
-            if (type == typeof(long))
+            if (type == typeof(int) || type == typeof(long) || type == typeof(uint))
             {
                 graphType = typeof(IntGraphType);
             }


### PR DESCRIPTION
Allow Unisgned Integers as type in parsing it as a normal integer.
This avoids casting uint to ints in the backend

Closes #473 