### PR TITLE
Simplify resolver interfaces and context

### DIFF
--- a/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
@@ -394,7 +394,7 @@ namespace GraphQL.Tests.Builders
             var field = objectType.Fields.First();
             field.Resolver.Resolve(new ResolveFieldContext
             {
-                Source = 12345
+                SourceObject = 12345
             });
         }
     }

--- a/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
@@ -58,8 +58,8 @@ namespace GraphQL.Tests.Instrumentation
                 };
             });
 
-            var result = _builder.Build().Invoke(_context).Result;
-            result.ShouldBe("One Quinn");
+            var result = _builder.Build().Invoke(_context);
+            result.Result.ShouldBe("One Quinn");
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
@@ -20,7 +20,7 @@ namespace GraphQL.Tests.Instrumentation
             _context = new ResolveFieldContext();
             _context.FieldName = "Name";
             _context.FieldAst = new Field(null, new NameNode("Name"));
-            _context.Source = new Person
+            _context.SourceObject = new Person
             {
                 Name = "Quinn"
             };

--- a/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GraphQL.Types;
 using Shouldly;
 using Xunit;
@@ -111,7 +112,7 @@ namespace GraphQL.Tests.StarWars
                ctx.SubFields.ShouldNotBeNull();
                ctx.SubFields.Keys.ShouldContain("id");
                ctx.SubFields.Keys.ShouldContain("friends");
-               return null;
+               return Task.FromResult<object>(null);
            });
             var query = @"
                 {

--- a/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
@@ -85,7 +85,7 @@ namespace GraphQL.Tests.Subscription
 
         private Message ResolveMessage(ResolveFieldContext context)
         {
-            var message = context.Source as Message;
+            var message = context.SourceObject as Message;
 
             return message;
         }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -86,6 +86,12 @@ namespace GraphQL.Builders
             return this;
         }
 
+        public FieldBuilder<TSourceType, TReturnType> Resolve(IAsyncFieldResolver resolver)
+        {
+            _fieldType.AsyncResolver = resolver;
+            return this;
+        }
+
         public FieldBuilder<TSourceType, TReturnType> Resolve(Func<ResolveFieldContext<TSourceType>, TReturnType> resolve)
         {
             return Resolve(new FuncFieldResolver<TSourceType, TReturnType>(resolve));

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -181,7 +181,7 @@ namespace GraphQL.Execution
                     ReturnType = node.FieldDefinition.ResolvedType,
                     ParentType = node.GetParentType(),
                     Arguments = arguments,
-                    Source = node.Source,
+                    SourceObject = node.Source,
                     Schema = context.Schema,
                     Document = context.Document,
                     Fragments = context.Fragments,

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -196,8 +196,17 @@ namespace GraphQL.Execution
                     SubFields = subFields
                 };
 
-                var resolver = node.FieldDefinition.Resolver ?? new NameFieldResolver();
-                var result = resolver.Resolve(resolveContext);
+                object result;
+                if (node.FieldDefinition.AsyncResolver != null)
+                {
+                    var asyncResolver = node.FieldDefinition.AsyncResolver;
+                    result = asyncResolver.Resolve(resolveContext);
+                }
+                else
+                {
+                    var resolver = node.FieldDefinition.Resolver ?? new NameFieldResolver();
+                    result = resolver.Resolve(resolveContext);
+                }
 
                 result = await UnwrapResultAsync(result)
                     .ConfigureAwait(false);

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -68,7 +68,7 @@ namespace GraphQL.Execution
                     ReturnType = node.FieldDefinition.ResolvedType,
                     ParentType = node.GraphType as IObjectGraphType,
                     Arguments = arguments,
-                    Source = source,
+                    SourceObject = source,
                     Schema = context.Schema,
                     Document = context.Document,
                     Fragments = context.Fragments,

--- a/src/GraphQL/Instrumentation/MiddlewareResolver.cs
+++ b/src/GraphQL/Instrumentation/MiddlewareResolver.cs
@@ -4,7 +4,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Instrumentation
 {
-    public class MiddlewareResolver : IFieldResolver<Task<object>>
+    public class MiddlewareResolver : IAsyncFieldResolver
     {
         private readonly IFieldResolver _next;
 
@@ -23,11 +23,6 @@ namespace GraphQL.Instrumentation
             }
 
             return Task.FromResult(result);
-        }
-
-        object IFieldResolver.Resolve(ResolveFieldContext context)
-        {
-            return Resolve(context);
         }
     }
 }

