### PR TITLE
Expose ExecutionContext through the IDocumentExecutionListener

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -523,11 +523,11 @@ namespace GraphQL.DataLoader
     public class DataLoaderDocumentListener : GraphQL.Execution.IDocumentExecutionListener
     {
         public DataLoaderDocumentListener(GraphQL.DataLoader.IDataLoaderContextAccessor accessor) { }
-        public System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context) { }
+        public System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult) { }
+        public System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context) { }
+        public System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context) { }
+        public System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context) { }
     }
     public static class DataLoaderExtensions
     {
@@ -569,11 +569,11 @@ namespace GraphQL.Execution
     public abstract class DocumentExecutionListenerBase : GraphQL.Execution.IDocumentExecutionListener
     {
         protected DocumentExecutionListenerBase() { }
-        public virtual System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
+        public virtual System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context) { }
+        public virtual System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult) { }
+        public virtual System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context) { }
+        public virtual System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context) { }
+        public virtual System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context) { }
     }
     public class ExecutionContext : GraphQL.Execution.IExecutionContext, GraphQL.Execution.IProvideUserContext
     {
@@ -648,11 +648,11 @@ namespace GraphQL.Execution
     }
     public interface IDocumentExecutionListener
     {
-        System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context);
+        System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult);
+        System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context);
+        System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context);
+        System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context);
     }
     public interface IExecutionContext : GraphQL.Execution.IProvideUserContext
     {

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -523,11 +523,11 @@ namespace GraphQL.DataLoader
     public class DataLoaderDocumentListener : GraphQL.Execution.IDocumentExecutionListener
     {
         public DataLoaderDocumentListener(GraphQL.DataLoader.IDataLoaderContextAccessor accessor) { }
-        public System.Threading.Tasks.Task AfterExecutionAsync(object userContext, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task AfterValidationAsync(object userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionAsync(object userContext, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(object userContext, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(object userContext, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
     }
     public static class DataLoaderExtensions
     {
@@ -566,16 +566,16 @@ namespace GraphQL.Execution
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode> Items { get; set; }
         public override object ToValue() { }
     }
-    public abstract class DocumentExecutionListenerBase<T> : GraphQL.Execution.IDocumentExecutionListener, GraphQL.Execution.IDocumentExecutionListener<T>
+    public abstract class DocumentExecutionListenerBase : GraphQL.Execution.IDocumentExecutionListener
     {
         protected DocumentExecutionListenerBase() { }
-        public virtual System.Threading.Tasks.Task AfterExecutionAsync(T userContext, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task AfterValidationAsync(T userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionAsync(T userContext, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(T userContext, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(T userContext, System.Threading.CancellationToken token) { }
+        public virtual System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
+        public virtual System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
+        public virtual System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
+        public virtual System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
+        public virtual System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token) { }
     }
-    public class ExecutionContext : GraphQL.Execution.IProvideUserContext
+    public class ExecutionContext : GraphQL.Execution.IExecutionContext, GraphQL.Execution.IProvideUserContext
     {
         public ExecutionContext() { }
         public System.Threading.CancellationToken CancellationToken { get; set; }
@@ -648,19 +648,27 @@ namespace GraphQL.Execution
     }
     public interface IDocumentExecutionListener
     {
-        System.Threading.Tasks.Task AfterExecutionAsync(object userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task AfterValidationAsync(object userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAsync(object userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(object userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(object userContext, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task AfterExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task AfterValidationAsync(GraphQL.Execution.IExecutionContext context, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task BeforeExecutionAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(GraphQL.Execution.IExecutionContext context, System.Threading.CancellationToken token);
     }
-    public interface IDocumentExecutionListener<in T>
+    public interface IExecutionContext : GraphQL.Execution.IProvideUserContext
     {
-        System.Threading.Tasks.Task AfterExecutionAsync(T userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task AfterValidationAsync(T userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAsync(T userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(T userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(T userContext, System.Threading.CancellationToken token);
+        System.Threading.CancellationToken CancellationToken { get; }
+        GraphQL.Language.AST.Document Document { get; }
+        GraphQL.ExecutionErrors Errors { get; }
+        GraphQL.Language.AST.Fragments Fragments { get; }
+        System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
+        int? MaxParallelExecutionCount { get; }
+        GraphQL.Instrumentation.Metrics Metrics { get; }
+        GraphQL.Language.AST.Operation Operation { get; }
+        object RootValue { get; }
+        GraphQL.Types.ISchema Schema { get; }
+        bool ThrowOnUnhandledException { get; }
+        System.Action<GraphQL.Execution.UnhandledExceptionContext> UnhandledExceptionDelegate { get; }
+        GraphQL.Language.AST.Variables Variables { get; }
     }
     public interface IExecutionStrategy
     {

--- a/src/GraphQL.Tests/Execution/ExecutionListenerTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionListenerTests.cs
@@ -45,7 +45,7 @@ namespace GraphQL.Tests.Execution
 
         public class TestExecutionListener : DocumentExecutionListenerBase
         {
-            public override Task BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token)
+            public override Task BeforeExecutionAwaitedAsync(IExecutionContext context)
             {
                 var testContext = context.UserContext as TestContext;
                 testContext.Complete("bar");
@@ -54,7 +54,7 @@ namespace GraphQL.Tests.Execution
             }
         }
 
-        public class TestContext: Dictionary<string, object>
+        public class TestContext : Dictionary<string, object>
         {
             private TaskCompletionSource<string> _tcs;
 

--- a/src/GraphQL.Tests/Execution/ExecutionListenerTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionListenerTests.cs
@@ -43,11 +43,12 @@ namespace GraphQL.Tests.Execution
             }
         }
 
-        public class TestExecutionListener : DocumentExecutionListenerBase<TestContext>
+        public class TestExecutionListener : DocumentExecutionListenerBase
         {
-            public override Task BeforeExecutionAwaitedAsync(TestContext userContext, CancellationToken token)
+            public override Task BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token)
             {
-                userContext.Complete("bar");
+                var testContext = context.UserContext as TestContext;
+                testContext.Complete("bar");
 
                 return Task.CompletedTask;
             }

--- a/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
+++ b/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
@@ -18,12 +18,12 @@ namespace GraphQL.DataLoader
             _accessor = accessor;
         }
 
-        public Task AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token)
+        public Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult, CancellationToken token)
         {
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionAsync(object userContext, CancellationToken token)
+        public Task BeforeExecutionAsync(IExecutionContext context, CancellationToken token)
         {
             if (_accessor.Context == null)
                 _accessor.Context = new DataLoaderContext();
@@ -31,22 +31,23 @@ namespace GraphQL.DataLoader
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionAwaitedAsync(object userContext, CancellationToken token)
+        public Task BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token)
         {
             return Task.CompletedTask;
         }
 
-        public Task AfterExecutionAsync(object userContext, CancellationToken token)
+        public Task AfterExecutionAsync(IExecutionContext context, CancellationToken token)
         {
             _accessor.Context = null;
 
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token)
+        public Task BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token)
         {
-            var context = _accessor.Context;
-            return context.DispatchAllAsync(token);
+            var dataLoaderContext = _accessor.Context;
+
+            return dataLoaderContext.DispatchAllAsync(token);
         }
     }
 }

--- a/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
+++ b/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Execution;
 using GraphQL.Validation;
@@ -18,12 +17,12 @@ namespace GraphQL.DataLoader
             _accessor = accessor;
         }
 
-        public Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult, CancellationToken token)
+        public Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult)
         {
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionAsync(IExecutionContext context, CancellationToken token)
+        public Task BeforeExecutionAsync(IExecutionContext context)
         {
             if (_accessor.Context == null)
                 _accessor.Context = new DataLoaderContext();
@@ -31,23 +30,23 @@ namespace GraphQL.DataLoader
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token)
+        public Task BeforeExecutionAwaitedAsync(IExecutionContext context)
         {
             return Task.CompletedTask;
         }
 
-        public Task AfterExecutionAsync(IExecutionContext context, CancellationToken token)
+        public Task AfterExecutionAsync(IExecutionContext context)
         {
             _accessor.Context = null;
 
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token)
+        public Task BeforeExecutionStepAwaitedAsync(IExecutionContext context)
         {
             var dataLoaderContext = _accessor.Context;
 
-            return dataLoaderContext.DispatchAllAsync(token);
+            return dataLoaderContext.DispatchAllAsync(context.CancellationToken);
         }
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -129,10 +129,7 @@ namespace GraphQL
 
                 foreach (var listener in options.Listeners)
                 {
-                    await listener.AfterValidationAsync(
-                            context,
-                            validationResult,
-                            options.CancellationToken)
+                    await listener.AfterValidationAsync(context, validationResult)
                         .ConfigureAwait(false);
                 }
 
@@ -161,7 +158,7 @@ namespace GraphQL
                     if (context.Listeners != null)
                         foreach (var listener in context.Listeners)
                         {
-                            await listener.BeforeExecutionAsync(context, context.CancellationToken)
+                            await listener.BeforeExecutionAsync(context)
                                 .ConfigureAwait(false);
                         }
 
@@ -176,7 +173,7 @@ namespace GraphQL
                     if (context.Listeners != null)
                         foreach (var listener in context.Listeners)
                         {
-                            await listener.BeforeExecutionAwaitedAsync(context, context.CancellationToken)
+                            await listener.BeforeExecutionAwaitedAsync(context)
                                 .ConfigureAwait(false);
                         }
 
@@ -185,7 +182,7 @@ namespace GraphQL
                     if (context.Listeners != null)
                         foreach (var listener in context.Listeners)
                         {
-                            await listener.AfterExecutionAsync(context, context.CancellationToken)
+                            await listener.AfterExecutionAsync(context)
                                 .ConfigureAwait(false);
                         }
                 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -113,10 +113,24 @@ namespace GraphQL
                         _complexityAnalyzer.Validate(document, options.ComplexityConfiguration);
                 }
 
+                context = BuildExecutionContext(
+                    options.Schema,
+                    options.Root,
+                    document,
+                    operation,
+                    options.Inputs,
+                    options.UserContext,
+                    options.CancellationToken,
+                    metrics,
+                    options.Listeners,
+                    options.ThrowOnUnhandledException,
+                    options.UnhandledExceptionDelegate,
+                    options.MaxParallelExecutionCount);
+
                 foreach (var listener in options.Listeners)
                 {
                     await listener.AfterValidationAsync(
-                            options.UserContext,
+                            context,
                             validationResult,
                             options.CancellationToken)
                         .ConfigureAwait(false);
@@ -131,20 +145,6 @@ namespace GraphQL
                         Perf = metrics.Finish()
                     };
                 }
-
-                context = BuildExecutionContext(
-                    options.Schema,
-                    options.Root,
-                    document,
-                    operation,
-                    options.Inputs,
-                    options.UserContext,
-                    options.CancellationToken,
-                    metrics,
-                    options.Listeners,
-                    options.ThrowOnUnhandledException,
-                    options.UnhandledExceptionDelegate,
-                    options.MaxParallelExecutionCount);
 
                 if (context.Errors.Count > 0)
                 {
@@ -161,7 +161,7 @@ namespace GraphQL
                     if (context.Listeners != null)
                         foreach (var listener in context.Listeners)
                         {
-                            await listener.BeforeExecutionAsync(context.UserContext, context.CancellationToken)
+                            await listener.BeforeExecutionAsync(context, context.CancellationToken)
                                 .ConfigureAwait(false);
                         }
 
@@ -176,7 +176,7 @@ namespace GraphQL
                     if (context.Listeners != null)
                         foreach (var listener in context.Listeners)
                         {
-                            await listener.BeforeExecutionAwaitedAsync(context.UserContext, context.CancellationToken)
+                            await listener.BeforeExecutionAwaitedAsync(context, context.CancellationToken)
                                 .ConfigureAwait(false);
                         }
 
@@ -185,7 +185,7 @@ namespace GraphQL
                     if (context.Listeners != null)
                         foreach (var listener in context.Listeners)
                         {
-                            await listener.AfterExecutionAsync(context.UserContext, context.CancellationToken)
+                            await listener.AfterExecutionAsync(context, context.CancellationToken)
                                 .ConfigureAwait(false);
                         }
                 }

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -38,15 +38,5 @@ namespace GraphQL.Execution
         public virtual Task AfterExecutionAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
 
         public virtual Task BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
-
-        Task IDocumentExecutionListener.AfterValidationAsync(IExecutionContext context, IValidationResult validationResult, CancellationToken token) => AfterValidationAsync(context, validationResult, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionAsync(IExecutionContext context, CancellationToken token) => BeforeExecutionAsync(context, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token) => BeforeExecutionAwaitedAsync(context, token);
-
-        Task IDocumentExecutionListener.AfterExecutionAsync(IExecutionContext context, CancellationToken token) => AfterExecutionAsync(context, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token) => BeforeExecutionStepAwaitedAsync(context, token);
     }
 }

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -1,7 +1,6 @@
-using System.Threading;
 using System.Threading.Tasks;
-using GraphQL.Validation;
 using GraphQL.Resolvers;
+using GraphQL.Validation;
 
 namespace GraphQL.Execution
 {
@@ -11,32 +10,32 @@ namespace GraphQL.Execution
     public interface IDocumentExecutionListener
     {
         /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
-        Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult, CancellationToken token);
+        Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult);
 
         /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
-        Task BeforeExecutionAsync(IExecutionContext context, CancellationToken token);
+        Task BeforeExecutionAsync(IExecutionContext context);
 
         /// <summary>Executes before the <see cref="IDocumentExecuter"/> awaits the <see cref="Task"/> returned by <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/></summary>
-        Task BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token);
+        Task BeforeExecutionAwaitedAsync(IExecutionContext context);
 
         /// <summary>Executes after the <see cref="IExecutionStrategy"/> has completed executing the request</summary>
-        Task AfterExecutionAsync(IExecutionContext context, CancellationToken token);
+        Task AfterExecutionAsync(IExecutionContext context);
 
         /// <summary>Executes before each time the <see cref="IExecutionStrategy"/> awaits the <see cref="Task{TResult}"/> returned by <see cref="IFieldResolver.Resolve"/>. For parallel resolvers, this may execute a single time prior to awaiting multiple tasks.</summary>
-        Task BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token);
+        Task BeforeExecutionStepAwaitedAsync(IExecutionContext context);
     }
 
     /// <inheritdoc cref="IDocumentExecutionListener"/>
     public abstract class DocumentExecutionListenerBase : IDocumentExecutionListener
     {
-        public virtual Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult, CancellationToken token) => Task.CompletedTask;
+        public virtual Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult) => Task.CompletedTask;
 
-        public virtual Task BeforeExecutionAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
+        public virtual Task BeforeExecutionAsync(IExecutionContext context) => Task.CompletedTask;
 
-        public virtual Task BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
+        public virtual Task BeforeExecutionAwaitedAsync(IExecutionContext context) => Task.CompletedTask;
 
-        public virtual Task AfterExecutionAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
+        public virtual Task AfterExecutionAsync(IExecutionContext context) => Task.CompletedTask;
 
-        public virtual Task BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
+        public virtual Task BeforeExecutionStepAwaitedAsync(IExecutionContext context) => Task.CompletedTask;
     }
 }

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -11,61 +11,42 @@ namespace GraphQL.Execution
     public interface IDocumentExecutionListener
     {
         /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
-        Task AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token);
+        Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult, CancellationToken token);
 
         /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
-        Task BeforeExecutionAsync(object userContext, CancellationToken token);
+        Task BeforeExecutionAsync(IExecutionContext context, CancellationToken token);
 
         /// <summary>Executes before the <see cref="IDocumentExecuter"/> awaits the <see cref="Task"/> returned by <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/></summary>
-        Task BeforeExecutionAwaitedAsync(object userContext, CancellationToken token);
+        Task BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token);
 
         /// <summary>Executes after the <see cref="IExecutionStrategy"/> has completed executing the request</summary>
