### PR TITLE
fieldnameconverter no longer allocates memory

### DIFF
--- a/src/GraphQL.Tests/Bugs/CamelCaseArgumentTest.cs
+++ b/src/GraphQL.Tests/Bugs/CamelCaseArgumentTest.cs
@@ -20,7 +20,7 @@ namespace GraphQL.Tests.Bugs
         {
             var ctx = new ResolveFieldContext
             {
-                Arguments = new Dictionary<string, object> {{"argumentValue", "42"}}
+                Arguments = new Dictionary<string, object> { { "argumentValue", "42" } }
             };
 
             var result = ctx.GetArgument("ArgumentValue", "defaultValue");

--- a/src/GraphQL.Tests/Bugs/PascalCaseTests.cs
+++ b/src/GraphQL.Tests/Bugs/PascalCaseTests.cs
@@ -1,0 +1,31 @@
+using GraphQL.Conversion;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public sealed class PascalCaseTests : QueryTestBase<PascalCaseSchema>
+    {
+        [Fact]
+        public void get_argument_camel_to_pascal_case()
+        {
+            var query = "{ Query(ArgumentValue: 42) }";
+            var expectedResult = "{ 'Query': 42 }";
+            AssertQuery(query, CreateQueryResult(expectedResult), null, null, fieldNameConverter: PascalCaseFieldNameConverter.Instance);
+        }
+    }
+
+    public sealed class PascalCaseSchema : Schema
+    {
+        public PascalCaseSchema()
+        {
+            var query = new ObjectGraphType();
+            query.Field<IntGraphType>(
+                name: "query",
+                arguments: new QueryArguments(new QueryArgument<IntGraphType> { Name = "argumentValue" }),
+                resolve: context => context.GetArgument<int>("argumentValue")
+            );
+            Query = query;
+        }
+    }
+}

