### PR TITLE
Obsolete SchemaExtensions.Execute

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -400,7 +400,6 @@ namespace GraphQL
     }
     public static class SchemaExtensions
     {
-        public static string Execute(this GraphQL.Types.ISchema schema, System.Action<GraphQL.ExecutionOptions> configure) { }
         public static System.Threading.Tasks.Task<string> ExecuteAsync(this GraphQL.Types.ISchema schema, System.Action<GraphQL.ExecutionOptions> configure) { }
     }
     public static class StringExtensions

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -184,7 +184,7 @@ namespace GraphQL.Tests.Utilities
             ");
 
             var root = new { Hello = "Hello World!" };
-            var result = schema.Execute(_ =>
+            var result = await schema.ExecuteAsync(_ =>
             {
                 _.Query = "{ hello }";
                 _.Root = root;
@@ -208,7 +208,7 @@ namespace GraphQL.Tests.Utilities
                 _.Types.Include<ParametersType>();
             });
 
-            var result = schema.Execute(_ =>
+            var result = await schema.ExecuteAsync(_ =>
             {
                 _.Query = "{ source }";
                 _.Root = new { Hello =  "World" };
@@ -232,7 +232,7 @@ namespace GraphQL.Tests.Utilities
                 _.Types.Include<ParametersType>();
             });
 
-            var result = schema.Execute(_ =>
+            var result = await schema.ExecuteAsync(_ =>
             {
                 _.Query = "{ resolve }";
                 _.ExposeExceptions = true;
@@ -256,7 +256,7 @@ namespace GraphQL.Tests.Utilities
                 _.Types.Include<ParametersType>();
             });
 
-            var result = schema.Execute(_ =>
+            var result = await schema.ExecuteAsync(_ =>
             {
                 _.Query = @"{ resolveWithParam(id: ""abcd"") }";
             });
@@ -279,7 +279,7 @@ namespace GraphQL.Tests.Utilities
                 _.Types.Include<ParametersType>();
             });
 
-            var result = schema.Execute(_ =>
+            var result = await schema.ExecuteAsync(_ =>
             {
                 _.Query = @"{ userContext }";
                 _.UserContext = new MyUserContext { Name = "Quinn" };
@@ -318,7 +318,7 @@ namespace GraphQL.Tests.Utilities
                 _.Types.Include<ParametersType>();
             });
 
-            var result = schema.Execute(_ =>
+            var result = await schema.ExecuteAsync(_ =>
             {
                 _.Query = @"{ userContextWithParam(id: ""abcd"") }";
                 _.UserContext = new MyUserContext { Name = "Quinn" };
@@ -342,7 +342,7 @@ namespace GraphQL.Tests.Utilities
                 _.Types.Include<ParametersType>();
             });
 
-            var result = schema.Execute(_ =>
+            var result = await schema.ExecuteAsync(_ =>
             {
                 _.Query = @"{ three }";
                 _.Root = new { Hello = "World" };
@@ -367,7 +367,7 @@ namespace GraphQL.Tests.Utilities
                 _.Types.Include<ParametersType>();
             });
 
-            var result = schema.Execute(_ =>
+            var result = await schema.ExecuteAsync(_ =>
             {
                 _.Query = @"{ four(id: 123) }";
                 _.Root = new { Hello = "World" };

--- a/src/GraphQL/SchemaExtensions.cs
+++ b/src/GraphQL/SchemaExtensions.cs
@@ -7,6 +7,7 @@ namespace GraphQL
 {
     public static class SchemaExtensions
     {
+        [Obsolete(@"This action is async. Use ExecuteAsync. Will be removed in v4.")]
         public static string Execute(this ISchema schema, Action<ExecutionOptions> configure)
         {
             return ExecuteAsync(schema, configure).GetAwaiter().GetResult();
@@ -21,7 +22,8 @@ namespace GraphQL
                 configure(options);
             }).ConfigureAwait(false);
 
-            return await new DocumentWriter(indent: true).WriteToStringAsync(result).ConfigureAwait(false);
+            var documentWriter = new DocumentWriter(indent: true);
+            return await documentWriter.WriteToStringAsync(result).ConfigureAwait(false);
         }
     }
 }

--- a/src/GraphQL/SchemaExtensions.cs
+++ b/src/GraphQL/SchemaExtensions.cs
@@ -7,12 +7,6 @@ namespace GraphQL
 {
     public static class SchemaExtensions
     {
-        [Obsolete(@"This action is async. Use ExecuteAsync. Will be removed in v4.")]
-        public static string Execute(this ISchema schema, Action<ExecutionOptions> configure)
-        {
-            return ExecuteAsync(schema, configure).GetAwaiter().GetResult();
-        }
-
         public static async Task<string> ExecuteAsync(this ISchema schema, Action<ExecutionOptions> configure)
         {
             var executor = new DocumentExecuter();


### PR DESCRIPTION
removes an unnecessarily `.GetAwaiter().GetResult();`