### PR TITLE
Added the ability to extract an optional DescriptionAttribute from the enum within the EnumerationGraphType<TEnum> constructor

### DIFF
--- a/src/GraphQL.Tests/Types/EnumGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/EnumGraphTypeTests.cs
@@ -1,5 +1,6 @@
 using GraphQL.Types;
 using Shouldly;
+using System.ComponentModel;
 using System.Linq;
 using Xunit;
 
@@ -12,6 +13,8 @@ namespace GraphQL.Tests.Types
             Blue,
             Green,
             Yellow,
+
+            [Description("A pale purple color named after the mallow flower.")]
             Mauve
         }
 
@@ -43,6 +46,21 @@ namespace GraphQL.Tests.Types
         {
             type.Values.Count().ShouldBe(5);
             type.Values.First().Name.ShouldBe("RED");
+        }
+
+        [Fact]
+        public void adds_values_from_enum_no_description_attribute()
+        {
+            type.Values.Count().ShouldBe(5);
+            type.Values.First().Description.ShouldBeNull();
+        }
+
+
+        [Fact]
+        public void adds_values_from_enum_with_description_attribute()
+        {
+            type.Values.Count().ShouldBe(5);
+            type.Values.Last().Description.ShouldBe("A pale purple color named after the mallow flower.");
         }
 
         [Fact]

--- a/src/GraphQL/Types/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/EnumerationGraphType.cs
@@ -71,12 +71,14 @@ namespace GraphQL.Types
         public EnumerationGraphType()
         {
             var type = typeof(TEnum);
-            var values = (TEnum[])Enum.GetValues(typeof(TEnum));
-            var enumFields = values.Select(v => (value: v, field: v.GetType().GetField(v.ToString())));
-            var enumGraphData = enumFields.Select(e => (
-                name: Enum.GetName(typeof(TEnum), e.value),
-                e.value,
-                description: (e.field.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault() as DescriptionAttribute)?.Description
+            var names = Enum.GetNames(type);
+            var enumMembers = names.Select(n => (name: n, memeber: type
+                    .GetMember(n, BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                    .First()));
+            var enumGraphData = enumMembers.Select(e => (
+                name: ChangeEnumCase(e.name),
+                value: Enum.Parse(type, e.name),
+                description: (e.memeber.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault() as DescriptionAttribute)?.Description
             ));
 
             Name = Name ?? StringUtils.ToPascalCase(type.Name);


### PR DESCRIPTION
Having an optional Description is a nice-to-have that makes integrating C# enums into GraphQL Enums more complete.

**Example usage:**

Enum:
```
[Flags]
public enum OrderStatuses {
    [Description("Order was created")]
    CREATED = 2,

    [Description("Order is being processed")]
    PROCESSING = 4,

    [Description("Order is completed")]
    COMPLETED = 8,

    [Description("Order was cancelled")]
    CANCELLED = 16,

    [Description("Order was closed")]
    CLOSED = 32
}
```

GraphQL Type:
` public class OrderStatusesEnum : EnumerationGraphType<OrderStatuses> { }`