--- a/src/GraphQL/Reflection/AccessorFieldResolver.cs
+++ b/src/GraphQL/Reflection/AccessorFieldResolver.cs
@@ -21,8 +21,8 @@ namespace GraphQL.Reflection
         {
             var arguments = BuildArguments(_accessor.Parameters, context);
 
-            var target = _accessor.DeclaringType.IsInstanceOfType(context.Source)
-                    ? context.Source
+            var target = _accessor.DeclaringType.IsInstanceOfType(context.SourceObject)
+                    ? context.SourceObject
                     : _dependencyResolver.Resolve(_accessor.DeclaringType);
 
             if (target == null)

--- a/src/GraphQL/Reflection/AccessorFieldResolver.cs
+++ b/src/GraphQL/Reflection/AccessorFieldResolver.cs
@@ -6,7 +6,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Reflection
 {
-    internal class AccessorFieldResolver : FieldResolverBase
+    internal class AccessorFieldResolver : ReflectionFieldResolverBase
     {
         private readonly IAccessor _accessor;
         private readonly IDependencyResolver _dependencyResolver;

--- a/src/GraphQL/Resolvers/AsyncEventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/AsyncEventStreamResolver.cs
@@ -33,7 +33,7 @@ namespace GraphQL.Resolvers
 
         public async Task<IObservable<object>> SubscribeAsync(ResolveEventStreamContext context)
         {
-            var result = await _subscriber(context.As<TSourceType>());
+            var result = await _subscriber(new ResolveEventStreamContext<TSourceType>(context));
             return (IObservable<object>) result;
         }
     }

--- a/src/GraphQL/Resolvers/AsyncEventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/AsyncEventStreamResolver.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Resolvers
         public async Task<IObservable<object>> SubscribeAsync(ResolveEventStreamContext context)
         {
             var result = await _subscriber(context);
-            return (IObservable<object>)result;
+            return (IObservable<object>) result;
         }
     }
 
@@ -34,7 +34,7 @@ namespace GraphQL.Resolvers
         public async Task<IObservable<object>> SubscribeAsync(ResolveEventStreamContext context)
         {
             var result = await _subscriber(context.As<TSourceType>());
-            return (IObservable<object>)result;
+            return (IObservable<object>) result;
         }
     }
 }

--- a/src/GraphQL/Resolvers/AsyncEventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/AsyncEventStreamResolver.cs
@@ -4,7 +4,7 @@ using GraphQL.Subscription;
 
 namespace GraphQL.Resolvers
 {
-    public class AsyncEventStreamResolver<T> : IAsyncEventStreamResolver<T>
+    public class AsyncEventStreamResolver<T> : IAsyncEventStreamResolver
     {
         private readonly Func<ResolveEventStreamContext, Task<IObservable<T>>> _subscriber;
 
@@ -14,19 +14,14 @@ namespace GraphQL.Resolvers
             _subscriber = subscriber ?? throw new ArgumentNullException(nameof(subscriber));
         }
 
-        public Task<IObservable<T>> SubscribeAsync(ResolveEventStreamContext context)
+        public async Task<IObservable<object>> SubscribeAsync(ResolveEventStreamContext context)
         {
-            return _subscriber(context);
-        }
-
-        async Task<IObservable<object>> IAsyncEventStreamResolver.SubscribeAsync(ResolveEventStreamContext context)
-        {
-            var result = await SubscribeAsync(context);
+            var result = await _subscriber(context);
             return (IObservable<object>)result;
         }
     }
 
-    public class AsyncEventStreamResolver<TSourceType, TReturnType> : IAsyncEventStreamResolver<TReturnType>
+    public class AsyncEventStreamResolver<TSourceType, TReturnType> : IAsyncEventStreamResolver
     {
         private readonly Func<ResolveEventStreamContext<TSourceType>, Task<IObservable<TReturnType>>> _subscriber;
 
@@ -36,14 +31,9 @@ namespace GraphQL.Resolvers
             _subscriber = subscriber ?? throw new ArgumentNullException(nameof(subscriber));
         }
 
