### PR TITLE
Add possibility to set Data in ExecutionErrors ctor

### DIFF
--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -58,8 +58,7 @@ namespace GraphQL
 
         private void SetData(Exception exception)
         {
-            var exceptionDoesntContainData = exception?.Data == null || exception.Data.Count == 0;
-            if (exceptionDoesntContainData)
+            if (exception?.Data == null)
                 return;
 
             SetData(exception.Data);

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 using GraphQL.Language.AST;
 using GraphQLParser;
@@ -16,6 +15,12 @@ namespace GraphQL
         public ExecutionError(string message)
             : base(message)
         {
+        }
+
+        public ExecutionError(string message, IDictionary data)
+            : base(message)
+        {
+            SetData(data);
         }
 
         public ExecutionError(string message, Exception exception)
@@ -53,14 +58,19 @@ namespace GraphQL
 
         private void SetData(Exception exception)
         {
-            if (exception?.Data == null || exception.Data.Count == 0)
-            {
+            var exceptionDoesntContainData = exception?.Data == null || exception.Data.Count == 0;
+            if (exceptionDoesntContainData)
                 return;
-            }
-            foreach (DictionaryEntry entry in exception.Data)
+
+            SetData(exception.Data);
+        }
+
+        private void SetData(IDictionary dict)
+        {
+            foreach (DictionaryEntry keyValuePair in dict)
             {
-                var key = entry.Key.ToString();
-                var value = entry.Value;
+                var key = keyValuePair.Key.ToString();
+                var value = keyValuePair.Value;
                 Data[key] = value;
             }
         }


### PR DESCRIPTION
I realize that there is no possibility to add Data to a `Data` field in an `ExecutionError` constructor explicitly. It could be set only via the Exception object. Since someone could use some `ResultType` with an `IError` which in fact doesn't have to be an `Exception` it is a little bit overhead to set an Error.Data via adding it like:
```csharp
var err = new ExecutionError("");
var err.Data.Add("key", "value");
var err.Data.Add("key1", "value");
var err.Data.Add("key2", "value");
var err.Data.Add("key3", "value");
```
so it would be more suitable to set "error data" via constructor like that:
```csharp
var errData = new Dictionary<string, object>();
var err = new ExecutionError("", errData);
```
this pr is a proposition if it doesn't align with how the library is intended to "look like" it could be closed.

CC: @joemcbride 