### PR TITLE
remove some redundant parse calls

### DIFF
--- a/src/GraphQL/Types/DateGraphType.cs
+++ b/src/GraphQL/Types/DateGraphType.cs
@@ -33,7 +33,7 @@ namespace GraphQL.Types
         {
             if (value is DateTimeValue timeValue)
             {
-                return ParseValue(timeValue.Value);
+                return timeValue.Value;
             }
 
             if (value is StringValue stringValue)

--- a/src/GraphQL/Types/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/DateTimeGraphType.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Types
         {
             if (value is DateTimeValue timeValue)
             {
-                return ParseValue(timeValue.Value);
+                return timeValue.Value;
             }
 
             if (value is StringValue stringValue)

--- a/src/GraphQL/Types/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/DateTimeOffsetGraphType.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Types
         {
             if (value is DateTimeOffsetValue offsetValue)
             {
-                return ParseValue(offsetValue.Value);
+                return offsetValue.Value;
             }
 
             if (value is StringValue stringValue)

--- a/src/GraphQL/Types/DecimalGraphType.cs
+++ b/src/GraphQL/Types/DecimalGraphType.cs
@@ -43,7 +43,7 @@ namespace GraphQL.Types
 
             if (value is DecimalValue decimalValue)
             {
-                return ParseValue(decimalValue.Value);
+                return decimalValue.Value;
             }
 
             return null;

--- a/src/GraphQL/Types/UriGraphType.cs
+++ b/src/GraphQL/Types/UriGraphType.cs
@@ -17,11 +17,16 @@ namespace GraphQL.Types
         public override object ParseLiteral(IValue value)
         {
             if (value is UriValue uriValue)
-                return ParseValue(uriValue.Value);
+            {
+                return uriValue.Value;
+            }
 
-            return value is StringValue stringValue
-                ? ParseValue(stringValue.Value)
-                : null;
+            if (value is StringValue stringValue)
+            {
+                return ParseValue(stringValue.Value);
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
since we already have the strong type value, there is no point doing the call to `ParseValue`. so less code and avoids some calls to `ValueConverter.ConvertTo`