### PR TITLE
Allow custom casing on inferred enum graph types

### DIFF
--- a/src/GraphQL.Tests/Types/EnumGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/EnumGraphTypeTests.cs
@@ -23,6 +23,19 @@ namespace GraphQL.Tests.Types
             }
         }
 
+        class ColorEnumInverseCasing : EnumerationGraphType<Colors>
+        {
+            public ColorEnumInverseCasing()
+            {
+                Name = "ColorsEnum";
+            }
+
+            protected override string ChangeEnumCase(string val)
+            {
+                return new string(val.Select(c => char.IsUpper(c) ? char.ToLower(c) : char.ToUpper(c)).ToArray());
+            }
+        }
+
         private EnumerationGraphType<Colors> type = new EnumerationGraphType<Colors>();
 
         [Fact]
@@ -30,6 +43,12 @@ namespace GraphQL.Tests.Types
         {
             type.Values.Count().ShouldBe(5);
             type.Values.First().Name.ShouldBe("RED");
+        }
+
+        [Fact]
+        public void adds_values_from_enum_custom_casing()
+        {
+            type.ParseValue("rED").ShouldBe(Colors.Red);
         }
 
         [Fact]

--- a/src/GraphQL/Types/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/EnumerationGraphType.cs
@@ -79,8 +79,13 @@ namespace GraphQL.Types
                     .GetMember(enumName, BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)
                     .First();
 
-                AddValue(StringUtils.ToConstantCase(enumMember.Name), null, Enum.Parse(type, enumName));
+                AddValue(ChangeEnumCase(enumMember.Name), null, Enum.Parse(type, enumName));
             }
+        }
+
+        protected virtual string ChangeEnumCase(string val)
+        {
+            return StringUtils.ToConstantCase(val);
         }
     }
 


### PR DESCRIPTION
The default behavior of EnumGraphType<TEnum> converts the enum values to uppercase. This commit allows you to specify a custom behavior for changing case.