### PR TITLE
Fix derived type lookup in GraphTypesLookup

### DIFF
--- a/src/GraphQL.Tests/Types/GraphTypesLookupTests.cs
+++ b/src/GraphQL.Tests/Types/GraphTypesLookupTests.cs
@@ -9,6 +9,9 @@ namespace GraphQL.Tests.Types
     {
         private class TestType : GraphType { }
 
+        private class BaseTestType : GraphType { }
+        private class ConcreteTestType : BaseTestType { }
+
         private readonly ManualResetEvent _inIteration = new ManualResetEvent(false);
         private readonly ManualResetEvent _lookupModified = new ManualResetEvent(false);
         private readonly GraphTypesLookup _lookup = new GraphTypesLookup();
@@ -32,6 +35,14 @@ namespace GraphQL.Tests.Types
             _inIteration.WaitOne();
             _lookup["test"] = new TestType();
             _lookupModified.Set();
+        }
+
+        [Fact]
+        public void get_subclass_type()
+        {
+            _lookup["concrete"] = new ConcreteTestType();
+            IGraphType type = _lookup[typeof(BaseTestType)];
+            Assert.IsType<ConcreteTestType>(type);
         }
     }
 }

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -137,7 +137,7 @@ namespace GraphQL.Types
             {
                 lock (_lock)
                 {
-                    var result = _types.FirstOrDefault(x => type.IsAssignableFrom(x.Value.GetType()));
+                    var result = _types.SingleOrDefault(x => type.IsAssignableFrom(x.Value.GetType()));
                     return result.Value;
                 }
             }

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using GraphQL.Conversion;
 using GraphQL.Introspection;
 
@@ -136,7 +137,7 @@ namespace GraphQL.Types
             {
                 lock (_lock)
                 {
-                    var result = _types.FirstOrDefault(x => x.Value.GetType() == type);
+                    var result = _types.FirstOrDefault(x => type.IsAssignableFrom(x.Value.GetType()));
                     return result.Value;
                 }
             }


### PR DESCRIPTION
Previously, `this[Type type]` in GraphTypesLookup only got a resolver if the type given was exactly that type. This doesn't work if it's looking for a base type where you have a derived type registered.

When a schema is discovering abstract types, ordinarily it'll just fail to activate them. But with a resolver, it will retrieve the type, but fail to see the type is in the GraphTypesLookup, and attempt to add it again. Without a cycle, this isn't an issue - but with a cycle, this will recurse until your program crashes with a StackOverflowException.

Now, `this[Type type]` checks to see if any type can be assigned to the type. To avoid ambiguity, it uses SingleOrDefault now, rather than FirstOrDefault.