### PR TITLE
Prevent use ObjectGraphType in QueryArgument

### DIFF
--- a/src/GraphQL.Tests/Types/QueryArgumentTests.cs
+++ b/src/GraphQL.Tests/Types/QueryArgumentTests.cs
@@ -37,6 +37,13 @@ namespace GraphQL.Tests.Types
         }
 
         [Fact]
+        public void does_not_throw_when_set_null()
+        {
+            var type = new QueryArgument<StringGraphType>();
+            type.ResolvedType = null;
+        }
+
+        [Fact]
         public void throw_with_object_type()
         {
             Should.Throw<ArgumentOutOfRangeException>(() => new QueryArgument(typeof(ObjectGraphType)));

--- a/src/GraphQL.Tests/Types/QueryArgumentTests.cs
+++ b/src/GraphQL.Tests/Types/QueryArgumentTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using GraphQL.Types;
 using Shouldly;
 using Xunit;
@@ -30,13 +30,17 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void does_not_throw_with_valid_type()
         {
-            new QueryArgument(typeof(GraphType));
+            new QueryArgument<StringGraphType>();
+            new QueryArgument<InputObjectGraphType>();
+            new QueryArgument(typeof(StringGraphType));
+            new QueryArgument(typeof(InputObjectGraphType));
         }
 
         [Fact]
-        public void does_not_throw_with_object_type()
+        public void throw_with_object_type()
         {
-            new QueryArgument(typeof(ObjectGraphType));
+            Should.Throw<ArgumentOutOfRangeException>(() => new QueryArgument(typeof(ObjectGraphType)));
+            Should.Throw<ArgumentOutOfRangeException>(() => new QueryArgument<ObjectGraphType<int>>());
         }
     }
 }

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -16,6 +16,9 @@ namespace GraphQL.Types
     [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
     public class QueryArgument : MetadataProvider, IHaveDefaultValue
     {
+        private Type _type;
+        private IGraphType _resolvedType;
+
         public QueryArgument(IGraphType type)
         {
             ResolvedType = type ?? throw new ArgumentOutOfRangeException(nameof(type), "QueryArgument type is required");
@@ -37,8 +40,35 @@ namespace GraphQL.Types
 
         public object DefaultValue { get; set; }
 
-        public IGraphType ResolvedType { get; set; }
+        public IGraphType ResolvedType
+        {
+            get => _resolvedType;
+            set => _resolvedType = CheckResolvedType(value);
+        }
 
-        public Type Type { get; private set; }
+        public Type Type
+        {
+            get => _type;
+            private set => _type = CheckType(value);
+        }
+
+        private Type CheckType(Type type)
+        {
+            if (type?.IsInputType() == false)
+                throw Create(nameof(Type), type);
+
+            return type;
+        }
+
+        private IGraphType CheckResolvedType(IGraphType type)
+        {
+            if (!(type.GetNamedType() is GraphQLTypeReference) && type?.IsInputType() == false)
+                throw Create(nameof(ResolvedType), type.GetType());
+
+            return type;
+        }
+
+        private ArgumentOutOfRangeException Create(string paramName, Type value) => new ArgumentOutOfRangeException(paramName,
+            $"'{value.GetFriendlyName()}' is not a valid input type. QueryArgument must be one of the input types: ScalarGraphType, EnumerationGraphType or IInputObjectGraphType.");
     }
 }


### PR DESCRIPTION
Relates to #1436 

By the way, two tests were written incorrectly. Fixed.