### PR TITLE
Fix scalar types added in #812

### DIFF
--- a/src/GraphQL.Tests/Execution/RegisteredInstanceTests.cs
+++ b/src/GraphQL.Tests/Execution/RegisteredInstanceTests.cs
@@ -138,6 +138,8 @@ scalar DateTimeOffset
 
 scalar Decimal
 
+scalar Guid
+
 # The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds.
 scalar Milliseconds
 
@@ -151,6 +153,14 @@ type root {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Short
+
+scalar UInt
+
+scalar ULong
+
+scalar UShort
 ");
         }
 
@@ -177,6 +187,8 @@ scalar DateTimeOffset
 
 scalar Decimal
 
+scalar Guid
+
 # The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds.
 scalar Milliseconds
 
@@ -190,6 +202,14 @@ type root {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Short
+
+scalar UInt
+
+scalar ULong
+
+scalar UShort
 ");
         }
 
@@ -216,6 +236,8 @@ scalar DateTimeOffset
 
 scalar Decimal
 
+scalar Guid
+
 # The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds.
 scalar Milliseconds
 
@@ -229,6 +251,14 @@ type root {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Short
+
+scalar UInt
+
+scalar ULong
+
+scalar UShort
 ");
         }
 

--- a/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
+++ b/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
@@ -121,6 +121,56 @@ namespace GraphQL.Tests.Introspection
           ""possibleTypes"": null
         },
         {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Guid"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Short"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""UShort"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""UInt"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
+          ""kind"": ""SCALAR"",
+          ""name"": ""ULong"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
           ""kind"": ""OBJECT"",
           ""name"": ""__Schema"",
           ""description"": ""A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."",

--- a/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
@@ -240,6 +240,26 @@ namespace GraphQL.Tests.StarWars
                   'kind': 'SCALAR'
                 },
                 {
+                  'name': 'Guid',
+                  'kind': 'SCALAR',
+                },
+                {
+                  'name': 'Short',
+                  'kind': 'SCALAR',
+                },
+                {
+                  'name': 'UShort',
+                  'kind': 'SCALAR',
+                },
+                {
+                  'name': 'UInt',
+                  'kind': 'SCALAR',
+                },
+                {
+                  'name': 'ULong',
+                  'kind': 'SCALAR',
+                },
+                {
                   'name': '__Schema',
                   'kind': 'OBJECT'
                 },

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -416,12 +416,12 @@ scalar UShort
             var schema = new Schema { Query = root };
 
             AssertEqual(print(schema), "", @"
-type Bar implements Foo, Baaz {
-  str: String
-}
-
 interface Baaz {
   int: Int
+}
+
+type Bar implements Foo, Baaz {
+  str: String
 }
 
 # The `Date` scalar type represents a year, month and day in accordance with the

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -47,6 +47,26 @@ scalar Milliseconds"
 @"# The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds"
             },
+            {
+                "Guid",
+                @"scalar Guid"
+            },
+            {
+                "Short",
+                @"scalar Short"
+            },
+            {
+                "UShort",
+                @"scalar UShort"
+            },
+            {
+                "UInt",
+                @"scalar UInt"
+            },
+            {
+                "ULong",
+                @"scalar ULong"
+            }
         };
 
         private string printSingleFieldSchema<T>(
@@ -365,6 +385,8 @@ interface Foo {
   str: String
 }
 
+scalar Guid
+
 # The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds.
 scalar Milliseconds
 
@@ -374,6 +396,14 @@ type Root {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Short
+
+scalar UInt
+
+scalar ULong
+
+scalar UShort
 ", excludeScalars: true);
         }
 
@@ -386,12 +416,12 @@ scalar Seconds
             var schema = new Schema { Query = root };
 
             AssertEqual(print(schema), "", @"
-interface Baaz {
-  int: Int
-}
-
 type Bar implements Foo, Baaz {
   str: String
+}
+
+interface Baaz {
+  int: Int
 }
 
 # The `Date` scalar type represents a year, month and day in accordance with the
@@ -414,6 +444,8 @@ interface Foo {
   str: String
 }
 
+scalar Guid
+
 # The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds.
 scalar Milliseconds
 
@@ -423,6 +455,14 @@ type Query {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Short
+
+scalar UInt
+
+scalar ULong
+
+scalar UShort
 ", excludeScalars: true);
         }
 
@@ -460,6 +500,8 @@ interface Foo {
   str: String
 }
 
+scalar Guid
+
 # The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds.
 scalar Milliseconds
 
@@ -473,7 +515,15 @@ type Query {
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
 
+scalar Short
+
 union SingleUnion = Foo
+
+scalar UInt
+
+scalar ULong
+
+scalar UShort
 ", excludeScalars: true);
         }
 

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -410,6 +410,31 @@ namespace GraphQL
                 return new TimeSpanValue(span);
             }
 
+            if (serialized is Guid guid)
+            {
+                return new GuidValue(guid);
+            }
+
+            if(serialized is short int16)
+            {
+                return new ShortValue(int16);
+            }
+
+            if (serialized is ushort uint16)
+            {
+                return new UShortValue(uint16);
+            }
+
+            if (serialized is uint uint32)
+            {
+                return new UIntValue(uint32);
+            }
+
+            if (serialized is ulong uint64)
+            {
+                return new ULongValue(uint64);
+            }
+
             if (serialized is string)
             {
                 if (type is EnumerationGraphType)

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -25,6 +25,11 @@ namespace GraphQL.Types
             AddType<TimeSpanSecondsGraphType>();
             AddType<TimeSpanMillisecondsGraphType>();
             AddType<DecimalGraphType>();
+            AddType<GuidGraphType>();
+            AddType<ShortGraphType>();
+            AddType<UShortGraphType>();
+            AddType<UIntGraphType>();
+            AddType<ULongGraphType>();
 
             AddType<__Schema>();
             AddType<__Type>();

--- a/src/GraphQL/Types/GuidGraphType.cs
+++ b/src/GraphQL/Types/GuidGraphType.cs
@@ -5,6 +5,11 @@ namespace GraphQL.Types
 {
     public class GuidGraphType : ScalarGraphType
     {
+        public GuidGraphType()
+        {
+            this.Name = "Guid";
+        }
+
         public override object ParseLiteral(IValue value)
         {
             var guidValue = value as GuidValue;

--- a/src/GraphQL/Types/UIntGraphType.cs
+++ b/src/GraphQL/Types/UIntGraphType.cs
@@ -4,6 +4,11 @@ namespace GraphQL.Types
 {
     public class UIntGraphType : ScalarGraphType
     {
+        public UIntGraphType()
+        {
+            this.Name = "UInt";
+        }
+
         public override object ParseLiteral(IValue value)
         {
             var uintValue = value as UIntValue;

--- a/src/GraphQL/Types/ULongGraphType.cs
+++ b/src/GraphQL/Types/ULongGraphType.cs
@@ -1,10 +1,14 @@
-using System;
 using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
     public class ULongGraphType : ScalarGraphType
     {
+        public ULongGraphType()
+        {
+            this.Name = "ULong";
+        }
+
         public override object ParseLiteral(IValue value)
         {
             var ulongValue = value as ULongValue;


### PR DESCRIPTION
Using the scalar types added in #812 doesn't actually work. Causing all sorts of exceptions. 

First of all the types weren't registered, so it attempted to resolve the types from the dependency resolver delegate.

Once that was fixed it failed in the `GraphQL.GraphQLExtensions.AstFromValue` because it didn't actually convert the values to the various value node types that were added.

Lastly, some of the types didn't specify a proper name, causing the schema types to be very verbose.