### PR TITLE
Fix for null default value for field arguments

### DIFF
--- a/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
+++ b/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
@@ -1093,7 +1093,7 @@ namespace GraphQL.Tests.Introspection
                   ""ofType"": null
                 }
               },
-              ""defaultValue"": ""null""
+              ""defaultValue"": null
             }
           ]
         },
@@ -1118,7 +1118,7 @@ namespace GraphQL.Tests.Introspection
                   ""ofType"": null
                 }
               },
-              ""defaultValue"": ""null""
+              ""defaultValue"": null
             }
           ]
         },

--- a/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
@@ -440,7 +440,7 @@ namespace GraphQL.Tests.StarWars
                             'kind': 'SCALAR'
                           }
                         },
-                        'defaultValue': 'null'
+                        'defaultValue': null
                       }
                     ]
                   },
@@ -462,7 +462,7 @@ namespace GraphQL.Tests.StarWars
                             'kind': 'SCALAR'
                           }
                         },
-                        'defaultValue': 'null'
+                        'defaultValue': null
                       }
                     ]
                   }

--- a/src/GraphQL/Introspection/__InputValue.cs
+++ b/src/GraphQL/Introspection/__InputValue.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Introspection
                 resolve: context =>
                 {
                     var hasDefault = context.Source;
-                    if (context.Source == null) return null;
+                    if (hasDefault?.DefaultValue == null) return null;
 
                     var ast = hasDefault.DefaultValue.AstFromValue(context.Schema, hasDefault.ResolvedType);
                     var result = AstPrinter.Print(ast);


### PR DESCRIPTION
fixes #1055
fixes #1386

After making this change, GraphQL Playground began to correctly display arguments for which the default value is not set, that is, it stopped adding `="null"` in introspection response.

Before:
```
"defaultValue": "null"
```

After:
```
"defaultValue": null
```