### PR TITLE
Better UnhandledExceptionDelegate

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -263,7 +263,7 @@ namespace GraphQL
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Introspection.ISchemaFilter SchemaFilter { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
-        public System.Func<GraphQL.Execution.ExecutionContext, System.Exception, System.Exception> UnhandledExceptionDelegate { get; set; }
+        public System.Action<GraphQL.Execution.UnhandledExceptionContext> UnhandledExceptionDelegate { get; set; }
         public System.Collections.Generic.IDictionary<string, object> UserContext { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule> ValidationRules { get; set; }
     }
@@ -472,7 +472,7 @@ namespace GraphQL.Execution
         public object RootValue { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
-        public System.Func<GraphQL.Execution.ExecutionContext, System.Exception, System.Exception> UnhandledExceptionDelegate { get; set; }
+        public System.Action<GraphQL.Execution.UnhandledExceptionContext> UnhandledExceptionDelegate { get; set; }
         public System.Collections.Generic.IDictionary<string, object> UserContext { get; set; }
         public GraphQL.Language.AST.Variables Variables { get; set; }
     }
@@ -584,6 +584,14 @@ namespace GraphQL.Execution
         public SubscriptionExecutionStrategy() { }
         public override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.Execution.ExecutionContext context) { }
         protected virtual System.Threading.Tasks.Task<System.IObservable<GraphQL.ExecutionResult>> ResolveEventStreamAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
+    }
+    public class UnhandledExceptionContext
+    {
+        public UnhandledExceptionContext(GraphQL.Execution.ExecutionContext context, GraphQL.Types.ResolveFieldContext fieldContext, System.Exception originalException) { }
+        public GraphQL.Execution.ExecutionContext Context { get; }
+        public System.Exception Exception { get; set; }
+        public GraphQL.Types.ResolveFieldContext FieldContext { get; }
+        public System.Exception OriginalException { get; }
     }
     public class ValueExecutionNode : GraphQL.Execution.ExecutionNode
     {

--- a/src/GraphQL.Tests/Bugs/Issue1152ExceptionDelegate.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1152ExceptionDelegate.cs
@@ -22,7 +22,11 @@ query {
 
             var list = new List<Exception>();
 
-            var result = AssertQueryWithErrors(query, expected, expectedErrorCount: 1, unhandledExceptionDelegate: (ctx, ex) => { list.Add(ex); return new InvalidOperationException(ex.Message); } );
+            var result = AssertQueryWithErrors(query, expected, expectedErrorCount: 1, unhandledExceptionDelegate: ctx =>
+            {
+                list.Add(ctx.OriginalException);
+                ctx.Exception = new InvalidOperationException(ctx.OriginalException.Message);
+            });
 
             list.Count.ShouldBe(1);
             list[0].ShouldBeOfType<InvalidTimeZoneException>().StackTrace.ShouldNotBeNull();

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -61,7 +61,7 @@ namespace GraphQL.Tests
             CancellationToken cancellationToken = default,
             int expectedErrorCount = 0,
             bool renderErrors = false,
-            Func<GraphQL.Execution.ExecutionContext, Exception, Exception> unhandledExceptionDelegate = null)
+            Action<UnhandledExceptionContext> unhandledExceptionDelegate = null)
         {
             var queryResult = CreateQueryResult(expected);
             return AssertQueryIgnoreErrors(
@@ -85,7 +85,7 @@ namespace GraphQL.Tests
             CancellationToken cancellationToken = default,
             int expectedErrorCount = 0,
             bool renderErrors = false,
-            Func<GraphQL.Execution.ExecutionContext, Exception, Exception> unhandledExceptionDelegate = null)
+            Action<UnhandledExceptionContext> unhandledExceptionDelegate = null)
         {
             var runResult = Executer.ExecuteAsync(options =>
             {
@@ -95,7 +95,7 @@ namespace GraphQL.Tests
                 options.Inputs = inputs;
                 options.UserContext = userContext;
                 options.CancellationToken = cancellationToken;
-                options.UnhandledExceptionDelegate = unhandledExceptionDelegate ?? ((ctx, ex) => ex);
+                options.UnhandledExceptionDelegate = unhandledExceptionDelegate ?? (ctx => { });
             }).GetAwaiter().GetResult();
 
             var renderResult = renderErrors ? runResult : new ExecutionResult { Data = runResult.Data };
@@ -120,7 +120,7 @@ namespace GraphQL.Tests
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
             IEnumerable<IValidationRule> rules = null,
-            Func<GraphQL.Execution.ExecutionContext, Exception, Exception> unhandledExceptionDelegate = null,
+            Action<UnhandledExceptionContext> unhandledExceptionDelegate = null,
             IFieldNameConverter fieldNameConverter = null)
         {
             var runResult = Executer.ExecuteAsync(options =>
@@ -132,7 +132,7 @@ namespace GraphQL.Tests
                 options.UserContext = userContext;
                 options.CancellationToken = cancellationToken;
                 options.ValidationRules = rules;
-                options.UnhandledExceptionDelegate = unhandledExceptionDelegate ?? ((ctx, ex) => ex);
+                options.UnhandledExceptionDelegate = unhandledExceptionDelegate ?? (ctx => { });
                 options.FieldNameConverter = fieldNameConverter ?? CamelCaseFieldNameConverter.Instance;
             }).GetAwaiter().GetResult();
 

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -207,7 +207,12 @@ namespace GraphQL
                 if (options.ThrowOnUnhandledException)
                     throw;
 
