### PR TITLE
Add DI support for Field Middleware, IFieldMiddleware interface

### DIFF
--- a/docs2/site/docs/getting-started/dependency-injection.md
+++ b/docs2/site/docs/getting-started/dependency-injection.md
@@ -46,7 +46,7 @@ How you integrate this into your system will depend on the dependency injection 
 
 [See this example.](https://github.com/graphql-dotnet/examples/blob/8d5b7544006902f45b818010585b1ffa86ef446b/src/AspNetCoreCustom/Example/Startup.cs#L16-L34)
 
-`Microsoft.Extensions.DependencyInjection` package used in ASP.NET Core already has support for `IServiceProvider` interface so no additional settings are required - just add your required dependencies:
+`Microsoft.Extensions.DependencyInjection` package used in ASP.NET Core already has support for resolving `IServiceProvider` interface so no additional settings are required - just add your required dependencies:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -84,6 +84,7 @@ If you use `IFieldMiddlewareBuilder.Use` overloads which accept type parameter (
 those that do not accept a `IFieldMiddleware` instance or a middleware delegate) then your
 middleware creation will be delegated to DI-container. Thus, you can pass any dependencies to
 the Field Middleware constructor, provided that you have registered them correctly in DI.
+Note that it is required to have a schema that inherits from `Schema` or implements `IServiceProvider`.
 
 Also, the middleware itself should be registered in DI:
 

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -90,7 +90,7 @@ services.AddSingleton<InstrumentFieldsMiddleware>();
 ## Known issues
 
 Perhaps the most important thing with Field Middlewares that you should be aware of is that the
-default `DocumentExecuter` applies middlewares to the schema only once before the schema is
+default `DocumentExecuter` applies middlewares to the schema only once while the schema is being
 initialized. After this, calling any `IFieldMiddlewareBuilder.Use` methods has no effect.
 
 Field Middleware, when applying the schema, **modifies** the resolver of each field. Therefore,

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -81,6 +81,12 @@ those that do not accept a `IFieldMiddleware` instance or a middleware delegate)
 middleware creation will be delegated to DI-container. Thus, you can pass any dependencies to
 the Field Middleware constructor, provided that you have registered them correctly in DI.
 
+Also, the middleware itself should be registered in DI:
+
+```csharp
+services.AddSingleton<InstrumentFieldsMiddleware>();
+```
+
 ## Known issues
 
 Perhaps the most important thing with Field Middlewares that you should be aware of is that the

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -48,7 +48,10 @@ _.FieldMiddleware.Use(next =>
 {
   return context =>
   {
-    return next(context);
+    // your code here
+    var result = next(context);
+    // your code here
+    return result;
   };
 });
 ```

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -62,7 +62,7 @@ public interface IFieldMiddleware
 }
 ```
 
-It doesn’t have to be implemented on your middleware. Then a search will be made for such a method
+It doesn’t have to be implemented on your middleware. If you do not, a search will be made for a method named `Resolve`
 with a suitable signature.
 
 Nevertheless, **to improve performance, it is recommended to implement this interface.**

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -5,7 +5,7 @@ calculating the field value. You can write middleware for fields to provide addi
 during field resolution. After connecting the middleware to the schema, it is applied to all
 fields of all schema types. You can connect several middlewares to the schema. In this case,
 they will be called sequentially along the chain where the previous middleware decides to call
-the next one. This process is very similar to how middlewares work in ASP.NET Core HTTP request
+the next one. This process is very similar to how middlewares work in the ASP.NET Core HTTP request
 pipeline.
 
 The following example is how Metrics are captured. You register Field Middleware in the `ExecutionOptions`.

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -1,6 +1,6 @@
 # Field Middleware
 
-Field Middleware is a component connected to the schema, which is embedded in the process of
+Field Middleware is a component connected to the schema, which is embedded into the process of
 calculating the field value. You can write middleware for fields to provide additional behaviors
 during field resolution. After connecting the middleware to the schema, it is applied to all
 fields of all schema types. You can connect several middlewares to the schema. In this case,

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -8,7 +8,7 @@ they will be called sequentially along the chain where the previous middleware d
 the next one. This process is very similar to how middlewares work in the ASP.NET Core HTTP request
 pipeline.
 
-The following example is how Metrics are captured. You register Field Middleware in the `ExecutionOptions`.
+The following example is how Metrics are captured. You register Field Middleware in `ExecutionOptions`.
 
 ```csharp
 await schema.ExecuteAsync(_ =>

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -1,6 +1,14 @@
 # Field Middleware
 
-You can write middleware for fields to provide additional behaviors during field resolution.  The following example is how Metrics are captured.  You register Field Middleware in the `ExecutionOptions`.
+Field Middleware is a component connected to the schema, which is embedded in the process of
+calculating the field value. You can write middleware for fields to provide additional behaviors
+during field resolution. After connecting the middleware to the schema, it is applied to all
+fields of all schema types. You can connect several middlewares to the schema. In this case,
+they will be called sequentially along the chain where the previous middleware decides to call
+the next one. This process is very similar to how middlewares work in ASP.NET Core HTTP request
+pipeline.
+
+The following example is how Metrics are captured. You register Field Middleware in the `ExecutionOptions`.
 
 ```csharp
 await schema.ExecuteAsync(_ =>
@@ -10,7 +18,7 @@ await schema.ExecuteAsync(_ =>
 });
 ```
 
-You can write a class that has a `Resolve` method or you can register a middleware delegate directly.
+You can write a class that has a `Resolve` method:
 
 ```csharp
 public class InstrumentFieldsMiddleware
