### PR TITLE
Implemented #798: IDocumentWriter - added support writing to response stream directly.

### DIFF
--- a/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
+++ b/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
@@ -74,8 +74,8 @@ namespace GraphQL.DataLoader.Tests
                 opts.ExposeExceptions = true;
             }));
 
-            var writtenResult = writer.Write(runResult);
-            var expectedResult = writer.Write(expectedExecutionResult);
+            var writtenResult = AsyncContext.Run(() => writer.WriteToStringAsync(runResult));
+            var expectedResult = AsyncContext.Run(() => writer.WriteToStringAsync(expectedExecutionResult));
 
             string additionalInfo = null;
 

--- a/src/GraphQL.Harness.Tests/SuccessResultAssertion.cs
+++ b/src/GraphQL.Harness.Tests/SuccessResultAssertion.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Harness.Tests
         public override void Assert(Scenario scenario, ScenarioAssertionException ex)
         {
             var writer = (IDocumentWriter)scenario.Context.RequestServices.GetService(typeof(IDocumentWriter));
-            var expectedResult = writer.Write(CreateQueryResult(_result));
+            var expectedResult = writer.WriteToStringAsync(CreateQueryResult(_result)).GetAwaiter().GetResult();
 
             var body = ex.ReadBody(scenario);
             if (!body.Equals(expectedResult))

--- a/src/GraphQL.Harness/GraphQLMiddleware.cs
+++ b/src/GraphQL.Harness/GraphQLMiddleware.cs
@@ -65,12 +65,10 @@ namespace Example
 
         private async Task WriteResponseAsync(HttpContext context, ExecutionResult result)
         {
-            var json = _writer.Write(result);
-
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = result.Errors?.Any() == true ? (int)HttpStatusCode.BadRequest : (int)HttpStatusCode.OK;
 
-            await context.Response.WriteAsync(json);
+            await _writer.WriteAsync(context.Response.Body, result);
         }
 
         public static T Deserialize<T>(Stream s)

--- a/src/GraphQL.Tests/BasicQueryTestBase.cs
+++ b/src/GraphQL.Tests/BasicQueryTestBase.cs
@@ -40,8 +40,8 @@ namespace GraphQL.Tests
         {
             var runResult = Executer.ExecuteAsync(options).Result;
 
-            var writtenResult = Writer.Write(runResult);
-            var expectedResult = Writer.Write(expectedExecutionResult);
+            var writtenResult = Writer.WriteToStringAsync(runResult).Result;
+            var expectedResult = Writer.WriteToStringAsync(expectedExecutionResult).Result;
 
 //#if DEBUG
 //            Console.WriteLine(writtenResult);
@@ -82,8 +82,8 @@ namespace GraphQL.Tests
                 _.ValidationRules = rules;
             }).GetAwaiter().GetResult();
 
-            var writtenResult = Writer.Write(runResult);
-            var expectedResult = Writer.Write(expectedExecutionResult);
+            var writtenResult = Writer.WriteToStringAsync(runResult).GetAwaiter().GetResult();
+            var expectedResult = Writer.WriteToStringAsync(expectedExecutionResult).GetAwaiter().GetResult();
 
 //#if DEBUG
 //            Console.WriteLine(writtenResult);

