### PR TITLE
Fixed support for list with nulls (#838)

### DIFF
--- a/src/GraphQL.Tests/Bugs/ListWithNullablesTest.cs
+++ b/src/GraphQL.Tests/Bugs/ListWithNullablesTest.cs
@@ -1,0 +1,59 @@
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class ListWithNullablesTest : QueryTestBase<ListWithNullablesSchema>
+    {
+        [Fact]
+        public void Can_Accept_Null_List_From_Literal()
+        {
+            var query = @"
+                query _ {
+                  list {
+                    value
+                  }
+                }";
+            var expected = @"
+                {
+                    'list': [{ value: ""one""}, null, { value: ""three"" }]
+                }";
+            AssertQuerySuccess(query, expected);
+        }
+    }
+
+    public class ListWithNullablesSchema : Schema
+    {
+        public ListWithNullablesSchema()
+        {
+            Query = new ListWithNullablesQuery();
+        }
+    }
+
+    public class ListWithNullablesQuery : ObjectGraphType
+    {
+        public ListWithNullablesQuery()
+        {
+            Name = "Query";
+
+            Field<ListGraphType<ListEntityGraphType>>(
+                "list",
+                resolve: context => new[] {new ListEntity {Value = "one"}, null, new ListEntity {Value = "three"}});
+        }
+    }
+
+    public class ListEntity
+    {
+        public string Value { get; set; }
+    }
+
+    public class ListEntityGraphType : ObjectGraphType<ListEntity>
+    {
+        public ListEntityGraphType()
+        {
+            Name = "Entity";
+
+            Field(x => x.Value);
+        }
+    }
+}

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -106,15 +106,26 @@ namespace GraphQL.Execution
             {
                 var path = AppendPath(parent.Path, (index++).ToString());
 
-                ExecutionNode node = BuildExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, path);
-                node.Result = d;
-
-                if (node is ObjectExecutionNode objectNode)
+                if (d != null)
                 {
-                    SetSubFieldNodes(context, objectNode);
-                }
+                    var node = BuildExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, path);
+                    node.Result = d;
 
-                arrayItems.Add(node);
+                    if (node is ObjectExecutionNode objectNode)
+                    {
+                        SetSubFieldNodes(context, objectNode);
+                    }
+
+                    arrayItems.Add(node);
+                }
+                else
+                {
+                    var valueExecutionNode = new ValueExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, path)
+                    {
+                        Result = null
+                    };
+                    arrayItems.Add(valueExecutionNode);
+                }
             }
 
             parent.Items = arrayItems;


### PR DESCRIPTION
This fix may be BREAKING. If an application uses null as source in resolving complex types. Though no tests fail so it is not an intended use-case. 