### PR TITLE
[WIP] Astprinter fix and forgotten nodes

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -2151,20 +2151,21 @@ namespace GraphQL.Types.Relay.DataObjects
 }
 namespace GraphQL.Utilities
 {
-    public class AstPrintConfig
+    public abstract class AstPrintConfig
     {
-        public AstPrintConfig() { }
+        protected AstPrintConfig() { }
         public System.Collections.Generic.IEnumerable<GraphQL.Utilities.AstPrintFieldDefinition> Fields { get; }
-        public System.Func<GraphQL.Language.AST.INode, bool> Matches { get; set; }
-        public System.Func<System.Collections.Generic.IDictionary<string, object>, object> PrintAst { get; set; }
+        public abstract System.Func<GraphQL.Language.AST.INode, bool> Matches { get; }
+        public abstract System.Func<System.Collections.Generic.IDictionary<string, object>, object> PrintAst { get; }
         public void Field(GraphQL.Utilities.AstPrintFieldDefinition field) { }
     }
     public class AstPrintConfig<T> : GraphQL.Utilities.AstPrintConfig
         where T : GraphQL.Language.AST.INode
     {
-        public AstPrintConfig() { }
+        public AstPrintConfig(System.Func<GraphQL.Utilities.PrintFormat<T>, object> configure) { }
+        public override System.Func<GraphQL.Language.AST.INode, bool> Matches { get; }
+        public override System.Func<System.Collections.Generic.IDictionary<string, object>, object> PrintAst { get; }
         public void Field<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> resolve) { }
-        public void Print(System.Func<GraphQL.Utilities.PrintFormat<T>, object> configure) { }
     }
     public class AstPrintFieldDefinition
     {
@@ -2176,7 +2177,7 @@ namespace GraphQL.Utilities
     {
         public AstPrintVisitor() { }
         public object ApplyConfig(GraphQL.Language.AST.INode node) { }
-        public void Config<T>(System.Action<GraphQL.Utilities.AstPrintConfig<T>> configure)
+        public void Config<T>(System.Func<GraphQL.Utilities.PrintFormat<T>, object> printAst, System.Action<GraphQL.Utilities.AstPrintConfig<T>> configure = null)
             where T : GraphQL.Language.AST.INode { }
         public object Visit(GraphQL.Language.AST.INode node) { }
     }

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -24,20 +24,22 @@ namespace GraphQL.Utilities
         }
     }
 
-    public class AstPrintConfig
+    public abstract class AstPrintConfig
     {
-        private readonly List<AstPrintFieldDefinition> _fields = new List<AstPrintFieldDefinition>();
+        private List<AstPrintFieldDefinition> _fields;
 
         public IEnumerable<AstPrintFieldDefinition> Fields => _fields;
-        public Func<INode, bool> Matches { get; set; }
-        public Func<IDictionary<string, object>, object> PrintAst { get; set; }
+
+        public abstract Func<INode, bool> Matches { get; }
+
+        public abstract Func<IDictionary<string, object>, object> PrintAst { get; }
 
         public void Field(AstPrintFieldDefinition field)
         {
-            if (_fields.Exists(x => x.Name == field.Name))
-            {
+            if (_fields == null)
+                _fields = new List<AstPrintFieldDefinition>();
+            else if (_fields.Exists(x => x.Name == field.Name))
                 throw new ExecutionError($"A field with name \"{field.Name}\" already exists!");
-            }
 
             _fields.Add(field);
         }
@@ -79,6 +81,21 @@ namespace GraphQL.Utilities
     public class AstPrintConfig<T> : AstPrintConfig
         where T : INode
     {
+        private readonly Func<IDictionary<string, object>, object> _printAst;
+
+        public AstPrintConfig(Func<PrintFormat<T>, object> configure)
+        {
+            _printAst = args =>
+            {
+                var f = new PrintFormat<T>(args);
+                return configure(f);
+            };
+        }
+
+        public override Func<INode, bool> Matches => node => node is T;
+
+        public override Func<IDictionary<string, object>, object> PrintAst => _printAst;
+
         public void Field<TProperty>(Expression<Func<T, TProperty>> resolve)
         {
             var name = resolve.NameOf();
@@ -89,15 +106,6 @@ namespace GraphQL.Utilities
             };
 
             Field(def);
-        }
-
-        public void Print(Func<PrintFormat<T>, object> configure)
-        {
-            PrintAst = args =>
-            {
-                var f = new PrintFormat<T>(args);
-                return configure(f);
-            };
         }
     }
 
