### PR TITLE
Ensures StringGraphType serializes values to strings

### DIFF
--- a/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
+++ b/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
@@ -757,7 +757,7 @@ namespace GraphQL.Tests.Introspection
                 ""name"": null,
                 ""ofType"": {
                   ""kind"": ""SCALAR"",
-                  ""name"": ""String"",
+                  ""name"": ""Boolean"",
                   ""ofType"": null
                 }
               },

--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using GraphQL.Http;
 using GraphQL.Introspection;
 using GraphQL.Types;
@@ -9,19 +10,19 @@ namespace GraphQL.Tests.Introspection
     public class SchemaIntrospectionTests
     {
         [Fact]
-        public void validate_core_schema()
+        public async Task validate_core_schema()
         {
             var documentExecuter = new DocumentExecuter();
-            var executionResult = documentExecuter.ExecuteAsync(_ =>
+            var executionResult = await documentExecuter.ExecuteAsync(_ =>
             {
                 _.Schema = new Schema
                 {
                     Query = new TestQuery()
                 };
                 _.Query = SchemaIntrospection.IntrospectionQuery;
-            }).GetAwaiter().GetResult();
+            });
 
-            var json = new DocumentWriter(true).WriteToStringAsync(executionResult).GetAwaiter().GetResult();
+            var json = await new DocumentWriter(true).WriteToStringAsync(executionResult);
 
             ShouldBe(json, IntrospectionResult.Data);
         }
@@ -30,18 +31,18 @@ namespace GraphQL.Tests.Introspection
         {
             public TestQuery() => Name = "TestQuery";
         }
-        
+
         [Fact]
-        public void validate_non_null_schema()
+        public async Task validate_non_null_schema()
         {
             var documentExecuter = new DocumentExecuter();
-            var executionResult = documentExecuter.ExecuteAsync(_ =>
+            var executionResult = await documentExecuter.ExecuteAsync(_ =>
             {
                 _.Schema = new TestSchema();
                 _.Query = InputObjectBugQuery;
-            }).GetAwaiter().GetResult();
+            });
 
-            var json = new DocumentWriter(true).WriteToStringAsync(executionResult).GetAwaiter().GetResult();
+            var json = await new DocumentWriter(true).WriteToStringAsync(executionResult);
             executionResult.Errors.ShouldBeNull();
 
             ShouldBe(json, InputObjectBugResult);

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -12,6 +12,8 @@ using Xunit;
 
 namespace GraphQL.Tests.Types
 {
+    #pragma warning disable 618
+
     public class ComplexGraphTypeTests
     {
         internal class ComplexType<T> : ComplexGraphType<T> {
@@ -331,4 +333,6 @@ namespace GraphQL.Tests.Types
             type.Fields.Last().Name.ShouldBe(fieldName);
         }
     }
+
+    #pragma warning restore 618
 }

--- a/src/GraphQL.Tests/Types/StringGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/StringGraphTypeTests.cs
@@ -32,6 +32,12 @@ namespace GraphQL.Tests.Types
         }
 
         [Fact]
+        public void serializes_null_to_null()
+        {
+            _type.Serialize(null).ShouldBeNull();
+        }
+
+        [Fact]
         public void parse_value_keeps__quotes()
         {
             _type.ParseValue("\"one\"").ShouldBe("\"one\"");

--- a/src/GraphQL.Tests/Types/StringGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/StringGraphTypeTests.cs
@@ -20,6 +20,18 @@ namespace GraphQL.Tests.Types
         }
 
         [Fact]
+        public void serializes_int_to_string()
+        {
+            _type.Serialize(1).ShouldBe("1");
+        }
+
+        [Fact]
+        public void serializes_long_to_string()
+        {
+            _type.Serialize(long.MaxValue).ShouldBe($"{long.MaxValue}");
+        }
+
+        [Fact]
         public void parse_value_keeps__quotes()
         {
             _type.ParseValue("\"one\"").ShouldBe("\"one\"");

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -936,7 +936,7 @@ enum __DirectiveLocation {
 type __EnumValue {
   name: String!
   description: String
-  isDeprecated: String!
+  isDeprecated: Boolean!
   deprecationReason: String
 }
 

--- a/src/GraphQL/Introspection/__EnumValue.cs
+++ b/src/GraphQL/Introspection/__EnumValue.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Introspection
             Field(f => f.Name);
             Field(f => f.Description, nullable: true);
 
-            Field<NonNullGraphType<StringGraphType>>("isDeprecated", resolve: context =>
+            Field<NonNullGraphType<BooleanGraphType>>("isDeprecated", resolve: context =>
             {
                 return !string.IsNullOrWhiteSpace(context.Source?.DeprecationReason);
             });

--- a/src/GraphQL/Types/StringGraphType.cs
+++ b/src/GraphQL/Types/StringGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types
     {
         public StringGraphType() => Name = "String";
 
-        public override object Serialize(object value) => value;
+        public override object Serialize(object value) => value?.ToString();
 
         public override object ParseValue(object value) => value?.ToString();
 


### PR DESCRIPTION
* `__EnumValue` introspection `isDeprecated` field was defined as a `String` vs. `Boolean`

fixes #1177