### PR TITLE
Fix Guid not mapped correctly to IdGraphyType when AutoGenerating Obj…

### DIFF
--- a/src/GraphQL/Utilities/GraphTypeTypeRegistry.cs
+++ b/src/GraphQL/Utilities/GraphTypeTypeRegistry.cs
@@ -21,7 +21,8 @@ namespace GraphQL.Utilities
                 [typeof(bool)] = typeof(BooleanGraphType),
                 [typeof(DateTime)] = typeof(DateGraphType),
                 [typeof(DateTimeOffset)] = typeof(DateTimeOffsetGraphType),
-                [typeof(TimeSpan)] = typeof(TimeSpanSecondsGraphType)
+                [typeof(TimeSpan)] = typeof(TimeSpanSecondsGraphType),
+                [typeof(Guid)] = typeof(IdGraphType)
             };
         }
 


### PR DESCRIPTION
fixes error when Poco type includes a Guid 
`System.ArgumentOutOfRangeException: 'The type: Guid cannot be coerced effectively to a GraphQL type`