### PR TITLE
Populate subfields for all graph types that have a SelectionSet. #547

### DIFF
--- a/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
@@ -21,7 +21,6 @@ namespace GraphQL.Tests.StarWars
         {
             RootQuery.FieldAsync<ListGraphType<HumanType>>("listOfHumans", resolve: async (ctx) =>
             {
-                //this test fails
                 ctx.SubFields.ShouldNotBeNull();
                 ctx.SubFields.Keys.ShouldContain("id");
                 ctx.SubFields.Keys.ShouldContain("friends");

--- a/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+using GraphQL.StarWars.Types;
+using GraphQL.StarWars;
+
+namespace GraphQL.Tests.StarWars
+{
+    public class StarWarsSubFieldsTests : StarWarsTestBase
+    {
+        public StarWarsSubFieldsTests() : base()
+        {
+            this.RootQuery = (StarWarsQuery)this.Schema.Query;
+        }
+
+        public StarWarsQuery RootQuery;
+
+        [Fact]
+        public void subfields_is_not_null_for_ListGraphType()
+        {
+            RootQuery.FieldAsync<ListGraphType<HumanType>>("listOfHumans", resolve: async (ctx) =>
+            {
+                //this test fails
+                ctx.SubFields.ShouldNotBeNull();
+                ctx.SubFields.Keys.ShouldContain("id");
+                ctx.SubFields.Keys.ShouldContain("friends");
+                return new List<Human>();
+            });
+            var query = @"
+                {
+                    listOfHumans {
+                        id
+                        friends {
+                            name
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"
+                {
+                    listOfHumans: []
+                }
+            ";
+            AssertQuerySuccess(query, expected);
+        }
+
+        [Fact]
+        public void subfields_is_not_null_for_custom_graph_type()
+        {
+            RootQuery.Field<HumanType>("singleHuman", resolve: (ctx) =>
+            {
+                ctx.SubFields.ShouldNotBeNull();
+                ctx.SubFields.Keys.ShouldContain("id");
+                ctx.SubFields.Keys.ShouldContain("friends");
+                return null;
+            });
+
+            var query = @"
+                {
+                    singleHuman {
+                        id
+                        friends {
+                            name
+                        }
+                    }
+                }
+            ";
+            var expected = @"
+                {
+                    singleHuman: null
+                }
+            ";
+            AssertQuerySuccess(query, expected);
+        }
+
+        [Fact]
+        public void subfields_does_not_throw_for_primative()
+        {
+            RootQuery.Field<IntGraphType>("someNumber", resolve: (ctx) =>
+            {
+                ctx.SubFields.ShouldBeNull();
+                return 1;
+            });
+
+            var query = @"
+                {
+                    someNumber
+                }
+            ";
+            var expected = @"
+                {
+                    someNumber: 1
+                }
+            ";
+            AssertQuerySuccess(query, expected);
+        }
+
+        [Fact]
+        public void subfields_does_not_throw_for_list_of_primative()
+        {
+            RootQuery.Field<ListGraphType<IntGraphType>>("someNumbers", resolve: (ctx) =>
+            {
+                ctx.SubFields.ShouldBeNull();
+                return new int[] { 1, 2 };
+            });
+
+            var query = @"
+                {
+                    someNumbers
+                }
+            ";
+            var expected = @"
+                {
+                    someNumbers: [1,2]
+                }
+            ";
+            AssertQuerySuccess(query, expected);
+        }
+
+    }
+}

--- a/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
@@ -17,9 +17,9 @@ namespace GraphQL.Tests.StarWars
         public StarWarsQuery RootQuery;
 
         [Fact]
-        public void subfields_is_not_null_for_ListGraphType()
+        public void subfields_is_not_null_for_ListGraphType_of_ObjectGraphType()
         {
-            RootQuery.FieldAsync<ListGraphType<HumanType>>("listOfHumans", resolve: async (ctx) =>
+            RootQuery.Field<ListGraphType<HumanType>>("listOfHumans", resolve: (ctx) =>
             {
                 ctx.SubFields.ShouldNotBeNull();
                 ctx.SubFields.Keys.ShouldContain("id");
@@ -46,7 +46,7 @@ namespace GraphQL.Tests.StarWars
         }
 
         [Fact]
-        public void subfields_is_not_null_for_custom_graph_type()
+        public void subfields_is_not_null_for_single_ObjectGraphType()
         {
             RootQuery.Field<HumanType>("singleHuman", resolve: (ctx) =>
             {
@@ -73,6 +73,65 @@ namespace GraphQL.Tests.StarWars
             ";
             AssertQuerySuccess(query, expected);
         }
+
+        [Fact]
+        public void subfields_is_not_null_for_ListGraphType_of_InterfaceGraphType()
+        {
+            RootQuery.Field<ListGraphType<CharacterInterface>>("listOfCharacters", resolve: (ctx) =>
+            {
+                ctx.SubFields.ShouldNotBeNull();
+                ctx.SubFields.Keys.ShouldContain("id");
+                ctx.SubFields.Keys.ShouldContain("friends");
+                return new List<Human>();
+            });
+            var query = @"
+                {
+                    listOfCharacters {
+                        id
+                        friends {
+                            name
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"
+                {
+                    listOfCharacters: []
+                }
+            ";
+            AssertQuerySuccess(query, expected);
+        }
+
+        [Fact]
+        public void subfields_is_not_null_for_single_InterfaceGraphType()
+        {
+            RootQuery.FieldAsync<CharacterInterface>("singleCharacter", resolve: (ctx) =>
+           {
+               ctx.SubFields.ShouldNotBeNull();
+               ctx.SubFields.Keys.ShouldContain("id");
+               ctx.SubFields.Keys.ShouldContain("friends");
+               return null;
+           });
+            var query = @"
+                {
+                    singleCharacter {
+                        id
+                        friends {
+                            name
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"
+                {
+                    singleCharacter: null
+                }
+            ";
+            AssertQuerySuccess(query, expected);
+        }
+
 
         [Fact]
         public void subfields_does_not_throw_for_primative()

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -388,7 +388,9 @@ namespace GraphQL.Execution
 
         public static IDictionary<string, Field> SubFieldsFor(ExecutionContext context, IGraphType fieldType, Field field)
         {
-            if (!(fieldType is IObjectGraphType) || !field.SelectionSet.Selections.Any())
+            var selections = field?.SelectionSet?.Selections;
+            //if the field has no subfields
+            if (selections == null || selections.Any() == false)
             {
                 return null;
             }


### PR DESCRIPTION
Fixed bug where the ResolveFieldContext.SubFields was null for ListGraphType items. 