### PR TITLE
Fix regression with private output class

### DIFF
--- a/src/GraphQL.Tests/Execution/AsyncMutationTests.cs
+++ b/src/GraphQL.Tests/Execution/AsyncMutationTests.cs
@@ -1,0 +1,88 @@
+using System.Threading.Tasks;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Execution
+{
+    public class AsyncMutationTests : QueryTestBase<AsyncMutationSchema>
+    {
+        [Fact]
+        public void runs_async_mutation_returning_Task_of_private_class()
+        {
+            var query = @"
+                mutation M {
+                  addAsync {
+                    value
+                  }
+                }
+            ";
+
+            var expected = @"
+                {
+                  'addAsync': {
+                    'value': 29
+                  }
+                }";
+
+            AssertQuerySuccess(query, expected, root: new AsyncMutationRoot(6));
+        }
+    }
+
+    public class AsyncMutationRoot
+    {
+        public AsyncMutationRoot(int addend)
+        {
+            Addend = addend;
+        }
+
+        public int Addend { get; }
+    }
+
+    public class AsyncMutationSchema : Schema
+    {
+        public AsyncMutationSchema()
+        {
+            Mutation = new AsyncMutationGraphType();
+        }
+    }
+
+    public class AsyncMutationGraphType : ObjectGraphType
+    {
+        public AsyncMutationGraphType()
+        {
+            Name = "Mutation";
+
+            var field = new FieldType
+            {
+                Name = "addAsync",
+                ResolvedType = new AsyncMutationOutputGraphType(),
+                Resolver = new FuncFieldResolver<Task<AsyncMutationOutput>>(context =>
+                {
+                    var source = context.Source as AsyncMutationRoot;
+                    return Task.FromResult(new AsyncMutationOutput(23 + source.Addend));
+                })
+            };
+            AddField(field);
+        }
+
+        private class AsyncMutationOutput
+        {
+            public AsyncMutationOutput(int value)
+            {
+                Value = value;
+            }
+
+            public int Value { get; }
+        }
+
+        private class AsyncMutationOutputGraphType : ObjectGraphType<AsyncMutationOutput>
+        {
+            public AsyncMutationOutputGraphType()
+            {
+                Name = "AsyncMutationOutput";
+                Field("value", o => o.Value);
+            }
+        }
+    }
+}

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using GraphQL.Introspection;
 using GraphQL.Language.AST;
@@ -430,7 +431,17 @@ namespace GraphQL.Execution
                 }
                 else
                 {
-                    result = ((dynamic)task).Result;
+                    var taskType = task.GetType();
+                    if (taskType.GetGenericTypeDefinition() == typeof(Task<>))
+                    {
+                        var wrappedType = taskType.GetGenericArguments()[0];
+                        var method = UnwrapTaskOfTMethod.MakeGenericMethod(wrappedType);
+                        result = method.Invoke(null, new object[] { task });
+                    }
+                    else
+                    {
+                        result = null;
+                    }
                 }
             }
 
@@ -460,5 +471,12 @@ namespace GraphQL.Execution
 
             return newPath;
         }
+
+        private static T UnwrapTaskOfT<T>(Task<T> task)
+        {
+            return task.Result;
+        }
+
+        private static readonly MethodInfo UnwrapTaskOfTMethod = typeof(ExecutionHelper).GetMethod(nameof(UnwrapTaskOfT), BindingFlags.Static | BindingFlags.NonPublic);
     }
 }

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -474,7 +474,7 @@ namespace GraphQL.Execution
 
         private static T UnwrapTaskOfT<T>(Task<T> task)
         {
-            return task.Result;
+            return task.GetAwaiter().GetResult();
         }
 
         private static readonly MethodInfo UnwrapTaskOfTMethod = typeof(ExecutionHelper).GetMethod(nameof(UnwrapTaskOfT), BindingFlags.Static | BindingFlags.NonPublic);


### PR DESCRIPTION
When upgrading my project from alpha-802 to alpha-870 I noticed some strange errors coming from `GraphQL.ExecutionHelper.UnwrapResultAsync`:

> 'System.Threading.Tasks.Task' does not contain a definition for 'Result'

I was able to determine that this occurs when you have a field that returns a `Task<T>`, where `T` is a private class. The dynamic lookup doesn't see `task` as being a `Task<T>` when the generic type is private, but rather only a `Task`, which it can't find a `Result` property on. I was able to solve the problem by using reflection to get `Result` instead of `dynamic`.