### PR TITLE
Getting error with the existing query structure

### DIFF
--- a/docs2/site/docs/getting-started/introduction.md
+++ b/docs2/site/docs/getting-started/introduction.md
@@ -155,7 +155,7 @@ public class Program
     var json = schema.Execute(_ =>
     {
       _.Schema = schema;
-      _.Query = "hero { id name }";
+      _.Query = "{ hero { id name } }";
     });
 
     Console.WriteLine(json);


### PR DESCRIPTION
The Query property has the string without the curly braces, which does not work and leads to an error as shown below,
```js
{
  "errors": [
    {
      "message": "Syntax Error GraphQL (1:1) Unexpected Name \"hero\"\n1: hero { id name }\n   ^\n",
      "code": "SYNTAX_ERROR"
    }
  ]
}
```