### PR TITLE
fix backward compatibility in batching

### DIFF
--- a/src/GraphQL.DataLoader.Tests/Stores/UsersStore.cs
+++ b/src/GraphQL.DataLoader.Tests/Stores/UsersStore.cs
@@ -25,7 +25,7 @@ namespace GraphQL.DataLoader.Tests.Stores
         private int _getAllUsersCalled;
         public int GetAllUsersCalledCount => _getAllUsersCalled;
 
-        public async Task<IDictionary<int, User>> GetUsersByIdAsync(IEnumerable<int> userIds,
+        public async Task<IEnumerable<KeyValuePair<int, User>>> GetUsersByIdAsync(IEnumerable<int> userIds,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Interlocked.Increment(ref _getUsersByIdCalled);

--- a/src/GraphQL/DataLoader/BatchDataLoader.cs
+++ b/src/GraphQL/DataLoader/BatchDataLoader.cs
@@ -102,17 +102,16 @@ namespace GraphQL.DataLoader
                 _pendingKeys.Clear();
             }
 
-            var dictionary = await _loader(keys, cancellationToken).ConfigureAwait(false);
+            var dictionary = (await _loader(keys, cancellationToken).ConfigureAwait(false)).ToDictionary(x => x.Key, x => x.Value);
 
             // Populate cache
             lock (_cache)
             {
                 foreach (TKey key in keys)
                 {
-                    var keyValuePair = dictionary.FirstOrDefault(x => x.Key.Equals(key));
-                    if (!keyValuePair.Equals(default(KeyValuePair<TKey, T>)))
+                    if (dictionary.TryGetValue(key, out T value))
                     {
-                        _cache[key] = keyValuePair.Value;
+                        _cache[key] = value;
                     }
                     else
                     {

--- a/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
+++ b/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
@@ -60,7 +60,7 @@ namespace GraphQL.DataLoader
         /// <param name="fetchFunc">A cancellable delegate to fetch data for some keys asynchronously</param>
         /// <param name="keyComparer">An <seealso cref="IEqualityComparer<T>"/> to compare keys.</param>
         /// <returns>A new or existing DataLoader instance</returns>
-        public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<IDictionary<TKey, T>>> fetchFunc,
+        public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<IEnumerable<KeyValuePair<TKey, T>>>> fetchFunc,
             IEqualityComparer<TKey> keyComparer = null, T defaultValue = default(T))
         {
             if (context == null)
@@ -82,7 +82,7 @@ namespace GraphQL.DataLoader
         /// <param name="fetchFunc">A delegate to fetch data for some keys asynchronously</param>
         /// <param name="keyComparer">An <seealso cref="IEqualityComparer<T>"/> to compare keys.</param>
         /// <returns>A new or existing DataLoader instance</returns>
-        public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, Task<IDictionary<TKey, T>>> fetchFunc,
+        public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, Task<IEnumerable<KeyValuePair<TKey, T>>>> fetchFunc,
             IEqualityComparer<TKey> keyComparer = null, T defaultValue = default(T))
         {
             if (context == null)


### PR DESCRIPTION
This fixes a problem introduced in a #709 . After update we could assign to a batch only IDictionary, Dictionary is not acceptable. In this pr the accepted values would be an `IEnumerable<KeyValuePair<TKey, T>>` so we could assign, Dictionary, IDictionary, IReadOnlyDictionary. But I'm not 100% sure if this change is okay since the time needed to access an element right now is O(n) instead of O(1).

cc: @joemcbride 