### PR TITLE
Move IDisposable from ISchema to Schema

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -1799,7 +1799,7 @@ namespace GraphQL.Types
     {
         TSource Source { get; }
     }
-    public interface ISchema : System.IDisposable
+    public interface ISchema
     {
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AllTypes { get; }

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace GraphQL.Types
 {
-    public interface ISchema : IDisposable
+    public interface ISchema
     {
         bool Initialized { get; }
 

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace GraphQL.Types
 {
-    public class Schema : MetadataProvider, ISchema
+    public class Schema : MetadataProvider, ISchema, IDisposable
     {
         private Lazy<GraphTypesLookup> _lookup;
         private readonly List<Type> _additionalTypes;


### PR DESCRIPTION
Shouldn't `IDisposable` be implemented on `Schema`, rather than `ISchema`?  It's not like `ISchema` is expected to hold any unmanaged references, so implementing `IDisposable` at all seems questionable.

Ok to merge or close.