### PR TITLE
Use IDictionary for IResolveFieldContext.Arguments

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.approved.txt
@@ -1818,7 +1818,7 @@ namespace GraphQL.Types
     }
     public interface IResolveFieldContext : GraphQL.Execution.IProvideUserContext
     {
-        System.Collections.Generic.Dictionary<string, object> Arguments { get; }
+        System.Collections.Generic.IDictionary<string, object> Arguments { get; }
         System.Threading.CancellationToken CancellationToken { get; }
         GraphQL.Language.AST.Document Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
@@ -1986,7 +1986,7 @@ namespace GraphQL.Types
     {
         public ResolveFieldContext() { }
         public ResolveFieldContext(GraphQL.Types.IResolveFieldContext context) { }
-        public System.Collections.Generic.Dictionary<string, object> Arguments { get; set; }
+        public System.Collections.Generic.IDictionary<string, object> Arguments { get; set; }
         public System.Threading.CancellationToken CancellationToken { get; set; }
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }

--- a/src/GraphQL/Types/IResolveFieldContext.cs
+++ b/src/GraphQL/Types/IResolveFieldContext.cs
@@ -19,7 +19,7 @@ namespace GraphQL.Types
 
         IObjectGraphType ParentType { get; }
 
-        Dictionary<string, object> Arguments { get; }
+        IDictionary<string, object> Arguments { get; }
 
         object RootValue { get; }
 

--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Types
 
         public IObjectGraphType ParentType { get; set; }
 
-        public Dictionary<string, object> Arguments { get; set; }
+        public IDictionary<string, object> Arguments { get; set; }
 
         public object RootValue { get; set; }
 


### PR DESCRIPTION
I suggest that IResolveFieldContext.Arguments be of type `IDictionary<string, object>` rather than `Dictionary<string, object>`, similar to the SubFields property.

Note: this PR will need to be updated if/when #1500 is pulled (or vice versa).