### PR TITLE
Update and disable field validation on input object graph types progress

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -318,7 +318,9 @@ namespace GraphQL
         public static System.Type GetNamedType(this System.Type type) { }
         public static bool IsCompositeType(this GraphQL.Types.IGraphType type) { }
         public static bool IsInputObjectType(this GraphQL.Types.IGraphType type) { }
+        public static bool IsInputObjectType(this System.Type type) { }
         public static bool IsInputType(this GraphQL.Types.IGraphType type) { }
+        public static bool IsInputType(this System.Type type) { }
         public static bool IsLeafType(this GraphQL.Types.IGraphType type) { }
         public static bool IsSubtypeOf(this GraphQL.Types.IGraphType maybeSubType, GraphQL.Types.IGraphType superType, GraphQL.Types.ISchema schema) { }
         public static System.Collections.Generic.IEnumerable<string> IsValidLiteralValue(this GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue valueAst, GraphQL.Types.ISchema schema) { }

--- a/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Tests.Types
             var type = new InputObjectGraphType();
             var exception = Should.Throw<ArgumentException>(() => type.Field<NonNullGraphType<ListGraphType<MyObjectGraphType>>>().Name("test"));
 
-            exception.Message.ShouldContain("InputObjectGraphType cannot have fields containing a ObjectGraphType.");
+            exception.Message.ShouldContain("InputObjectGraphType should contain only fields of 'input types' - enumerations, scalars and other InputObjectGraphTypes");
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
@@ -7,11 +7,15 @@ namespace GraphQL.Tests.Types
 {
     public class InputObjectGraphTypeTests
     {
-        [Fact]
+        private class MyObjectGraphType : ObjectGraphType { }
+        private class MyInputGraphType : InputObjectGraphType { }
+        private class MyEnumGraphType : EnumerationGraphType { }
+
+        [Fact(Skip = "Exception disabled due to SchemaBuilder using GraphQLTypeReference")]
         public void should_throw_an_exception_if_input_object_graph_type_contains_object_graph_type_field()
         {
             var type = new InputObjectGraphType();
-            var exception = Should.Throw<ArgumentException>(() => type.Field<ObjectGraphType>().Name("test"));
+            var exception = Should.Throw<ArgumentException>(() => type.Field<NonNullGraphType<ListGraphType<MyObjectGraphType>>>().Name("test"));
 
             exception.Message.ShouldContain("InputObjectGraphType cannot have fields containing a ObjectGraphType.");
         }
@@ -20,7 +24,9 @@ namespace GraphQL.Tests.Types
         public void should_not_throw_an_exception_if_input_object_graph_type_doesnt_contains_object_graph_type_field()
         {
             var type = new InputObjectGraphType();
-            var exception = type.Field<ComplexGraphType<object>>().Name("test");
+            var field1 = type.Field<NonNullGraphType<ListGraphType<MyInputGraphType>>>().Name("test1");
+            var field2 = type.Field<StringGraphType>().Name("test2");
+            var field3 = type.Field<MyEnumGraphType>().Name("test3");
         }
     }
 }

--- a/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Tests.Types
         private class MyInputGraphType : InputObjectGraphType { }
         private class MyEnumGraphType : EnumerationGraphType { }
 
-        [Fact(Skip = "Exception disabled due to SchemaBuilder using GraphQLTypeReference")]
+        [Fact]
         public void should_throw_an_exception_if_input_object_graph_type_contains_object_graph_type_field()
         {
             var type = new InputObjectGraphType();

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -93,6 +93,20 @@ namespace GraphQL
                        $"Expected non-null value, {nameof(resolve)} delegate return null for \"${type}\"");
         }
 
