### PR TITLE
Change return type of DataLoader batches to IDictionary instead of Dictionary

### DIFF
--- a/src/GraphQL.DataLoader.Tests/Stores/UsersStore.cs
+++ b/src/GraphQL.DataLoader.Tests/Stores/UsersStore.cs
@@ -25,7 +25,7 @@ namespace GraphQL.DataLoader.Tests.Stores
         private int _getAllUsersCalled;
         public int GetAllUsersCalledCount => _getAllUsersCalled;
 
-        public async Task<Dictionary<int, User>> GetUsersByIdAsync(IEnumerable<int> userIds,
+        public async Task<IDictionary<int, User>> GetUsersByIdAsync(IEnumerable<int> userIds,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Interlocked.Increment(ref _getUsersByIdCalled);

--- a/src/GraphQL/DataLoader/BatchDataLoader.cs
+++ b/src/GraphQL/DataLoader/BatchDataLoader.cs
@@ -6,14 +6,14 @@ using System.Threading.Tasks;
 
 namespace GraphQL.DataLoader
 {
-    public class BatchDataLoader<TKey, T> : DataLoaderBase<Dictionary<TKey, T>>, IDataLoader<TKey, T>
+    public class BatchDataLoader<TKey, T> : DataLoaderBase<IDictionary<TKey, T>>, IDataLoader<TKey, T>
     {
-        private readonly Func<IEnumerable<TKey>, CancellationToken, Task<Dictionary<TKey, T>>> _loader;
+        private readonly Func<IEnumerable<TKey>, CancellationToken, Task<IDictionary<TKey, T>>> _loader;
         private readonly HashSet<TKey> _pendingKeys;
         private readonly Dictionary<TKey, T> _cache;
         private readonly T _defaultValue;
 
-        public BatchDataLoader(Func<IEnumerable<TKey>, CancellationToken, Task<Dictionary<TKey, T>>> loader,
+        public BatchDataLoader(Func<IEnumerable<TKey>, CancellationToken, Task<IDictionary<TKey, T>>> loader,
             IEqualityComparer<TKey> keyComparer = null,
             T defaultValue = default(T))
         {
@@ -39,7 +39,7 @@ namespace GraphQL.DataLoader
 
             keyComparer = keyComparer ?? EqualityComparer<TKey>.Default;
 
-            async Task<Dictionary<TKey, T>> LoadAndMapToDictionary(IEnumerable<TKey> keys, CancellationToken cancellationToken)
+            async Task<IDictionary<TKey, T>> LoadAndMapToDictionary(IEnumerable<TKey> keys, CancellationToken cancellationToken)
             {
                 var values = await loader(keys, cancellationToken).ConfigureAwait(false);
                 return values.ToDictionary(keySelector, keyComparer);
@@ -88,7 +88,7 @@ namespace GraphQL.DataLoader
             }
         }
 
-        protected override async Task<Dictionary<TKey, T>> FetchAsync(CancellationToken cancellationToken)
+        protected override async Task<IDictionary<TKey, T>> FetchAsync(CancellationToken cancellationToken)
         {
             IList<TKey> keys;
 

--- a/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
+++ b/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
@@ -60,7 +60,7 @@ namespace GraphQL.DataLoader
         /// <param name="fetchFunc">A cancellable delegate to fetch data for some keys asynchronously</param>
         /// <param name="keyComparer">An <seealso cref="IEqualityComparer<T>"/> to compare keys.</param>
         /// <returns>A new or existing DataLoader instance</returns>
-        public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<Dictionary<TKey, T>>> fetchFunc,
+        public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<IDictionary<TKey, T>>> fetchFunc,
             IEqualityComparer<TKey> keyComparer = null, T defaultValue = default(T))
         {
             if (context == null)
@@ -82,7 +82,7 @@ namespace GraphQL.DataLoader
         /// <param name="fetchFunc">A delegate to fetch data for some keys asynchronously</param>
         /// <param name="keyComparer">An <seealso cref="IEqualityComparer<T>"/> to compare keys.</param>
         /// <returns>A new or existing DataLoader instance</returns>
-        public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, Task<Dictionary<TKey, T>>> fetchFunc,
+        public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, Task<IDictionary<TKey, T>>> fetchFunc,
             IEqualityComparer<TKey> keyComparer = null, T defaultValue = default(T))
         {
             if (context == null)


### PR DESCRIPTION
DataLoader batches are currently required to return `Dictionary`, which is a bit rigid.

This changes it to `IDictionary`.