### PR TITLE
Check for redefinitions in SDL

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -2302,6 +2302,7 @@ namespace GraphQL.Utilities
         protected virtual GraphQL.Types.IObjectGraphType ToObjectGraphType(GraphQLParser.AST.GraphQLObjectTypeDefinition astType, bool isExtensionType = False) { }
         protected virtual GraphQL.Types.FieldType ToSubscriptionFieldType(string parentTypeName, GraphQLParser.AST.GraphQLFieldDefinition fieldDef) { }
         protected virtual GraphQL.Types.UnionGraphType ToUnionType(GraphQLParser.AST.GraphQLUnionTypeDefinition unionDef) { }
+        protected virtual void Validate(GraphQLParser.AST.GraphQLDocument document) { }
         protected virtual void VisitNode(object node, System.Action<GraphQL.Utilities.ISchemaNodeVisitor> action) { }
     }
     public abstract class SchemaDirectiveVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="4.1.2" />
+    <PackageReference Include="GraphQL-Parser" Version="4.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -62,15 +62,13 @@ namespace GraphQL.Utilities
 
         protected virtual void Validate(GraphQLDocument document)
         {
-            // this can be simplified once https://github.com/graphql-dotnet/parser/pull/43 is done
-            var definitions = document.Definitions.OfType<GraphQLTypeDefinition>().Where(def => def is INamedNode && !(def is GraphQLTypeExtensionDefinition)).ToList();
-            var definitionsByName = definitions.ToLookup(def => ((INamedNode)def).Name.Value);
+            var definitionsByName = document.Definitions.OfType<GraphQLTypeDefinition>().Where(def => !(def is GraphQLTypeExtensionDefinition)).ToLookup(def => def.Name.Value);
             var duplicates = definitionsByName.Where(grouping => grouping.Count() > 1).ToArray();
             if (duplicates.Length > 0)
                 throw new ArgumentException(@$"All types within a GraphQL schema must have unique names. No two provided types may have the same name.
 Schema contains a redefinition of these types: {string.Join(", ", duplicates.Select(item => item.Key))}", nameof(document));
 
-            // checks may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653 
+            // checks for parsed SDL may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653 
         }
 
         private static GraphQLDocument Parse(string document)

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -56,7 +56,21 @@ namespace GraphQL.Utilities
         public virtual ISchema Build(string typeDefinitions)
         {
             var document = Parse(typeDefinitions);
+            Validate(document);
             return BuildSchemaFrom(document);
+        }
+
+        protected virtual void Validate(GraphQLDocument document)
+        {
+            // this can be simplified once https://github.com/graphql-dotnet/parser/pull/43 is done
+            var definitions = document.Definitions.OfType<GraphQLTypeDefinition>().Where(def => def is INamedNode && !(def is GraphQLTypeExtensionDefinition)).ToList();
+            var definitionsByName = definitions.ToLookup(def => ((INamedNode)def).Name.Value);
+            var duplicates = definitionsByName.Where(grouping => grouping.Count() > 1).ToArray();
+            if (duplicates.Length > 0)
+                throw new ArgumentException(@$"All types within a GraphQL schema must have unique names. No two provided types may have the same name.
+Schema contains a redefinition of these types: {string.Join(", ", duplicates.Select(item => item.Key))}", nameof(document));
+
+            // checks may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653 
         }
 
         private static GraphQLDocument Parse(string document)

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -3,5 +3,6 @@
   <packageSources>
     <clear />
     <add key="NuGet.org (v3)" value="https://api.nuget.org/v3/index.json" />
+    <add key="myget-graphql-dotnet" value="https://myget.org/F/graphql-dotnet/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Relates to graphql/graphql-spec#653

`SchemaBuilder` should fail to build incorrectly typed SDL. Otherwise, one could came across the problem of non-deterministic behavior. When constructing the schema, a second instance of the type (some input type in my case) was created and replaced the reference to this type already added in the type dictionary. This led to the fact that, depending on the type arrangement in the SDL, the `GraphTypesLookup.ApplyTypeReferences` method did not completely replace `GraphQLTypeReference`.  And this, in turn, led to runtime errors:
```
System.InvalidCastException: 'Unable to cast object of type 'GraphQL.Types.GraphQLTypeReference' to type 'GraphQL.Types.ScalarGraphType'.'
```
in `GraphQLExtensions.IsValidLiteralValue`.