+        public static bool IsInputType(this Type type)
+        {
+            var namedType = type.GetNamedType();
+            return typeof(ScalarGraphType).IsAssignableFrom(namedType) ||
+                   typeof(EnumerationGraphType).IsAssignableFrom(namedType) ||
+                   typeof(IInputObjectGraphType).IsAssignableFrom(namedType);
+        }
+
+        public static bool IsInputObjectType(this Type type)
+        {
+            var namedType = type.GetNamedType();
+            return typeof(IInputObjectGraphType).IsAssignableFrom(namedType);
+        }
+
         public static Type GetNamedType(this Type type)
         {
             if (type.IsGenericType

--- a/src/GraphQL/Types/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/InputObjectGraphType.cs
@@ -16,10 +16,7 @@ namespace GraphQL.Types
         {
             if (!ValidateFieldType(fieldType))
             {
-                // todo: must fix errors in SchemaBuilder before uncommenting
-                // test named "should_throw_an_exception_if_input_object_graph_type_contains_object_graph_type_field" is disabled until this bug is fixed
-
-                // throw new ArgumentException("InputObjectGraphType cannot have fields containing a ObjectGraphType.", nameof(fieldType.Type));
+                throw new ArgumentException("InputObjectGraphType cannot have fields containing a ObjectGraphType.", nameof(fieldType.Type));
             }
 
             return base.AddField(fieldType);
@@ -27,9 +24,29 @@ namespace GraphQL.Types
 
         private static bool ValidateFieldType(FieldType fieldType)
         {
-            if (fieldType.ResolvedType != null && fieldType.ResolvedType.IsInputType()) return true;
-            if (fieldType.Type != null && fieldType.Type.IsInputType()) return true;
+            if (fieldType.ResolvedType != null)
+            {
+                if (fieldType.ResolvedType.IsInputType()) return true;
+                if (IsProxyType(fieldType.ResolvedType)) return true;
+            }
+            if (fieldType.Type != null)
+            {
+                if (fieldType.Type.IsInputType()) return true;
+                if (IsProxyType(fieldType.Type)) return true;
+            }
             return false;
+        }
+
+        private static bool IsProxyType(IGraphType type)
+        {
+            var namedType = type.GetNamedType();
+            return namedType is GraphQLTypeReference;
+        }
+
+        private static bool IsProxyType(Type type)
+        {
+            var namedType = type.GetNamedType();
+            return typeof(GraphQLTypeReference).IsAssignableFrom(namedType);
         }
     }
 }

--- a/src/GraphQL/Types/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/InputObjectGraphType.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Types
         {
             if (!ValidateFieldType(fieldType))
             {
-                throw new ArgumentException("InputObjectGraphType cannot have fields containing a ObjectGraphType.", nameof(fieldType.Type));
+                throw new ArgumentException("InputObjectGraphType should contain only fields of 'input types' - enumerations, scalars and other InputObjectGraphTypes", nameof(fieldType.Type));
             }
 
             return base.AddField(fieldType);

--- a/src/GraphQL/Types/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/InputObjectGraphType.cs
@@ -14,12 +14,22 @@ namespace GraphQL.Types
     {
         public override FieldType AddField(FieldType fieldType)
         {
-            if (fieldType.Type == typeof(ObjectGraphType))
+            if (!ValidateFieldType(fieldType))
             {
-                throw new ArgumentException("InputObjectGraphType cannot have fields containing a ObjectGraphType.", nameof(fieldType.Type));
+                // todo: must fix errors in SchemaBuilder before uncommenting
+                // test named "should_throw_an_exception_if_input_object_graph_type_contains_object_graph_type_field" is disabled until this bug is fixed
+
+                // throw new ArgumentException("InputObjectGraphType cannot have fields containing a ObjectGraphType.", nameof(fieldType.Type));
             }
 
             return base.AddField(fieldType);
+        }
+
+        private static bool ValidateFieldType(FieldType fieldType)
+        {
+            if (fieldType.ResolvedType != null && fieldType.ResolvedType.IsInputType()) return true;
+            if (fieldType.Type != null && fieldType.Type.IsInputType()) return true;
+            return false;
         }
     }
 }


### PR DESCRIPTION
Please see issue #1383 

Validation code added and disabled (along with associated tests) until the issue with the SchemaBuilder has been fixed.  I'm not sure what needs to be done from this point.