### PR TITLE
Fix small typo ("in" → "on")

### DIFF
--- a/docs2/site/docs/guides/links.md
+++ b/docs2/site/docs/guides/links.md
@@ -1,5 +1,5 @@
 # Links
 
 * [API Development in .NET with GraphQL](https://www.lynda.com/NET-tutorials/API-Development-NET-GraphQL/664823-2.html) by [Glenn Block](https://twitter.com/gblock) - demonstrates how to use the GraphQL .NET framework to build a fully functional GraphQL endpoint.
-* [ASP.NET Core GraphQL Boxed Project Template](https://github.com/Dotnet-Boxed/Templates/blob/master/Docs/GraphQL.md) - A fully featured GraphQL server project template with lots of optional features built in top of ASP.NET Core.
+* [ASP.NET Core GraphQL Boxed Project Template](https://github.com/Dotnet-Boxed/Templates/blob/master/Docs/GraphQL.md) - A fully featured GraphQL server project template with lots of optional features built on top of ASP.NET Core.
 * [10 part blog series](http://fiyazhasan.me/tag/graphql-dotnet/) by [Fiyaz Hasan](https://twitter.com/FiyazBinHasan)


### PR DESCRIPTION
Fixing a small typo on the "links" page.