### PR TITLE
change user context to a dictionary

### DIFF
--- a/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
+++ b/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
@@ -60,7 +60,7 @@ namespace GraphQL.DataLoader.Tests
             string query,
             string expected,
             Inputs inputs = null,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default)
             where TSchema : ISchema
         {
@@ -127,7 +127,7 @@ namespace GraphQL.DataLoader.Tests
             string query,
             ExecutionResult expectedExecutionResult,
             Inputs inputs = null,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default)
             where TSchema : ISchema
         {

--- a/src/GraphQL.Harness/GraphQLSettings.cs
+++ b/src/GraphQL.Harness/GraphQLSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 
 namespace Example
@@ -6,7 +7,7 @@ namespace Example
     public class GraphQLSettings
     {
         public PathString Path { get; set; } = "/api/graphql";
-        public Func<HttpContext, object> BuildUserContext { get; set; }
+        public Func<HttpContext, IDictionary<string, object>> BuildUserContext { get; set; }
         public bool EnableMetrics { get; set; }
     }
 }

--- a/src/GraphQL.Harness/GraphQLUserContext.cs
+++ b/src/GraphQL.Harness/GraphQLUserContext.cs
@@ -1,8 +1,9 @@
-﻿using System.Security.Claims;
+using System.Collections.Generic;
+using System.Security.Claims;
 
 namespace Example
 {
-    public class GraphQLUserContext
+    public class GraphQLUserContext: Dictionary<string, object>
     {
         public ClaimsPrincipal User { get; set; }
     }

--- a/src/GraphQL.Tests/BasicQueryTestBase.cs
+++ b/src/GraphQL.Tests/BasicQueryTestBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -22,7 +22,7 @@ namespace GraphQL.Tests
             string expected,
             Inputs inputs = null,
             object root = null,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default(CancellationToken),
             IEnumerable<IValidationRule> rules = null)
         {
@@ -67,7 +67,7 @@ namespace GraphQL.Tests
             ExecutionResult expectedExecutionResult,
             Inputs inputs,
             object root,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default(CancellationToken),
             IEnumerable<IValidationRule> rules = null)
         {

--- a/src/GraphQL.Tests/Execution/ExecutionListenerTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionListenerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Execution;
@@ -53,7 +54,7 @@ namespace GraphQL.Tests.Execution
             }
         }
 
-        public class TestContext
+        public class TestContext: Dictionary<string, object>
         {
             private TaskCompletionSource<string> _tcs;
 

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -47,7 +47,7 @@ namespace GraphQL.Tests
             string expected,
             Inputs inputs = null,
             object root = null,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default(CancellationToken),
             IEnumerable<IValidationRule> rules = null)
         {
@@ -60,7 +60,7 @@ namespace GraphQL.Tests
             string expected,
             Inputs inputs = null,
             object root = null,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default(CancellationToken),
             int expectedErrorCount = 0,
             bool renderErrors = false)
@@ -82,7 +82,7 @@ namespace GraphQL.Tests
             ExecutionResult expectedExecutionResult,
             Inputs inputs= null,
             object root = null,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default(CancellationToken),
             int expectedErrorCount = 0,
             bool renderErrors = false)
@@ -120,7 +120,7 @@ namespace GraphQL.Tests
             ExecutionResult expectedExecutionResult,
             Inputs inputs,
             object root,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default(CancellationToken),
             IEnumerable<IValidationRule> rules = null)
         {

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -501,7 +501,7 @@ type Mutation {
         }
     }
 
-    class MyUserContext
+    class MyUserContext: Dictionary<string, object>
     {
         public string Name { get; set; }
     }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -230,7 +230,7 @@ namespace GraphQL
             Document document,
             Operation operation,
             Inputs inputs,
-            object userContext,
+            IDictionary<string, object> userContext,
             CancellationToken cancellationToken,
             Metrics metrics,
             IEnumerable<IDocumentExecutionListener> listeners,

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Execution
 
         public object RootValue { get; set; }
 
-        public object UserContext { get; set; }
+        public IDictionary<string, object> UserContext { get; set; }
 
         public Operation Operation { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -20,7 +20,7 @@ namespace GraphQL
         public Inputs Inputs { get; set; }
         public CancellationToken CancellationToken { get; set; } = default;
         public IEnumerable<IValidationRule> ValidationRules { get; set; }
-        public object UserContext { get; set; }
+        public IDictionary<string, object> UserContext { get; set; } = new Dictionary<string, object>();
         public IFieldMiddlewareBuilder FieldMiddleware { get; set; } = new FieldMiddlewareBuilder();
         public ComplexityConfiguration ComplexityConfiguration { get; set; } = null;
 


### PR DESCRIPTION
change `ExecutionOptions.UserContext ` to be a `IDictionary<string,object>`

replaces https://github.com/graphql-dotnet/graphql-dotnet/pull/1037