### PR TITLE
Refactor validation to allow for modification by consumers

### DIFF
--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -98,6 +98,8 @@ namespace GraphQL.Tests.Execution
         }
     }
 
+
+
     public class TestType : ObjectGraphType
     {
         public TestType()
@@ -299,8 +301,8 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null field.");
+            caughtError?.ShouldNotBeNull();
+            caughtError?.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null field.");
         }
 
         [Fact]
@@ -315,8 +317,8 @@ namespace GraphQL.Tests.Execution
             var caughtError = result.Errors.Single();
 
             caughtError.ShouldNotBeNull();
-            caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe(
+            caughtError?.ShouldNotBeNull();
+            caughtError?.Message.ShouldBe(
                 "Variable '$input' is invalid. Unable to parse input as a 'TestInputObject' type. Did you provide a List or Scalar value accidentally?");
         }
 
@@ -331,8 +333,8 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null field.");
+            caughtError?.ShouldNotBeNull();
+            caughtError?.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null field.");
         }
 
         [Fact]
@@ -344,10 +346,39 @@ namespace GraphQL.Tests.Execution
 
             var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1);
 
+
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe("Variable '$input' is invalid. Unrecognized input fields 'e' for type 'TestInputObject'.");
+            caughtError?.Message.ShouldBe("Variable '$input' is invalid. Unrecognized input fields 'e' for type 'TestInputObject'.");
+        }
+
+        [Fact]
+        public void errors_on_addition_of_multiple_unknown_input_field()
+        {
+            const string expected = null;
+
+            var inputs = "{'input': {'a': 'foo', 'b': 'bar', 'c': 'baz', 'e': 'dog','f': 'cow'} }".ToInputs();
+
+            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1);
+
+            var caughtError = result.Errors.Single();
+            caughtError.ShouldNotBeNull();
+            caughtError.Message.ShouldBe("Variable '$input' is invalid. Unrecognized input fields 'e', 'f' for type 'TestInputObject'.");
+        }
+
+        [Fact]
+        public void multiple_errors_can_be_reported()
+        {
+            const string expected = null;
+
+            var inputs = "{'input': {'a': 'foo', 'b': 'bar', 'c': 'baz', 'd': 'dog', e:'test'} }".ToInputs();
+
+            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 2);
+
+            result.Errors[0].ShouldNotBeNull();
+            result.Errors[0].Message.ShouldBe("Variable '$input' is invalid. Unrecognized input fields 'e' for type 'TestInputObject'.");
+            result.Errors[1].ShouldNotBeNull();
+            result.Errors[1].Message.ShouldBe("Variable '$input.d' is invalid. Invalid Scalar value for input field.");
         }
 
         [Fact]
@@ -517,8 +548,7 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError.InnerException.ShouldNotBeNull();
-            caughtError.InnerException.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null field.");
+            caughtError.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null field.");
         }
 
         [Fact]
@@ -538,8 +568,7 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError.InnerException.ShouldNotBeNull();
-            caughtError.InnerException.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null field.");
+            caughtError.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null field.");
         }
 
         [Fact]

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -153,7 +153,8 @@ namespace GraphQL
                     options.CancellationToken,
                     metrics,
                     options.Listeners,
-                    options.ThrowOnUnhandledException);
+                    options.ThrowOnUnhandledException,
+                    options.FieldValidator);
 
                 if (context.Errors.Any())
                 {
@@ -234,7 +235,8 @@ namespace GraphQL
             CancellationToken cancellationToken,
             Metrics metrics,
             IEnumerable<IDocumentExecutionListener> listeners,
-            bool throwOnUnhandledException)
+            bool throwOnUnhandledException,
+            IFieldValidator fieldValidator)
         {
             var context = new ExecutionContext
             {
@@ -244,7 +246,6 @@ namespace GraphQL
                 UserContext = userContext,
 
                 Operation = operation,
-                Variables = GetVariableValues(document, schema, operation?.Variables, inputs),
                 Fragments = document.Fragments,
                 CancellationToken = cancellationToken,
 
@@ -252,6 +253,8 @@ namespace GraphQL
                 Listeners = listeners,
                 ThrowOnUnhandledException = throwOnUnhandledException
             };
+
+            context.Variables = GetVariableValues(document, schema, operation?.Variables, inputs, fieldValidator ?? new FieldValidator(), context);
 
             return context;
         }

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -27,6 +27,7 @@ namespace GraphQL
         public IList<IDocumentExecutionListener> Listeners { get; } = new List<IDocumentExecutionListener>();
 
         public IFieldNameConverter FieldNameConverter { get; set; } = new CamelCaseFieldNameConverter();
+        public IFieldValidator FieldValidator { set; get; }
 
         public bool ExposeExceptions { get; set; } = false;
 