-        Task AfterExecutionAsync(object userContext, CancellationToken token);
+        Task AfterExecutionAsync(IExecutionContext context, CancellationToken token);
 
         /// <summary>Executes before each time the <see cref="IExecutionStrategy"/> awaits the <see cref="Task{TResult}"/> returned by <see cref="IFieldResolver.Resolve"/>. For parallel resolvers, this may execute a single time prior to awaiting multiple tasks.</summary>
-        Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token);
+        Task BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token);
     }
 
     /// <inheritdoc cref="IDocumentExecutionListener"/>
-    public interface IDocumentExecutionListener<in T>
+    public abstract class DocumentExecutionListenerBase : IDocumentExecutionListener
     {
-        /// <inheritdoc cref="IDocumentExecutionListener.AfterValidationAsync(object, IValidationResult, CancellationToken)"/>
-        Task AfterValidationAsync(T userContext, IValidationResult validationResult, CancellationToken token);
+        public virtual Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult, CancellationToken token) => Task.CompletedTask;
 
-        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionAsync(object, CancellationToken)"/>
-        Task BeforeExecutionAsync(T userContext, CancellationToken token);
+        public virtual Task BeforeExecutionAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
 
-        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionAwaitedAsync(object, CancellationToken)"/>
-        Task BeforeExecutionAwaitedAsync(T userContext, CancellationToken token);
+        public virtual Task BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
 
