### PR TITLE
Fix DataLoader deadlock

### DIFF
--- a/src/GraphQL.DataLoader.Tests/DataLoaderDeadlockTest.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderDeadlockTest.cs
@@ -1,0 +1,50 @@
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GraphQL.DataLoader.Tests
+{
+    public class DataLoaderDeadlockTest : QueryTestBase
+    {
+        protected override void ConfigureServices(ServiceCollection services)
+        {
+            base.ConfigureServices(services);
+            services.AddSingleton<DataLoaderSchema>();
+        }
+        [Fact]
+        public void Await_before_LoadAsync_should_not_deadlock()
+        {
+            // Tests Github issue: DataLoader deadlock with multiple awaits #945
+            AssertQuerySuccess<DataLoaderSchema>(
+                query: "{ true }",
+                expected: @"
+                { true: true }
+                ");
+        }
+    }
+    public class DataLoaderSchema : Schema
+    {
+        public DataLoaderSchema(IServiceProvider services, IDataLoaderContextAccessor accessor)
+            :base(services)
+        {
+            var query = new ObjectGraphType();
+            query.Field<BooleanGraphType, bool>()
+                .Name("True")
+                .ResolveAsync(async ctx =>
+                {
+                    await Task.Delay(1);
+
+                    var loader = accessor.Context.GetOrAddLoader("GetTrue",
+                        () => Task.FromResult(true));
+
+                    return await loader.LoadAsync();
+                });
+
+            Query = query;
+        }
+    }
+}

--- a/src/GraphQL/DataLoader/DataLoaderContext.cs
+++ b/src/GraphQL/DataLoader/DataLoaderContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,9 +11,24 @@ namespace GraphQL.DataLoader
     /// </summary>
     public class DataLoaderContext
     {
+        private TaskCompletionSource<bool> _loaderAwaitedSource = new TaskCompletionSource<bool>();
         private readonly Dictionary<string, IDataLoader> _loaders = new Dictionary<string, IDataLoader>();
         private readonly Queue<IDataLoader> _queue = new Queue<IDataLoader>();
 
+        private void ListenToLoaderAwaited(IDataLoader loader)
+        {
+            loader.LoaderAwaited.ContinueWith(t =>
+            {
+                // This means the registered dataloader is awaited, complete the AnyLoaderAwaited task
+                // and recreate the TaskCompletionSource
+                _loaderAwaitedSource.TrySetResult(true);
+                _loaderAwaitedSource = new TaskCompletionSource<bool>();
+
+                // Since the LoaderAwaited task on the IDataLoader now is completed, we need to re-register
+                // this dataloader to catch any new awaits on it.
+                ListenToLoaderAwaited(loader);
+            });
+        }
         /// <summary>
         /// Add a new data loader if one does not already exist with the provided key
         /// </summary>
@@ -39,6 +55,7 @@ namespace GraphQL.DataLoader
 
                     _loaders.Add(loaderKey, loader);
                     _queue.Enqueue(loader);
+                    ListenToLoaderAwaited(loader);
                 }
             }
 
@@ -80,5 +97,7 @@ namespace GraphQL.DataLoader
 
             await task.ConfigureAwait(false);
         }
+        // Returns a task which will be completed when any of the registered dataloaders are awaited
+        public Task AnyLoaderAwaited => _loaderAwaitedSource.Task;
     }
 }

--- a/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
+++ b/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
@@ -48,6 +48,7 @@ namespace GraphQL.DataLoader
             var context = _accessor.Context;
             return context.DispatchAllAsync(token);
         }
-        public Task AnyLoaderAwaited => _accessor.Context.AnyLoaderAwaited;
+
+        public Task DispatchNeeded => _accessor.Context.DispatchNeeded;
     }
 }

--- a/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
+++ b/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
@@ -48,5 +48,6 @@ namespace GraphQL.DataLoader
             var context = _accessor.Context;
             return context.DispatchAllAsync(token);
         }
+        public Task AnyLoaderAwaited => _accessor.Context.AnyLoaderAwaited;
     }
 }

--- a/src/GraphQL/DataLoader/IDataLoader.cs
+++ b/src/GraphQL/DataLoader/IDataLoader.cs
@@ -14,9 +14,9 @@ namespace GraphQL.DataLoader
         /// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to pass to fetch delegate</param>
         Task DispatchAsync(CancellationToken cancellationToken = default);
         /// <summary>
-        /// A task that completes when the dataloader is awaited and without the result ready (Waiting for DispatchAsync)
+        /// A task that is completed when this loader is in need of dispatch (I.e. a LoadAsync call is requesting data that is not cached/ready)
         /// </summary>
-        Task LoaderAwaited { get; }
+        Task DispatchNeeded { get; }
     }
 
     /// <summary>

