### PR TITLE
Optimize ParallelExecutionStrategy: Mark2

### DIFF
--- a/src/GraphQL/DataLoader/DataLoaderContext.cs
+++ b/src/GraphQL/DataLoader/DataLoaderContext.cs
@@ -11,7 +11,6 @@ namespace GraphQL.DataLoader
     public class DataLoaderContext
     {
         private readonly Dictionary<string, IDataLoader> _loaders = new Dictionary<string, IDataLoader>();
-        private readonly Queue<IDataLoader> _queue = new Queue<IDataLoader>();
 
         /// <summary>
         /// Add a new data loader if one does not already exist with the provided key
@@ -38,7 +37,6 @@ namespace GraphQL.DataLoader
                     loader = dataLoaderFactory();
 
                     _loaders.Add(loaderKey, loader);
-                    _queue.Enqueue(loader);
                 }
             }
 
@@ -48,37 +46,27 @@ namespace GraphQL.DataLoader
         /// <summary>
         /// Dispatch all registered data loaders
         /// </summary>
-        /// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to pass to fetch delegate</param>
+        /// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to pass to fetch delegates</param>
         public async Task DispatchAllAsync(CancellationToken cancellationToken = default)
         {
             Task task;
 
             lock (_loaders)
             {
-                if (_queue.Count == 0)
-                {
+                if (_loaders.Count == 0)
                     return;
-                }
-                else if (_queue.Count == 1)
-                {
-                    var loader = _queue.Peek();
-                    task = loader.DispatchAsync(cancellationToken);
-                }
-                else
-                {
-                    var tasks = new List<Task>(_queue.Count);
 
-                    // We don't want to pop any loaders off the queue because they may get more work later
-                    foreach (var loader in _queue)
-                    {
-                        tasks.Add(loader.DispatchAsync(cancellationToken));
-                    }
+                var tasks = new List<Task>(_loaders.Count);
 
-                    task = Task.WhenAll(tasks);
+                foreach (var loader in _loaders.Values)
+                {
+                    tasks.Add(loader.DispatchAsync(cancellationToken));
                 }
+
+                task = Task.WhenAll(tasks);
             }
 
-            await task.ConfigureAwait(false);
+            await task;
         }
     }
 }


### PR DESCRIPTION
re apply https://github.com/graphql-dotnet/graphql-dotnet/pull/891

> Based on the conversation in #889, I looked at how the `ParallelExecutionStrategy` could be improved upon. 
> 
> Currently it executes in steps where nodes are executed and then we wait for them all to complete before starting to execute the child nodes. This repeats until the edges of the graph are reached. 
> 
> The problem with this is that the currently executing nodes could finish at different times. If one node takes a long time, we have to wait for that node to complete before executing the child nodes of the nodes that have already completed. 
> 
> I made some changes so that we can start executing child nodes as soon as parent nodes complete. And this works with the DataLoader because `OnBeforeExecutionStepAwaitedAsync` is called at the appropriate times. If we can start executing child nodes as soon as parent nodes are complete, it's possible to greatly reduce execution time.
> 
> I wrote a test for this, but I know that timing/multi-threaded tests can be flaky with AppVeyor, so if it fails, I'll see if there's another way I can do it.
> 
> I still want to do a bit more work on this. I might clean up some stuff and add another test.