### PR TITLE
Have AccessorFieldResolver use context.Source when appropriate

### DIFF
--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -343,7 +343,7 @@ namespace GraphQL.Tests.Utilities
             Builder.Types.Include<Blog>();
 
             var query = @"query Posts($blogId: ID!, $postId: ID!){ blog(id: $blogId){ title post(id: $postId) { id title } } }";
-            var expected = @"{ 'blog': { 'title': 'New Blog', 'post': { 'id' : '1', 'title': 'Post One' } } }";
+            var expected = @"{ 'blog': { 'title': 'New blog', 'post': { 'id' : '1', 'title': 'Post One' } } }";
             var variables = "{ 'blogId': '1', 'postId': '1' }";
 
             AssertQuery(_ =>

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GraphQL.Types;
 using Shouldly;
 using Xunit;
@@ -341,8 +342,8 @@ namespace GraphQL.Tests.Utilities
             Builder.Types.Include<BlogQueryType>();
             Builder.Types.Include<Blog>();
 
-            var query = @"query Posts($blogId: ID!, $postId: ID!){ blog(id: $blogId){ post(id: $postId) { id title } } }";
-            var expected = @"{ 'blog': { 'post': { 'id' : '1', 'title': 'Post One' } } }";
+            var query = @"query Posts($blogId: ID!, $postId: ID!){ blog(id: $blogId){ title post(id: $postId) { id title } } }";
+            var expected = @"{ 'blog': { 'title': 'New Blog', 'post': { 'id' : '1', 'title': 'Post One' } } }";
             var variables = "{ 'blogId': '1', 'postId': '1' }";
 
             AssertQuery(_ =>

--- a/src/GraphQL/Reflection/AccessorFieldResolver.cs
+++ b/src/GraphQL/Reflection/AccessorFieldResolver.cs
@@ -21,7 +21,9 @@ namespace GraphQL.Reflection
         {
             var arguments = BuildArguments(_accessor.Parameters, context);
 
-            var target = _dependencyResolver.Resolve(_accessor.DeclaringType);
+            var target = _accessor.DeclaringType.IsInstanceOfType(context.Source)
+                    ? context.Source
+                    : _dependencyResolver.Resolve(_accessor.DeclaringType);
 
             if (target == null)
             {


### PR DESCRIPTION
Fix for issue #579.

`AccessorFieldResolver` was always attempting to resolve a target from its `_dependencyResolver` when asked to resolve a field value. Doing so loses context for the field accessor which is attempting to derive values from the `context.Source` in many cases.

It may be a naive fix, but I've altered it to check to see if `context.Source` is of the type declaring the field, if so, use the `context.Source` as the field accessor target, else resolve a new instance.