### PR TITLE
Change ExecuteNodeAsync to return Task

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -530,7 +530,7 @@ namespace GraphQL.Execution
     {
         protected ExecutionStrategy() { }
         public virtual System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.Execution.ExecutionContext context) { }
-        protected virtual System.Threading.Tasks.Task<GraphQL.Execution.ExecutionNode> ExecuteNodeAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
+        protected virtual System.Threading.Tasks.Task ExecuteNodeAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
         protected abstract System.Threading.Tasks.Task ExecuteNodeTreeAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode rootNode);
         protected virtual System.Threading.Tasks.Task OnBeforeExecutionStepAwaitedAsync(GraphQL.Execution.ExecutionContext context) { }
         protected virtual void ValidateNodeResult(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -186,12 +186,12 @@ namespace GraphQL.Execution
         /// <remarks>
         /// Builds child nodes, but does not execute them
         /// </remarks>
-        protected virtual async Task<ExecutionNode> ExecuteNodeAsync(ExecutionContext context, ExecutionNode node)
+        protected virtual async Task ExecuteNodeAsync(ExecutionContext context, ExecutionNode node)
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
             if (node.IsResultSet)
-                return node;
+                return;
 
             IResolveFieldContext resolveContext = null;
 
@@ -253,8 +253,6 @@ namespace GraphQL.Execution
 
                 node.Result = null;
             }
-
-            return node;
         }
 
         protected virtual void ValidateNodeResult(ExecutionContext context, ExecutionNode node)


### PR DESCRIPTION
This small change reduces an allocation per _synchronous_ resolver.  Note that some of the performance benefits may be lost with the updated DataLoader code, unfortunately.

```
// * Summary *

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
Intel Core i7-7740X CPU 4.30GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.101
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT

*** BEFORE ***

|        Method |        Mean |    Error |   StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |------------:|---------:|---------:|---------:|--------:|------:|----------:|
| Introspection | 1,509.92 us | 9.103 us | 8.070 us | 207.0313 | 76.1719 |     - | 1050.9 KB |
|          Hero |    31.69 us | 0.201 us | 0.178 us |   6.2256 |       - |     - |  25.55 KB |

*** AFTER ***

|        Method |        Mean |     Error |   StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |------------:|----------:|---------:|---------:|--------:|------:|----------:|
| Introspection | 1,478.62 us | 10.099 us | 9.446 us | 187.5000 | 76.1719 |     - | 943.65 KB |
|          Hero |    31.95 us |  0.320 us | 0.299 us |   6.1646 |       - |     - |   25.3 KB |
```