@@ -33,11 +41,7 @@ public class InstrumentFieldsMiddleware
 }
 ```
 
-The middleware delegate is defined as:
-
-``` csharp
-public delegate Task<object> FieldMiddlewareDelegate(IResolveFieldContext context);
-```
+Or you can register a middleware delegate directly:
 
 ```csharp
 _.FieldMiddleware.Use(next =>
@@ -48,3 +52,63 @@ _.FieldMiddleware.Use(next =>
   };
 });
 ```
+
+Also you can implement `IFieldMiddleware` interface in your Field Middleware:
+
+```csharp
+public interface IFieldMiddleware
+{
+  Task<object> Resolve(IResolveFieldContext context, FieldMiddlewareDelegate next);
+}
+```
+
+It doesn’t have to be implemented on your middleware. Then a search will be made for such a method
+with a suitable signature. Nevertheless, to improve performance, it is recommended to implement
+this interface.
+
+The middleware delegate is defined as:
+
+```csharp
+public delegate Task<object> FieldMiddlewareDelegate(IResolveFieldContext context);
+```
+
+## Field Middleware and Dependency Injection
+
+First, you are advised to read the article about [Dependency Injection](Dependency-Injection).
+
+If you use `IFieldMiddlewareBuilder.Use` overloads which accept type parameter (that is,
+those that do not accept a `IFieldMiddleware` instance or a middleware delegate) then your
+middleware creation will be delegated to DI-container. Thus, you can pass any dependencies to
+the Field Middleware constructor, provided that you have registered them correctly in DI.
+
+## Known issues
+
+Perhaps the most important thing with Field Middlewares that you should be aware of is that the
+default `DocumentExecuter` applies middlewares to the schema only once before the schema is
+initialized. After this, calling any `IFieldMiddlewareBuilder.Use` methods has no effect.
+
+Field Middleware, when applying the schema, **modifies** the resolver of each field. Therefore,
+you should be careful when using different lifetimes (singleton, scoped, transient) for your
+GraphTypes, Schema and Field Middleware. You **can** use any of lifetime, but for example in
+case of using singleton lifetime for some GraphType and scoped lifetime for Field Middleware
+and Schema this will cause the middleware to be applied to the same fields multiple times.
+In the case of ASP.NET Core app the resolvers of these fields will be wrapped again on each
+HTTP request to the server.
+
+General recommendations for lifetimes are:
+
+| Schema    | Graph Type | Middleware | Rating | 
+|-----------|------------|------------|--------|
+| singleton | singleton  | singleton  | the safest and the most performant option recommended by default |
+| scoped    | scoped     | singleton  | much less performant option |
+| scoped    | scoped     | scoped     | the least performant option |
+| scoped    | singleton  | scoped     | DO NOT DO THAT! |
+
+Options are also possible using transient lifetime, but are not given here (not recommended).
+
+## Field Middleware vs Directive
+
+If we consider Field Middleware as a way to globally affect the method of calculating all fields
+of all types in the Schema, then the directive can be considered as a way to locally affect only
+specific fields. The mechanism of their work is similar. For more information about directives
+see [Directives](Directives).

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -63,8 +63,9 @@ public interface IFieldMiddleware
 ```
 
 It doesn’t have to be implemented on your middleware. Then a search will be made for such a method
-with a suitable signature. Nevertheless, to improve performance, it is recommended to implement
-this interface.
+with a suitable signature.
+
+Nevertheless, **to improve performance, it is recommended to implement this interface.**
 
 The middleware delegate is defined as:
 
@@ -93,7 +94,7 @@ Perhaps the most important thing with Field Middlewares that you should be aware
 default `DocumentExecuter` applies middlewares to the schema only once while the schema is being
 initialized. After this, calling any `IFieldMiddlewareBuilder.Use` methods has no effect.
 
-Field Middleware, when applying the schema, **modifies** the resolver of each field. Therefore,
+Field Middleware, when applying to the schema, **modifies** the resolver of each field. Therefore,
 you should be careful when using different lifetimes (singleton, scoped, transient) for your
 GraphTypes, Schema and Field Middleware. You **can** use any of lifetime, but for example in
 case of using singleton lifetime for some GraphType and scoped lifetime for Field Middleware

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -53,7 +53,7 @@ _.FieldMiddleware.Use(next =>
 });
 ```
 
-Also you can implement `IFieldMiddleware` interface in your Field Middleware:
+Also, you can implement the `IFieldMiddleware` interface in your Field Middleware class:
 
 ```csharp
 public interface IFieldMiddleware

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -679,13 +679,14 @@ namespace GraphQL.Instrumentation
     {
         public FieldMiddlewareBuilder() { }
         public void ApplyTo(GraphQL.Types.ISchema schema) { }
-        public GraphQL.Instrumentation.FieldMiddlewareDelegate Build(GraphQL.Instrumentation.FieldMiddlewareDelegate start = null) { }
-        public GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
+        public GraphQL.Instrumentation.FieldMiddlewareDelegate Build(GraphQL.Types.ISchema schema = null, GraphQL.Instrumentation.FieldMiddlewareDelegate start = null) { }
+        public GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
     }
     public delegate System.Threading.Tasks.Task<object> FieldMiddlewareDelegate(GraphQL.Types.IResolveFieldContext context);
     public static class FieldResolverBuilderExtensions
     {
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, GraphQL.Instrumentation.IFieldMiddleware middleware) { }
+        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Type middleware) { }
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder) { }
     }
@@ -704,7 +705,7 @@ namespace GraphQL.Instrumentation
     public interface IFieldMiddlewareBuilder
     {
         void ApplyTo(GraphQL.Types.ISchema schema);
-        GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware);
+        GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware);
     }
     public class InstrumentFieldsMiddleware : GraphQL.Instrumentation.IFieldMiddleware
     {

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -679,7 +679,6 @@ namespace GraphQL.Instrumentation
     {
         public FieldMiddlewareBuilder() { }
         public void ApplyTo(GraphQL.Types.ISchema schema) { }
-        public GraphQL.Instrumentation.FieldMiddlewareDelegate Build(GraphQL.Instrumentation.FieldMiddlewareDelegate start = null, GraphQL.Types.ISchema schema = null) { }
         public GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
     }
     public static class FieldMiddlewareBuilderExtensions

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -679,7 +679,7 @@ namespace GraphQL.Instrumentation
     {
         public FieldMiddlewareBuilder() { }
         public void ApplyTo(GraphQL.Types.ISchema schema) { }
-        public GraphQL.Instrumentation.FieldMiddlewareDelegate Build(GraphQL.Types.ISchema schema = null, GraphQL.Instrumentation.FieldMiddlewareDelegate start = null) { }
+        public GraphQL.Instrumentation.FieldMiddlewareDelegate Build(GraphQL.Instrumentation.FieldMiddlewareDelegate start = null, GraphQL.Types.ISchema schema = null) { }
         public GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
     }
     public delegate System.Threading.Tasks.Task<object> FieldMiddlewareDelegate(GraphQL.Types.IResolveFieldContext context);

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -2012,7 +2012,7 @@ namespace GraphQL.Types
         public abstract object ParseValue(object value);
         public abstract object Serialize(object value);
     }