--- a/src/GraphQL.Tests/Conversion/FieldNameConverterTests.cs
+++ b/src/GraphQL.Tests/Conversion/FieldNameConverterTests.cs
@@ -12,20 +12,20 @@ namespace GraphQL.Tests.Conversion
         {
             var schema = new Schema
             {
-                FieldNameConverter = converter ?? new CamelCaseFieldNameConverter()
+                FieldNameConverter = converter ?? CamelCaseFieldNameConverter.Instance
             };
 
-            var person = new ObjectGraphType {Name = "Person"};
+            var person = new ObjectGraphType { Name = "Person" };
             person.Field("Name", new StringGraphType());
 
-            var query = new ObjectGraphType {Name = "Query"};
+            var query = new ObjectGraphType { Name = "Query" };
             query.Field(
                 "PeRsoN",
                 person,
                 arguments: new QueryArguments(new QueryArgument<StringGraphType> { Name = argument }),
                 resolve: ctx =>
                 {
-                    return new Person{ Name = "Quinn" };
+                    return new Person { Name = "Quinn" };
                 });
 
             schema.Query = query;

--- a/src/GraphQL.Tests/Execution/Performance/ListPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/ListPerformanceTests.cs
@@ -77,7 +77,7 @@ namespace GraphQL.Tests.Execution.Performance
         {
             var query = @"
                 query AQuery {
-                    people{
+                    people {
                         name
                         name1:name
                         name2:name
@@ -117,7 +117,7 @@ namespace GraphQL.Tests.Execution.Performance
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;
-                _.FieldNameConverter = new CamelCaseFieldNameConverter();
+                _.FieldNameConverter = CamelCaseFieldNameConverter.Instance;
             });
 
             smallListTimer.Stop();
@@ -129,12 +129,11 @@ namespace GraphQL.Tests.Execution.Performance
         }
 
         [Fact(Skip = "Benchmarks only, these numbers are machine dependant.")]
-        // [Fact]
         public async Task Executes_SimpleLists_Are_Performant()
         {
             var query = @"
                 query AQuery {
-                    people{
+                    people {
                         name
                     }
                 }
@@ -155,7 +154,7 @@ namespace GraphQL.Tests.Execution.Performance
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;
-                _.FieldNameConverter = new CamelCaseFieldNameConverter();
+                _.FieldNameConverter = CamelCaseFieldNameConverter.Instance;
             });
 
             smallListTimer.Stop();
@@ -167,12 +166,11 @@ namespace GraphQL.Tests.Execution.Performance
         }
 
         [Fact(Skip = "Benchmarks only, these numbers are machine dependant.")]
-        // [Fact]
         public async Task Executes_UnionLists_Are_Performant()
         {
             var query = @"
                 query AQuery {
-                    people{
+                    people {
                       __typename
                       name
                       pets {
@@ -205,7 +203,7 @@ namespace GraphQL.Tests.Execution.Performance
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;
-                _.FieldNameConverter = new CamelCaseFieldNameConverter();
+                _.FieldNameConverter = CamelCaseFieldNameConverter.Instance;
             });
 
             smallListTimer.Stop();

--- a/src/GraphQL.Tests/Execution/Performance/StarWarsPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/StarWarsPerformanceTests.cs
@@ -51,7 +51,7 @@ namespace GraphQL.Tests.Execution.Performance
                     _.UserContext = null;
                     _.CancellationToken = default;
                     _.ValidationRules = null;
-                    _.FieldNameConverter = new CamelCaseFieldNameConverter();
+                    _.FieldNameConverter = CamelCaseFieldNameConverter.Instance;
                 }).GetAwaiter().GetResult();
             }
 

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -122,7 +122,8 @@ namespace GraphQL.Tests
             object root,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
-            IEnumerable<IValidationRule> rules = null)
+            IEnumerable<IValidationRule> rules = null,
+            IFieldNameConverter fieldNameConverter = null)
         {
             var runResult = Executer.ExecuteAsync(_ =>
             {
@@ -133,7 +134,7 @@ namespace GraphQL.Tests
                 _.UserContext = userContext;
                 _.CancellationToken = cancellationToken;
                 _.ValidationRules = rules;
-                _.FieldNameConverter = new CamelCaseFieldNameConverter();
+                _.FieldNameConverter = fieldNameConverter ?? CamelCaseFieldNameConverter.Instance;
             }).GetAwaiter().GetResult();
 
             var writtenResult = Writer.WriteToStringAsync(runResult).GetAwaiter().GetResult();

--- a/src/GraphQL/Conversion/CamelCaseFieldNameConverter.cs
+++ b/src/GraphQL/Conversion/CamelCaseFieldNameConverter.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GraphQL.Conversion
+{
+    public class CamelCaseFieldNameConverter : IFieldNameConverter
+    {
+        public static readonly CamelCaseFieldNameConverter Instance = new CamelCaseFieldNameConverter();
+
+        public string NameFor(string field, Type parentType) => field.ToCamelCase();
+    }
+}

--- a/src/GraphQL/Conversion/DefaultFieldNameConverter.cs
+++ b/src/GraphQL/Conversion/DefaultFieldNameConverter.cs
@@ -1,0 +1,17 @@
+using GraphQL.Introspection;
+using System;
+using System.Linq;
+
+namespace GraphQL.Conversion
+{
+    public class DefaultFieldNameConverter : IFieldNameConverter
+    {
+        private static readonly Type[] IntrospectionTypes = { typeof(SchemaIntrospection) };
+
+        public static readonly DefaultFieldNameConverter Instance = new DefaultFieldNameConverter();
+
+        public string NameFor(string field, Type parentType) => isIntrospectionType(parentType) ? field.ToCamelCase() : field;
+
+        private bool isIntrospectionType(Type type) => IntrospectionTypes.Contains(type);
+    }
+}

--- a/src/GraphQL/Conversion/IFieldNameConverter.cs
+++ b/src/GraphQL/Conversion/IFieldNameConverter.cs
@@ -1,59 +1,9 @@
 using System;
-using System.Linq;
-using GraphQL.Introspection;
 
 namespace GraphQL.Conversion
 {
     public interface IFieldNameConverter
     {
         string NameFor(string field, Type parentType);
-    }
-
-    public class DefaultFieldNameConverter : IFieldNameConverter
-    {
-        private static readonly Type[] IntrospectionTypes = { typeof(SchemaIntrospection) };
-
-        public string NameFor(string field, Type parentType)
-        {
-            if (isIntrospectionType(parentType))
-            {
-                return field.ToCamelCase();
-            }
-
-            return field;
-        }
-
-        private bool isIntrospectionType(Type type)
-        {
-            return IntrospectionTypes.Contains(type);
-        }
-    }
-
-    public class CamelCaseFieldNameConverter : IFieldNameConverter
-    {
-        public string NameFor(string field, Type parentType)
-        {
-            return field.ToCamelCase();
-        }
-    }
-
-    public class PascalCaseFieldNameConverter : IFieldNameConverter
-    {
-        private static readonly Type[] IntrospectionTypes = { typeof(SchemaIntrospection) };
-
-        public string NameFor(string field, Type parentType)
-        {
-            if (isIntrospectionType(parentType))
-            {
-                return field.ToCamelCase();
-            }
-
-            return field.ToPascalCase();
-        }
-
-        private bool isIntrospectionType(Type type)
-        {
-            return IntrospectionTypes.Contains(type);
-        }
     }
 }

--- a/src/GraphQL/Conversion/PascalCaseFieldNameConverter.cs
+++ b/src/GraphQL/Conversion/PascalCaseFieldNameConverter.cs
@@ -1,0 +1,17 @@
+using GraphQL.Introspection;
+using System;
+using System.Linq;
+
+namespace GraphQL.Conversion
+{
+    public class PascalCaseFieldNameConverter : IFieldNameConverter
+    {
+        private static readonly Type[] IntrospectionTypes = { typeof(SchemaIntrospection) };
+
+        public static readonly PascalCaseFieldNameConverter Instance = new PascalCaseFieldNameConverter();
+
+        public string NameFor(string field, Type parentType) => isIntrospectionType(parentType) ? field.ToCamelCase() : field.ToPascalCase();
+
+        private bool isIntrospectionType(Type type) => IntrospectionTypes.Contains(type);
+    }
+}

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -27,7 +27,7 @@ namespace GraphQL
 
         public IList<IDocumentExecutionListener> Listeners { get; } = new List<IDocumentExecutionListener>();
 
-        public IFieldNameConverter FieldNameConverter { get; set; } = new CamelCaseFieldNameConverter();
+        public IFieldNameConverter FieldNameConverter { get; set; } = CamelCaseFieldNameConverter.Instance;
 
         public bool ExposeExceptions { get; set; } = false;
 

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -52,7 +52,7 @@ namespace GraphQL.Types
         {
             var lookup = new GraphTypesLookup
             {
-                FieldNameConverter = fieldNameConverter ?? new CamelCaseFieldNameConverter()
+                FieldNameConverter = fieldNameConverter ?? CamelCaseFieldNameConverter.Instance
             };
 
             var ctx = new TypeCollectionContext(resolveType, (name, graphType, context) =>
@@ -97,7 +97,7 @@ namespace GraphQL.Types
             return lookup;
         }
 
-        public IFieldNameConverter FieldNameConverter { get; set; } = new CamelCaseFieldNameConverter();
+        public IFieldNameConverter FieldNameConverter { get; set; } = CamelCaseFieldNameConverter.Instance;
 
         public void Clear()
         {

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Types
 
         void Initialize();
 
-        IFieldNameConverter FieldNameConverter { get; set;}
+        IFieldNameConverter FieldNameConverter { get; set; }
 
         IObjectGraphType Query { get; set; }
 
@@ -101,7 +101,7 @@ namespace GraphQL.Types
             return builder.Build(typeDefinitions);
         }
 
-        public IFieldNameConverter FieldNameConverter { get; set;} = new CamelCaseFieldNameConverter();
+        public IFieldNameConverter FieldNameConverter { get; set; } = CamelCaseFieldNameConverter.Instance;
 
         public bool Initialized => _lookup.IsValueCreated;
 

--- a/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using GraphQL.Language.AST;
 using GraphQL.Utilities;
 
@@ -17,7 +17,7 @@ namespace GraphQL.Validation.Rules
             var message = $"Unknown argument \"{argName}\" on field \"{fieldName}\" of type \"{type}\".";
             if (suggestedArgs != null && suggestedArgs.Length > 0)
             {
-                message += $"Did you mean {StringUtils.QuotedOrList(suggestedArgs)}";
+                message += $" Did you mean {StringUtils.QuotedOrList(suggestedArgs)}";
             }
             return message;
         }
@@ -27,7 +27,7 @@ namespace GraphQL.Validation.Rules
             var message = $"Unknown argument \"{argName}\" on directive \"{directiveName}\".";
             if (suggestedArgs != null && suggestedArgs.Length > 0)
             {
-                message += $"Did you mean {StringUtils.QuotedOrList(suggestedArgs)}";
+                message += $" Did you mean {StringUtils.QuotedOrList(suggestedArgs)}";
             }
             return message;
         }


### PR DESCRIPTION
Converters are stateless and can be reused.