### PR TITLE
#606 boolean graph type not converting numerical string

### DIFF
--- a/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
@@ -63,7 +63,7 @@ namespace GraphQL.Tests.Types
         public void coerces_input_to_exception(string input)
         {
             FormatException formatException = Assert.Throws<FormatException>(() => type.ParseValue(input));
-            Assert.Equal("String was not recognized as a valid Boolean.", formatException.Message);
+            formatException.Message.ShouldBe("String was not recognized as a valid Boolean.");
         }
 
         [Theory]

--- a/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Types;
+using GraphQL.Types;
 using Shouldly;
 using Xunit;
 
@@ -42,6 +42,18 @@ namespace GraphQL.Tests.Types
         public void coerces_string_True()
         {
             type.ParseValue("True").ShouldBe(true);
+        }
+
+        [Fact]
+        public void coerces_string_1_to_true()
+        {
+            type.ParseValue("1").ShouldBe(true);
+        }
+
+        [Fact]
+        public void coerces_zero_string_to_false()
+        {
+            type.ParseValue("0").ShouldBe(false);
         }
     }
 }

--- a/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
@@ -71,6 +71,7 @@ namespace GraphQL.Tests.Types
         [InlineData("0")]
         [InlineData("False")]
         [InlineData("false")]
+        [InlineData(false)]
         public void serialize_input_to_false(object input)
         {
             type.Serialize(input).ShouldBe(false);
@@ -81,6 +82,7 @@ namespace GraphQL.Tests.Types
         [InlineData("1")]
         [InlineData("True")]
         [InlineData("true")]
+        [InlineData(true)]
         public void serialize_input_to_true(object input)
         {
             type.Serialize(input).ShouldBe(true);

--- a/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
@@ -1,5 +1,6 @@
 using GraphQL.Types;
 using Shouldly;
+using System;
 using Xunit;
 
 namespace GraphQL.Tests.Types
@@ -54,6 +55,35 @@ namespace GraphQL.Tests.Types
         public void coerces_zero_string_to_false()
         {
             type.ParseValue("0").ShouldBe(false);
+        }
+
+        [Theory]
+        [InlineData("abc")]
+        [InlineData("21")]
+        public void coerces_input_to_exception(string input)
+        {
+            FormatException formatException = Assert.Throws<FormatException>(() => type.ParseValue(input));
+            Assert.Equal("String was not recognized as a valid Boolean.", formatException.Message);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData("0")]
+        [InlineData("False")]
+        [InlineData("false")]
+        public void serialize_input_to_false(object input)
+        {
+            type.Serialize(input).ShouldBe(false);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData("1")]
+        [InlineData("True")]
+        [InlineData("true")]
+        public void serialize_input_to_true(object input)
+        {
+            type.Serialize(input).ShouldBe(true);
         }
     }
 }

--- a/src/GraphQL/Types/BooleanGraphType.cs
+++ b/src/GraphQL/Types/BooleanGraphType.cs
@@ -1,4 +1,5 @@
 using GraphQL.Language.AST;
+using System;
 
 namespace GraphQL.Types
 {
@@ -11,10 +12,11 @@ namespace GraphQL.Types
 
         public override object Serialize(object value)
         {
-            if (value is bool)
+            try
             {
-                return (bool) value;
+                return ParseValue(value);
             }
+            catch(Exception) { }
 
             return false;
         }

--- a/src/GraphQL/Types/BooleanGraphType.cs
+++ b/src/GraphQL/Types/BooleanGraphType.cs
@@ -12,13 +12,7 @@ namespace GraphQL.Types
 
         public override object Serialize(object value)
         {
-            try
-            {
-                return ParseValue(value);
-            }
-            catch(Exception) { }
-
-            return false;
+            return ParseValue(value);
         }
 
         public override object ParseValue(object value)

--- a/src/GraphQL/ValueConverter.cs
+++ b/src/GraphQL/ValueConverter.cs
@@ -73,6 +73,12 @@ namespace GraphQL
 
         private static object ParseBool(object value)
         {
+            string stringValue = (string)value;
+            if (string.CompareOrdinal(stringValue, "1") == 0)
+                return true;
+            else if (string.CompareOrdinal(stringValue, "0") == 0)
+                return false;
+
             return Convert.ToBoolean(value, NumberFormatInfo.InvariantInfo);
         }
 


### PR DESCRIPTION
- [x] Add ability to convert `"1"` to `"0"` to `true` and `false` respectively
- [x] Change `Serialize` for `BooleanGraphType` to call `ParseValue`
- [x] Added Test cases for changes
