### PR TITLE
Add ability to support things like apollo tracing

### DIFF
--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -1,11 +1,10 @@
+using System.Collections.Generic;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using Newtonsoft.Json;
 
 namespace GraphQL
 {
-    using System.Collections.Generic;
-
     [JsonConverter(typeof(ExecutionResultJsonConverter))]
     public class ExecutionResult
     {

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -1,9 +1,11 @@
-﻿using GraphQL.Instrumentation;
+using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using Newtonsoft.Json;
 
 namespace GraphQL
 {
+    using System.Collections.Generic;
+
     [JsonConverter(typeof(ExecutionResultJsonConverter))]
     public class ExecutionResult
     {
@@ -20,5 +22,7 @@ namespace GraphQL
         public PerfRecord[] Perf { get; set; }
 
         public bool ExposeExceptions { get; set; }
+
+        public Dictionary<string, object> Extensions { get; set; }
     }
 }

--- a/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
@@ -4,8 +4,6 @@ using Newtonsoft.Json;
 
 namespace GraphQL
 {
-    using System.Collections.Generic;
-
     public class ExecutionResultJsonConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -18,7 +16,7 @@ namespace GraphQL
 
             WriteData(result, writer, serializer);
             WriteErrors(result.Errors, writer, serializer, result.ExposeExceptions);
-            WriteExtensions(result.Extensions, writer, serializer);
+            WriteExtensions(result, writer, serializer);
 
             writer.WriteEndObject();
         }
@@ -84,15 +82,15 @@ namespace GraphQL
             writer.WriteEndArray();
         }
 
-        private void WriteExtensions(Dictionary<string, object> extensions, JsonWriter writer, JsonSerializer serializer)
+        private void WriteExtensions(ExecutionResult result, JsonWriter writer, JsonSerializer serializer)
         {
-            if (extensions == null || !extensions.Any())
+            if (result.Data == null || result.Extensions == null || !result.Extensions.Any())
             {
                 return;
             }
 
             writer.WritePropertyName("extensions");
-            serializer.Serialize(writer, extensions);
+            serializer.Serialize(writer, result.Extensions);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)

--- a/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 using System.Linq;
 using Newtonsoft.Json;
 
 namespace GraphQL
 {
+    using System.Collections.Generic;
+
     public class ExecutionResultJsonConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -14,13 +16,14 @@ namespace GraphQL
 
             writer.WriteStartObject();
 
-            writeData(result, writer, serializer);
-            writeErrors(result.Errors, writer, serializer, result.ExposeExceptions);
+            WriteData(result, writer, serializer);
+            WriteErrors(result.Errors, writer, serializer, result.ExposeExceptions);
+            WriteExtensions(result.Extensions, writer, serializer);
 
             writer.WriteEndObject();
         }
 
-        private void writeData(ExecutionResult result, JsonWriter writer, JsonSerializer serializer)
+        private void WriteData(ExecutionResult result, JsonWriter writer, JsonSerializer serializer)
         {
             var data = result.Data;
 
@@ -33,7 +36,7 @@ namespace GraphQL
             serializer.Serialize(writer, data);
         }
 
-        private void writeErrors(ExecutionErrors errors, JsonWriter writer, JsonSerializer serializer, bool exposeExceptions)
+        private void WriteErrors(ExecutionErrors errors, JsonWriter writer, JsonSerializer serializer, bool exposeExceptions)
         {
             if (errors == null || !errors.Any())
             {
@@ -79,6 +82,17 @@ namespace GraphQL
             });
 
             writer.WriteEndArray();
+        }
+
+        private void WriteExtensions(Dictionary<string, object> extensions, JsonWriter writer, JsonSerializer serializer)
+        {
+            if (extensions == null || !extensions.Any())
+            {
+                return;
+            }
+
+            writer.WritePropertyName("extensions");
+            serializer.Serialize(writer, extensions);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)

--- a/src/GraphQL/Instrumentation/Metrics.cs
+++ b/src/GraphQL/Instrumentation/Metrics.cs
@@ -47,7 +47,7 @@ namespace GraphQL.Instrumentation
                 return null;
             }
 
-            var record = new PerfRecord(category, subject, _stopwatch.ElapsedMilliseconds, metadata);
+            var record = new PerfRecord(category, subject, _stopwatch.Elapsed.TotalMilliseconds, metadata);
             _records.Add(record);
             return new Marker(record, _stopwatch);
         }
@@ -61,7 +61,7 @@ namespace GraphQL.Instrumentation
                 return null;
             }
 
-            _main?.MarkEnd(_stopwatch.ElapsedMilliseconds);
+            _main?.MarkEnd(_stopwatch.Elapsed.TotalMilliseconds);
             _stopwatch.Stop();
             return AllRecords;
         }
@@ -79,7 +79,7 @@ namespace GraphQL.Instrumentation
 
             public void Dispose()
             {
-                _record.MarkEnd(_stopwatch.ElapsedMilliseconds);
+                _record.MarkEnd(_stopwatch.Elapsed.TotalMilliseconds);
             }
         }
 

--- a/src/GraphQL/Instrumentation/PerfRecord.cs
+++ b/src/GraphQL/Instrumentation/PerfRecord.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -17,7 +17,7 @@ namespace GraphQL.Instrumentation
         {
         }
 
-        public PerfRecord(string category, string subject, long start, Dictionary<string, object> metadata = null)
+        public PerfRecord(string category, string subject, double start, Dictionary<string, object> metadata = null)
         {
             Category = category;
             Subject = subject;
@@ -25,7 +25,7 @@ namespace GraphQL.Instrumentation
             Metadata = metadata;
         }
 
-        public void MarkEnd(long end)
+        public void MarkEnd(double end)
         {
             End = end;
         }
@@ -36,11 +36,11 @@ namespace GraphQL.Instrumentation
 
         public Dictionary<string, object> Metadata { get; set; }
 
-        public long Start { get; set; }
+        public double Start { get; set; }
 
-        public long End { get; set; }
+        public double End { get; set; }
 
-        public long Duration => End - Start;
+        public double Duration => End - Start;
 
         public T MetaField<T>(string key)
         {
@@ -61,9 +61,9 @@ namespace GraphQL.Instrumentation
         public string ReturnType { get; set; }
 
         // TODO: switch this to a histogram
-        public long Latency { get; set; }
+        public double Latency { get; set; }
 
-        public void AddLatency(long duration)
+        public void AddLatency(double duration)
         {
             Latency += duration;
         }
@@ -119,7 +119,7 @@ namespace GraphQL.Instrumentation
 
         public DateTime Start { get; set; }
         public DateTime End { get; set; }
-        public long Duration { get; set; }
+        public double Duration { get; set; }
 
         public Dictionary<string, StatsPerSignature> PerSignature { get; set; }
         public Type[] Types { get; set; }


### PR DESCRIPTION
In order to support the tracing proposed by https://github.com/apollographql/apollo-tracing there a few changes needed as far as i see it.

Firstly, the current time measurements in metrics is not precise enough. It is currently measured in milliseconds, but the spec expects nanoseconds.

Secondly, for things like apollo-tracing, apollo-cache-control, and other future extension points to work. There is a requirement to be able to expose an extension point in the result.

I've added this as a simple optional dictionary, that these types of extensions can choose to add to. The extensions will themselves be responsible to specify a JsonConverter in order to output expected JSON.