### PR TITLE
Include symbols for the nuget packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ deploy:
   server: https://www.myget.org/F/graphql-dotnet/api/v2/package
   api_key:
     secure: +l1vfBMajn1WfmXkQ2LdILKxK4fQ5AHSnnU1kf11Bn1xRGUOTCdPhLwHx232piEn
-  skip_symbols: true
+  skip_symbols: false
   on:
     branch:
       - master

--- a/tools/tasks/dotnetPack.js
+++ b/tools/tasks/dotnetPack.js
@@ -24,7 +24,7 @@ export default function compile() {
     versionSuffix = `--version-suffix ${settings.versionSuffix}${settings.revision}`;
   }
 
-  const cmd = `dotnet pack src/GraphQL -o ${settings.artifacts} -c ${settings.target} ${versionSuffix}`
+  const cmd = `dotnet pack src/GraphQL -o ${settings.artifacts} -c ${settings.target} ${versionSuffix} --include-symbols`
   const one = run(cmd)
 
   const cmd2 = `dotnet pack src/GraphQL.StarWars -o ${settings.artifacts} -c ${settings.target}`

--- a/tools/tasks/dotnetPack.js
+++ b/tools/tasks/dotnetPack.js
@@ -24,7 +24,7 @@ export default function compile() {
     versionSuffix = `--version-suffix ${settings.versionSuffix}${settings.revision}`;
   }
 
-  const cmd = `dotnet pack src/GraphQL -o ${settings.artifacts} -c ${settings.target} ${versionSuffix} --include-symbols`
+  const cmd = `dotnet pack src/GraphQL -o ${settings.artifacts} -c ${settings.target} ${versionSuffix} --include-symbols --include-source`
   const one = run(cmd)
 
   const cmd2 = `dotnet pack src/GraphQL.StarWars -o ${settings.artifacts} -c ${settings.target}`


### PR DESCRIPTION
I think it could be useful for debugging purposes:
Added `--include-symbols` and `--include-source` flags to the main nuget package in order to get pdbs and sources available via the source server.
This will not affect the main package, it will just create a separate `symbols.nupkg` which will be pushed to the symbol server (See [docu](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack?tabs=netcore2x#description) for details)


I can't seem to find the logic which pushes to nuget.org, only to myget. Could you please help me out with that? In case you want to have this change of course.