### PR TITLE
Add interface match check

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -324,6 +324,7 @@ namespace GraphQL
         public static bool IsOutputType(this System.Type type) { }
         public static bool IsOutputType(this GraphQL.Types.IGraphType type) { }
         public static bool IsSubtypeOf(this GraphQL.Types.IGraphType maybeSubType, GraphQL.Types.IGraphType superType, GraphQL.Types.ISchema schema) { }
+        public static bool IsValidInterfaceFor(this GraphQL.Types.IInterfaceGraphType iface, GraphQL.Types.IObjectGraphType type, bool throwError = True) { }
         public static System.Collections.Generic.IEnumerable<string> IsValidLiteralValue(this GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue valueAst, GraphQL.Types.ISchema schema) { }
         public static string NameOf<TSourceType, TProperty>(this System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
         public static string TrimGraphQLTypes(this string name) { }

--- a/src/GraphQL.StarWars/Types/CharacterInterface.cs
+++ b/src/GraphQL.StarWars/Types/CharacterInterface.cs
@@ -1,4 +1,5 @@
 using GraphQL.Types;
+using GraphQL.Types.Relay;
 
 namespace GraphQL.StarWars.Types
 {
@@ -12,7 +13,7 @@ namespace GraphQL.StarWars.Types
             Field(d => d.Name, nullable: true).Description("The name of the character.");
 
             Field<ListGraphType<CharacterInterface>>("friends");
-            Field<ListGraphType<CharacterInterface>>("friendsConnection");
+            Field<ConnectionType<CharacterInterface, EdgeType<CharacterInterface>>>("friendsConnection");
             Field<ListGraphType<EpisodeEnum>>("appearsIn", "Which movie they appear in.");
         }
     }

--- a/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
@@ -327,14 +327,6 @@ namespace GraphQL.Tests.StarWars
                   'kind': 'INTERFACE'
                 },
                 {
-                  'name': 'Episode',
-                  'kind': 'ENUM'
-                },
-                {
-                  'name': 'Human',
-                  'kind': 'OBJECT'
-                },
-                {
                   'name': 'CharacterInterfaceConnection',
                   'kind': 'OBJECT'
                 },
