### PR TITLE
Performance improvements

### DIFF
--- a/src/GraphQL.Tests/Validation/ValidationErrorAssertion.cs
+++ b/src/GraphQL.Tests/Validation/ValidationErrorAssertion.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace GraphQL.Tests.Validation
 {
@@ -7,7 +7,7 @@ namespace GraphQL.Tests.Validation
         private readonly List<ErrorLocation> _locations = new List<ErrorLocation>();
 
         public string Message { get; set; }
-        public IEnumerable<ErrorLocation> Locations => _locations;
+        public IList<ErrorLocation> Locations => _locations;
 
         public void Loc(int line, int column)
         {

--- a/src/GraphQL.Tests/Validation/ValidationTestBase.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestBase.cs
@@ -34,29 +34,34 @@ namespace GraphQL.Tests.Validation
 
             result.IsValid.ShouldBeFalse("Expected validation errors though there were none.");
             result.Errors.Count.ShouldBe(
-                config.Assertions.Count(),
+                config.Assertions.Count,
                 $"The number of errors found ({result.Errors.Count}) does not match the number of errors expected ({config.Assertions.Count()}).");
 
-            config.Assertions.Apply((assert, idx) =>
+            for (int i = 0; i < config.Assertions.Count; i++)
             {
-                var error = result.Errors.Skip(idx).First();
+                var assert = config.Assertions[i];
+                var error = result.Errors[i];
+
                 error.Message.ShouldBe(assert.Message);
 
-                var allLocations = string.Join("", error.Locations.Select(l => $"({l.Line},{l.Column})"));
+                var allLocations = string.Concat(error.Locations.Select(l => $"({l.Line},{l.Column})"));
+                var locations = error.Locations.ToList();
 
-                assert.Locations.Apply((assertLoc, locIdx) =>
+                for (int j = 0; j < assert.Locations.Count; j++)
                 {
-                    var errorLoc = error.Locations.Skip(locIdx).First();
+                    var assertLoc = assert.Locations[j];
+                    var errorLoc = locations[j];
+
                     errorLoc.Line.ShouldBe(
                         assertLoc.Line,
                         $"Expected line {assertLoc.Line} but was {errorLoc.Line} - {error.Message} {allLocations}");
                     errorLoc.Column.ShouldBe(
                         assertLoc.Column,
                         $"Expected column {assertLoc.Column} but was {errorLoc.Column} - {error.Message} {allLocations}");
-                });
+                }
 
-                error.Locations.Count().ShouldBe(assert.Locations.Count());
-            });
+                locations.Count.ShouldBe(assert.Locations.Count);
+            }
         }
 
         protected void ShouldPassRule(string query)

--- a/src/GraphQL.Tests/Validation/ValidationTestConfig.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using GraphQL.Validation;
 
@@ -10,8 +10,8 @@ namespace GraphQL.Tests.Validation
         private readonly List<ValidationErrorAssertion> _assertions = new List<ValidationErrorAssertion>();
 
         public string Query { get; set; }
-        public IEnumerable<IValidationRule> Rules => _rules;
-        public IEnumerable<ValidationErrorAssertion> Assertions => _assertions;
+        public IList<IValidationRule> Rules => _rules;
+        public IList<ValidationErrorAssertion> Assertions => _assertions;
 
         public void Error(string message, int? line = null, int? column = null)
         {

--- a/src/GraphQL/EnumerableExtensions.cs
+++ b/src/GraphQL/EnumerableExtensions.cs
@@ -1,30 +1,10 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace GraphQL
 {
     public static class EnumerableExtensions
     {
-        ///// <summary>
-        ///// Equivalent to .Select(...).ToList()
-        ///// </summary>
-        //public static IEnumerable<TK> Map<T, TK>(this IEnumerable<T> items, Func<T, TK> map)
-        //{
-        //    var mappedItems = from T item in items select map(item);
-        //    return mappedItems.ToList();
-        //}
-
-        ///// <summary>
-        ///// Equivalent to .Select(...).ToList()
-        ///// </summary>
-        //public static IEnumerable<T> Map<T>(this IEnumerable items, Func<object, T> map)
-        //{
-        //    var mappedItems = from object item in items select map(item);
-        //    return mappedItems.ToList();
-        //}
-
         /// <summary>
         /// Performs the indicated action on each item.
         /// </summary>
@@ -37,74 +17,5 @@ namespace GraphQL
                 action(item);
             }
         }
-
-        ///// <summary>
-        ///// Performs the indicated action on each item.
-        ///// </summary>
-        ///// <param name="action">The action to be performed.</param>
-        ///// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
-        //public static void Apply<T>(this IEnumerable<T> items, Action<T, int> action)
-        //{
-        //    var count = 0;
-        //    foreach (var item in items)
-        //    {
-        //        action(item, count);
-        //        count++;
-        //    }
-        //}
-
-        ///// <summary>
-        ///// Performs the indicated action on each item in reverse order.
-        ///// </summary>
-        ///// <param name="action">The action to be performed.</param>
-        ///// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
-        //public static void ApplyReverse<T>(this IEnumerable<T> items, Action<T> action)
-        //{
-        //    var list = items.ToList();
-
-        //    for (var i = list.Count - 1; i >= 0; i--)
-        //    {
-        //        action(list[i]);
-        //    }
-        //}
-
-        //public static bool All(this IEnumerable items, Func<object, bool> check)
-        //{
-        //    foreach (var item in items)
-        //    {
-        //        if (!check(item))
-        //        {
-        //            return false;
-        //        }
-        //    }
-
-        //    return true;
-        //}
-
-        ///// <summary>
-        ///// Adds the item to the list, unless the list already contains the item.
-        ///// </summary>
-        ///// <param name="items">The list to be updated.</param>
-        ///// <param name="itemToAdd">The item to be conditionally added.</param>
-        //public static void Fill<T>(this IList<T> items, T itemToAdd)
-        //{
-        //    Fill(items, new[] { itemToAdd });
-        //}
-
-        ///// <summary>
-        ///// Adds each item to the list, unless the list already contains the item.
-        ///// </summary>
-        ///// <param name="items">The list to be updated.</param>
-        ///// <param name="itemsToAdd">The items to be conditionally added.</param>
-        //public static void Fill<T>(this IList<T> items, IEnumerable<T> itemsToAdd)
-        //{
-        //    itemsToAdd.Apply(x =>
-        //    {
-        //        if (!items.Contains(x))
-        //        {
-        //            items.Add(x);
-        //        }
-        //    });
-        //}
     }
 }