@@ -158,168 +166,193 @@ namespace GraphQL.Utilities
 
         public AstPrintVisitor()
         {
-            Config<Document>(c =>
-            {
-                c.Field(x => x.Operations);
-                c.Field(x => x.Fragments);
-                c.Print(p =>
+            Config<Document>(
+                f =>
                 {
-                    var ops = Join(p.ArgArray(x => x.Operations), "\n\n");
-                    var frags = Join(p.ArgArray(x => x.Fragments), "\n\n");
+                    var ops = Join(f.ArgArray(x => x.Operations), "\n\n");
+                    var frags = Join(f.ArgArray(x => x.Fragments), "\n\n");
 
-                    var result = Join(new[] {ops, frags}, "\n\n") + "\n";
+                    var result = Join(new[] { ops, frags }, "\n\n") + "\n";
                     return result;
-                });
-            });
-
-            Config<Operation>(c =>
-            {
-                c.Field(x => x.OperationType);
-                c.Field(x => x.Name);
-                c.Field(x => x.Variables);
-                c.Field(x => x.Directives);
-                c.Field(x => x.SelectionSet);
-                c.Print(p =>
+                },
+                c =>
                 {
-                    var op = p.Arg(x => x.OperationType).ToString().ToLower(CultureInfo.InvariantCulture);
-                    var name = p.Arg(x => x.Name)?.ToString();
-                    var variables = Wrap("(", Join(p.ArgArray(x => x.Variables), ", "), ")");
-                    var directives = Join(p.ArgArray(x => x.Directives), " ");
-                    var selectionSet = p.Arg(x => x.SelectionSet);
+                    c.Field(x => x.Operations);
+                    c.Field(x => x.Fragments);
+                }
+            );
+
+            Config<Operation>(
+                f =>
+                {
+                    var op = f.Arg(x => x.OperationType).ToString().ToLower(CultureInfo.InvariantCulture);
+                    var name = f.Arg(x => x.Name)?.ToString();
+                    var variables = Wrap("(", Join(f.ArgArray(x => x.Variables), ", "), ")");
+                    var directives = Join(f.ArgArray(x => x.Directives), " ");
+                    var selectionSet = f.Arg(x => x.SelectionSet);
 
                     return string.IsNullOrWhiteSpace(name)
                            && string.IsNullOrWhiteSpace(directives)
                            && string.IsNullOrWhiteSpace(variables)
                         ? selectionSet
-                        : Join(new[] {op, Join(new[] {name, variables}, ""), directives, selectionSet}, " ");
-                });
-            });
-
-            Config<InlineFragment>(c =>
-            {
-                c.Field(x => x.Directives);
-                c.Field(x => x.SelectionSet);
-                c.Field(x => x.Type);
-                c.Print(p =>
+                        : Join(new[] { op, Join(new[] { name, variables }, ""), directives, selectionSet }, " ");
+                },
+                c =>
                 {
-                    var directives = Join(p.ArgArray(x => x.Directives), " ");
-                    var selectionSet = p.Arg(x => x.SelectionSet);
-                    var typename = p.Arg(x => x.Type);
+                    c.Field(x => x.OperationType);
+                    c.Field(x => x.Name);
+                    c.Field(x => x.Variables);
+                    c.Field(x => x.Directives);
+                    c.Field(x => x.SelectionSet);
+                }
+            );
+
+            Config<InlineFragment>(
+                f =>
+                {
+                    var directives = Join(f.ArgArray(x => x.Directives), " ");
+                    var selectionSet = f.Arg(x => x.SelectionSet);
+                    var typename = f.Arg(x => x.Type);
                     var body = string.IsNullOrWhiteSpace(directives)
                         ? selectionSet
                         : Join(new[] { directives, selectionSet }, " ");
 
                     return $"... on {typename} {body}";
-                });
-            });
-
-            Config<VariableDefinition>(c =>
-            {
-                c.Field(x => x.Name);
-                c.Field(x => x.Type);
-                c.Field(x => x.DefaultValue);
-                c.Print(p =>
+                },
+                c =>
                 {
-                    return $"${p.Arg(x => x.Name)}: {p.Arg(x => x.Type)}";
-                });
-            });
+                    c.Field(x => x.Directives);
+                    c.Field(x => x.SelectionSet);
+                    c.Field(x => x.Type);
+                }
+            );
 
