### PR TITLE
Add notes about backward compatibility and link to api diff, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,18 @@
 
 This is an implementation of [Facebook's GraphQL](https://github.com/facebook/graphql) in .NET.
 
-Now the [specification](https://github.com/graphql/graphql-spec) is being developed by the [GraphQL Foundation](https://foundation.graphql.org/).
+Now the [specification](https://github.com/graphql/graphql-spec) is being developed by the
+[GraphQL Foundation](https://foundation.graphql.org/).
 
-This project uses a [lexer/parser](http://github.com/graphql-dotnet/parser) originally written by [Marek Magdziak](https://github.com/mkmarek) and released with a MIT license.  Thank you Marek!
+This project uses a [lexer/parser](http://github.com/graphql-dotnet/parser) originally written
+by [Marek Magdziak](https://github.com/mkmarek) and released with a MIT license. Thank you Marek!
 
 ## Installation
 
 > WARNING: The latest stable version 2.4.0 has many known issues that have been fixed in 3.0.0-preview-XXXX versions.
 > If errors occur, it is recommended that you first check the behavior on the latest available preview version before
-> reporting a issue.
+> reporting a issue. Latest 3.0.0-preview-XXXX versions are **backwards incompatible** with latest stable 2.4.0 version.
+> You can see the changes in public APIs using [fuget.org](https://www.fuget.org/packages/GraphQL/3.0.0-preview-1352/lib/netstandard2.0/diff/2.4.0/).
 
 You can install the latest version via [NuGet](https://www.nuget.org/packages/GraphQL/).
 
@@ -84,7 +87,9 @@ Console.WriteLine(json);
 
 ### Schema First Approach
 
-This example uses the [Graphql schema language](https://graphql.org/learn/schema/#type-language).  See the [documentation](https://graphql-dotnet.github.io/docs/getting-started/introduction) for more examples and information.
+This example uses the [Graphql schema language](https://graphql.org/learn/schema/#type-language).
+See the [documentation](https://graphql-dotnet.github.io/docs/getting-started/introduction) for
+more examples and information.
 
 ```csharp
 public class Droid
@@ -246,7 +251,8 @@ publish nuget from MyGet
 ```
 
 ### Running on OSX with mono
-To run this project on OSX with mono you will need to add some configuration.  Make sure mono is installed and add the following to your bash configuration:
+To run this project on OSX with mono you will need to add some configuration.
+Make sure mono is installed and add the following to your bash configuration:
 
 ```bash
 export FrameworkPathOverride=/Library/Frameworks/Mono.framework/Versions/4.6.2/lib/mono/4.5/

--- a/docs2/site/docs/getting-started/authorization.md
+++ b/docs2/site/docs/getting-started/authorization.md
@@ -1,8 +1,11 @@
 # Authorization
 
-> See the [Authorization](https://github.com/graphql-dotnet/authorization) project for a more in depth implementation of the following idea.
+> See the [Authorization](https://github.com/graphql-dotnet/authorization) project for a
+> more in depth implementation of the following idea.
 
-You can write validation rules that will run before a query is executed.  You can use this pattern to check that the user is authenticated or has permissions for a specific field.  This example uses the `Metadata` dictionary available on Fields to set permissons per field.
+You can write validation rules that will run before a query is executed. You can use this
+pattern to check that the user is authenticated or has permissions for a specific field.
+This example uses the `Metadata` dictionary available on Fields to set permissions per field.
 
 ```csharp
 public class MyGraphType : ObjectGraphType

--- a/docs2/site/docs/getting-started/malicious-queries.md
+++ b/docs2/site/docs/getting-started/malicious-queries.md
@@ -47,7 +47,7 @@ The query depth setting is a good estimation of complexity for most use cases an
 One step further would be specifying ```MaxComplexity``` and ```FieldImpact``` to look at the estimated number of entities (or cells in a database) that are expected to be returned by each query. Obviously this depends on the size of your database (i.e. number of records per entity) so you will need to find the average number of records per database entity and input that into ```FieldImpact```. For example if I have 3 tables with 100, 120 and 98 rows and I know I will be querying the first table twice as much then a good estimation for ```avgImpact``` would be 105.
 
 Note: I highly recommend setting a higher bound on the number of returned entities by each resolve function in your code. if you use this approach already in your code then you can input that upper bound (which would be the maximum possible items returned per entity) as your avgImpact.
-It is also possilbe to use a theorical value for this (for example 2.0) to asses the query's impact on a theorical database hence decoupling this calculation from your actual database.
+It is also possible to use a theoretical value for this (for example 2.0) to asses the query's impact on a theoretical database hence decoupling this calculation from your actual database.
 
 Imagine if we had a simple test database for the query in the previous example and we assume an average impact of 2.0 (each entity will return ~2 results) then we can calculate the complexity as following:
 


### PR DESCRIPTION
Some time ago, I began to consider options for how it is more convenient to provide api diff between major versions. I even started writing my own utility for this, although I was looking for ready-made solutions. As a result, I settled on the fact that the simplest and cheapest solution would be to give a link to this wonderful site - https://www.fuget.org