### PR TITLE
Add basic xml comments to IDocumentExecutionListener

### DIFF
--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -12,7 +12,6 @@ namespace GraphQL.Execution
     {
         /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
         Task AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token);
-
         /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
         Task BeforeExecutionAsync(object userContext, CancellationToken token);
 

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -22,7 +22,7 @@ namespace GraphQL.Execution
         /// <summary>Executes after the <see cref="IExecutionStrategy"/> has completed executing the request</summary>
         Task AfterExecutionAsync(object userContext, CancellationToken token);
 
-        /// <summary>Executes before each time the <see cref="IExecutionStrategy"/> awaits the <see cref="Task{TResult}"/> returned by <see cref="IFieldResolver.Resolve"/></summary>
+        /// <summary>Executes before each time the <see cref="IExecutionStrategy"/> awaits the <see cref="Task{TResult}"/> returned by <see cref="IFieldResolver.Resolve"/>. For parallel resolvers, this may execute a single time prior to awaiting multiple tasks.</summary>
         Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token);
     }
 

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -1,77 +1,63 @@
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Validation;
+using GraphQL.Resolvers;
 
 namespace GraphQL.Execution
 {
+    /// <summary>
+    /// Provides the ability to log query validation failures and monitor progress of a GraphQL request's execution.
+    /// </summary>
     public interface IDocumentExecutionListener
     {
+        /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
         Task AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token);
+        /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
         Task BeforeExecutionAsync(object userContext, CancellationToken token);
+        /// <summary>Executes before the <see cref="IDocumentExecuter"/> awaits the <see cref="Task"/> returned by <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/></summary>
         Task BeforeExecutionAwaitedAsync(object userContext, CancellationToken token);
+        /// <summary>Executes after the <see cref="IExecutionStrategy"/> has completed executing the request</summary>
         Task AfterExecutionAsync(object userContext, CancellationToken token);
+        /// <summary>Executes before each time the <see cref="IExecutionStrategy"/> awaits the <see cref="Task{TResult}"/> returned by <see cref="IFieldResolver.Resolve"/></summary>
         Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token);
     }
 
+    /// <inheritdoc cref="IDocumentExecutionListener"/>
     public interface IDocumentExecutionListener<in T>
     {
+        /// <inheritdoc cref="IDocumentExecutionListener.AfterValidationAsync(object, IValidationResult, CancellationToken)"/>
         Task AfterValidationAsync(T userContext, IValidationResult validationResult, CancellationToken token);
+        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionAsync(object, CancellationToken)"/>
         Task BeforeExecutionAsync(T userContext, CancellationToken token);
+        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionAwaitedAsync(object, CancellationToken)"/>
         Task BeforeExecutionAwaitedAsync(T userContext, CancellationToken token);
+        /// <inheritdoc cref="IDocumentExecutionListener.AfterExecutionAsync(object, CancellationToken)"/>
         Task AfterExecutionAsync(T userContext, CancellationToken token);
+        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object, CancellationToken)"/>
         Task BeforeExecutionStepAwaitedAsync(T userContext, CancellationToken token);
     }
 
+    /// <inheritdoc cref="IDocumentExecutionListener"/>
     public abstract class DocumentExecutionListenerBase<T> : IDocumentExecutionListener<T>, IDocumentExecutionListener
     {
-        public virtual Task AfterValidationAsync(T userContext, IValidationResult validationResult, CancellationToken token)
-        {
-            return Task.CompletedTask;
-        }
+        public virtual Task AfterValidationAsync(T userContext, IValidationResult validationResult, CancellationToken token) => Task.CompletedTask;
 
-        public virtual Task BeforeExecutionAsync(T userContext, CancellationToken token)
-        {
-            return Task.CompletedTask;
-        }
+        public virtual Task BeforeExecutionAsync(T userContext, CancellationToken token) => Task.CompletedTask;
 
-        public virtual Task BeforeExecutionAwaitedAsync(T userContext, CancellationToken token)
-        {
-            return Task.CompletedTask;
-        }
+        public virtual Task BeforeExecutionAwaitedAsync(T userContext, CancellationToken token) => Task.CompletedTask;
 
-        public virtual Task AfterExecutionAsync(T userContext, CancellationToken token)
-        {
-            return Task.CompletedTask;
-        }
+        public virtual Task AfterExecutionAsync(T userContext, CancellationToken token) => Task.CompletedTask;
 
-        public virtual Task BeforeExecutionStepAwaitedAsync(T userContext, CancellationToken token)
-        {
-            return Task.CompletedTask;
-        }
+        public virtual Task BeforeExecutionStepAwaitedAsync(T userContext, CancellationToken token) => Task.CompletedTask;
 
-        Task IDocumentExecutionListener.AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token)
-        {
-            return AfterValidationAsync((T)userContext, validationResult, token);
-        }
+        Task IDocumentExecutionListener.AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token) => AfterValidationAsync((T)userContext, validationResult, token);
 
