### PR TITLE
Proposal: update target test FWs

### DIFF
--- a/src/GraphQL.DataLoader.Tests/GraphQL.DataLoader.Tests.csproj
+++ b/src/GraphQL.DataLoader.Tests/GraphQL.DataLoader.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/src/GraphQL.Harness.Tests/GraphQL.Harness.Tests.csproj
+++ b/src/GraphQL.Harness.Tests/GraphQL.Harness.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/GraphQL.Harness/GraphQL.Harness.csproj
+++ b/src/GraphQL.Harness/GraphQL.Harness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
     <AssemblyName>GraphQL.Tests</AssemblyName>
     <PackageId>GraphQL.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Shouldly" Version="3.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
IMO test suites should target the newest current release of supported runtimes. In this case that would be netcoreapp2.2 and net472. at the moment there is no consistency in the sln. eg `GraphQL.Tests.csproj` uses`netcoreapp2.1;netcoreapp2.0;netcoreapp1.1;net452`. ie 3 non-current netcore frameworks and one non-current desktop framework