### PR TITLE
Middleware regression fix - create middleware once

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -697,7 +697,8 @@ namespace GraphQL.Instrumentation
     public delegate System.Threading.Tasks.Task<object> FieldMiddlewareDelegate(GraphQL.Types.ResolveFieldContext context);
     public static class FieldResolverBuilderExtensions
     {
-        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder) { }
+        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder)
+            where T : new() { }
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Type middleware) { }
     }
     public class FieldStat

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -697,8 +697,7 @@ namespace GraphQL.Instrumentation
     public delegate System.Threading.Tasks.Task<object> FieldMiddlewareDelegate(GraphQL.Types.ResolveFieldContext context);
     public static class FieldResolverBuilderExtensions
     {
-        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder)
-            where T : new() { }
+        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder) { }
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Type middleware) { }
     }
     public class FieldStat

--- a/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
@@ -10,36 +10,36 @@ namespace GraphQL.Instrumentation
     {
         private const string InvokeMethodName = "Resolve";
 
-        public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) => Use(builder, typeof(T));
+        public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) where T : new() => Use(builder, typeof(T));
 
         public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, System.Type middleware)
         {
+            var methods = middleware.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+            var invokeMethods = methods.Where(m => string.Equals(m.Name, InvokeMethodName, StringComparison.Ordinal)).ToArray();
+            if (invokeMethods.Length > 1)
+            {
+                throw new InvalidOperationException($"There should be only a single method named {InvokeMethodName}. Middleware actually has {invokeMethods.Length} methods.");
+            }
+
+            if (invokeMethods.Length == 0)
+            {
+                throw new InvalidOperationException($"Could not find a method named {InvokeMethodName}. Middleware must have a public instance method named {InvokeMethodName}.");
+            }
+
+            var methodInfo = invokeMethods[0];
+            if (!typeof(Task<object>).IsAssignableFrom(methodInfo.ReturnType))
+            {
+                throw new InvalidOperationException($"The {InvokeMethodName} method should return a Task<object>.");
+            }
+
+            var parameters = methodInfo.GetParameters();
+            if (parameters.Length != 2 || parameters[0].ParameterType != typeof(ResolveFieldContext) || parameters[1].ParameterType != typeof(FieldMiddlewareDelegate))
+            {
+                throw new InvalidOperationException($"The {InvokeMethodName} method of middleware should take a parameter of type {nameof(ResolveFieldContext)} as the first parameter and a parameter of type {nameof(FieldMiddlewareDelegate)} as the second parameter.");
+            }
+
             return builder.Use(next =>
             {
-                var methods = middleware.GetMethods(BindingFlags.Instance | BindingFlags.Public);
-                var invokeMethods = methods.Where(m => string.Equals(m.Name, InvokeMethodName, StringComparison.Ordinal)).ToArray();
-                if (invokeMethods.Length > 1)
-                {
-                    throw new InvalidOperationException($"There should be only a single method named {InvokeMethodName}. Middleware actually has {invokeMethods.Length} methods.");
-                }
-
-                if (invokeMethods.Length == 0)
-                {
-                    throw new InvalidOperationException($"Could not find a method named {InvokeMethodName}. Middleware must have a public instance method named {InvokeMethodName}.");
-                }
-
-                var methodInfo = invokeMethods[0];
-                if (!typeof(Task<object>).IsAssignableFrom(methodInfo.ReturnType))
-                {
-                    throw new InvalidOperationException($"The {InvokeMethodName} method should return a Task<object>.");
-                }
-
-                var parameters = methodInfo.GetParameters();
-                if (parameters.Length != 2 || parameters[0].ParameterType != typeof(ResolveFieldContext) || parameters[1].ParameterType != typeof(FieldMiddlewareDelegate))
-                {
-                    throw new InvalidOperationException($"The {InvokeMethodName} method of middleware should take a parameter of type {nameof(ResolveFieldContext)} as the first parameter and a parameter of type {nameof(FieldMiddlewareDelegate)} as the second parameter.");
-                }
-
                 var instance = Activator.CreateInstance(middleware);
 
                 return context => (Task<object>)methodInfo.Invoke(instance, new object[] { context, next });

--- a/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
@@ -1,7 +1,6 @@
 using GraphQL.Types;
 using System;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -11,50 +10,39 @@ namespace GraphQL.Instrumentation
     {
         private const string InvokeMethodName = "Resolve";
 
-        public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) where T : new() => Use(builder, typeof(T));
+        public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) => Use(builder, typeof(T));
 
         public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, System.Type middleware)
         {
-            var methods = middleware.GetMethods(BindingFlags.Instance | BindingFlags.Public);
-            var invokeMethods = methods.Where(m => string.Equals(m.Name, InvokeMethodName, StringComparison.Ordinal)).ToArray();
-            if (invokeMethods.Length > 1)
-            {
-                throw new InvalidOperationException($"There should be only a single method named {InvokeMethodName}. Middleware actually has {invokeMethods.Length} methods.");
-            }
-
-            if (invokeMethods.Length == 0)
-            {
-                throw new InvalidOperationException($"Could not find a method named {InvokeMethodName}. Middleware must have a public instance method named {InvokeMethodName}.");
-            }
-
-            var methodInfo = invokeMethods[0];
-            if (!typeof(Task<object>).IsAssignableFrom(methodInfo.ReturnType))
-            {
-                throw new InvalidOperationException($"The {InvokeMethodName} method should return a Task<object>.");
-            }
-
-            var parameters = methodInfo.GetParameters();
-            if (parameters.Length != 2 || parameters[0].ParameterType != typeof(ResolveFieldContext) || parameters[1].ParameterType != typeof(FieldMiddlewareDelegate))
-            {
-                throw new InvalidOperationException($"The {InvokeMethodName} method of middleware should take a parameter of type {nameof(ResolveFieldContext)} as the first parameter and a parameter of type {nameof(FieldMiddlewareDelegate)} as the second parameter.");
-            }
-
-            //func = (context, next) => (new <middleware>()).Resolve(context, next);
-            var paramContext = Expression.Parameter(typeof(ResolveFieldContext));
-            var paramNext = Expression.Parameter(typeof(FieldMiddlewareDelegate));
-            var func = Expression.Lambda<Func<ResolveFieldContext, FieldMiddlewareDelegate, Task<object>>>(
-                Expression.Call(
-                    Expression.New(middleware),
-                    methodInfo,
-                    paramContext,
-                    paramNext),
-                paramContext,
-                paramNext)
-                .Compile();
-
             return builder.Use(next =>
             {
-                return context => func(context, next);
+                var methods = middleware.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+                var invokeMethods = methods.Where(m => string.Equals(m.Name, InvokeMethodName, StringComparison.Ordinal)).ToArray();
+                if (invokeMethods.Length > 1)
+                {
+                    throw new InvalidOperationException($"There should be only a single method named {InvokeMethodName}. Middleware actually has {invokeMethods.Length} methods.");
+                }
+
+                if (invokeMethods.Length == 0)
+                {
+                    throw new InvalidOperationException($"Could not find a method named {InvokeMethodName}. Middleware must have a public instance method named {InvokeMethodName}.");
+                }
+
+                var methodInfo = invokeMethods[0];
+                if (!typeof(Task<object>).IsAssignableFrom(methodInfo.ReturnType))
+                {
+                    throw new InvalidOperationException($"The {InvokeMethodName} method should return a Task<object>.");
+                }
+
+                var parameters = methodInfo.GetParameters();
+                if (parameters.Length != 2 || parameters[0].ParameterType != typeof(ResolveFieldContext) || parameters[1].ParameterType != typeof(FieldMiddlewareDelegate))
+                {
+                    throw new InvalidOperationException($"The {InvokeMethodName} method of middleware should take a parameter of type {nameof(ResolveFieldContext)} as the first parameter and a parameter of type {nameof(FieldMiddlewareDelegate)} as the second parameter.");
+                }
+
+                var instance = Activator.CreateInstance(middleware);
+
+                return context => (Task<object>)methodInfo.Invoke(instance, new object[] { context, next });
             });
         }
     }


### PR DESCRIPTION
In #1442 middleware functionality was changed to create an instance of the middleware every time the middleware's resolve function was executed.  This PR fixes that behavior.