### PR TITLE
Bug fix: introspection includeDeprecated field argument does not work with PascalCaseFieldNameConverter

### DIFF
--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using GraphQL.Conversion;
 using GraphQL.Introspection;
 using GraphQL.Types;
 using Shouldly;
@@ -20,6 +21,27 @@ namespace GraphQL.Tests.Introspection
                     Query = new TestQuery()
                 };
                 _.Query = SchemaIntrospection.IntrospectionQuery;
+            });
+
+            var json = await documentWriter.WriteToStringAsync(executionResult);
+
+            ShouldBe(json, IntrospectionResult.Data);
+        }
+
+        [Theory]
+        [ClassData(typeof(DocumentWritersTestData))]
+        public async Task validate_core_schema_pascal_case(IDocumentWriter documentWriter)
+        {
+            var documentExecuter = new DocumentExecuter();
+            var executionResult = await documentExecuter.ExecuteAsync(_ =>
+            {
+                _.Schema = new Schema
+                {
+                    Query = new TestQuery(),
+                };
+                _.FieldNameConverter = PascalCaseFieldNameConverter.Instance;
+                _.Query = SchemaIntrospection.IntrospectionQuery;
+                //_.Query = @"{  __type (name: ""__Directive"") {    fields (includeDeprecated: true) {      name    }  }}";
             });
 
             var json = await documentWriter.WriteToStringAsync(executionResult);

--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -41,7 +41,6 @@ namespace GraphQL.Tests.Introspection
                 };
                 _.FieldNameConverter = PascalCaseFieldNameConverter.Instance;
                 _.Query = SchemaIntrospection.IntrospectionQuery;
-                //_.Query = @"{  __type (name: ""__Directive"") {    fields (includeDeprecated: true) {      name    }  }}";
             });
 
             var json = await documentWriter.WriteToStringAsync(executionResult);

--- a/src/GraphQL/Introspection/__Type.cs
+++ b/src/GraphQL/Introspection/__Type.cs
@@ -40,7 +40,7 @@ namespace GraphQL.Introspection
                 {
                     if (context.Source is IObjectGraphType || context.Source is IInterfaceGraphType)
                     {
-                        var includeDeprecated = context.GetArgument<bool>("includeDeprecated");
+                        var includeDeprecated = (bool)context.Arguments["includeDeprecated"];
                         var type = context.Source as IComplexGraphType;
                         var fields = !includeDeprecated
                             ? type?.Fields.Where(f => string.IsNullOrWhiteSpace(f.DeprecationReason))
@@ -78,7 +78,7 @@ namespace GraphQL.Introspection
                 {
                     if (context.Source is EnumerationGraphType type)
                     {
-                        var includeDeprecated = context.GetArgument<bool>("includeDeprecated");
+                        var includeDeprecated = (bool)context.Arguments["includeDeprecated"];
                         var values = !includeDeprecated
                             ? type.Values.Where(e => string.IsNullOrWhiteSpace(e.DeprecationReason)).ToList()
                             : type.Values.ToList();


### PR DESCRIPTION
`GetArgument` converts argument names via the `NameFieldConverter`.  As introspection field names and arguments are not subject to the schema's `NameFieldConverter`, but rather always have camel case naming conventions, `GetArgument` cannot be used within field resolvers of introspection types.