### PR TITLE
Increase appveyor testing reliability

### DIFF
--- a/src/GraphQL.DataLoader.Tests/SimpleDataLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/SimpleDataLoaderTests.cs
@@ -59,7 +59,7 @@ namespace GraphQL.DataLoader.Tests
             mock.Setup(store => store.GetAllUsersAsync(cts.Token))
                 .Returns(async (CancellationToken ct) =>
                 {
-                    await Task.Delay(200);
+                    await Task.Delay(5000, ct);
                     ct.ThrowIfCancellationRequested();
 
                     return users;

--- a/src/GraphQL.DataLoader.Tests/SimpleDataLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/SimpleDataLoaderTests.cs
@@ -59,7 +59,7 @@ namespace GraphQL.DataLoader.Tests
             mock.Setup(store => store.GetAllUsersAsync(cts.Token))
                 .Returns(async (CancellationToken ct) =>
                 {
-                    await Task.Delay(5000, ct);
+                    await Task.Delay(60000, ct);
                     ct.ThrowIfCancellationRequested();
 
                     return users;


### PR DESCRIPTION
Occassionally appveyor fails testing due to SimpleDataLoaderTests.Operation_Can_Be_Cancelled

See: https://ci.appveyor.com/project/graphql-dotnet-ci/graphql-dotnet/builds/30927760

This is due to the wrong order of execution of the threads of testing, probably due to server load.  This increases the time limit for a successful test from 200ms to 5 sec.  It also configures `Task.Delay` to immediately return if the task is canceled (which it should be canceled after 5ms), so it actually runs faster in most instances (since it would wait a fixed 200ms previously).