### PR TITLE
Add the ability to filter execution nodes

### DIFF
--- a/src/GraphQL.Tests/NodeFilter/BasicNodeFilterQueryTestBase.cs
+++ b/src/GraphQL.Tests/NodeFilter/BasicNodeFilterQueryTestBase.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using GraphQL.Execution;
+using GraphQL.Types;
+using GraphQL.Http;
+using GraphQL.Validation;
+using GraphQLParser.Exceptions;
+using Shouldly;
+using Newtonsoft.Json.Linq;
+
+namespace GraphQL.Tests
+{
+    public class BasicNodeFilterQueryTestBase
+    {
+        protected readonly IDocumentExecuter Executer = new DocumentExecuter();
+        protected readonly IDocumentWriter Writer = new DocumentWriter(indent: true);
+
+        public ExecutionResult AssertQuerySuccess(
+            ISchema schema,
+            string query,
+            string expected,
+            Inputs inputs = null,
+            object root = null,
+            object userContext = null,
+            CancellationToken cancellationToken = default(CancellationToken),
+            IEnumerable<IValidationRule> rules = null,
+            Func<ExecutionNode, bool> nodeFilter = null)
+        {
+            var queryResult = CreateQueryResult(expected);
+            return AssertQuery(schema, query, queryResult, inputs, root, userContext, cancellationToken, rules, nodeFilter);
+        }
+
+        public ExecutionResult AssertQuerySuccess(Action<ExecutionOptions> options, string expected)
+        {
+            var queryResult = CreateQueryResult(expected);
+            return AssertQuery(options, queryResult);
+        }
+
+        public ExecutionResult AssertQuery(Action<ExecutionOptions> options, ExecutionResult expectedExecutionResult)
+        {
+            var runResult = Executer.ExecuteAsync(options).Result;
+
+            var writtenResult = Writer.Write(runResult);
+            var expectedResult = Writer.Write(expectedExecutionResult);
+
+//#if DEBUG
+//            Console.WriteLine(writtenResult);
+//#endif
+
+            string additionalInfo = null;
+
+            if (runResult.Errors?.Any() == true)
+            {
+                additionalInfo = string.Join(Environment.NewLine, runResult.Errors
+                    .Where(x => x.InnerException is GraphQLSyntaxErrorException)
+                    .Select(x => x.InnerException.Message));
+            }
+
+            writtenResult.ShouldBe(expectedResult, additionalInfo);
+
+            return runResult;
+        }
+
+        public ExecutionResult AssertQuery(
+            ISchema schema,
+            string query,
+            ExecutionResult expectedExecutionResult,
+            Inputs inputs,
+            object root,
+            object userContext = null,
+            CancellationToken cancellationToken = default(CancellationToken),
+            IEnumerable<IValidationRule> rules = null,
+            Func<ExecutionNode, bool> nodeFilter = null )
+        {
+            var runResult = Executer.ExecuteAsync(_ =>
+            {
+                _.Schema = schema;
+                _.Query = query;
+                _.Root = root;
+                _.Inputs = inputs;
+                _.UserContext = userContext;
+                _.CancellationToken = cancellationToken;
+                _.ValidationRules = rules;
+                _.NodeFilter = nodeFilter;
+            }).GetAwaiter().GetResult();
+
+            var writtenResult = Writer.Write(runResult);
+            var expectedResult = Writer.Write(expectedExecutionResult);
+
+//#if DEBUG
+//            Console.WriteLine(writtenResult);
+//#endif
+
+            string additionalInfo = null;
+
+            if (runResult.Errors?.Any() == true)
+            {
+                additionalInfo = string.Join(Environment.NewLine, runResult.Errors
+                    .Where(x => x.InnerException is GraphQLSyntaxErrorException)
+                    .Select(x => x.InnerException.Message));
+            }
+
+            writtenResult.ShouldBe(expectedResult, additionalInfo);
+
+            return runResult;
+        }
+
+        public ExecutionResult CreateQueryResult(string result)
+        {
+            object expected = null;
+            if (!string.IsNullOrWhiteSpace(result))
+            {
+                expected = JObject.Parse(result);
+            }
+            return new ExecutionResult { Data = expected };
+        }
+    }
+}

--- a/src/GraphQL.Tests/NodeFilter/NodeFilter.cs
+++ b/src/GraphQL.Tests/NodeFilter/NodeFilter.cs
@@ -1,4 +1,3 @@
-using GraphQL.Execution;
 using GraphQL.Tests.Execution;
 using GraphQL.Types;
 using Xunit;

