### PR TITLE
#475 when registering a field throw an error if the name doesn't match the spec

### DIFF
--- a/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,6 +17,17 @@ namespace GraphQL.Tests.Builders
         {
             var objectType = new ParentType();
             objectType.Fields.First().Name.ShouldBe("connection1");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void should_throw_error_if_name_is_null_or_empty(string fieldName)
+        {
+            var type = new ObjectGraphType();
+            var exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Connection<ObjectGraphType>().Name(fieldName));
+
+            exception.Message.ShouldStartWith($"A field name can not be null or empty.");
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.StarWars.Types;
+using GraphQL.StarWars.Types;
 using GraphQL.Types;
 using System;
 using System.Collections.Generic;
@@ -120,6 +120,57 @@ namespace GraphQL.Tests.Types
             );
 
             type.Fields.Last().Type.ShouldBe(typeof(StringGraphType));
+        }
+
+        [Theory]
+        [InlineData("__id")]
+        [InlineData("___id")]
+        public void throws_when_field_name_prefix_with_reserved_underscores(string fieldName)
+        {
+            var type = new ComplexType<TestObject>();
+            var exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Field<StringGraphType>(fieldName));
+
+            exception.Message.ShouldStartWith($"A field name: {fieldName} must not begin with \"__\", which is reserved by GraphQL introspection.");
+        }
+
+        [Theory]
+        [InlineData("i#d")]
+        [InlineData("i$d")]
+        [InlineData("id$")]
+        public void throws_when_field_name_doesnot_follow_spec(string fieldName)
+        {
+            var type = new ComplexType<TestObject>();
+            var exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Field<StringGraphType>(fieldName));
+
+            exception.Message.ShouldStartWith($"A field name must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but {fieldName} does not.");
+        }
+
+        [Theory]
+        [InlineData("name")]
+        [InlineData("Name")]
+        [InlineData("_name")]
+        [InlineData("test_name")]
+        [InlineData(null)]
+        public void should_not_throw_exption_on_valid_field_name(string fieldName)
+        {
+            var type = new ComplexType<TestObject>();
+            var field = type.Field<StringGraphType>(fieldName);
+
+            field.Name.ShouldBe(fieldName);
+        }
+
+        [Theory]
+        [InlineData("name")]
+        [InlineData("Name")]
+        [InlineData("_name")]
+        [InlineData("test_name")]
+        [InlineData(null)]
+        public void should_not_throw_exption_on_valid_field_name_using_field_builder(string fieldName)
+        {
+            var type = new ComplexType<TestObject>();
+            type.Field<StringGraphType>().Name(fieldName);
+
+            type.Fields.Last().Name.ShouldBe(fieldName);
         }
     }
 }

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -146,11 +146,32 @@ namespace GraphQL.Tests.Types
         }
 
         [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void throws_when_field_name_is_null_or_empty(string fieldName)
+        {
+            var type = new ComplexType<TestObject>();
+            var exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Field<StringGraphType>(fieldName));
+
+            exception.Message.ShouldStartWith($"A field name can not be null or empty.");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void throws_when_field_name_is_null_or_empty_using_field_builder(string fieldName)
+        {
+            var type = new ComplexType<TestObject>();
+            var exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Field<StringGraphType>().Name(fieldName));
+
+            exception.Message.ShouldStartWith($"A field name can not be null or empty.");
+        }
+
+        [Theory]
         [InlineData("name")]
         [InlineData("Name")]
         [InlineData("_name")]
         [InlineData("test_name")]