--- a/src/GraphQL/EnumerableExtensions.cs
+++ b/src/GraphQL/EnumerableExtensions.cs
@@ -2,68 +2,28 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace GraphQL
 {
     public static class EnumerableExtensions
     {
-        /// <summary>
-        /// Equivalent to .Select(...).ToList()
-        /// </summary>
-        public static IEnumerable<TK> Map<T, TK>(this IEnumerable<T> items, Func<T, TK> map)
-        {
-            var mappedItems = from T item in items select map(item);
-            return mappedItems.ToList();
-        }
+        ///// <summary>
+        ///// Equivalent to .Select(...).ToList()
+        ///// </summary>
+        //public static IEnumerable<TK> Map<T, TK>(this IEnumerable<T> items, Func<T, TK> map)
+        //{
+        //    var mappedItems = from T item in items select map(item);
+        //    return mappedItems.ToList();
+        //}
 
-        /// <summary>
-        /// Equivalent to .Select(...).ToList()
-        /// </summary>
-        public static IEnumerable<T> Map<T>(this IEnumerable items, Func<object, T> map)
-        {
-            var mappedItems = from object item in items select map(item);
-            return mappedItems.ToList();
-        }
-
-        /// <summary>
-        /// Equivalent to .Select(...).ToList(), except the Select function is executed asynchronously.
-        /// </summary>
-        public static Task<object[]> MapAsync(this IEnumerable items, Func<object, Task<object>> map)
-        {
-            var tasks = items
-                .Cast<object>()
-                .Select(map);
-            return Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Equivalent to .Select(...).ToList()
-        /// </summary>
-        public static async Task<IEnumerable<object>> MapAsync(this IEnumerable enumerable, Func<int, object, Task<object>> mapFunction)
-        {
-            var index = 0;
-            var results = new List<object>();
-
-            foreach (var item in enumerable)
-            {
-                var result = await mapFunction(index++, item);
-
-                results.Add(result);
-            }
-
-            return results;
-
-            //return await enumerable
-            //    .Cast<object>()
-            //    .Select((item, index) => Tuple.Create(index, item))
-            //    .MapAsync(async tuple =>
-            //    {
-            //        var data = (Tuple<int, object>)tuple;
-            //        return await mapFunction(data.Item1, data.Item2).ConfigureAwait(false);
-            //    })
-            //    .ConfigureAwait(false);
-        }
+        ///// <summary>
+        ///// Equivalent to .Select(...).ToList()
+        ///// </summary>
+        //public static IEnumerable<T> Map<T>(this IEnumerable items, Func<object, T> map)
+        //{
+        //    var mappedItems = from object item in items select map(item);
+        //    return mappedItems.ToList();
+        //}
 
         /// <summary>
         /// Performs the indicated action on each item.
@@ -78,73 +38,73 @@ namespace GraphQL
             }
         }
 
-        /// <summary>
-        /// Performs the indicated action on each item.
-        /// </summary>
-        /// <param name="action">The action to be performed.</param>
-        /// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
-        public static void Apply<T>(this IEnumerable<T> items, Action<T, int> action)
-        {
-            var count = 0;
-            foreach (var item in items)
-            {
-                action(item, count);
-                count++;
-            }
-        }
+        ///// <summary>
+        ///// Performs the indicated action on each item.
+        ///// </summary>
+        ///// <param name="action">The action to be performed.</param>
+        ///// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
+        //public static void Apply<T>(this IEnumerable<T> items, Action<T, int> action)
+        //{
+        //    var count = 0;
+        //    foreach (var item in items)
+        //    {
+        //        action(item, count);
+        //        count++;
+        //    }
+        //}
 
-        /// <summary>
-        /// Performs the indicated action on each item in reverse order.
-        /// </summary>
-        /// <param name="action">The action to be performed.</param>
-        /// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
-        public static void ApplyReverse<T>(this IEnumerable<T> items, Action<T> action)
-        {
-            var list = items.ToList();
+        ///// <summary>
+        ///// Performs the indicated action on each item in reverse order.
+        ///// </summary>
+        ///// <param name="action">The action to be performed.</param>
+        ///// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
+        //public static void ApplyReverse<T>(this IEnumerable<T> items, Action<T> action)
+        //{
+        //    var list = items.ToList();
 
-            for (var i = list.Count - 1; i >= 0; i--)
-            {
-                action(list[i]);
-            }
-        }
+        //    for (var i = list.Count - 1; i >= 0; i--)
+        //    {
+        //        action(list[i]);
+        //    }
+        //}
 
-        public static bool All(this IEnumerable items, Func<object, bool> check)
-        {
-            foreach (var item in items)
-            {
-                if (!check(item))
-                {
-                    return false;
-                }
-            }
+        //public static bool All(this IEnumerable items, Func<object, bool> check)
+        //{
+        //    foreach (var item in items)
+        //    {
+        //        if (!check(item))
+        //        {
+        //            return false;
+        //        }
+        //    }
 
-            return true;
-        }
+        //    return true;
+        //}
 
-        /// <summary>
-        /// Adds the item to the list, unless the list already contains the item.
-        /// </summary>
-        /// <param name="items">The list to be updated.</param>
-        /// <param name="itemToAdd">The item to be conditionally added.</param>
-        public static void Fill<T>(this IList<T> items, T itemToAdd)
-        {
-            Fill(items, new[] { itemToAdd });
-        }
+        ///// <summary>
+        ///// Adds the item to the list, unless the list already contains the item.
+        ///// </summary>
+        ///// <param name="items">The list to be updated.</param>
+        ///// <param name="itemToAdd">The item to be conditionally added.</param>
+        //public static void Fill<T>(this IList<T> items, T itemToAdd)
+        //{
+        //    Fill(items, new[] { itemToAdd });
+        //}
 
-        /// <summary>
-        /// Adds each item to the list, unless the list already contains the item.
-        /// </summary>
-        /// <param name="items">The list to be updated.</param>
-        /// <param name="itemsToAdd">The items to be conditionally added.</param>
-        public static void Fill<T>(this IList<T> items, IEnumerable<T> itemsToAdd)
-        {
-            itemsToAdd.Apply(x =>
-            {
-                if (!items.Contains(x))
-                {
-                    items.Add(x);
-                }
-            });
-        }
+        ///// <summary>
+        ///// Adds each item to the list, unless the list already contains the item.
+        ///// </summary>
+        ///// <param name="items">The list to be updated.</param>
+        ///// <param name="itemsToAdd">The items to be conditionally added.</param>
+        //public static void Fill<T>(this IList<T> items, IEnumerable<T> itemsToAdd)
+        //{
+        //    itemsToAdd.Apply(x =>
+        //    {
+        //        if (!items.Contains(x))
+        //        {
+        //            items.Add(x);
+        //        }
+        //    });
+        //}
     }
 }

--- a/src/GraphQL/Execution/ExecutionErrors.cs
+++ b/src/GraphQL/Execution/ExecutionErrors.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace GraphQL
@@ -18,6 +18,8 @@ namespace GraphQL
         }
 
         public int Count => _errors.Count;
+
+        public ExecutionError this[int index] => _errors[index];
 
         public IEnumerator<ExecutionError> GetEnumerator()
         {

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -435,29 +435,6 @@ namespace GraphQL.Execution
             return false;
         }
 
-        /// <summary>
-        /// Unwrap nested Tasks to get the result
-        /// </summary>
-        public static async Task<object> UnwrapResultAsync(object result)
-        {
-            while (result is Task task)
-            {
-                await task.ConfigureAwait(false);
-
-                // Most performant if available
-                if (task is Task<object> t)
-                {
-                    result = t.Result;
-                }
-                else
-                {
-                    result = ((dynamic)task).Result;
-                }
-            }
-
-            return result;
-        }
-
         public static IDictionary<string, Field> SubFieldsFor(ExecutionContext context, IGraphType fieldType, Field field)
         {
             var selections = field?.SelectionSet?.Selections;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -74,25 +74,30 @@ namespace GraphQL.Execution
                 throw error;
             }
 
-            return parentType.Fields.FirstOrDefault(f => f.Name == field.Name);
+            return parentType.GetField(field.Name);
         }
 
         public static Variables GetVariableValues(Document document, ISchema schema, VariableDefinitions variableDefinitions, Inputs inputs)
         {
             var variables = new Variables();
-            variableDefinitions?.Apply(v =>
+
+            if (variableDefinitions != null)
             {
-                var variable = new Variable
+                foreach (var v in variableDefinitions)
                 {
-                    Name = v.Name
-                };
+                    var variable = new Variable
+                    {
+                        Name = v.Name
+                    };
 
-                object variableValue = null;
-                inputs?.TryGetValue(v.Name, out variableValue);
-                variable.Value = GetVariableValue(document, schema, v, variableValue);
+                    object variableValue = null;
+                    inputs?.TryGetValue(v.Name, out variableValue);
+                    variable.Value = GetVariableValue(document, schema, v, variableValue);
 
-                variables.Add(variable);
-            });
+                    variables.Add(variable);
+                }
+            }
+
             return variables;
         }
 
@@ -174,11 +179,16 @@ namespace GraphQL.Execution
                 }
 
                 // ensure every provided field is defined
-                var unknownFields = type is IInputObjectGraphType
-                    ? dict.Keys.Where(key => complexType.Fields.All(field => field.Name != key)).ToArray()
-                    : null;
+                IList<string> unknownFields = null;
 
