### PR TITLE
Extend IProvideMetadata with default value factory

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -1606,16 +1606,13 @@ namespace GraphQL.Types
         [System.ComponentModel.DescriptionAttribute("Location adjacent to an input object field definition.")]
         InputFieldDefinition = 17,
     }
-    public class EnumValueDefinition : GraphQL.Types.IProvideMetadata
+    public class EnumValueDefinition : GraphQL.Utilities.MetadataProvider
     {
         public EnumValueDefinition() { }
         public string DeprecationReason { get; set; }
         public string Description { get; set; }
-        public System.Collections.Generic.IDictionary<string, object> Metadata { get; set; }
         public string Name { get; set; }
         public object Value { get; set; }
-        public TType GetMetadata<TType>(string key, TType defaultValue = null) { }
-        public bool HasMetadata(string key) { }
     }
     public class EnumValues : System.Collections.Generic.IEnumerable<GraphQL.Types.EnumValueDefinition>, System.Collections.IEnumerable
     {
@@ -1646,20 +1643,17 @@ namespace GraphQL.Types
         public GraphQL.Resolvers.IAsyncEventStreamResolver AsyncSubscriber { get; set; }
         public GraphQL.Resolvers.IEventStreamResolver Subscriber { get; set; }
     }
-    public class FieldType : GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
+    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
     {
         public FieldType() { }
         public GraphQL.Types.QueryArguments Arguments { get; set; }
         public object DefaultValue { get; set; }
         public string DeprecationReason { get; set; }
         public string Description { get; set; }
-        public System.Collections.Generic.IDictionary<string, object> Metadata { get; set; }
         public string Name { get; set; }
         public GraphQL.Types.IGraphType ResolvedType { get; set; }
         public GraphQL.Resolvers.IFieldResolver Resolver { get; set; }
         public System.Type Type { get; set; }
-        public TType GetMetadata<TType>(string key, TType defaultValue = null) { }
-        public bool HasMetadata(string key) { }
     }
     public class FloatGraphType : GraphQL.Types.ScalarGraphType
     {
@@ -1683,19 +1677,16 @@ namespace GraphQL.Types
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
-    public abstract class GraphType : GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
+    public abstract class GraphType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
         protected GraphType() { }
         public string DeprecationReason { get; set; }
         public string Description { get; set; }
-        public System.Collections.Generic.IDictionary<string, object> Metadata { get; set; }
         public string Name { get; set; }
         public virtual string CollectTypes(GraphQL.Types.TypeCollectionContext context) { }
         protected bool Equals(GraphQL.Types.IGraphType other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public TType GetMetadata<TType>(string key, TType defaultValue = null) { }
-        public bool HasMetadata(string key) { }
         public override string ToString() { }
     }
     public class GraphTypesLookup
@@ -1779,6 +1770,7 @@ namespace GraphQL.Types
     {
         System.Collections.Generic.IDictionary<string, object> Metadata { get; }
         TType GetMetadata<TType>(string key, TType defaultValue = null);
+        TType GetMetadata<TType>(string key, System.Func<TType> defaultValueFactory);
         bool HasMetadata(string key);
     }
     public interface ISchema : System.IDisposable
@@ -1898,18 +1890,15 @@ namespace GraphQL.Types
             where TInterface : GraphQL.Types.IInterfaceGraphType { }
         public void Interface(System.Type type) { }
     }
-    public class QueryArgument : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
+    public class QueryArgument : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IHaveDefaultValue
     {
         public QueryArgument(GraphQL.Types.IGraphType type) { }
         public QueryArgument(System.Type type) { }
         public object DefaultValue { get; set; }
         public string Description { get; set; }
-        public System.Collections.Generic.IDictionary<string, object> Metadata { get; set; }
         public string Name { get; set; }
         public GraphQL.Types.IGraphType ResolvedType { get; set; }
         public System.Type Type { get; }
-        public TType GetMetadata<TType>(string key, TType defaultValue = null) { }
-        public bool HasMetadata(string key) { }
     }
     public class QueryArgument<TType> : GraphQL.Types.QueryArgument
         where TType : GraphQL.Types.IGraphType
@@ -2247,6 +2236,7 @@ namespace GraphQL.Utilities
         public MetadataProvider() { }
         public System.Collections.Generic.IDictionary<string, object> Metadata { get; set; }
         public TType GetMetadata<TType>(string key, TType defaultValue = null) { }