--- a/src/GraphQL.Tests/NodeFilter/NodeFilter.cs
+++ b/src/GraphQL.Tests/NodeFilter/NodeFilter.cs
@@ -1,0 +1,122 @@
+using GraphQL.Execution;
+using GraphQL.Tests.Execution;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.NodeFilter
+{
+    public class NodeFilterTest : BasicNodeFilterQueryTestBase
+
+    {
+        public class Person
+        {
+            public string Name { get; set; }
+            public Business Business { get; set; }
+        }
+
+        public class Business
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public Address Address { get; set; }
+        }
+
+        public class Address
+        {
+            public string Id { get; set; }
+            public string Street { get; set; }
+            public string City { get; set; }
+            public string State { get; set; }
+        }
+
+        public ISchema build_schema()
+        {
+            var schema = new Schema();
+
+            var address = new ObjectGraphType();
+            address.Name = "Address";
+            address.Field("id", new IdGraphType());
+            address.Field("street", new StringGraphType());
+            address.Field("city", new StringGraphType());
+            address.Field("state", new StringGraphType());
+
+            var business = new ObjectGraphType();
+            business.Name = "Business";
+            business.Field("id", new IdGraphType());
+            business.Field("name", new StringGraphType());
+            business.Field("address", address);
+
+            var person = new ObjectGraphType();
+            person.Name = "Person";
+            person.Field("id", new StringGraphType());
+            person.Field("name", new StringGraphType());
+            person.Field("business", business);
+
+            var query = new ObjectGraphType();
+            query.Name = "Query";
+            query.Field(
+                "person",
+                person,
+                resolve: ctx =>
+                {
+                    return new Person
+                    {
+                        Name = "Quinn",
+                        Business = new Business
+                        {
+                            Id = "4",
+                            Name = "Stuntman Express",
+                            Address = new Address
+                            {
+                                Id = "123",
+                                Street = "Las Vegas Blvd",
+                                City = "Las Vegas",
+                                State = "NV"
+                            }
+                        }
+                    };
+                });
+
+            schema.Query = query;
+            return schema;
+        }
+
+        [Fact]
+        public void FilterOutTopNodeAndChildren()
+        {
+            var schema = build_schema();
+            AssertQuerySuccess(_ =>
+                {
+                    _.NodeFilter = node => !(node.Source is Person);
+                    _.Schema = build_schema();
+                    _.Query = @"
+                {
+                  person {
+                    name
+                    business { id name }
+                    business { id address { id street city state } }
+                  }
+                }";
+                },
+                "{ person: { } }");
+        }
+
+        [Fact]
+        public void FilterOutLeafNode()
+        {
+            var schema = build_schema();
+            AssertQuerySuccess(_ =>
+                {
+                    _.NodeFilter = node => !(node.Source is Address);
+                    _.Schema = build_schema();
+                    _.Query = @"
+                {
+                  person {
+                    business { id name address { id street city state } }
+                  }
+                }";
+                },
+                "{ person: { business: { id: \"4\", name: \"Stuntman Express\", address: { } } } }");
+        }
+    }
+}

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -69,7 +69,7 @@ namespace GraphQL
                 Inputs = inputs,
                 UserContext = userContext,
                 CancellationToken = cancellationToken,
-                ValidationRules = rules
+                ValidationRules = rules,
             });
         }
 
@@ -186,7 +186,8 @@ namespace GraphQL
                     options.CancellationToken,
                     metrics,
                     options.Listeners,
-                    options.ThrowOnUnhandledException);
+                    options.ThrowOnUnhandledException,
+                    options.NodeFilter);
 
                 if (context.Errors.Any())
                 {
@@ -265,7 +266,8 @@ namespace GraphQL
             CancellationToken cancellationToken,
             Metrics metrics,
             IEnumerable<IDocumentExecutionListener> listeners,
-            bool throwOnUnhandledException)
+            bool throwOnUnhandledException,
+            Func<ExecutionNode, bool> nodeFilter = null)
         {
             var context = new ExecutionContext();
             context.Document = document;
@@ -277,11 +279,10 @@ namespace GraphQL
             context.Variables = GetVariableValues(document, schema, operation?.Variables, inputs);
             context.Fragments = document.Fragments;
             context.CancellationToken = cancellationToken;
-
+            context.NodeFilter = nodeFilter;
             context.Metrics = metrics;
             context.Listeners = listeners;
             context.ThrowOnUnhandledException = throwOnUnhandledException;
-
             return context;
         }
 

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -9,6 +10,8 @@ namespace GraphQL.Execution
 {
     public class ExecutionContext
     {
+        public Func<ExecutionNode,bool> NodeFilter { get; set; }
+
         public ExecutionContext()
         {
             Fragments = new Fragments();

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using GraphQL.Conversion;
@@ -32,6 +33,8 @@ namespace GraphQL
 
         //Note disabling will increase performance
         public bool EnableMetrics { get; set; } = true;
+
+        public Func<ExecutionNode, bool> NodeFilter { get; set; }
 
         //Note disabling will increase performance. When true all nodes will have the middleware injected for resolving fields.
         public bool SetFieldMiddleware { get; set; } = true;

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -78,6 +78,14 @@ namespace GraphQL.Execution
                 if (node == null)
                     continue;
 
+                if (context.NodeFilter != null)
+                {
+                    if (!context.NodeFilter(node))
+                    {
+                        continue;
+                    }
+                }
+
                 subFields[kvp.Key] = node;
             }
 
@@ -114,9 +122,15 @@ namespace GraphQL.Execution
                     SetSubFieldNodes(context, objectNode);
                 }
 
+                if (context.NodeFilter != null)
+                {
+                    if (!context.NodeFilter(node))
+                    {
+                        continue;
+                    }
+                }
                 arrayItems.Add(node);
             }
-
             parent.Items = arrayItems;
         }
 


### PR DESCRIPTION
I needed the ability to suppress certain data based on a set of hierarchical access rules.
I couldn't find an extension point that allowed me to do this so I've introduced one.
The solution I came up with was to add an optional func to the execution options and then evaluate the func result prior to adding the data to the execution result.  

If there is another way I've missed please let me know :)



