### PR TITLE
IsTypeOfFunc may be specified through GraphQLMetadata

### DIFF
--- a/src/GraphQL.Tests/Utilities/CustomGraphQLAttributeTests.cs
+++ b/src/GraphQL.Tests/Utilities/CustomGraphQLAttributeTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using GraphQL.Types;
 using GraphQL.Utilities;
 using Shouldly;
@@ -31,6 +31,38 @@ namespace GraphQL.Tests.Utilities
             var field = query.Fields.Single(x => x.Name == "post");
             field.GetMetadata<string>("Authorize").ShouldBe("SomePolicy");
         }
+
+        [Fact]
+        public void impl_type_sets_isTypeOfFunc()
+        {
+            var defs = @"
+                interface IUniqueElement
+                {
+                    id: ID!
+                }
+
+                type ABlog implements IUniqueElement
+                {
+                    id: ID!
+                    name: String!
+                }
+
+                type Query
+                {
+                    blog(id: ID!): ABlog
+                }
+            ";
+
+            Builder.Types.Include<ABlog>();
+
+            var schema = Builder.Build(defs);
+            schema.Initialize();
+
+            var blog = schema.FindType("ABlog") as IObjectGraphType;
+
+            blog.IsTypeOf.ShouldNotBeNull();
+            blog.IsTypeOf(new ABlog()).ShouldBeTrue();
+        }
     }
 
     public class MyAuthorizeAttribute : GraphQLAttribute
@@ -56,5 +88,30 @@ namespace GraphQL.Tests.Utilities
         {
             return PostData.Posts.FirstOrDefault(x => x.Id == id);
         }
+
+        public ABlog Blog(string id)
+        {
+            return new ABlog();
+        }
     }
+
+    [GraphQLMetadata("IUniqueElement")]
+    public abstract class UniqueElement
+    {
+        public abstract string Id { get; }
+    }
+
+    [GraphQLMetadata(IsTypeOf = typeof(ABlog))]
+    public class ABlog : UniqueElement
+    {
+        public ABlog()
+        {
+            Id = "Id-0";
+            Name = $"Blog Name {Id}";
+        }
+
+        public override string Id { get; }
+        public string Name { get; }
+    }
+
 }

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,9 +32,7 @@ namespace GraphQL
 
         public IEnumerable<string> Path { get; set; }
 
-        public Dictionary<string, object> DataAsDictionary { get; } = new Dictionary<string, object>();
-
-        public override IDictionary Data => DataAsDictionary;
+        public new Dictionary<string, object> Data { get; private set; } = null;
 
         public void AddLocation(int line, int column)
         {
@@ -57,6 +55,7 @@ namespace GraphQL
             {
                 return;
             }
+            Data = new Dictionary<string, object>();
             foreach (DictionaryEntry entry in exception.Data)
             {
                 var key = entry.Key.ToString();

--- a/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
@@ -82,11 +82,11 @@ namespace GraphQL
                     serializer.Serialize(writer, error.Code);
                 }
 
-                if (error.Data.Count > 0)
+                if (error.Data != null && error.Data.Count > 0)
                 {
                     writer.WritePropertyName("data");
                     writer.WriteStartObject();
-                    error.DataAsDictionary.Apply(entry =>
+                    error.Data.Apply(entry =>
                     {
                         writer.WritePropertyName(entry.Key);
                         serializer.Serialize(writer, entry.Value);

--- a/src/GraphQL/GraphQLMetadataAttribute.cs
+++ b/src/GraphQL/GraphQLMetadataAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Reflection;
 using GraphQL.Utilities;
 
 namespace GraphQL
@@ -31,10 +32,15 @@ namespace GraphQL
         public string Description { get; set; }
         public string DeprecationReason { get; set; }
 
+        public Type IsTypeOf { get; set; }
+
         public override void Modify(TypeConfig type)
         {
             type.Description = Description;
             type.DeprecationReason = DeprecationReason;
+
+            if (IsTypeOf != null)
+                type.IsTypeOfFunc = t => IsTypeOf.GetTypeInfo().IsAssignableFrom(t.GetType().GetTypeInfo());
         }
 
         public override void Modify(FieldConfig field)

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -86,7 +86,7 @@ namespace GraphQL
         {
             var attr = type.GetTypeInfo().GetCustomAttribute<GraphQLMetadataAttribute>();
 
-            if (attr != null)
+            if (!string.IsNullOrEmpty(attr?.Name))
             {
                 return attr.Name;
             }


### PR DESCRIPTION
When schema language is employed to generate GraphQL runtime wiring classes they don't contain an implementation of IsTypeOfFunc needed for types implementing interfaces. The resolving classes may then be decorated with GraphQLMetadatattribute containing a new property IsTypeOf which allows specifying what type will be used to implement the iinterface.

Fixed a minor error in TypeExtensions.GetGraphQLName() when the GraphQLmetadata attribute is being used without specifying a name