--- a/src/GraphQL/DataLoader/IDataLoader.cs
+++ b/src/GraphQL/DataLoader/IDataLoader.cs
@@ -13,6 +13,10 @@ namespace GraphQL.DataLoader
         /// </summary>
         /// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to pass to fetch delegate</param>
         Task DispatchAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// A task that completes when the dataloader is awaited and without the result ready (Waiting for DispatchAsync)
+        /// </summary>
+        Task LoaderAwaited { get; }
     }
 
     /// <summary>

--- a/src/GraphQL/Execution/ParallelExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ParallelExecutionStrategy.cs
@@ -1,3 +1,4 @@
+using GraphQL.DataLoader;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,8 +7,23 @@ namespace GraphQL.Execution
 {
     public class ParallelExecutionStrategy : ExecutionStrategy
     {
+        private TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
         protected override Task ExecuteNodeTreeAsync(ExecutionContext context, ObjectExecutionNode rootNode)
             => ExecuteNodeTreeAsync(context, rootNode);
+
+        private Task AnyLoaderAwaited(ExecutionContext context)
+        {
+            var dataLoaderDocumentListeners = context.Listeners.OfType<DataLoaderDocumentListener>();
+            if (dataLoaderDocumentListeners.Any())
+            {
+                // Return a task that completes when any dataloader in the DataLoaderDocumentListener is awaited
+                return (dataLoaderDocumentListeners.Count() == 1) ? dataLoaderDocumentListeners.First().AnyLoaderAwaited :
+                    Task.WhenAny(dataLoaderDocumentListeners.Select(l => l.AnyLoaderAwaited));
+            }
+            // No DataLoaderDocumentListener registered, so just return a task that never completes
+            // since this means no dataloaders will ever be awaited and in need of dispatch.
+            return _tcs.Task;
+        }
 
         protected async Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode)
         {
@@ -28,12 +44,24 @@ namespace GraphQL.Execution
                 }
 
                 pendingNodes.Clear();
+                
+                // Create a task that completes when all currentTasks are complete
+                var commonTask = Task.WhenAll(currentTasks);
+                
+                // Await tasks for this execution step, use loop to keep dispatching dataloaders
+                // in case resolvers uses multiple dataloaders, or the dataloader is not the first async method awaited.
+                while (!commonTask.IsCompleted)
+                {
+                    // Dispatches any waiting dataloaders
+                    await OnBeforeExecutionStepAwaitedAsync(context)
+                        .ConfigureAwait(false);
 
-                await OnBeforeExecutionStepAwaitedAsync(context)
-                    .ConfigureAwait(false);
-
-                // Await tasks for this execution step
-                var completedNodes = await Task.WhenAll(currentTasks)
+                    // Wait for either all currentTask to complete, or any new awaits on dataloader(s)
+                    // which will continue the loop and dispatch the waiting dataloader(s)
+                    await Task.WhenAny(commonTask, AnyLoaderAwaited(context))
+                        .ConfigureAwait(false);
+                }
+                var completedNodes = await commonTask
                     .ConfigureAwait(false);
 
                 // Add child nodes to pending nodes to execute the next level in parallel


### PR DESCRIPTION
This PR is an attempt to fix #945. It adds a task `DispatchNeeded` on the `DataLoaderBase`, this task is completed when the dataloader is waiting for a dispatch. This property is propagated up thru the `DataLoaderContext` and `DataLoaderDocumentListener`, and used in `ParallelExecutionStrategy` to detect that a dataloader needs a dispatch to avoid the deadlock.

The main change in `ParallelExecutionStrategy` is this:
```cs
                // Create a task that completes when all currentTasks are complete
                var commonTask = Task.WhenAll(currentTasks);
                
                // Await tasks for this execution step, use loop to keep dispatching dataloaders
                // in case resolvers uses multiple dataloaders, or the dataloader is not the first async method awaited.
                while (!commonTask.IsCompleted)
                {
                    // Dispatches any waiting dataloaders
                    await OnBeforeExecutionStepAwaitedAsync(context)
                        .ConfigureAwait(false);

                    // Wait for either all currentTask to complete, or any dataloader(s) in need of dispatching
                    // which will continue the loop and dispatch the waiting dataloader(s)
                    await Task.WhenAny(commonTask, DataLoaderDispatchNeeded(context))
                        .ConfigureAwait(false);
                }
                var completedNodes = await commonTask
                    .ConfigureAwait(false);
```

In the scenario that fields do not use dataloaders or the dataloaders are the first async/await in the fields the execution is the same (i.e. the while loop above is only run once/first time).
However if any field use multiple dataloaders or awaits a dataloader after another await this will be detected and cause the loop to continue and dispatch the dataloader(s).

I also added a test for #945, which deadlocked before and now passes.

A potential issue I see is if the dataloaders are awaited after another await, the operations might not be batched as good since the dispatch is triggered when the first field reaches the 'LoadAsync' on a dataloader. However since we don't know how many fields use the dataloader it is impossible to know how long to wait. But atleast the deadlock is avoided.