### PR TITLE
Add xml comments to IProvideUserContext

### DIFF
--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -39,12 +39,6 @@ namespace GraphQL
         /// <summary>Validation rules to be used by the <see cref="IDocumentValidator"/>; defaults to standard list of of validation rules - see <see cref="DocumentValidator.CoreRules"/></summary>
         public IEnumerable<IValidationRule> ValidationRules { get; set; }
 
-        /// <summary>
-        /// Mutable user-defined context to be passed and shared by all field resolvers.<br/>
-        /// <br/>
-        /// A custom implementation of <see cref="IDictionary{TKey, TValue}">IDictionary</see> may be
-        /// used in place of the default <see cref="Dictionary{TKey, TValue}">Dictionary</see>.
-        /// </summary>
         public IDictionary<string, object> UserContext { get; set; } = new Dictionary<string, object>();
 
         /// <summary>

--- a/src/GraphQL/Execution/IProvideUserContext.cs
+++ b/src/GraphQL/Execution/IProvideUserContext.cs
@@ -2,8 +2,17 @@ using System.Collections.Generic;
 
 namespace GraphQL.Execution
 {
+    /// <summary>
+    /// Provides access to a mutable user-defined context for the duration of the query
+    /// </summary>
     public interface IProvideUserContext
     {
+        /// <summary>
+        /// Mutable user-defined context to be passed to and shared by all field resolvers.<br/>
+        /// <br/>
+        /// A custom implementation of <see cref="IDictionary{TKey, TValue}">IDictionary</see> may be
+        /// used in place of the default <see cref="Dictionary{TKey, TValue}">Dictionary</see>.
+        /// </summary>
         IDictionary<string, object> UserContext { get; }
     }
 }


### PR DESCRIPTION
Moving the xml comment from ExecutionOptions.UserContext to IProvideUserContext.UserContext

Intellisense will pick up the comment within ExecutionOptions so there is no need to duplicate the comment

Also provides the same xml comment to field resolvers, etc.