@@ -344,6 +336,14 @@ namespace GraphQL.Tests.StarWars
                 },
                 {
                   'name': 'CharacterInterfaceEdge',
+                  'kind': 'OBJECT'
+                },
+                {
+                  'name': 'Episode',
+                  'kind': 'ENUM'
+                },
+                {
+                  'name': 'Human',
                   'kind': 'OBJECT'
                 },
                 {

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -539,6 +539,8 @@ interface Baaz {
 type Bar implements IFoo & Baaz {
   # This is of type String
   str: String
+  # This is of type Integer
+  int: Int
 }
 
 scalar BigInt
@@ -618,6 +620,8 @@ interface Baaz {
 type Bar implements IFoo, Baaz {
   # This is of type String
   str: String
+  # This is of type Integer
+  int: Int
 }
 
 scalar BigInt
@@ -698,6 +702,8 @@ interface Baaz {
 type Bar implements IFoo & Baaz {
   # This is of type String
   str: String
+  # This is of type Integer
+  int: Int
 }
 
 scalar BigInt
@@ -1129,6 +1135,9 @@ enum __TypeKind {
                 Field<StringGraphType>(
                     name: "str",
                     description: "This is of type String");
+                Field<IntGraphType>(
+                  name: "int",
+                  description: "This is of type Integer");
                 Interface<FooInterfaceType>();
                 Interface<BaazInterfaceType>();
             }

--- a/src/GraphQL.Tests/Validation/ResultTypeValidationSchema.cs
+++ b/src/GraphQL.Tests/Validation/ResultTypeValidationSchema.cs
@@ -36,7 +36,7 @@ namespace GraphQL.Tests.Validation
         public StringBox()
         {
             Field<StringGraphType>("scalar");
-            Field<StringBox>("deepBox");
+            Field<SomeBox>("deepBox");
             Field<StringGraphType>("unrelatedField");
             Field<ListGraphType<StringBox>>("listStringBox");
             Field<StringBox>("stringBox");
@@ -52,7 +52,7 @@ namespace GraphQL.Tests.Validation
         public IntBox()
         {
             Field<IntGraphType>("scalar");
-            Field<IntBox>("deepBox");
+            Field<SomeBox>("deepBox");
             Field<StringGraphType>("unrelatedField");
             Field<ListGraphType<StringBox>>("listStringBox");
             Field<StringBox>("stringBox");

--- a/src/GraphQL.Tests/Validation/ValidationSchema.cs
+++ b/src/GraphQL.Tests/Validation/ValidationSchema.cs
@@ -131,7 +131,7 @@ namespace GraphQL.Tests.Validation
                 ));
             Field<ListGraphType<Pet>>("pets");
             Field<ListGraphType<Human>>("relatives");
-            Field<IntGraphType>("iq");
+            Field<IntGraphType>("id");
 
             Interface<Being>();
             Interface<Intelligent>();
@@ -151,7 +151,7 @@ namespace GraphQL.Tests.Validation
                 ));
             Field<ListGraphType<Pet>>("pets");
             Field<ListGraphType<Human>>("relatives");
-            Field<IntGraphType>("iq");
+            Field<IntGraphType>("id");
             Field<IntGraphType>("numEyes");
 
             Interface<Being>();

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -100,6 +100,34 @@ namespace GraphQL
                 : type;
         }
 
+        /// <summary>
+        /// An Interface defines a list of fields; Object types that implement that interface are guaranteed to implement those fields.
+        /// Whenever the type system claims it will return an interface, it will return a valid implementing type.
+        /// </summary>
+        /// <param name="iface"></param>
+        /// <param name="type"></param>
+        /// <param name="throwError"> Set to <c>true</c> to generate an error if the type does not match the interface. </param>
+        /// <returns></returns>
+        public static bool IsValidInterfaceFor(this IInterfaceGraphType iface, IObjectGraphType type, bool throwError = true)
+        {
+            foreach (var field in iface.Fields)
+            {
+                var found = type.GetField(field.Name);
+
+                if (found == null)
+                {
+                    return throwError ? throw new ArgumentException($"Type '{type.Name}' ({type.GetType().GetFriendlyName()}) does not implement '{iface.Name}' interface. Type '{type.Name}' has no field '{field.Name}'.") : false;
+                }
+
+                if (found.Type != field.Type)
+                {
+                    return throwError ? throw new ArgumentException($"Type '{type.Name}' ({type.GetType().GetFriendlyName()}) does not implement '{iface.Name}' interface. Field '{type.Name}.{field.Name}' must be of type '{field.Type.GetFriendlyName()}', but in fact it is of type '{found.Type.GetFriendlyName()}'.") : false;
+                }
+            }
+
+            return true;
+        }
+
         public static IGraphType BuildNamedType(this Type type, Func<Type, IGraphType> resolve = null)
         {
             resolve ??= t => (IGraphType)Activator.CreateInstance(t);

--- a/src/GraphQL/Types/InterfaceGraphType.cs
+++ b/src/GraphQL/Types/InterfaceGraphType.cs
@@ -19,6 +19,7 @@ namespace GraphQL.Types
         {
             if (!_possibleTypes.Contains(type))
             {
+                this.IsValidInterfaceFor(type, throwError: true);
                 _possibleTypes.Add(type ?? throw new ArgumentNullException(nameof(type)));
             }
         }

--- a/src/GraphQL/Types/ObjectGraphType.cs
+++ b/src/GraphQL/Types/ObjectGraphType.cs
@@ -27,6 +27,7 @@ namespace GraphQL.Types
         {
             if (!_resolvedInterfaces.Contains(graphType))
             {
+                graphType.IsValidInterfaceFor(this, throwError: true);
                 _resolvedInterfaces.Add(graphType ?? throw new ArgumentNullException(nameof(graphType)));
             }
         }


### PR DESCRIPTION
Also fixes `friendsConnection` field type and some tests. Regression in #995.

This PR fixes the problem of mismatching field types in interface implementations. I came across this problem when I wanted to add GraphQL Playground. It was a long time ago and I did not understand why Playground refuses to work. Now I managed to take a closer look at the problem. It turned out that the server returned an invalid introspection response, and the SPA application validated it and displayed an error in the console. At the same time, neither the schema nor the docs were displayed as if the server was not responding to the request at all.