### PR TITLE
Fix TimeSpan Parsing

### DIFF
--- a/src/GraphQL.Tests/Types/TimeSpanMillisecondsGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/TimeSpanMillisecondsGraphTypeTests.cs
@@ -21,6 +21,28 @@ namespace GraphQL.Tests.Types
         }
 
         [Fact]
+        public void serialize_long()
+        {
+            CultureTestHelper.UseCultures(() =>
+            {
+                long input = 1;
+                var actual = _type.Serialize(input);
+                actual.ShouldBe(input);
+            });
+        }
+
+        [Fact]
+        public void serialize_int()
+        {
+            CultureTestHelper.UseCultures(() =>
+            {
+                int input = 1;
+                var actual = _type.Serialize(input);
+                actual.ShouldBe(input);
+            });
+        }
+
+        [Fact]
         public void serialize_timespan_returns_total_seconds_as_long()
         {
             CultureTestHelper.UseCultures(() =>

--- a/src/GraphQL.Tests/Types/TimeSpanSecondsGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/TimeSpanSecondsGraphTypeTests.cs
@@ -20,6 +20,28 @@ namespace GraphQL.Tests.Types
         }
 
         [Fact]
+        public void serialize_long()
+        {
+            CultureTestHelper.UseCultures(() =>
+            {
+                long input = 1;
+                var actual = _type.Serialize(input);
+                actual.ShouldBe(input);
+            });
+        }
+
+        [Fact]
+        public void serialize_int()
+        {
+            CultureTestHelper.UseCultures(() =>
+            {
+                int input = 1;
+                var actual = _type.Serialize(input);
+                actual.ShouldBe(input);
+            });
+        }
+
+        [Fact]
         public void serialize_timespan_returns_total_seconds_as_long()
         {
             CultureTestHelper.UseCultures(() =>

--- a/src/GraphQL/Types/TimeSpanMillisecondsGraphType.cs
+++ b/src/GraphQL/Types/TimeSpanMillisecondsGraphType.cs
@@ -18,6 +18,14 @@ namespace GraphQL.Types
             {
                 return (long)timeSpan.TotalMilliseconds;
             }
+            else if (value is int i)
+            {
+                return i;
+            }
+            else if (value is long l)
+            {
+                return l;
+            }
 
             return null;
         }

--- a/src/GraphQL/Types/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/TimeSpanSecondsGraphType.cs
@@ -18,6 +18,14 @@ namespace GraphQL.Types
             {
                 return (long)timeSpan.TotalSeconds;
             }
+            else if (value is int i)
+            {
+                return i;
+            }
+            else if (value is long l)
+            {
+                return l;
+            }
 
             return null;
         }


### PR DESCRIPTION
With timespans not being a supported type from the GraphQL side of things they are transported as a numeric value and converted in the library.  

When the library is parsing values into their fields it refers back to the AST where the value is an numeric value.  This currently fails as it expects a TimeSpan to have been passed which isn't the case.  The only conversion I can see is validation of the field value but this doesn't affect the value stored in the AST.