### PR TITLE
More Parallelism using Dataflow Blocks

### DIFF
--- a/src/GraphQL/Execution/DataflowBlocksParallelExecutionStrategy.cs
+++ b/src/GraphQL/Execution/DataflowBlocksParallelExecutionStrategy.cs
@@ -1,26 +1,29 @@
-using GraphQL.Execution;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
-using ExecutionContext = GraphQL.Execution.ExecutionContext;
 
 namespace GraphQL.Execution
 {
 
+    //TODO: Add unit tests.
+    //TODO: Validate performance overhead of creating data flow blocks on each request.
+    //TODO: Check for SynchronizationContext issues.
+    //TODO: Validate DataLoader can work with this strategy.
+    //TODO: Store maxDegreesOfParallelism in settings.
+    //TODO: Ensure ConfigureAwait is correct.
+    //TODO: This is needed to prevent the DataLoader from deadlocking... not sure exactly where this
+    //      needs to go...
+    //      await OnBeforeExecutionStepAwaitedAsync(context).ConfigureAwait(false);
     public class DataflowBlocksParallelExecutionStrategy : ExecutionStrategy
     {
         protected override async Task ExecuteNodeTreeAsync(ExecutionContext context, ObjectExecutionNode rootNode)
         {
-            //TODO: This is needed to prevent the DataLoader from deadlocking... not sure exactly where this
-            //      needs to go...
-            //await OnBeforeExecutionStepAwaitedAsync(context)
-            //    .ConfigureAwait(false);
             //Options
             var blockOptions = new ExecutionDataflowBlockOptions
             {
                 CancellationToken = context.CancellationToken,
-                MaxDegreeOfParallelism = 1024 //TODO: Store maxDegreesOfParallelism in settings. 
+                MaxDegreeOfParallelism = 1024
             };
             //Execute Block
             var block = new TransformManyBlock<Job, Job>(

--- a/src/GraphQL/Execution/DataflowBlocksParallelExecutionStrategy.cs
+++ b/src/GraphQL/Execution/DataflowBlocksParallelExecutionStrategy.cs
@@ -1,0 +1,78 @@
+using GraphQL.Execution;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using ExecutionContext = GraphQL.Execution.ExecutionContext;
+
+namespace GraphQL.Execution
+{
+
+    public class DataflowBlocksParallelExecutionStrategy : ExecutionStrategy
+    {
+
+        //TO DO: I have to believe there is a better way to do this...
+        private static int _refCount = 0;
+
+        protected override async Task ExecuteNodeTreeAsync(ExecutionContext context, ObjectExecutionNode rootNode)
+        {
+            var cancellationSource = new CancellationTokenSource();
+            await ExecuteDataBlocksPipeline(context, rootNode, cancellationSource, 1024);
+            //await OnBeforeExecutionStepAwaitedAsync(context)
+            //    .ConfigureAwait(false);
+        }
+
+        private async Task ExecuteDataBlocksPipeline(
+            ExecutionContext context, ObjectExecutionNode rootNode,
+            CancellationTokenSource cancellationSource, int maxDegreesOfParallelism)
+        {
+            //Options
+            var blockOptions = new ExecutionDataflowBlockOptions
+            {
+                CancellationToken = cancellationSource.Token,
+                MaxDegreeOfParallelism = maxDegreesOfParallelism
+            };
+            //NavigateChildren Block
+            var navigateChildren = new TransformManyBlock<Job, Job>(
+                job =>
+                {
+                    var childJobs = (job.Node as IParentExecutionNode)?
+                        .GetChildNodes()
+                        .Select(child => new Job(job.Context, child))
+                        .ToArray();
+                    return childJobs;
+                }, blockOptions);
+            //Execute Block
+            var executeBlock = new TransformBlock<Job, Job>(
+                async job => {
+                    var node = await ExecuteNodeAsync(job.Context, job.Node).ConfigureAwait(false);
+                    Interlocked.Add(ref _refCount, (node as IParentExecutionNode)?.GetChildNodes().Count() ?? 0);
+                    Interlocked.Decrement(ref _refCount);
+                    if (_refCount == 0)
+                        navigateChildren.Complete();
+                    return new Job(job.Context, node);
+                },
+                blockOptions);
+            //Pipeline
+            var linkOptions = new DataflowLinkOptions { PropagateCompletion = false };
+            executeBlock.LinkTo(navigateChildren, linkOptions);
+            navigateChildren.LinkTo(executeBlock, linkOptions);
+            _refCount = 1;
+            await executeBlock.SendAsync(new Job(context, rootNode));
+            await navigateChildren.Completion;
+        }
+
+        private class Job
+        {
+            public Job(ExecutionContext context, ExecutionNode node)
+            {
+                Context = context;
+                Node = node;
+            }
+            public ExecutionContext Context { get; private set; }
+            public ExecutionNode Node { get; private set; }
+        }
+
+    }
+
+}

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">


### PR DESCRIPTION
The pull request is to provide an alternative to the current ParallelStrategy. The DataflowBlocksParallelStrategy uses DataflowBlocks to "queue" tasks so that once a node has executed, it's child nodes are immediately added to the queue for processing. MaxDegreesOfParallelism provides control over the number of concurrent threads.

Some preliminary testing with my use case shows about 3-4 times improvement. Before and after charts included below. The after chart could be better, but the response time from the dependent API had a particularly slow response (AWS Lambda cold start), but the difference is still rather obvious.

The code still needs some work/validation/tests and review. @johnrutherford has pointed out a couple of possible issues:
- Possible performance overhead of creating data flow blocks on each request.
- Possible SynchronizationContext issues (see #795).
- Possible DataLoader issues with this strategy.

Also, I'm not sure where the best location would be to invoke: OnBeforeExecutionStepAwaitedAsync(context), but I understand this is necessary to prevent the DataLoader from deadlocking.

Before
![parallel-strategy-before](https://user-images.githubusercontent.com/2086859/47959831-b6969380-dfbb-11e8-9748-af7bd765544f.png)
After
![parallel-strategy-after](https://user-images.githubusercontent.com/2086859/47959832-b9918400-dfbb-11e8-9a9d-cace720b6256.png)
