### PR TITLE
Optimize ParallelExecutionStrategy

### DIFF
--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -189,6 +190,77 @@ namespace GraphQL.DataLoader.Tests
         }
     }
 }");
+
+            result.Errors.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task ParallelExecution_SubNodeExecution()
+        {
+            DateTime usersFetched = default;
+            DateTime ordersFetched = default;
+
+            var users = Fake.Users.Generate(10);
+            var products = Fake.Products.Generate(100);
+            var reviews = Fake.GenerateReviewsForUsers(users, 2);
+            var orders = Fake.GenerateOrdersForUsers(users, 1);
+
+            var usersMock = Services.GetRequiredService<Mock<IUsersStore>>();
+            var productsMock = Services.GetRequiredService<Mock<IProductsStore>>();
+            var reviewsMock = Services.GetRequiredService<Mock<IProductReviewsStore>>();
+            var ordersMock = Services.GetRequiredService<Mock<IOrdersStore>>();
+
+            reviewsMock.Setup(x => x.GetAllProductReviewsAsync())
+                .ReturnsAsync(reviews);
+
+            usersMock.Setup(x => x.GetUsersByIdAsync(It.IsAny<IEnumerable<int>>(), default))
+                .Returns(async () =>
+                {
+                    usersFetched = DateTime.Now;
+                    await Task.Delay(100);
+
+                    return users.ToDictionary(x => x.UserId);
+                });
+
+            ordersMock.Setup(x => x.GetOrdersByUserIdAsync(It.IsAny<IEnumerable<int>>(), default))
+                .ReturnsAsync(() =>
+                {
+                    ordersFetched = DateTime.Now;
+                    return orders.ToLookup(x => x.UserId);
+                });
+
+            productsMock.Setup(x => x.GetProductsByIdAsync(It.IsAny<IEnumerable<int>>()))
+                .Returns(async () =>
+                {
+                    await Task.Delay(500);
+                    return products.ToDictionary(x => x.ProductId);
+                });
+
+            // The User nodes should finish executing first after .10 seconds.
+            // The user->orders nodes should be able to start executing then.
+            // The products node will take 1 second to execute
+            // So everything should take around 1 second, not 1.5
+
+            var result = await ExecuteQueryAsync<DataLoaderTestSchema>(
+@"
+{
+    allReviews {
+        user {
+            userId
+            firstName
+            orders {
+                orderId
+                orderedOn
+            }
+        }
+        product {
+            productId
+        }
+    }
+}");
+
+            // Make sure orders were fetched soon after orders were fetched
+            (ordersFetched - usersFetched).ShouldBeLessThan(TimeSpan.FromSeconds(0.2));
 
             result.Errors.ShouldBeNull();
         }

--- a/src/GraphQL.DataLoader.Tests/Models/Fake.cs
+++ b/src/GraphQL.DataLoader.Tests/Models/Fake.cs
@@ -12,11 +12,13 @@ namespace GraphQL.DataLoader.Tests.Models
         private int userId;
         private int orderId;
         private int productId;
+        private int productReviewId;
 
         public Faker<Order> Orders { get; }
         public Faker<OrderItem> OrderItems { get; }
         public Faker<Product> Products { get; }
         public Faker<User> Users { get; }
+        public Faker<ProductReview> ProductReviews { get; }
 
         public Fake()
         {
@@ -43,6 +45,12 @@ namespace GraphQL.DataLoader.Tests.Models
                 .RuleFor(x => x.Name, f => f.Commerce.ProductName())
                 .RuleFor(x => x.Price, f => f.Finance.Amount())
                 .RuleFor(x => x.Description, f => f.Lorem.Paragraphs(2));
+
+            ProductReviews = new Faker<ProductReview>()
+                .RuleFor(x => x.ProductReviewId, f => ++productReviewId)
+                .RuleFor(x => x.ProductId, f => (productId > 0) ? f.Random.Number(1, productId) : 0)
+                .RuleFor(x => x.Rating, f => f.PickRandom(1, 2, 3, 4, 4, 5, 5, 5))
+                .RuleFor(x => x.Text, f => f.Lorem.Paragraphs(2));
         }
 
         public List<Order> GenerateOrdersForUsers(IEnumerable<User> users, int each)
@@ -60,6 +68,23 @@ namespace GraphQL.DataLoader.Tests.Models
             }
 
             return orders;
+        }
+
+        public List<ProductReview> GenerateReviewsForUsers(IEnumerable<User> users, int each)
+        {
+            var reviews = new List<ProductReview>();
+
+            foreach (var user in users)
+            {
+                foreach (var review in ProductReviews.Generate(each))
+                {
+                    review.UserId = user.UserId;
+
+                    reviews.Add(review);
+                }
+            }
+
+            return reviews;
         }
 
         public List<OrderItem> GetItemsForOrders(IEnumerable<Order> orders, int each)