-                if (unknownFields?.Any() == true)
+                if (type is IInputObjectGraphType)
+                {
+                    unknownFields = dict.Keys
+                        .Except(complexType.Fields.Select(f => f.Name))
+                        .ToList();
+                }
+
+                if (unknownFields?.Count > 0)
                 {
                     throw new InvalidValueException(fieldName,
                         $"Unrecognized input fields {string.Join(", ", unknownFields.Select(k => $"'{k}'"))} for type '{type.Name}'.");
@@ -207,25 +217,27 @@ namespace GraphQL.Execution
 
         public static Dictionary<string, object> GetArgumentValues(ISchema schema, QueryArguments definitionArguments, Arguments astArguments, Variables variables)
         {
-            if (definitionArguments == null || !definitionArguments.Any())
+            if (definitionArguments == null || definitionArguments.Count == 0)
             {
                 return null;
             }
 
-            return definitionArguments.Aggregate(new Dictionary<string, object>(), (acc, arg) =>
+            var values = new Dictionary<string, object>(definitionArguments.Count);
+
+            foreach (var arg in definitionArguments)
             {
                 var value = astArguments?.ValueFor(arg.Name);
                 var type = arg.ResolvedType;
 
-                var coercedValue = CoerceValue(schema, type, value, variables);
-                coercedValue = coercedValue ?? arg.DefaultValue;
+                var coercedValue = CoerceValue(schema, type, value, variables) ?? arg.DefaultValue;
+
                 if (coercedValue != null)
                 {
-                    acc[arg.Name] = coercedValue;
+                    values[arg.Name] = coercedValue;
                 }
+            }
 
-                return acc;
-            });
+            return values;
         }
 
         public static object CoerceValue(ISchema schema, IGraphType type, IValue input, Variables variables = null)
@@ -249,22 +261,29 @@ namespace GraphQL.Execution
             {
                 var listItemType = listType.ResolvedType;
 
-                return input is ListValue list
-                    ? list.Values.Map(item => CoerceValue(schema, listItemType, item, variables)).ToArray()
-                    : new[] { CoerceValue(schema, listItemType, input, variables) };
+                if (input is ListValue list)
+                {
+                    return list.Values
+                        .Select(item => CoerceValue(schema, listItemType, item, variables))
+                        .ToList();
+                }
+                else
+                {
+                    return new[] { CoerceValue(schema, listItemType, input, variables) };
+                }
             }
 
             if (type is IObjectGraphType || type is IInputObjectGraphType)
             {
-                var complexType = type as IComplexGraphType;
-                var obj = new Dictionary<string, object>();
-
                 if (!(input is ObjectValue objectValue))
                 {
                     return null;
                 }
 
-                complexType.Fields.Apply(field =>
+                var complexType = type as IComplexGraphType;
+                var obj = new Dictionary<string, object>();
+
+                foreach (var field in complexType.Fields)
                 {
                     var objectField = objectValue.Field(field.Name);
                     if (objectField != null)
@@ -274,7 +293,7 @@ namespace GraphQL.Execution
 
                         obj[field.Name] = fieldValue;
                     }
-                });
+                }
 
                 return obj;
             }
@@ -294,50 +313,54 @@ namespace GraphQL.Execution
             Fields fields,
             List<string> visitedFragmentNames)
         {
-            selectionSet?.Selections.Apply(selection =>
+            if (selectionSet != null)
             {
-                if (selection is Field field)
+                foreach (var selection in selectionSet.Selections)
                 {
-                    if (!ShouldIncludeNode(context, field.Directives))
+                    if (selection is Field field)
                     {
-                        return;
+                        if (!ShouldIncludeNode(context, field.Directives))
+                        {
+                            continue;
+                        }
+
+                        fields.Add(field);
+                    }
+                    else if (selection is FragmentSpread spread)
+                    {
+                        if (visitedFragmentNames.Contains(spread.Name)
+                            || !ShouldIncludeNode(context, spread.Directives))
+                        {
+                            continue;
+                        }
+
+                        visitedFragmentNames.Add(spread.Name);
+
+                        var fragment = context.Fragments.FindDefinition(spread.Name);
+                        if (fragment == null
+                            || !ShouldIncludeNode(context, fragment.Directives)
+                            || !DoesFragmentConditionMatch(context, fragment.Type.Name, specificType))
+                        {
+                            continue;
+                        }
+
+                        CollectFields(context, specificType, fragment.SelectionSet, fields, visitedFragmentNames);
+                    }
+                    else if (selection is InlineFragment inline)
+                    {
+                        var name = inline.Type != null ? inline.Type.Name : specificType.Name;
+
+                        if (!ShouldIncludeNode(context, inline.Directives)
+                          || !DoesFragmentConditionMatch(context, name, specificType))
+                        {
+                            continue;
+                        }
+
+                        CollectFields(context, specificType, inline.SelectionSet, fields, visitedFragmentNames);
                     }
 
-                    fields.Add(field);
                 }
-                else if (selection is FragmentSpread spread)
-                {
-                    if (visitedFragmentNames.Contains(spread.Name)
-                        || !ShouldIncludeNode(context, spread.Directives))
-                    {
-                        return;
-                    }
-
-                    visitedFragmentNames.Add(spread.Name);
-
-                    var fragment = context.Fragments.FindDefinition(spread.Name);
-                    if (fragment == null
-                        || !ShouldIncludeNode(context, fragment.Directives)
-                        || !DoesFragmentConditionMatch(context, fragment.Type.Name, specificType))
-                    {
-                        return;
-                    }
-
-                    CollectFields(context, specificType, fragment.SelectionSet, fields, visitedFragmentNames);
-                }
-                else if (selection is InlineFragment inline)
-                {
-                    var name = inline.Type != null ? inline.Type.Name : specificType.Name;
-
-                    if (!ShouldIncludeNode(context, inline.Directives)
-                      || !DoesFragmentConditionMatch(context, name, specificType))
-                    {
-                        return;
-                    }
-
-                    CollectFields(context, specificType, inline.SelectionSet, fields, visitedFragmentNames);
-                }
-            });
+            }
 
             return fields;
         }
@@ -438,7 +461,7 @@ namespace GraphQL.Execution
         public static IDictionary<string, Field> SubFieldsFor(ExecutionContext context, IGraphType fieldType, Field field)
         {
             var selections = field?.SelectionSet?.Selections;
-            if (selections == null || selections.Any() == false)
+            if (selections == null || selections.Count == 0)
             {
                 return null;
             }
@@ -447,9 +470,6 @@ namespace GraphQL.Execution
 
         public static string[] AppendPath(string[] path, string pathSegment)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-
             var newPath = new string[path.Length + 1];
 
             path.CopyTo(newPath, 0);

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -89,7 +89,7 @@ namespace GraphQL.Execution
             if (SubFields == null)
                 return null;
 
-            var fields = new Dictionary<string, object>();
+            var fields = new Dictionary<string, object>(SubFields.Count);
 
             foreach (var kvp in SubFields)
             {
@@ -131,7 +131,7 @@ namespace GraphQL.Execution
 
             return Items
                 .Select(x => x.ToValue())
-                .ToArray();
+                .ToList();
         }
 
         IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes()

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -191,8 +191,11 @@ namespace GraphQL.Execution
                 var resolver = node.FieldDefinition.Resolver ?? new NameFieldResolver();
                 var result = resolver.Resolve(resolveContext);
 
-                result = await UnwrapResultAsync(result)
-                    .ConfigureAwait(false);
+                if (result is Task task)
+                {
+                    await task.ConfigureAwait(false);
+                    result = task.GetResult();
+                }
 
                 node.Result = result;
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -58,7 +58,7 @@ namespace GraphQL.Execution
         {
             var parentType = parent.GetObjectGraphType(context.Schema);
 
-            var subFields = new Dictionary<string, ExecutionNode>();
+            var subFields = new Dictionary<string, ExecutionNode>(fields.Count);
 
             foreach (var kvp in fields)
             {
@@ -92,7 +92,6 @@ namespace GraphQL.Execution
             if (itemType is NonNullGraphType nonNullGraphType)
                 itemType = nonNullGraphType.ResolvedType;
 
-
             if (!(parent.Result is IEnumerable data))
             {
                 var error = new ExecutionError("User error: expected an IEnumerable list though did not find one.");
@@ -100,7 +99,9 @@ namespace GraphQL.Execution
             }
 
             var index = 0;
-            var arrayItems = new List<ExecutionNode>();
+            var arrayItems = (data is ICollection collection)
+                ? new List<ExecutionNode>(collection.Count)
+                : new List<ExecutionNode>();
 
             foreach (var d in data)
             {

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>GraphQL for .NET</Description>
@@ -34,8 +34,12 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -18,6 +18,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -38,18 +38,17 @@ namespace GraphQL.Instrumentation
 
         public void ApplyTo(ISchema schema)
         {
-            schema.AllTypes.Apply(item =>
+            foreach (var complex in schema.AllTypes.OfType<IComplexGraphType>())
             {
-                var complex = item as IComplexGraphType;
-                complex?.Fields.Apply(field =>
+                foreach (var field in complex.Fields)
                 {
                     var resolver = new MiddlewareResolver(field.Resolver);
 
                     FieldMiddlewareDelegate app = Build(resolver.Resolve);
 
                     field.Resolver = new FuncFieldResolver<object>(app.Invoke);
-                });
-            });
+                }
+            }
         }
     }
 }