-            Config<SelectionSet>(c =>
-            {
-                c.Field(x => x.Selections);
-                c.Print(p =>
+            Config<VariableDefinition>(
+                f => $"${f.Arg(x => x.Name)}: {f.Arg(x => x.Type)}",
+                c =>
                 {
-                    return Block(p.ArgArray(x => x.Selections));
-                });
-            });
+                    c.Field(x => x.Name);
+                    c.Field(x => x.Type);
+                    c.Field(x => x.DefaultValue);
+                }
+            );
 
-            Config<Arguments>(c =>
-            {
-                c.Field(x => x.Children);
-                c.Print(p =>
+            Config<SelectionSet>(
+                f => Block(f.ArgArray(x => x.Selections)),
+                c => c.Field(x => x.Selections)
+            );
+
+            Config<Arguments>(
+                f => f.Arg(x => x.Children),
+                c => c.Field(x => x.Children)
+            );
+
+            Config<Argument>(
+                f => $"{f.Arg(x => x.Name)}: {f.Arg(x => x.Value)}",
+                c =>
                 {
-                    var result = p.Arg(x => x.Children);
-                    return result;
-                });
-            });
+                    c.Field(x => x.Name);
+                    c.Field(x => x.Value);
+                }
+            );
 
-            Config<Argument>(c =>
-            {
-                c.Field(x => x.Name);
-                c.Field(x => x.Value);
-                c.Print(p => $"{p.Arg(x => x.Name)}: {p.Arg(x => x.Value)}");
-            });
-
-            Config<Field>(c =>
-            {
-                c.Field(x => x.Alias);
-                c.Field(x => x.Name);
-                c.Field(x => x.Arguments);
-                c.Field(x => x.Directives);
-                c.Field(x => x.SelectionSet);
-                c.Print(n =>
+            Config<Field>(
+                f =>
                 {
-                    var alias = n.Arg(x => x.Alias);
-                    var name = n.Arg(x => x.Name);
-                    var args = Join(n.ArgArray(x => x.Arguments), ", ");
-                    var directives = Join(n.ArgArray(x => x.Directives), " ");
-                    var selectionSet = n.Arg(x => x.SelectionSet);
+                    var alias = f.Arg(x => x.Alias);
+                    var name = f.Arg(x => x.Name);
+                    var args = Join(f.ArgArray(x => x.Arguments), ", ");
+                    var directives = Join(f.ArgArray(x => x.Directives), " ");
+                    var selectionSet = f.Arg(x => x.SelectionSet);
 
-                    var result = Join(new []
+                    var result = Join(new[]
                     {
-                        Wrap("", alias, ": ") + name + Wrap("(", args, ")"),
-                        directives,
-                        selectionSet
-                    }, " ");
+                            Wrap("", alias, ": ") + name + Wrap("(", args, ")"),
+                            directives,
+                            selectionSet
+                        }, " ");
                     return result;
-                });
-            });
+                },
+                c =>
+                {
+                    c.Field(x => x.Alias);
+                    c.Field(x => x.Name);
+                    c.Field(x => x.Arguments);
+                    c.Field(x => x.Directives);
+                    c.Field(x => x.SelectionSet);
+                }
+            );
 
             // Value
 
