### PR TITLE
remove debug asserts

### DIFF
--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using GraphQL.Language.AST;
 using GraphQLParser;
@@ -192,72 +191,61 @@ namespace GraphQL.Language
             {
                 case ASTNodeKind.StringValue:
                 {
-                    var str = source as GraphQLScalarValue;
-                    Debug.Assert(str != null, nameof(str) + " != null");
-
+                    var str = (GraphQLScalarValue)source;
                     return new StringValue(str.Value).WithLocation(str, _body);
                 }
                 case ASTNodeKind.IntValue:
                 {
-                    var str = source as GraphQLScalarValue;
-                    Debug.Assert(str != null, nameof(str) + " != null");
+                    var str = (GraphQLScalarValue)source;
 
                     if (int.TryParse(str.Value, out var intResult))
                     {
-                        var val = new IntValue(intResult).WithLocation(str, _body);
-                        return val;
+                        return new IntValue(intResult).WithLocation(str, _body);
                     }
 
                     // If the value doesn't fit in an integer, revert to using long...
                     if (long.TryParse(str.Value, out var longResult))
                     {
-                        var val = new LongValue(longResult).WithLocation(str, _body);
-                        return val;
+                        return new LongValue(longResult).WithLocation(str, _body);
                     }
 
                     throw new ExecutionError($"Invalid number {str.Value}");
                 }
                 case ASTNodeKind.FloatValue:
                 {
-                    var str = source as GraphQLScalarValue;
-                    Debug.Assert(str != null, nameof(str) + " != null");
+                    var str = (GraphQLScalarValue)source;
                     return new FloatValue(ValueConverter.ConvertTo<double>(str.Value)).WithLocation(str, _body);
                 }
                 case ASTNodeKind.BooleanValue:
                 {
-                    var str = source as GraphQLScalarValue;
-                    Debug.Assert(str != null, nameof(str) + " != null");
+                    var str = (GraphQLScalarValue)source;
                     return new BooleanValue(ValueConverter.ConvertTo<bool>(str.Value)).WithLocation(str, _body);
                 }
                 case ASTNodeKind.EnumValue:
                 {
-                    var str = source as GraphQLScalarValue;
-                    Debug.Assert(str != null, nameof(str) + " != null");
+                    var str = (GraphQLScalarValue)source;
                     return new EnumValue(str.Value).WithLocation(str, _body);
                 }
                 case ASTNodeKind.Variable:
                 {
-                    var vari = source as GraphQLVariable;
-                    Debug.Assert(vari != null, nameof(vari) + " != null");
+                    var vari = (GraphQLVariable)source;
                     return new VariableReference(Name(vari.Name)).WithLocation(vari, _body);
                 }
                 case ASTNodeKind.ObjectValue:
                 {
-                    var obj = source as GraphQLObjectValue;
-                    Debug.Assert(obj != null, nameof(obj) + " != null");
+                    var obj = (GraphQLObjectValue)source;
                     var fields = obj.Fields.Select(ObjectField);
                     return new ObjectValue(fields).WithLocation(obj, _body);
                 }
                 case ASTNodeKind.ListValue:
                 {
-                    var list = source as GraphQLListValue;
-                    Debug.Assert(list != null, nameof(list) + " != null");
+                    var list = (GraphQLListValue)source;
                     var values = list.Values.Select(Value);
                     return new ListValue(values).WithLocation(list, _body);
                 }
                 case ASTNodeKind.NullValue:
                 {
-                    var str = source as GraphQLScalarValue;
+                    var str = (GraphQLScalarValue)source;
                     return new NullValue().WithLocation(str, _body);
                 }
             }
@@ -267,14 +255,12 @@ namespace GraphQL.Language
 
         public ObjectField ObjectField(GraphQLObjectField source)
         {
-            var field = new ObjectField(Name(source.Name), Value(source.Value)).WithLocation(source, _body);
-            return field;
+            return new ObjectField(Name(source.Name), Value(source.Value)).WithLocation(source, _body);
         }
 
         public NamedType NamedType(GraphQLNamedType source)
         {
-            var type = new NamedType(Name(source.Name)).WithLocation(source, _body);
-            return type;
+            return new NamedType(Name(source.Name)).WithLocation(source, _body);
         }
 
         public IType Type(GraphQLType type)


### PR DESCRIPTION
these are at best redundant, at worse make it difficult to debug issues in release mode

In debug mode, when we r running the solution locally, the debugs currently do not trigger. So changing them to casts will still protect against the same scenario.

In release mode the asserts are compiled out, and could result in a null ref exception