### PR TITLE
Call FlushInternalAsync when disposing

### DIFF
--- a/src/GraphQL/Http/HttpResponseStreamWriter.cs
+++ b/src/GraphQL/Http/HttpResponseStreamWriter.cs
@@ -246,7 +246,7 @@ namespace GraphQL.Http
                 _disposed = true;
                 try
                 {
-                    FlushInternal(flushEncoder: true);
+                    FlushInternalAsync(flushEncoder: true).Wait();
                 }
                 finally
                 {


### PR DESCRIPTION
This prevents the invalid operation exception

![image](https://user-images.githubusercontent.com/4342380/65925013-f261f500-e3e6-11e9-8173-ef38ffde2bba.png)
