### PR TITLE
Add xml comments to ISchema

### DIFF
--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -44,7 +44,7 @@ namespace GraphQL
         /// <summary>
         /// Note that field middlewares apply only to an uninitialized schema. If the schema is initialized
         /// then applying different middleware through options does nothing. The schema is initialized (if not yet)
-        /// at the beginning of the first call to DocumentExecuter.ExecuteAsync.
+        /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(Action{ExecutionOptions})">ExecuteAsync</see>.
         /// </summary>
         public IFieldMiddlewareBuilder FieldMiddleware { get; set; } = new FieldMiddlewareBuilder();
 

--- a/src/GraphQL/SchemaExtensions.cs
+++ b/src/GraphQL/SchemaExtensions.cs
@@ -6,6 +6,10 @@ namespace GraphQL
 {
     public static class SchemaExtensions
     {
+        /// <summary>
+        /// Executes a GraphQL request with the default <see cref="DocumentExecuter"/>, serializes the result using the specified <see cref="IDocumentWriter"/>, and returns the result
+        /// </summary>
+        /// <param name="configure">A delegate which configures the execution options</param>
         public static async Task<string> ExecuteAsync(this ISchema schema, IDocumentWriter documentWriter, Action<ExecutionOptions> configure)
         {
             if (configure == null)

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -112,7 +112,7 @@ namespace GraphQL.Types
         /// Add a specific directive to the schema.<br/>
         /// <br/>
         /// Directives are used by the GraphQL runtime as a way of modifying execution
-        /// behavior. Type system creators will usually not create these directly.
+        /// behavior. Type system creators do not usually create them directly.
         /// </summary>
         void RegisterDirective(DirectiveGraphType directive);
 

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -72,7 +72,7 @@ namespace GraphQL.Types
         DirectiveGraphType FindDirective(string name);
 
         /// <summary>
-        /// A list of additional graph types manually added to the schema
+        /// A list of additional graph types manually added to the schema by RegisterType call.
         /// </summary>
         IEnumerable<Type> AdditionalTypes { get; }
 

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -137,6 +137,8 @@ namespace GraphQL.Types
         /// <summary>
         /// Provides the ability to filter the schema upon introspection to hide types. This is set by <see cref="IDocumentExecuter"/>
         /// to the filter passed to it within <see cref="ExecutionOptions.SchemaFilter"/>. By default, no types are hidden.
+        /// Note that this filter in fact does not prohibit the execution of queries that contain hidden types. To limit
+        /// access to the particular fields, you should use some authorization logic.
         /// </summary>
         ISchemaFilter Filter { get; set; }
     }

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -5,48 +5,138 @@ using System.Collections.Generic;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The schema for the GraphQL request. Contains references to the 'query', 'mutation', and 'subscription' base graph types.<br/>
+    /// <br/>
+    /// Also allows for adding custom directives, additional graph types, and custom value converters.<br/>
+    /// <br/>
+    /// <see cref="Schema"/> only requires the <see cref="Schema.Query">Query</see> property to be set; although commonly the <see cref="Schema.Mutation">Mutation</see> and/or <see cref="Schema.Subscription">Subscription</see> properties are also set.
+    /// </summary>
     public interface ISchema
     {
+        /// <summary>
+        /// Returns true once the schema has been initialized
+        /// </summary>
         bool Initialized { get; }
 
+        /// <summary>
+        /// Initializes the schema. Called by <see cref="IDocumentExecuter"/> before validating or executing the request.<br/>
+        /// <br/>
+        /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="ExecutionOptions.FieldMiddleware"/>.
+        /// </summary>
         void Initialize();
 
+        /// <summary>
+        /// The <see cref="IFieldNameConverter"/> used by the schema. This is set by <see cref="IDocumentExecuter"/> to the converter passed to it within <see cref="ExecutionOptions.FieldNameConverter"/>.
+        /// </summary>
         IFieldNameConverter FieldNameConverter { get; set; }
 
+        /// <summary>
+        /// The 'query' base graph type; required
+        /// </summary>
         IObjectGraphType Query { get; set; }
 
+        /// <summary>
+        /// The 'mutation' base graph type; optional
+        /// </summary>
         IObjectGraphType Mutation { get; set; }
 
+        /// <summary>
+        /// The 'subscription' base graph type; optional
+        /// </summary>
         IObjectGraphType Subscription { get; set; }
 
+        /// <summary>
+        /// Returns a list of directives supported by the schema.<br/>
+        /// <br/>
+        /// Directives are used by the GraphQL runtime as a way of modifying execution
+        /// behavior. Type system creators will usually not create these directly.<br/>
+        /// <br/>
+        /// <see cref="Schema"/> intializes the list to include <see cref="DirectiveGraphType.Include"/>, <see cref="DirectiveGraphType.Skip"/> and <see cref="DirectiveGraphType.Deprecated"/> by default.
+        /// </summary>
         IEnumerable<DirectiveGraphType> Directives { get; set; }
 
+        /// <summary>
+        /// Returns a list of all the graph types utilized by this schema
+        /// </summary>
         IEnumerable<IGraphType> AllTypes { get; }
 
+        /// <summary>
+        /// Returns a <see cref="IGraphType"/> for a given name
+        /// </summary>
         IGraphType FindType(string name);
 
+        /// <summary>
+        /// Returns a <see cref="DirectiveGraphType"/> for a given name
+        /// </summary>
         DirectiveGraphType FindDirective(string name);
 
+        /// <summary>
+        /// A list of additional graph types manually added to the schema
+        /// </summary>
         IEnumerable<Type> AdditionalTypes { get; }
 
+        /// <summary>
+        /// Add a specific instance of an <see cref="IGraphType"/> to the schema.<br/>
+        /// <br/>
+        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+        /// </summary>
         void RegisterType(IGraphType type);
 
+        /// <summary>
+        /// Add specific instances of <see cref="IGraphType"/>s to the schema.<br/>
+        /// <br/>
+        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+        /// </summary>
         void RegisterTypes(params IGraphType[] types);
 
+        /// <summary>
+        /// Add specific graph types to the schema. Each type must implement <see cref="IGraphType"/>.<br/>
+        /// <br/>
+        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+        /// </summary>
         void RegisterTypes(params Type[] types);
 
+        /// <summary>
+        /// Add a specific graph type to the schema.<br/>
+        /// <br/>
+        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+        /// </summary>
         void RegisterType<T>() where T : IGraphType;
 
+        /// <summary>
+        /// Add a specific directive to the schema.<br/>
+        /// <br/>
+        /// Directives are used by the GraphQL runtime as a way of modifying execution
+        /// behavior. Type system creators will usually not create these directly.
+        /// </summary>
         void RegisterDirective(DirectiveGraphType directive);
 
+        /// <summary>
+        /// Add specific directives to the schema.<br/>
+        /// <br/>
+        /// Directives are used by the GraphQL runtime as a way of modifying execution
+        /// behavior. Type system creators will usually not create these directly.
+        /// </summary>
         void RegisterDirectives(params DirectiveGraphType[] directives);
 
+        /// <summary>
+        /// Register a custom value converter to the schema.
+        /// </summary>
         void RegisterValueConverter(IAstFromValueConverter converter);
 
+        /// <summary>
+        /// Search the schema for a <see cref="IAstFromValueConverter"/> that matches the provided object and graph type, and return the converter.
+        /// </summary>
         IAstFromValueConverter FindValueConverter(object value, IGraphType type);
 
         /// <summary>
-        /// Provides the ability to filter the schema upon introspection to hide types.
+        /// Provides the ability to filter the schema upon introspection to hide types. This is set by <see cref="IDocumentExecuter"/>
+        /// to the filter passed to it within <see cref="ExecutionOptions.SchemaFilter"/>. By default, no types are hidden.
         /// </summary>
         ISchemaFilter Filter { get; set; }
     }

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -120,7 +120,7 @@ namespace GraphQL.Types
         /// Add specific directives to the schema.<br/>
         /// <br/>
         /// Directives are used by the GraphQL runtime as a way of modifying execution
-        /// behavior. Type system creators will usually not create these directly.
+        /// behavior. Type system creators do not usually create them directly.
         /// </summary>
         void RegisterDirectives(params DirectiveGraphType[] directives);
 

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -50,7 +50,7 @@ namespace GraphQL.Types
         /// Returns a list of directives supported by the schema.<br/>
         /// <br/>
         /// Directives are used by the GraphQL runtime as a way of modifying execution
-        /// behavior. Type system creators will usually not create these directly.<br/>
+        /// behavior. Type system creators do not usually create them directly.<br/>
         /// <br/>
         /// <see cref="Schema"/> intializes the list to include <see cref="DirectiveGraphType.Include"/>, <see cref="DirectiveGraphType.Skip"/> and <see cref="DirectiveGraphType.Deprecated"/> by default.
         /// </summary>

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -7,6 +7,7 @@ using System.Linq;
 
 namespace GraphQL.Types
 {
+    /// <inheritdoc cref="ISchema"/>
     public class Schema : MetadataProvider, ISchema, IDisposable
     {
         private Lazy<GraphTypesLookup> _lookup;
@@ -15,11 +16,19 @@ namespace GraphQL.Types
         private readonly List<DirectiveGraphType> _directives;
         private readonly List<IAstFromValueConverter> _converters;
 
+        /// <summary>
+        /// Create an instance of <see cref="Schema"/> with the <see cref="DefaultServiceProvider"/>, which
+        /// uses <see cref="Activator.CreateInstance(Type)"/> to create required instances of graph types
+        /// </summary>
         public Schema()
             : this(new DefaultServiceProvider())
         {
         }
 
+        /// <summary>
+        /// Create an instance of <see cref="Schema"/> with a specified <see cref="IServiceProvider"/>, used
+        /// to create required instances of graph types
+        /// </summary>
         public Schema(IServiceProvider services)
         {
             Services = services;
@@ -66,11 +75,11 @@ namespace GraphQL.Types
 
         public IObjectGraphType Subscription { get; set; }
 
+        /// <summary>
+        /// The service provider used to create instances of graph types during initialization of the schema
+        /// </summary>
         public IServiceProvider Services { get; set; }
 
-        /// <summary>
-        /// Provides the ability to filter the schema upon introspection to hide types.
-        /// </summary>
         public ISchemaFilter Filter { get; set; } = new DefaultSchemaFilter();
 
         public IEnumerable<DirectiveGraphType> Directives

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Create an instance of <see cref="Schema"/> with the <see cref="DefaultServiceProvider"/>, which
-        /// uses <see cref="Activator.CreateInstance(Type)"/> to create required instances of graph types
+        /// uses <see cref="Activator.CreateInstance(Type)"/> to create required objects
         /// </summary>
         public Schema()
             : this(new DefaultServiceProvider())
@@ -27,7 +27,7 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Create an instance of <see cref="Schema"/> with a specified <see cref="IServiceProvider"/>, used
-        /// to create required instances of graph types
+        /// to create required objects
         /// </summary>
         public Schema(IServiceProvider services)
         {
@@ -76,7 +76,7 @@ namespace GraphQL.Types
         public IObjectGraphType Subscription { get; set; }
 
         /// <summary>
-        /// The service provider used to create instances of graph types during initialization of the schema
+        /// The service provider used to create objects during initialization of the schema
         /// </summary>
         public IServiceProvider Services { get; set; }
 

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -80,7 +80,7 @@ namespace GraphQL.Types
         /// <br/>
         /// Note that most objects are created during schema initialization, which then have the same lifetime as the schema's lifetime.<br/>
         /// <br/>
-        /// Other types created by the service provider include directives, middleware, validation rules, and name converters, among others.
+        /// Other types created by the service provider may include directives, middleware, validation rules, and name converters, among others.
         /// </summary>
         public IServiceProvider Services { get; set; }
 


### PR DESCRIPTION
@sungam3r Please review. In particular, the comments for `RegisterValueConverter` and `FindValueConverter`, as I do not know how that would be used.  Perhaps a short example would be fitting.  Would this be for a custom date/time formatter?  But then wouldn't you simply implement a custom `ScalarFieldType` for bi-directional conversion?

Note that #1537 and #1549 will both slightly affect these comments, but this PR is based off the current `master` branch.  If we pull this PR first, I'll update #1549 - or vice versa.

The comment from `Schema.Filter` was removed so that it inherits the comments from `ISchema.Filter`.  Also, the `Schema` class was set to clone the comment from the `ISchema` interface.