### PR TITLE
Allow before and after to be used together and with first or last

### DIFF
--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using GraphQL.Types;
 using GraphQL.Types.Relay;
 
@@ -154,25 +154,13 @@ namespace GraphQL.Builders
 
         private void CheckForErrors(ResolveConnectionContext<TSourceType> args)
         {
-            if (args.First.HasValue && args.Before != null)
-            {
-                throw new ArgumentException("Cannot specify both `first` and `before`.");
-            }
-            if (args.Last.HasValue && args.After != null)
-            {
-                throw new ArgumentException("Cannot specify both `last` and `after`.");
-            }
-            if (args.Before != null && args.After != null)
-            {
-                throw new ArgumentException("Cannot specify both `before` and `after`.");
-            }
             if (args.First.HasValue && args.Last.HasValue)
             {
                 throw new ArgumentException("Cannot specify both `first` and `last`.");
             }
-            if (args.IsUnidirectional && (args.Last.HasValue || args.Before != null))
+            if (args.IsUnidirectional && args.Last.HasValue)
             {
-                throw new ArgumentException("Cannot use `last` and `before` with unidirectional connections.");
+                throw new ArgumentException("Cannot use `last` with unidirectional connections.");
             }
             if (args.IsPartial && args.NumberOfSkippedEntries.HasValue)
             {


### PR DESCRIPTION
The `ConnectionBuilder` was throwing exceptions the use of `before` when `first` or `after` were used. It also threw exceptions when `after` was used with `last` or `before`.

I can't see these restrictions in the [GraphQL Relay spec](https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo) but I could be wrong.

Using both `after` and `before` is used by Twitter when they add a `load more tweets` button:

1. Load some tweets.
2. User becomes inactive for a long period, not sure of the time Twitter uses.
3. User is active, load the latest tweets, then show a `load more tweets` button.
4. Clicking on `load more tweets` would load tweets `after` the latest tweets but `before` the older set.