### PR TITLE
Changed dispose method to async

### DIFF
--- a/src/GraphQL/Http/HttpResponseStreamWriter.cs
+++ b/src/GraphQL/Http/HttpResponseStreamWriter.cs
@@ -239,14 +239,14 @@ namespace GraphQL.Http
             return FlushInternalAsync(flushEncoder: true);
         }
 
-        protected override void Dispose(bool disposing)
+        protected override async void Dispose(bool disposing)
         {
             if (disposing && !_disposed)
             {
                 _disposed = true;
                 try
                 {
-                    FlushInternal(flushEncoder: true);
+                    await FlushInternalAsync(flushEncoder: true);
                 }
                 finally
                 {


### PR DESCRIPTION
This avoids the invalid operations exception regarding sync operations:

![image](https://user-images.githubusercontent.com/4342380/65926184-e4fb3980-e3eb-11e9-8b53-b6e9ef6d7125.png)
