### PR TITLE
Add converter for DateTimeOffset type

### DIFF
--- a/src/GraphQL.Tests/Utilities/DateTimeOffsetTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/DateTimeOffsetTypeTests.cs
@@ -1,0 +1,56 @@
+// <copyright file="DateTimeOffsetTypeTests.cs" company="eVote">
+//   Copyright © eVote
+// </copyright>
+
+using System;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Utilities
+{
+    public class DateTimeOffsetTypeTests : SchemaBuilderTestBase
+    {
+        [Fact]
+        public void can_use_DateTimeOffset_type()
+        {
+            var schema = Schema.For(@"
+                input DateTimeOffsetInput{
+                    value: Date
+                }
+                type Query {
+                  five(model: DateTimeOffsetInput): Date
+                }
+            ", _ =>
+            {
+                _.Types.Include<ParametersType>();
+            });
+
+            var utcNow = DateTimeOffset.UtcNow;
+
+            var result = schema.Execute(_ =>
+            {
+                _.Query = $"{{ five(model:{{ value:\"{utcNow}\"}}) }}";
+            });
+
+            var expectedResult = CreateQueryResult($"{{ 'five': \"{utcNow.AddDays(1):yyyy-MM-ddTHH:mm:ssZ}\" }}");
+            var serializedExpectedResult = Writer.Write(expectedResult);
+
+            result.ShouldBe(serializedExpectedResult);
+        }
+
+        [GraphQLMetadata("Query")]
+        class ParametersType
+        {
+            public DateTimeOffset Five(DateTimeOffsetInput model)
+            {
+                return model.Value.AddDays(1);
+            }
+        }
+    }
+
+    class DateTimeOffsetInput
+    {
+        public DateTimeOffset Value { get; set; }
+    }
+}

--- a/src/GraphQL.Tests/Utilities/DateTimeOffsetTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/DateTimeOffsetTypeTests.cs
@@ -1,7 +1,3 @@
-// <copyright file="DateTimeOffsetTypeTests.cs" company="eVote">
-//   Copyright © eVote
-// </copyright>
-
 using System;
 using GraphQL.Types;
 using Shouldly;

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Types;
@@ -301,7 +301,6 @@ namespace GraphQL.Tests.Utilities
         public void can_use_context_source_usercontext_with_params()
         {
             var schema = Schema.For(@"
-                input
                 type Query {
                   four(id: Int): Boolean
                 }
@@ -323,32 +322,6 @@ namespace GraphQL.Tests.Utilities
             result.ShouldBe(serializedExpectedResult);
         }
 
-        [Fact]
-        public void can_use_DateTimeOffset_type(){
-            var schema = Schema.For(@"
-                input DateTimeOffsetInput{
-                    value: Date
-                }
-                type Query {
-                  five(model: DateTimeOffsetInput): Date
-                }
-            ", _=>
-            {
-                _.Types.Include<ParametersType>();
-            });
-
-            var utcNow = DateTimeOffset.UtcNow;
-
-            var result = schema.Execute(_ =>
-            {
-                _.Query = $"{{ five(model:{{ value:\"{utcNow}\"}}) }}";
-            });
-
-            var expectedResult = CreateQueryResult($"{{ 'five': \"{utcNow.AddDays(1).ToString("yyyy-MM-ddTHH:mm:ssZ")}\" }}");
-            var serializedExpectedResult = Writer.Write(expectedResult);
-
-            result.ShouldBe(serializedExpectedResult);
-        }
     }
 
     public class PostData
@@ -456,20 +429,10 @@ namespace GraphQL.Tests.Utilities
         {
             return resolveContext != null && context != null && source != null && id != 0;
         }
-
-        public DateTimeOffset Five(DateTimeOffsetInput model)
-        {
-            return model.Value.AddDays(1);
-        }
     }
 
     class MyUserContext
     {
         public string Name { get; set; }
-    }
-
-    class DateTimeOffsetInput
-    {
-        public DateTimeOffset Value { get; set; }
     }
 }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Types;
@@ -321,7 +320,6 @@ namespace GraphQL.Tests.Utilities
 
             result.ShouldBe(serializedExpectedResult);
         }
-
     }
 
     public class PostData

--- a/src/GraphQL/Conversion/Conversions.cs
+++ b/src/GraphQL/Conversion/Conversions.cs
@@ -39,6 +39,7 @@ namespace GraphQL.Conversion
             RegisterConversion(uint.Parse);
             RegisterConversion(ulong.Parse);
             RegisterConversion(DateTimeConverter.GetDateTime);