-        public Task<IObservable<TReturnType>> SubscribeAsync(ResolveEventStreamContext context)
+        public async Task<IObservable<object>> SubscribeAsync(ResolveEventStreamContext context)
         {
-            return _subscriber(context.As<TSourceType>());
-        }
-
-        async Task<IObservable<object>> IAsyncEventStreamResolver.SubscribeAsync(ResolveEventStreamContext context)
-        {
-            var result = await SubscribeAsync(context);
+            var result = await _subscriber(context.As<TSourceType>());
             return (IObservable<object>)result;
         }
     }

--- a/src/GraphQL/Resolvers/AsyncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/AsyncFieldResolver.cs
@@ -4,43 +4,25 @@ using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
-    public class AsyncFieldResolver<TReturnType> : IFieldResolver<Task<TReturnType>>
-    {
-        private readonly Func<ResolveFieldContext, Task<TReturnType>> _resolver;
-
-        public AsyncFieldResolver(Func<ResolveFieldContext, Task<TReturnType>> resolver)
-        {
-            _resolver = resolver;
-        }
-
-        public Task<TReturnType> Resolve(ResolveFieldContext context)
-        {
-            return _resolver(context);
-        }
-
-        object IFieldResolver.Resolve(ResolveFieldContext context)
-        {
-            return Resolve(context);
-        }
-    }
-
-    public class AsyncFieldResolver<TSourceType, TReturnType> : IFieldResolver<Task<TReturnType>>
+    public class AsyncFieldResolver<TSourceType, TReturnType> : IAsyncFieldResolver
     {
         private readonly Func<ResolveFieldContext<TSourceType>, Task<TReturnType>> _resolver;
 
         public AsyncFieldResolver(Func<ResolveFieldContext<TSourceType>, Task<TReturnType>> resolver)
         {
-            _resolver = resolver ?? throw new ArgumentNullException("A resolver function must be specified");
+            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
         }
 
-        public Task<TReturnType> Resolve(ResolveFieldContext context)
+        public async Task<object> Resolve(ResolveFieldContext context)
         {
-            return _resolver(context.As<TSourceType>());
-        }
+            var result = _resolver(context.As<TSourceType>());
 
-        object IFieldResolver.Resolve(ResolveFieldContext context)
-        {
-            return Resolve(context);
+            if (result == null)
+                throw new InvalidOperationException(
+                    "Resolver result is null when Task<object> is expected. When using resolvers with " +
+                    "Task<object> and null results you must provide a valid return value Task<object>");
+
+            return await result;
         }
     }
 }

--- a/src/GraphQL/Resolvers/AsyncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/AsyncFieldResolver.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Resolvers
 
         public async Task<object> Resolve(ResolveFieldContext context)
         {
-            var result = _resolver(context.As<TSourceType>());
+            var result = _resolver(new ResolveFieldContext<TSourceType>(context));
 
             if (result == null)
                 throw new InvalidOperationException(

--- a/src/GraphQL/Resolvers/DelegateFieldModelBinderResolver.cs
+++ b/src/GraphQL/Resolvers/DelegateFieldModelBinderResolver.cs
@@ -1,18 +1,18 @@
 using System;
-using System.Linq;
 using System.Reflection;
 using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
-    public class DelegateFieldModelBinderResolver : FieldResolverBase
+    public class DelegateFieldModelBinderResolver : ReflectionFieldResolverBase
     {
-        private readonly Delegate _resolver;
         private readonly ParameterInfo[] _parameters;
+        private readonly Delegate _resolver;
 
         public DelegateFieldModelBinderResolver(Delegate resolver)
         {
-            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver), "A resolver function must be specified");
+            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver),
+                            "A resolver function must be specified");
             _parameters = _resolver.GetMethodInfo().GetParameters();
         }
 

--- a/src/GraphQL/Resolvers/EventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/EventStreamResolver.cs
@@ -31,7 +31,7 @@ namespace GraphQL.Resolvers
 
         public IObservable<object> Subscribe(ResolveEventStreamContext context)
         {
-            return (IObservable<object>) _subscriber(context.As<TSourceType>());
+            return (IObservable<object>) _subscriber(new ResolveEventStreamContext<TSourceType>(context));
         }
     }
 }

--- a/src/GraphQL/Resolvers/EventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/EventStreamResolver.cs
@@ -3,28 +3,23 @@ using GraphQL.Subscription;
 
 namespace GraphQL.Resolvers
 {
-    public class EventStreamResolver<T> : IEventStreamResolver<T>
+    public class EventStreamResolver<TReturnType> : IEventStreamResolver
     {
-        private readonly Func<ResolveEventStreamContext, IObservable<T>> _subscriber;
+        private readonly Func<ResolveEventStreamContext, IObservable<TReturnType>> _subscriber;
 
         public EventStreamResolver(
-            Func<ResolveEventStreamContext, IObservable<T>> subscriber)
+            Func<ResolveEventStreamContext, IObservable<TReturnType>> subscriber)
         {
             _subscriber = subscriber ?? throw new ArgumentNullException(nameof(subscriber));
         }
 
-        public IObservable<T> Subscribe(ResolveEventStreamContext context)
+        public IObservable<object> Subscribe(ResolveEventStreamContext context)
         {
-            return _subscriber(context);
-        }
-
-        IObservable<object> IEventStreamResolver.Subscribe(ResolveEventStreamContext context)
-        {
-            return (IObservable<object>)Subscribe(context);
+            return (IObservable<object>) _subscriber(context);
         }
     }
 
-    public class EventStreamResolver<TSourceType, TReturnType> : IEventStreamResolver<TReturnType>
+    public class EventStreamResolver<TSourceType, TReturnType> : IEventStreamResolver
     {
         private readonly Func<ResolveEventStreamContext<TSourceType>, IObservable<TReturnType>> _subscriber;
 
@@ -34,14 +29,9 @@ namespace GraphQL.Resolvers
             _subscriber = subscriber ?? throw new ArgumentNullException(nameof(subscriber));
         }
 
-        public IObservable<TReturnType> Subscribe(ResolveEventStreamContext context)
+        public IObservable<object> Subscribe(ResolveEventStreamContext context)
         {
-            return _subscriber(context.As<TSourceType>());
-        }
-
-        IObservable<object> IEventStreamResolver.Subscribe(ResolveEventStreamContext context)
-        {
-            return (IObservable<object>)Subscribe(context);
+            return (IObservable<object>) _subscriber(context.As<TSourceType>());
         }
     }
 }

--- a/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
+++ b/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
@@ -4,7 +4,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
-    public class ExpressionFieldResolver<TSourceType, TProperty> : IFieldResolver<TProperty>
+    public class ExpressionFieldResolver<TSourceType, TProperty> : IFieldResolver
     {
         private readonly Func<TSourceType, TProperty> _property;
 
@@ -13,14 +13,9 @@ namespace GraphQL.Resolvers
             _property = property.Compile();
         }
 
-        public TProperty Resolve(ResolveFieldContext context)
+        public object Resolve(ResolveFieldContext context)
         {
             return _property(context.As<TSourceType>().Source);
-        }
-
-        object IFieldResolver.Resolve(ResolveFieldContext context)
-        {
-            return Resolve(context);
         }
     }
 }

--- a/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
+++ b/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Resolvers
 
         public object Resolve(ResolveFieldContext context)
         {
-            return _property(context.As<TSourceType>().Source);
+            return _property(new ResolveFieldContext<TSourceType>(context).Source);
         }
     }
 }

--- a/src/GraphQL/Resolvers/FuncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/FuncFieldResolver.cs
@@ -1,10 +1,9 @@
 using System;
-using System.Threading.Tasks;
 using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
-    public class FuncFieldResolver<TReturnType> : IFieldResolver<TReturnType>
+    public class FuncFieldResolver<TReturnType> : IFieldResolver
     {
         private readonly Func<ResolveFieldContext, TReturnType> _resolver;
 
@@ -13,38 +12,24 @@ namespace GraphQL.Resolvers
             _resolver = resolver;
         }
 
-        public TReturnType Resolve(ResolveFieldContext context)
+        public object Resolve(ResolveFieldContext context)
         {
             return _resolver(context);
         }
-
-        object IFieldResolver.Resolve(ResolveFieldContext context)
-        {
-            return Resolve(context);
-        }
     }
 
-    public class FuncFieldResolver<TSourceType, TReturnType> : IFieldResolver<TReturnType>
+    public class FuncFieldResolver<TSourceType, TReturnType> : IFieldResolver
     {
         private readonly Func<ResolveFieldContext<TSourceType>, TReturnType> _resolver;
 
         public FuncFieldResolver(Func<ResolveFieldContext<TSourceType>, TReturnType> resolver)
         {
-            if (resolver == null)
-            {
-                throw new ArgumentNullException("A resolver function must be specified");
-            }
-            _resolver = resolver;
+            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
         }
 
-        public TReturnType Resolve(ResolveFieldContext context)
+        public object Resolve(ResolveFieldContext context)
         {
             return _resolver(context.As<TSourceType>());
-        }
-
-        object IFieldResolver.Resolve(ResolveFieldContext context)
-        {
-            return Resolve(context);
         }
     }
 }

--- a/src/GraphQL/Resolvers/FuncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/FuncFieldResolver.cs
@@ -29,7 +29,7 @@ namespace GraphQL.Resolvers
 
         public object Resolve(ResolveFieldContext context)
         {
-            return _resolver(context.As<TSourceType>());
+            return _resolver(new ResolveFieldContext<TSourceType>(context));
         }
     }
 }

--- a/src/GraphQL/Resolvers/IEventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/IEventStreamResolver.cs
@@ -9,18 +9,8 @@ namespace GraphQL.Resolvers
         IObservable<object> Subscribe(ResolveEventStreamContext context);
     }
 
-    public interface IEventStreamResolver<out T> : IEventStreamResolver
-    {
-        new IObservable<T> Subscribe(ResolveEventStreamContext context);
-    }
-
     public interface IAsyncEventStreamResolver
     {
         Task<IObservable<object>> SubscribeAsync(ResolveEventStreamContext context);
-    }
-
-    public interface IAsyncEventStreamResolver<T> : IAsyncEventStreamResolver
-    {
-        new Task<IObservable<T>> SubscribeAsync(ResolveEventStreamContext context);
     }
 }

--- a/src/GraphQL/Resolvers/IFieldResolver.cs
+++ b/src/GraphQL/Resolvers/IFieldResolver.cs
@@ -8,8 +8,8 @@ namespace GraphQL.Resolvers
         object Resolve(ResolveFieldContext context);
     }
 
