### PR TITLE
Fix schema printing of multiple interfaces

### DIFF
--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -390,7 +390,7 @@ interface Baaz {
   int: Int
 }
 
-type Bar implements Foo, Baaz {
+type Bar implements Foo & Baaz {
   str: String
 }
 

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -209,7 +209,7 @@ namespace GraphQL.Utilities
 
             var interfaces = type.ResolvedInterfaces.Select(x => x.Name).ToList();
             var implementedInterfaces = interfaces.Any()
-                ? " implements {0}".ToFormat(string.Join(", ", interfaces))
+                ? " implements {0}".ToFormat(string.Join(" & ", interfaces))
                 : "";
 
             return description + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));


### PR DESCRIPTION
The [GraphQL Schema Documentation](https://facebook.github.io/graphql/draft/#sec-Interfaces) calls for separating multiple interfaces by an ampersand rather than a comma.

This allows for Apollo code generation based on the schema, which currently fails because interfaces are separated by commas.