+        public TType GetMetadata<TType>(string key, System.Func<TType> defaultValueFactory) { }
         public bool HasMetadata(string key) { }
     }
     public class static NameValidator

--- a/src/GraphQL/Types/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/EnumerationGraphType.cs
@@ -117,21 +117,11 @@ namespace GraphQL.Types
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
-    public class EnumValueDefinition : IProvideMetadata
+    public class EnumValueDefinition : MetadataProvider
     {
         public string Name { get; set; }
         public string Description { get; set; }
         public string DeprecationReason { get; set; }
         public object Value { get; set; }
-
-        public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
-
-        public TType GetMetadata<TType>(string key, TType defaultValue = default)
-        {
-            var local = Metadata;
-            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
-        }
-
-        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
     }
 }

--- a/src/GraphQL/Types/FieldType.cs
+++ b/src/GraphQL/Types/FieldType.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
@@ -15,7 +16,7 @@ namespace GraphQL.Types
     }
 
     [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
-    public class FieldType : IFieldType
+    public class FieldType : MetadataProvider, IFieldType
     {
         public string Name { get; set; }
         public string Description { get; set; }
@@ -25,14 +26,5 @@ namespace GraphQL.Types
         public IGraphType ResolvedType { get; set; }
         public QueryArguments Arguments { get; set; }
         public IFieldResolver Resolver { get; set; }
-        public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
-
-        public TType GetMetadata<TType>(string key, TType defaultValue = default)
-        {
-            var local = Metadata;
-            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
-        }
-
-        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
     }
 }

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
-    public abstract class GraphType : IGraphType
+    public abstract class GraphType : MetadataProvider, IGraphType
     {
         protected GraphType()
         {
@@ -18,16 +19,6 @@ namespace GraphQL.Types
         public string Description { get; set; }
 
         public string DeprecationReason { get; set; }
-
-        public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
-
-        public TType GetMetadata<TType>(string key, TType defaultValue = default)
-        {
-            var local = Metadata;
-            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
-        }
-
-        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
 
         public virtual string CollectTypes(TypeCollectionContext context)
         {

--- a/src/GraphQL/Types/IProvideMetadata.cs
+++ b/src/GraphQL/Types/IProvideMetadata.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Types
@@ -6,6 +7,7 @@ namespace GraphQL.Types
     {
         IDictionary<string, object> Metadata { get; }
         TType GetMetadata<TType>(string key, TType defaultValue = default);
+        TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory);
         bool HasMetadata(string key);
     }
 }

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
@@ -15,7 +16,7 @@ namespace GraphQL.Types
     }
 
     [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
-    public class QueryArgument : IHaveDefaultValue, IProvideMetadata
+    public class QueryArgument : MetadataProvider, IHaveDefaultValue
     {
         public QueryArgument(IGraphType type)
         {
@@ -41,15 +42,5 @@ namespace GraphQL.Types
         public IGraphType ResolvedType { get; set; }
 
         public Type Type { get; private set; }
-
-        public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
-
-        public TType GetMetadata<TType>(string key, TType defaultValue = default)
-        {
-            var local = Metadata;
-            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
-        }
-
-        public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
     }
 }

--- a/src/GraphQL/Utilities/MetadataProvider.cs
+++ b/src/GraphQL/Utilities/MetadataProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using GraphQL.Types;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -10,8 +11,13 @@ namespace GraphQL.Utilities
 
         public TType GetMetadata<TType>(string key, TType defaultValue = default)
         {
+            return GetMetadata(key, () => defaultValue);
+        }
+
+        public TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory)
+        {
             var local = Metadata;
-            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValue;
+            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValueFactory();
         }
 
         public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;

--- a/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
+++ b/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
@@ -57,7 +57,7 @@ namespace GraphQL.Utilities
 
         public static List<ASTNode> GetExtensionAstTypes(this IProvideMetadata type)
         {
-            return type.GetMetadata(__EXTENSION_AST_MetaField__, new List<ASTNode>());
+            return type.GetMetadata(__EXTENSION_AST_MetaField__, () => new List<ASTNode>());
         }
 
         public static IEnumerable<GraphQLDirective> GetExtensionDirectives<T>(this IProvideMetadata type) where T : ASTNode


### PR DESCRIPTION
* Added `TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory)` to IProvideMetadata to prevent unnecessary memory allocation
* Inherited all possible classes from default implementation MetadataProvider to remove identical implementation.