### PR TITLE
Adds flexible type registry

### DIFF
--- a/src/GraphQL/GraphTypeRegistry.cs
+++ b/src/GraphQL/GraphTypeRegistry.cs
@@ -11,6 +11,8 @@ namespace GraphQL
 
         static GraphTypeRegistry()
         {
+            _entries = new Dictionary<Type, Type>();
+
             _entries[typeof(int)] = typeof(IntGraphType);
             _entries[typeof(long)] = typeof(IntGraphType);
             _entries[typeof(double)] = typeof(FloatGraphType);

--- a/src/GraphQL/GraphTypeRegistry.cs
+++ b/src/GraphQL/GraphTypeRegistry.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+using GraphQL.Types;
+
+namespace GraphQL
+{
+	public static class GraphTypeRegistry
+	{
+		static Stack<RegistryEntry> _entries;
+
+		static GraphTypeRegistry()
+		{
+			_entries.Push(new RegistryEntry(typeof(int), typeof(IntGraphType)));
+			_entries.Push(new RegistryEntry(typeof(long), typeof(IntGraphType)));
+			_entries.Push(new RegistryEntry(typeof(double), typeof(FloatGraphType)));
+			_entries.Push(new RegistryEntry(typeof(float), typeof(FloatGraphType)));
+			_entries.Push(new RegistryEntry(typeof(decimal), typeof(DecimalGraphType)));
+			_entries.Push(new RegistryEntry(typeof(string), typeof(StringGraphType)));
+			_entries.Push(new RegistryEntry(typeof(bool), typeof(BooleanGraphType)));
+			_entries.Push(new RegistryEntry(typeof(DateTime), typeof(DateGraphType)));
+		}
+
+		public static void Register(Type clrType, Type graphType)
+		{
+			_entries.Push(new RegistryEntry(clrType, graphType));
+		}
+
+		public static Type Get(Type clrType)
+		{
+			foreach (var entry in _entries)
+			{
+				if (entry.CLRType == clrType)
+				{
+					return entry.GraphType;
+				}
+			}
+			return null;
+		}
+	}
+
+	public class RegistryEntry
+	{
+		public Type CLRType { get; }
+		public Type GraphType { get; }
+
+		public RegistryEntry(Type clrType, Type graphType)
+		{
+			CLRType = clrType;
+			GraphType = graphType;
+		}
+	}
+}

--- a/src/GraphQL/GraphTypeRegistry.cs
+++ b/src/GraphQL/GraphTypeRegistry.cs
@@ -5,49 +5,35 @@ using GraphQL.Types;
 
 namespace GraphQL
 {
-	public static class GraphTypeRegistry
-	{
-		static Stack<RegistryEntry> _entries;
+    public static class GraphTypeRegistry
+    {
+        static Dictionary<Type, Type> _entries;
 
-		static GraphTypeRegistry()
-		{
-			_entries.Push(new RegistryEntry(typeof(int), typeof(IntGraphType)));
-			_entries.Push(new RegistryEntry(typeof(long), typeof(IntGraphType)));
-			_entries.Push(new RegistryEntry(typeof(double), typeof(FloatGraphType)));
-			_entries.Push(new RegistryEntry(typeof(float), typeof(FloatGraphType)));
-			_entries.Push(new RegistryEntry(typeof(decimal), typeof(DecimalGraphType)));
-			_entries.Push(new RegistryEntry(typeof(string), typeof(StringGraphType)));
-			_entries.Push(new RegistryEntry(typeof(bool), typeof(BooleanGraphType)));
-			_entries.Push(new RegistryEntry(typeof(DateTime), typeof(DateGraphType)));
-		}
+        static GraphTypeRegistry()
+        {
+            _entries[typeof(int)] = typeof(IntGraphType);
+            _entries[typeof(long)] = typeof(IntGraphType);
+            _entries[typeof(double)] = typeof(FloatGraphType);
+            _entries[typeof(float)] = typeof(FloatGraphType);
+            _entries[typeof(decimal)] = typeof(DecimalGraphType);
+            _entries[typeof(string)] = typeof(StringGraphType);
+            _entries[typeof(bool)] = typeof(BooleanGraphType);
+            _entries[typeof(DateTime)] = typeof(DateGraphType);
+        }
 
-		public static void Register(Type clrType, Type graphType)
-		{
-			_entries.Push(new RegistryEntry(clrType, graphType));
-		}
+        public static void Register(Type clrType, Type graphType)
+        {
+            _entries[clrType] = graphType;
+        }
 
-		public static Type Get(Type clrType)
-		{
-			foreach (var entry in _entries)
-			{
-				if (entry.CLRType == clrType)
-				{
-					return entry.GraphType;
-				}
-			}
-			return null;
-		}
-	}
+        public static Type Get(Type clrType)
+        {
+            if (_entries.TryGetValue(clrType, out var graphType))
+            {
+                return graphType;
+            }
 
-	public class RegistryEntry
-	{
-		public Type CLRType { get; }
-		public Type GraphType { get; }
-
-		public RegistryEntry(Type clrType, Type graphType)
-		{
-			CLRType = clrType;
-			GraphType = graphType;
-		}
-	}
+            return null;
+        }
+    }
 }

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -129,42 +129,6 @@ namespace GraphQL
                 }
             }
 
-
-            if (type == typeof(int))
-            {
-                graphType = typeof(IntGraphType);
-            }
-
-            if (type == typeof(long))
-            {
-                graphType = typeof(IntGraphType);
-            }
-
-            if (type == typeof(double) || type == typeof(float))
-            {
-                graphType = typeof(FloatGraphType);
-            }
-
-            if (type == typeof(decimal))
-            {
-                graphType = typeof(DecimalGraphType);
-            }
-
-            if (type == typeof(string))
-            {
-                graphType = typeof(StringGraphType);
-            }
-
-            if (type == typeof(bool))
-            {
-                graphType = typeof(BooleanGraphType);
-            }
-
-            if (type == typeof(DateTime))
-            {
-                graphType = typeof(DateGraphType);
-            }
-
             if (type.IsArray)
             {
                 var elementType = GetGraphTypeFromType(type.GetElementType(), isNullable);
@@ -178,6 +142,8 @@ namespace GraphQL
                 var listType = typeof(ListGraphType<>);
                 graphType = listType.MakeGenericType(elementType);
             }
+
+            graphType = GraphQL.GraphTypeRegistry.Get(type);
 
             if (graphType == null)
             {

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -129,6 +129,9 @@ namespace GraphQL
                 }
             }
 
+            graphType = GraphQL.GraphTypeRegistry.Get(type);
+
+
             if (type.IsArray)
             {
                 var elementType = GetGraphTypeFromType(type.GetElementType(), isNullable);
@@ -142,8 +145,6 @@ namespace GraphQL
                 var listType = typeof(ListGraphType<>);
                 graphType = listType.MakeGenericType(elementType);
             }
-
-            graphType = GraphQL.GraphTypeRegistry.Get(type);
 
             if (graphType == null)
             {


### PR DESCRIPTION
Thoughts?

Proposing so the library doesn't have to worry about any other scalars than listed, but it'd be great if I didn't have to `ToString()` every time I have a Guid on the API.

Happy to touch up further to match project style and add tests, just wanted to get a rough implementation down before I forgot and moved on.