### PR TITLE
Performance enhancements

### DIFF
--- a/src/GraphQL.Tests/Validation/UniqueDirectivesPerLocationTests.cs
+++ b/src/GraphQL.Tests/Validation/UniqueDirectivesPerLocationTests.cs
@@ -57,7 +57,7 @@ namespace GraphQL.Tests.Validation
         }
 
         [Fact]
-        public void duplicare_directives_in_one_location()
+        public void duplicate_directives_in_one_location()
         {
             ShouldFailRule(_ =>
             {
@@ -71,7 +71,7 @@ namespace GraphQL.Tests.Validation
         }
 
         [Fact]
-        public void many_duplicare_directives_in_one_location()
+        public void many_duplicate_directives_in_one_location()
         {
             ShouldFailRule(_ =>
             {
@@ -86,7 +86,7 @@ namespace GraphQL.Tests.Validation
         }
 
         [Fact]
-        public void different_duplicare_directives_in_one_location()
+        public void different_duplicate_directives_in_one_location()
         {
             ShouldFailRule(_ =>
             {
@@ -101,7 +101,7 @@ namespace GraphQL.Tests.Validation
         }
 
         [Fact]
-        public void duplicare_directives_in_many_locations()
+        public void duplicate_directives_in_many_locations()
         {
             ShouldFailRule(_ =>
             {

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -356,8 +356,7 @@ namespace GraphQL
                 var fields = dict
                     .Select(pair =>
                     {
-                        var field = input.Fields.FirstOrDefault(x => x.Name == pair.Key);
-                        var fieldType = field?.ResolvedType;
+                        var fieldType = input.GetField(pair.Key)?.ResolvedType;
                         return new ObjectField(pair.Key, AstFromValue(pair.Value, schema, fieldType));
                     })
                     .ToList();

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -13,9 +13,15 @@ namespace GraphQL
 {
     public static class GraphQLExtensions
     {
+#if NETSTANDARD1_1
+        private static readonly Regex TrimPattern = new Regex("[\\[!\\]]");
+#else
+        private static readonly Regex TrimPattern = new Regex("[\\[!\\]]", RegexOptions.Compiled);
+#endif
+
         public static string TrimGraphQLTypes(this string name)
         {
-            return Regex.Replace(name, "[\\[!\\]]", "").Trim();
+            return TrimPattern.Replace(name, string.Empty).Trim();
         }
 
         public static bool IsCompositeType(this IGraphType type)

--- a/src/GraphQL/Instrumentation/Metrics.cs
+++ b/src/GraphQL/Instrumentation/Metrics.cs
@@ -9,13 +9,19 @@ namespace GraphQL.Instrumentation
     public class Metrics : IDisposable
     {
         private readonly bool _enabled;
-        private readonly Stopwatch _stopwatch = new Stopwatch();
-        private readonly ConcurrentBag<PerfRecord> _records = new ConcurrentBag<PerfRecord>();
+        private readonly Stopwatch _stopwatch;
+        private readonly ConcurrentBag<PerfRecord> _records;
         private PerfRecord _main;
 
         public Metrics(bool enabled = true)
         {
             _enabled = enabled;
+
+            if (enabled)
+            {
+                _stopwatch = new Stopwatch();
+                _records = new ConcurrentBag<PerfRecord>();
+            }
         }
 
         public void Start(string operationName)

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +18,7 @@ namespace GraphQL.Language.AST
 
         public Directive Find(string name)
         {
-            return _directives.FirstOrDefault(d => d.Name == name);
+            return _directives.FirstOrDefault(d => d.Name.Equals(name, StringComparison.Ordinal));
         }
 
         public IEnumerator<Directive> GetEnumerator()

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Reflection;
 using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
     internal class NameFieldResolver : IFieldResolver
     {
-        private static readonly BindingFlags _flags = BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
-
         public object Resolve(ResolveFieldContext context)
         {
             return Resolve(context?.Source, context?.FieldAst?.Name);
@@ -20,7 +17,14 @@ namespace GraphQL.Resolvers
                 return null;
             }
 
-            return source.GetPropertyValue(name);
+            var propertyValue = source.GetPropertyValue(name);
+
+            if (propertyValue == null)
+            {
+                throw new InvalidOperationException($"Expected to find property {name} on {source.GetType().Name} but it does not exist.");
+            }
+
+            return propertyValue;
         }
     }
 }

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -20,15 +20,7 @@ namespace GraphQL.Resolvers
                 return null;
             }
 
-            var prop = source.GetType()
-                .GetProperty(name, _flags);
-
-            if (prop == null)
-            {
-                throw new InvalidOperationException($"Expected to find property {name} on {source.GetType().Name} but it does not exist.");
-            }
-
-            return prop.GetValue(source, null);
+            return source.GetPropertyValue(name);
         }
     }
 }

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Reflection;
 using GraphQL.Types;
 
 namespace GraphQL.Resolvers
 {
     internal class NameFieldResolver : IFieldResolver
     {
+        private static readonly BindingFlags _flags = BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
+
         public object Resolve(ResolveFieldContext context)
         {
             return Resolve(context?.Source, context?.FieldAst?.Name);
@@ -17,14 +20,13 @@ namespace GraphQL.Resolvers
                 return null;
             }
 
-            var propertyValue = source.GetPropertyValue(name);
-
-            if (propertyValue == null)
+            var prop = source.GetType().GetProperty(name, _flags);
+            if (prop == null)
             {
                 throw new InvalidOperationException($"Expected to find property {name} on {source.GetType().Name} but it does not exist.");
             }
 
-            return propertyValue;
+            return prop.GetValue(source, null);
         }
     }
 }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -35,7 +35,7 @@ namespace GraphQL.Types
 
         public bool HasField(string name)
         {
-            return _fields.Any(x => string.Equals(x.Name, name));
+            return _fields.Any(x => string.Equals(x.Name, name, StringComparison.Ordinal));
         }
 
         public virtual FieldType AddField(FieldType fieldType)

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -37,14 +37,14 @@ namespace GraphQL.Types
 
         public bool HasField(string name)
         {
-            if (string.IsNullOrEmpty(name)) return false;
+            if (string.IsNullOrWhiteSpace(name)) return false;
 
             return _fields.Any(x => string.Equals(x.Name, name, StringComparison.Ordinal));
         }
 
         public FieldType GetField(string name)
         {
-            if (string.IsNullOrEmpty(name)) return null;
+            if (string.IsNullOrWhiteSpace(name)) return null;
 
             return _fields.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
         }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -17,6 +17,8 @@ namespace GraphQL.Types
         FieldType AddField(FieldType fieldType);
 
         bool HasField(string name);
+
+        FieldType GetField(string name);
     }
 
     public abstract class ComplexGraphType<TSourceType> : GraphType, IComplexGraphType
@@ -35,7 +37,16 @@ namespace GraphQL.Types
 
         public bool HasField(string name)
         {
+            if (string.IsNullOrEmpty(name)) return false;
+
             return _fields.Any(x => string.Equals(x.Name, name, StringComparison.Ordinal));
+        }
+
+        public FieldType GetField(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return null;
+
+            return _fields.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
         }
 
         public virtual FieldType AddField(FieldType fieldType)

--- a/src/GraphQL/Types/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/EnumerationGraphType.cs
@@ -35,7 +35,8 @@ namespace GraphQL.Types
 
         public override object Serialize(object value)
         {
-            var foundByName = Values.FirstOrDefault(v => v.Name.Equals(value + "", StringComparison.OrdinalIgnoreCase));
+            var valueString = value.ToString();
+            var foundByName = Values.FirstOrDefault(v => v.Name.Equals(valueString, StringComparison.OrdinalIgnoreCase));
             if (foundByName != null)
             {
                 return foundByName.Name;

--- a/src/GraphQL/Types/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/EnumerationGraphType.cs
@@ -69,7 +69,6 @@ namespace GraphQL.Types
         public EnumerationGraphType()
         {
             var type = typeof(TEnum);
-            var typeInfo = type.GetTypeInfo();
 
             Name = Name ?? StringUtils.ToPascalCase(type.Name);
 

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -11,11 +11,15 @@ namespace GraphQL.Utilities
 {
     public static class AstPrinter
     {
+        // new-ing AstPrintVisitor every time we called AstPrinter
+        // was killing the performance of introspection queries (20-30% of the call time)
+        // because of continually re-running its constructor lambdas
+        // so we cache one copy of it here - it's not changed ever anyway
+        private static readonly AstPrintVisitor Visitor = new AstPrintVisitor();
+
         public static string Print(INode node)
         {
-            var printer = new AstPrintVisitor();
-
-            var result = printer.Visit(node);
+            var result = Visitor.Visit(node);
             return result?.ToString() ?? string.Empty;
         }
     }

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -134,16 +134,16 @@ namespace GraphQL.Utilities
 
     public class ExpressionValueResolver<TObject, TProperty> : IValueResolver<TProperty>
     {
-        private readonly Expression<Func<TObject, TProperty>> _property;
+        private readonly Func<TObject, TProperty> _property;
 
         public ExpressionValueResolver(Expression<Func<TObject, TProperty>> property)
         {
-            _property = property;
+            _property = property.Compile();
         }
 
         public TProperty Resolve(ResolveValueContext context)
         {
-            return _property.Compile()(context.SourceAs<TObject>());
+            return _property(context.SourceAs<TObject>());
         }
 
         object IValueResolver.Resolve(ResolveValueContext context)

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -67,9 +67,8 @@ namespace GraphQL.Validation
                 return;
             }
 
-            if (node is Field)
+            if (node is Field field)
             {
-                var field = (Field) node;
                 var parentType = _parentTypeStack.Peek().GetNamedType();
                 var fieldType = GetFieldDef(_schema, parentType, field);
                 _fieldDefStack.Push(fieldType);
@@ -78,15 +77,13 @@ namespace GraphQL.Validation
                 return;
             }
 
-            if (node is Directive)
+            if (node is Directive directive)
             {
-                var directive = (Directive) node;
                 _directive = _schema.FindDirective(directive.Name);
             }
 
-            if (node is Operation)
+            if (node is Operation op)
             {
-                var op = (Operation) node;
                 IGraphType type = null;
                 if (op.OperationType == OperationType.Query)
                 {
@@ -104,33 +101,29 @@ namespace GraphQL.Validation
                 return;
             }
 
-            if (node is FragmentDefinition)
+            if (node is FragmentDefinition def1)
             {
-                var def = (FragmentDefinition) node;
-                var type = _schema.FindType(def.Type.Name);
+                var type = _schema.FindType(def1.Type.Name);
                 _typeStack.Push(type);
                 return;
             }
 
-            if (node is InlineFragment)
+            if (node is InlineFragment def)
             {
-                var def = (InlineFragment) node;
                 var type = def.Type != null ? _schema.FindType(def.Type.Name) : GetLastType();
                 _typeStack.Push(type);
                 return;
             }
 
-            if (node is VariableDefinition)
+            if (node is VariableDefinition varDef)
             {
-                var varDef = (VariableDefinition) node;
                 var inputType = varDef.Type.GraphTypeFromType(_schema);
                 _inputTypeStack.Push(inputType);
                 return;
             }
 
-            if (node is Argument)
+            if (node is Argument argAst)
             {
-                var argAst = (Argument) node;
                 QueryArgument argDef = null;
                 IGraphType argType = null;
 
@@ -157,10 +150,10 @@ namespace GraphQL.Validation
                 var objectType = GetInputType().GetNamedType();
                 IGraphType fieldType = null;
 
-                if (objectType is IInputObjectGraphType)
+                if (objectType is IInputObjectGraphType complexType)
                 {
-                    var complexType = objectType as IComplexGraphType;
-                    var inputField = complexType.Fields.FirstOrDefault(x => x.Name == ((ObjectField) node).Name);
+                    var inputField = complexType.Fields.FirstOrDefault(x => x.Name == ((ObjectField)node).Name);
+
                     fieldType = inputField?.ResolvedType;
                 }
 
@@ -242,7 +235,8 @@ namespace GraphQL.Validation
 
             if (parentType is IObjectGraphType || parentType is IInterfaceGraphType)
             {
-                var complexType = parentType as IComplexGraphType;
+                var complexType = (IComplexGraphType) parentType;
+
                 return complexType.Fields.FirstOrDefault(x => x.Name == field.Name);
             }
 

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -145,14 +145,14 @@ namespace GraphQL.Validation
                 _inputTypeStack.Push(type);
             }
 
-            if (node is ObjectField)
+            if (node is ObjectField objectField)
             {
                 var objectType = GetInputType().GetNamedType();
                 IGraphType fieldType = null;
 
                 if (objectType is IInputObjectGraphType complexType)
                 {
-                    var inputField = complexType.Fields.FirstOrDefault(x => x.Name == ((ObjectField)node).Name);
+                    var inputField = complexType.GetField(objectField.Name);
 
                     fieldType = inputField?.ResolvedType;
                 }
@@ -237,7 +237,7 @@ namespace GraphQL.Validation
             {
                 var complexType = (IComplexGraphType) parentType;
 
-                return complexType.Fields.FirstOrDefault(x => x.Name == field.Name);
+                return complexType.GetField(field.Name);
             }
 
             return null;


### PR DESCRIPTION
A collection of minor non-breaking code tweaks that enhances the performance and scalability of graphql-dotnet significantly.

In particular, 92fc0a520ac920d9b3813ac3a4412bd4afa8dc5e improves service time of introspection queries on larger schemas by 30% by avoiding repeatedly new-ing an object thousands of times. The rest of the tweaks are simple things like reducing casting or avoiding reallocating objects in a loop.

Let me know if you've got any questions, and thanks for `graphql-dotnet` :)