### PR TITLE
#625 rename GraphTypeRegistries and move them to the same location

### DIFF
--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using GraphQL.Utilities;
 
 namespace GraphQL
 {
@@ -127,7 +128,7 @@ namespace GraphQL
                 }
             }
 
-            graphType = GraphQL.GraphTypeRegistry.Get(type);
+            graphType = GraphTypeTypeRegistry.Get(type);
 
             if (type.IsArray)
             {

--- a/src/GraphQL/Utilities/GraphTypeInstanceRegistry.cs
+++ b/src/GraphQL/Utilities/GraphTypeInstanceRegistry.cs
@@ -1,14 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using GraphQL.Types;
 
 namespace GraphQL.Utilities
 {
-    public class TypeToGraphTypeConverter
+    public class GraphTypeInstanceRegistry
     {
         private readonly IDictionary<Type, IGraphType> _typeMap;
 
-        public TypeToGraphTypeConverter()
+        public GraphTypeInstanceRegistry()
         {
             var stringType = new GraphQLTypeReference("String");
             var booleanType = new GraphQLTypeReference("Boolean");
@@ -39,15 +39,15 @@ namespace GraphQL.Utilities
             };
         }
 
-        public IGraphType Convert(Type type)
-        {
-            _typeMap.TryGetValue(type, out IGraphType graphType);
-            return graphType;
-        }
-
         public void Register(Type type, IGraphType graphType)
         {
             _typeMap[type] = graphType;
+        }
+
+        public IGraphType Get(Type type)
+        {
+            _typeMap.TryGetValue(type, out IGraphType graphType);
+            return graphType;
         }
     }
 }

--- a/src/GraphQL/Utilities/GraphTypeTypeRegistry.cs
+++ b/src/GraphQL/Utilities/GraphTypeTypeRegistry.cs
@@ -1,15 +1,14 @@
 using System;
 using System.Collections.Generic;
-
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL.Utilities
 {
-    public static class GraphTypeRegistry
+    public static class GraphTypeTypeRegistry
     {
         static readonly Dictionary<Type, Type> _entries;
 
-        static GraphTypeRegistry()
+        static GraphTypeTypeRegistry()
         {
             _entries = new Dictionary<Type, Type>
             {
@@ -23,7 +22,6 @@ namespace GraphQL
                 [typeof(DateTime)] = typeof(DateGraphType),
                 [typeof(DateTimeOffset)] = typeof(DateGraphType)
             };
-
         }
 
         public static void Register(Type clrType, Type graphType)


### PR DESCRIPTION
Fixes: #625 

* rename `TypeToGraphConverter` to a `GraphQLTypeTypeRegistry`
* move `TypeToGraphConverter` to `GraphQL.Utilities`
* rename function Convert to `Get` in `GraphQLTypeTypeRegistry` so it is coherent with function `Get` from `GraphQLInstanceRegistry`

CC: @joemcbride 