-        /// <inheritdoc cref="IDocumentExecutionListener.AfterExecutionAsync(object, CancellationToken)"/>
-        Task AfterExecutionAsync(T userContext, CancellationToken token);
+        public virtual Task AfterExecutionAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
 
-        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object, CancellationToken)"/>
-        Task BeforeExecutionStepAwaitedAsync(T userContext, CancellationToken token);
-    }
+        public virtual Task BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token) => Task.CompletedTask;
 
-    /// <inheritdoc cref="IDocumentExecutionListener"/>
-    public abstract class DocumentExecutionListenerBase<T> : IDocumentExecutionListener<T>, IDocumentExecutionListener
-    {
-        public virtual Task AfterValidationAsync(T userContext, IValidationResult validationResult, CancellationToken token) => Task.CompletedTask;
+        Task IDocumentExecutionListener.AfterValidationAsync(IExecutionContext context, IValidationResult validationResult, CancellationToken token) => AfterValidationAsync(context, validationResult, token);
 
-        public virtual Task BeforeExecutionAsync(T userContext, CancellationToken token) => Task.CompletedTask;
+        Task IDocumentExecutionListener.BeforeExecutionAsync(IExecutionContext context, CancellationToken token) => BeforeExecutionAsync(context, token);
 
-        public virtual Task BeforeExecutionAwaitedAsync(T userContext, CancellationToken token) => Task.CompletedTask;
+        Task IDocumentExecutionListener.BeforeExecutionAwaitedAsync(IExecutionContext context, CancellationToken token) => BeforeExecutionAwaitedAsync(context, token);
 
-        public virtual Task AfterExecutionAsync(T userContext, CancellationToken token) => Task.CompletedTask;
+        Task IDocumentExecutionListener.AfterExecutionAsync(IExecutionContext context, CancellationToken token) => AfterExecutionAsync(context, token);
 
-        public virtual Task BeforeExecutionStepAwaitedAsync(T userContext, CancellationToken token) => Task.CompletedTask;
-
-        Task IDocumentExecutionListener.AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token) => AfterValidationAsync((T)userContext, validationResult, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionAsync(object userContext, CancellationToken token) => BeforeExecutionAsync((T)userContext, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionAwaitedAsync(object userContext, CancellationToken token) => BeforeExecutionAwaitedAsync((T)userContext, token);
-
-        Task IDocumentExecutionListener.AfterExecutionAsync(object userContext, CancellationToken token) => AfterExecutionAsync((T)userContext, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token) => BeforeExecutionStepAwaitedAsync((T)userContext, token);
+        Task IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(IExecutionContext context, CancellationToken token) => BeforeExecutionStepAwaitedAsync(context, token);
     }
 }

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -8,7 +8,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Execution
 {
-    public class ExecutionContext : IProvideUserContext
+    public class ExecutionContext : IExecutionContext
     {
         public Document Document { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -289,7 +289,7 @@ namespace GraphQL.Execution
             if (context.Listeners != null)
                 foreach (var listener in context.Listeners)
                 {
-                    await listener.BeforeExecutionStepAwaitedAsync(context, context.CancellationToken)
+                    await listener.BeforeExecutionStepAwaitedAsync(context)
                         .ConfigureAwait(false);
                 }
         }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -289,7 +289,7 @@ namespace GraphQL.Execution
             if (context.Listeners != null)
                 foreach (var listener in context.Listeners)
                 {
-                    await listener.BeforeExecutionStepAwaitedAsync(context.UserContext, context.CancellationToken)
+                    await listener.BeforeExecutionStepAwaitedAsync(context, context.CancellationToken)
                         .ConfigureAwait(false);
                 }
         }

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using GraphQL.Instrumentation;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+
+namespace GraphQL.Execution
+{
+    public interface IExecutionContext : IProvideUserContext
+    {
+        CancellationToken CancellationToken { get; set; }
+        Document Document { get; set; }
+        ExecutionErrors Errors { get; set; }
+        Fragments Fragments { get; set; }
+        List<IDocumentExecutionListener> Listeners { get; set; }
+        int? MaxParallelExecutionCount { get; set; }
+        Metrics Metrics { get; set; }
+        Operation Operation { get; set; }
+        object RootValue { get; set; }
+        ISchema Schema { get; set; }
+        bool ThrowOnUnhandledException { get; set; }
+        Action<UnhandledExceptionContext> UnhandledExceptionDelegate { get; set; }
+        Variables Variables { get; set; }
+    }
+}

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -10,17 +10,30 @@ namespace GraphQL.Execution
     public interface IExecutionContext : IProvideUserContext
     {
         CancellationToken CancellationToken { get; }
+
         Document Document { get; }
+
         ExecutionErrors Errors { get; }
+
         Fragments Fragments { get; }
+
         List<IDocumentExecutionListener> Listeners { get; }
+
         int? MaxParallelExecutionCount { get; }
+
         Metrics Metrics { get; }
+
         Operation Operation { get; }
+
         object RootValue { get; }
+
         ISchema Schema { get; }
+
         bool ThrowOnUnhandledException { get; }
+
         Action<UnhandledExceptionContext> UnhandledExceptionDelegate { get; }
+
         Variables Variables { get; }
+
     }
 }

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -9,18 +9,18 @@ namespace GraphQL.Execution
 {
     public interface IExecutionContext : IProvideUserContext
     {
-        CancellationToken CancellationToken { get; set; }
-        Document Document { get; set; }
-        ExecutionErrors Errors { get; set; }
-        Fragments Fragments { get; set; }
-        List<IDocumentExecutionListener> Listeners { get; set; }
-        int? MaxParallelExecutionCount { get; set; }
-        Metrics Metrics { get; set; }
-        Operation Operation { get; set; }
-        object RootValue { get; set; }
-        ISchema Schema { get; set; }
-        bool ThrowOnUnhandledException { get; set; }
-        Action<UnhandledExceptionContext> UnhandledExceptionDelegate { get; set; }
-        Variables Variables { get; set; }
+        CancellationToken CancellationToken { get; }
+        Document Document { get; }
+        ExecutionErrors Errors { get; }
+        Fragments Fragments { get; }
+        List<IDocumentExecutionListener> Listeners { get; }
+        int? MaxParallelExecutionCount { get; }
+        Metrics Metrics { get; }
+        Operation Operation { get; }
+        object RootValue { get; }
+        ISchema Schema { get; }
+        bool ThrowOnUnhandledException { get; }
+        Action<UnhandledExceptionContext> UnhandledExceptionDelegate { get; }
+        Variables Variables { get; }
     }
 }

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -34,6 +34,5 @@ namespace GraphQL.Execution
         Action<UnhandledExceptionContext> UnhandledExceptionDelegate { get; }
 
         Variables Variables { get; }
