### PR TITLE
#587 inputobjectgraphtype referencing an objectgraphyype should throw specific error

### DIFF
--- a/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
@@ -1,0 +1,19 @@
+using System;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Types
+{
+    public class InputObjectGraphTypeTests
+    {
+        [Fact]
+        public void should_throw_an_exception_if_input_object_graph_type_contains_object_graph_type_field()
+        {
+            var type = new InputObjectGraphType();
+            var exception = Should.Throw<ArgumentException>(() => type.Field<ObjectGraphType>().Name("test"));
+
+            exception.Message.ShouldContain("InputObjectGraphType cannot have fields containing a ObjectGraphType.");
+        }
+    }
+}

--- a/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
@@ -15,5 +15,12 @@ namespace GraphQL.Tests.Types
 
             exception.Message.ShouldContain("InputObjectGraphType cannot have fields containing a ObjectGraphType.");
         }
+
+        [Fact]
+        public void should_not_throw_an_exception_if_input_object_graph_type_doesnt_contains_object_graph_type_field()
+        {
+            var type = new InputObjectGraphType();
+            var exception = type.Field<ComplexGraphType<object>>().Name("test");
+        }
     }
 }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Types
             return _fields.Any(x => string.Equals(x.Name, name));
         }
 
-        public FieldType AddField(FieldType fieldType)
+        public virtual FieldType AddField(FieldType fieldType)
         {
             if (HasField(fieldType.Name))
             {

--- a/src/GraphQL/Types/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/InputObjectGraphType.cs
@@ -1,9 +1,4 @@
-using GraphQL.Builders;
-using GraphQL.Resolvers;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 
 namespace GraphQL.Types
 {
@@ -16,8 +11,17 @@ namespace GraphQL.Types
     }
 
     public class InputObjectGraphType<TSourceType> : ComplexGraphType<TSourceType>, IInputObjectGraphType
-    {        
+    {
+        public override FieldType AddField(FieldType fieldType)
+        {
+            if(fieldType.Type == typeof(ObjectGraphType))
+            {
+                throw new ArgumentException(nameof(fieldType.Type),
+                    "InputObjectGraphType cannot have fields containing a ObjectGraphType.");
+            }
 
+            return base.AddField(fieldType);
+        }
     }
 }
 


### PR DESCRIPTION
Fix: #587 

- [x] Update `AddFIeld` method in `ComplexGraphType` to be virtual.
- [x] Override `AddField` method in `nputObjectGraphType<TSourceType>` to throw an exception if fields contains `ObjectGraphType`.
- [x] Added Test cases for changes