-    public class Schema : GraphQL.Utilities.MetadataProvider, GraphQL.Types.ISchema, System.IDisposable
+    public class Schema : GraphQL.Utilities.MetadataProvider, GraphQL.Types.ISchema, System.IDisposable, System.IServiceProvider
     {
         public Schema() { }
         public Schema(System.IServiceProvider services) { }
@@ -2024,7 +2024,6 @@ namespace GraphQL.Types
         public bool Initialized { get; }
         public GraphQL.Types.IObjectGraphType Mutation { get; set; }
         public GraphQL.Types.IObjectGraphType Query { get; set; }
-        public System.IServiceProvider Services { get; set; }
         public GraphQL.Types.IObjectGraphType Subscription { get; set; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -678,9 +678,9 @@ namespace GraphQL.Instrumentation
     public delegate System.Threading.Tasks.Task<object> FieldMiddlewareDelegate(GraphQL.Types.IResolveFieldContext context);
     public static class FieldResolverBuilderExtensions
     {
+        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, GraphQL.Instrumentation.IFieldMiddleware middleware) { }
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Type middleware) { }
-        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder)
-            where T : new() { }
+        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder) { }
     }
     public class FieldStat
     {
@@ -689,6 +689,10 @@ namespace GraphQL.Instrumentation
         public string Name { get; set; }
         public string ReturnType { get; set; }
         public void AddLatency(double duration) { }
+    }
+    public interface IFieldMiddleware
+    {
+        System.Threading.Tasks.Task<object> Resolve(GraphQL.Types.IResolveFieldContext context, GraphQL.Instrumentation.FieldMiddlewareDelegate next);
     }
     public interface IFieldMiddlewareBuilder
     {

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -682,14 +682,14 @@ namespace GraphQL.Instrumentation
         public GraphQL.Instrumentation.FieldMiddlewareDelegate Build(GraphQL.Instrumentation.FieldMiddlewareDelegate start = null, GraphQL.Types.ISchema schema = null) { }
         public GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
     }
-    public delegate System.Threading.Tasks.Task<object> FieldMiddlewareDelegate(GraphQL.Types.IResolveFieldContext context);
-    public static class FieldResolverBuilderExtensions
+    public static class FieldMiddlewareBuilderExtensions
     {
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, GraphQL.Instrumentation.IFieldMiddleware middleware) { }
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Type middleware) { }
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder) { }
     }
+    public delegate System.Threading.Tasks.Task<object> FieldMiddlewareDelegate(GraphQL.Types.IResolveFieldContext context);
     public class FieldStat
     {
         public FieldStat() { }

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -699,7 +699,7 @@ namespace GraphQL.Instrumentation
         void ApplyTo(GraphQL.Types.ISchema schema);
         GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware);
     }
-    public class InstrumentFieldsMiddleware
+    public class InstrumentFieldsMiddleware : GraphQL.Instrumentation.IFieldMiddleware
     {
         public InstrumentFieldsMiddleware() { }
         public System.Threading.Tasks.Task<object> Resolve(GraphQL.Types.IResolveFieldContext context, GraphQL.Instrumentation.FieldMiddlewareDelegate next) { }

--- a/src/GraphQL.Harness/CountFieldMiddleware.cs
+++ b/src/GraphQL.Harness/CountFieldMiddleware.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL.Instrumentation;
+using GraphQL.StarWars;
+using GraphQL.Types;
+using Microsoft.AspNetCore.Http;
+
+namespace Example
+{
+    /// <summary>
+    /// Example of Field Middleware with dependencies. When configured as singleton in DI
+    /// counts fields execution for the entire application lifetime. When configured as
+    /// scoped counts how many fields were executed when processing the single request.
+    /// </summary>
+    public sealed class CountFieldMiddleware : IFieldMiddleware, IDisposable
+    {
+        private int _count;
+
+        public CountFieldMiddleware(IHttpContextAccessor accessor, StarWarsData data)
+        {
+            // these dependencies are not needed here and are used only for demonstration purposes
+            Debug.Assert(accessor != null);
+            Debug.Assert(data != null);
+        }
+
+        public Task<object> Resolve(IResolveFieldContext context, FieldMiddlewareDelegate next)
+        {
+            Interlocked.Increment(ref _count);
+
+            return next(context);
+        }
+
+        public void Dispose()
+        {
+            Console.WriteLine($"{_count} fields were executed");
+        }
+    }
+}

--- a/src/GraphQL.Harness/CountFieldMiddleware.cs
+++ b/src/GraphQL.Harness/CountFieldMiddleware.cs
@@ -12,7 +12,7 @@ namespace Example
     /// <summary>
     /// Example of Field Middleware with dependencies. When configured as singleton in DI
     /// counts fields execution for the entire application lifetime. When configured as
-    /// scoped counts how many fields were executed when processing the single request.
+    /// scoped (with a scoped schema), counts how many fields were executed when processing the single request.
     /// </summary>
     public sealed class CountFieldMiddleware : IFieldMiddleware, IDisposable
     {

--- a/src/GraphQL.Harness/GraphQLMiddleware.cs
+++ b/src/GraphQL.Harness/GraphQLMiddleware.cs
@@ -67,7 +67,9 @@ namespace Example
                 options.ExposeExceptions = _settings.ExposeExceptions;
                 if (_settings.EnableMetrics)
                 {
-                    options.FieldMiddleware.Use<InstrumentFieldsMiddleware>();
+                    options.FieldMiddleware
+                        .Use<CountFieldMiddleware>()
+                        .Use<InstrumentFieldsMiddleware>();
                 }
             });
 

--- a/src/GraphQL.Harness/Startup.cs
+++ b/src/GraphQL.Harness/Startup.cs
@@ -1,4 +1,5 @@
 using Example;
+using GraphQL.Instrumentation;
 using GraphQL.StarWars;
 using GraphQL.StarWars.Types;
 using GraphQL.SystemTextJson;
@@ -24,10 +25,14 @@ namespace GraphQL.Harness
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            // add execution components
             services.AddSingleton<IDocumentExecuter, DocumentExecuter>();
             services.AddSingleton<IDocumentWriter, DocumentWriter>();
 
+            // add something like repository
             services.AddSingleton<StarWarsData>();
+
+            // add graph types
             services.AddSingleton<StarWarsQuery>();
             services.AddSingleton<StarWarsMutation>();
             services.AddSingleton<HumanType>();