--- a/src/GraphQL/Instrumentation/MiddlewareResolver.cs
+++ b/src/GraphQL/Instrumentation/MiddlewareResolver.cs
@@ -13,16 +13,19 @@ namespace GraphQL.Instrumentation
             _next = next ?? new NameFieldResolver();
         }
 
-        public Task<object> Resolve(ResolveFieldContext context)
+        public async Task<object> Resolve(ResolveFieldContext context)
         {
             object result = _next.Resolve(context);
 
-            if (result is Task<object> task)
+            if (result is Task task)
             {
-                return task;
+                await task.ConfigureAwait(false);
+                return task.GetResult();
             }
-
-            return Task.FromResult(result);
+            else
+            {
+                return result;
+            }
         }
 
         object IFieldResolver.Resolve(ResolveFieldContext context)

--- a/src/GraphQL/Language/AST/Directive.cs
+++ b/src/GraphQL/Language/AST/Directive.cs
@@ -21,11 +21,14 @@ namespace GraphQL.Language.AST
 
         public override string ToString()
         {
-            return "Directive{{name='{0}',arguments={1}}}".ToFormat(Name, Arguments);
+            return $"Directive{{name='{Name}',arguments={Arguments}}}";
         }
 
         protected bool Equals(Directive other)
         {
+            if (other == null)
+                return false;
+
             return string.Equals(Name, other.Name);
         }
 

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -1,24 +1,30 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace GraphQL.Language.AST
 {
     public class Directives : AbstractNode, IEnumerable<Directive>
     {
         private readonly List<Directive> _directives = new List<Directive>();
+        private readonly Dictionary<string, Directive> _unique = new Dictionary<string, Directive>(StringComparer.Ordinal);
 
         public override IEnumerable<INode> Children => _directives;
 
         public void Add(Directive directive)
         {
             _directives.Add(directive);
+
+            if (!_unique.ContainsKey(directive.Name))
+            {
+                _unique.Add(directive.Name, directive);
+            }
         }
 
         public Directive Find(string name)
         {
-            return _directives.FirstOrDefault(d => d.Name.Equals(name, StringComparison.Ordinal));
+            _unique.TryGetValue(name, out Directive value);
+            return value;
         }
 
         public IEnumerator<Directive> GetEnumerator()

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -27,6 +27,10 @@ namespace GraphQL.Language.AST
             return value;
         }
 
+        public int Count => _directives.Count;
+
+        public bool HasDuplicates => _directives.Count != _unique.Count;
+
         public IEnumerator<Directive> GetEnumerator()
         {
             return _directives.GetEnumerator();

--- a/src/GraphQL/Language/AST/Fields.cs
+++ b/src/GraphQL/Language/AST/Fields.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using GraphQL.Language.AST;
 
 namespace GraphQL.Language.AST
 {
@@ -18,7 +17,15 @@ namespace GraphQL.Language.AST
         public void Add(Field field)
         {
             var name = field.Alias ?? field.Name;
-            _fields[name] = _fields.ContainsKey(name) ? MergeField(_fields[name], field) : field;
+
+            if (_fields.TryGetValue(name, out Field original))
+            {
+                _fields[name] = original.MergeSelectionSet(field);
+            }
+            else
+            {
+                _fields[name] = field;
+            }
         }
 
         public IEnumerator<Field> GetEnumerator()
@@ -30,8 +37,6 @@ namespace GraphQL.Language.AST
         {
             return GetEnumerator();
         }
-
-        private Field MergeField(Field originalField, Field newField) => originalField.MergeSelectionSet(newField);
 
         public static implicit operator Dictionary<string, Field>(Fields fields) => fields._fields;
     }

--- a/src/GraphQL/Language/AST/SelectionSet.cs
+++ b/src/GraphQL/Language/AST/SelectionSet.cs
@@ -5,8 +5,11 @@ namespace GraphQL.Language.AST
 {
     public class SelectionSet : AbstractNode
     {
+        private readonly List<ISelection> _selections;
+
         public SelectionSet()
         {
+            _selections = new List<ISelection>();
         }
 
         private SelectionSet(List<ISelection> selections)
@@ -14,9 +17,7 @@ namespace GraphQL.Language.AST
             _selections = selections;
         }
 
-        private readonly List<ISelection> _selections = new List<ISelection>();
-
-        public IEnumerable<ISelection> Selections => _selections;
+        public IList<ISelection> Selections => _selections;
         public override IEnumerable<INode> Children => _selections;
 
         public void Add(ISelection selection)

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -28,7 +28,7 @@ namespace GraphQL.Language
 
         public void AddDefinitions(GraphQLDocument source, Document target)
         {
-            source.Definitions.Apply(def =>
+            foreach (var def in source.Definitions)
             {
                 if (def is GraphQLOperationDefinition op)
                 {
@@ -39,7 +39,7 @@ namespace GraphQL.Language
                 {
                     target.AddDefinition(Fragment(frag));
                 }
-            });
+            }
         }
 
         public Operation Operation(GraphQLOperationDefinition source)
@@ -82,8 +82,14 @@ namespace GraphQL.Language
         public VariableDefinitions VariableDefinitions(IEnumerable<GraphQLVariableDefinition> source)
         {
             var defs = new VariableDefinitions();
-            var list = source?.Select(VariableDefinition);
-            list?.Apply(defs.Add);
+
+            if (source != null)
+            {
+                foreach (var def in source.Select(VariableDefinition))
+                {
+                    defs.Add(def);
+                }
+            }
             return defs;
         }
 
@@ -105,10 +111,16 @@ namespace GraphQL.Language
         public SelectionSet SelectionSet(GraphQLSelectionSet source)
         {
             var set = new SelectionSet().WithLocation(source, _body);
-            source?.Selections.Apply(s =>
+
+            if (source != null)
             {
-                set.Add(Selection(s));
-            });
+                foreach (var s in source.Selections)
+                {
+                    set.Add(Selection(s));
+
+                }
+            }
+
             return set;
         }
 
@@ -146,12 +158,17 @@ namespace GraphQL.Language
         public Directives Directives(IEnumerable<GraphQLDirective> directives)
         {
             var target = new Directives();
-            directives?.Apply(d =>
+
+            if (directives != null)
             {
-                var dir = new Directive(Name(d.Name)).WithLocation(d, _body);
-                dir.Arguments = Arguments(d.Arguments);
-                target.Add(dir);
-            });
+                foreach (var d in directives)
+                {
+                    var dir = new Directive(Name(d.Name)).WithLocation(d, _body);
+                    dir.Arguments = Arguments(d.Arguments);
+                    target.Add(dir);
+                }
+            }
+
             return target;
         }
 
@@ -159,12 +176,12 @@ namespace GraphQL.Language
         {
             var target = new Arguments();
 
-            source.Apply(s =>
+            foreach (var s in source)
             {
                 var arg = new Argument(Name(s.Name)).WithLocation(s.Name, _body);
                 arg.Value = Value(s.Value);
                 target.Add(arg);
-            });
+            }
 
             return target;
         }