--- a/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
+++ b/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
@@ -4,134 +4,254 @@ namespace GraphQL.Tests.Introspection
     {
         public static readonly string Data =
 @"{
-  ""__schema"": {
-    ""queryType"": null,
-    ""mutationType"": null,
-    ""subscriptionType"": null,
-    ""types"": [
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""String"",
-        ""description"": null,
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""Boolean"",
-        ""description"": null,
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""Float"",
-        ""description"": null,
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""Int"",
-        ""description"": null,
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""ID"",
-        ""description"": null,
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""Date"",
-        ""description"": ""The `Date` scalar type represents a year, month and day in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard."",
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""DateTime"",
-        ""description"": ""The `DateTime` scalar type represents a date and time. `DateTime` expects timestamps to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard."",
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""DateTimeOffset"",
-        ""description"": ""The `DateTimeOffset` scalar type represents a date, time and offset from UTC. `DateTimeOffset` expects timestamps to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard."",
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""Seconds"",
-        ""description"": ""The `Seconds` scalar type represents a period of time represented as the total number of seconds."",
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""Milliseconds"",
-        ""description"": ""The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds."",
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""SCALAR"",
-        ""name"": ""Decimal"",
-        ""description"": null,
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""OBJECT"",
-        ""name"": ""__Schema"",
-        ""description"": ""A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."",
-        ""fields"": [
-          {
-            ""name"": ""directives"",
-            ""description"": ""A list of all directives supported by this server."",
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+  ""data"": {
+    ""__schema"": {
+      ""queryType"": null,
+      ""mutationType"": null,
+      ""subscriptionType"": null,
+      ""types"": [
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""String"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Boolean"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Float"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Int"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""ID"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Date"",
+          ""description"": ""The `Date` scalar type represents a year, month and day in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard."",
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""DateTime"",
+          ""description"": ""The `DateTime` scalar type represents a date and time. `DateTime` expects timestamps to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard."",
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""DateTimeOffset"",
+          ""description"": ""The `DateTimeOffset` scalar type represents a date, time and offset from UTC. `DateTimeOffset` expects timestamps to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard."",
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Seconds"",
+          ""description"": ""The `Seconds` scalar type represents a period of time represented as the total number of seconds."",
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Milliseconds"",
+          ""description"": ""The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds."",
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Decimal"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""OBJECT"",
+          ""name"": ""__Schema"",
+          ""description"": ""A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."",
+          ""fields"": [
+            {
+              ""name"": ""directives"",
+              ""description"": ""A list of all directives supported by this server."",
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""LIST"",
+                  ""name"": null,
+                  ""ofType"": {
+                    ""kind"": ""NON_NULL"",
+                    ""name"": null,
+                    ""ofType"": {
+                      ""kind"": ""OBJECT"",
+                      ""name"": ""__Directive"",
+                      ""ofType"": null
+                    }
+                  }
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""mutationType"",
+              ""description"": ""If this server supports mutation, the type that mutation operations will be rooted at."",
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""OBJECT"",
+                ""name"": ""__Type"",
+                ""ofType"": null
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""queryType"",
+              ""description"": ""The type that query operations will be rooted at."",
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""OBJECT"",
+                  ""name"": ""__Type"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""subscriptionType"",
+              ""description"": ""If this server supports subscription, the type that subscription operations will be rooted at."",
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""OBJECT"",
+                ""name"": ""__Type"",
+                ""ofType"": null
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""types"",
+              ""description"": ""A list of all types supported by this server."",
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""LIST"",
+                  ""name"": null,
+                  ""ofType"": {
+                    ""kind"": ""NON_NULL"",
+                    ""name"": null,
+                    ""ofType"": {
+                      ""kind"": ""OBJECT"",
+                      ""name"": ""__Type"",
+                      ""ofType"": null
+                    }
+                  }
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            }
+          ],
+          ""inputFields"": null,
+          ""interfaces"": [],
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""OBJECT"",
+          ""name"": ""__Type"",
+          ""description"": ""The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\r\n\r\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types."",
+          ""fields"": [
+            {
+              ""name"": ""description"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""SCALAR"",
+                ""name"": ""String"",
+                ""ofType"": null
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""enumValues"",
+              ""description"": null,
+              ""args"": [
+                {
+                  ""name"": ""includeDeprecated"",
+                  ""description"": null,
+                  ""type"": {
+                    ""kind"": ""SCALAR"",
+                    ""name"": ""Boolean"",
+                    ""ofType"": null
+                  },
+                  ""defaultValue"": ""false""
+                }
+              ],
+              ""type"": {
                 ""kind"": ""LIST"",
                 ""name"": null,
                 ""ofType"": {
@@ -139,63 +259,70 @@ namespace GraphQL.Tests.Introspection
                   ""name"": null,
                   ""ofType"": {
                     ""kind"": ""OBJECT"",
-                    ""name"": ""__Directive"",
+                    ""name"": ""__EnumValue"",
                     ""ofType"": null
                   }
                 }
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""mutationType"",
-            ""description"": ""If this server supports mutation, the type that mutation operations will be rooted at."",
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""OBJECT"",
-              ""name"": ""__Type"",
-              ""ofType"": null
+            {
+              ""name"": ""fields"",
+              ""description"": null,
+              ""args"": [
+                {
+                  ""name"": ""includeDeprecated"",
+                  ""description"": null,
+                  ""type"": {
+                    ""kind"": ""SCALAR"",
+                    ""name"": ""Boolean"",
+                    ""ofType"": null
+                  },
+                  ""defaultValue"": ""false""
+                }
+              ],
+              ""type"": {
+                ""kind"": ""LIST"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""NON_NULL"",
+                  ""name"": null,
+                  ""ofType"": {
+                    ""kind"": ""OBJECT"",
+                    ""name"": ""__Field"",
+                    ""ofType"": null
+                  }
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""queryType"",
-            ""description"": ""The type that query operations will be rooted at."",
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""OBJECT"",
-                ""name"": ""__Type"",
-                ""ofType"": null
-              }
+            {
+              ""name"": ""inputFields"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""LIST"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""NON_NULL"",
+                  ""name"": null,
+                  ""ofType"": {
+                    ""kind"": ""OBJECT"",
+                    ""name"": ""__InputValue"",
+                    ""ofType"": null
+                  }
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""subscriptionType"",
-            ""description"": ""If this server supports subscription, the type that subscription operations will be rooted at."",
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""OBJECT"",
-              ""name"": ""__Type"",
-              ""ofType"": null
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""types"",
-            ""description"": ""A list of all types supported by this server."",
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""interfaces"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""LIST"",
                 ""name"": null,
                 ""ofType"": {
@@ -207,274 +334,55 @@ namespace GraphQL.Tests.Introspection
                     ""ofType"": null
                   }
                 }
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          }
-        ],
-        ""inputFields"": null,
-        ""interfaces"": [],
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""OBJECT"",
-        ""name"": ""__Type"",
-        ""description"": ""The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\r\n\r\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types."",
-        ""fields"": [
-          {
-            ""name"": ""description"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""enumValues"",
-            ""description"": null,
-            ""args"": [
-              {
-                ""name"": ""includeDeprecated"",
-                ""description"": null,
-                ""type"": {
-                  ""kind"": ""SCALAR"",
-                  ""name"": ""Boolean"",
-                  ""ofType"": null
-                },
-                ""defaultValue"": ""false""
-              }
-            ],
-            ""type"": {
-              ""kind"": ""LIST"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""kind"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""NON_NULL"",
                 ""name"": null,
                 ""ofType"": {
-                  ""kind"": ""OBJECT"",
-                  ""name"": ""__EnumValue"",
+                  ""kind"": ""ENUM"",
+                  ""name"": ""__TypeKind"",
                   ""ofType"": null
                 }
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""fields"",
-            ""description"": null,
-            ""args"": [
-              {
-                ""name"": ""includeDeprecated"",
-                ""description"": null,
-                ""type"": {
-                  ""kind"": ""SCALAR"",
-                  ""name"": ""Boolean"",
-                  ""ofType"": null
-                },
-                ""defaultValue"": ""false""
-              }
-            ],
-            ""type"": {
-              ""kind"": ""LIST"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""NON_NULL"",
-                ""name"": null,
-                ""ofType"": {
-                  ""kind"": ""OBJECT"",
-                  ""name"": ""__Field"",
-                  ""ofType"": null
-                }
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""inputFields"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""LIST"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""NON_NULL"",
-                ""name"": null,
-                ""ofType"": {
-                  ""kind"": ""OBJECT"",
-                  ""name"": ""__InputValue"",
-                  ""ofType"": null
-                }
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""interfaces"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""LIST"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""NON_NULL"",
-                ""name"": null,
-                ""ofType"": {
-                  ""kind"": ""OBJECT"",
-                  ""name"": ""__Type"",
-                  ""ofType"": null
-                }
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""kind"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""ENUM"",
-                ""name"": ""__TypeKind"",
+            {
+              ""name"": ""name"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""SCALAR"",
+                ""name"": ""String"",
                 ""ofType"": null
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""name"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
+            {
+              ""name"": ""ofType"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""OBJECT"",
+                ""name"": ""__Type"",
+                ""ofType"": null
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""ofType"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""OBJECT"",
-              ""name"": ""__Type"",
-              ""ofType"": null
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""possibleTypes"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""LIST"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""NON_NULL"",
-                ""name"": null,
-                ""ofType"": {
-                  ""kind"": ""OBJECT"",
-                  ""name"": ""__Type"",
-                  ""ofType"": null
-                }
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          }
-        ],
-        ""inputFields"": null,
-        ""interfaces"": [],
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""ENUM"",
-        ""name"": ""__TypeKind"",
-        ""description"": ""An enum describing what kind of type a given __Type is."",
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": [
-          {
-            ""name"": ""SCALAR"",
-            ""description"": ""Indicates this type is a scalar."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""OBJECT"",
-            ""description"": ""Indicates this type is an object.  `fields` and `possibleTypes` are valid fields."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""INTERFACE"",
-            ""description"": ""Indicates this type is an interface.  `fields` and `possibleTypes` are valid fields."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""UNION"",
-            ""description"": ""Indicates this type is a union.  `possibleTypes` is a valid field."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""ENUM"",
-            ""description"": ""Indicates this type is an num.  `enumValues` is a valid field."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""INPUT_OBJECT"",
-            ""description"": ""Indicates this type is an input object.  `inputFields` is a valid field."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""LIST"",
-            ""description"": ""Indicates this type is a list.  `ofType` is a valid field."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""NON_NULL"",
-            ""description"": ""Indicates this type is a non-null.  `ofType` is a valid field."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          }
-        ],
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""OBJECT"",
-        ""name"": ""__Field"",
-        ""description"": ""Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type."",
-        ""fields"": [
-          {
-            ""name"": ""args"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""possibleTypes"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""LIST"",
                 ""name"": null,
                 ""ofType"": {
@@ -482,555 +390,664 @@ namespace GraphQL.Tests.Introspection
                   ""name"": null,
                   ""ofType"": {
                     ""kind"": ""OBJECT"",
-                    ""name"": ""__InputValue"",
+                    ""name"": ""__Type"",
                     ""ofType"": null
                   }
                 }
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            }
+          ],
+          ""inputFields"": null,
+          ""interfaces"": [],
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""ENUM"",
+          ""name"": ""__TypeKind"",
+          ""description"": ""An enum describing what kind of type a given __Type is."",
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": [
+            {
+              ""name"": ""SCALAR"",
+              ""description"": ""Indicates this type is a scalar."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""deprecationReason"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
+            {
+              ""name"": ""OBJECT"",
+              ""description"": ""Indicates this type is an object.  `fields` and `possibleTypes` are valid fields."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""description"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
+            {
+              ""name"": ""INTERFACE"",
+              ""description"": ""Indicates this type is an interface.  `fields` and `possibleTypes` are valid fields."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""isDeprecated"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""SCALAR"",
-                ""name"": ""Boolean"",
-                ""ofType"": null
-              }
+            {
+              ""name"": ""UNION"",
+              ""description"": ""Indicates this type is a union.  `possibleTypes` is a valid field."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""name"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""SCALAR"",
-                ""name"": ""String"",
-                ""ofType"": null
-              }
+            {
+              ""name"": ""ENUM"",
+              ""description"": ""Indicates this type is an num.  `enumValues` is a valid field."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""type"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""OBJECT"",
-                ""name"": ""__Type"",
-                ""ofType"": null
-              }
+            {
+              ""name"": ""INPUT_OBJECT"",
+              ""description"": ""Indicates this type is an input object.  `inputFields` is a valid field."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          }
-        ],
-        ""inputFields"": null,
-        ""interfaces"": [],
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""OBJECT"",
-        ""name"": ""__InputValue"",
-        ""description"": ""Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value."",
-        ""fields"": [
-          {
-            ""name"": ""defaultValue"",
-            ""description"": ""A GraphQL-formatted string representing the default value for this input value."",
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
+            {
+              ""name"": ""LIST"",
+              ""description"": ""Indicates this type is a list.  `ofType` is a valid field."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""description"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""name"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""SCALAR"",
-                ""name"": ""String"",
-                ""ofType"": null
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""type"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""OBJECT"",
-                ""name"": ""__Type"",
-                ""ofType"": null
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          }
-        ],
-        ""inputFields"": null,
-        ""interfaces"": [],
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""OBJECT"",
-        ""name"": ""__EnumValue"",
-        ""description"": ""One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string."",
-        ""fields"": [
-          {
-            ""name"": ""deprecationReason"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""description"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""isDeprecated"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""SCALAR"",
-                ""name"": ""String"",
-                ""ofType"": null
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""name"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""SCALAR"",
-                ""name"": ""String"",
-                ""ofType"": null
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          }
-        ],
-        ""inputFields"": null,
-        ""interfaces"": [],
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""OBJECT"",
-        ""name"": ""__Directive"",
-        ""description"": ""A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\r\n\r\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor."",
-        ""fields"": [
-          {
-            ""name"": ""args"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""LIST"",
+            {
+              ""name"": ""NON_NULL"",
+              ""description"": ""Indicates this type is a non-null.  `ofType` is a valid field."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            }
+          ],
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""OBJECT"",
+          ""name"": ""__Field"",
+          ""description"": ""Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type."",
+          ""fields"": [
+            {
+              ""name"": ""args"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
                 ""name"": null,
                 ""ofType"": {
-                  ""kind"": ""NON_NULL"",
+                  ""kind"": ""LIST"",
                   ""name"": null,
                   ""ofType"": {
-                    ""kind"": ""OBJECT"",
-                    ""name"": ""__InputValue"",
-                    ""ofType"": null
+                    ""kind"": ""NON_NULL"",
+                    ""name"": null,
+                    ""ofType"": {
+                      ""kind"": ""OBJECT"",
+                      ""name"": ""__InputValue"",
+                      ""ofType"": null
+                    }
                   }
                 }
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""description"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""locations"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
-                ""kind"": ""LIST"",
-                ""name"": null,
-                ""ofType"": {
-                  ""kind"": ""NON_NULL"",
-                  ""name"": null,
-                  ""ofType"": {
-                    ""kind"": ""ENUM"",
-                    ""name"": ""__DirectiveLocation"",
-                    ""ofType"": null
-                  }
-                }
-              }
-            },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""name"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""deprecationReason"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""SCALAR"",
                 ""name"": ""String"",
                 ""ofType"": null
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""onField"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""description"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""SCALAR"",
-                ""name"": ""Boolean"",
+                ""name"": ""String"",
                 ""ofType"": null
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": true,
-            ""deprecationReason"": ""Use 'locations'.""
-          },
-          {
-            ""name"": ""onFragment"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""isDeprecated"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""Boolean"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""name"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""String"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""type"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""OBJECT"",
+                  ""name"": ""__Type"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            }
+          ],
+          ""inputFields"": null,
+          ""interfaces"": [],
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""OBJECT"",
+          ""name"": ""__InputValue"",
+          ""description"": ""Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value."",
+          ""fields"": [
+            {
+              ""name"": ""defaultValue"",
+              ""description"": ""A GraphQL-formatted string representing the default value for this input value."",
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""SCALAR"",
-                ""name"": ""Boolean"",
+                ""name"": ""String"",
                 ""ofType"": null
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": true,
-            ""deprecationReason"": ""Use 'locations'.""
-          },
-          {
-            ""name"": ""onOperation"",
-            ""description"": null,
-            ""args"": [],
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""description"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""SCALAR"",
-                ""name"": ""Boolean"",
+                ""name"": ""String"",
                 ""ofType"": null
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""isDeprecated"": true,
-            ""deprecationReason"": ""Use 'locations'.""
-          }
-        ],
-        ""inputFields"": null,
-        ""interfaces"": [],
-        ""enumValues"": null,
-        ""possibleTypes"": null
-      },
-      {
-        ""kind"": ""ENUM"",
-        ""name"": ""__DirectiveLocation"",
-        ""description"": ""A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies."",
-        ""fields"": null,
-        ""inputFields"": null,
-        ""interfaces"": null,
-        ""enumValues"": [
-          {
-            ""name"": ""QUERY"",
-            ""description"": ""Location adjacent to a query operation."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""MUTATION"",
-            ""description"": ""Location adjacent to a mutation operation."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""SUBSCRIPTION"",
-            ""description"": ""Location adjacent to a subscription operation."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""FIELD"",
-            ""description"": ""Location adjacent to a field."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""FRAGMENT_DEFINITION"",
-            ""description"": ""Location adjacent to a fragment definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""FRAGMENT_SPREAD"",
-            ""description"": ""Location adjacent to a fragment spread."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""INLINE_FRAGMENT"",
-            ""description"": ""Location adjacent to an inline fragment."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""SCHEMA"",
-            ""description"": ""Location adjacent to a schema definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""SCALAR"",
-            ""description"": ""Location adjacent to a scalar definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""OBJECT"",
-            ""description"": ""Location adjacent to an object type definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""FIELD_DEFINITION"",
-            ""description"": ""Location adjacent to a field definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""ARGUMENT_DEFINITION"",
-            ""description"": ""Location adjacent to an argument definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""INTERFACE"",
-            ""description"": ""Location adjacent to an interface definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""UNION"",
-            ""description"": ""Location adjacent to a union definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""ENUM"",
-            ""description"": ""Location adjacent to an enum definition"",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""ENUM_VALUE"",
-            ""description"": ""Location adjacent to an enum value definition"",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""INPUT_OBJECT"",
-            ""description"": ""Location adjacent to an input object type definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          },
-          {
-            ""name"": ""INPUT_FIELD_DEFINITION"",
-            ""description"": ""Location adjacent to an input object field definition."",
-            ""isDeprecated"": false,
-            ""deprecationReason"": null
-          }
-        ],
-        ""possibleTypes"": null
-      }
-    ],
-    ""directives"": [
-      {
-        ""name"": ""include"",
-        ""description"": ""Directs the executor to include this field or fragment only when the 'if' argument is true."",
-        ""locations"": [
-          ""FIELD"",
-          ""FRAGMENT_SPREAD"",
-          ""INLINE_FRAGMENT""
-        ],
-        ""args"": [
-          {
-            ""name"": ""if"",
-            ""description"": ""Included when true."",
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""name"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""String"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""type"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""OBJECT"",
+                  ""name"": ""__Type"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            }
+          ],
+          ""inputFields"": null,
+          ""interfaces"": [],
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""OBJECT"",
+          ""name"": ""__EnumValue"",
+          ""description"": ""One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string."",
+          ""fields"": [
+            {
+              ""name"": ""deprecationReason"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""SCALAR"",
-                ""name"": ""Boolean"",
+                ""name"": ""String"",
                 ""ofType"": null
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""defaultValue"": ""null""
-          }
-        ]
-      },
-      {
-        ""name"": ""skip"",
-        ""description"": ""Directs the executor to skip this field or fragment when the 'if' argument is true."",
-        ""locations"": [
-          ""FIELD"",
-          ""FRAGMENT_SPREAD"",
-          ""INLINE_FRAGMENT""
-        ],
-        ""args"": [
-          {
-            ""name"": ""if"",
-            ""description"": ""Skipped when true."",
-            ""type"": {
-              ""kind"": ""NON_NULL"",
-              ""name"": null,
-              ""ofType"": {
+            {
+              ""name"": ""description"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
                 ""kind"": ""SCALAR"",
-                ""name"": ""Boolean"",
+                ""name"": ""String"",
                 ""ofType"": null
-              }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""defaultValue"": ""null""
-          }
-        ]
-      },
-      {
-        ""name"": ""deprecated"",
-        ""description"": ""Marks an element of a GraphQL schema as no longer supported."",
-        ""locations"": [
-          ""FIELD_DEFINITION"",
-          ""ENUM_VALUE""
-        ],
-        ""args"": [
-          {
-            ""name"": ""reason"",
-            ""description"": ""Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/)."",
-            ""type"": {
-              ""kind"": ""SCALAR"",
-              ""name"": ""String"",
-              ""ofType"": null
+            {
+              ""name"": ""isDeprecated"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""String"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
             },
-            ""defaultValue"": ""\""No longer supported\""""
-          }
-        ]
-      }
-    ]
-  }
+            {
+              ""name"": ""name"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""String"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            }
+          ],
+          ""inputFields"": null,
+          ""interfaces"": [],
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""OBJECT"",
+          ""name"": ""__Directive"",
+          ""description"": ""A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\r\n\r\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor."",
+          ""fields"": [
+            {
+              ""name"": ""args"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""LIST"",
+                  ""name"": null,
+                  ""ofType"": {
+                    ""kind"": ""NON_NULL"",
+                    ""name"": null,
+                    ""ofType"": {
+                      ""kind"": ""OBJECT"",
+                      ""name"": ""__InputValue"",
+                      ""ofType"": null
+                    }
+                  }
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""description"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""SCALAR"",
+                ""name"": ""String"",
+                ""ofType"": null
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""locations"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""LIST"",
+                  ""name"": null,
+                  ""ofType"": {
+                    ""kind"": ""NON_NULL"",
+                    ""name"": null,
+                    ""ofType"": {
+                      ""kind"": ""ENUM"",
+                      ""name"": ""__DirectiveLocation"",
+                      ""ofType"": null
+                    }
+                  }
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""name"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""String"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""onField"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""Boolean"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": true,
+              ""deprecationReason"": ""Use 'locations'.""
+            },
+            {
+              ""name"": ""onFragment"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""Boolean"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": true,
+              ""deprecationReason"": ""Use 'locations'.""
+            },
+            {
+              ""name"": ""onOperation"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""Boolean"",
+                  ""ofType"": null
+                }
+              },
+              ""isDeprecated"": true,
+              ""deprecationReason"": ""Use 'locations'.""
+            }
+          ],
+          ""inputFields"": null,
+          ""interfaces"": [],
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""ENUM"",
+          ""name"": ""__DirectiveLocation"",
+          ""description"": ""A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies."",
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": [
+            {
+              ""name"": ""QUERY"",
+              ""description"": ""Location adjacent to a query operation."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""MUTATION"",
+              ""description"": ""Location adjacent to a mutation operation."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""SUBSCRIPTION"",
+              ""description"": ""Location adjacent to a subscription operation."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""FIELD"",
+              ""description"": ""Location adjacent to a field."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""FRAGMENT_DEFINITION"",
+              ""description"": ""Location adjacent to a fragment definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""FRAGMENT_SPREAD"",
+              ""description"": ""Location adjacent to a fragment spread."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""INLINE_FRAGMENT"",
+              ""description"": ""Location adjacent to an inline fragment."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""SCHEMA"",
+              ""description"": ""Location adjacent to a schema definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""SCALAR"",
+              ""description"": ""Location adjacent to a scalar definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""OBJECT"",
+              ""description"": ""Location adjacent to an object type definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""FIELD_DEFINITION"",
+              ""description"": ""Location adjacent to a field definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""ARGUMENT_DEFINITION"",
+              ""description"": ""Location adjacent to an argument definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""INTERFACE"",
+              ""description"": ""Location adjacent to an interface definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""UNION"",
+              ""description"": ""Location adjacent to a union definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""ENUM"",
+              ""description"": ""Location adjacent to an enum definition"",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""ENUM_VALUE"",
+              ""description"": ""Location adjacent to an enum value definition"",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""INPUT_OBJECT"",
+              ""description"": ""Location adjacent to an input object type definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
+            {
+              ""name"": ""INPUT_FIELD_DEFINITION"",
+              ""description"": ""Location adjacent to an input object field definition."",
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            }
+          ],
+          ""possibleTypes"": null
+        }
+      ],
+      ""directives"": [
+        {
+          ""name"": ""include"",
+          ""description"": ""Directs the executor to include this field or fragment only when the 'if' argument is true."",
+          ""locations"": [
+            ""FIELD"",
+            ""FRAGMENT_SPREAD"",
+            ""INLINE_FRAGMENT""
+          ],
+          ""args"": [
+            {
+              ""name"": ""if"",
+              ""description"": ""Included when true."",
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""Boolean"",
+                  ""ofType"": null
+                }
+              },
+              ""defaultValue"": ""null""
+            }
+          ]
+        },
+        {
+          ""name"": ""skip"",
+          ""description"": ""Directs the executor to skip this field or fragment when the 'if' argument is true."",
+          ""locations"": [
+            ""FIELD"",
+            ""FRAGMENT_SPREAD"",
+            ""INLINE_FRAGMENT""
+          ],
+          ""args"": [
+            {
+              ""name"": ""if"",
+              ""description"": ""Skipped when true."",
+              ""type"": {
+                ""kind"": ""NON_NULL"",
+                ""name"": null,
+                ""ofType"": {
+                  ""kind"": ""SCALAR"",
+                  ""name"": ""Boolean"",
+                  ""ofType"": null
+                }
+              },
+              ""defaultValue"": ""null""
+            }
+          ]
+        },
+        {
+          ""name"": ""deprecated"",
+          ""description"": ""Marks an element of a GraphQL schema as no longer supported."",
+          ""locations"": [
+            ""FIELD_DEFINITION"",
+            ""ENUM_VALUE""
+          ],
+          ""args"": [
+            {
+              ""name"": ""reason"",
+              ""description"": ""Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/)."",
+              ""type"": {
+                ""kind"": ""SCALAR"",
+                ""name"": ""String"",
+                ""ofType"": null
+              },
+              ""defaultValue"": ""\""No longer supported\""""
+            }
+          ]
+        }
+      ]
+    }
+  },
+  ""errors"": [
+    {
+      ""message"": ""Cannot return null for non-null type. Field: queryType, Type: __Type!."",
+      ""locations"": [
+        {
+          ""line"": 4,
+          ""column"": 7
+        }
+      ],
+      ""path"": [
+        ""__schema"",
+        ""queryType""
+      ]
+    }
+  ]
 }";
     }
 }

--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Tests.Introspection
                 _.Query = SchemaIntrospection.IntrospectionQuery;
             }).GetAwaiter().GetResult();
 
-            var json = new DocumentWriter(true).Write(executionResult.Data);
+            var json = new DocumentWriter(true).WriteToStringAsync(executionResult).GetAwaiter().GetResult();
 
             ShouldBe(json, IntrospectionResult.Data);
         }
@@ -33,7 +33,7 @@ namespace GraphQL.Tests.Introspection
                 _.Query = InputObjectBugQuery;
             }).GetAwaiter().GetResult();
 
-            var json = new DocumentWriter(true).Write(executionResult.Data);
+            var json = new DocumentWriter(true).WriteToStringAsync(executionResult).GetAwaiter().GetResult();
             executionResult.Errors.ShouldBeNull();
 
             ShouldBe(json, InputObjectBugResult);
@@ -64,7 +64,7 @@ query test {
     }
 }";
 
-        public static readonly string InputObjectBugResult = "{\r\n  \"__type\": {\r\n    \"inputFields\": [\r\n      {\r\n        \"type\": {\r\n          \"name\": \"String\",\r\n          \"description\": null,\r\n          \"ofType\": null\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}";
+        public static readonly string InputObjectBugResult = "{\r\n \"data\": {\r\n  \"__type\": {\r\n    \"inputFields\": [\r\n      {\r\n        \"type\": {\r\n          \"name\": \"String\",\r\n          \"description\": null,\r\n          \"ofType\": null\r\n        }\r\n      }\r\n    ]\r\n  }\r\n }\r\n}";
 
         public class SomeInputType : InputObjectGraphType
         {

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -99,8 +99,8 @@ namespace GraphQL.Tests
 
             var renderResult = renderErrors ? runResult : new ExecutionResult {Data = runResult.Data};
 
-            var writtenResult = Writer.Write(renderResult);
-            var expectedResult = Writer.Write(expectedExecutionResult);
+            var writtenResult = Writer.WriteToStringAsync(renderResult).GetAwaiter().GetResult();
+            var expectedResult = Writer.WriteToStringAsync(expectedExecutionResult).GetAwaiter().GetResult();
 
 // #if DEBUG
 //             Console.WriteLine(writtenResult);
@@ -136,8 +136,8 @@ namespace GraphQL.Tests
                 _.FieldNameConverter = new CamelCaseFieldNameConverter();
             }).GetAwaiter().GetResult();
 
-            var writtenResult = Writer.Write(runResult);
-            var expectedResult = Writer.Write(expectedExecutionResult);
+            var writtenResult = Writer.WriteToStringAsync(runResult).GetAwaiter().GetResult();
+            var expectedResult = Writer.WriteToStringAsync(expectedExecutionResult).GetAwaiter().GetResult();
 
 // #if DEBUG
 //             Console.WriteLine(writtenResult);

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Http;
 using GraphQL.Types;
 using Shouldly;
 using Xunit;
@@ -131,7 +133,7 @@ namespace GraphQL.Tests.Utilities
         }
 
         [Fact]
-        public void minimal_schema()
+        public async Task minimal_schema()
         {
             var schema = Schema.For(@"
                 type Query {
@@ -147,13 +149,13 @@ namespace GraphQL.Tests.Utilities
             });
 
             var expectedResult = CreateQueryResult("{ 'hello': 'Hello World!' }");
-            var serializedExpectedResult = Writer.Write(expectedResult);
+            var serializedExpectedResult = await Writer.WriteToStringAsync(expectedResult);
 
             result.ShouldBe(serializedExpectedResult);
         }
 
         [Fact]
-        public void can_use_source_without_params()
+        public async Task can_use_source_without_params()
         {
             var schema = Schema.For(@"
                 type Query {
@@ -171,13 +173,13 @@ namespace GraphQL.Tests.Utilities
             });
 
             var expectedResult = CreateQueryResult("{ 'source': true }");
-            var serializedExpectedResult = Writer.Write(expectedResult);
+            var serializedExpectedResult = await Writer.WriteToStringAsync(expectedResult);
 
             result.ShouldBe(serializedExpectedResult);
         }
 
         [Fact]
-        public void can_use_resolvefieldcontext_without_params()
+        public async Task can_use_resolvefieldcontext_without_params()
         {
             var schema = Schema.For(@"
                 type Query {
@@ -195,13 +197,13 @@ namespace GraphQL.Tests.Utilities
             });
 
             var expectedResult = CreateQueryResult("{ 'resolve': 'Resolved' }");
-            var serializedExpectedResult = Writer.Write(expectedResult);
+            var serializedExpectedResult = await Writer.WriteToStringAsync(expectedResult);
 
             result.ShouldBe(serializedExpectedResult);
         }
 
         [Fact]
-        public void can_use_resolvefieldcontext_with_params()
+        public async Task can_use_resolvefieldcontext_with_params()
         {
             var schema = Schema.For(@"
                 type Query {
@@ -218,13 +220,13 @@ namespace GraphQL.Tests.Utilities
             });
 
             var expectedResult = CreateQueryResult("{ 'resolveWithParam': 'Resolved abcd' }");
-            var serializedExpectedResult = Writer.Write(expectedResult);
+            var serializedExpectedResult = await Writer.WriteToStringAsync(expectedResult);
 
             result.ShouldBe(serializedExpectedResult);
         }
 
         [Fact]
-        public void can_use_usercontext()
+        public async Task can_use_usercontext()
         {
             var schema = Schema.For(@"
                 type Query {
@@ -242,13 +244,13 @@ namespace GraphQL.Tests.Utilities
             });
 
             var expectedResult = CreateQueryResult("{ 'userContext': 'Quinn' }");
-            var serializedExpectedResult = Writer.Write(expectedResult);
+            var serializedExpectedResult = await Writer.WriteToStringAsync(expectedResult);
 
             result.ShouldBe(serializedExpectedResult);
         }
 
         [Fact]
-        public void can_use_usercontext_with_params()
+        public async Task can_use_usercontext_with_params()
         {
             var schema = Schema.For(@"
                 type Query {
@@ -266,13 +268,13 @@ namespace GraphQL.Tests.Utilities
             });
 
             var expectedResult = CreateQueryResult("{ 'userContextWithParam': 'Quinn abcd' }");
-            var serializedExpectedResult = Writer.Write(expectedResult);
+            var serializedExpectedResult = await Writer.WriteToStringAsync(expectedResult);
 
             result.ShouldBe(serializedExpectedResult);
         }
 
         [Fact]
-        public void can_use_context_source_usercontext()
+        public async Task can_use_context_source_usercontext()
         {
             var schema = Schema.For(@"
                 type Query {
@@ -291,13 +293,13 @@ namespace GraphQL.Tests.Utilities
             });
 
             var expectedResult = CreateQueryResult("{ 'three': true }");
-            var serializedExpectedResult = Writer.Write(expectedResult);
+            var serializedExpectedResult = await Writer.WriteToStringAsync(expectedResult);
 
             result.ShouldBe(serializedExpectedResult);
         }
 
         [Fact]
-        public void can_use_context_source_usercontext_with_params()
+        public async Task can_use_context_source_usercontext_with_params()
         {
             var schema = Schema.For(@"
                 type Query {
@@ -316,7 +318,7 @@ namespace GraphQL.Tests.Utilities
             });
 
             var expectedResult = CreateQueryResult("{ 'four': true }");
-            var serializedExpectedResult = Writer.Write(expectedResult);
+            var serializedExpectedResult = await Writer.WriteToStringAsync(expectedResult);
 
             result.ShouldBe(serializedExpectedResult);
         }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTestBase.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTestBase.cs
@@ -43,8 +43,8 @@ namespace GraphQL.Tests.Utilities
         {
             var runResult = Executer.ExecuteAsync(options).Result;
 
-            var writtenResult = Writer.Write(runResult);
-            var expectedResult = Writer.Write(expectedExecutionResult);
+            var writtenResult = Writer.WriteToStringAsync(runResult).Result;
+            var expectedResult = Writer.WriteToStringAsync(expectedExecutionResult).Result;
 
             string additionalInfo = null;
 

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="GraphQL-Parser" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
   </ItemGroup>

--- a/src/GraphQL/Http/DocumentWriter.cs
+++ b/src/GraphQL/Http/DocumentWriter.cs
@@ -1,16 +1,24 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace GraphQL.Http
 {
     public interface IDocumentWriter
     {
+        Task WriteAsync(Stream stream, ExecutionResult value);
+
+        [Obsolete("This method is obsolete and will be removed in the next major version.  Use WriteAsync instead.")]
         string Write(object value);
     }
 
     public class DocumentWriter : IDocumentWriter
     {
-        private readonly Formatting _formatting;
-        private readonly JsonSerializerSettings _settings;
+        private readonly JsonSerializer _serializer;
+        private static readonly Encoding Utf8Encoding = new UTF8Encoding(false);
 
         public DocumentWriter()
             : this(indent: false)
@@ -26,13 +34,56 @@ namespace GraphQL.Http
 
         public DocumentWriter(Formatting formatting, JsonSerializerSettings settings)
         {
-            _formatting = formatting;
-            _settings = settings;
+            _serializer = JsonSerializer.CreateDefault(settings);
+            _serializer.Formatting = formatting;
+        }
+
+        public Task WriteAsync(Stream stream, ExecutionResult value)
+        {
+            using (var writer = new StreamWriter(stream, Utf8Encoding, 1024, true))
+            using (var jsonWriter = new JsonTextWriter(writer))
+            {
+                _serializer.Serialize(jsonWriter, value);
+            }
+
+            return TaskExtensions.CompletedTask;
         }
 
         public string Write(object value)
         {
-            return JsonConvert.SerializeObject(value, _formatting, _settings);
+            return this.WriteToStringAsync((ExecutionResult) value).GetAwaiter().GetResult();
+        }
+    }
+
+    public static class DocumentWriterExtensions
+    {
+        /// <summary>
+        /// Writes the <paramref name="value"/> to string.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="encoding"></param>
+        /// <returns></returns>
+        public static async Task<string> WriteToStringAsync(this IDocumentWriter writer,
+            ExecutionResult value,
+            Encoding encoding = null)
+        {
+            var resolvedEncoding = encoding ?? Encoding.UTF8;
+            using (var stream = new MemoryStream())
+            {
+                await writer.WriteAsync(stream, value).ConfigureAwait(false);
+#if NET45
+                var length = (int) stream.Length;
+                var offset = (int) stream.Seek(0, SeekOrigin.Begin);
+                var buffer = stream.GetBuffer();
+
+                return resolvedEncoding.GetString(buffer, offset, length - offset);
+#else
+// Will succeed since we use default MemoryStream constructor
+                stream.TryGetBuffer(out var buffer);
+                return resolvedEncoding.GetString(buffer.Array, buffer.Offset, buffer.Count);
+#endif
+            }
         }
     }
 }

--- a/src/GraphQL/Http/DocumentWriter.cs
+++ b/src/GraphQL/Http/DocumentWriter.cs
@@ -45,7 +45,7 @@ namespace GraphQL.Http
 
         public async Task WriteAsync<T>(Stream stream, T value)
         {
-            using (var writer = new StreamWriter(stream, Utf8Encoding, 1024, true))
+            using (var writer = new HttpResponseStreamWriter(stream, Utf8Encoding))
             using (var jsonWriter = new JsonTextWriter(writer)
             {
                 ArrayPool = _jsonArrayPool,

--- a/src/GraphQL/Http/HttpResponseStreamWriter.cs
+++ b/src/GraphQL/Http/HttpResponseStreamWriter.cs
@@ -1,0 +1,342 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// A copy from https://github.com/aspnet/HttpAbstractions/blob/057fc816fab1062700959cdaad2a32e9d85efca6/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GraphQL.Http
+{
+    /// <summary>
+    /// Writes to the <see cref="Stream"/> using the supplied <see cref="Encoding"/>.
+    /// It does not write the BOM and also does not close the stream.
+    /// </summary>
+    public class HttpResponseStreamWriter : TextWriter
+    {
+        private const int MinBufferSize = 128;
+        internal const int DefaultBufferSize = 16 * 1024;
+
+        private Stream _stream;
+        private readonly Encoder _encoder;
+        private readonly ArrayPool<byte> _bytePool;
+        private readonly ArrayPool<char> _charPool;
+        private readonly int _charBufferSize;
+
+        private byte[] _byteBuffer;
+        private char[] _charBuffer;
+
+        private int _charBufferCount;
+        private bool _disposed;
+
+        public HttpResponseStreamWriter(Stream stream, Encoding encoding)
+            : this(stream, encoding, DefaultBufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
+        {
+        }
+
+        public HttpResponseStreamWriter(Stream stream, Encoding encoding, int bufferSize)
+            : this(stream, encoding, bufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared)
+        {
+        }
+
+        public HttpResponseStreamWriter(
+            Stream stream,
+            Encoding encoding,
+            int bufferSize,
+            ArrayPool<byte> bytePool,
+            ArrayPool<char> charPool)
+        {
+            _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
+            _bytePool = bytePool ?? throw new ArgumentNullException(nameof(bytePool));
+            _charPool = charPool ?? throw new ArgumentNullException(nameof(charPool));
+
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize));
+            }
+            if (!_stream.CanWrite)
+            {
+                throw new ArgumentException("Stream is now writable", nameof(stream));
+            }
+
+            _charBufferSize = bufferSize;
+
+            _encoder = encoding.GetEncoder();
+            _charBuffer = charPool.Rent(bufferSize);
+
+            try
+            {
+                var requiredLength = encoding.GetMaxByteCount(bufferSize);
+                _byteBuffer = bytePool.Rent(requiredLength);
+            }
+            catch
+            {
+                charPool.Return(_charBuffer);
+
+                if (_byteBuffer != null)
+                {
+                    bytePool.Return(_byteBuffer);
+                }
+
+                throw;
+            }
+        }
+
+        public override Encoding Encoding { get; }
+
+        public override void Write(char value)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+            }
+
+            if (_charBufferCount == _charBufferSize)
+            {
+                FlushInternal(flushEncoder: false);
+            }
+
+            _charBuffer[_charBufferCount] = value;
+            _charBufferCount++;
+        }
+
+        public override void Write(char[] values, int index, int count)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+            }
+
+            if (values == null)
+            {
+                return;
+            }
+
+            while (count > 0)
+            {
+                if (_charBufferCount == _charBufferSize)
+                {
+                    FlushInternal(flushEncoder: false);
+                }
+
+                CopyToCharBuffer(values, ref index, ref count);
+            }
+        }
+
+        public override void Write(string value)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+            }
+
+            if (value == null)
+            {
+                return;
+            }
+
+            var count = value.Length;
+            var index = 0;
+            while (count > 0)
+            {
+                if (_charBufferCount == _charBufferSize)
+                {
+                    FlushInternal(flushEncoder: false);
+                }
+
+                CopyToCharBuffer(value, ref index, ref count);
+            }
+        }
+
+        public override async Task WriteAsync(char value)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+            }
+
+            if (_charBufferCount == _charBufferSize)
+            {
+                await FlushInternalAsync(flushEncoder: false);
+            }
+
+            _charBuffer[_charBufferCount] = value;
+            _charBufferCount++;
+        }
+
+        public override async Task WriteAsync(char[] values, int index, int count)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+            }
+
+            if (values == null)
+            {
+                return;
+            }
+
+            while (count > 0)
+            {
+                if (_charBufferCount == _charBufferSize)
+                {
+                    await FlushInternalAsync(flushEncoder: false);
+                }
+
+                CopyToCharBuffer(values, ref index, ref count);
+            }
+        }
+
+        public override async Task WriteAsync(string value)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+            }
+
+            if (value == null)
+            {
+                return;
+            }
+
+            var count = value.Length;
+            var index = 0;
+            while (count > 0)
+            {
+                if (_charBufferCount == _charBufferSize)
+                {
+                    await FlushInternalAsync(flushEncoder: false);
+                }
+
+                CopyToCharBuffer(value, ref index, ref count);
+            }
+        }
+
+        // We want to flush the stream when Flush/FlushAsync is explicitly
+        // called by the user (example: from a Razor view).
+
+        public override void Flush()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+            }
+
+            FlushInternal(flushEncoder: true);
+        }
+
+        public override Task FlushAsync()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HttpResponseStreamWriter));
+            }
+
+            return FlushInternalAsync(flushEncoder: true);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                _disposed = true;
+                try
+                {
+                    FlushInternal(flushEncoder: true);
+                }
+                finally
+                {
+                    _bytePool.Return(_byteBuffer);
+                    _charPool.Return(_charBuffer);
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        // Note: our FlushInternal method does NOT flush the underlying stream. This would result in
+        // chunking.
+        private void FlushInternal(bool flushEncoder)
+        {
+            if (_charBufferCount == 0)
+            {
+                return;
+            }
+
+            var count = _encoder.GetBytes(
+                _charBuffer,
+                0,
+                _charBufferCount,
+                _byteBuffer,
+                0,
+                flush: flushEncoder);
+
+            _charBufferCount = 0;
+
+            if (count > 0)
+            {
+                _stream.Write(_byteBuffer, 0, count);
+            }
+        }
+
+        // Note: our FlushInternalAsync method does NOT flush the underlying stream. This would result in
+        // chunking.
+        private async Task FlushInternalAsync(bool flushEncoder)
+        {
+            if (_charBufferCount == 0)
+            {
+                return;
+            }
+
+            var count = _encoder.GetBytes(
+                _charBuffer,
+                0,
+                _charBufferCount,
+                _byteBuffer,
+                0,
+                flush: flushEncoder);
+
+            _charBufferCount = 0;
+
+            if (count > 0)
+            {
+                await _stream.WriteAsync(_byteBuffer, 0, count);
+            }
+        }
+
+        private void CopyToCharBuffer(string value, ref int index, ref int count)
+        {
+            var remaining = Math.Min(_charBufferSize - _charBufferCount, count);
+
+            value.CopyTo(
+                sourceIndex: index,
+                destination: _charBuffer,
+                destinationIndex: _charBufferCount,
+                count: remaining);
+
+            _charBufferCount += remaining;
+            index += remaining;
+            count -= remaining;
+        }
+
+        private void CopyToCharBuffer(char[] values, ref int index, ref int count)
+        {
+            var remaining = Math.Min(_charBufferSize - _charBufferCount, count);
+
+            Buffer.BlockCopy(
+                src: values,
+                srcOffset: index * sizeof(char),
+                dst: _charBuffer,
+                dstOffset: _charBufferCount * sizeof(char),
+                count: remaining * sizeof(char));
+
+            _charBufferCount += remaining;
+            index += remaining;
+            count -= remaining;
+        }
+    }
+}

