### PR TITLE
Cursor Helper Class

### DIFF
--- a/src/GraphQL.Tests/Types/Relay/CursorTests.cs
+++ b/src/GraphQL.Tests/Types/Relay/CursorTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using GraphQL.Types.Relay;
+using Xunit;
+
+namespace GraphQL.Tests.Types.Relay
+{
+    public class CursorTests
+    {
+        [Fact]
+        public void GetFirstAndLastCursor_NullCollection_ReturnsNull()
+        {
+            List<Entity> items = null;
+
+            var (firstCursor, lastCursor) = Cursor.GetFirstAndLastCursor(items, x => x.Property);
+
+            Assert.Null(firstCursor);
+            Assert.Null(lastCursor);
+        }
+
+        [Fact]
+        public void GetFirstAndLastCursor_EmptyCollection_ReturnsNull()
+        {
+            List<Entity> items = new List<Entity>();
+
+            var (firstCursor, lastCursor) = Cursor.GetFirstAndLastCursor(items, x => x.Property);
+
+            Assert.Null(firstCursor);
+            Assert.Null(lastCursor);
+        }
+
+        [Fact]
+        public void GetFirstAndLastCursor_NullGetpropertyFunc_ThrowsArgumentNullException()
+        {
+            List<Entity> items = new List<Entity>();
+
+            Assert.Throws<ArgumentNullException>(() => Cursor.GetFirstAndLastCursor<Entity, int>(items, null));
+        }
+
+        [Fact]
+        public void GetFirstAndLastCursor_ThreeItems_ReturnsTheCursorForTheFirstAndLastItems()
+        {
+            List<Entity> items = new List<Entity>()
+            {
+                new Entity() { Property = 1 },
+                new Entity() { Property = 2 },
+                new Entity() { Property = 3 },
+            };
+
+            var (firstCursor, lastCursor) = Cursor.GetFirstAndLastCursor(items, x => x.Property);
+
+            Assert.Equal("YXJyYXljb25uZWN0aW9uOjE=", firstCursor);
+            Assert.Equal("YXJyYXljb25uZWN0aW9uOjM=", lastCursor);
+        }
+
+        [Fact]
+        public void FromNullableCursor_NullValue_ReturnsNull()
+        {
+            var cursor = (string)null;
+
+            var value = Cursor.FromNullableCursor<int>(cursor);
+
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void FromNullableCursor_IntValue_ReturnsValueFromCursor()
+        {
+            var cursor = "YXJyYXljb25uZWN0aW9uOjU=";
+
+            var value = Cursor.FromNullableCursor<int>(cursor);
+
+            Assert.Equal(5, value);
+        }
+
+        [Fact]
+        public void FromNullableCursor_DateTimeValue_ReturnsValueFromCursor()
+        {
+            var cursor = "YXJyYXljb25uZWN0aW9uOjAxLzAxLzIwMDAgMDA6MDA6MDA=";
+
+            var value = Cursor.FromNullableCursor<DateTime>(cursor);
+
+            Assert.Equal(new DateTime(2000, 1, 1), value);
+        }
+
+        [Fact]
+        public void FromCursor_NullValue_ReturnsNull()
+        {
+            var cursor = (string)null;
+
+            var value = Cursor.FromCursor<string>(cursor);
+
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void FromCursor_IntValue_ReturnsValueFromCursor()
+        {
+            var cursor = "YXJyYXljb25uZWN0aW9uOjU=";
+
+            var value = Cursor.FromCursor<int>(cursor);
+
+            Assert.Equal(5, value);
+        }
+
+        [Fact]
+        public void FromCursor_StringValue_ReturnsValueFromCursor()
+        {
+            var cursor = "YXJyYXljb25uZWN0aW9uOmZvbw==";
+
+            var value = Cursor.FromCursor<string>(cursor);
+
+            Assert.Equal("foo", value);
+        }
+
+        [Fact]
+        public void FromCursor_DateTimeValue_ReturnsValueFromCursor()
+        {
+            var cursor = "YXJyYXljb25uZWN0aW9uOjAxLzAxLzIwMDAgMDA6MDA6MDA=";
+
+            var value = Cursor.FromCursor<DateTime>(cursor);
+
+            Assert.Equal(new DateTime(2000, 1, 1), value);
+        }
+
+        [Fact]
+        public void ToCursor_NullValue_ThrowsArgumentNullException()
+        {
+            var value = (string)null;
+
+            Assert.Throws<ArgumentNullException>(() => Cursor.ToCursor(value));
+        }
+
+        [Fact]
+        public void ToCursor_IntValue_ReturnsBase64Cursor()
+        {
+            var value = 5;
+
+            var cursor = Cursor.ToCursor(value);
+
+            Assert.Equal("YXJyYXljb25uZWN0aW9uOjU=", cursor);
+        }
+
+        [Fact]
+        public void ToCursor_StringValue_ReturnsBase64Cursor()
+        {
+            var value = "foo";
+
+            var cursor = Cursor.ToCursor(value);
+
+            Assert.Equal("YXJyYXljb25uZWN0aW9uOmZvbw==", cursor);
+        }
+
+        [Fact]
+        public void ToCursor_DateTimeValue_ReturnsBase64Cursor()
+        {
+            var value = new DateTime(2000, 1, 1);
+
+            var cursor = Cursor.ToCursor(value);
+
+            Assert.Equal("YXJyYXljb25uZWN0aW9uOjAxLzAxLzIwMDAgMDA6MDA6MDA=", cursor);
+        }
+
+        private class Entity
+        {
+            public int Property { get; set; }
+        }
+    }
+}

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>GraphQL for .NET</Description>
@@ -28,6 +28,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/GraphQL/Types/Relay/Cursor.cs
+++ b/src/GraphQL/Types/Relay/Cursor.cs
@@ -1,0 +1,69 @@
+namespace GraphQL.Types.Relay
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    public static class Cursor
+    {
+        private const string Prefix = "arrayconnection";
+
+        public static (string firstCursor, string lastCursor) GetFirstAndLastCursor<TItem, TCursor>(
+            IEnumerable<TItem> enumerable,
+            Func<TItem, TCursor> getCursorProperty)
+        {
+            if (getCursorProperty == null)
+            {
+                throw new ArgumentNullException(nameof(getCursorProperty));
+            }
+
+            if (enumerable == null || enumerable.Count() == 0)
+            {
+                return (null, null);
+            }
+
+            var firstCursor = ToCursor(getCursorProperty(enumerable.First()));
+            var lastCursor = ToCursor(getCursorProperty(enumerable.Last()));
+
+            return (firstCursor, lastCursor);
+        }
+
+        public static T? FromNullableCursor<T>(string cursor)
+            where T : struct
+        {
+            if (string.IsNullOrEmpty(cursor))
+            {
+                return null;
+            }
+
+            var value = Base64Decode(cursor).Substring(Prefix.Length + 1);
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+
+        public static T FromCursor<T>(string cursor)
+        {
+            if (string.IsNullOrEmpty(cursor))
+            {
+                return default(T);
+            }
+
+            var value = Base64Decode(cursor).Substring(Prefix.Length + 1);
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+
+        public static string ToCursor<T>(T value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return Base64Encode($"{Prefix}:{value}");
+        }
+
+        private static string Base64Decode(string value) => Encoding.UTF8.GetString(Convert.FromBase64String(value));
+
+        private static string Base64Encode(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+    }
+}


### PR DESCRIPTION
This cursor helper class can be used to convert from values of any type to base64 encoded cursor strings. It can also be used to return the first and last cursor given a collection (or null if the collection is null or empty).