--- a/src/GraphQL/Reflection/ReflectionHelper.cs
+++ b/src/GraphQL/Reflection/ReflectionHelper.cs
@@ -77,7 +77,7 @@ namespace GraphQL.Reflection
 
         public static object[] BuildArguments<T>(ParameterInfo[] parameters,  T context) where T : ResolveFieldContext<object>
         {
-            if (parameters == null || !parameters.Any()) return null;
+            if (parameters == null || parameters.Length == 0) return null;
 
             object[] arguments = new object[parameters.Length];
 

--- a/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
+++ b/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Resolvers
 
         public TProperty Resolve(ResolveFieldContext context)
         {
-            return _property(context.As<TSourceType>().Source);
+            return _property((TSourceType)context.Source);
         }
 
         object IFieldResolver.Resolve(ResolveFieldContext context)

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Reflection;
 using GraphQL.Types;
 
@@ -6,12 +7,14 @@ namespace GraphQL.Resolvers
 {
     internal class NameFieldResolver : IFieldResolver
     {
-        private static readonly BindingFlags _flags = BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
+        private const BindingFlags _flags = BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance;
 
         public object Resolve(ResolveFieldContext context)
         {
             return Resolve(context?.Source, context?.FieldAst?.Name);
         }
+
+#if NETSTANDARD1_3
 
         public static object Resolve(object source, string name)
         {
@@ -28,5 +31,57 @@ namespace GraphQL.Resolvers
 
             return prop.GetValue(source, null);
         }
+#else
+
+        private static readonly ConcurrentDictionary<(Type, string), Func<object, object>> _propertyDelegates
+            = new ConcurrentDictionary<(Type, string), Func<object, object>>();
+
+        public static object Resolve(object source, string name)
+        {
+            if (source == null || name == null)
+            {
+                return null;
+            }
+
+            // We use reflection to create a delegate to access the property
+            // Then cache the delegate
+            // This is over 10x faster that just using reflection to get the property value
+
+            var sourceType = source.GetType();
+            var func = _propertyDelegates.GetOrAdd((sourceType, name), t => CreatePropertyDelegate(t.Item1, t.Item2));
+
+            return func(source);
+        }
+
+        private static Func<object, object> CreatePropertyDelegate(Type target, string name)
+        {
+            // Get the property with reflection
+            var property = target.GetProperty(name, _flags);
+
+            if (property == null)
+            {
+                throw new InvalidOperationException($"Expected to find property {name} on {target.Name} but it does not exist.");
+            }
+
+            // Use reflection to call the method to generate our delegate
+            MethodInfo constructedHelper = delegateHelperMethod.MakeGenericMethod(
+                property.DeclaringType, property.GetMethod.ReturnType);
+
+            return (Func<object, object>)constructedHelper.Invoke(null, new object[] { property });
+        }
+
+        private static readonly MethodInfo delegateHelperMethod = typeof(NameFieldResolver).GetMethod(nameof(DelegateHelper),
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        private static Func<object, object> DelegateHelper<TTarget, TReturn>(PropertyInfo property)
+        {
+            // Convert the slow MethodInfo into a fast, strongly typed, open delegate
+            Func<TTarget, TReturn> func = (Func<TTarget, TReturn>)
+                Delegate.CreateDelegate(typeof(Func<TTarget, TReturn>), property.GetMethod);
+
+            // Now create a more weakly typed delegate which will call the strongly typed one
+            return (object target) => func((TTarget)target);
+        }
+#endif
     }
 }

--- a/src/GraphQL/TaskExtensions.cs
+++ b/src/GraphQL/TaskExtensions.cs
@@ -7,7 +7,6 @@ namespace GraphQL
     /// </summary>
     public static class TaskExtensions
     {
-
         /// <summary>
         /// Returns a completed task. Equivalent to Task.CompletedTask.
         /// </summary>
@@ -17,5 +16,27 @@ namespace GraphQL
         public static Task CompletedTask { get; } = Task.FromResult(0);
 #endif
 
+        /// <summary>
+        /// Gets the result of a completed <see cref="Task&lt;TResult&gt;"/> when TResult is not known
+        /// </summary>
+        /// <remarks>
+        /// The Task should already be awaited or this call will block.
+        /// This will also throw an exception if the task is not Task&lt;TResult&gt;.
+        /// </remarks>
+        /// <param name="task">A task that has already been awaited</param>
+        /// <returns></returns>
+        internal static object GetResult(this Task task)
+        {
+            if (task is Task<object> to)
+            {
+                // Most performant if available
+                return to.Result;
+            }
+            else
+            {
+                // Using dynamic is over 10x faster than reflection
+                return ((dynamic)task).Result;
+            }
+        }
     }
 }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -46,7 +46,7 @@ namespace GraphQL.Types
         {
             if (string.IsNullOrWhiteSpace(name)) return null;
 
-            return _fields.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
+            return _fields.Find(x => string.Equals(x.Name, name, StringComparison.Ordinal));
         }
 
         public virtual FieldType AddField(FieldType fieldType)

--- a/src/GraphQL/Types/InterfaceGraphType.cs
+++ b/src/GraphQL/Types/InterfaceGraphType.cs
@@ -17,7 +17,10 @@ namespace GraphQL.Types
 
         public void AddPossibleType(IObjectGraphType type)
         {
-            _possibleTypes.Fill(type);
+            if (!_possibleTypes.Contains(type))
+            {
+                _possibleTypes.Add(type);
+            }
         }
     }
 

--- a/src/GraphQL/Types/ObjectGraphType.cs
+++ b/src/GraphQL/Types/ObjectGraphType.cs
@@ -26,7 +26,10 @@ namespace GraphQL.Types
 
         public void AddResolvedInterface(IInterfaceGraphType graphType)
         {
-            _resolvedInterfaces.Fill(graphType);
+            if (!_resolvedInterfaces.Contains(graphType))
+            {
+                _resolvedInterfaces.Add(graphType);
+            }
         }
 
         public IEnumerable<IInterfaceGraphType> ResolvedInterfaces

--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -142,6 +142,9 @@ namespace GraphQL.Types
     {
         internal ResolveFieldContext<TSourceType> As<TSourceType>()
         {
+            if (this is ResolveFieldContext<TSourceType> typedContext)
+                return typedContext;
+
             return new ResolveFieldContext<TSourceType>(this);
         }
 

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -133,7 +133,7 @@ namespace GraphQL.Types
                 }
 
                 _directives.Clear();
-                _directives.Fill(value);
+                _directives.AddRange(value);
             }
         }
 
@@ -162,7 +162,10 @@ namespace GraphQL.Types
                 throw new ArgumentNullException(nameof(types));
             }
 
-            types.Apply(RegisterType);
+            foreach (var type in types)
+            {
+                RegisterType(type);
+            }
         }
 
         public void RegisterType<T>() where T : IGraphType
@@ -177,7 +180,7 @@ namespace GraphQL.Types
 
         public void RegisterDirectives(params DirectiveGraphType[] directives)
         {
-            directives.Apply(RegisterDirective);
+            _directives.AddRange(directives);
         }
 
         public DirectiveGraphType FindDirective(string name)
@@ -228,7 +231,10 @@ namespace GraphQL.Types
                 throw new ArgumentOutOfRangeException(nameof(type), "Type must be of GraphType.");
             }
 
