### PR TITLE
Fix SchemaPrinter bug + optional print options

### DIFF
--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -12,9 +12,7 @@ namespace GraphQL.Utilities
     {
         private ISchema _schema;
 
-        private readonly bool _fieldDescriptions;
-
-        private readonly bool _fieldDeprecationReasons;
+        private readonly SchemaPrinterOptions _options;
 
         private readonly List<string> _scalars = new List<string>(
             new[]
@@ -29,8 +27,7 @@ namespace GraphQL.Utilities
         public SchemaPrinter(
             ISchema schema,
             IEnumerable<string> customScalars = null,
-            bool fieldDescriptions = false,
-            bool fieldDeprecationReasons = false)
+            SchemaPrinterOptions options = null)
         {
             _schema = schema;
 
@@ -39,8 +36,7 @@ namespace GraphQL.Utilities
                 _scalars.Fill(customScalars);
             }
 
-            _fieldDescriptions = fieldDescriptions;
-            _fieldDeprecationReasons = fieldDeprecationReasons;
+            _options = options ?? new SchemaPrinterOptions();
         }
 
         private ISchema Schema => _schema;
@@ -257,8 +253,8 @@ namespace GraphQL.Utilities
                     x.Name,
                     Type = ResolveName(x.ResolvedType),
                     Args = PrintArgs(x),
-                    Description = _fieldDescriptions ? PrintDescription(type.Description, "  ") : string.Empty,
-                    Deprecation = _fieldDeprecationReasons ? PrintDeprecation(type.DeprecationReason) : string.Empty,
+                    Description = _options.IncludeDescriptions ? PrintDescription(type.Description, "  ") : string.Empty,
+                    Deprecation = _options.IncludeDeprecationReasons ? PrintDeprecation(type.DeprecationReason) : string.Empty,
                 }).ToList();
 
             return string.Join(Environment.NewLine, fields?.Select(

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -26,17 +26,15 @@ namespace GraphQL.Utilities
 
         public SchemaPrinter(
             ISchema schema,
-            IEnumerable<string> customScalars = null,
             SchemaPrinterOptions options = null)
         {
             _schema = schema;
-
-            if (customScalars != null)
-            {
-                _scalars.Fill(customScalars);
-            }
-
             _options = options ?? new SchemaPrinterOptions();
+
+            if (_options.CustomScalars?.Count > 0)
+            {
+                _scalars.Fill(_options.CustomScalars);
+            }
         }
 
         private ISchema Schema => _schema;

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -339,13 +339,7 @@ namespace GraphQL.Utilities
 
         private static bool IsEnumType(IGraphType type)
         {
-            if (type is NonNullGraphType)
-            {
-                var nullable = (NonNullGraphType)type;
-                type = nullable.ResolvedType;
-            }
-
-            return type is EnumerationGraphType;
+            return type.GetNamedType() is EnumerationGraphType;
         }
 
         private static object SerializeEnumValue(IGraphType type, object value)

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -12,6 +12,10 @@ namespace GraphQL.Utilities
     {
         private ISchema _schema;
 
+        private readonly bool _fieldDescriptions;
+
+        private readonly bool _fieldDeprecationReasons;
+
         private readonly List<string> _scalars = new List<string>(
             new[]
             {
@@ -22,7 +26,11 @@ namespace GraphQL.Utilities
                 "ID"
             });
 
-        public SchemaPrinter(ISchema schema, IEnumerable<string> customScalars = null)
+        public SchemaPrinter(
+            ISchema schema,
+            IEnumerable<string> customScalars = null,
+            bool fieldDescriptions = false,
+            bool fieldDeprecationReasons = false)
         {
             _schema = schema;
 
@@ -30,6 +38,9 @@ namespace GraphQL.Utilities
             {
                 _scalars.Fill(customScalars);
             }
+
+            _fieldDescriptions = fieldDescriptions;
+            _fieldDeprecationReasons = fieldDeprecationReasons;
         }
 
         private ISchema Schema => _schema;
@@ -245,11 +256,13 @@ namespace GraphQL.Utilities
                 {
                     x.Name,
                     Type = ResolveName(x.ResolvedType),
-                    Args = PrintArgs(x)
+                    Args = PrintArgs(x),
+                    Description = _fieldDescriptions ? PrintDescription(type.Description, "  ") : string.Empty,
+                    Deprecation = _fieldDeprecationReasons ? PrintDeprecation(type.DeprecationReason) : string.Empty,
                 }).ToList();
 
             return string.Join(Environment.NewLine, fields?.Select(
-                f => "  {0}{1}: {2}".ToFormat(f.Name, f.Args, f.Type)));
+                f => "{3}  {0}{1}: {2}{4}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation)));
         }
 
         public string PrintArgs(FieldType field)
@@ -269,7 +282,7 @@ namespace GraphQL.Utilities
 
             if (argument.DefaultValue != null)
             {
-                desc += " = {0}".ToFormat(FormatDefaultValue(argument.DefaultValue));
+                desc += " = {0}".ToFormat(FormatDefaultValue(argument.DefaultValue, argumentType));
             }
 
             return desc;
@@ -282,7 +295,7 @@ namespace GraphQL.Utilities
 
             if (argument.DefaultValue != null)
             {
-                desc += " = {0}".ToFormat(FormatDefaultValue(argument.DefaultValue));
+                desc += " = {0}".ToFormat(FormatDefaultValue(argument.DefaultValue, argumentType));
             }
 
             return desc;
@@ -310,7 +323,7 @@ namespace GraphQL.Utilities
             return string.Join(" | ", locations.Select(x => enums.Serialize(x)));
         }
 
