### PR TITLE
Add null/duplicates checks for public API

### DIFF
--- a/src/GraphQL/Execution/ExecutionErrors.cs
+++ b/src/GraphQL/Execution/ExecutionErrors.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -9,12 +10,13 @@ namespace GraphQL
 
         public void Add(ExecutionError error)
         {
-            _errors.Add(error);
+            _errors.Add(error ?? throw new ArgumentNullException(nameof(error)));
         }
 
         public void AddRange(IEnumerable<ExecutionError> errors)
         {
-            _errors.AddRange(errors);
+            foreach (var error in errors)
+                Add(error);
         }
 
         public int Count => _errors.Count;

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -20,7 +20,7 @@ namespace GraphQL.Instrumentation
 
         public IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
         {
-            _components.Add(middleware);
+            _components.Add(middleware ?? throw new ArgumentNullException(nameof(middleware)));
             return this;
         }
 

--- a/src/GraphQL/Language/AST/Arguments.cs
+++ b/src/GraphQL/Language/AST/Arguments.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace GraphQL.Language.AST
 
         public void Add(Argument arg)
         {
-            _arguments.Add(arg);
+            _arguments.Add(arg ?? throw new ArgumentNullException(nameof(arg)));
         }
 
         public IValue ValueFor(string name)

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Language.AST
 
         public void Add(Directive directive)
         {
-            _directives.Add(directive);
+            _directives.Add(directive ?? throw new ArgumentNullException(nameof(directive)));
 
             if (!_unique.ContainsKey(directive.Name))
             {

--- a/src/GraphQL/Language/AST/Document.cs
+++ b/src/GraphQL/Language/AST/Document.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -23,7 +24,7 @@ namespace GraphQL.Language.AST
 
         public void AddDefinition(IDefinition definition)
         {
-            _definitions.Add(definition);
+            _definitions.Add(definition ?? throw new ArgumentNullException(nameof(definition)));
 
             if (definition is FragmentDefinition fragmentDefinition)
             {

--- a/src/GraphQL/Language/AST/Fragments.cs
+++ b/src/GraphQL/Language/AST/Fragments.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,7 +11,7 @@ namespace GraphQL.Language.AST
 
         public void Add(FragmentDefinition fragment)
         {
-            _fragments.Add(fragment);
+            _fragments.Add(fragment ?? throw new ArgumentNullException(nameof(fragment)));
         }
 
         public FragmentDefinition FindDefinition(string name)

--- a/src/GraphQL/Language/AST/Operations.cs
+++ b/src/GraphQL/Language/AST/Operations.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +16,7 @@ namespace GraphQL.Language.AST
 
         public void Add(Operation operation)
         {
-            _operations.Add(operation);
+            _operations.Add(operation ?? throw new ArgumentNullException(nameof(operation)));
         }
 
         public Operation WithName(string operationName)

--- a/src/GraphQL/Language/AST/SelectionSet.cs
+++ b/src/GraphQL/Language/AST/SelectionSet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -22,7 +23,7 @@ namespace GraphQL.Language.AST
 
         public void Add(ISelection selection)
         {
-            _selections.Add(selection);
+            _selections.Add(selection ?? throw new ArgumentNullException(nameof(selection)));
         }
 
         public SelectionSet Merge(SelectionSet otherSelection)

--- a/src/GraphQL/Language/AST/Variables.cs
+++ b/src/GraphQL/Language/AST/Variables.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,7 +11,7 @@ namespace GraphQL.Language.AST
 
         public void Add(Variable variable)
         {
-            _variables.Add(variable);
+            _variables.Add(variable ?? throw new ArgumentNullException(nameof(variable)));
         }
 
         public object ValueFor(string name)
@@ -36,7 +37,7 @@ namespace GraphQL.Language.AST
 
         public void Add(VariableDefinition variable)
         {
-            _variables.Add(variable);
+            _variables.Add(variable ?? throw new ArgumentNullException(nameof(variable)));
         }
 
         public IEnumerator<VariableDefinition> GetEnumerator()

--- a/src/GraphQL/Types/ComplexGraphType.cs
+++ b/src/GraphQL/Types/ComplexGraphType.cs
@@ -51,6 +51,9 @@ namespace GraphQL.Types
 
         public virtual FieldType AddField(FieldType fieldType)
         {
+            if (fieldType == null)
+                throw new ArgumentNullException(nameof(fieldType));
+
             NameValidator.ValidateName(fieldType.Name);
 
             if (HasField(fieldType.Name))

--- a/src/GraphQL/Types/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/EnumerationGraphType.cs
@@ -29,6 +29,9 @@ namespace GraphQL.Types
 
         public void AddValue(EnumValueDefinition value)
         {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
             NameValidator.ValidateName(value.Name, "enum");
             Values.Add(value);
         }
@@ -101,7 +104,7 @@ namespace GraphQL.Types
 
         public void Add(EnumValueDefinition value)
         {
-            _values.Add(value);
+            _values.Add(value ?? throw new ArgumentNullException(nameof(value)));
         }
 
         public IEnumerator<EnumValueDefinition> GetEnumerator()

--- a/src/GraphQL/Types/InterfaceGraphType.cs
+++ b/src/GraphQL/Types/InterfaceGraphType.cs
@@ -19,7 +19,7 @@ namespace GraphQL.Types
         {
             if (!_possibleTypes.Contains(type))
             {
-                _possibleTypes.Add(type);
+                _possibleTypes.Add(type ?? throw new ArgumentNullException(nameof(type)));
             }
         }
     }

--- a/src/GraphQL/Types/ObjectGraphType.cs
+++ b/src/GraphQL/Types/ObjectGraphType.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Types
         {
             if (!_resolvedInterfaces.Contains(graphType))
             {
-                _resolvedInterfaces.Add(graphType);
+                _resolvedInterfaces.Add(graphType ?? throw new ArgumentNullException(nameof(graphType)));
             }
         }
 
@@ -54,7 +54,8 @@ namespace GraphQL.Types
         public void Interface<TInterface>()
             where TInterface : IInterfaceGraphType
         {
-            _interfaces.Add(typeof(TInterface));
+            if (!_interfaces.Contains(typeof(TInterface)))
+                _interfaces.Add(typeof(TInterface));
         }
 
         public void Interface(Type type)
@@ -67,7 +68,8 @@ namespace GraphQL.Types
             {
                 throw new ArgumentException("Interface must implement IInterfaceGraphType", nameof(type));
             }
-            _interfaces.Add(type);
+            if (!_interfaces.Contains(type))
+                _interfaces.Add(type);
         }
     }
 

--- a/src/GraphQL/Types/QueryArguments.cs
+++ b/src/GraphQL/Types/QueryArguments.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,6 +44,9 @@ namespace GraphQL.Types
 
         public void Add(QueryArgument argument)
         {
+            if (argument == null)
+                throw new ArgumentNullException(nameof(argument));
+
             NameValidator.ValidateName(argument.Name, "argument");
             _arguments.Add(argument);
         }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -140,12 +140,13 @@ namespace GraphQL.Types
 
         public void RegisterType(IGraphType type)
         {
-            _additionalInstances.Add(type);
+            _additionalInstances.Add(type ?? throw new ArgumentNullException(nameof(type)));
         }
 
         public void RegisterTypes(params IGraphType[] types)
         {
-            _additionalInstances.AddRange(types);
+            foreach (var type in types)
+                RegisterType(type);
         }
 
         public void RegisterTypes(params Type[] types)
@@ -168,12 +169,13 @@ namespace GraphQL.Types
 
         public void RegisterDirective(DirectiveGraphType directive)
         {
-            _directives.Add(directive);
+            _directives.Add(directive ?? throw new ArgumentNullException(nameof(directive)));
         }
 
         public void RegisterDirectives(params DirectiveGraphType[] directives)
         {
-            _directives.AddRange(directives);
+            foreach (var directive in directives)
+                RegisterDirective(directive);
         }
 
         public DirectiveGraphType FindDirective(string name)
@@ -183,7 +185,7 @@ namespace GraphQL.Types
 
         public void RegisterValueConverter(IAstFromValueConverter converter)
         {
-            _converters.Add(converter);
+            _converters.Add(converter ?? throw new ArgumentNullException(nameof(converter)));
         }
 
         public IAstFromValueConverter FindValueConverter(object value, IGraphType type)
@@ -218,6 +220,9 @@ namespace GraphQL.Types
 
         private void RegisterType(Type type)
         {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+
             if (!typeof(IGraphType).IsAssignableFrom(type))
             {
                 throw new ArgumentOutOfRangeException(nameof(type), "Type must be of GraphType.");

--- a/src/GraphQL/Types/UnionGraphType.cs
+++ b/src/GraphQL/Types/UnionGraphType.cs
@@ -48,16 +48,22 @@ namespace GraphQL.Types
         public void Type<TType>()
             where TType : IObjectGraphType
         {
-            _types.Add(typeof(TType));
+            if (!_types.Contains(typeof(TType)))
+                _types.Add(typeof(TType));
         }
 
         public void Type(Type type)
         {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+
             if (!type.GetInterfaces().Contains(typeof(IObjectGraphType)))
             {
                 throw new ArgumentException($"Added union type must implement {nameof(IObjectGraphType)}", nameof(type));
             }
-            _types.Add(type);
+
+            if (!_types.Contains(type))
+                _types.Add(type);
         }
     }
 }

--- a/src/GraphQL/Utilities/TypeSettings.cs
+++ b/src/GraphQL/Utilities/TypeSettings.cs
@@ -62,7 +62,7 @@ namespace GraphQL.Utilities
 
         public void Include(Type type, Type typeOfType)
         {
-            var name = type.GraphQLName();
+            var name = (type ?? throw new ArgumentNullException(nameof(type))).GraphQLName();
             Include(name, type, typeOfType);
         }
 


### PR DESCRIPTION
Relates to #978.

Identifies at an earlier stage the situation when trying to add the `null` value to collections.