### PR TITLE
Added Altair GraphQL Client usage to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ http://graphql-dotnet.github.io
 https://github.com/graphql-dotnet/examples
 
 You can also try an example of GraphQL demo server inside this repo - [GraphQL.Harness](src/GraphQL.Harness/GraphQL.Harness.csproj).
-It supports two popular IDE for managing GraphQL requests - GraphQL Playground and GraphiQL.
+It supports the popular IDEs for managing GraphQL requests - GraphQL Playground, GraphiQL and Altair.
 
 ## Training
 

--- a/docs2/site/docs/getting-started/altair-graphql.md
+++ b/docs2/site/docs/getting-started/altair-graphql.md
@@ -1,0 +1,18 @@
+# Altair GraphQL Client
+
+[Altair GraphQL Client](https://altair.sirmuel.design/) is a beautiful feature-rich GraphQL Client IDE that enables you interact with any GraphQL server you are authorized to access from any platform you are on.
+You can easily test and optimize your GraphQL implementations. You also have several features to make your GraphQL development process much easier including subscriptions, query scaffolding, formatting, multiple languages, themes, and many more.
+
+![altair-graphql](https://i.imgur.com/h63OBPA.png)
+
+The easiest way to add Altair into your ASP.NET Core app is to use the [GraphQL.Server.Ui.Altair](https://www.nuget.org/packages/GraphQL.Server.Ui.Altair) package.
+All you need to do after installing nuget is to append one extra line in your `Startup.cs`:
+```c#
+public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+{
+    app.UseGraphQLAltair();
+}
+```
+If you do not explicitly specify an endpoints through the optional `options` argument then
+GraphiQL by default will run on `/altair` endpoint and will send requests to `/graphql`
+GraphQL API endpoint.

--- a/docs2/site/docs/getting-started/altair-graphql.md
+++ b/docs2/site/docs/getting-started/altair-graphql.md
@@ -14,5 +14,5 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 }
 ```
 If you do not explicitly specify an endpoints through the optional `options` argument then
-GraphiQL by default will run on `/altair` endpoint and will send requests to `/graphql`
+Altair by default will run on `/altair` endpoint and will send requests to `/graphql`
 GraphQL API endpoint.

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -16,6 +16,8 @@
             file: installation.md
           - title: GraphiQL
             file: graphiql.md
+          - title: Altair GraphQL
+            file: altair-graphql.md
           - title: Queries
             file: queries.md
           - title: Schema Types


### PR DESCRIPTION
Added [Altair GraphQL Client](https://altair.sirmuel.design/) usage to the docs.