@@ -35,13 +40,21 @@ namespace GraphQL.Harness
             services.AddSingleton<DroidType>();
             services.AddSingleton<CharacterInterface>();
             services.AddSingleton<EpisodeEnum>();
+
+            // add schema
             services.AddSingleton<ISchema, StarWarsSchema>();
 
+            // add infrastructure stuff
             services.AddHttpContextAccessor();
             services.AddLogging(builder => builder.AddConsole());
 
+            // add options configuration
             services.Configure<GraphQLSettings>(Configuration);
             services.Configure<GraphQLSettings>(settings => settings.BuildUserContext = ctx => new GraphQLUserContext { User = ctx.User });
+
+            // add Field Middlewares
+            services.AddSingleton<CountFieldMiddleware>();
+            services.AddSingleton<InstrumentFieldsMiddleware>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
+++ b/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
@@ -21,15 +21,8 @@ namespace GraphQL.Tests.Bugs
             overriddenBuilder.ApplyTo(schema);
         }
 
-        public FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start = null)
-        {
-            return overriddenBuilder.Build(start);
-        }
-
         public IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
-        {
-            return overriddenBuilder.Use(middleware);
-        }
+            => overriddenBuilder.Use(middleware);
     }
 
     public class Bug252ExecutorAppliesBuilderOnceTests

--- a/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
+++ b/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
@@ -23,10 +23,10 @@ namespace GraphQL.Tests.Bugs
 
         public FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start = null)
         {
-            return overriddenBuilder.Build(start);
+            return overriddenBuilder.Build(null, start);
         }
 
-        public IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
+        public IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
         {
             return overriddenBuilder.Use(middleware);
         }

--- a/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
+++ b/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
@@ -23,7 +23,7 @@ namespace GraphQL.Tests.Bugs
 
         public FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start = null)
         {
-            return overriddenBuilder.Build(null, start);
+            return overriddenBuilder.Build(start);
         }
 
         public IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)

--- a/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
@@ -24,6 +24,7 @@ namespace GraphQL.Tests.Instrumentation
                 FieldAst = new Field(null, new NameNode("Name")),
                 Source = new Person { Name = "Quinn" },
                 Errors = new ExecutionErrors(),
+                Schema = new Schema(),
                 Metrics = new Metrics().Start(null)
             };
         }

--- a/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
@@ -86,7 +86,7 @@ namespace GraphQL.Tests.Instrumentation
         {
             _builder.Use<SimpleMiddleware>();
 
-            var result = _builder.Build().Invoke(_context).Result;
+            var result = _builder.Build(_context.Schema).Invoke(_context).Result;
             result.ShouldBe("Quinn");
 
             var record = _context.Metrics.Finish().Skip(1).Single();

--- a/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
@@ -86,7 +86,7 @@ namespace GraphQL.Tests.Instrumentation
         {
             _builder.Use<SimpleMiddleware>();
 
-            var result = _builder.Build(schema: _context.Schema).Invoke(_context).Result;
+            var result = _builder.Build(start: null, schema: _context.Schema).Invoke(_context).Result;
             result.ShouldBe("Quinn");
 
             var record = _context.Metrics.Finish().Skip(1).Single();
@@ -156,5 +156,10 @@ namespace GraphQL.Tests.Instrumentation
                 }
             }
         }
+    }
+
+    internal static class TestExtensions
+    {
+        public static FieldMiddlewareDelegate Build(this FieldMiddlewareBuilder builder) => builder.Build(null, null);
     }
 }

