### PR TITLE
Remove pre release installation instruction

### DIFF
--- a/docs2/site/docs/getting-started/installation.md
+++ b/docs2/site/docs/getting-started/installation.md
@@ -5,9 +5,3 @@
 ```
 dotnet add package GraphQL
 ```
-
-To install the latest pre-release, specify the version.
-
-```
-dotnet add package GraphQL --version 2.0.0-alpha-952
-```


### PR DESCRIPTION
Not needed IMO since the latest release is the stable one