### PR TITLE
For discussion: Documentation reorg

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -11,17 +11,19 @@ As its name suggests, this library is a .NET implementation of [GraphQL](http://
 +------------------------------------+
 +------------------------------------+
 |         +-----------------------+  |
-|         | Queries and Mutations |  |
-| GraphQL +-----------------------+  |
+|         | Execution             |  |
+|         +-----------------------+  |
+| GraphQL | Queries and Mutations |  |
+|         +-----------------------+  |
 |         | Types and Interfaces  |  |
 |         +-----------------------+  |
 +------------------------------------+
 +------------------------------------+
-|              Database              |
+|                Data                |
 +------------------------------------+
 ```
 
-GraphQL sits between your database the "outside world." This library only concerns itself with this middle layer. For simplicity, the documentation uses hard-coded data, but in a real-world application your database layer would consist of some sort of ORM, like Entity Framework. And the only aspect of interactivity we will discuss here is how to actually execute the query. How specifically the query is received and the output returned is beyond the scope of this document. See the ["Further Reading"](#further-reading) section at the end of this document for examples and tutorials specific to various ORMs and deployment scenarios.
+GraphQL sits between your data and the "outside world." This library only concerns itself with this middle layer. For simplicity, the documentation uses hard-coded data, but in a real-world application your data layer would consist of some sort of ORM (like Entity Framework) or other data provider. And as for interactivity, how specifically the query is received and the output returned is beyond the scope of this document. See the ["Further Reading"](#further-reading) section at the end of this document for examples and tutorials specific to various ORMs and deployment scenarios.
 
 ## Example
 
@@ -82,7 +84,7 @@ namespace ConsoleApplication
      * of searches and filters you support.
      *
      * In this example, the data itself is hardcoded in the `resolve:` line.
-     * In the "real world," you'd be querying your database.
+     * In the "real world," you'd be querying your data provider.
      */
     public class StarWarsQuery : ObjectGraphType
     {

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -107,7 +107,7 @@ namespace ConsoleApplication
         }
 
         /*
-         * Interactivity Layer
+         * Execution Layer
          * First you generate the schema using your root query object.
          * Then you use `DocumentExecuter` to run the query against that schema.
          * How the query is received or the results returned is beyond the scope

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -177,7 +177,7 @@ public class DroidType : ObjectGraphType<Droid>
 }
 ```
 
-> TODO: Talk about the `Field` function and the various ways it can be used (e.g., `Field<Type>(...)`). Be sure to mention the default resolver. Also, there appears to be some case transformation of the property name happening in the background (e.g., "Id" automatically becoming "id").
+> TODO: Talk about the `Field` function and the various ways it can be used (e.g., `Field<Type>(...)`). Be sure to mention the default resolver. Also, there appears to be some case transformation of the property name happening in the background (e.g., "Id" automatically becoming "id"). Some introduction of `FieldAsync` would probably be appropriate at this point, too.
 
 > TODO: Be sure to introduce `ListGraphType`!
 


### PR DESCRIPTION
Here's my suggestion for restructured documentation (just the "Getting Started" page). Almost all the original text is still there, but I moved things around to be in a more logical order. I welcome any and all feedback. People can push to the commit or give me text that I can add myself. Whatever people want to do.

What I did:
* Rewrote the intro to clarify the library's scope. The audience needs to already understand basic GraphQL concepts. The library documentation should be as agnostic as possible about the database and interactivity layers.

* I reordered the top-level headings to mirror the introduction, putting things in a logical order:
  * Types & Interfaces
  * Queries & Mutations
  * Execution
    * Schema Generation
    * `DocumentExecuter`
  * Further Reading

* I added many `TODO:` tags highlighting areas that need expansion (IMO).

Here's a list of the TODO comments for discussion, in order of appearance:

* "Types" section
  * Explain more fully the `Field` function and its variants.
  * Be sure to introduce the `ListGraphType`.
  * Introduce `context.Source`.
  * Give concrete examples of more-complex field structures.

* "Resolving Ambiguity" section
  * First off, is this section even necessary? If `ObjectGraphType<Type>` already gives a default `IsTypeOf`, why bother the reader with this information? Are there situations where the default doesn't work? If so, explain.
  * Give some indication of why one should choose one method over another. Are there performance implications, for example?
  * In the `ResolveType` example, you need explain the interface constructor signature.
  * In the `IsTypeOf` example, there may be an error in the code.

* "Arguments" section
  * In the sample code, the `context.Arguments` line is never explained or used.
  * We need to introduce optional (nullable) arguments.

* "Queries" section
  * Needs to be expanded to demonstrate basics like how to search and return multiple results.

* "Mutations" section
  * Sample code should be cleaned up to focus on the mutation-specific code (delete the schema generation code, for example).
  * Talk more about error handling and validation. What will be returned if something goes wrong at the database layer?

* "Schema Generation" section
  * Needs to essentially be written from scratch. There are two approaches scattered throughout the docs, but they need to be consolidated and fully explained.

* "DocumentExecuter" section
  * Also needs to be written from scratch. Nowhere do we explicitly explain how this function works and can be modified.