### PR TITLE
Added else-case for generic Task

### DIFF
--- a/src/GraphQL/TaskExtensions.cs
+++ b/src/GraphQL/TaskExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace GraphQL
@@ -22,8 +23,11 @@ namespace GraphQL
             {
                 // Most performant if available
                 return to.Result;
-            }
-            else
+            } else if (task.GetType().IsGenericType)
+            {
+                Type t = task.GetType();
+                return t.GetProperty("Result").GetValue(task, null);
+            }  else
             {
                 // Using dynamic is over 10x faster than reflection
                 return ((dynamic)task).Result;


### PR DESCRIPTION
Method ExecuteAsync on DocumentExecuter failed with Result Property not found on Task.
The following piece of code caused the failure: Task<ILookup<String, Person>> GetPersonsByChefIds(IEnumerable<String> chefIds);

An "is Task<object>" check does not cover all and especially this case.

The proposed change mitigates this error.