-                ex = options.UnhandledExceptionDelegate(context, ex);
+                if (options.UnhandledExceptionDelegate != null)
+                {
+                    var exceptionContext = new UnhandledExceptionContext(context, null, ex);
+                    options.UnhandledExceptionDelegate(exceptionContext);
+                    ex = exceptionContext.Exception;
+                }
 
                 result = new ExecutionResult
                 {
@@ -238,7 +243,7 @@ namespace GraphQL
             Metrics metrics,
             IEnumerable<IDocumentExecutionListener> listeners,
             bool throwOnUnhandledException,
-            Func<ExecutionContext, Exception, Exception> unhandledExceptionDelegate)
+            Action<UnhandledExceptionContext> unhandledExceptionDelegate)
         {
             var context = new ExecutionContext
             {

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -38,6 +38,6 @@ namespace GraphQL.Execution
         /// Allows to override, hide, modify or just log the unhandled exception before wrap it into ExecutionError.
         /// This can be useful for hiding error messages that reveal server implementation details.
         /// </summary>
-        public Func<ExecutionContext, Exception, Exception> UnhandledExceptionDelegate { get; set; }
+        public Action<UnhandledExceptionContext> UnhandledExceptionDelegate { get; set; }
     }
 }

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -50,7 +50,7 @@ namespace GraphQL
         /// Allows to override, hide, modify or just log the unhandled exception before wrap it into ExecutionError.
         /// This can be useful for hiding error messages that reveal server implementation details.
         /// </summary>
-        public Func<Execution.ExecutionContext, Exception, Exception> UnhandledExceptionDelegate { get; set; } = (ctx, ex) => ex;
+        public Action<UnhandledExceptionContext> UnhandledExceptionDelegate { get; set; } = context => { };
 
         /// <summary>
         /// Provides the ability to filter the schema upon introspection to hide types.

--- a/src/GraphQL/Execution/UnhandledExceptionContext.cs
+++ b/src/GraphQL/Execution/UnhandledExceptionContext.cs
@@ -1,0 +1,36 @@
+using GraphQL.Types;
+using System;
+
+namespace GraphQL.Execution
+{
+    /// <summary>
+    /// Provides contextual information for the unhandled exception delegate, <see cref="ExecutionContext.UnhandledExceptionDelegate"/>.
+    /// </summary>
+    public class UnhandledExceptionContext
+    {
+        public UnhandledExceptionContext(ExecutionContext context, ResolveFieldContext fieldContext, Exception originalException)
+        {
+            Context = context;
+            FieldContext = fieldContext;
+            OriginalException = originalException;
+            Exception = originalException;
+        }
+
+        public ExecutionContext Context { get; }
+
+        /// <summary>
+        /// Field context whose resolver generated an error. Can be null if the error came from DocumentExecuter.
+        /// </summary>
+        public ResolveFieldContext FieldContext { get; }
+
+        /// <summary>
+        /// Original exception from field resolver or DocumentExecuter.
+        /// </summary>
+        public Exception OriginalException { get; }
+
+        /// <summary>
+        /// Allows to change resulting exception keeping original exception unmodified.
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
+}


### PR DESCRIPTION
Move from `Func<>` to `Action<>` to get away from future method signature changes