--- a/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
@@ -86,7 +86,7 @@ namespace GraphQL.Tests.Instrumentation
         {
             _builder.Use<SimpleMiddleware>();
 
-            var result = _builder.Build(_context.Schema).Invoke(_context).Result;
+            var result = _builder.Build(schema: _context.Schema).Invoke(_context).Result;
             result.ShouldBe("Quinn");
 
             var record = _context.Metrics.Finish().Skip(1).Single();

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -17,7 +17,7 @@ namespace GraphQL
     {
         /// <summary>
         /// Schema of graph to use; required
-        /// <br/>
+        /// <br/><br/>
         /// Schema will be initialized if it has not yet been initialized.
         /// </summary>
         public ISchema Schema { get; set; }

--- a/src/GraphQL/Execution/IDocumentExecuter.cs
+++ b/src/GraphQL/Execution/IDocumentExecuter.cs
@@ -6,7 +6,7 @@ namespace GraphQL
     /// <summary>
     /// Processes an entire GraphQL request, given an input GraphQL request string. This is intended to
     /// be called by user code to process a query.
-    /// <br/>
+    /// <br/><br/>
     /// Typical implementation starts metrics if enabled (see <see cref="Instrumentation.Metrics">Metrics</see>),
     /// relies on <see cref="Execution.IDocumentBuilder">IDocumentBuilder</see> to parse the query,
     /// <see cref="Validation.IDocumentValidator">IDocumentValidator</see> to validate it, and

--- a/src/GraphQL/Execution/IExecutionStrategy.cs
+++ b/src/GraphQL/Execution/IExecutionStrategy.cs
@@ -2,8 +2,17 @@ using System.Threading.Tasks;
 
 namespace GraphQL.Execution
 {
+    /// <summary>
+    /// Processes a parsed GraphQL request, resolving all the nodes and returning the result; exceptions
+    /// are unhandled. Should not run any <see cref="IDocumentExecutionListener">IDocumentExecutionListener</see>s except
+    /// for <see cref="IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object, System.Threading.CancellationToken)">BeforeExecutionStepAwaitedAsync</see>.
+    /// </summary>
     public interface IExecutionStrategy
     {
+        /// <summary>
+        /// Executes a GraphQL request and returns the result
+        /// </summary>
+        /// <param name="context">The execution parameters</param>
         Task<ExecutionResult> ExecuteAsync(ExecutionContext context);
     }
 }

--- a/src/GraphQL/Execution/IProvideUserContext.cs
+++ b/src/GraphQL/Execution/IProvideUserContext.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Execution
     {
         /// <summary>
         /// Mutable user-defined context to be passed to and shared by all field resolvers.
-        /// <br/>
+        /// <br/><br/>
         /// A custom implementation of <see cref="IDictionary{TKey, TValue}">IDictionary</see> may be
         /// used in place of the default <see cref="Dictionary{TKey, TValue}">Dictionary</see>.
         /// </summary>

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -7,38 +7,34 @@ using System.Threading.Tasks;
 
 namespace GraphQL.Instrumentation
 {
-    public interface IFieldMiddlewareBuilder
-    {
-        IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware);
-
-        void ApplyTo(ISchema schema);
-    }
-
+    /// <summary>
+    /// Default implementation of <see cref="IFieldMiddlewareBuilder"/>.
+    /// </summary>
     public class FieldMiddlewareBuilder : IFieldMiddlewareBuilder
     {
-        private Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> _singleComponent;
-        private IList<Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate>> _components;
+        private Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> _singleMiddleware;
+        private IList<Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate>> _middlewares;
 
         public IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
         {
             middleware = middleware ?? throw new ArgumentNullException(nameof(middleware));
 
-            if (_singleComponent == null)
+            if (_singleMiddleware == null)
             {
                 // allocation free optimization for single middleware (InstrumentFieldsMiddleware)
-                _singleComponent = middleware;
+                _singleMiddleware = middleware;
             }
-            else if (_components == null)
+            else if (_middlewares == null)
             {
-                _components = new List<Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate>>
+                _middlewares = new List<Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate>>
                 {
-                    _singleComponent,
+                    _singleMiddleware,
                     middleware
                 };
             }
             else
             {
-                _components.Add(middleware);
+                _middlewares.Add(middleware);
             }
 
             return this;
@@ -46,24 +42,24 @@ namespace GraphQL.Instrumentation
 
         public FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start = null, ISchema schema = null)
         {
-            var app = start ?? (context => Task.FromResult(NameFieldResolver.Instance.Resolve(context)));
+            var middlewareDelegate = start ?? (context => Task.FromResult(NameFieldResolver.Instance.Resolve(context)));
 
-            if (_components != null)
+            if (_middlewares != null)
             {
-                foreach (var component in _components.Reverse())
+                foreach (var middleware in _middlewares.Reverse())
                 {
-                    app = component(schema, app);
+                    middlewareDelegate = middleware(schema, middlewareDelegate);
                 }
             }
-            else if (_singleComponent != null)
+            else if (_singleMiddleware != null)
             {
-                app = _singleComponent(schema, app);
+                middlewareDelegate = _singleMiddleware(schema, middlewareDelegate);
             }
 
-            return app;
+            return middlewareDelegate;
         }
 
-        private bool Empty => _singleComponent == null;
+        private bool Empty => _singleMiddleware == null;
 
         public void ApplyTo(ISchema schema)
         {
@@ -76,9 +72,9 @@ namespace GraphQL.Instrumentation
                     {
                         var resolver = new MiddlewareResolver(field.Resolver);
 
-                        FieldMiddlewareDelegate app = Build(resolver.Resolve, schema);
+                        var fieldMiddlewareDelegate = Build(resolver.Resolve, schema);
 
-                        field.Resolver = new FuncFieldResolver<object>(app.Invoke);
+                        field.Resolver = new FuncFieldResolver<object>(fieldMiddlewareDelegate.Invoke);
                     }
                 }
             }

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -44,7 +44,7 @@ namespace GraphQL.Instrumentation
             return this;
         }
 
-        public FieldMiddlewareDelegate Build(ISchema schema = null, FieldMiddlewareDelegate start = null)
+        public FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start = null, ISchema schema = null)
         {
             var app = start ?? (context => Task.FromResult(NameFieldResolver.Instance.Resolve(context)));
 
@@ -76,7 +76,7 @@ namespace GraphQL.Instrumentation
                     {
                         var resolver = new MiddlewareResolver(field.Resolver);
 
-                        FieldMiddlewareDelegate app = Build(schema, resolver.Resolve);
+                        FieldMiddlewareDelegate app = Build(resolver.Resolve, schema);
 
                         field.Resolver = new FuncFieldResolver<object>(app.Invoke);
                     }

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -40,7 +40,7 @@ namespace GraphQL.Instrumentation
             return this;
         }
 
-        public FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start = null, ISchema schema = null)
+        internal FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start, ISchema schema)
         {
             var middlewareDelegate = start ?? (context => Task.FromResult(NameFieldResolver.Instance.Resolve(context)));
 

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -65,8 +65,7 @@ namespace GraphQL.Instrumentation
             static ISchema CheckSchemaNotNull(ISchema schema)
             {
                 if (schema == null)
-                    throw new InvalidOperationException(@"Schema is null. Schema required for resolving middlewares from DI container.
-If you called 'FieldMiddlewareBuilder.Build()' manually set the 'schema' parameter.");
+                    throw new InvalidOperationException("Schema is null. Schema required for resolving middlewares from DI container.");
                 return schema;
             }
 

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Instrumentation
         /// <summary>
         /// Adds middleware to the list of delegates that will be applied to the schema when invoking <see cref="ApplyTo(ISchema)"/>.
         /// </summary>
-        /// <param name="builder"></param>
+        /// <param name="builder">Interface for connecting middlewares to a schema.</param>
         /// <param name="middleware">Middleware instance.</param>
         /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
         public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, IFieldMiddleware middleware)
@@ -39,7 +39,7 @@ namespace GraphQL.Instrumentation
         /// Middleware will be created using DI container.
         /// </summary>
         /// <typeparam name="T">Middleware type.</typeparam>
-        /// <param name="builder"></param>
+        /// <param name="builder">Interface for connecting middlewares to a schema.</param>
         /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
         public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) => Use(builder, typeof(T));
 
@@ -48,7 +48,7 @@ namespace GraphQL.Instrumentation
         /// <br/><br/>
         /// Middleware will be created using DI container.
         /// </summary>
