### PR TITLE
Fixes different sort order in SchemaPrinter on Windows and Linux

### DIFF
--- a/src/GraphQL.Tests/Execution/RegisteredInstanceTests.cs
+++ b/src/GraphQL.Tests/Execution/RegisteredInstanceTests.cs
@@ -131,10 +131,6 @@ type NestedObjType {
   intField: Int
 }
 
-type root {
-  listOfObjField: [NestedObjType]
-}
-
 scalar SByte
 
 scalar Seconds
@@ -145,9 +141,13 @@ scalar UInt
 
 scalar ULong
 
+scalar UShort
+
 scalar Uri
 
-scalar UShort
+type root {
+  listOfObjField: [NestedObjType]
+}
 ");
         }
 
@@ -180,10 +180,6 @@ type NestedObjType {
   intField: Int
 }
 
-type root {
-  listOfObjField: NestedObjType!
-}
-
 scalar SByte
 
 scalar Seconds
@@ -194,9 +190,13 @@ scalar UInt
 
 scalar ULong
 
+scalar UShort
+
 scalar Uri
 
-scalar UShort
+type root {
+  listOfObjField: NestedObjType!
+}
 ");
         }
 
@@ -229,10 +229,6 @@ type NestedObjType {
   intField: Int
 }
 
-type root {
-  listOfObjField: NestedObjType
-}
-
 scalar SByte
 
 scalar Seconds
@@ -243,9 +239,13 @@ scalar UInt
 
 scalar ULong
 
+scalar UShort
+
 scalar Uri
 
-scalar UShort
+type root {
+  listOfObjField: NestedObjType
+}
 ");
         }
 

--- a/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
@@ -60,14 +60,14 @@ scalar UInt
 
 scalar ULong
 
+scalar UShort
+
 scalar Uri
 
 type User @key(fields: ""id"") {
   id: ID! @external
   username: String!
 }
-
-scalar UShort
 ";
 
             var expected = $@"{{ '_service': {{ 'sdl' : '{sdl}' }}}}";

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -148,7 +148,7 @@ scalar Seconds"
                 var orderedScalars = built_in_scalars
                     .ToDictionary(x => x.Key, x => x.Value)
                     .Union(expected)
-                    .OrderBy(x => x.Key)
+                    .OrderBy(x => x.Key, StringComparer.Ordinal)
                     .Select(x => x.Value);
                 exp = Environment.NewLine + string.Join($"{Environment.NewLine}{Environment.NewLine}", orderedScalars) + Environment.NewLine;
             }
@@ -514,9 +514,9 @@ scalar UInt
 
 scalar ULong
 
-scalar Uri
-
 scalar UShort
+
+scalar Uri
 ", excludeScalars: true);
         }
 
@@ -589,9 +589,9 @@ scalar UInt
 
 scalar ULong
 
-scalar Uri
-
 scalar UShort
+
+scalar Uri
 ", excludeScalars: true);
         }
 
@@ -668,9 +668,9 @@ scalar UInt
 
 scalar ULong
 
-scalar Uri
-
 scalar UShort
+
+scalar Uri
 ", excludeScalars: true);
         }
 
@@ -748,9 +748,9 @@ scalar UInt
 
 scalar ULong
 
-scalar Uri
-
 scalar UShort
+
+scalar Uri
 ", excludeScalars: true);
         }
 
@@ -830,9 +830,9 @@ scalar UInt
 
 scalar ULong
 
-scalar Uri
-
 scalar UShort
+
+scalar Uri
 ", excludeScalars: true);
         }
 
@@ -930,6 +930,11 @@ schema {
   query: Root
 }
 
+# Marks an element of a GraphQL schema as no longer supported.
+directive @deprecated(
+  reason: String = ""No longer supported""
+) on FIELD_DEFINITION | ENUM_VALUE
+
 # Directs the executor to include this field or fragment only when the 'if' argument is true.
 directive @include(
   if: Boolean!
@@ -939,11 +944,6 @@ directive @include(
 directive @skip(
   if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-# Marks an element of a GraphQL schema as no longer supported.
-directive @deprecated(
-  reason: String = ""No longer supported""
-) on FIELD_DEFINITION | ENUM_VALUE
 
 # A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 #

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -3,6 +3,7 @@ using GraphQL.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -56,10 +57,10 @@ namespace GraphQL.Utilities
                 Schema.Initialize();
             }
 
-            var directives = Schema.Directives.Where(d => directiveFilter(d.Name)).ToList();
+            var directives = Schema.Directives.Where(d => directiveFilter(d.Name)).OrderBy(d => d.Name, StringComparer.Ordinal).ToList();
             var types = Schema.AllTypes
                 .Where(t => typeFilter(t.Name))
-                .OrderBy(x => x.Name)
+                .OrderBy(x => x.Name, StringComparer.Ordinal)
                 .ToList();
 
             var result = new[]


### PR DESCRIPTION
Relates to ChilliCream/hotchocolate#890
Also see dotnet/corefx#15825

We personally faced such a problem on our projects. Our tests began to fail because the approved graphql schema was generated on a Windows (by developer) machine and the CI tests (deploy, introspection, etc.) run on Linux machine. It turned out a different type order in the schema.