### PR TITLE
Make ResolveFieldContextExtensions.As public

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -216,6 +216,8 @@ namespace GraphQL
     }
     public static class ResolveFieldContextExtensions
     {
+        public static GraphQL.Subscription.IResolveEventStreamContext<T> As<T>(this GraphQL.Subscription.IResolveEventStreamContext context) { }
+        public static GraphQL.Types.IResolveFieldContext<TSourceType> As<TSourceType>(this GraphQL.Types.IResolveFieldContext context) { }
         public static object GetArgument(this GraphQL.Types.IResolveFieldContext context, System.Type argumentType, string name, object defaultValue = null) { }
         public static TType GetArgument<TType>(this GraphQL.Types.IResolveFieldContext context, string name, TType defaultValue = null) { }
         public static bool HasArgument(this GraphQL.Types.IResolveFieldContext context, string argumentName) { }

--- a/src/GraphQL/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContextExtensions.cs
@@ -59,6 +59,7 @@ namespace GraphQL
         public static bool HasArgument(this IResolveFieldContext context, string argumentName) => context.Arguments?.ContainsKey(argumentName) ?? false;
 
         /// <summary>Returns the <see cref="IResolveFieldContext"/> typed as an <see cref="IResolveFieldContext{TSource}"/></summary>
+        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>
         public static IResolveFieldContext<TSourceType> As<TSourceType>(this IResolveFieldContext context)
         {
             if (context is IResolveFieldContext<TSourceType> typedContext)
@@ -68,6 +69,7 @@ namespace GraphQL
         }
 
         /// <summary>Returns the <see cref="IResolveEventStreamContext"/> typed as an <see cref="IResolveEventStreamContext{TSource}"/></summary>
+        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveEventStreamContext.Source"/> property cannot be cast to the specified type</exception>
         public static IResolveEventStreamContext<T> As<T>(this IResolveEventStreamContext context)
         {
             if (context is IResolveEventStreamContext<T> typedContext)

--- a/src/GraphQL/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContextExtensions.cs
@@ -58,7 +58,8 @@ namespace GraphQL
         /// <summary>Determines if the specified field argument has been provided in the GraphQL query request</summary>
         public static bool HasArgument(this IResolveFieldContext context, string argumentName) => context.Arguments?.ContainsKey(argumentName) ?? false;
 
-        internal static IResolveFieldContext<TSourceType> As<TSourceType>(this IResolveFieldContext context)
+        /// <summary>Returns the <see cref="IResolveFieldContext"/> typed as an <see cref="IResolveFieldContext{TSource}"/></summary>
+        public static IResolveFieldContext<TSourceType> As<TSourceType>(this IResolveFieldContext context)
         {
             if (context is IResolveFieldContext<TSourceType> typedContext)
                 return typedContext;
@@ -66,7 +67,8 @@ namespace GraphQL
             return new ResolveFieldContextAdapter<TSourceType>(context);
         }
 
-        internal static IResolveEventStreamContext<T> As<T>(this IResolveEventStreamContext context)
+        /// <summary>Returns the <see cref="IResolveEventStreamContext"/> typed as an <see cref="IResolveEventStreamContext{TSource}"/></summary>
+        public static IResolveEventStreamContext<T> As<T>(this IResolveEventStreamContext context)
         {
             if (context is IResolveEventStreamContext<T> typedContext)
                 return typedContext;

--- a/src/GraphQL/Types/ResolveFieldContext.cs
+++ b/src/GraphQL/Types/ResolveFieldContext.cs
@@ -87,7 +87,10 @@ namespace GraphQL.Types
         {
         }
 
-        /// <inheritdoc cref="ResolveFieldContext.ResolveFieldContext(IResolveFieldContext)"/>
+        /// <summary>
+        /// Clone the specified <see cref="IResolveFieldContext"/>
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to <see cref="TSource"/></exception>
         public ResolveFieldContext(IResolveFieldContext context) : base(context)
         {
             if (context.Source != null && !(context.Source is TSource))

--- a/src/GraphQL/Types/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/Types/ResolveFieldContextAdapter.cs
@@ -10,6 +10,10 @@ namespace GraphQL.Types
     {
         private readonly IResolveFieldContext _baseContext;
 
+        /// <summary>
+        /// Creates an instance that maps to the specified base <see cref="IResolveFieldContext"/>
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>
         public ResolveFieldContextAdapter(IResolveFieldContext baseContext)
         {
             _baseContext = baseContext ?? throw new ArgumentNullException(nameof(baseContext));


### PR DESCRIPTION
I'd like to make `ResolveFieldContextExtensions.As` public, as I have a need for it in one of my projects.  I can of course duplicate the entire `ResolveFieldContextAdapter` into my own project, but if it's okay, I'd like to simply make the method public.