### PR TITLE
Fix an issue causing unspecified optional arguments to have value

### DIFF
--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -130,6 +130,18 @@ namespace GraphQL.Tests.Execution
                     return result;
                 });
 
+            Field<IntGraphType>(
+                "fieldWithNullableIntInput",
+                arguments: new QueryArguments(
+                    new QueryArgument<IntGraphType> { Name = "input" }
+                ),
+                resolve: context =>
+                {
+                    var val = context.GetArgument<int>("input");
+                    var result = JsonConvert.SerializeObject(val);
+                    return result;
+                });
+
             Field<StringGraphType>(
                 "fieldWithNonNullableStringInput",
                 arguments: new QueryArguments(
@@ -360,6 +372,24 @@ namespace GraphQL.Tests.Execution
 
     public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
     {
+        [Fact]
+        public void allows_nullable_int_input_to_be_ommited()
+        {
+            var query = @"
+{
+  fieldWithNullableIntInput
+}
+";
+
+            var expected = @"
+{
+  'fieldWithNullableIntInput': 0
+}
+";
+
+            AssertQuerySuccess(query, expected);
+        }
+
         [Fact]
         public void allows_nullable_inputs_to_be_ommited()
         {

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -220,7 +220,10 @@ namespace GraphQL.Execution
 
                 var coercedValue = CoerceValue(schema, type, value, variables);
                 coercedValue = coercedValue ?? arg.DefaultValue;
-                acc[arg.Name] = coercedValue;
+                if (coercedValue != null)
+                {
+                    acc[arg.Name] = coercedValue;
+                }
 
                 return acc;
             });


### PR DESCRIPTION
When an argument is optional, has no default value specified, and it is not specified in the query, the arguments on the resolve context still contain the argument with a value of null.

This does not seem to manifest itself when using a nullable type such as `string`, so I added a test that uses `int`, which fails without the change.

When attempting to retrieve the value using `context.GetArgument`, an object reference exception is thrown because `context.HasArgument` returns true, so value resolving is attempted.