### PR TITLE
Create new SchemaPrinterOptions to allow old implements syntax. Also …

### DIFF
--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -208,11 +208,9 @@ namespace GraphQL.Utilities
             var description = PrintDescription(type.Description);
 
             var interfaces = type.ResolvedInterfaces.Select(x => x.Name).ToList();
-            string interfacesString = _options.OldImplementsSyntax
-                ? string.Join(", ", interfaces)
-                : string.Join(" & ", interfaces);
+            var delimiter = _options.OldImplementsSyntax ? ", " : " & ";
             var implementedInterfaces = interfaces.Any()
-                ? " implements {0}".ToFormat(interfacesString)
+                ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
                 : "";
 
             var result =  description + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -213,9 +213,7 @@ namespace GraphQL.Utilities
                 ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
                 : "";
 
-            var result =  description + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));
-
-            return result;
+            return description + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));
         }
 
         public string PrintInterface(IInterfaceGraphType type)
@@ -258,10 +256,8 @@ namespace GraphQL.Utilities
                     Deprecation = _options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : string.Empty,
                 }).ToList();
 
-            var result = string.Join(Environment.NewLine, fields?.Select(
+            return string.Join(Environment.NewLine, fields?.Select(
                 f => "{3}  {0}{1}: {2}{4}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation)));
-
-            return result;
         }
 
         public string PrintArgs(FieldType field)

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -208,11 +208,16 @@ namespace GraphQL.Utilities
             var description = PrintDescription(type.Description);
 
             var interfaces = type.ResolvedInterfaces.Select(x => x.Name).ToList();
+            string interfacesString = _options.OldImplementsSyntax
+                ? string.Join(", ", interfaces)
+                : string.Join(" & ", interfaces);
             var implementedInterfaces = interfaces.Any()
-                ? " implements {0}".ToFormat(string.Join(", ", interfaces))
+                ? " implements {0}".ToFormat(interfacesString)
                 : "";
 
-            return description + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));
+            var result =  description + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));
+
+            return result;
         }
 
         public string PrintInterface(IInterfaceGraphType type)
@@ -251,12 +256,14 @@ namespace GraphQL.Utilities
                     x.Name,
                     Type = ResolveName(x.ResolvedType),
                     Args = PrintArgs(x),
-                    Description = _options.IncludeDescriptions ? PrintDescription(type.Description, "  ") : string.Empty,
-                    Deprecation = _options.IncludeDeprecationReasons ? PrintDeprecation(type.DeprecationReason) : string.Empty,
+                    Description = _options.IncludeDescriptions ? PrintDescription(x.Description, "  ") : string.Empty,
+                    Deprecation = _options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : string.Empty,
                 }).ToList();
 
-            return string.Join(Environment.NewLine, fields?.Select(
+            var result = string.Join(Environment.NewLine, fields?.Select(
                 f => "{3}  {0}{1}: {2}{4}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation)));
+
+            return result;
         }
 
         public string PrintArgs(FieldType field)

--- a/src/GraphQL/Utilities/SchemaPrinterOptions.cs
+++ b/src/GraphQL/Utilities/SchemaPrinterOptions.cs
@@ -9,5 +9,7 @@ namespace GraphQL.Utilities
         public bool IncludeDescriptions { get; set; } = false;
 
         public bool IncludeDeprecationReasons { get; set; } = false;
+
+        public bool OldImplementsSyntax { get; set; } = false;
     }
 }


### PR DESCRIPTION
1. Create new SchemaPrinterOptions to allow old implements syntax.
- Creating `SchemaPrinterOptions.OldImplementsSyntax` will fix discontinuity issues that were incidentally created from this [ticket](https://github.com/graphql/graphql-js/pull/1169) for graphql/graphql-js while still allowing backwards compatibility.

2. Fix `SchemaPrinterOptions.IncludeDescriptions` option to print field descriptions and not the object type description.
- This is a bug fix to correctly output field descriptions.