-            Config<VariableReference>(c =>
-            {
-                c.Field(x => x.Name);
-                c.Print(p => $"${p.Arg(x => x.Name)}");
-            });
+            Config<VariableReference>(
+                f => $"${f.Arg(x => x.Name)}",
+                c => c.Field(x => x.Name)
+            );
 
-            Config<IntValue>(c =>
-            {
-                c.Field(x => x.Value);
-                c.Print(f => f.Arg(x => x.Value));
-            });
+            Config<NullValue>(f => "null");
 
-            Config<NullValue>(c =>
-            {
-                c.Print(f => "null");
-            });
+            Config<IntValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
 
-            Config<LongValue>(c =>
-            {
-                c.Field(x => x.Value);
-                c.Print(f => f.Arg(x => x.Value));
-            });
+            Config<UIntValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
 
-            Config<BigIntValue>(c =>
-            {
-                c.Field(x => x.Value);
-                c.Print(f => f.Arg(x => x.Value));
-            });
+            Config<ULongValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
 
-            Config<FloatValue>(c =>
-            {
-                c.Field(x => x.Value);
-                c.Print(f =>
+            Config<ByteValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
+
+            Config<SByteValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
+
+            Config<ShortValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
+
+            Config<UShortValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
+
+            Config<DecimalValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
+
+            Config<LongValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
+
+            Config<BigIntValue>(
+                f => f.Arg(x => x.Value),
+                c => c.Field(x => x.Value)
+            );
+
+            Config<FloatValue>(
+                f =>
                 {
                     var val = (double)f.Arg(x => x.Value);
                     return val.ToString("0.0##############", CultureInfo.InvariantCulture);
-                });
-            });
+                },
+                c => c.Field(x => x.Value)
+            );
 
-            Config<StringValue>(c =>
-            {
-                c.Field(x => x.Value);
-                c.Print(f =>
+            Config<StringValue>(
+                f =>
                 {
                     var val = f.Arg(x => x.Value);
                     if (!string.IsNullOrWhiteSpace(val?.ToString()) && !val.ToString().StartsWith("\"", StringComparison.InvariantCulture))
@@ -327,89 +360,86 @@ namespace GraphQL.Utilities
                         val = $"\"{val}\"";
                     }
                     return val;
-                });
-            });
+                },
+                c => c.Field(x => x.Value)
+            );
 
-            Config<BooleanValue>(c =>
-            {
-                c.Field(x => x.Value);
-                c.Print(f => f.Arg(x => x.Value)?.ToString().ToLower(CultureInfo.InvariantCulture));
-            });
+            Config<BooleanValue>(
+                f => f.Arg(x => x.Value)?.ToString().ToLower(CultureInfo.InvariantCulture),
+                c => c.Field(x => x.Value)
+            );
 
-            Config<EnumValue>(c =>
-            {
-                c.Field(x => x.Name);
-                c.Print(p => p.Arg(x => x.Name));
-            });
+            Config<EnumValue>(
+                f => f.Arg(x => x.Name),
+                c => c.Field(x => x.Name)
+            );
 
-            Config<ListValue>(c =>
-            {
-                c.Field(x => x.Values);
-                c.Print(p => $"[{Join(p.ArgArray(x => x.Values), ", ")}]");
-            });
+            Config<ListValue>(
+                f => $"[{Join(f.ArgArray(x => x.Values), ", ")}]",
+                c => c.Field(x => x.Values)
+            );
 
-            Config<ObjectValue>(c =>
-            {
-                c.Field(x => x.ObjectFields);
-                c.Print(p => $"{{{Join(p.ArgArray(x=>x.ObjectFields), ", ")}}}");
-            });
+            Config<ObjectValue>(
+                f => $"{{{Join(f.ArgArray(x => x.ObjectFields), ", ")}}}",
+                c => c.Field(x => x.ObjectFields)
+            );
 
