### PR TITLE
Bug fix - handle null list inputs

### DIFF
--- a/src/GraphQL.Tests/Bugs/NullableInputListTests.cs
+++ b/src/GraphQL.Tests/Bugs/NullableInputListTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class NullableInputListTests : QueryTestBase<TestSchema>
+    {
+        [Fact]
+        public async void Can_Accept_Null_List_From_Literal()
+        {
+            var query = @"
+                query _ {
+                  example(testInputs:null)
+                }";
+            var expected = @"
+                {
+                    'example': ""null""
+                }";
+            AssertQuerySuccess(query, expected);
+        }
+
+        [Fact]
+        public async void Can_Accept_Null_List_From_Input()
+        {
+            var query = @"
+                query _($inputs:[TestInput]) {
+                  example(testInputs: $inputs)
+                }";
+            var expected = @"
+                {
+                    'example': ""null""
+                }";
+            AssertQuerySuccess(query, expected, inputs: new Inputs(new Dictionary<string, object>
+            {
+                { "inputs", null }
+            }));
+        }
+    }
+
+    public class TestSchema : Schema
+    {
+        public TestSchema()
+        {
+            Query = new TestQuery();
+        }
+    }
+
+    public class TestQuery : ObjectGraphType
+    {
+        public TestQuery()
+        {
+            Name = "Query";
+            Field<StringGraphType>(
+                "example",
+                arguments: new QueryArguments(
+                    new QueryArgument<ListGraphType<TestInputType>>
+                    {
+                        Name = "testInputs"
+                    }
+                ),
+                resolve: context =>
+                {
+                    var testInputs = context.GetArgument<List<TestInput>>("testInputs");
+                    return testInputs == null
+                        ? "null"
+                        : "[" + string.Join(",", testInputs.Select(x => x == null ? "null" : x.Text)) + "]";
+                }
+            );
+        }
+    }
+
+    public class TestInputType : InputObjectGraphType
+    {
+        public TestInputType()
+        {
+            Name = "TestInput";
+            Field<StringGraphType>("text");
+        }
+    }
+
+    public class TestInput
+    {
+        public string Text { get; set; }
+    }
+}

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -237,7 +237,7 @@ namespace GraphQL.Execution
                 return CoerceValue(schema, nonNull.ResolvedType, input, variables);
             }
 
-            if (input == null)
+            if (input == null || input is NullValue)
             {
                 return null;
             }


### PR DESCRIPTION
Handle issue raised by @amay in the [graphql-dotnet/conventions](https://github.com/graphql-dotnet/conventions) repository - null literals not treated properly for input lists:

https://github.com/graphql-dotnet/conventions/issues/73