-        public string FormatDefaultValue(object value)
+        public string FormatDefaultValue(object value, IGraphType graphType)
         {
             if (value is string)
             {
@@ -322,7 +335,34 @@ namespace GraphQL.Utilities
                 return value.ToString().ToLower();
             }
 
+            if (IsEnumType(graphType))
+            {
+                return "{0}".ToFormat(SerializeEnumValue(graphType, value));
+            }
+
             return "{0}".ToFormat(value);
+        }
+
+        private static bool IsEnumType(IGraphType type)
+        {
+            if (type is NonNullGraphType)
+            {
+                var nullable = (NonNullGraphType)type;
+                type = nullable.ResolvedType;
+            }
+
+            return type is EnumerationGraphType;
+        }
+
+        private static object SerializeEnumValue(IGraphType type, object value)
+        {
+            if (type is NonNullGraphType)
+            {
+                var nullable = (NonNullGraphType)type;
+                type = nullable.ResolvedType;
+            }
+
+            return ((EnumerationGraphType)type).Serialize(value);
         }
 
         public static string ResolveName(IGraphType type)

--- a/src/GraphQL/Utilities/SchemaPrinterOptions.cs
+++ b/src/GraphQL/Utilities/SchemaPrinterOptions.cs
@@ -1,9 +1,13 @@
+using System.Collections.Generic;
+
 namespace GraphQL.Utilities
 {
     public class SchemaPrinterOptions
     {
-        public bool IncludeDescriptions { get; set; }
+        public List<string> CustomScalars { get; set; } = new List<string>();
 
-        public bool IncludeDeprecationReasons { get; set; }
+        public bool IncludeDescriptions { get; set; } = false;
+
+        public bool IncludeDeprecationReasons { get; set; } = false;
     }
 }

--- a/src/GraphQL/Utilities/SchemaPrinterOptions.cs
+++ b/src/GraphQL/Utilities/SchemaPrinterOptions.cs
@@ -1,0 +1,9 @@
+namespace GraphQL.Utilities
+{
+    public class SchemaPrinterOptions
+    {
+        public bool IncludeDescriptions { get; set; }
+
+        public bool IncludeDeprecationReasons { get; set; }
+    }
+}


### PR DESCRIPTION
 * Fix printing of default input values of enum type
 * Optional printing of descriptions
 * Optional printing of deprecation reasons

(related PRs: graphql-dotnet/conventions#82)