-            _additionalTypes.Fill(type);
+            if (!_additionalTypes.Contains(type))
+            {
+                _additionalTypes.Add(type);
+            }
         }
 
         private GraphTypesLookup CreateTypesLookup()

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -33,7 +33,7 @@ namespace GraphQL.Utilities
 
             if (_options.CustomScalars?.Count > 0)
             {
-                _scalars.Fill(_options.CustomScalars);
+                _scalars.AddRange(_options.CustomScalars);
             }
         }
 

--- a/src/GraphQL/Utilities/TypeConfig.cs
+++ b/src/GraphQL/Utilities/TypeConfig.cs
@@ -96,7 +96,14 @@ namespace GraphQL.Utilities
         private void ApplyMetadata(Type type)
         {
             var attributes = type?.GetTypeInfo().GetCustomAttributes<GraphQLAttribute>();
-            attributes?.Apply(a => a.Modify(this));
+
+            if (attributes == null)
+                return;
+
+            foreach (var a in attributes)
+            {
+                a.Modify(this);
+            }
         }
     }
 }

--- a/src/GraphQL/Validation/BasicVisitor.cs
+++ b/src/GraphQL/Validation/BasicVisitor.cs
@@ -1,13 +1,19 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using GraphQL.Language.AST;
 
 namespace GraphQL.Validation
 {
     public class BasicVisitor
     {
-        private readonly IEnumerable<INodeVisitor> _visitors;
+        private readonly IList<INodeVisitor> _visitors;
 
         public BasicVisitor(params INodeVisitor[] visitors)
+        {
+            _visitors = visitors;
+        }
+
+        public BasicVisitor(IList<INodeVisitor> visitors)
         {
             _visitors = visitors;
         }
@@ -19,11 +25,23 @@ namespace GraphQL.Validation
                 return;
             }
 
-            _visitors.Apply(l => l.Enter(node));
+            foreach (var visitor in _visitors)
+            {
+                visitor.Enter(node);
+            }
 
-            node.Children?.Apply(Visit);
+            if (node.Children != null)
+            {
+                foreach (var child in node.Children)
+                {
+                    Visit(child);
+                }
+            }
 
-            _visitors.ApplyReverse(l => l.Leave(node));
+            foreach (var visitor in _visitors.Reverse())
+            {
+                visitor.Leave(node);
+            }
         }
     }
 }

--- a/src/GraphQL/Validation/BasicVisitor.cs
+++ b/src/GraphQL/Validation/BasicVisitor.cs
@@ -25,9 +25,9 @@ namespace GraphQL.Validation
                 return;
             }
 
-            foreach (var visitor in _visitors)
+            for (int i = 0; i < _visitors.Count; i++)
             {
-                visitor.Enter(node);
+                _visitors[i].Enter(node);
             }
 
             if (node.Children != null)
@@ -38,9 +38,9 @@ namespace GraphQL.Validation
                 }
             }
 
-            foreach (var visitor in _visitors.Reverse())
+            for (int i = _visitors.Count - 1; i >= 0; i--)
             {
-                visitor.Leave(node);
+                _visitors[i].Leave(node);
             }
         }
     }

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalyzer.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalyzer.cs
@@ -63,12 +63,12 @@ namespace GraphQL.Validation.Complexity
 
             var context = new AnalysisContext();
 
-            doc.Children.OfType<FragmentDefinition>().Apply(node =>
+            foreach (var node in doc.Children.OfType<FragmentDefinition>())
             {
                 var fragResult = new FragmentComplexity();
                 FragmentIterator(context, node, fragResult, avgImpact, avgImpact, 1d);
                 context.FragmentMap[node.Name] = fragResult;
-            });
+            }
 
             TreeIterator(context, doc, avgImpact, avgImpact, 1d);
 

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -54,7 +54,7 @@ namespace GraphQL.Validation
 //             visitors.Insert(1, new DebugNodeVisitor());
 // #endif
 
-            var basic = new BasicVisitor(visitors.ToArray());
+            var basic = new BasicVisitor(visitors);
 
             basic.Visit(document);
 

--- a/src/GraphQL/Validation/EnterLeaveListener.cs
+++ b/src/GraphQL/Validation/EnterLeaveListener.cs
@@ -1,22 +1,18 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using GraphQL.Language.AST;
 
 namespace GraphQL.Validation
 {
-    public class MatchingNodeListener
-    {
-        public Func<INode, bool> Matches { get; set; }
-        public Action<INode> Enter { get; set; }
-        public Action<INode> Leave { get; set; }
-    }
-
     public class EnterLeaveListener : INodeVisitor
     {
-        private readonly List<MatchingNodeListener> _listeners =
-            new List<MatchingNodeListener>();
+        private readonly List<INodeVisitor> _listeners =
+            new List<INodeVisitor>();
+
+        public EnterLeaveListener()
+        {
+
+        }
 
         public EnterLeaveListener(Action<EnterLeaveListener> configure)
         {
@@ -25,45 +21,27 @@ namespace GraphQL.Validation
 
         void INodeVisitor.Enter(INode node)
         {
-            _listeners
-                .Where(l => l.Enter != null && l.Matches(node))
-                .Apply(l => l.Enter(node));
+            foreach (var listener in _listeners)
+            {
+                listener.Enter(node);
+            }
         }
 
         void INodeVisitor.Leave(INode node)
         {
-            _listeners
-                .Where(l => l.Leave != null && l.Matches(node))
-                .Apply(l => l.Leave(node));
+            // Shouldn't this be done in reverse?
+            foreach (var listener in _listeners)
+            {
+                listener.Leave(node);
+            }
         }
 
-        public void Match<T>(
-            Action<T> enter = null,
-            Action<T> leave = null)
-            where T : INode
+        public void Match<TNode>(
+            Action<TNode> enter = null,
+            Action<TNode> leave = null)
+            where TNode : INode
         {
-            if (enter == null && leave == null)
-            {
-                throw new ExecutionError("Must provide an enter or leave function.");
-            }
-
-            Func<INode, bool> matches = n => n.GetType().IsAssignableFrom(typeof(T));
-
-            var listener = new MatchingNodeListener
-            {
-                Matches = matches
-            };
-
-            if (enter != null)
-            {
-                listener.Enter = n => enter((T) n);
-            }
-
-            if (leave != null)
-            {
-                listener.Leave = n => leave((T) n);
-            }
-
+            var listener = new MatchingNodeVisitor<TNode>(enter, leave);
             _listeners.Add(listener);
         }
     }

--- a/src/GraphQL/Validation/MatchingNodeVisitor.cs
+++ b/src/GraphQL/Validation/MatchingNodeVisitor.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using GraphQL.Language.AST;
+
+namespace GraphQL.Validation
+{
+    public class MatchingNodeVisitor<TNode> : INodeVisitor
+        where TNode : INode
+    {
+        private readonly Action<TNode> _enter;
+        private readonly Action<TNode> _leave;
+
+        public MatchingNodeVisitor(Action<TNode> enter = null, Action<TNode> leave = null)
+        {
+            if (enter == null && leave == null)
+            {
+                throw new ExecutionError("Must provide an enter or leave function.");
+            }
+
+            _enter = enter;
+            _leave = leave;
+        }
+
+        void INodeVisitor.Enter(INode node)
+        {
+            if (_enter != null && node is TNode n)
+            {
+                _enter(n);
+            }
+        }
+
+        void INodeVisitor.Leave(INode node)
+        {
+            if (_leave != null && node is TNode n)
+            {
+                _leave(n);
+            }
+        }
+    }
+}

--- a/src/GraphQL/Validation/Rules/NoFragmentCycles.cs
+++ b/src/GraphQL/Validation/Rules/NoFragmentCycles.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Language.AST;
 
@@ -49,8 +49,8 @@ namespace GraphQL.Validation.Rules
             var fragmentName = fragment.Name;
             visitedFrags[fragmentName] = true;
 
-            var spreadNodes = context.GetFragmentSpreads(fragment.SelectionSet).ToArray();
-            if (!spreadNodes.Any())
+            var spreadNodes = context.GetFragmentSpreads(fragment.SelectionSet);
+            if (spreadNodes.Count == 0)
             {
                 return;
             }

--- a/src/GraphQL/Validation/Rules/NoUndefinedVariables.cs
+++ b/src/GraphQL/Validation/Rules/NoUndefinedVariables.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using GraphQL.Language.AST;
 
@@ -29,8 +29,7 @@ namespace GraphQL.Validation.Rules
                     enter: op => variableNameDefined = new Dictionary<string, bool>(),
                     leave: op =>
                     {
-                        var usages = context.GetRecursiveVariables(op);
-                        usages.Apply(usage =>
+                        foreach (var usage in context.GetRecursiveVariables(op))
                         {
                             var varName = usage.Node.Name;
                             bool found;
@@ -44,7 +43,7 @@ namespace GraphQL.Validation.Rules
                                     op);
                                 context.ReportError(error);
                             }
-                        });
+                        }
                     });
             });
         }