-            Config<ObjectField>(c =>
-            {
-                c.Field(x => x.Name);
-                c.Field(x => x.Value);
-                c.Print(p => $"{p.Arg(x => x.Name)}: {p.Arg(x => x.Value)}");
-            });
+            Config<ObjectField>(
+                f => $"{f.Arg(x => x.Name)}: {f.Arg(x => x.Value)}",
+                c =>
+                {
+                    c.Field(x => x.Name);
+                    c.Field(x => x.Value);
+                }
+            );
 
-            Config<UriValue>(c =>
-            {
-                c.Field(x => x.Value);
-                c.Print(p => p.Arg(x => x.Value)?.ToString().ToLower(CultureInfo.InvariantCulture));
-            });
+            Config<UriValue>(
+                f => f.Arg(x => x.Value)?.ToString().ToLower(CultureInfo.InvariantCulture),
+                c => c.Field(x => x.Value)
+            );
 
             // Directive
-            Config<Directive>(c =>
-            {
-                c.Field(x => x.Name);
-                c.Field(x => x.Arguments);
-                c.Print(n =>
+            Config<Directive>(
+                f =>
                 {
-                    var name = n.Arg(x => x.Name);
-                    var args = Join(n.ArgArray(x => x.Arguments), ", ");
+                    var name = f.Arg(x => x.Name);
+                    var args = Join(f.ArgArray(x => x.Arguments), ", ");
                     return $"@{name}" + Wrap("(", args, ")");
-                });
-            });
+                },
+                c =>
+                {
+                    c.Field(x => x.Name);
+                    c.Field(x => x.Arguments);
+                }
+            );
 
             // Type
-            Config<NamedType>(c =>
-            {
-                c.Field(x => x.Name);
-                c.Print(p => p.Arg(x => x.Name));
-            });
+            Config<NamedType>(
+                f => f.Arg(x => x.Name),
+                c => c.Field(x => x.Name)
+            );
 
-            Config<ListType>(c =>
-            {
-                c.Field(x => x.Type);
-                c.Print(p => $"[{p.Arg(x => x.Type)}]");
-            });
+            Config<ListType>(
+                f => $"[{f.Arg(x => x.Type)}]",
+                c => c.Field(x => x.Type)
+            );
 
-            Config<NonNullType>(c =>
-            {
-                c.Field(x => x.Type);
-                c.Print(p => $"{p.Arg(x => x.Type)}!");
-            });
+            Config<NonNullType>(
+                f => $"{f.Arg(x => x.Type)}!",
+                c => c.Field(x => x.Type)
+            );
 
             // Type System Definitions
         }
 
-        public void Config<T>(Action<AstPrintConfig<T>> configure)
+        public void Config<T>(Func<PrintFormat<T>, object> printAst, Action<AstPrintConfig<T>> configure = null)
             where T : INode
         {
-            var config = new AstPrintConfig<T>
-            {
-                Matches = n => n is T
-            };
-            configure(config);
+            if (_configs.Any(c => c is AstPrintConfig<T>))
+                throw new ExecutionError($"A config for \"{typeof(T).Name}\" already exists!");
+
+            var config = new AstPrintConfig<T>(printAst);
+            configure?.Invoke(config);
             _configs.Add(config);
         }
 
@@ -458,7 +488,7 @@ namespace GraphQL.Utilities
             {
                 var vals = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
-                config.Fields.Apply(f =>
+                config.Fields?.Apply(f =>
                 {
                     var ctx = new ResolveValueContext
                     {


### PR DESCRIPTION
- support for some `ValueNodes`: `SByteValue`, `UIntValue` etc; **DateTime, Guid, TimeSpan nodes still require support, clarification about formatting required**
- turn `Matches` from gettable/settable property to virtual/override only gettable property
- move `PrintAst` from settable property to the required ctor argument - actually all `Configure` calls for different nodes was required to call `Print` otherwise there would be a NRE on
```c#
return config.PrintAst(vals);
```
It seems to me that the resulting api is cleaner.

@joemcbride  While adding printing support for the _built-in custom scalars_ (forgotten nodes) in the library, I wondered, but what about user-defined scalars? Now for them there is no support and the introspection request will return `null` as the default value for `__InputValue` even if it is specified as not null.