### PR TITLE
Fix issues with the DataLoaders and non-existent keys

### DIFF
--- a/src/GraphQL.DataLoader.Tests/CollectionBatchLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/CollectionBatchLoaderTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.DataLoader.Tests.Models;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.DataLoader.Tests
+{
+    public class CollectionBatchLoaderTests : DataLoaderTestBase
+    {
+        public CollectionBatchLoaderTests()
+        {
+            Users.AddUsers(
+                new User
+                {
+                    UserId = 1
+                },
+                new User
+                {
+                    UserId = 2
+                }
+            );
+
+            Orders.AddOrders(
+                new Order()
+                {
+                    OrderId = 1,
+                    UserId = 1
+                    
+                },
+                new Order()
+                {
+                    OrderId = 2,
+                    UserId = 1
+                }
+            );
+        }
+
+        [Fact]
+        public async Task NonExistent_Key_Should_Return_Empty()
+        {
+            var loader = new CollectionBatchDataLoader<int, Order>((ids, ct) => Orders.GetOrdersByUserIdAsync(ids));
+
+            // Start async tasks to load by User ID
+            var task1 = loader.LoadAsync(1);
+            var task2 = loader.LoadAsync(2);
+
+            // Dispatch loading
+            loader.Dispatch();
+
+            var user1Orders = await task1;
+            var user2Orders = await task2;
+
+            user1Orders.ShouldNotBeNull();
+            user2Orders.ShouldNotBeNull();
+
+            user1Orders.Count().ShouldBe(2);
+            user2Orders.Count().ShouldBe(0);
+
+            // This should have been called only once to load in a single batch
+            Orders.GetOrdersByUserIdCalledCount.ShouldBe(1, "Operations should be batched");
+        }
+
+        [Fact]
+        public async Task All_Requested_Keys_Should_Be_Cached()
+        {
+            var loader = new CollectionBatchDataLoader<int, Order>((ids, ct) => Orders.GetOrdersByUserIdAsync(ids));
+
+            // Start async tasks to load by User ID
+            var task1 = loader.LoadAsync(1);
+            var task2 = loader.LoadAsync(2);
+
+            // Dispatch loading
+            loader.Dispatch();
+
+            var user1Orders = await task1;
+            var user2Orders = await task2;
+
+            user1Orders.ShouldNotBeNull();
+            user2Orders.ShouldNotBeNull();
+
+            user1Orders.Count().ShouldBe(2);
+            user2Orders.Count().ShouldBe(0);
+
+            // Request keys 1 and 2 again. Result should be cached.
+            // Key 3 should NOT be cached
+
+            var task1b = loader.LoadAsync(1);
+            var task2b = loader.LoadAsync(2);
+            var task3 = loader.LoadAsync(3);
+
+            task1b.Status.ShouldBe(TaskStatus.RanToCompletion, "Result should already be cached");
+            task2b.Status.ShouldBe(TaskStatus.RanToCompletion, "Result should already be cached");
+            task3.Status.ShouldNotBe(TaskStatus.RanToCompletion, "Result should already be cached");
+
+            // Dispatch loading
+            loader.Dispatch();
+
+            var user1bOrders = await task1b;
+            var user2bOrders = await task2b;
+            var user3Orders = await task3;
+
+            user1bOrders.ShouldNotBeNull();
+            user2bOrders.ShouldNotBeNull();
+            user3Orders.ShouldNotBeNull();
+
+            user1Orders.Count().ShouldBe(2);
+            user2Orders.Count().ShouldBe(0);
+            user3Orders.Count().ShouldBe(0);
+
+
+            // This should have been called only once to load in a single batch
+            Orders.GetOrdersByUserIdCalledCount.ShouldBe(2, "Operations should be batched");
+        }
+    }
+}

--- a/src/GraphQL/DataLoader/CollectionBatchDataLoader.cs
+++ b/src/GraphQL/DataLoader/CollectionBatchDataLoader.cs
@@ -84,9 +84,9 @@ namespace GraphQL.DataLoader
             // Populate cache
             lock (_cache)
             {
-                foreach (var group in lookup)
+                foreach (TKey key in keys)
                 {
-                    _cache[group.Key] = group;
+                    _cache[key] = lookup[key].ToArray();
                 }
             }
 

--- a/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
+++ b/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
@@ -35,7 +35,7 @@ namespace GraphQL.DataLoader
         }
 
         public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<Dictionary<TKey, T>>> fetchFunc,
-            IEqualityComparer<TKey> keyComparer = null)
+            IEqualityComparer<TKey> keyComparer = null, T defaultValue = default(T))
         {
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
@@ -43,11 +43,11 @@ namespace GraphQL.DataLoader
             if (fetchFunc == null)
                 throw new ArgumentNullException(nameof(fetchFunc));
 
-            return context.GetOrAdd(loaderKey, () => new BatchDataLoader<TKey, T>(fetchFunc, keyComparer));
+            return context.GetOrAdd(loaderKey, () => new BatchDataLoader<TKey, T>(fetchFunc, keyComparer, defaultValue));
         }
 
         public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, Task<Dictionary<TKey, T>>> fetchFunc,
-            IEqualityComparer<TKey> keyComparer = null)
+            IEqualityComparer<TKey> keyComparer = null, T defaultValue = default(T))
         {
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
@@ -55,11 +55,11 @@ namespace GraphQL.DataLoader
             if (fetchFunc == null)
                 throw new ArgumentNullException(nameof(fetchFunc));
 
-            return context.GetOrAdd(loaderKey, () => new BatchDataLoader<TKey, T>(WrapNonCancellableFunc(fetchFunc), keyComparer));
+            return context.GetOrAdd(loaderKey, () => new BatchDataLoader<TKey, T>(WrapNonCancellableFunc(fetchFunc), keyComparer, defaultValue));
         }
 
         public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<IEnumerable<T>>> fetchFunc,
-            Func<T, TKey> keySelector, IEqualityComparer<TKey> keyComparer = null)
+            Func<T, TKey> keySelector, IEqualityComparer<TKey> keyComparer = null, T defaultValue = default(T))
         {
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
@@ -70,11 +70,11 @@ namespace GraphQL.DataLoader
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return context.GetOrAdd(loaderKey, () => new BatchDataLoader<TKey, T>(fetchFunc, keySelector, keyComparer));
+            return context.GetOrAdd(loaderKey, () => new BatchDataLoader<TKey, T>(fetchFunc, keySelector, keyComparer, defaultValue));
         }
 
         public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, Task<IEnumerable<T>>> fetchFunc,
-            Func<T, TKey> keySelector, IEqualityComparer<TKey> keyComparer = null)
+            Func<T, TKey> keySelector, IEqualityComparer<TKey> keyComparer = null, T defaultValue = default(T))
         {
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
@@ -85,7 +85,7 @@ namespace GraphQL.DataLoader
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return context.GetOrAdd(loaderKey, () => new BatchDataLoader<TKey, T>(WrapNonCancellableFunc(fetchFunc), keySelector, keyComparer));
+            return context.GetOrAdd(loaderKey, () => new BatchDataLoader<TKey, T>(WrapNonCancellableFunc(fetchFunc), keySelector, keyComparer, defaultValue));
         }
 
         public static IDataLoader<TKey, IEnumerable<T>> GetOrAddCollectionBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<ILookup<TKey, T>>> fetchFunc,


### PR DESCRIPTION
I found an issue with the `BatchDataLoader` and `CollectionBatchDataLoader`. If a key is requested in a batch, but not included in the results returned by the fetch delegate, it should return the default value or an empty enumerable. And this should be cached. 

I added unit tests for these scenarios and implemented the fixes.