--- a/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
+++ b/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
@@ -41,12 +41,14 @@ namespace GraphQL.DataLoader.Tests
             services.AddSingleton<UserType>();
             services.AddSingleton<OrderItemType>();
             services.AddSingleton<ProductType>();
+            services.AddSingleton<ProductReviewType>();
             services.AddSingleton<IDataLoaderContextAccessor, DataLoaderContextAccessor>();
             services.AddSingleton<IDocumentExecutionListener, DataLoaderDocumentListener>();
 
             var ordersMock = new Mock<IOrdersStore>();
             var usersMock = new Mock<IUsersStore>();
             var productsMock = new Mock<IProductsStore>();
+            var reviewsMock = new Mock<IProductReviewsStore>();
 
             services.AddSingleton(ordersMock);
             services.AddSingleton(ordersMock.Object);
@@ -54,6 +56,8 @@ namespace GraphQL.DataLoader.Tests
             services.AddSingleton(usersMock.Object);
             services.AddSingleton(productsMock);
             services.AddSingleton(productsMock.Object);
+            services.AddSingleton(reviewsMock);
+            services.AddSingleton(reviewsMock.Object);
         }
 
         public ExecutionResult AssertQuerySuccess<TSchema>(

--- a/src/GraphQL.DataLoader.Tests/Stores/IProductReviewsStore.cs
+++ b/src/GraphQL.DataLoader.Tests/Stores/IProductReviewsStore.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL.DataLoader.Tests.Models;
+
+namespace GraphQL.DataLoader.Tests.Stores
+{
+    public interface IProductReviewsStore
+    {
+        Task<IEnumerable<ProductReview>> GetAllProductReviewsAsync();
+    }
+}

--- a/src/GraphQL.DataLoader.Tests/Types/ProductReviewType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/ProductReviewType.cs
@@ -1,0 +1,39 @@
+using GraphQL.DataLoader.Tests.Models;
+using GraphQL.DataLoader.Tests.Stores;
+using GraphQL.Types;
+
+namespace GraphQL.DataLoader.Tests.Types
+{
+    public class ProductReviewType : ObjectGraphType<ProductReview>
+    {
+        public ProductReviewType(IDataLoaderContextAccessor accessor, IProductsStore products, IUsersStore users)
+        {
+            Name = "ProductReview";
+
+            Field(x => x.ProductReviewId);
+
+            Field<ProductType, Product>()
+                .Name("Product")
+                .ResolveAsync(ctx =>
+                {
+                    var loader = accessor.Context.GetOrAddBatchLoader<int, Product>("GetProductsById",
+                        products.GetProductsByIdAsync);
+
+                    return loader.LoadAsync(ctx.Source.ProductId);
+                });
+
+            Field<UserType, User>()
+                .Name("User")
+                .ResolveAsync(ctx =>
+                {
+                    var loader = accessor.Context.GetOrAddBatchLoader<int, User>("GetUsersById",
+                        users.GetUsersByIdAsync);
+
+                    return loader.LoadAsync(ctx.Source.UserId);
+                });
+
+            Field(x => x.Rating);
+            Field(x => x.Text);
+        }
+    }
+}

--- a/src/GraphQL.DataLoader.Tests/Types/QueryType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/QueryType.cs
@@ -7,7 +7,7 @@ namespace GraphQL.DataLoader.Tests.Types
 {
     public class QueryType : ObjectGraphType
     {
-        public QueryType(IDataLoaderContextAccessor accessor, IUsersStore users, IOrdersStore orders)
+        public QueryType(IDataLoaderContextAccessor accessor, IUsersStore users, IOrdersStore orders, IProductReviewsStore reviews)
         {
             Name = "Query";
 
@@ -15,7 +15,7 @@ namespace GraphQL.DataLoader.Tests.Types
                 .Name("Users")
                 .Description("Get all Users")
                 .Returns<IEnumerable<User>>()
-                .ResolveAsync(ctx =>
+                .ResolveAsync(_ =>
                 {
                     var loader = accessor.Context.GetOrAddLoader("GetAllUsers",
                         users.GetAllUsersAsync);
@@ -38,12 +38,20 @@ namespace GraphQL.DataLoader.Tests.Types
             Field<ListGraphType<OrderType>, IEnumerable<Order>>()
                 .Name("Orders")
                 .Description("Get all Orders")
-                .ResolveAsync(ctx =>
+                .ResolveAsync(_ =>
                 {
                     var loader = accessor.Context.GetOrAddLoader("GetAllOrders",
                         orders.GetAllOrdersAsync);
 
                     return loader.LoadAsync();
+                });
+
+            Field<ListGraphType<ProductReviewType>, IEnumerable<ProductReview>>()
+                .Name("AllReviews")
+                .Description("Get all reviews")
+                .ResolveAsync(_ =>
+                {
+                    return reviews.GetAllProductReviewsAsync();
                 });
         }
     }

--- a/src/GraphQL/Execution/ParallelExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ParallelExecutionStrategy.cs
@@ -8,30 +8,69 @@ namespace GraphQL.Execution
     {
         protected override async Task ExecuteNodeTreeAsync(ExecutionContext context, ObjectExecutionNode rootNode)
         {
+            // Nodes that are ready to be executed
             var pendingNodes = new List<ExecutionNode>
             {
                 rootNode
             };
 
-            while (pendingNodes.Count > 0)
-            {
-                var currentTasks = new Task<ExecutionNode>[pendingNodes.Count];
+            // Currently executing nodes
+            var currentTasks = new List<Task<ExecutionNode>>();
 
+            // Nodes that have completed after each step
+            var completedNodes = new List<ExecutionNode>();
+
+            var executionStepTasks = new List<Task>();
+
+            while (pendingNodes.Count > 0 || currentTasks.Count > 0)
+            {
                 // Start executing all pending nodes
                 for (int i = 0; i < pendingNodes.Count; i++)
                 {
                     context.CancellationToken.ThrowIfCancellationRequested();
-                    currentTasks[i] = ExecuteNodeAsync(context, pendingNodes[i]);
+
+                    var task = ExecuteNodeAsync(context, pendingNodes[i]);
+                    currentTasks.Add(task);
                 }
 
                 pendingNodes.Clear();
 
-                await OnBeforeExecutionStepAwaitedAsync(context)
+                // This is used to dispatch any pending DataLoaders
+                // But we don't need to wait for it to complete
+                var executionStepTask = OnBeforeExecutionStepAwaitedAsync(context);
+                executionStepTasks.Add(executionStepTask);
+
+                // Wait for one or more of the current tasks to finish
+                await Task.WhenAny(currentTasks)
                     .ConfigureAwait(false);
 
-                // Await tasks for this execution step
-                var completedNodes = await Task.WhenAll(currentTasks)
-                    .ConfigureAwait(false);
+                // Remove each completed Task from the list and await them
+                for (int i = 0; i < currentTasks.Count; i++)
+                {
+                    if (currentTasks[i].IsCompleted)
+                    {
+                        var task = currentTasks[i];
+
+                        // Remove the completed task and adjust index
+                        // so we don't skip the next item in the list
+                        currentTasks.RemoveAt(i--);
+
+                        var node = await task.ConfigureAwait(false);
+                        completedNodes.Add(node);
+                    }
+                }
+
+                // If the execution task(s) are complete, await them
+                for (int i = 0; i < executionStepTasks.Count; i++)
+                {
+                    if (executionStepTasks[i].IsCompleted)
+                    {
+                        var task = executionStepTasks[i];
+                        executionStepTasks.RemoveAt(i--);
+
+                        await task.ConfigureAwait(false);
+                    }
+                }
 
                 // Add child nodes to pending nodes to execute the next level in parallel
                 var childNodes = completedNodes
@@ -39,7 +78,12 @@ namespace GraphQL.Execution
                     .SelectMany(x => x.GetChildNodes());
 
                 pendingNodes.AddRange(childNodes);
+                completedNodes.Clear();
             }
+
+            // This shouldn't be necessary, but just in case
+            await Task.WhenAll(executionStepTasks)
+                .ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Based on the conversation in #889, I looked at how the `ParallelExecutionStrategy` could be improved upon. 

Currently it executes in steps where nodes are executed and then we wait for them all to complete before starting to execute the child nodes. This repeats until the edges of the graph are reached. 

The problem with this is that the currently executing nodes could finish at different times. If one node takes a long time, we have to wait for that node to complete before executing the child nodes of the nodes that have already completed. 

I made some changes so that we can start executing child nodes as soon as parent nodes complete. And this works with the DataLoader because `OnBeforeExecutionStepAwaitedAsync` is called at the appropriate times. If we can start executing child nodes as soon as parent nodes are complete, it's possible to greatly reduce execution time.

I wrote a test for this, but I know that timing/multi-threaded tests can be flaky with AppVeyor, so if it fails, I'll see if there's another way I can do it.

I still want to do a bit more work on this. I might clean up some stuff and add another test.