### PR TITLE
Updated ConnectionBuilder to allow bidirectional slicing

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -19,7 +19,7 @@ namespace GraphQL.Builders
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Argument<TArgumentGraphType, TArgumentType>(string name, string description, TArgumentType defaultValue = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType> Bidirectional() { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Bidirectional(bool allowBidirectionalSlicing = False) { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -36,6 +36,8 @@ namespace GraphQL.Builders
 
         private bool _isBidirectional;
 
+        private bool _allowBidirectionalSlicing;
+
         private int? _pageSize;
 
         public FieldType FieldType { get; protected set; }
@@ -48,6 +50,7 @@ namespace GraphQL.Builders
         {
             _isUnidirectional = isUnidirectional;
             _isBidirectional = isBidirectional;
+            _allowBidirectionalSlicing = false;
             _pageSize = pageSize;
             FieldType = fieldType;
         }
@@ -98,10 +101,11 @@ namespace GraphQL.Builders
             return this;
         }
 
-        public ConnectionBuilder<TSourceType> Bidirectional()
+        public ConnectionBuilder<TSourceType> Bidirectional(bool allowBidirectionalSlicing = false)
         {
             if (_isBidirectional)
             {
+                _allowBidirectionalSlicing = allowBidirectionalSlicing;
                 return this;
             }
 
@@ -112,6 +116,7 @@ namespace GraphQL.Builders
 
             _isUnidirectional = false;
             _isBidirectional = true;
+            _allowBidirectionalSlicing = allowBidirectionalSlicing;
 
             return this;
         }
@@ -194,7 +199,7 @@ namespace GraphQL.Builders
 
         private void CheckForErrors(ResolveConnectionContext<TSourceType> args)
         {
-            if (args.First.HasValue && args.Last.HasValue)
+            if (args.First.HasValue && args.Last.HasValue && !_allowBidirectionalSlicing)
             {
                 throw new ArgumentException("Cannot specify both `first` and `last`.");
             }


### PR DESCRIPTION
According to the relay specification "before" and "after" are allowed to be specified simultaneously when querying a connection. I need this in a project so I have included support for it by adding an optional parameter to .Bidirectional() which defaults to false to preserve backwards compatibility.