### PR TITLE
generate Apollo Tracing report from execution metrics. fixes #381

### DIFF
--- a/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Instrumentation;
+using GraphQL.Tests.StarWars;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Instrumentation
+{
+    public class ApolloTracingTests : StarWarsTestBase
+    {
+        public ApolloTracingTests()
+            : base()
+        {
+        }
+
+        [Fact]
+        public void extension_has_expected_format()
+        {
+            var query = @"
+query {
+  hero {
+    name
+    friends {
+      name
+    }
+  }
+}";
+
+            var start = DateTime.UtcNow;
+            var result = Executer.ExecuteAsync(_ =>
+            {
+                _.Schema = Schema;
+                _.Query = query;
+                _.EnableMetrics = true;
+                _.FieldMiddleware.Use<InstrumentFieldsMiddleware>();
+            }).Result;
+            result.EnrichWithApolloTracing(start);
+            var trace = (ApolloTrace)result.Extensions["tracing"];
+
+            trace.Version.ShouldBe(1);
+            trace.Parsing.StartOffset.ShouldNotBe(0);
+            trace.Parsing.Duration.ShouldNotBe(0);
+
+            var expectedPaths = new HashSet<List<object>>
+            {
+                new List<object> { "hero" },
+                new List<object> { "hero", "name" },
+                new List<object> { "hero", "friends" },
+                new List<object> { "hero", "friends", 0, "name" },
+                new List<object> { "hero", "friends", 1, "name" },
+            };
+
+            var paths = new List<List<object>>();
+            foreach (var resolver in trace.Execution.Resolvers)
+            {
+                resolver.StartOffset.ShouldNotBe(0);
+                resolver.Duration.ShouldNotBe(0);
+                resolver.ParentType.ShouldNotBeNull();
+                resolver.ReturnType.ShouldNotBeNull();
+                resolver.FieldName.ShouldBe((string)resolver.Path.Last());
+                paths.Add(resolver.Path);
+            }
+            paths.Count.ShouldBe(expectedPaths.Count);
+            new HashSet<List<object>>(paths).ShouldBe(expectedPaths);
+        }
+    }
+}

