### PR TITLE
suppress obsolete warning inside the src

### DIFF
--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -73,7 +73,9 @@ namespace GraphQL.Types
         public Schema(IDependencyResolver dependencyResolver)
         {
             DependencyResolver = dependencyResolver;
+            #pragma warning disable 0618
             ResolveType = type => dependencyResolver.Resolve(type) as IGraphType;
+            #pragma warning restore 0618
 
             _lookup = new Lazy<GraphTypesLookup>(CreateTypesLookup);
             _additionalTypes = new List<Type>();
@@ -207,11 +209,6 @@ namespace GraphQL.Types
 
         public void Dispose()
         {
-            ResolveType = null;
-            DependencyResolver = null;
-            Query = null;
-            Mutation = null;
-            Subscription = null;
             _additionalInstances.Clear();
             _additionalTypes.Clear();
 


### PR DESCRIPTION
suppress "obsolete" warning during the build

cleanup the null refferences inside dispose (https://social.msdn.microsoft.com/Forums/en-US/3532073e-816a-4f66-9922-9f527e4cca6b/setting-object-to-null-after-dispose?forum=csharplanguage). It is not so required, but why do we need to keep unrequiered code.. 