### PR TITLE
Remove ConcurrentBag<T> usage im Metrics in favor of List<T>

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -709,8 +709,7 @@ namespace GraphQL.Instrumentation
     public class Metrics
     {
         public Metrics(bool enabled = True) { }
-        public System.Collections.Generic.IEnumerable<GraphQL.Instrumentation.PerfRecord> AllRecords { get; }
-        public System.Collections.Generic.IEnumerable<GraphQL.Instrumentation.PerfRecord> Finish() { }
+        public GraphQL.Instrumentation.PerfRecord[] Finish() { }
         public GraphQL.Instrumentation.Metrics SetOperationName(string name) { }
         public GraphQL.Instrumentation.Metrics Start(string operationName) { }
         public GraphQL.Instrumentation.Metrics.Marker Subject(string category, string subject, System.Collections.Generic.Dictionary<string, object> metadata = null) { }

--- a/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
@@ -78,7 +78,7 @@ namespace GraphQL.Tests.Instrumentation
             var result = _builder.Build().Invoke(_context).Result;
             result.ShouldBe("Quinn");
 
-            var record = _context.Metrics.AllRecords.Skip(1).Single();
+            var record = _context.Metrics.Finish().Skip(1).Single();
             record.Category.ShouldBe("test");
             record.Subject.ShouldBe("testing name");
         }
@@ -91,7 +91,7 @@ namespace GraphQL.Tests.Instrumentation
             var result = _builder.Build().Invoke(_context).Result;
             result.ShouldBe("Quinn");
 
-            var record = _context.Metrics.AllRecords.Skip(1).Single();
+            var record = _context.Metrics.Finish().Skip(1).Single();
             record.Category.ShouldBe("class");
             record.Subject.ShouldBe("from class");
         }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -139,7 +139,7 @@ namespace GraphQL
                     {
                         Errors = validationResult.Errors,
                         ExposeExceptions = options.ExposeExceptions,
-                        Perf = metrics.Finish()?.ToArray()
+                        Perf = metrics.Finish()
                     };
                 }
 
@@ -162,7 +162,7 @@ namespace GraphQL
                     {
                         Errors = context.Errors,
                         ExposeExceptions = options.ExposeExceptions,
-                        Perf = metrics.Finish()?.ToArray()
+                        Perf = metrics.Finish()
                     };
                 }
 
@@ -226,7 +226,7 @@ namespace GraphQL
             {
                 result = result ?? new ExecutionResult();
                 result.ExposeExceptions = options.ExposeExceptions;
-                result.Perf = metrics.Finish()?.ToArray();
+                result.Perf = metrics.Finish();
             }
 
             return result;


### PR DESCRIPTION
fixes #1324

I myself faced the problem of excessive memory consumption on one of my projects. Profiling and investigation led to the real culprit - `ConcurrentBag<T>`:

https://stackoverflow.com/questions/5353164/possible-memoryleak-in-concurrentbag
https://stackoverflow.com/questions/9256735/is-concurrentbag-cause-of-memory-leak
https://stackoverflow.com/questions/10850443/is-there-a-memory-leak-in-the-concurrentbagt-implementation

So just changing it to ordinary `List<T>` with simple locking. I think that there will be problems with such blocking, because adding to the list is almost instantaneous, and the lock design is hybrid and first makes the spinlock instead of putting the thread in the wait state.