-        Task IDocumentExecutionListener.BeforeExecutionAsync(object userContext, CancellationToken token)
-        {
-            return BeforeExecutionAsync((T)userContext, token);
-        }
+        Task IDocumentExecutionListener.BeforeExecutionAsync(object userContext, CancellationToken token) => BeforeExecutionAsync((T)userContext, token);
 
-        Task IDocumentExecutionListener.BeforeExecutionAwaitedAsync(object userContext, CancellationToken token)
-        {
-            return BeforeExecutionAwaitedAsync((T)userContext, token);
-        }
+        Task IDocumentExecutionListener.BeforeExecutionAwaitedAsync(object userContext, CancellationToken token) => BeforeExecutionAwaitedAsync((T)userContext, token);
 
-        Task IDocumentExecutionListener.AfterExecutionAsync(object userContext, CancellationToken token)
-        {
-            return AfterExecutionAsync((T)userContext, token);
-        }
+        Task IDocumentExecutionListener.AfterExecutionAsync(object userContext, CancellationToken token) => AfterExecutionAsync((T)userContext, token);
 
-        Task IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token)
-        {
-            return BeforeExecutionStepAwaitedAsync((T)userContext, token);
-        }
+        Task IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token) => BeforeExecutionStepAwaitedAsync((T)userContext, token);
     }
 }

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -22,7 +22,6 @@ namespace GraphQL.Execution
         Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token);
     }
 
-
     /// <inheritdoc cref="IDocumentExecutionListener"/>
     public interface IDocumentExecutionListener<in T>
     {

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -22,6 +22,7 @@ namespace GraphQL.Execution
         Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token);
     }
 
+
     /// <inheritdoc cref="IDocumentExecutionListener"/>
     public interface IDocumentExecutionListener<in T>
     {

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -12,6 +12,7 @@ namespace GraphQL.Execution
     {
         /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
         Task AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token);
+
         /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
         Task BeforeExecutionAsync(object userContext, CancellationToken token);
 

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -12,12 +12,16 @@ namespace GraphQL.Execution
     {
         /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
         Task AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token);
+
         /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
         Task BeforeExecutionAsync(object userContext, CancellationToken token);
+
         /// <summary>Executes before the <see cref="IDocumentExecuter"/> awaits the <see cref="Task"/> returned by <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/></summary>
         Task BeforeExecutionAwaitedAsync(object userContext, CancellationToken token);
+
         /// <summary>Executes after the <see cref="IExecutionStrategy"/> has completed executing the request</summary>
         Task AfterExecutionAsync(object userContext, CancellationToken token);
+
         /// <summary>Executes before each time the <see cref="IExecutionStrategy"/> awaits the <see cref="Task{TResult}"/> returned by <see cref="IFieldResolver.Resolve"/></summary>
         Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token);
     }
@@ -27,12 +31,16 @@ namespace GraphQL.Execution
     {
         /// <inheritdoc cref="IDocumentExecutionListener.AfterValidationAsync(object, IValidationResult, CancellationToken)"/>
         Task AfterValidationAsync(T userContext, IValidationResult validationResult, CancellationToken token);
+
         /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionAsync(object, CancellationToken)"/>
         Task BeforeExecutionAsync(T userContext, CancellationToken token);
+
         /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionAwaitedAsync(object, CancellationToken)"/>
         Task BeforeExecutionAwaitedAsync(T userContext, CancellationToken token);
+
         /// <inheritdoc cref="IDocumentExecutionListener.AfterExecutionAsync(object, CancellationToken)"/>
         Task AfterExecutionAsync(T userContext, CancellationToken token);
+
         /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object, CancellationToken)"/>
         Task BeforeExecutionStepAwaitedAsync(T userContext, CancellationToken token);
     }


### PR DESCRIPTION
Added very basic comments for this interface. See changed files.

I might suggest that `IDocumentExecutionListener<T>` inherit from `IDocumentExecutionListener`.  Since the infrastructure only supports the latter interface, it is basically required for any implementation.  If you agree I can make that change also, or do so in a separate PR.  For now I just let it alone.