### PR TITLE
fix typos InvalidNumberOfRootFieldMessaage

### DIFF
--- a/src/GraphQL.Tests/Validation/SingleRootFieldSubscriptionsTests.cs
+++ b/src/GraphQL.Tests/Validation/SingleRootFieldSubscriptionsTests.cs
@@ -43,7 +43,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(config =>
             {
                 config.Query = query;
-                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessaage(null), 4, 21);
+                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessage(null), 4, 21);
             });
         }
 
@@ -60,7 +60,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(config =>
             {
                 config.Query = query;
-                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessaage(null), 4, 21);
+                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessage(null), 4, 21);
             });
         }
 
@@ -78,7 +78,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(config =>
             {
                 config.Query = query;
-                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessaage(subscriptionName), 4, 21);
+                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessage(subscriptionName), 4, 21);
             });
         }
 
@@ -96,7 +96,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(config =>
             {
                 config.Query = query;
-                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessaage(subscriptionName), 4, 21);
+                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessage(subscriptionName), 4, 21);
             });
         }
 
@@ -121,7 +121,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(config =>
             {
                 config.Query = query;
-                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessaage(subscriptionName), 3, 21);
+                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessage(subscriptionName), 3, 21);
             });
         }
 
@@ -144,7 +144,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(config =>
             {
                 config.Query = query;
-                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessaage(subscriptionName), 3, 21);
+                config.Error(SingleRootFieldSubscriptions.InvalidNumberOfRootFieldMessage(subscriptionName), 3, 21);
             });
         }
 

--- a/src/GraphQL/Validation/Rules/SingleRootFieldSubscriptions.cs
+++ b/src/GraphQL/Validation/Rules/SingleRootFieldSubscriptions.cs
@@ -29,7 +29,7 @@ namespace GraphQL.Validation.Rules
                             new ValidationError(
                                 context.OriginalQuery,
                                 RuleCode,
-                                InvalidNumberOfRootFieldMessaage(operation.Name),
+                                InvalidNumberOfRootFieldMessage(operation.Name),
                                 operation.SelectionSet.Selections.Skip(1).ToArray()));
                     }
 
@@ -56,7 +56,7 @@ namespace GraphQL.Validation.Rules
                             new ValidationError(
                                 context.OriginalQuery,
                                 RuleCode,
-                                InvalidNumberOfRootFieldMessaage(operation.Name),
+                                InvalidNumberOfRootFieldMessage(operation.Name),
                                 fragment));
                     }
 
@@ -64,7 +64,7 @@ namespace GraphQL.Validation.Rules
             });
         }
 
-        public static string InvalidNumberOfRootFieldMessaage(string name)
+        public static string InvalidNumberOfRootFieldMessage(string name)
         {
             string prefix = name != null ? $"Subscription '{name}'" : "Anonymous Subscription";
             return $"{prefix} must select only one top level field.";


### PR DESCRIPTION
@joemcbride this is a public method. so good to fix for v3. do u want me to re-add the old method with an obsolete attribute?