### PR TITLE
Add error code and data to ExecutionError

### DIFF
--- a/src/GraphQL.Tests/Errors/ErrorCodeTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorCodeTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Errors
+{
+    public class ErrorCodeTests : QueryTestBase<ErrorCodeTests.TestSchema>
+    {
+        [Theory]
+        [InlineData("{ firstSync }", "FIRST")]
+        [InlineData("{ secondSync }", "SECOND_TEST")]
+        [InlineData("{ uncodedSync }", "")]
+        public async Task should_show_code_when_exception_is_thrown_with_sync_field(string query, string code)
+        {
+            var result = await Executer.ExecuteAsync(_ =>
+            {
+                _.Schema = Schema;
+                _.Query = query;
+            });
+
+            result.Errors.Count.ShouldBe(1);
+            var error = result.Errors.First();
+            error.Code.ShouldBe(code);
+        }
+
+        [Theory]
+        [InlineData("{ firstAsync }", "FIRST")]
+        [InlineData("{ secondAsync }", "SECOND_TEST")]
+        [InlineData("{ uncodedAsync }", "")]
+        public async Task should_show_code_when_exception_thrown_with_async_field(string query, string code)
+        {
+            var result = await Executer.ExecuteAsync(_ =>
+            {
+                _.Schema = Schema;
+                _.Query = query;
+            });
+
+            result.Errors.Count.ShouldBe(1);
+            var error = result.Errors.First();
+            error.Code.ShouldBe(code);
+        }
+
+        [Fact]
+        public async Task should_propagate_exception_data_when_exception_is_thrown_in_field_resolver()
+        {
+            var result = await Executer.ExecuteAsync(_ =>
+            {
+                _.Schema = Schema;
+                _.Query = @"{ secondSync }";
+            });
+
+            result.Errors.Count.ShouldBe(1);
+            var error = result.Errors.First();
+            error.Data["Foo"].ShouldBe("Bar");
+        }
+
+        public class TestQuery : ObjectGraphType
+        {
+            public TestQuery()
+            {
+                Name = "Query";
+                Field<StringGraphType>(
+                    "firstSync",
+                    resolve: _ => throw new FirstException("Exception from synchronous resolver")
+                );
+                FieldAsync<StringGraphType>(
+                    "firstAsync",
+                    resolve: async _ => throw new FirstException("Exception from asynchronous resolver")
+                );
+                Field<StringGraphType>(
+                    "secondSync",
+                    resolve: _ => throw new SecondTestException("Exception from synchronous resolver")
+                );
+                FieldAsync<StringGraphType>(
+                    "secondAsync",
+                    resolve: async _ => throw new SecondTestException("Exception from asynchronous resolver")
+                );
+                Field<StringGraphType>(
+                    "uncodedSync",
+                    resolve: _ => throw new Exception("Exception from synchronous resolver")
+                );
+                FieldAsync<StringGraphType>(
+                    "uncodedAsync",
+                    resolve: async _ => throw new Exception("Exception from asynchronous resolver")
+                );
+            }
+        }
+
+        public class TestSchema : Schema
+        {
+            public TestSchema()
+            {
+                Query = new TestQuery();
+            }
+        }
+
+        public class FirstException : Exception
+        {
+            public FirstException(string message)
+                : base(message)
+            {
+            }
+        }
+
+        public class SecondTestException : Exception
+        {
+            public SecondTestException(string message)
+                : base(message)
+            {
+                Data["Foo"] = "Bar";
+            }
+        }
+    }
+}

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using GraphQL.Language.AST;
 using GraphQLParser;
 
@@ -14,14 +17,21 @@ namespace GraphQL
         {
         }
 
-        public ExecutionError(string message, Exception innerException)
-            : base(message, innerException)
+        public ExecutionError(string message, Exception exception)
+            : base(message, exception)
         {
+            var ex = exception?.InnerException ?? exception;
+            SetCode(ex);
+            SetData(ex);
         }
 
         public IEnumerable<ErrorLocation> Locations => _errorLocations;
 
+        public string Code { get; set; }
+
         public IEnumerable<string> Path { get; set; }
+
+        public new Dictionary<string, object> Data { get; private set; } = null;
 
         public void AddLocation(int line, int column)
         {
@@ -31,6 +41,63 @@ namespace GraphQL
             }
 
             _errorLocations.Add(new ErrorLocation { Line = line, Column = column });
+        }
+
+        private void SetCode(Exception exception)
+        {
+            Code = NormalizeErrorCode(exception);
+        }
+
+        private void SetData(Exception exception)
+        {
+            if (exception?.Data == null || exception.Data.Count == 0)
+            {
+                return;
+            }
+            Data = new Dictionary<string, object>();
+            foreach (DictionaryEntry entry in exception.Data)
+            {
+                var key = entry.Key.ToString();
+                var value = entry.Value;
+                Data[key] = value;
+            }
+        }
+
+        private static string NormalizeErrorCode(Exception exception)
+        {
+            var code = exception?.GetType().Name ?? string.Empty;
+            if (code.EndsWith(nameof(Exception)))
+            {
+                code = code.Substring(0, code.Length - nameof(Exception).Length);
+            }
+            if (code.StartsWith("GraphQL"))
+            {
+                code = code.Substring("GraphQL".Length);
+            }
+            return GetAllCapsRepresentation(code);
+        }
+
+        private static string GetAllCapsRepresentation(string str)
+        {
+            return Regex
+                .Replace(NormalizeString(str), @"([A-Z])([A-Z][a-z])|([a-z0-9])([A-Z])", "$1$3_$2$4")
+                .ToUpperInvariant();
+        }
+
+        private static string NormalizeString(string str)
+        {
+            str = str?.Trim();
+            return string.IsNullOrWhiteSpace(str)
+                ? string.Empty
+                : NormalizeTypeName(str);
+        }
+
+        private static string NormalizeTypeName(string name)
+        {
+            var tickIndex = name.IndexOf('`');
+            return tickIndex >= 0
+                ? name.Substring(0, tickIndex)
+                : name;
         }
     }
 

--- a/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
@@ -76,6 +76,24 @@ namespace GraphQL
                     serializer.Serialize(writer, error.Path);
                 }
 
+                if (!string.IsNullOrWhiteSpace(error.Code))
+                {
+                    writer.WritePropertyName("code");
+                    serializer.Serialize(writer, error.Code);
+                }
+
+                if (error.Data != null && error.Data.Count > 0)
+                {
+                    writer.WritePropertyName("data");
+                    writer.WriteStartObject();
+                    error.Data.Apply(entry =>
+                    {
+                        writer.WritePropertyName(entry.Key);
+                        serializer.Serialize(writer, entry.Value);
+                    });
+                    writer.WriteEndObject();
+                }
+
                 writer.WriteEndObject();
             });
 


### PR DESCRIPTION
We've been using this to more easily determine the reason for an error on the client side. E.g.,
instead of regex matching on the error message itself (which can even be localised), we can check `errors[*].code`.

Further we have enabled enrichment of errors by forwarding data that has been put into `Exception.Data` to the response.

 - The error code is derived from the exception name; e.g., thrown `DatabaseQueryException`
   results in an error code of `DATABASE_QUERY`.

 - Any data included in a thrown exception (e.g., `Exception.Data`) gets put into `ExecutionError.Data` and consequently included in the serialised output.

The `Path` concept was also introduced in GraphQL.Conventions, but seems like that was been added to the main repo a while ago as well :) :+1: