### PR TITLE
First Should Return DefaultPageSize

### DIFF
--- a/src/GraphQL/Builders/ResolveConnectionContext.cs
+++ b/src/GraphQL/Builders/ResolveConnectionContext.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Builders
                     return _defaultPageSize;
                 }
                 
-                return first
+                return first;
             }
         }
         

--- a/src/GraphQL/Builders/ResolveConnectionContext.cs
+++ b/src/GraphQL/Builders/ResolveConnectionContext.cs
@@ -20,6 +20,20 @@ namespace GraphQL.Builders
         {
             get
             {
+                var first = FirstInternal;
+                if (!first.HasValue && !Last.HasValue)
+                {
+                    return _defaultPageSize;
+                }
+                
+                return first
+            }
+        }
+        
+        private int? FirstInternal
+        {
+            get
+            {
                 var first = GetArgument<int?>("first");
                 return first.HasValue ? (int?)Math.Abs(first.Value) : null;
             }


### PR DESCRIPTION
If the `first` and `last` properties are not set, `first` should default to the `defaultPageSize`. Right now, I have to write the following code for every `Connection`:

```
var first = context.First;
if (!context.First.HasValue && !context.Last.HasValue)
{
    first = context.PageSize;
}
```