### PR TITLE
add context dictionary

### DIFF
--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -153,7 +153,8 @@ namespace GraphQL
                     options.CancellationToken,
                     metrics,
                     options.Listeners,
-                    options.ThrowOnUnhandledException);
+                    options.ThrowOnUnhandledException,
+                    options.ContextBag);
 
                 if (context.Errors.Any())
                 {
@@ -234,14 +235,15 @@ namespace GraphQL
             CancellationToken cancellationToken,
             Metrics metrics,
             IEnumerable<IDocumentExecutionListener> listeners,
-            bool throwOnUnhandledException)
+            bool throwOnUnhandledException,
+            Dictionary<string, object> contextBag)
         {
             var context = new ExecutionContext();
             context.Document = document;
             context.Schema = schema;
             context.RootValue = root;
             context.UserContext = userContext;
-
+            context.ContextBag = contextBag;
             context.Operation = operation;
             context.Variables = GetVariableValues(document, schema, operation?.Variables, inputs);
             context.Fragments = document.Fragments;

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -21,6 +21,8 @@ namespace GraphQL.Execution
 
         public object RootValue { get; set; }
 
+        public Dictionary<string, object> ContextBag { get; set; }
+
         public object UserContext { get; set; }
 
         public Operation Operation { get; set; }

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -37,5 +37,7 @@ namespace GraphQL
         public bool SetFieldMiddleware { get; set; } = true;
 
         public bool ThrowOnUnhandledException { get; set; } = false;
+        
+        public Dictionary<string, object> ContextBag { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -26,6 +26,8 @@ namespace GraphQL.Types
 
         public object UserContext { get; set; }
 
+        public Dictionary<string, object> ContextBag { get; set; }
+
         public TSource Source { get; set; }
 
         public ISchema Schema { get; set; }
@@ -67,6 +69,7 @@ namespace GraphQL.Types
             Fragments = context.Fragments;
             RootValue = context.RootValue;
             UserContext = context.UserContext;
+            ContextBag = context.ContextBag;
             Operation = context.Operation;
             Variables = context.Variables;
             CancellationToken = context.CancellationToken;
@@ -167,6 +170,7 @@ namespace GraphQL.Types
             Fragments = context.Fragments;
             RootValue = context.RootValue;
             UserContext = context.UserContext;
+            ContextBag = context.ContextBag;
             Operation = context.Operation;
             Variables = context.Variables;
             CancellationToken = context.CancellationToken;


### PR DESCRIPTION
when writing extensions for for graphql, it is really helpful to have a dictionary that can be passed through all contexts

fixes #637