### PR TITLE
Fix schema printing of field annotations

### DIFF
--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -251,8 +251,8 @@ namespace GraphQL.Utilities
                     x.Name,
                     Type = ResolveName(x.ResolvedType),
                     Args = PrintArgs(x),
-                    Description = _options.IncludeDescriptions ? PrintDescription(type.Description, "  ") : string.Empty,
-                    Deprecation = _options.IncludeDeprecationReasons ? PrintDeprecation(type.DeprecationReason) : string.Empty,
+                    Description = _options.IncludeDescriptions ? PrintDescription(x.Description, "  ") : string.Empty,
+                    Deprecation = _options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : string.Empty,
                 }).ToList();
 
             return string.Join(Environment.NewLine, fields?.Select(


### PR DESCRIPTION
When including descriptions and deprecation reasons on fields in SchemaPrinter, the current code reprints the annotations on the parent type, rather than the annotations from the fields themselves. This fixes the problem by printing the annotations on the fields.