--- a/src/GraphQL/Instrumentation/ApolloTrace.cs
+++ b/src/GraphQL/Instrumentation/ApolloTrace.cs
@@ -1,0 +1,60 @@
+namespace GraphQL.Instrumentation
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public class ApolloTrace
+    {
+        public ApolloTrace(DateTime start, double durationMs)
+        {
+            this.StartTime = start;
+            this.EndTime = start.AddMilliseconds(durationMs);
+            this.Duration = ConvertTime(durationMs);
+        }
+
+        public int Version => 1;
+
+        public DateTime StartTime { get; }
+
+        public DateTime EndTime { get; }
+
+        public long Duration { get; }
+
+        public OperationTrace Parsing { get; } = new OperationTrace();
+
+        public OperationTrace Validation { get; } = new OperationTrace();
+
+        public ExecutionTrace Execution { get; } = new ExecutionTrace();
+
+        public static long ConvertTime(double ms) => (int)(ms * 1000 * 1000);
+
+        [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+        public class OperationTrace
+        {
+            public long StartOffset { get; set; }
+
+            public long Duration { get; set; }
+        }
+
+        [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+        public class ExecutionTrace
+        {
+            public List<ResolverTrace> Resolvers { get; } = new List<ResolverTrace>();
+        }
+
+        public class ResolverTrace : OperationTrace
+        {
+            public List<object> Path { get; set; } = new List<object>();
+
+            public string ParentType { get; set; }
+
+            public string FieldName { get; set; }
+
+            public string ReturnType { get; set; }
+        }
+    }
+}

--- a/src/GraphQL/Instrumentation/ApolloTrace.cs
+++ b/src/GraphQL/Instrumentation/ApolloTrace.cs
@@ -1,11 +1,10 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
 namespace GraphQL.Instrumentation
 {
-    using System;
-    using System.Collections.Generic;
-
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Serialization;
-
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class ApolloTrace
     {

--- a/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
@@ -1,12 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL;
+using GraphQL.Language.AST;
+
 namespace GraphQL.Instrumentation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
-    using GraphQL;
-    using GraphQL.Language.AST;
-
     public static class ApolloTracingExtensions
     {
         public static void EnrichWithApolloTracing(this ExecutionResult result, DateTime start)

--- a/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
@@ -1,0 +1,80 @@
+namespace GraphQL.Instrumentation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using GraphQL;
+    using GraphQL.Language.AST;
+
+    public static class ApolloTracingExtensions
+    {
+        public static void EnrichWithApolloTracing(this ExecutionResult result, DateTime start)
+        {
+            var perf = result?.Perf;
+            if (perf == null)
+            {
+                return;
+            }
+
+            var trace = CreateTrace(result.Operation, perf, start);
+            if (result.Extensions == null)
+            {
+                result.Extensions = new Dictionary<string, object>();
+            }
+            result.Extensions["tracing"] = trace;
+        }
+
+        public static ApolloTrace CreateTrace(
+            Operation operation,
+            PerfRecord[] perf,
+            DateTime start)
+        {
+            var operationStat = perf.Single(x => x.Category == "operation");
+            var documentStats = perf.Where(x => x.Category == "document");
+            var fieldStats = perf.Where(x => x.Category == "field");
+
+            var trace = new ApolloTrace(start, operationStat.Duration);
+
+            var parsingStat = documentStats.Single(x => x.Subject == "Building document");
+            trace.Parsing.StartOffset = ApolloTrace.ConvertTime(parsingStat.Start);
+            trace.Parsing.Duration = ApolloTrace.ConvertTime(parsingStat.Duration);
+
+            var validationStat = documentStats.Single(x => x.Subject == "Validating document");
+            trace.Validation.StartOffset = ApolloTrace.ConvertTime(parsingStat.Start);
+            trace.Validation.Duration = ApolloTrace.ConvertTime(parsingStat.Duration);
+
+            foreach (var fieldStat in fieldStats)
+            {
+                var stringPath = fieldStat.MetaField<IEnumerable<string>>("path");
+                trace.Execution.Resolvers.Add(
+                    new ApolloTrace.ResolverTrace
+                    {
+                        FieldName = fieldStat.MetaField<string>("fieldName"),
+                        Path = ConvertPath(stringPath).ToList(),
+                        ParentType = fieldStat.MetaField<string>("typeName"),
+                        ReturnType = fieldStat.MetaField<string>("returnTypeName"),
+                        StartOffset = ApolloTrace.ConvertTime(fieldStat.Start),
+                        Duration = ApolloTrace.ConvertTime(fieldStat.Duration),
+                    });
+            }
+
+            return trace;
+        }
+
+        private static IEnumerable<object> ConvertPath(IEnumerable<string> stringPath)
+        {
+             foreach (var step in stringPath)
+            {
+                if (int.TryParse(step, out int arrayIndex))
+                {
+                    yield return arrayIndex;
+                }
+                else
+                {
+                    yield return step;
+                }
+            }
+        }
+    }
+}

--- a/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
+++ b/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Types;
+using GraphQL.Utilities;
 
 namespace GraphQL.Instrumentation
 {
@@ -11,7 +12,9 @@ namespace GraphQL.Instrumentation
             var metadata = new Dictionary<string, object>
             {
                 {"typeName", context.ParentType.Name},
-                {"fieldName", context.FieldName}
+                {"fieldName", context.FieldName},
+                {"returnTypeName", SchemaPrinter.ResolveName(context.ReturnType)},
+                {"path", context.Path},
             };
 
             using (context.Metrics.Subject("field", context.FieldName, metadata))


### PR DESCRIPTION
Adds an extension method `EnrichWithApolloTracing` to `ExecutionResult` for adding a `tracing` extension in the [Apollo Tracing](https://github.com/apollographql/apollo-tracing) format, generated from the existing performance metrics. To get the necessary information for this, `InstrumentFieldsMiddleware` was modified to include the schema language-formatted name of the field's return type as well as the path to the field.