### PR TITLE
Extend check for List<> to include ICollection<> and IList<>

### DIFF
--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -139,7 +139,9 @@ namespace GraphQL
                 graphType = listType.MakeGenericType(elementType);
             }
 
-            if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+            if (type.GetTypeInfo().IsGenericType && (type.GetGenericTypeDefinition() == typeof(List<>)
+                                                    || type.GetGenericTypeDefinition() == typeof(ICollection<>) 
+                                                    || type.GetGenericTypeDefinition() == typeof(IList<>)))
             {
                 var elementType = GetGraphTypeFromType(type.GenericTypeArguments.First(), isNullable);
                 var listType = typeof(ListGraphType<>);


### PR DESCRIPTION
Extend check for List<T> to include ICollection<T> and IList<T>.
Because these are also valid to be used as long as T is a GraphType