### PR TITLE
fix UriGraphType registration and related failing test cases

### DIFF
--- a/src/GraphQL.Tests/Execution/RegisteredInstanceTests.cs
+++ b/src/GraphQL.Tests/Execution/RegisteredInstanceTests.cs
@@ -151,6 +151,8 @@ type root {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Uri
 ");
         }
 
@@ -190,6 +192,8 @@ type root {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Uri
 ");
         }
 
@@ -229,6 +233,8 @@ type root {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Uri
 ");
         }
 

--- a/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
+++ b/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
@@ -121,6 +121,16 @@ namespace GraphQL.Tests.Introspection
           ""possibleTypes"": null
         },
         {
+          ""kind"": ""SCALAR"",
+          ""name"": ""Uri"",
+          ""description"": null,
+          ""fields"": null,
+          ""inputFields"": null,
+          ""interfaces"": null,
+          ""enumValues"": null,
+          ""possibleTypes"": null
+        },
+        {
           ""kind"": ""OBJECT"",
           ""name"": ""__Schema"",
           ""description"": ""A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."",

--- a/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
@@ -240,6 +240,10 @@ namespace GraphQL.Tests.StarWars
                   'kind': 'SCALAR'
                 },
                 {
+                  'name': 'Uri',
+                  'kind': 'SCALAR'
+                },
+                {
                   'name': '__Schema',
                   'kind': 'OBJECT'
                 },

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -47,6 +47,10 @@ scalar Milliseconds"
 @"# The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds"
             },
+            {
+                "Uri",
+                "scalar Uri"
+            },
         };
 
         private string printSingleFieldSchema<T>(
@@ -374,6 +378,8 @@ type Root {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Uri
 ", excludeScalars: true);
         }
 
@@ -423,6 +429,8 @@ type Query {
 
 # The `Seconds` scalar type represents a period of time represented as the total number of seconds.
 scalar Seconds
+
+scalar Uri
 ", excludeScalars: true);
         }
 
@@ -474,6 +482,8 @@ type Query {
 scalar Seconds
 
 union SingleUnion = Foo
+
+scalar Uri
 ", excludeScalars: true);
         }
 

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -25,6 +25,7 @@ namespace GraphQL.Types
             AddType<TimeSpanSecondsGraphType>();
             AddType<TimeSpanMillisecondsGraphType>();
             AddType<DecimalGraphType>();
+            AddType<UriGraphType>();
 
             AddType<__Schema>();
             AddType<__Type>();


### PR DESCRIPTION
Fix #949

- [x] Registered the `UriGraphType` in GraphTypesLookup
- [x] Fix failing test cases