--- a/src/GraphQL/Http/JsonArrayPool.cs
+++ b/src/GraphQL/Http/JsonArrayPool.cs
@@ -1,0 +1,25 @@
+using System.Buffers;
+using Newtonsoft.Json;
+
+namespace GraphQL.Http
+{
+    public class JsonArrayPool : IArrayPool<char>
+    {
+        private readonly ArrayPool<char> _inner;
+
+        public JsonArrayPool(ArrayPool<char> inner)
+        {
+            _inner = inner;
+        }
+
+        public char[] Rent(int minimumLength)
+        {
+            return _inner.Rent(minimumLength);
+        }
+
+        public void Return(char[] array)
+        {
+            _inner.Return(array);
+        }
+    }
+}

--- a/src/GraphQL/Http/PooledByteResult.cs
+++ b/src/GraphQL/Http/PooledByteResult.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Buffers;
+using System.IO;
+
+namespace GraphQL.Http
+{
+    public interface IByteResult : IDisposable
+    {
+        ArraySegment<byte> Result { get; }
+    }
+
+    public class PooledByteResult : IByteResult
+    {
+        private readonly byte[] _buffer;
+        private readonly ArrayPool<byte> _pool;
+
+        public PooledByteResult(ArrayPool<byte> pool, int minLength)
+        {
+            _pool = pool;
+            _buffer = _pool.Rent(minLength);
+            Stream = new MemoryStream(_buffer);
+        }
+
+        public ArraySegment<byte> Result { get; private set; }
+
+        internal MemoryStream Stream { get; }
+
+        internal void InitResponseFromCurrentStreamPosition()
+        {
+            Result = new ArraySegment<byte>(_buffer, 0, (int)Stream.Position);
+        }
+
+        private void ReleaseUnmanagedResources()
+        {
+            _pool.Return(_buffer);
+            Stream.Dispose();
+        }
+
+        public void Dispose()
+        {
+            ReleaseUnmanagedResources();
+            GC.SuppressFinalize(this);
+        }
+
+        ~PooledByteResult()
+        {
+            ReleaseUnmanagedResources();
+        }
+    }
+}