--- a/src/GraphQL/Validation/Rules/NoUnusedVariables.cs
+++ b/src/GraphQL/Validation/Rules/NoUnusedVariables.cs
@@ -32,7 +32,9 @@ namespace GraphQL.Validation.Rules
                 enter: op => variableDefs = new List<VariableDefinition>(),
                 leave: op =>
                 {
-                    var usages = context.GetRecursiveVariables(op).Select(usage => usage.Node.Name);
+                    var usages = context.GetRecursiveVariables(op)
+                        .Select(usage => usage.Node.Name)
+                        .ToList();
 
                     foreach (var variableDef in variableDefs)
                     {

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Language.AST;
+using GraphQL.Language.AST;
 using GraphQL.Types;
 
 namespace GraphQL.Validation.Rules
@@ -29,12 +29,12 @@ namespace GraphQL.Validation.Rules
                 {
                     var fieldDef = context.TypeInfo.GetFieldDef();
 
-                    if (fieldDef == null)
+                    if (fieldDef == null || fieldDef.Arguments == null)
                     {
                         return;
                     }
 
-                    fieldDef.Arguments?.Apply(arg =>
+                    foreach (var arg in fieldDef.Arguments)
                     {
                         var argAst = node.Arguments?.ValueFor(arg.Name);
                         var type = arg.ResolvedType;
@@ -48,19 +48,19 @@ namespace GraphQL.Validation.Rules
                                     MissingFieldArgMessage(node.Name, arg.Name, context.Print(type)),
                                     node));
                         }
-                    });
+                    }
                 });
 
                 _.Match<Directive>(leave: node =>
                 {
                     var directive = context.TypeInfo.GetDirective();
 
-                    if (directive == null)
+                    if (directive == null || directive.Arguments == null)
                     {
                         return;
                     }
 
-                    directive.Arguments?.Apply(arg =>
+                    foreach (var arg in directive.Arguments)
                     {
                         var argAst = node.Arguments?.ValueFor(arg.Name);
                         var type = arg.ResolvedType;
@@ -74,7 +74,7 @@ namespace GraphQL.Validation.Rules
                                     MissingDirectiveArgMessage(node.Name, arg.Name, context.Print(type)),
                                     node));
                         }
-                    });
+                    }
                 });
             });
         }

--- a/src/GraphQL/Validation/Rules/ScalarLeafs.cs
+++ b/src/GraphQL/Validation/Rules/ScalarLeafs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using GraphQL.Types;
 using System.Linq;
 using GraphQL.Language.AST;
@@ -36,13 +36,13 @@ namespace GraphQL.Validation.Rules
 
             if (type.IsLeafType())
             {
-                if (field.SelectionSet != null && field.SelectionSet.Selections.Any())
+                if (field.SelectionSet != null && field.SelectionSet.Selections.Count > 0)
                 {
                     var error = new ValidationError(context.OriginalQuery, "5.2.3", NoSubselectionAllowedMessage(field.Name, context.Print(type)), field.SelectionSet);
                     context.ReportError(error);
                 }
             }
-            else if(field.SelectionSet == null || !field.SelectionSet.Selections.Any())
+            else if(field.SelectionSet == null || field.SelectionSet.Selections.Count == 0)
             {
                 var error = new ValidationError(context.OriginalQuery, "5.2.3", RequiredSubselectionMessage(field.Name, context.Print(type)), field);
                 context.ReportError(error);

--- a/src/GraphQL/Validation/Rules/UniqueArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueArgumentNames.cs
@@ -1,42 +1,42 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using GraphQL.Language.AST;
 
 namespace GraphQL.Validation.Rules
 {
     public class UniqueArgumentNames : IValidationRule
-  {
-    public string DuplicateArgMessage(string argName)
     {
-      return $"There can be only one argument named \"{argName}\".";
-    }
-
-    public INodeVisitor Validate(ValidationContext context)
-    {
-      var knownArgs = new Dictionary<string, Argument>();
-
-      return new EnterLeaveListener(_ =>
-      {
-        _.Match<Field>(field => knownArgs = new Dictionary<string, Argument>());
-        _.Match<Directive>(field => knownArgs = new Dictionary<string, Argument>());
-
-        _.Match<Argument>(argument =>
+        public string DuplicateArgMessage(string argName)
         {
-          var argName = argument.Name;
-          if (knownArgs.ContainsKey(argName))
-          {
-              var error = new ValidationError(context.OriginalQuery,
-                  "5.3.2",
-                  DuplicateArgMessage(argName),
-                  knownArgs[argName],
-                  argument);
-            context.ReportError(error);
-          }
-          else
-          {
-            knownArgs[argName] = argument;
-          }
-        });
-      });
+            return $"There can be only one argument named \"{argName}\".";
+        }
+
+        public INodeVisitor Validate(ValidationContext context)
+        {
+            var knownArgs = new Dictionary<string, Argument>();
+
+            return new EnterLeaveListener(_ =>
+            {
+                _.Match<Field>(__ => knownArgs = new Dictionary<string, Argument>());
+                _.Match<Directive>(__ => knownArgs = new Dictionary<string, Argument>());
+
+                _.Match<Argument>(argument =>
+                {
+                    var argName = argument.Name;
+                    if (knownArgs.ContainsKey(argName))
+                    {
+                        var error = new ValidationError(context.OriginalQuery,
+                            "5.3.2",
+                            DuplicateArgMessage(argName),
+                            knownArgs[argName],
+                            argument);
+                        context.ReportError(error);
+                    }
+                    else
+                    {
+                        knownArgs[argName] = argument;
+                    }
+                });
+            });
+        }
     }
-  }
 }

--- a/src/GraphQL/Validation/Rules/UniqueDirectivesPerLocation.cs
+++ b/src/GraphQL/Validation/Rules/UniqueDirectivesPerLocation.cs
@@ -49,10 +49,13 @@ namespace GraphQL.Validation.Rules
 
         private void CheckDirectives(ValidationContext context, Directives directives)
         {
-            if (directives == null)
+            if (directives == null || directives.Count == 0)
                 return;
 
-            var knownDirectives = new Dictionary<string, Directive>();
+            if (!directives.HasDuplicates)
+                return;
+
+            var knownDirectives = new Dictionary<string, Directive>(directives.Count);
 
             foreach (var directive in directives)
             {
@@ -64,6 +67,7 @@ namespace GraphQL.Validation.Rules
                         DuplicateDirectiveMessage(directive.Name),
                         knownDirectives[directive.Name],
                         directive);
+
                     context.ReportError(error);
                 }
                 else

