### PR TITLE
Add int to double conversion

### DIFF
--- a/src/GraphQL.Tests/Execution/InputConversionTests.cs
+++ b/src/GraphQL.Tests/Execution/InputConversionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Shouldly;
@@ -18,6 +18,7 @@ namespace GraphQL.Tests.Execution
             public List<int?> F { get; set; }
             public List<List<int?>> G { get; set; }
             public DateTime H { get; set; }
+            public Double I { get; set; }
         }
 
         public class EnumInput
@@ -166,6 +167,17 @@ namespace GraphQL.Tests.Execution
             var myInput = inputs.ToObject<MyInput>();
             myInput.ShouldNotBeNull();
             myInput.D.ShouldBe(5);
+        }
+
+        [Fact]
+        public void can_convert_int_to_double()
+        {
+            var json = @"{'i': 1 }";
+            var inputs = json.ToInputs();
+            inputs.ShouldNotBeNull();
+            var myInput = inputs.ToObject<MyInput>();
+            myInput.ShouldNotBeNull();
+            myInput.I.ShouldBe(1.0);
         }
 
         [Fact]

--- a/src/GraphQL/ValueConverter.cs
+++ b/src/GraphQL/ValueConverter.cs
@@ -27,11 +27,18 @@ namespace GraphQL
 
             Register(typeof(int), typeof(bool), IntToBool);
             Register(typeof(int), typeof(long), IntToLong);
+            Register(typeof(int), typeof(double), IntToDouble);
             Register(typeof(int), typeof(decimal), IntToDecimal);
 
             Register(typeof(long), typeof(int), LongToInt);
 
             Register(typeof(double), typeof(decimal), DoubleToDecimal);
+        }
+
+        private static object IntToDouble(object value)
+        {
+            var intValue = (int)value;
+            return Convert.ToDouble(intValue, NumberFormatInfo.InvariantInfo);
         }
 
         private static object IntToDecimal(object value)


### PR DESCRIPTION
When sending integer value instead of float, upon calling `GetArgument<float>` on ResolveFieldContext, we're getting `System.InvalidOperationException : Could not find conversion from System.Int32 to System.Double`.

This PR allows integers to be converted to floats.