### PR DESCRIPTION
### Summary of changes:

- Added a new method to IDocumentWriter.
` Task WriteAsync(Stream stream, ExecutionResult value);`
- Marked the old method as obsolete
- Added implementation for DocumentWriter. 
   **Note**: the StreamWriter can be a bottleneck here, since it doesn't use ArrayPool in default implementation (see https://github.com/dotnet/corefx/issues/23874, Asp.Net has it's own implementation https://github.com/aspnet/HttpAbstractions/blob/bcb7bcbb7a6461204f4cefd9848e2a782ebb0a6b/src/Microsoft.AspNetCore.WebUtilities/HttpResponseStreamWriter.cs). This can further improve the performance.
- Added an extension method for DocumentWriter that mimics the old behavior. After some thought, I've allowed encoding to be passed.
- Updates unit tests to use the extension method in place of now obsolete method.
- Updated middleware in GraphQL.Harness project.

### The benchmark
Tested serializing of 10 000 Droid objects for 2 DocumentWriter implementations (one using Newtonsoft.Json, another using Utf8Json). The results can be found below. 
``` ini

BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17134.228 (1803/April2018Update/Redstone4)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.401
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|                 Method |      Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|----------------------- |----------:|----------:|----------:|----------:|----------:|----------:|----------:|
| GetHeroesNewtonsoftOld | 20.740 ms | 0.4793 ms | 0.4249 ms | 1312.5000 | 1156.2500 |  656.2500 |   7.02 MB |
| GetHeroesNewtonsoftNew | 18.919 ms | 0.1921 ms | 0.1702 ms | 1062.5000 |  468.7500 |  468.7500 |   3.69 MB |
|       GetHeroesUtf8Old |  4.841 ms | 0.0919 ms | 0.1021 ms | 1000.0000 | 1000.0000 | 1000.0000 |   5.42 MB |
|       GetHeroesUtf8New |  3.417 ms | 0.0326 ms | 0.0305 ms |  656.2500 |  656.2500 |  656.2500 |   2.76 MB |

Once this is merged, I can update the usages of this API in server project.