### PR TITLE
Metadata for QueryArgument

### DIFF
--- a/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -103,16 +104,17 @@ namespace GraphQL.Tests.Builders
         }
 
         [Fact]
-        public void can_have_arguments_with_and_without_default_values()
+        public void can_have_arguments_with_and_without_default_values_and_with_metadata()
         {
             var objectType = new ObjectGraphType();
             objectType.Field<IntGraphType>()
                 .Argument<StringGraphType, string>("arg1", "desc1", "12345")
                 .Argument<IntGraphType, int>("arg2", "desc2", 9)
-                .Argument<IntGraphType>("arg3", "desc3");
+                .Argument<IntGraphType>("arg3", "desc3", cfg => cfg.WithMetadata("secure", true))
+                .Argument<BooleanGraphType>("arg4", cfg => cfg.WithMetadata("useBefore", new DateTime(2030, 1, 2)).DefaultValue = true);
 
             var field = objectType.Fields.First();
-            field.Arguments.Count.ShouldBe(3);
+            field.Arguments.Count.ShouldBe(4);
 
             field.Arguments[0].Name.ShouldBe("arg1");
             field.Arguments[0].Description.ShouldBe("desc1");
@@ -128,6 +130,13 @@ namespace GraphQL.Tests.Builders
             field.Arguments[2].Description.ShouldBe("desc3");
             field.Arguments[2].Type.ShouldBe(typeof(IntGraphType));
             field.Arguments[2].DefaultValue.ShouldBe(null);
+            field.Arguments[2].Metadata["secure"].ShouldBe(true);
+
+            field.Arguments[3].Name.ShouldBe("arg4");
+            field.Arguments[3].Description.ShouldBeNull();
+            field.Arguments[3].Type.ShouldBe(typeof(BooleanGraphType));
+            field.Arguments[3].DefaultValue.ShouldBe(true);
+            field.Arguments[3].Metadata["useBefore"].ShouldBe(new DateTime(2030, 1, 2));
         }
 
         [Fact]

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -112,25 +112,30 @@ namespace GraphQL.Builders
             return new FieldBuilder<TSourceType, TNewReturnType>(FieldType);
         }
 
-        public FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string description)
-        {
-            _fieldType.Arguments.Add(new QueryArgument(typeof(TArgumentGraphType))
+        public FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string description, Action<QueryArgument> configure = null)
+            => Argument<TArgumentGraphType>(name, arg =>
             {
-                Name = name,
-                Description = description,
+                arg.Description = description;
+                configure?.Invoke(arg);
             });
-            return this;
-        }
 
         public FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string description,
-            TArgumentType defaultValue = default)
+            TArgumentType defaultValue = default, Action<QueryArgument> configure = null)
+            => Argument<TArgumentGraphType>(name, arg =>
+            {
+                arg.Description = description;
+                arg.DefaultValue = defaultValue;
+                configure?.Invoke(arg);
+            });
+
+        public FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, Action<QueryArgument> configure = null)
         {
-            _fieldType.Arguments.Add(new QueryArgument(typeof(TArgumentGraphType))
+            var arg = new QueryArgument(typeof(TArgumentGraphType))
             {
                 Name = name,
-                Description = description,
-                DefaultValue = defaultValue,
-            });
+            };
+            configure?.Invoke(arg);
+            _fieldType.Arguments.Add(arg);
             return this;
         }
 

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -226,6 +226,13 @@ namespace GraphQL
                 : null;
         }
 
+        public static TMetadataProvider WithMetadata<TMetadataProvider>(this TMetadataProvider provider, string key, object value)
+            where TMetadataProvider : IProvideMetadata
+        {
+            provider.Metadata[key] = value;
+            return provider;
+        }
+
         /// <summary>
         /// Provided a type and a super type, return true if the first type is either
         /// equal or a subset of the second super type (covariant).

--- a/src/GraphQL/Types/FieldType.cs
+++ b/src/GraphQL/Types/FieldType.cs
@@ -1,7 +1,7 @@
+using GraphQL.Resolvers;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using GraphQL.Resolvers;
 
 namespace GraphQL.Types
 {
@@ -27,22 +27,10 @@ namespace GraphQL.Types
 
         public TType GetMetadata<TType>(string key, TType defaultValue = default)
         {
-            if (!HasMetadata(key))
-            {
-                return defaultValue;
-            }
-
-            if (Metadata.TryGetValue(key, out var item))
-            {
-                return (TType) item;
-            }
-
-            return defaultValue;
+            var local = Metadata;
+            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
         }
 
-        public bool HasMetadata(string key)
-        {
-            return Metadata?.ContainsKey(key) ?? false;
-        }
+        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
     }
 }

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -16,23 +16,11 @@ namespace GraphQL.Types
 
         public TType GetMetadata<TType>(string key, TType defaultValue = default)
         {
-            if (!HasMetadata(key))
-            {
-                return defaultValue;
-            }
-
-            if (Metadata.TryGetValue(key, out var item))
-            {
-                return (TType) item;
-            }
-
-            return defaultValue;
+            var local = Metadata;
+            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
         }
 
-        public bool HasMetadata(string key)
-        {
-            return Metadata?.ContainsKey(key) ?? false;
-        }
+        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
 
         public virtual string CollectTypes(TypeCollectionContext context)
         {

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace GraphQL.Types
 {
@@ -11,7 +13,7 @@ namespace GraphQL.Types
         }
     }
 
-    public class QueryArgument : IHaveDefaultValue
+    public class QueryArgument : IHaveDefaultValue, IProvideMetadata
     {
         public QueryArgument(IGraphType type)
         {
@@ -37,5 +39,15 @@ namespace GraphQL.Types
         public IGraphType ResolvedType { get; set; }
 
         public Type Type { get; private set; }
+
+        public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
+
+        public TType GetMetadata<TType>(string key, TType defaultValue = default)
+        {
+            var local = Metadata;
+            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
+        }
+
+        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
     }
 }

--- a/src/GraphQL/Utilities/MetadataProvider.cs
+++ b/src/GraphQL/Utilities/MetadataProvider.cs
@@ -1,6 +1,6 @@
+using GraphQL.Types;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using GraphQL.Types;
 
 namespace GraphQL.Utilities
 {
@@ -10,22 +10,10 @@ namespace GraphQL.Utilities
 
         public TType GetMetadata<TType>(string key, TType defaultValue = default)
         {
-            if (!HasMetadata(key))
-            {
-                return defaultValue;
-            }
-
-            if (Metadata.TryGetValue(key, out var item))
-            {
-                return (TType) item;
-            }
-
-            return defaultValue;
+            var local = Metadata;
+            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
         }
 
-        public bool HasMetadata(string key)
-        {
-            return Metadata.ContainsKey(key);
-        }
+        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
     }
 }


### PR DESCRIPTION
- fixes #1019
- avoid double metadata checking
- fixes potential NRE in MetadataProvider.HasMetadata