-    public interface IFieldResolver<out T> : IFieldResolver
+    public interface IAsyncFieldResolver
     {
-        new T Resolve(ResolveFieldContext context);
+        Task<object> Resolve(ResolveFieldContext context);
     }
 }

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Resolvers
 
         public object Resolve(ResolveFieldContext context)
         {
-            return Resolve(context?.Source, context?.FieldAst?.Name);
+            return Resolve(context?.SourceObject, context?.FieldAst?.Name);
         }
 
         public static object Resolve(object source, string name)

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -6,7 +6,8 @@ namespace GraphQL.Resolvers
 {
     internal class NameFieldResolver : IFieldResolver
     {
-        private static readonly BindingFlags _flags = BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
+        private static readonly BindingFlags _flags =
+            BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
 
         public object Resolve(ResolveFieldContext context)
         {
@@ -15,18 +16,14 @@ namespace GraphQL.Resolvers
 
         public static object Resolve(object source, string name)
         {
-            if (source == null || name == null)
-            {
-                return null;
-            }
+            if (source == null || name == null) return null;
 
             var prop = source.GetType()
                 .GetProperty(name, _flags);
 
             if (prop == null)
-            {
-                throw new InvalidOperationException($"Expected to find property {name} on {source.GetType().Name} but it does not exist.");
-            }
+                throw new InvalidOperationException(
+                    $"Expected to find property {name} on {source.GetType().Name} but it does not exist.");
 
             return prop.GetValue(source, null);
         }

--- a/src/GraphQL/Resolvers/ReflectionFieldResolverBase.cs
+++ b/src/GraphQL/Resolvers/ReflectionFieldResolverBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using GraphQL.Types;
@@ -23,11 +23,11 @@ namespace GraphQL.Resolvers
             }
 
             if (parameters.Length > index
-                && context.Source != null
-                && (context.Source?.GetType() == parameters[index].ParameterType
+                && context.SourceObject != null
+                && (context.SourceObject?.GetType() == parameters[index].ParameterType
                     || string.Equals(parameters[index].Name, "source", StringComparison.OrdinalIgnoreCase)))
             {
-                arguments[index] = context.Source;
+                arguments[index] = context.SourceObject;
                 index++;
             }
 

--- a/src/GraphQL/Resolvers/ReflectionFieldResolverBase.cs
+++ b/src/GraphQL/Resolvers/ReflectionFieldResolverBase.cs
@@ -5,15 +5,15 @@ using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
-    public abstract class FieldResolverBase : IFieldResolver
+    public abstract class ReflectionFieldResolverBase : IFieldResolver
     {
         public abstract object Resolve(ResolveFieldContext context);
 
         protected object[] BuildArguments(ParameterInfo[] parameters, ResolveFieldContext context)
         {
-            if(parameters == null || !parameters.Any()) return null;
+            if (parameters == null || !parameters.Any()) return null;
 
-            object[] arguments = new object[parameters.Length];
+            var arguments = new object[parameters.Length];
 
             var index = 0;
             if (typeof(ResolveFieldContext) == parameters[index].ParameterType)

--- a/src/GraphQL/Subscription/ResolveEventStreamContext.cs
+++ b/src/GraphQL/Subscription/ResolveEventStreamContext.cs
@@ -1,14 +1,17 @@
-﻿using GraphQL.Types;
+using GraphQL.Types;
 
 namespace GraphQL.Subscription
 {
-    public class ResolveEventStreamContext<T> : ResolveFieldContext<T>
+    public class ResolveEventStreamContext : ResolveFieldContext
     {
-        public ResolveEventStreamContext() { }
+        public ResolveEventStreamContext()
+        {
+            
+        }
 
         public ResolveEventStreamContext(ResolveEventStreamContext context)
         {
-            Source = (T)context.Source;
+            SourceObject = context.SourceObject;
             FieldName = context.FieldName;
             FieldAst = context.FieldAst;
             FieldDefinition = context.FieldDefinition;
@@ -28,11 +31,13 @@ namespace GraphQL.Subscription
         }
     }
 
-    public class ResolveEventStreamContext : ResolveEventStreamContext<object>
+    public class ResolveEventStreamContext<TSourceType> : ResolveEventStreamContext
     {
-        internal ResolveEventStreamContext<TSourceType> As<TSourceType>()
+        public ResolveEventStreamContext(ResolveEventStreamContext context): base(context)
         {
-            return new ResolveEventStreamContext<TSourceType>(this);
+            
         }
+
+        public TSourceType Source => (TSourceType) SourceObject;
     }
 }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -134,7 +134,7 @@ namespace GraphQL.Types
                 DeprecationReason = deprecationReason,
                 Type = type,
                 Arguments = arguments,
-                Resolver = resolve != null
+                AsyncResolver = resolve != null
                     ? new AsyncFieldResolver<TSourceType, object>(resolve)
                     : null
             });
@@ -155,7 +155,7 @@ namespace GraphQL.Types
                 DeprecationReason = deprecationReason,
                 Type = typeof(TGraphType),
                 Arguments = arguments,
-                Resolver = resolve != null
+                AsyncResolver = resolve != null
                     ? new AsyncFieldResolver<TSourceType, object>(resolve)
                     : null
             });
@@ -176,7 +176,7 @@ namespace GraphQL.Types
                 DeprecationReason = deprecationReason,
                 Type = typeof(TGraphType),
                 Arguments = arguments,
-                Resolver = resolve != null
+                AsyncResolver = resolve != null
                     ? new AsyncFieldResolver<TSourceType, TReturnType>(resolve)
                     : null
             });

--- a/src/GraphQL/Types/FieldType.cs
+++ b/src/GraphQL/Types/FieldType.cs
@@ -22,7 +22,11 @@ namespace GraphQL.Types
         public Type Type { get; set; }
         public IGraphType ResolvedType { get; set; }
         public QueryArguments Arguments { get; set; }
+
         public IFieldResolver Resolver { get; set; }
+
+        public IAsyncFieldResolver AsyncResolver { get; set; }
+
         public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
 
         public TType GetMetadata<TType>(string key, TType defaultValue = default(TType))


### PR DESCRIPTION
* AsyncResolver (No more returning Task<T> with null value)
* Make more sense with the inheritance chain of the ResolverFieldContext