-        /// <param name="builder"></param>
+        /// <param name="builder">Interface for connecting middlewares to a schema.</param>
         /// <param name="middleware">Middleware type.</param>
         /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
         public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, System.Type middleware)

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -58,15 +58,15 @@ namespace GraphQL.Instrumentation
             static T CheckNotNull<T>(T instance, System.Type type)
             {
                 if (instance == null)
-                    throw new InvalidOperationException(@$"Field middleware of type '{type.FullName}' must be registered in DI container.
-If you called 'FieldMiddlewareBuilder.Build()' manually set the 'schema' parameter.");
+                    throw new InvalidOperationException($"Field middleware of type '{type.FullName}' must be registered in DI container.");
                 return instance;
             }
 
             static ISchema CheckSchemaNotNull(ISchema schema)
             {
                 if (schema == null)
-                    throw new InvalidOperationException("Schema is null. Schema required for resolving middlewares from DI container.");
+                    throw new InvalidOperationException(@"Schema is null. Schema required for resolving middlewares from DI container.
+If you called 'FieldMiddlewareBuilder.Build()' manually set the 'schema' parameter.");
                 return schema;
             }
 

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Instrumentation
         /// <summary>
         /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="ApplyTo(ISchema)"/>.
         /// <br/><br/>
-        /// This is a compatibility shim when compiling delegates without schema specified. https://github.com/graphql-dotnet/graphql-dotnet/pull/1537#issuecomment-589798669
+        /// This is a compatibility shim when compiling delegates without schema specified.
         /// </summary>
         /// <param name="middleware">Middleware delegate.</param>
         /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -46,7 +46,7 @@ namespace GraphQL.Instrumentation
         /// <summary>
         /// Adds middleware specified by its type to the list of delegates that will be applied to the schema when invoking <see cref="ApplyTo(ISchema)"/>.
         /// <br/><br/>
-        /// Middleware will be created using DI container.
+        /// Middleware will be created using the DI container obtained from the <see cref="Schema"/>.
         /// </summary>
         /// <param name="builder">Interface for connecting middlewares to a schema.</param>
         /// <param name="middleware">Middleware type.</param>

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace GraphQL.Instrumentation
         /// <summary>
         /// Adds middleware specified by its type to the list of delegates that will be applied to the schema when invoking <see cref="ApplyTo(ISchema)"/>.
         /// <br/><br/>
-        /// Middleware will be created using DI container.
+        /// Middleware will be created using the DI container obtained from the <see cref="Schema"/>.
         /// </summary>
         /// <typeparam name="T">Middleware type.</typeparam>
         /// <param name="builder">Interface for connecting middlewares to a schema.</param>

--- a/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
@@ -33,6 +33,7 @@ namespace GraphQL.Instrumentation
                 {
                     return context =>
                     {
+                        // Not an ideal solution, but at least it allows to work with custom schemas which are not inherited from Schema type
                         return context.Schema is IServiceProvider provider
                             ? CheckNotNull((IFieldMiddleware)provider.GetService(middleware), middleware).Resolve(context, next)
                             : throw NotSupported(context.Schema);
@@ -70,6 +71,7 @@ namespace GraphQL.Instrumentation
                 {
                     return context =>
                     {
+                        // Not an ideal solution, but at least it allows to work with custom schemas which are not inherited from Schema type
                         return context.Schema is IServiceProvider provider
                             ? (Task<object>)methodInfo.Invoke(CheckNotNull(provider.GetService(middleware), middleware), new object[] { context, next })
                             : throw NotSupported(context.Schema);

--- a/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
@@ -20,12 +20,13 @@ namespace GraphQL.Instrumentation
 
         public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, System.Type middleware)
         {
-            static Exception NotSupported(ISchema schema) => new NotSupportedException($"{schema.GetType().FullName} should implement IServiceProvider interface");
+            static Exception NotSupported(ISchema schema) => new NotSupportedException($"'{schema.GetType().FullName}' should implement 'IServiceProvider' interface for resolving middlewares.");
 
             static T CheckNotNull<T>(T instance, System.Type type)
             {
                 if (instance == null)
-                    throw new InvalidOperationException($"Field middleware of type '{type.FullName}' must be registered in DI container.");
+                    throw new InvalidOperationException(@$"Field middleware of type '{type.FullName}' must be registered in DI container.
+If you called 'FieldMiddlewareBuilder.Build()' manually set the 'schema' parameter.");
                 return instance;
             }
 

--- a/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldResolverBuilderExtensions.cs
@@ -8,42 +8,72 @@ namespace GraphQL.Instrumentation
 {
     public static class FieldResolverBuilderExtensions
     {
-        private const string InvokeMethodName = "Resolve";
+        private const string INVOKE_METHOD_NAME = "Resolve";
 
-        public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) where T : new() => Use(builder, typeof(T));
+        public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, IFieldMiddleware middleware)
+            => builder.Use(next => context => middleware.Resolve(context, next));
+
+        public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) => Use(builder, typeof(T));
 
         public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, System.Type middleware)
         {
-            var methods = middleware.GetMethods(BindingFlags.Instance | BindingFlags.Public);
-            var invokeMethods = methods.Where(m => string.Equals(m.Name, InvokeMethodName, StringComparison.Ordinal)).ToArray();
-            if (invokeMethods.Length > 1)
+            // if IFieldMiddleware interface is supported, then just call its Resolve method
+            if (typeof(IFieldMiddleware).IsAssignableFrom(middleware))
             {
-                throw new InvalidOperationException($"There should be only a single method named {InvokeMethodName}. Middleware actually has {invokeMethods.Length} methods.");
+                return builder.Use(next =>
+                {
+                    return context =>
+                    {
+                        return context.Schema is Schema schema
+                            ? CheckNotNull((IFieldMiddleware)schema.Services.GetService(middleware), middleware).Resolve(context, next)
+                            : throw new NotSupportedException();
+                    };
+                });
             }
-
-            if (invokeMethods.Length == 0)
+            // otherwise, we first find this method on the type and then call it through reflection
+            else
             {
-                throw new InvalidOperationException($"Could not find a method named {InvokeMethodName}. Middleware must have a public instance method named {InvokeMethodName}.");
+                var methods = middleware.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+                var invokeMethods = methods.Where(m => string.Equals(m.Name, INVOKE_METHOD_NAME, StringComparison.Ordinal)).ToArray();
+                if (invokeMethods.Length > 1)
+                {
+                    throw new InvalidOperationException($"There should be only a single method named {INVOKE_METHOD_NAME}. Middleware actually has {invokeMethods.Length} methods.");
+                }
+
+                if (invokeMethods.Length == 0)
+                {
+                    throw new InvalidOperationException($"Could not find a method named {INVOKE_METHOD_NAME}. Middleware must have a public instance method named {INVOKE_METHOD_NAME}.");
+                }
+
+                var methodInfo = invokeMethods[0];
+                if (!typeof(Task<object>).IsAssignableFrom(methodInfo.ReturnType))
+                {
+                    throw new InvalidOperationException($"The {INVOKE_METHOD_NAME} method should return a Task<object>.");
+                }
+
+                var parameters = methodInfo.GetParameters();
+                if (parameters.Length != 2 || parameters[0].ParameterType != typeof(IResolveFieldContext) || parameters[1].ParameterType != typeof(FieldMiddlewareDelegate))
+                {
+                    throw new InvalidOperationException($"The {INVOKE_METHOD_NAME} method of middleware should take a parameter of type {nameof(IResolveFieldContext)} as the first parameter and a parameter of type {nameof(FieldMiddlewareDelegate)} as the second parameter.");
+                }
+
+                return builder.Use(next =>
+                {
+                    return context =>
+                    {
+                        return context.Schema is Schema schema
+                            ? (Task<object>)methodInfo.Invoke(CheckNotNull(schema.Services.GetService(middleware), middleware), new object[] { context, next })
+                            : throw new NotSupportedException();
+                    };
+                });
             }
+        }
 
-            var methodInfo = invokeMethods[0];
-            if (!typeof(Task<object>).IsAssignableFrom(methodInfo.ReturnType))
-            {
-                throw new InvalidOperationException($"The {InvokeMethodName} method should return a Task<object>.");
-            }
-
-            var parameters = methodInfo.GetParameters();
-            if (parameters.Length != 2 || parameters[0].ParameterType != typeof(IResolveFieldContext) || parameters[1].ParameterType != typeof(FieldMiddlewareDelegate))
-            {
-                throw new InvalidOperationException($"The {InvokeMethodName} method of middleware should take a parameter of type {nameof(IResolveFieldContext)} as the first parameter and a parameter of type {nameof(FieldMiddlewareDelegate)} as the second parameter.");
-            }
-
-            return builder.Use(next =>
-            {
-                var instance = Activator.CreateInstance(middleware);
-
-                return context => (Task<object>)methodInfo.Invoke(instance, new object[] { context, next });
-            });
+        private static T CheckNotNull<T>(T instance, System.Type type)
+        {
+            if (instance == null)
+                throw new InvalidOperationException($"Field middleware of type '{type.FullName}' must be registered in schema.Services.");
+            return instance;
         }
     }
 }

--- a/src/GraphQL/Instrumentation/IFieldMiddleware.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddleware.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using GraphQL.Types;
+
+namespace GraphQL.Instrumentation
+{
+    /// <summary>
+    /// Interface for field middleware. It doesn’t have to be implemented on your middleware.
+    /// Then a search will be made for such a method with a suitable signature. Nevertheless,
+    /// to improve performance, it is recommended to implement this interface.
+    /// </summary>
+    public interface IFieldMiddleware
+    {
+        Task<object> Resolve(IResolveFieldContext context, FieldMiddlewareDelegate next);
+    }
+}

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -10,8 +10,10 @@ namespace GraphQL.Instrumentation
     {
         /// <summary>
         /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="ApplyTo(ISchema)"/>.
+        /// <br/><br/>
+        /// The delegate is used to unify the different ways of specifying middleware. See additional methods in <see cref="FieldMiddlewareBuilderExtensions"/>.
         /// </summary>
-        /// <param name="middleware"></param>
+        /// <param name="middleware">Middleware delegate.</param>
         /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
         IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware);
 

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using GraphQL.Types;
+
+namespace GraphQL.Instrumentation
+{
+    /// <summary>
+    /// Interface for connecting middlewares to a schema.
+    /// </summary>
+    public interface IFieldMiddlewareBuilder
+    {
+        /// <summary>
+        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="ApplyTo(ISchema)"/>.
+        /// </summary>
+        /// <param name="middleware"></param>
+        /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
+        IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware);
+
+        /// <summary>
+        /// Applies all delegates specified by the <see cref="Use(Func{ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate})"/> method to the schema.
+        /// <br/><br/>
+        /// When applying to the schema, modifies the resolver of each field of each graph type adding required behavior.
+        /// Therefore, as a rule, this method should be called only once during schema initialization. See <see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)"/>.
+        /// </summary>
+        /// <param name="schema">The schema to which you want to apply middlewares.</param>
+        void ApplyTo(ISchema schema);
+    }
+}

--- a/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
+++ b/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
@@ -5,7 +5,7 @@ using GraphQL.Utilities;
 
 namespace GraphQL.Instrumentation
 {
-    public class InstrumentFieldsMiddleware
+    public class InstrumentFieldsMiddleware : IFieldMiddleware
     {
         public async Task<object> Resolve(IResolveFieldContext context, FieldMiddlewareDelegate next)
         {

--- a/src/GraphQL/Resolvers/AsyncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/AsyncFieldResolver.cs
@@ -34,7 +34,7 @@ namespace GraphQL.Resolvers
     /// <summary>
     /// When resolving a field, this implementation calls a predefined <see cref="Func{T, TResult}"/> and returns the result.
     /// The returned value must be of an <see cref="Task{TResult}"/> type.
-    /// <br/>
+    /// <br/><br/>
     /// This implementation provides a typed <see cref="IResolveFieldContext{TSource}"/> to the resolver function.
     /// </summary>
     public class AsyncFieldResolver<TSourceType, TReturnType> : IFieldResolver<Task<TReturnType>>

--- a/src/GraphQL/Resolvers/FuncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/FuncFieldResolver.cs
@@ -28,7 +28,7 @@ namespace GraphQL.Resolvers
 
     /// <summary>
     /// When resolving a field, this implementation calls a predefined <see cref="Func{T, TResult}"/> and returns the result.
-    /// <br/>
+    /// <br/><br/>
     /// This implementation provides a typed <see cref="IResolveFieldContext{TSource}"/> to the resolver function.
     /// </summary>
     public class FuncFieldResolver<TSourceType, TReturnType> : IFieldResolver<TReturnType>

--- a/src/GraphQL/Resolvers/IFieldResolver.cs
+++ b/src/GraphQL/Resolvers/IFieldResolver.cs
@@ -5,19 +5,19 @@ namespace GraphQL.Resolvers
 {
     /// <summary>
     /// A field resolver returns an object for a given field within a graph.
-    /// <br/>
+    /// <br/><br/>
     /// The <see cref="FieldType.Resolver"/> property defines the field resolver to be used for the field.
-    /// <br/>
+    /// <br/><br/>
     /// Typically an instance of <see cref="FuncFieldResolver{TSourceType, TReturnType}">FuncFieldResolver</see> or
     /// <see cref="AsyncFieldResolver{TSourceType, TReturnType}">AsyncFieldResolver</see> is created when code needs
     /// to execute within the field resolver - typically by calling
     /// <see cref="Builders.FieldBuilder{TSourceType, TReturnType}">FieldBuilder</see>.<see cref="Builders.FieldBuilder{TSourceType, TReturnType}.Resolve(System.Func{IResolveFieldContext{TSourceType}, TReturnType})">Resolve</see>
     /// or <see cref="Builders.FieldBuilder{TSourceType, TReturnType}">FieldBuilder</see>.<see cref="Builders.FieldBuilder{TSourceType, TReturnType}.ResolveAsync(System.Func{IResolveFieldContext{TSourceType}, System.Threading.Tasks.Task{TReturnType}})">ResolveAsync</see>.
-    /// <br/>
+    /// <br/><br/>
     /// When mapping fields to source object properties via
     /// <see cref="ComplexGraphType{TSourceType}.Field{TProperty}(System.Linq.Expressions.Expression{System.Func{TSourceType, TProperty}}, bool, System.Type)">Field(x => x.Name)</see>,
     /// <see cref="ExpressionFieldResolver{TSourceType, TProperty}">ExpressionFieldResolver</see> is used.
-    /// <br/>
+    /// <br/><br/>
     /// When a field resolver is not defined, such as with <see cref="ComplexGraphType{TSourceType}.Field{TGraphType, TReturnType}(string)">Field("Name")</see>,
     /// the static instance of <see cref="NameFieldResolver"/> is used.
     /// </summary>

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Resolvers
     /// <summary>
     /// Attempts to return a value for a field from the graph's source object, matching the name of
     /// the field to a property or a method with the same name on the source object.
-    /// <br/>
+    /// <br/><br/>
     /// Call <see cref="NameFieldResolver.Instance"/> to retrieve an instance of this class.
     /// </summary>
     public class NameFieldResolver : IFieldResolver

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -7,9 +7,9 @@ namespace GraphQL.Types
 {
     /// <summary>
     /// The schema for the GraphQL request. Contains references to the 'query', 'mutation', and 'subscription' base graph types.
-    /// <br/>
+    /// <br/><br/>
     /// Also allows for adding custom directives, additional graph types, and custom value converters.
-    /// <br/>
+    /// <br/><br/>
     /// <see cref="Schema"/> only requires the <see cref="Schema.Query">Query</see> property to be set; although commonly the <see cref="Schema.Mutation">Mutation</see> and/or <see cref="Schema.Subscription">Subscription</see> properties are also set.
     /// </summary>
     public interface ISchema
@@ -21,7 +21,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Initializes the schema. Called by <see cref="IDocumentExecuter"/> before validating or executing the request.
-        /// <br/>
+        /// <br/><br/>
         /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="ExecutionOptions.FieldMiddleware"/>.
         /// </summary>
         void Initialize();
@@ -48,10 +48,10 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Returns a list of directives supported by the schema.
-        /// <br/>
+        /// <br/><br/>
         /// Directives are used by the GraphQL runtime as a way of modifying execution
         /// behavior. Type system creators do not usually create them directly.
-        /// <br/>
+        /// <br/><br/>
         /// <see cref="Schema"/> initializes the list to include <see cref="DirectiveGraphType.Include"/>, <see cref="DirectiveGraphType.Skip"/> and <see cref="DirectiveGraphType.Deprecated"/> by default.
         /// </summary>
         IEnumerable<DirectiveGraphType> Directives { get; set; }
@@ -78,7 +78,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Add a specific instance of an <see cref="IGraphType"/> to the schema.
-        /// <br/>
+        /// <br/><br/>
         /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
         /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
         /// </summary>
@@ -86,7 +86,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Add specific instances of <see cref="IGraphType"/>s to the schema.
-        /// <br/>
+        /// <br/><br/>
         /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
         /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
         /// </summary>
@@ -94,7 +94,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Add specific graph types to the schema. Each type must implement <see cref="IGraphType"/>.
-        /// <br/>
+        /// <br/><br/>
         /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
         /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
         /// </summary>
@@ -102,7 +102,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Add a specific graph type to the schema.
-        /// <br/>
+        /// <br/><br/>
         /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
         /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
         /// </summary>
@@ -110,7 +110,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Add a specific directive to the schema.
-        /// <br/>
+        /// <br/><br/>
         /// Directives are used by the GraphQL runtime as a way of modifying execution
         /// behavior. Type system creators do not usually create them directly.
         /// </summary>
@@ -118,7 +118,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Add specific directives to the schema.
-        /// <br/>
+        /// <br/><br/>
         /// Directives are used by the GraphQL runtime as a way of modifying execution
         /// behavior. Type system creators do not usually create them directly.
         /// </summary>

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -79,13 +79,13 @@ namespace GraphQL.Types
         /// <summary>
         /// Gets the service object of the specified type. Schema itself acts as a service provider used to
         /// create objects, such as graph types, requested by the schema.
-        /// <br/>
+        /// <br/><br/>
         /// Note that most objects are created during schema initialization, which then have the same lifetime
         /// as the schema's lifetime.
-        /// <br/>
+        /// <br/><br/>
         /// Other types created by the service provider may include directive visitors, middlewares, validation
         /// rules, and name converters, among others.
-        /// <br/>
+        /// <br/><br/>
         /// Explicit implementation of the <see cref="IServiceProvider.GetService"/> method makes this method
         /// less visible to the calling code, which reduces the likelihood of using it as so called ServiceLocator
         /// anti-pattern. However, in some advanced scenarios this may be necessary.
@@ -99,9 +99,9 @@ namespace GraphQL.Types
 
         /// <summary>
         /// The service provider used to create objects, such as graph types, requested by the schema.
-        /// <br/>
+        /// <br/><br/>
         /// Note that most objects are created during schema initialization, which then have the same lifetime as the schema's lifetime.
-        /// <br/>
+        /// <br/><br/>
         /// Other types created by the service provider may include directives, middleware, validation rules, and name converters, among others.
         /// </summary>
         public IServiceProvider Services { get; set; }


### PR DESCRIPTION
Fixes #1020 

Requires changes in server project: `InstrumentFieldsMiddleware` must be registered in DI now.

@Shane32 You might be interested. You had a PR #1443 that was not merged. It was an attempt to improve Field Middlewares though without all DI stuff. It so happened that on our projects there was a need to use middleware with dependencies, so I returned to this issue. As it turned out, adding this feature was not so difficult.

@joemcbride Please review this and update the site with the documentation.
