### PR TITLE
No more GetTypeInfo()

### DIFF
--- a/src/GraphQL.StarWars/IoC/SimpleContainer.cs
+++ b/src/GraphQL.StarWars/IoC/SimpleContainer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace GraphQL.StarWars.IoC
 {
@@ -65,7 +64,7 @@ namespace GraphQL.StarWars.IoC
                 return creator();
             }
 
-            if (!serviceType.GetTypeInfo().IsAbstract)
+            if (!serviceType.IsAbstract)
             {
                 return CreateInstance(serviceType);
             }

--- a/src/GraphQL.Tests/Bugs/Bug68NonNullEnumGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug68NonNullEnumGraphTypeTests.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
 using GraphQL.Introspection;
 using GraphQL.Types;
 using Shouldly;
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace GraphQL.Tests.Bugs
@@ -94,7 +94,7 @@ namespace GraphQL.Tests.Bugs
     {
         public EnumType()
         {
-            if (!typeof(T).GetTypeInfo().IsEnum)
+            if (!typeof(T).IsEnum) //TODO: remove it in favor of enum constraint in C# 7.3
             {
                 throw new ArgumentException($"{typeof(T).Name} must be of type enum");
             }
@@ -102,7 +102,7 @@ namespace GraphQL.Tests.Bugs
             var type = typeof(T);
             Name = DeriveGraphQlName(type.Name);
 
-            foreach (var enumName in type.GetTypeInfo().GetEnumNames())
+            foreach (var enumName in type.GetEnumNames())
             {
                 var enumMember = type
                   .GetMember(enumName, BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace GraphQL
@@ -66,7 +65,7 @@ namespace GraphQL
                 resolve = t => (IGraphType) Activator.CreateInstance(t);
             }
 
-            if (type.GetTypeInfo().IsGenericType)
+            if (type.IsGenericType)
             {
                 if (type.GetGenericTypeDefinition() == typeof(NonNullGraphType<>))
                 {
@@ -90,7 +89,7 @@ namespace GraphQL
 
         public static Type GetNamedType(this Type type)
         {
-            if (type.GetTypeInfo().IsGenericType
+            if (type.IsGenericType
                 && (type.GetGenericTypeDefinition() == typeof(NonNullGraphType<>) ||
                     type.GetGenericTypeDefinition() == typeof(ListGraphType<>)))
             {

--- a/src/GraphQL/GraphQLMetadataAttribute.cs
+++ b/src/GraphQL/GraphQLMetadataAttribute.cs
@@ -1,6 +1,5 @@
-using System;
-using System.Reflection;
 using GraphQL.Utilities;
+using System;
 
 namespace GraphQL
 {
@@ -41,7 +40,7 @@ namespace GraphQL
             type.DeprecationReason = DeprecationReason;
 
             if (IsTypeOf != null)
-                type.IsTypeOfFunc = t => IsTypeOf.GetTypeInfo().IsAssignableFrom(t.GetType().GetTypeInfo());
+                type.IsTypeOfFunc = t => IsTypeOf.IsAssignableFrom(t.GetType());
         }
 
         public override void Modify(FieldConfig field)

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -121,7 +121,7 @@ namespace GraphQL
                 return ToObject(objects, fieldType);
             }
 
-            if (fieldType.GetTypeInfo().IsEnum)
+            if (fieldType.IsEnum)
             {
                 if (value == null)
                 {

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -1,9 +1,9 @@
 using GraphQL.Types;
+using GraphQL.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using GraphQL.Utilities;
 
 namespace GraphQL
 {
@@ -34,9 +34,7 @@ namespace GraphQL
         {
             if (type == null) return false;
 
-            var typeInfo = type.GetTypeInfo();
-
-            return !typeInfo.IsAbstract && !typeInfo.IsInterface;
+            return !type.IsAbstract && !type.IsInterface;
         }
 
         /// <summary>
@@ -48,8 +46,7 @@ namespace GraphQL
         /// </returns>
         public static bool IsNullable(this Type type)
         {
-            var typeInfo = type.GetTypeInfo();
-            return type == typeof(string) || (typeInfo.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+            return type == typeof(string) || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
         }
 
         /// <summary>
@@ -87,7 +84,7 @@ namespace GraphQL
         /// <returns>A string containing a GraphQL compatible type name.</returns>
         public static string GraphQLName(this Type type)
         {
-            var attr = type.GetTypeInfo().GetCustomAttribute<GraphQLMetadataAttribute>();
+            var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
 
             if (!string.IsNullOrEmpty(attr?.Name))
             {
@@ -96,7 +93,7 @@ namespace GraphQL
 
             var typeName = type.Name;
 
-            if (type.GetTypeInfo().IsGenericType)
+            if (type.IsGenericType)
             {
                 typeName = typeName.Substring(0, typeName.IndexOf('`'));
             }
@@ -117,9 +114,7 @@ namespace GraphQL
         /// <remarks>This can handle arrays and lists, but not other collection types.</remarks>
         public static Type GetGraphTypeFromType(this Type type, bool isNullable = false)
         {
-            TypeInfo info = type.GetTypeInfo();
-
-            if (info.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
                 type = type.GetGenericArguments()[0];
                 if (isNullable == false)

--- a/src/GraphQL/Types/ObjectGraphType.cs
+++ b/src/GraphQL/Types/ObjectGraphType.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace GraphQL.Types
 {
@@ -64,7 +63,7 @@ namespace GraphQL.Types
             {
                 throw new ArgumentNullException(nameof(type));
             }
-            if (!type.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IInterfaceGraphType)))
+            if (!type.GetInterfaces().Contains(typeof(IInterfaceGraphType)))
             {
                 throw new ArgumentException("Interface must implement IInterfaceGraphType", nameof(type));
             }

--- a/src/GraphQL/Types/UnionGraphType.cs
+++ b/src/GraphQL/Types/UnionGraphType.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace GraphQL.Types
 {
@@ -54,7 +53,7 @@ namespace GraphQL.Types
 
         public void Type(Type type)
         {
-            if (!type.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IObjectGraphType)))
+            if (!type.GetInterfaces().Contains(typeof(IObjectGraphType)))
             {
                 throw new ArgumentException($"Added union type must implement {nameof(IObjectGraphType)}", nameof(type));
             }

--- a/src/GraphQL/Utilities/TypeConfig.cs
+++ b/src/GraphQL/Utilities/TypeConfig.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Reflection;
-using System.Threading.Tasks;
 using GraphQL.Reflection;
 using GraphQL.Resolvers;
 using GraphQL.Types;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
 
 namespace GraphQL.Utilities
 {
@@ -95,7 +95,7 @@ namespace GraphQL.Utilities
 
         private void ApplyMetadata(Type type)
         {
-            var attributes = type?.GetTypeInfo().GetCustomAttributes<GraphQLAttribute>();
+            var attributes = type?.GetCustomAttributes<GraphQLAttribute>();
 
             if (attributes == null)
                 return;


### PR DESCRIPTION
Remove unnecessary use of `GetTypeInfo()` because of netstandard2.0 only  (also see https://github.com/dotnet/corefx/issues/16305)