### PR TITLE
Added an error code to the errors json when the error is a ValidationError and the ErrorCode was provided

### DIFF
--- a/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
@@ -1,3 +1,4 @@
+using GraphQL.Validation;
 using Xunit;
 
 namespace GraphQL.Tests.StarWars
@@ -90,7 +91,7 @@ namespace GraphQL.Tests.StarWars
                }
             ";
             var errors = new ExecutionErrors();
-            var error = new ExecutionError(@"Unknown fragment ""unknown_fragment"".");
+            var error = new ValidationError(query, "5.4.2.1", @"Unknown fragment ""unknown_fragment"".");
             error.AddLocation(4, 25);
             errors.Add(error);
 

--- a/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using GraphQL.Validation;
 using Newtonsoft.Json;
 
 namespace GraphQL
@@ -53,6 +54,14 @@ namespace GraphQL
 
                 // check if return StackTrace, including all inner exceptions
                 serializer.Serialize(writer, exposeExceptions ? error.ToString() : error.Message);
+
+                // Check if the current error is a validation error and an error code has been provided...
+                if (error is ValidationError validationError && !string.IsNullOrEmpty(validationError.ErrorCode))
+                {
+                    // ...it seems like so
+                    writer.WritePropertyName("code");
+                    serializer.Serialize(writer, validationError.ErrorCode);
+                }
 
                 if (error.Locations != null)
                 {


### PR DESCRIPTION
This simple modification will add the JSON property "code" to the generated errors JSON when the error is an instance of the class ValidationError and the property ErrorCode isn't empty or whitespace.