### PR TITLE
 Cancel executions before calling ExecuteNodeAsync

### DIFF
--- a/src/GraphQL/Execution/ParallelExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ParallelExecutionStrategy.cs
@@ -20,6 +20,7 @@ namespace GraphQL.Execution
                 // Start executing all pending nodes
                 for (int i = 0; i < pendingNodes.Count; i++)
                 {
+                    context.CancellationToken.ThrowIfCancellationRequested();
                     currentTasks[i] = ExecuteNodeAsync(context, pendingNodes[i]);
                 }
 


### PR DESCRIPTION
Even though `ExecuteNodeAsync` calls `ThrowIfCancellationRequested`, the state machine wraps the exception and lets the `for` loop to finish before it unwraps on `Task.WhenAll`. In my code I terminate the query if it is taking too long to execute. The problem appears when all the objects are already created (and in my worst case it's ~5000) and we cancel. In this case we get 5000 exceptions.
What my fix does is it checks before each `ExecuteNodeAsync` is called. This way we don't create a bunch of tasks, which unwrap later.