+            RegisterConversion(DateTimeOffsetConverter.GetDateTimeOffset);
             RegisterConversion(Guid.Parse);
 
             RegisterConversion(x =>

--- a/src/GraphQL/Conversion/DateTimeOffsetConverter.cs
+++ b/src/GraphQL/Conversion/DateTimeOffsetConverter.cs
@@ -1,7 +1,3 @@
-// <copyright file="DateTimeOffsetConverter.cs" company="wut">
-//   Copyright © wut
-// </copyright>
-
 using System;
 using System.Globalization;
 using System.Linq;

--- a/src/GraphQL/Conversion/DateTimeOffsetConverter.cs
+++ b/src/GraphQL/Conversion/DateTimeOffsetConverter.cs
@@ -1,0 +1,81 @@
+// <copyright file="DateTimeOffsetConverter.cs" company="wut">
+//   Copyright © wut
+// </copyright>
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace GraphQL.Conversion
+{
+    public class DateTimeOffsetConverter
+    {
+        public const string Today = "TODAY";
+
+        private static readonly Regex iso8601Expression = new Regex(@"^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$");
+
+        public static DateTimeOffset GetDateTime(string dateString)
+        {
+            var trimmedString = dateString.Trim();
+            if (trimmedString == Today)
+            {
+                return DateTimeOffset.UtcNow.DateTime;
+            }
+
+            if (trimmedString.Contains(Today))
+            {
+                var dayString = trimmedString.Substring(5, trimmedString.Length - 5);
+                var days = int.Parse(dayString);
+
+                return DateTimeOffset.UtcNow.DateTime.AddDays(days);
+            }
+
+            if (IsDayOfWeek(dateString))
+            {
+                return ConvertToDateFromDayAndTime(dateString);
+            }
+
+            if (iso8601Expression.IsMatch(trimmedString))
+            {
+                //Thank you jon skeet : http://stackoverflow.com/questions/10029099/DateTimeOffset-parse2012-09-30t230000-0000000z-always-converts-to-datetimekind-l
+                var success = DateTimeOffset.TryParse(trimmedString, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var result);
+
+                if (success)
+                {
+                    return result;
+                }
+            }
+
+            return DateTimeOffset.Parse(trimmedString);
+        }
+
+        private static DateTimeOffset ConvertToDateFromDayAndTime(string dateString)
+        {
+            dateString = dateString.Replace("  ", " ");
+            var parts = dateString.Split(' ');
+            var day = (DayOfWeek)Enum.Parse(typeof(DayOfWeek), parts[0], true);
+            var minutes = MinutesFrom24HourTime(parts[1]);
+
+            var date = DateTimeOffset.UtcNow.DateTime.AddMinutes(minutes);
+            while (date.DayOfWeek != day)
+            {
+                date = date.AddDays(1);
+            }
+
+            return date;
+        }
+
+        private static bool IsDayOfWeek(string text)
+        {
+            var days = Enum.GetNames(typeof(DayOfWeek));
+            return days.FirstOrDefault(x => text.ToLower().StartsWith(x.ToLower())) != null;
+        }
+
+        private static int MinutesFrom24HourTime(string time)
+        {
+            var parts = time.Split(':');
+            return 60 * int.Parse(parts[0]) + int.Parse(parts[1]);
+        }
+    }
+}

--- a/src/GraphQL/Conversion/DateTimeOffsetConverter.cs
+++ b/src/GraphQL/Conversion/DateTimeOffsetConverter.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Conversion
 
         private static readonly Regex iso8601Expression = new Regex(@"^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$");
 
-        public static DateTimeOffset GetDateTime(string dateString)
+        public static DateTimeOffset GetDateTimeOffset(string dateString)
         {
             var trimmedString = dateString.Trim();
             if (trimmedString == Today)

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -132,14 +132,13 @@ namespace GraphQL
             if (value == null) return null;
 
             // exact type match
-            if ((fieldType == typeof(DateTime) && value is DateTime) ||
-                (fieldType == typeof(DateTimeOffset) && value is DateTimeOffset))
+            if (fieldType.IsInstanceOfType(value))
             {
                 return value;
             }
 
             // DateTime -> DateTimeOffset convertion
-            if(fieldType == typeof(DateTimeOffset) && value is DateTime dateTimeValue && dateTimeValue.Kind == DateTimeKind.Utc)
+            if (fieldType == typeof(DateTimeOffset) && value is DateTime dateTimeValue && dateTimeValue.Kind == DateTimeKind.Utc)
             {
                 return (DateTimeOffset)dateTimeValue;
             }

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -38,7 +38,7 @@ namespace GraphQL
 
         public static object GetPropertyValue(this object propertyValue, Type fieldType)
         {
-            // Short-circuit conversion if the property value already 
+            // Short-circuit conversion if the property value already
             if (fieldType.IsInstanceOfType(propertyValue))
             {
                 return propertyValue;
@@ -131,9 +131,23 @@ namespace GraphQL
         {
             if (value == null) return null;
 
-            if (fieldType == typeof(DateTime) && value is DateTime)
+            // exact type match
+            if ((fieldType == typeof(DateTime) && value is DateTime) ||
+                (fieldType == typeof(DateTimeOffset) && value is DateTimeOffset))
             {
                 return value;
+            }
+
+            // DateTime -> DateTimeOffset convertion
+            if(fieldType == typeof(DateTimeOffset) && value is DateTime dateTimeValue && dateTimeValue.Kind == DateTimeKind.Utc)
+            {
+                return (DateTimeOffset)dateTimeValue;
+            }
+
+            // DateTimeOffset -> DateTime convertion
+            if(fieldType == typeof(DateTime) && value is DateTimeOffset dateTimeOffsetValue)
+            {
+                return dateTimeOffsetValue.DateTime;
             }
 
             string text;


### PR DESCRIPTION
That allows to pass `DateTimeOffset` type to methods marked with `[GraphQLMetadata]` attribute.