### PR TITLE
Add support to return IEnumerable as a ListGraphType

### DIFF
--- a/src/GraphQL.Tests/Utilities/TypeExtensionsTests.cs
+++ b/src/GraphQL.Tests/Utilities/TypeExtensionsTests.cs
@@ -24,6 +24,10 @@ namespace GraphQL.Tests.Utilities
             typeof(IList<string>).GetGraphTypeFromType(true).ShouldBe(typeof(ListGraphType<StringGraphType>));
 
         [Fact]
+        public void GetGraphTypeFromType_ForIReadOnlyCollection_EqualToListGraphType() =>
+            typeof(IReadOnlyCollection<string>).GetGraphTypeFromType(true).ShouldBe(typeof(ListGraphType<StringGraphType>));
+
+        [Fact]
         public void GetGraphTypeFromType_ForIEnumerable_EqualToListGraphType() =>
             typeof(IEnumerable<string>).GetGraphTypeFromType(true).ShouldBe(typeof(ListGraphType<StringGraphType>));
 

--- a/src/GraphQL.Tests/Utilities/TypeExtensionsTests.cs
+++ b/src/GraphQL.Tests/Utilities/TypeExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Types;
+using GraphQL.Types;
 using Shouldly;
 using System.Collections.Generic;
 using Xunit;
@@ -20,9 +20,27 @@ namespace GraphQL.Tests.Utilities
         }
 
         [Fact]
-        public void supports_list_type()
-        {
+        public void GetGraphTypeFromType_ForIList_EqualToListGraphType() =>
+            typeof(IList<string>).GetGraphTypeFromType(true).ShouldBe(typeof(ListGraphType<StringGraphType>));
+
+        [Fact]
+        public void GetGraphTypeFromType_ForIEnumerable_EqualToListGraphType() =>
+            typeof(IEnumerable<string>).GetGraphTypeFromType(true).ShouldBe(typeof(ListGraphType<StringGraphType>));
+
+        [Fact]
+        public void GetGraphTypeFromType_ForICollection_EqualToListGraphType() =>
+            typeof(ICollection<string>).GetGraphTypeFromType(true).ShouldBe(typeof(ListGraphType<StringGraphType>));
+
+        [Fact]
+        public void GetGraphTypeFromType_ForList_EqualToListGraphType() =>
             typeof(List<string>).GetGraphTypeFromType(true).ShouldBe(typeof(ListGraphType<StringGraphType>));
-        }
+
+        [Fact]
+        public void GetGraphTypeFromType_ForArray_EqualToListGraphType() =>
+            typeof(string[]).GetGraphTypeFromType(true).ShouldBe(typeof(ListGraphType<StringGraphType>));
+
+        [Fact]
+        public void GetGraphTypeFromType_ForString_EqualToStringGraphType() =>
+            typeof(string).GetGraphTypeFromType(true).ShouldBe(typeof(StringGraphType));
     }
 }

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 
 namespace GraphQL
 {
+    using System.Collections;
+
     public static class TypeExtensions
     {
         /// <summary>
@@ -136,7 +138,7 @@ namespace GraphQL
                 graphType = listType.MakeGenericType(elementType);
             }
 
-            if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+            if (IsAnIEnumerable(type))
             {
                 var elementType = GetGraphTypeFromType(type.GenericTypeArguments.First(), isNullable);
                 var listType = typeof(ListGraphType<>);
@@ -157,5 +159,8 @@ namespace GraphQL
 
             return graphType;
         }
+
+        private static bool IsAnIEnumerable(Type type) =>
+            type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type) && !type.IsArray;
     }
 }


### PR DESCRIPTION
Right now as a `ListGraphType` could be returned only a `List`. I want to be able to return `ICollection`, `IList`, `IEnumerable`, `IReadOnlyCollection` etc. as a `ListGraphType` I add some unit tests so we would be sure that everything works fine.

CC: @joemcbride