### PR TITLE
Synchronous operations are disallowed on ASP.NET Core 3

### DIFF
--- a/src/GraphQL/Http/DocumentWriter.cs
+++ b/src/GraphQL/Http/DocumentWriter.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Buffers;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace GraphQL.Http
 {
@@ -43,10 +43,12 @@ namespace GraphQL.Http
             {
                 ArrayPool = _jsonArrayPool,
                 CloseOutput = false,
-                AutoCompleteOnClose = false
+                AutoCompleteOnClose = false,
+                Formatting = _serializer.Formatting
             })
             {
-                _serializer.Serialize(jsonWriter, value);
+                var json = JToken.FromObject(value, _serializer);
+                await json.WriteToAsync(jsonWriter).ConfigureAwait(false);
                 await jsonWriter.FlushAsync().ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
To use the lib on an ASPNET Core 3 project, you must manually allow syncronous operations.

```csharp
// Startup.ConfigureServices
services.Configure<IISServerOptions>(options =>
{
  options.AllowSynchronousIO = true;
});
```

This pull request is to make it work without changing the default config.
"Serialize" was making syncronous writes to the Body stream, causing exceptions.

I dont know if is the best way to do this, but I couldn't find better async methods in Newtonsoft.Json.

Related to: graphql-dotnet/server#271