### PR TITLE
Updateed introduction.md

### DIFF
--- a/docs2/site/docs/getting-started/introduction.md
+++ b/docs2/site/docs/getting-started/introduction.md
@@ -154,7 +154,6 @@ public class Program
 
     var json = schema.Execute(_ =>
     {
-      _.Schema = schema;
       _.Query = "{ hero { id name } }";
     });
 


### PR DESCRIPTION
having an instance method of schema(e.g. Execute) taking the schema instance as argument is confusing. Why do I have to pass the schema instance twice( once as this and again as Schema property)