### PR TITLE
IsNullable should include strings

### DIFF
--- a/src/GraphQL.Tests/TypeExtensionsTests.cs
+++ b/src/GraphQL.Tests/TypeExtensionsTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests
+{
+    public class TypeExtensionsTests
+    {
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(float))]
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(char))]
+        [InlineData(typeof(TestEnum))]
+        public void is_nullable_using_non_nullable_types(Type type)
+        {
+            TypeExtensions.IsNullable(type).ShouldBeFalse();
+        }
+
+        [Theory]
+        [InlineData(typeof(int?))]
+        [InlineData(typeof(double?))]
+        [InlineData(typeof(float?))]
+        [InlineData(typeof(bool?))]
+        [InlineData(typeof(char?))]
+        [InlineData(typeof(TestEnum?))]
+        [InlineData(typeof(Nullable<>))]
+        [InlineData(typeof(string))]
+        public void is_nullable_using_nullable_types(Type type)
+        {
+            TypeExtensions.IsNullable(type).ShouldBeTrue();
+        }
+
+        private enum TestEnum { }
+    }
+}

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -49,7 +49,7 @@ namespace GraphQL
         public static bool IsNullable(this Type type)
         {
             var typeInfo = type.GetTypeInfo();
-            return typeInfo.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+            return type == typeof(string) || (typeInfo.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
         }
 
         /// <summary>


### PR DESCRIPTION
When using `AutoRegisteringObjectGraphType`, strings are being registered as non-nullable. This fixes this issue.