### PR TITLE
Adds support for read comments from SDL

### DIFF
--- a/src/GraphQL.Tests/Files/PetComplex.graphql
+++ b/src/GraphQL.Tests/Files/PetComplex.graphql
@@ -1,0 +1,23 @@
+type Query {
+    animal: Pet
+    allAnimalsCount: [Int!] @deprecated(reason: "do not touch!")
+    catsGroups: [[Cat!]!]!
+}
+
+# A cat
+type Cat {
+  # cat's name
+  name: String!
+  weight(
+  #comment on argument
+  inPounds: Boolean) : Float!
+}
+
+# A dog
+type Dog {
+  # dog's age
+  age: Int!
+}
+
+#Cats with dogs
+union Pet = Cat | Dog

--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -9,6 +9,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <NoWarn>$(NoWarn);IDE1006</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -7,7 +7,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		Directory.Build.props = Directory.Build.props
-		..\global.json = ..\global.json
 		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		..\global.json = ..\global.json
+		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL", "GraphQL\GraphQL.csproj", "{1DD5E10B-2361-467A-82AC-36EFB8C61A1D}"
@@ -15,13 +16,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.Tests", "GraphQL.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.DataLoader.Tests", "GraphQL.DataLoader.Tests\GraphQL.DataLoader.Tests.csproj", "{21FA4059-CF8D-4A5B-8C1B-D4DB645311B9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQL.Harness", "GraphQL.Harness\GraphQL.Harness.csproj", "{00D40874-DCB7-4D44-B2B0-F88EB1FAA28E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.Harness", "GraphQL.Harness\GraphQL.Harness.csproj", "{00D40874-DCB7-4D44-B2B0-F88EB1FAA28E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.StarWars", "GraphQL.StarWars\GraphQL.StarWars.csproj", "{11A414C3-7847-4852-8A62-DCF8A438B938}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{BC80C071-B8B6-42D2-9CF8-6169C6169B74}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQL.Harness.Tests", "GraphQL.Harness.Tests\GraphQL.Harness.Tests.csproj", "{CB5C204A-FBE9-40CC-B4C7-A29E7E162DBE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.Harness.Tests", "GraphQL.Harness.Tests\GraphQL.Harness.Tests.csproj", "{CB5C204A-FBE9-40CC-B4C7-A29E7E162DBE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/GraphQL/DataLoader/DataLoaderBase.cs
+++ b/src/GraphQL/DataLoader/DataLoaderBase.cs
@@ -9,7 +9,9 @@ namespace GraphQL.DataLoader
         protected abstract Task<T> FetchAsync(CancellationToken cancellationToken);
 
         protected Task<T> DataLoaded => _completionSource.Task;
-        private TaskCompletionSource<T> _completionSource = new TaskCompletionSource<T>();
+        private TaskCompletionSource<T> _completionSource = CreateCompletionsSource();
+
+        private static TaskCompletionSource<T> CreateCompletionsSource() => new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         protected abstract bool IsFetchNeeded();
 
@@ -20,7 +22,7 @@ namespace GraphQL.DataLoader
                 return;
             }
 
-            var tcs = Interlocked.Exchange(ref _completionSource, new TaskCompletionSource<T>());
+            var tcs = Interlocked.Exchange(ref _completionSource, CreateCompletionsSource());
 
             if (cancellationToken.IsCancellationRequested)
             {

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="3.1.0-preview-39" />
+    <PackageReference Include="GraphQL-Parser" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="3.0.0" />
+    <PackageReference Include="GraphQL-Parser" Version="3.1.0-preview-39" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -62,7 +62,7 @@ namespace GraphQL
         {
             if (resolve == null)
             {
-                resolve = t => (IGraphType) Activator.CreateInstance(t);
+                resolve = t => (IGraphType)Activator.CreateInstance(t);
             }
 
             if (type.IsGenericType)

--- a/src/GraphQL/Introspection/__Type.cs
+++ b/src/GraphQL/Introspection/__Type.cs
@@ -111,40 +111,27 @@ namespace GraphQL.Introspection
 
         public TypeKind KindForInstance(GraphType type)
         {
-            if (type is EnumerationGraphType)
+            switch (type)
             {
-                return TypeKind.ENUM;
+                case EnumerationGraphType _:
+                    return TypeKind.ENUM;
+                case ScalarGraphType _:
+                    return TypeKind.SCALAR;
+                case IObjectGraphType _:
+                    return TypeKind.OBJECT;
+                case IInterfaceGraphType _:
+                    return TypeKind.INTERFACE;
+                case UnionGraphType _:
+                    return TypeKind.UNION;
+                case IInputObjectGraphType _:
+                    return TypeKind.INPUT_OBJECT;
+                case ListGraphType _:
+                    return TypeKind.LIST;
+                case NonNullGraphType _:
+                    return TypeKind.NON_NULL;
+                default:
+                    throw new ExecutionError("Unknown kind of type: {0}".ToFormat(type));
             }
-            if (type is ScalarGraphType)
-            {
-                return TypeKind.SCALAR;
-            }
-            if (type is IObjectGraphType)
-            {
-                return TypeKind.OBJECT;
-            }
-            if (type is IInterfaceGraphType)
-            {
-                return TypeKind.INTERFACE;
-            }
-            if (type is UnionGraphType)
-            {
-                return TypeKind.UNION;
-            }
-            if (type is IInputObjectGraphType)
-            {
-                return TypeKind.INPUT_OBJECT;
-            }
-            if (type is ListGraphType)
-            {
-                return TypeKind.LIST;
-            }
-            if (type is NonNullGraphType)
-            {
-                return TypeKind.NON_NULL;
-            }
-
-            throw new ExecutionError("Unknown kind of type: {0}".ToFormat(type));
         }
 
         public TypeKind KindForType(Type type)
@@ -169,11 +156,11 @@ namespace GraphQL.Introspection
             {
                 return TypeKind.UNION;
             }
-            if (typeof (IInputObjectGraphType).IsAssignableFrom(type))
+            if (typeof(IInputObjectGraphType).IsAssignableFrom(type))
             {
                 return TypeKind.INPUT_OBJECT;
             }
-            if (typeof (ListGraphType).IsAssignableFrom(type))
+            if (typeof(ListGraphType).IsAssignableFrom(type))
             {
                 return TypeKind.LIST;
             }

--- a/src/GraphQL/Language/AST/ValueNodes/IntValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/IntValue.cs
@@ -2,14 +2,8 @@ namespace GraphQL.Language.AST
 {
     public class IntValue : ValueNode<int>
     {
-        public IntValue(int value)
-        {
-            Value = value;
-        }
+        public IntValue(int value) => Value = value;
 
-        protected override bool Equals(ValueNode<int> other)
-        {
-            return Value == other.Value;
-        }
+        protected override bool Equals(ValueNode<int> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/LongValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/LongValue.cs
@@ -2,14 +2,8 @@ namespace GraphQL.Language.AST
 {
     public class LongValue : ValueNode<long>
     {
-        public LongValue(long value)
-        {
-            Value = value;
-        }
+        public LongValue(long value) => Value = value;
 
-        protected override bool Equals(ValueNode<long> other)
-        {
-            return Value == other.Value;
-        }
+        protected override bool Equals(ValueNode<long> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/UriValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/UriValue.cs
@@ -4,14 +4,8 @@ namespace GraphQL.Language.AST
 {
     public class UriValue : ValueNode<Uri>
     {
-        public UriValue(Uri value)
-        {
-            Value = value;
-        }
+        public UriValue(Uri value) => Value = value;
 
-        protected override bool Equals(ValueNode<Uri> other)
-        {
-            return Uri.Equals(Value, other.Value);
-        }
+        protected override bool Equals(ValueNode<Uri> other) => Equals(Value, other.Value);
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/ValueNode.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ValueNode.cs
@@ -6,10 +6,7 @@ namespace GraphQL.Language.AST
 
         object IValue.Value => Value;
 
-        public override string ToString()
-        {
-            return $"{GetType().Name}{{value={Value}}}";
-        }
+        public override string ToString() => $"{GetType().Name}{{value={Value}}}";
 
         public override bool IsEqualTo(INode obj)
         {

--- a/src/GraphQL/LightweightCache.cs
+++ b/src/GraphQL/LightweightCache.cs
@@ -14,9 +14,6 @@ namespace GraphQL
     public class LightweightCache<TKey, TValue> : IEnumerable<TValue>
     {
         private readonly IDictionary<TKey, TValue> _values;
-
-        private Func<TValue, TKey> _getKey = delegate { throw new NotImplementedException(); };
-
         private Func<TKey, TValue> _onMissing = delegate (TKey key)
         {
             var message = $"Key '{key}' could not be found";
@@ -62,7 +59,6 @@ namespace GraphQL
             _values = dictionary;
         }
 
-
         /// <summary>
         /// Action to perform if the key is missing. Defaults to <see cref="KeyNotFoundException"/>
         /// </summary>
@@ -71,19 +67,12 @@ namespace GraphQL
             set { _onMissing = value; }
         }
 
-        public Func<TValue, TKey> GetKey
-        {
-            get { return _getKey; }
-            set { _getKey = value; }
-        }
+        public Func<TValue, TKey> GetKey { get; set; } = delegate { throw new NotImplementedException(); };
 
         /// <summary>
         /// Gets the count.
         /// </summary>
-        public int Count
-        {
-            get { return _values.Count; }
-        }
+        public int Count => _values.Count;
 
         public TValue First
         {
@@ -140,19 +129,13 @@ namespace GraphQL
         /// Returns an enumerator that iterates through the values.
         /// </summary>
         /// <returns>An <see cref="T:System.Collections.IEnumerator"></see> object that can be used to iterate through the collection.</returns>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((IEnumerable<TValue>)this).GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<TValue>)this).GetEnumerator();
 
         /// <summary>
         /// Returns an enumerator that iterates through the values.
         /// </summary>
         /// <returns>An enumerator that can be used to iterate through the collection.</returns>
-        public IEnumerator<TValue> GetEnumerator()
-        {
-            return _values.Values.GetEnumerator();
-        }
+        public IEnumerator<TValue> GetEnumerator() => _values.Values.GetEnumerator();
 
         /// <summary>
         /// Guarantees that the Cache has a value for a given key.
@@ -228,10 +211,7 @@ namespace GraphQL
         /// Equivalent to ContainsKey
         /// </summary>
         /// <param name="key">The key.</param>
-        public bool Has(TKey key)
-        {
-            return _values.ContainsKey(key);
-        }
+        public bool Has(TKey key) => _values.ContainsKey(key);
 
         /// <summary>
         /// Determines if a given value exists in the dictionary.

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -161,7 +161,6 @@ namespace GraphQL
             return val;
         }
 
-
         /// <summary>
         /// Returns an interface implemented by the indicated type whose name matches the desired name.
         /// </summary>

--- a/src/GraphQL/Types/BooleanGraphType.cs
+++ b/src/GraphQL/Types/BooleanGraphType.cs
@@ -4,25 +4,12 @@ namespace GraphQL.Types
 {
     public class BooleanGraphType : ScalarGraphType
     {
-        public BooleanGraphType()
-        {
-            Name = "Boolean";
-        }
+        public BooleanGraphType() => Name = "Boolean";
 
-        public override object Serialize(object value)
-        {
-            return ParseValue(value);
-        }
+        public override object Serialize(object value) => ParseValue(value);
 
-        public override object ParseValue(object value)
-        {
-            return ValueConverter.ConvertTo(value, typeof(bool));
-        }
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(bool));
 
-        public override object ParseLiteral(IValue value)
-        {
-            var boolVal = value as BooleanValue;
-            return boolVal?.Value;
-        }
+        public override object ParseLiteral(IValue value) => (value as BooleanValue)?.Value;
     }
 }

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -1,12 +1,12 @@
 using GraphQL.Builders;
 using GraphQL.Resolvers;
+using GraphQL.Subscription;
+using GraphQL.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using GraphQL.Subscription;
-using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -1,6 +1,7 @@
 using GraphQL.Builders;
 using GraphQL.Resolvers;
 using GraphQL.Subscription;
+using GraphQL.Types.Relay;
 using GraphQL.Utilities;
 using System;
 using System.Collections.Generic;

--- a/src/GraphQL/Types/DateGraphType.cs
+++ b/src/GraphQL/Types/DateGraphType.cs
@@ -1,5 +1,5 @@
-using System;
 using GraphQL.Language.AST;
+using System;
 
 namespace GraphQL.Types
 {
@@ -24,10 +24,7 @@ namespace GraphQL.Types
             return null;
         }
 
-        public override object ParseValue(object value)
-        {
-            return ValueConverter.ConvertTo(value, typeof(DateTime));
-        }
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTime));
 
         public override object ParseLiteral(IValue value)
         {

--- a/src/GraphQL/Types/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/DateTimeGraphType.cs
@@ -1,5 +1,5 @@
-using System;
 using GraphQL.Language.AST;
+using System;
 
 namespace GraphQL.Types
 {
@@ -13,15 +13,9 @@ namespace GraphQL.Types
                 "to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.";
         }
 
-        public override object Serialize(object value)
-        {
-            return ParseValue(value);
-        }
+        public override object Serialize(object value) => ParseValue(value);
 
-        public override object ParseValue(object value)
-        {
-            return ValueConverter.ConvertTo(value, typeof(DateTime));
-        }
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTime));
 
         public override object ParseLiteral(IValue value)
         {

--- a/src/GraphQL/Types/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/DateTimeOffsetGraphType.cs
@@ -1,5 +1,5 @@
-using System;
 using GraphQL.Language.AST;
+using System;
 
 namespace GraphQL.Types
 {
@@ -13,15 +13,9 @@ namespace GraphQL.Types
                 "to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.";
         }
 
-        public override object Serialize(object value)
-        {
-            return ParseValue(value);
-        }
+        public override object Serialize(object value) => ParseValue(value);
 
-        public override object ParseValue(object value)
-        {
-            return ValueConverter.ConvertTo(value, typeof(DateTimeOffset));
-        }
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTimeOffset));
 
         public override object ParseLiteral(IValue value)
         {

--- a/src/GraphQL/Types/DecimalGraphType.cs
+++ b/src/GraphQL/Types/DecimalGraphType.cs
@@ -4,20 +4,11 @@ namespace GraphQL.Types
 {
     public class DecimalGraphType : ScalarGraphType
     {
-        public DecimalGraphType()
-        {
-            Name = "Decimal";
-        }
+        public DecimalGraphType() => Name = "Decimal";
 
-        public override object Serialize(object value)
-        {
-            return ParseValue(value);
-        }
+        public override object Serialize(object value) => ParseValue(value);
 
-        public override object ParseValue(object value)
-        {
-            return ValueConverter.ConvertTo(value, typeof(decimal));
-        }
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(decimal));
 
         public override object ParseLiteral(IValue value)
         {

--- a/src/GraphQL/Types/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/EnumerationGraphType.cs
@@ -1,11 +1,11 @@
+using GraphQL.Language.AST;
+using GraphQL.Utilities;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
-using GraphQL.Language.AST;
-using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
@@ -66,7 +66,7 @@ namespace GraphQL.Types
         }
     }
 
-    public class EnumerationGraphType<TEnum> : EnumerationGraphType
+    public class EnumerationGraphType<TEnum> : EnumerationGraphType where TEnum : Enum
     {
         public EnumerationGraphType()
         {
@@ -89,30 +89,18 @@ namespace GraphQL.Types
             }
         }
 
-        protected virtual string ChangeEnumCase(string val)
-        {
-            return StringUtils.ToConstantCase(val);
-        }
+        protected virtual string ChangeEnumCase(string val) => StringUtils.ToConstantCase(val);
     }
 
     public class EnumValues : IEnumerable<EnumValueDefinition>
     {
         private readonly List<EnumValueDefinition> _values = new List<EnumValueDefinition>();
 
-        public void Add(EnumValueDefinition value)
-        {
-            _values.Add(value);
-        }
+        public void Add(EnumValueDefinition value) => _values.Add(value);
 
-        public IEnumerator<EnumValueDefinition> GetEnumerator()
-        {
-            return _values.GetEnumerator();
-        }
+        public IEnumerator<EnumValueDefinition> GetEnumerator() => _values.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     public class EnumValueDefinition

--- a/src/GraphQL/Types/FieldType.cs
+++ b/src/GraphQL/Types/FieldType.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using GraphQL.Resolvers;
 
 namespace GraphQL.Types
@@ -13,6 +14,7 @@ namespace GraphQL.Types
         QueryArguments Arguments { get; set; }
     }
 
+    [DebuggerDisplay("{Name,nq}")]
     public class FieldType : IFieldType
     {
         public string Name { get; set; }
@@ -40,9 +42,6 @@ namespace GraphQL.Types
             return defaultValue;
         }
 
-        public bool HasMetadata(string key)
-        {
-            return Metadata?.ContainsKey(key) ?? false;
-        }
+        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
     }
 }

--- a/src/GraphQL/Types/FloatGraphType.cs
+++ b/src/GraphQL/Types/FloatGraphType.cs
@@ -4,20 +4,11 @@ namespace GraphQL.Types
 {
     public class FloatGraphType : ScalarGraphType
     {
-        public FloatGraphType()
-        {
-            Name = "Float";
-        }
+        public FloatGraphType() => Name = "Float";
 
-        public override object Serialize(object value)
-        {
-            return ParseValue(value);
-        }
+        public override object Serialize(object value) => ParseValue(value);
 
-        public override object ParseValue(object value)
-        {
-            return ValueConverter.ConvertTo(value, typeof(double));
-        }
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(double));
 
         public override object ParseLiteral(IValue value)
         {

--- a/src/GraphQL/Types/GraphQLTypeReference.cs
+++ b/src/GraphQL/Types/GraphQLTypeReference.cs
@@ -44,9 +44,6 @@ namespace GraphQL.Types
             return base.Equals(obj);
         }
 
-        public override int GetHashCode()
-        {
-            return TypeName?.GetHashCode() ?? 0;
-        }
+        public override int GetHashCode() => TypeName?.GetHashCode() ?? 0;
     }
 }

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -29,10 +29,7 @@ namespace GraphQL.Types
             return defaultValue;
         }
 
-        public bool HasMetadata(string key)
-        {
-            return Metadata?.ContainsKey(key) ?? false;
-        }
+        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
 
         public virtual string CollectTypes(TypeCollectionContext context)
         {
@@ -49,10 +46,7 @@ namespace GraphQL.Types
                 ? GetType().Name
                 : Name;
 
-        protected bool Equals(IGraphType other)
-        {
-            return string.Equals(Name, other.Name);
-        }
+        protected bool Equals(IGraphType other) => string.Equals(Name, other.Name);
 
         public override bool Equals(object obj)
         {
@@ -63,10 +57,7 @@ namespace GraphQL.Types
             return Equals((IGraphType)obj);
         }
 
-        public override int GetHashCode()
-        {
-            return Name?.GetHashCode() ?? 0;
-        }
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
     }
 
     /// <summary>

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using GraphQL.Conversion;
 using GraphQL.Introspection;
 using GraphQL.Types.Relay;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GraphQL.Types
 {

--- a/src/GraphQL/Types/GuidGraphType.cs
+++ b/src/GraphQL/Types/GuidGraphType.cs
@@ -5,10 +5,7 @@ namespace GraphQL.Types
 {
     public class GuidGraphType : ScalarGraphType
     {
-        public GuidGraphType()
-        {
-            this.Name = "Guid";
-        }
+        public GuidGraphType() => Name = "Guid";
 
         public override object ParseLiteral(IValue value)
         {
@@ -25,8 +22,7 @@ namespace GraphQL.Types
             return null;
         }
 
-        public override object ParseValue(object value) =>
-            ValueConverter.ConvertTo(value, typeof(Guid));
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(Guid));
 
         public override object Serialize(object value) => ParseValue(value);
     }

--- a/src/GraphQL/Types/IAstFromValueConverter.cs
+++ b/src/GraphQL/Types/IAstFromValueConverter.cs
@@ -1,4 +1,3 @@
-
 using GraphQL.Language.AST;
 
 namespace GraphQL.Types

--- a/src/GraphQL/Types/IdGraphType.cs
+++ b/src/GraphQL/Types/IdGraphType.cs
@@ -14,15 +14,9 @@ namespace GraphQL.Types
             //    "as `\"4\"`) or integer (such as `4`) input value will be accepted as an `ID`.";
         }
 
-        public override object Serialize(object value)
-        {
-            return value?.ToString();
-        }
+        public override object Serialize(object value) => value?.ToString();
 
-        public override object ParseValue(object value)
-        {
-            return value?.ToString().Trim(' ', '"');
-        }
+        public override object ParseValue(object value) => value?.ToString().Trim(' ', '"');
 
         public override object ParseLiteral(IValue value)
         {

--- a/src/GraphQL/Types/IntGraphType.cs
+++ b/src/GraphQL/Types/IntGraphType.cs
@@ -4,15 +4,9 @@ namespace GraphQL.Types
 {
     public class IntGraphType : ScalarGraphType
     {
-        public IntGraphType()
-        {
-            Name = "Int";
-        }
+        public IntGraphType() => Name = "Int";
 
-        public override object Serialize(object value)
-        {
-            return ParseValue(value);
-        }
+        public override object Serialize(object value) => ParseValue(value);
 
         public override object ParseValue(object value)
         {

--- a/src/GraphQL/Types/QueryArguments.cs
+++ b/src/GraphQL/Types/QueryArguments.cs
@@ -1,7 +1,7 @@
+using GraphQL.Utilities;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
@@ -47,19 +47,10 @@ namespace GraphQL.Types
             _arguments.Add(argument);
         }
 
-        public QueryArgument Find(string name)
-        {
-            return this.FirstOrDefault(x => x.Name == name);
-        }
+        public QueryArgument Find(string name) => this.FirstOrDefault(x => x.Name == name);
 
-        public IEnumerator<QueryArgument> GetEnumerator()
-        {
-            return _arguments.GetEnumerator();
-        }
+        public IEnumerator<QueryArgument> GetEnumerator() => _arguments.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -1,10 +1,10 @@
-using System.Collections.Generic;
-using System.Threading;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
-using Field = GraphQL.Language.AST.Field;
-using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Field = GraphQL.Language.AST.Field;
 
 namespace GraphQL.Types
 {
@@ -78,7 +78,7 @@ namespace GraphQL.Types
 
         public TType GetArgument<TType>(string name, TType defaultValue = default)
         {
-            return (TType) GetArgument(typeof(TType), name, defaultValue);
+            return (TType)GetArgument(typeof(TType), name, defaultValue);
         }
 
         public object GetArgument(System.Type argumentType, string name, object defaultValue = null)
@@ -103,11 +103,7 @@ namespace GraphQL.Types
             return arg.GetPropertyValue(argumentType);
         }
 
-        public bool HasArgument(string argumentName)
-        {
-            return Arguments?.ContainsKey(argumentName) ?? false;
-        }
-
+        public bool HasArgument(string argumentName) => Arguments?.ContainsKey(argumentName) ?? false;
 
         public Task<object> TryAsyncResolve(Func<ResolveFieldContext<TSource>, Task<object>> resolve, Func<ExecutionErrors, Task<object>> error = null)
         {

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -171,6 +171,11 @@ namespace GraphQL.Types
             _directives.Add(directive);
         }
 
+        public void RegisterDirectives(IEnumerable<DirectiveGraphType> directives)
+        {
+            _directives.AddRange(directives);
+        }
+
         public void RegisterDirectives(params DirectiveGraphType[] directives)
         {
             _directives.AddRange(directives);

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -174,7 +174,8 @@ namespace GraphQL.Types
 
         public void RegisterDirectives(IEnumerable<DirectiveGraphType> directives)
         {
-            _directives.AddRange(directives);
+            foreach (var directive in directives)
+                RegisterDirective(directive);
         }
 
         public void RegisterDirectives(params DirectiveGraphType[] directives)

--- a/src/GraphQL/Types/ShortGraphType.cs
+++ b/src/GraphQL/Types/ShortGraphType.cs
@@ -6,14 +6,9 @@ namespace GraphQL.Types
     {
         public ShortGraphType() => Name = "Short";
 
-        public override object ParseLiteral(IValue value)
-        {
-            var shortValue = value as ShortValue;
-            return shortValue?.Value;
-        }
+        public override object ParseLiteral(IValue value) => (value as ShortValue)?.Value;
 
-        public override object ParseValue(object value) =>
-            ValueConverter.ConvertTo(value, typeof(short));
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(short));
 
         public override object Serialize(object value) => ParseValue(value);
     }

--- a/src/GraphQL/Types/StringGraphType.cs
+++ b/src/GraphQL/Types/StringGraphType.cs
@@ -4,25 +4,12 @@ namespace GraphQL.Types
 {
     public class StringGraphType : ScalarGraphType
     {
-        public StringGraphType()
-        {
-            Name = "String";
-        }
+        public StringGraphType() => Name = "String";
 
-        public override object Serialize(object value)
-        {
-            return value;
-        }
+        public override object Serialize(object value) => value;
 
-        public override object ParseValue(object value)
-        {
-            return value?.ToString();
-        }
+        public override object ParseValue(object value) => value?.ToString();
 
-        public override object ParseLiteral(IValue value)
-        {
-            var stringValue = value as StringValue;
-            return stringValue?.Value;
-        }
+        public override object ParseLiteral(IValue value) => (value as StringValue)?.Value;
     }
 }

--- a/src/GraphQL/Types/UIntGraphType.cs
+++ b/src/GraphQL/Types/UIntGraphType.cs
@@ -4,19 +4,11 @@ namespace GraphQL.Types
 {
     public class UIntGraphType : ScalarGraphType
     {
-        public UIntGraphType()
-        {
-            this.Name = "UInt";
-        }
+        public UIntGraphType() => Name = "UInt";
 
-        public override object ParseLiteral(IValue value)
-        {
-            var uintValue = value as UIntValue;
-            return uintValue?.Value;
-        }
+        public override object ParseLiteral(IValue value) => (value as UIntValue)?.Value;
 
-        public override object ParseValue(object value) =>
-            ValueConverter.ConvertTo(value, typeof(uint));
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(uint));
 
         public override object Serialize(object value) => ParseValue(value);
     }

--- a/src/GraphQL/Types/ULongGraphType.cs
+++ b/src/GraphQL/Types/ULongGraphType.cs
@@ -4,19 +4,11 @@ namespace GraphQL.Types
 {
     public class ULongGraphType : ScalarGraphType
     {
-        public ULongGraphType()
-        {
-            this.Name = "ULong";
-        }
+        public ULongGraphType() => Name = "ULong";
 
-        public override object ParseLiteral(IValue value)
-        {
-            var ulongValue = value as ULongValue;
-            return ulongValue?.Value;
-        }
+        public override object ParseLiteral(IValue value) => (value as ULongValue)?.Value;
 
-        public override object ParseValue(object value) =>
-            ValueConverter.ConvertTo(value, typeof(ulong));
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(ulong));
 
         public override object Serialize(object value) => ParseValue(value);
     }

--- a/src/GraphQL/Types/UShortGraphType.cs
+++ b/src/GraphQL/Types/UShortGraphType.cs
@@ -6,14 +6,9 @@ namespace GraphQL.Types
     {
         public UShortGraphType() => Name = "UShort";
 
-        public override object ParseLiteral(IValue value)
-        {
-            var ushortValue = value as UShortValue;
-            return ushortValue?.Value;
-        }
+        public override object ParseLiteral(IValue value) => (value as UShortValue)?.Value;
 
-        public override object ParseValue(object value) =>
-            ValueConverter.ConvertTo(value, typeof(ushort));
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(ushort));
 
         public override object Serialize(object value) => ParseValue(value);
     }

--- a/src/GraphQL/Types/UriGraphType.cs
+++ b/src/GraphQL/Types/UriGraphType.cs
@@ -5,14 +5,11 @@ namespace GraphQL.Types
 {
     public class UriGraphType : ScalarGraphType
     {
-        public UriGraphType() =>
-            Name = "Uri";
+        public UriGraphType() => Name = "Uri";
 
-        public override object Serialize(object value) =>
-            ParseValue(value);
+        public override object Serialize(object value) => ParseValue(value);
 
-        public override object ParseValue(object value) =>
-            ValueConverter.ConvertTo(value, typeof(Uri));
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(Uri));
 
         public override object ParseLiteral(IValue value)
         {


### PR DESCRIPTION
Also I noticed that `SchemaBuilder.ApplyDeprecatedDirective `applies deprecation to a wider list of objects than the [specification](https://facebook.github.io/graphql/draft/#sec--deprecated) describes. Is it so specially made?