--- a/src/GraphQL/Validation/Rules/UniqueDirectivesPerLocation.cs
+++ b/src/GraphQL/Validation/Rules/UniqueDirectivesPerLocation.cs
@@ -49,25 +49,28 @@ namespace GraphQL.Validation.Rules
 
         private void CheckDirectives(ValidationContext context, Directives directives)
         {
+            if (directives == null)
+                return;
+
             var knownDirectives = new Dictionary<string, Directive>();
-            directives?.Apply(directive =>
+
+            foreach (var directive in directives)
             {
-                var directiveName = directive.Name;
-                if (knownDirectives.ContainsKey(directiveName))
+                if (knownDirectives.ContainsKey(directive.Name))
                 {
                     var error = new ValidationError(
                         context.OriginalQuery,
                         "5.6.3",
-                        DuplicateDirectiveMessage(directiveName),
-                        knownDirectives[directiveName],
+                        DuplicateDirectiveMessage(directive.Name),
+                        knownDirectives[directive.Name],
                         directive);
                     context.ReportError(error);
                 }
                 else
                 {
-                    knownDirectives[directiveName] = directive;
+                    knownDirectives[directive.Name] = directive;
                 }
-            });
+            }
         }
     }
 }

--- a/src/GraphQL/Validation/Rules/UniqueOperationNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueOperationNames.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using GraphQL.Language.AST;
 
@@ -16,7 +16,7 @@ namespace GraphQL.Validation.Rules
 
         public INodeVisitor Validate(ValidationContext context)
         {
-            var frequency = new Dictionary<string, string>();
+            var frequency = new HashSet<string>();
 
             return new EnterLeaveListener(_ =>
             {
@@ -32,7 +32,7 @@ namespace GraphQL.Validation.Rules
                             return;
                         }
 
-                        if (frequency.ContainsKey(op.Name))
+                        if (!frequency.Add(op.Name))
                         {
                             var error = new ValidationError(
                                 context.OriginalQuery,
@@ -40,10 +40,6 @@ namespace GraphQL.Validation.Rules
                                 DuplicateOperationNameMessage(op.Name),
                                 op);
                             context.ReportError(error);
-                        }
-                        else
-                        {
-                            frequency[op.Name] = op.Name;
                         }
                     });
             });

--- a/src/GraphQL/Validation/Rules/UniqueVariableNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueVariableNames.cs
@@ -9,39 +9,40 @@ namespace GraphQL.Validation.Rules
     /// A GraphQL operation is only valid if all its variables are uniquely named.
     /// </summary>
     public class UniqueVariableNames : IValidationRule
-  {
-    public string DuplicateVariableMessage(string variableName)
     {
-      return $"There can be only one variable named \"{variableName}\"";
-    }
-
-    public INodeVisitor Validate(ValidationContext context)
-    {
-      var knownVariables = new Dictionary<string, VariableDefinition>();
-
-      return new EnterLeaveListener(_ =>
-      {
-        _.Match<Operation>(op => knownVariables = new Dictionary<string, VariableDefinition>());
-
-        _.Match<VariableDefinition>(variableDefinition =>
+        public string DuplicateVariableMessage(string variableName)
         {
-          var variableName = variableDefinition.Name;
-          if (knownVariables.ContainsKey(variableName))
-          {
-              var error = new ValidationError(
-                  context.OriginalQuery,
-                  "5.7.1",
-                  DuplicateVariableMessage(variableName),
-                  knownVariables[variableName],
-                  variableDefinition);
-            context.ReportError(error);
-          }
-          else
-          {
-            knownVariables[variableName] = variableDefinition;
-          }
-        });
-      });
+            return $"There can be only one variable named \"{variableName}\"";
+        }
+
+        public INodeVisitor Validate(ValidationContext context)
+        {
+            Dictionary<string, VariableDefinition> knownVariables = null;
+
+            return new EnterLeaveListener(_ =>
+            {
+                _.Match<Operation>(__ => knownVariables = new Dictionary<string, VariableDefinition>());
+
+                _.Match<VariableDefinition>(variableDefinition =>
+                {
+                    var variableName = variableDefinition.Name;
+
+                    if (knownVariables.ContainsKey(variableName))
+                    {
+                        var error = new ValidationError(
+                            context.OriginalQuery,
+                            "5.7.1",
+                            DuplicateVariableMessage(variableName),
+                            knownVariables[variableName],
+                            variableDefinition);
+                        context.ReportError(error);
+                    }
+                    else
+                    {
+                        knownVariables[variableName] = variableDefinition;
+                    }
+                });
+            });
+        }
     }
-  }
 }

--- a/src/GraphQL/Validation/Rules/VariablesInAllowedPosition.cs
+++ b/src/GraphQL/Validation/Rules/VariablesInAllowedPosition.cs
@@ -30,8 +30,7 @@ namespace GraphQL.Validation.Rules
                     enter: op => varDefMap = new Dictionary<string, VariableDefinition>(),
                     leave: op =>
                     {
-                        var usages = context.GetRecursiveVariables(op);
-                        usages.Apply(usage =>
+                        foreach (var usage in context.GetRecursiveVariables(op))
                         {
                             var varName = usage.Node.Name;
                             if (!varDefMap.TryGetValue(varName, out var varDef))
@@ -60,7 +59,7 @@ namespace GraphQL.Validation.Rules
                                     context.ReportError(error);
                                 }
                             }
-                        });
+                        }
                     }
                 );
             });

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -29,22 +29,22 @@ namespace GraphQL.Validation
 
         public IGraphType GetLastType()
         {
-            return _typeStack.Any() ? _typeStack.Peek() : null;
+            return _typeStack.Count > 0 ? _typeStack.Peek() : null;
         }
 
         public IGraphType GetInputType()
         {
-            return _inputTypeStack.Any() ? _inputTypeStack.Peek() : null;
+            return _inputTypeStack.Count > 0 ? _inputTypeStack.Peek() : null;
         }
 
         public IGraphType GetParentType()
         {
-            return _parentTypeStack.Any() ? _parentTypeStack.Peek() : null;
+            return _parentTypeStack.Count > 0 ? _parentTypeStack.Peek() : null;
         }
 
         public FieldType GetFieldDef()
         {
-            return _fieldDefStack.Any() ? _fieldDefStack.Peek() : null;
+            return _fieldDefStack.Count > 0 ? _fieldDefStack.Peek() : null;
         }
 
         public DirectiveGraphType GetDirective()


### PR DESCRIPTION
We were having performance issues with our GraphQL endpoint at my company. I started using a profiler to track down the issues. Most of the issues were with our code, not this library, but I also took a look at what could be improved in this library. 

I went through a lot of iterations with the profiler and ended up improving a lot things:

* Replace calls to `Apply()` extension method with `foreach`. It was bad for perfomance in some places particularly when they were nested and closures were being created
* Similarly with `Map()` and `Fill()`
* Refactor `EnterLeaveListener` to create generic `MatchingNodeVisitor`. Use `is` to check type, rather than reflection
* Change calls to `Any()` to use `Count` property when possible
* Change calls to  `FirstOrDefault()` to use `Find()` on `List<T>`
* Create lists and dictionaries with an initial capacity where possible
* Use pattern matching rather than `is` + cast
* Add a Dictionary to `Directives` class for faster lookups
* Expose `SelectionSet.Selections` as `IList<ISelection>` to allow access to the `Count`
* In `ExpressionFieldResolver`, avoid creating a new `ResolveFieldContext<TSourceType>` and just cast the `Source`
* Avoid creating nested `Task`s in `MiddlewareResolver.Resolve()`
* Simplify code to retrieve `Task<TResult>.Result` when `TResult` is not known
* Improve performance of `NameFieldResolver` by creating and caching delegates

These are executions times for some of the "benchmark" unit tests before and after:

| Test | Before | After |
|------|------|-------|
| Executes_StarWarsBasicQuery_Performant	|	4,134ms|		2,311ms|
| Executes_MultipleProperties_Are_Performant	|6,639ms|		5,260ms|
| Executes_UnionLists_Are_Performant		|	6,208ms|		5,215ms|
| Executes_SimpleLists_Are_Performant		|	890ms|		844ms|