--- a/src/GraphQL/Validation/FieldValidator.cs
+++ b/src/GraphQL/Validation/FieldValidator.cs
@@ -1,0 +1,145 @@
+using GraphQL.Execution;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace GraphQL.Validation
+{
+    public class FieldValidator: IFieldValidator
+    {
+        public ExecutionErrors Validate(ISchema schema, IReadOnlyList<ValidationFrame> fieldStack)
+        {
+            var errors = new ExecutionErrors();
+            AssertValidValue(schema, fieldStack, errors);
+            return errors;
+        }
+
+        public void AssertValidValue(ISchema schema,  IReadOnlyList<ValidationFrame> fieldStack, ExecutionErrors errors)
+        {
+            var item = fieldStack.Last();
+            var fieldName = item.Name;
+            var input = item.Value;
+            var type = item.GraphType;
+            if (type is NonNullGraphType graphType)
+            {
+                var nonNullType = graphType.ResolvedType;
+
+                if (input == null)
+                {
+                    AddError("Received a null input for a non-null field.", fieldStack, errors);
+                }
+                else
+                {
+                    var newStack = AddFrame(fieldStack.Take(fieldStack.Count - 1), new ValidationFrame(fieldName, item.Value, nonNullType,null));
+                    AssertValidValue(schema, newStack, errors);
+                    return;
+                }
+            }
+
+            if (input == null)
+            {
+                return;
+            }
+
+            if (type is ScalarGraphType scalar)
+            {
+                try
+                {
+                    if (ValueFromScalar(scalar, input) == null)
+                        AddError("Invalid Scalar value for input field.", fieldStack, errors);
+                }
+                catch(Exception e)
+                {
+                    AddError($"Invalid Scalar value for input field: {e.Message}", fieldStack, errors);
+                }
+                return;
+            }
+
+            if (type is ListGraphType listType)
+            {
+                  var listItemType = listType.ResolvedType;
+
+                 if (input is IEnumerable list && !(input is string))
+                 {
+                     var index = -1;
+                    foreach (var listItem in list)
+                    {
+                        var newStack = AddFrame(fieldStack.Take(fieldStack.Count-1), new ValidationFrame(fieldName, listItem, listItemType, ++index));
+                        AssertValidValue(schema, newStack, errors);
+                    }
+                 }
+                 else
+                 {
+                    var newStack = AddFrame(fieldStack, new ValidationFrame(fieldName, input, listItemType, null));
+                    AssertValidValue(schema, newStack, errors);
+                 }
+                return;
+            }
+
+            if (type is IObjectGraphType || type is IInputObjectGraphType)
+            {
+                var complexType = (IComplexGraphType)type;
+
+                if (!(input is Dictionary<string, object> dict))
+                {
+                    AddError($"Unable to parse input as a '{type.Name}' type. Did you provide a List or Scalar value accidentally?", fieldStack, errors);
+                    return;
+                }
+                else
+                {
+                    // ensure every provided field is defined
+                    IList<string> unknownFields = null;
+
+                    if (type is IInputObjectGraphType)
+                    {
+                        unknownFields = dict.Keys
+                            .Except(complexType.Fields.Select(f => f.Name))
+                            .ToList();
+                    }
+
+                    if (unknownFields?.Count > 0)
+                    {
+                        AddError($"Unrecognized input fields {string.Join(", ", unknownFields.Select(k => $"'{k}'"))} for type '{type.Name}'.", fieldStack, errors);
+                    }
+
+                    foreach (var field in complexType.Fields)
+                    {
+                        dict.TryGetValue(field.Name, out object fieldValue);
+                        var newStack = AddFrame(fieldStack, new ValidationFrame(field.Name, fieldValue, field.ResolvedType, null));
+                        AssertValidValue(schema,newStack, errors);
+                    }
+                    return;
+                }
+            }
+
+            AddError("Invalid input", fieldStack, errors);
+        }
+
+        public virtual void AddError(string message , IReadOnlyList<ValidationFrame> fieldStack, ExecutionErrors errors)
+        {
+            var path = string.Join(".", fieldStack.Select(f => f.GetLocation()));
+            errors.Add(new ExecutionError($"Variable '${path}' is invalid. {message}"));
+        }
+
+        private IReadOnlyList<ValidationFrame> AddFrame(IEnumerable<ValidationFrame> oldStack, ValidationFrame f)
+        {
+            var stack = new List<ValidationFrame>(oldStack);
+            stack.Add(f);
+            return stack;
+        }
+
+        private object ValueFromScalar(ScalarGraphType scalar, object input)
+        {
+            if (input is IValue value)
+            {
+                return scalar.ParseLiteral(value);
+            }
+
+            return scalar.ParseValue(input);
+        }
+    }
+}

--- a/src/GraphQL/Validation/IFieldValidator.cs
+++ b/src/GraphQL/Validation/IFieldValidator.cs
@@ -1,0 +1,13 @@
+using GraphQL.Execution;
+using GraphQL.Types;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GraphQL.Validation
+{
+    public interface IFieldValidator
+    {
+        ExecutionErrors Validate(ISchema schema, IReadOnlyList<ValidationFrame> fieldStack);
+    }
+}

--- a/src/GraphQL/Validation/ValidationFrame.cs
+++ b/src/GraphQL/Validation/ValidationFrame.cs
@@ -1,0 +1,30 @@
+using GraphQL.Types;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GraphQL.Validation
+{
+    public class ValidationFrame
+    {
+        public ValidationFrame(string name, object value, IGraphType type, int? index)
+        {
+            Name = name;
+            Value = value;
+            GraphType = type;
+            Index = index;
+        }
+
+        public string Name { set; get; }
+        public object Value { set; get; }
+        public IGraphType GraphType { set; get; }
+        public int? Index { set; get; }
+
+        public string GetLocation()
+        {
+            if (Index.HasValue)
+                return $"{Name}[{Index}]";
+            return Name;
+        }
+    }
+}


### PR DESCRIPTION
This is largely just an extract refactor to allow for the default validation behaviour to be replaced.  

Where I am using this project I need to return the errors in a different format and also perform null checks differently and this allows me to do that by having pluggable validation.

I have also changed the validation so that when it encounters an error rather than throwing an exception and stopping there it validates all the fields, it then checks if there are any errors before starting execution which allows for all errors to be returned rather than just the first.  

If expose exceptions is turned on then the existing functionality is retained.  