### PR TITLE
Fix input types not being registered when ResolvedType is specified

### DIFF
--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -44,6 +44,18 @@ namespace GraphQL.Tests.Types
         }
 
         [Fact]
+        public void registers_argument_input_objects_when_argument_resolved_type_is_set()
+        {
+            var schema = new ARootSchema();
+            schema.FindType("a");
+
+            ContainsTypeNames(
+                schema,
+                "DInputType",
+                "DInputType2");
+        }
+
+        [Fact]
         public void registers_type_when_list()
         {
             var schema = new ARootSchema();
@@ -263,7 +275,7 @@ namespace GraphQL.Tests.Types
             Field<StringGraphType>("id", resolve: ctx => new {id = "id"});
             Field<StringGraphType>(
                 "filter",
-                arguments: new QueryArguments(new [] { new QueryArgument<DInputType> {Name = "input"} }),
+                arguments: new QueryArguments(new QueryArgument[] { new QueryArgument<DInputType> {Name = "input", ResolvedType = new DInputType() }, new QueryArgument<DInputType2> {Name = "input2", ResolvedType = new DInputType2()} }),
                 resolve: ctx => new {id = "id"});
             Field<ListGraphType<DListType>>("alist");
         }
@@ -273,7 +285,17 @@ namespace GraphQL.Tests.Types
     {
         public DInputType()
         {
+            Name = "DInputType";
             Field<StringGraphType>("one");
+        }
+    }
+
+    public class DInputType2 : InputObjectGraphType
+    {
+        public DInputType2()
+        {
+            Name = "DInputType2";
+            Field<StringGraphType>("two");
         }
     }
 

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -290,7 +290,7 @@ namespace GraphQL.Types
                 if (arg.ResolvedType != null)
                 {
                     AddTypeIfNotRegistered(arg.ResolvedType, context);
-                    return;
+                    continue;
                 }
 
                 AddTypeIfNotRegistered(arg.Type, context);


### PR DESCRIPTION
I ran into a problem after upgrading to v2.2.0+ where the input types was not being registered if there where multiple arguments and they have `ResolvedType` explicit specified. Only the first type was being registered but not the rest.

Not sure why this hasn't been a problem before.