### PR TITLE
remove  || namedType is EnumerationGraphType

### DIFF
--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -56,7 +56,7 @@ namespace GraphQL
             return typeof(ScalarGraphType).IsAssignableFrom(namedType) ||
                    typeof(IObjectGraphType).IsAssignableFrom(namedType) ||
                    typeof(IInterfaceGraphType).IsAssignableFrom(namedType) ||
-                   typeof(UnionGraphType).IsAssignableFrom(namedType)
+                   typeof(UnionGraphType).IsAssignableFrom(namedType);
         }
 
         // https://graphql.github.io/graphql-spec/June2018/#sec-Input-and-Output-Types
@@ -66,8 +66,7 @@ namespace GraphQL
             return namedType is ScalarGraphType ||
                    namedType is IObjectGraphType ||
                    namedType is IInterfaceGraphType ||
-                   namedType is UnionGraphType ||
-                   namedType is EnumerationGraphType; // EnumerationGraphType inherits ScalarGraphType, but for clarity let it be here
+                   namedType is UnionGraphType;
         }
 
         public static bool IsInputObjectType(this IGraphType type)

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -30,7 +30,7 @@ namespace GraphQL
         public static bool IsLeafType(this IGraphType type)
         {
             var namedType = type.GetNamedType();
-            return namedType is ScalarGraphType || namedType is EnumerationGraphType;
+            return namedType is ScalarGraphType;
         }
 
         // https://graphql.github.io/graphql-spec/June2018/#sec-Input-and-Output-Types

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -38,7 +38,6 @@ namespace GraphQL
         {
             var namedType = type.GetNamedType();
             return typeof(ScalarGraphType).IsAssignableFrom(namedType) ||
-                   typeof(EnumerationGraphType).IsAssignableFrom(namedType) || // EnumerationGraphType inherits ScalarGraphType, but for clarity let it be here
                    typeof(IInputObjectGraphType).IsAssignableFrom(namedType);
         }
 
@@ -47,7 +46,6 @@ namespace GraphQL
         {
             var namedType = type.GetNamedType();
             return namedType is ScalarGraphType ||
-                   namedType is EnumerationGraphType || // EnumerationGraphType inherits ScalarGraphType, but for clarity let it be here
                    namedType is IInputObjectGraphType;
         }
 
@@ -58,8 +56,7 @@ namespace GraphQL
             return typeof(ScalarGraphType).IsAssignableFrom(namedType) ||
                    typeof(IObjectGraphType).IsAssignableFrom(namedType) ||
                    typeof(IInterfaceGraphType).IsAssignableFrom(namedType) ||
-                   typeof(UnionGraphType).IsAssignableFrom(namedType) ||
-                   typeof(EnumerationGraphType).IsAssignableFrom(namedType); // EnumerationGraphType inherits ScalarGraphType, but for clarity let it be here
+                   typeof(UnionGraphType).IsAssignableFrom(namedType)
         }
 
         // https://graphql.github.io/graphql-spec/June2018/#sec-Input-and-Output-Types


### PR DESCRIPTION
EnumerationGraphType inherits from ScalarGraphType so the second "is" is redundant