### PR TITLE
Change the type of the UserContext-property in some places to IDictionary<string, object>

### DIFF
--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -24,7 +24,7 @@ namespace GraphQL.Types
 
         public object RootValue { get; set; }
 
-        public object UserContext { get; set; }
+        public IDictionary<string, object> UserContext { get; set; }
 
         public TSource Source { get; set; }
 

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation
             ISchema schema,
             Document document,
             IEnumerable<IValidationRule> rules = null,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             Inputs inputs = null);
     }
 
@@ -24,7 +24,7 @@ namespace GraphQL.Validation
             ISchema schema,
             Document document,
             IEnumerable<IValidationRule> rules = null,
-            object userContext = null,
+            IDictionary<string, object> userContext = null,
             Inputs inputs = null)
         {
             if (!schema.Initialized)

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -25,7 +25,7 @@ namespace GraphQL.Validation
 
         public TypeInfo TypeInfo { get; set; }
 
-        public object UserContext { get; set; }
+        public IDictionary<string, object> UserContext { get; set; }
 
         public IEnumerable<ValidationError> Errors => _errors;
 


### PR DESCRIPTION
The UserContext that is built by IUserContextBuilder.BuildUserContext is an IDictionary<string, object>. That should be reflected in some classes to make code more type safe and avoid tedious casting. Note: It changes an interface, IDocumentValidator, but I think it's ok given the recent change to IUserContextBuilder and the project being in some kind of preview state.