-
     }
 }

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -112,7 +112,7 @@ namespace GraphQL.Execution
                         if (context.Listeners != null)
                             foreach (var listener in context.Listeners)
                             {
-                                await listener.BeforeExecutionAsync(context.UserContext, context.CancellationToken)
+                                await listener.BeforeExecutionAsync(context, context.CancellationToken)
                                     .ConfigureAwait(false);
                             }
 
@@ -122,7 +122,7 @@ namespace GraphQL.Execution
                         if (context.Listeners != null)
                             foreach (var listener in context.Listeners)
                             {
-                                await listener.AfterExecutionAsync(context.UserContext, context.CancellationToken)
+                                await listener.AfterExecutionAsync(context, context.CancellationToken)
                                     .ConfigureAwait(false);
                             }
 

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -112,7 +112,7 @@ namespace GraphQL.Execution
                         if (context.Listeners != null)
                             foreach (var listener in context.Listeners)
                             {
-                                await listener.BeforeExecutionAsync(context, context.CancellationToken)
+                                await listener.BeforeExecutionAsync(context)
                                     .ConfigureAwait(false);
                             }
 
@@ -122,7 +122,7 @@ namespace GraphQL.Execution
                         if (context.Listeners != null)
                             foreach (var listener in context.Listeners)
                             {
-                                await listener.AfterExecutionAsync(context, context.CancellationToken)
+                                await listener.AfterExecutionAsync(context)
                                     .ConfigureAwait(false);
                             }
 


### PR DESCRIPTION
With this change, more meta data about the execution is exposed, in particular `ExecutionErrors` can be useful, if one wants a service to be able to report multiple errors, and add errors without throwing.
It is a breaking change though, as it changes the interface.