-        [InlineData(null)]
         public void should_not_throw_exption_on_valid_field_name(string fieldName)
         {
             var type = new ComplexType<TestObject>();
@@ -164,7 +185,6 @@ namespace GraphQL.Tests.Types
         [InlineData("Name")]
         [InlineData("_name")]
         [InlineData("test_name")]
-        [InlineData(null)]
         public void should_not_throw_exption_on_valid_field_name_using_field_builder(string fieldName)
         {
             var type = new ComplexType<TestObject>();

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -42,10 +42,11 @@ namespace GraphQL.Builders
             FieldType = fieldType;
         }
 
-        public static ConnectionBuilder<TGraphType, TSourceType> Create()
+        public static ConnectionBuilder<TGraphType, TSourceType> Create(string name = "default")
         {
             var fieldType = new FieldType
             {
+                Name = name,
                 Type = typeof(ConnectionType<TGraphType>),
                 Arguments = new QueryArguments(new QueryArgument[0]),
             };

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using GraphQL.Types;
 using GraphQL.Types.Relay;
+using GraphQL.Utilities;
 
 namespace GraphQL.Builders
 {
@@ -92,6 +93,8 @@ namespace GraphQL.Builders
 
         public ConnectionBuilder<TGraphType, TSourceType> Name(string name)
         {
+            FieldValidator.ValidateName(name);
+
             FieldType.Name = name;
             return this;
         }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -31,20 +31,22 @@ namespace GraphQL.Builders
             _fieldType = fieldType;
         }
 
-        public static FieldBuilder<TSourceType, TReturnType> Create(IGraphType type)
+        public static FieldBuilder<TSourceType, TReturnType> Create(IGraphType type, string name = "default")
         {
             var fieldType = new EventStreamFieldType
             {
+                Name = name,
                 ResolvedType = type,
                 Arguments = new QueryArguments(),
             };
             return new FieldBuilder<TSourceType, TReturnType>(fieldType);
         }
 
-        public static FieldBuilder<TSourceType, TReturnType> Create(Type type = null)
+        public static FieldBuilder<TSourceType, TReturnType> Create(Type type = null, string name = "default")
         {
             var fieldType = new EventStreamFieldType
             {
+                Name = name,
                 Type = type,
                 Arguments = new QueryArguments(),
             };

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -3,6 +3,7 @@ using GraphQL.Types;
 using GraphQL.Resolvers;
 using GraphQL.Subscription;
 using System.Threading.Tasks;
+using GraphQL.Utilities;
 
 namespace GraphQL.Builders
 {
@@ -58,6 +59,8 @@ namespace GraphQL.Builders
 
         public FieldBuilder<TSourceType, TReturnType> Name(string name)
         {
+            FieldValidator.ValidateName(name);
+
             _fieldType.Name = name;
             return this;
         }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using GraphQL.Subscription;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
@@ -36,9 +37,11 @@ namespace GraphQL.Types
         {
             return _fields.Any(x => string.Equals(x.Name, name));
         }
-
+        
         public FieldType AddField(FieldType fieldType)
         {
+            FieldValidator.ValidateName(fieldType.Name);
+
             if (HasField(fieldType.Name))
             {
                 throw new ArgumentOutOfRangeException(nameof(fieldType.Name),

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -235,19 +235,16 @@ namespace GraphQL.Types
             });
         }
 
-        public FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>()
+        public FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>(string name = "default")
         {
-            var builder = FieldBuilder.Create<TSourceType, TReturnType>(typeof(TGraphType));
+            var builder = FieldBuilder.Create<TSourceType, TReturnType>(typeof(TGraphType))
+                .Name(name);
             AddField(builder.FieldType);
             return builder;
         }
 
         public FieldBuilder<TSourceType, object> Field<TGraphType>()
-        {
-            var builder = FieldBuilder.Create<TSourceType, object>(typeof(TGraphType));
-            AddField(builder.FieldType);
-            return builder;
-        }
+            => Field<TGraphType, object>();
 
         public FieldBuilder<TSourceType, TProperty> Field<TProperty>(
            string name,

--- a/src/GraphQL/Utilities/FieldValidator.cs
+++ b/src/GraphQL/Utilities/FieldValidator.cs
@@ -10,9 +10,10 @@ namespace GraphQL.Utilities
 
         public static void ValidateName(string name)
         {
-            if (name == null)
+            if (string.IsNullOrWhiteSpace(name))
             {
-                return;
+                throw new ArgumentOutOfRangeException(nameof(name),
+                    $"A field name can not be null or empty.");
             }
 
             if (name.Length > 1 && name.StartsWith(RESERVED_PREFIX))

--- a/src/GraphQL/Utilities/FieldValidator.cs
+++ b/src/GraphQL/Utilities/FieldValidator.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace GraphQL.Utilities
+{
+    public class FieldValidator
+    {
+        private static readonly string RESERVED_PREFIX = "__";
+        private static readonly string NAME_RX = @"^[_A-Za-z][_0-9A-Za-z]*$";
+
+        public static void ValidateName(string name)
+        {
+            if (name == null)
+            {
+                return;
+            }
+
+            if (name.Length > 1 && name.StartsWith(RESERVED_PREFIX))
+            {
+                throw new ArgumentOutOfRangeException(nameof(name),
+                    $"A field name: {name} must not begin with \"__\", which is reserved by GraphQL introspection.");
+            }
+            if (!Regex.IsMatch(name, NAME_RX))
+            {
+                throw new ArgumentOutOfRangeException(nameof(name),
+                    $"A field name must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but {name} does not.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix: #475 
- [x] Adds field name validator as stated by spec
- [x] Update `AddField` in `ComplexGraphType` and `Name` in `FieldBuilder<TSourceType, TReturnType>` to call validator
- [x] Update `FieldBuilder` and `ConnectionBuilder` to set `default` as default field name.
- [x] Added Test cases for changes