### PR TITLE
Add failing DataLoader tests

### DIFF
--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -289,7 +289,6 @@ mutation {
             ordersMock.Verify(x => x.GetOrdersByUserIdAsync(new[] { 1, 2 }, default), Times.Once);
             ordersMock.Verify(x => x.GetItemsByOrderIdAsync(new[] { 1, 2, 3, 4 }), Times.Once);
             ordersMock.VerifyNoOtherCalls();
-
         }
 
         [Fact]

--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -39,6 +39,34 @@ namespace GraphQL.DataLoader.Tests
             usersMock.Verify(x => x.GetAllUsersAsync(default), Times.Once);
         }
 
+        [Fact(Skip = "Fails with deadlock due to listener executing before LoadAsync is called")]
+        public void SingleQueryRootWithDelay_Works()
+        {
+            var users = Fake.Users.Generate(2);
+
+            var usersMock = Services.GetRequiredService<Mock<IUsersStore>>();
+
+            usersMock.Setup(store => store.GetAllUsersAsync(default))
+                .ReturnsAsync(users);
+
+            AssertQuerySuccess<DataLoaderTestSchema>(
+                query: "{ usersWithDelay { userId firstName } }",
+                expected: @"
+{ usersWithDelay: [
+    {
+        userId: 1,
+        firstName: """ + users[0].FirstName + @"""
+    },
+    {
+        userId: 2,
+        firstName: """ + users[1].FirstName + @"""
+    }
+] }
+");
+
+            usersMock.Verify(x => x.GetAllUsersAsync(default), Times.Once);
+        }
+
         [Fact]
         public void TwoLevel_SingleResult_Works()
         {
@@ -115,6 +143,59 @@ namespace GraphQL.DataLoader.Tests
                 expected: @"
 {
     orders: [
+    {
+        orderId: 1,
+        user: {
+            userId: 1,
+            firstName: """ + users[0].FirstName + @"""
+        }
+    },
+    {
+        orderId: 2,
+        user: {
+            userId: 2,
+            firstName: """ + users[1].FirstName + @"""
+        }
+    }]
+}
+");
+
+            ordersMock.Verify(x => x.GetAllOrdersAsync(), Times.Once);
+            ordersMock.VerifyNoOtherCalls();
+
+            usersMock.Verify(x => x.GetUsersByIdAsync(new[] { 1, 2 }, default), Times.Once);
+            usersMock.VerifyNoOtherCalls();
+        }
+
+        [Fact(Skip = "DataLoader does not batch results with SerialExecutionStrategy")]
+        public void TwoLevel_MultipleResults_OperationsAreBatched_SerialExecution()
+        {
+            var users = Fake.Users.Generate(2);
+            var orders = Fake.GenerateOrdersForUsers(users, 1);
+
+            var ordersMock = Services.GetRequiredService<Mock<IOrdersStore>>();
+            var usersMock = Services.GetRequiredService<Mock<IUsersStore>>();
+
+            ordersMock.Setup(x => x.GetAllOrdersAsync())
+                .ReturnsAsync(orders);
+
+            usersMock.Setup(x => x.GetUsersByIdAsync(It.IsAny<IEnumerable<int>>(), default))
+                .ReturnsAsync(users.ToDictionary(x => x.UserId));
+
+            AssertQuerySuccess<DataLoaderTestSchema>(
+                query: @"
+mutation {
+    orders {
+        orderId
+        user {
+            userId
+            firstName
+        }
+    }
+}",
+                expected: @"
+{
+    ordersn: [
     {
         orderId: 1,
         user: {

--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -195,7 +195,7 @@ mutation {
 }",
                 expected: @"
 {
-    ordersn: [
+    orders: [
     {
         orderId: 1,
         user: {

--- a/src/GraphQL.DataLoader.Tests/DataLoaderTestSchema.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderTestSchema.cs
@@ -9,7 +9,8 @@ namespace GraphQL.DataLoader.Tests
         public DataLoaderTestSchema(IServiceProvider services, QueryType query, SubscriptionType subscriptionType)
             : base(services)
         {
-            Query = query;
+            Query = query; //runs with parallel execution strategy
+            Mutation = query; //runs with serial execution strategy
             Subscription = subscriptionType;
         }
     }

--- a/src/GraphQL.DataLoader.Tests/Types/QueryType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/QueryType.cs
@@ -23,6 +23,20 @@ namespace GraphQL.DataLoader.Tests.Types
                     return loader.LoadAsync();
                 });
 
+            Field<ListGraphType<UserType>, IEnumerable<User>>()
+                .Name("UsersWithDelay")
+                .Description("Get all Users")
+                .Returns<IEnumerable<User>>()
+                .ResolveAsync(async ctx =>
+                {
+                    await System.Threading.Tasks.Task.Delay(20);
+
+                    var loader = accessor.Context.GetOrAddLoader("GetAllUsersWithDelay",
+                        users.GetAllUsersAsync);
+
+                    return await loader.LoadAsync();
+                });
+
             Field<OrderType, Order>()
                 .Name("Order")
                 .Description("Get Order by ID")

--- a/src/GraphQL.DataLoader.Tests/Types/UserType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/UserType.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using GraphQL.DataLoader.Tests.Models;
 using GraphQL.DataLoader.Tests.Stores;
 using GraphQL.Types;
@@ -24,6 +26,33 @@ namespace GraphQL.DataLoader.Tests.Types
                         orders.GetOrdersByUserIdAsync);
 
                     return ordersLoader.LoadAsync(ctx.Source.UserId);
+                });
+
+            Field<ListGraphType<OrderItemType>, IEnumerable<OrderItem>>()
+                .Name("OrderedItems")
+                .ResolveAsync(async ctx =>
+                {
+                    //obtain a reference to the GetOrdersByUserId batch loader
+                    var ordersLoader = accessor.Context.GetOrAddCollectionBatchLoader<int, Order>("GetOrdersByUserId",
+                        orders.GetOrdersByUserIdAsync);
+
+                    //wait for dataloader to pull the orders for this user
+                    var orderResults = await ordersLoader.LoadAsync(ctx.Source.UserId);
+
+                    //obtain a reference to the GetOrderItemsById batch loader
+                    var itemsLoader = accessor.Context.GetOrAddCollectionBatchLoader<int, OrderItem>("GetOrderItemsById",
+                        orders.GetItemsByOrderIdAsync);
+
+                    //wait for dataloader to pull the items for each order
+                    var itemsTasks = orderResults.Select(o => itemsLoader.LoadAsync(o.OrderId));
+                    var allResults = await Task.WhenAll(itemsTasks);
+
+                    //without dataloader, this would be:
+                    //var batchResults = await orders.GetItemsByOrderIdAsync(orderResults.Select(o => o.OrderId));
+                    //var allResults = orderResults.Select(o => batchResults[o.OrderId]);
+
+                    //flatten and return the results
+                    return allResults.SelectMany(x => x);
                 });
         }
     }


### PR DESCRIPTION
This adds two failing tests to address the following bugs:
- DataLoaders do not batch load data when run with a SerialExecutionStrategy
- Field resolve functions that await before returning the DataLoaders's LoadAsync function result in deadlock.

The tests are set to skip execution so they will not run at present, so this PR can be merged if desired.

Relevant issues are:
#1191 DataLoader and SerialExecutionStrategy not bulking
#945 DataLoader deadlock with multiple awaits
#837 Should the DataLoader work inside a Mutation
Also reference:
#1310 ParallelExecution in queries

I suggest we define the tests; then we can work on solutions.

As #945 is tagged for 3.0 release, I will provide a separate PR suggesting a solution.

**UPDATE**

Added test for supporting chained data loaders within a resolver:
#1042 How to handle multiple data loader calls?