### PR TITLE
Remove generic listeners, change userContext to IDictionary<string, object>

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -514,11 +514,11 @@ namespace GraphQL.DataLoader
     public class DataLoaderDocumentListener : GraphQL.Execution.IDocumentExecutionListener
     {
         public DataLoaderDocumentListener(GraphQL.DataLoader.IDataLoaderContextAccessor accessor) { }
-        public System.Threading.Tasks.Task AfterExecutionAsync(object userContext, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task AfterValidationAsync(object userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionAsync(object userContext, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(object userContext, System.Threading.CancellationToken token) { }
-        public System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(object userContext, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task AfterExecutionAsync(System.Collections.Generic.IDictionary<string, object> userContext, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task AfterValidationAsync(System.Collections.Generic.IDictionary<string, object> userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task BeforeExecutionAsync(System.Collections.Generic.IDictionary<string, object> userContext, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(System.Collections.Generic.IDictionary<string, object> userContext, System.Threading.CancellationToken token) { }
+        public System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(System.Collections.Generic.IDictionary<string, object> userContext, System.Threading.CancellationToken token) { }
     }
     public static class DataLoaderExtensions
     {
@@ -556,15 +556,6 @@ namespace GraphQL.Execution
         public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode> Items { get; set; }
         public override object ToValue() { }
-    }
-    public abstract class DocumentExecutionListenerBase<T> : GraphQL.Execution.IDocumentExecutionListener, GraphQL.Execution.IDocumentExecutionListener<T>
-    {
-        protected DocumentExecutionListenerBase() { }
-        public virtual System.Threading.Tasks.Task AfterExecutionAsync(T userContext, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task AfterValidationAsync(T userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionAsync(T userContext, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(T userContext, System.Threading.CancellationToken token) { }
-        public virtual System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(T userContext, System.Threading.CancellationToken token) { }
     }
     public class ExecutionContext : GraphQL.Execution.IProvideUserContext
     {
@@ -639,19 +630,11 @@ namespace GraphQL.Execution
     }
     public interface IDocumentExecutionListener
     {
-        System.Threading.Tasks.Task AfterExecutionAsync(object userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task AfterValidationAsync(object userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAsync(object userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(object userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(object userContext, System.Threading.CancellationToken token);
-    }
-    public interface IDocumentExecutionListener<in T>
-    {
-        System.Threading.Tasks.Task AfterExecutionAsync(T userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task AfterValidationAsync(T userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAsync(T userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(T userContext, System.Threading.CancellationToken token);
-        System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(T userContext, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task AfterExecutionAsync(System.Collections.Generic.IDictionary<string, object> userContext, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task AfterValidationAsync(System.Collections.Generic.IDictionary<string, object> userContext, GraphQL.Validation.IValidationResult validationResult, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task BeforeExecutionAsync(System.Collections.Generic.IDictionary<string, object> userContext, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task BeforeExecutionAwaitedAsync(System.Collections.Generic.IDictionary<string, object> userContext, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task BeforeExecutionStepAwaitedAsync(System.Collections.Generic.IDictionary<string, object> userContext, System.Threading.CancellationToken token);
     }
     public interface IExecutionStrategy
     {

--- a/src/GraphQL.Tests/Execution/ExecutionListenerTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionListenerTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Execution;
 using GraphQL.Types;
+using GraphQL.Validation;
 using Xunit;
 
 namespace GraphQL.Tests.Execution
@@ -43,14 +44,22 @@ namespace GraphQL.Tests.Execution
             }
         }
 
-        public class TestExecutionListener : DocumentExecutionListenerBase<TestContext>
+        public class TestExecutionListener : IDocumentExecutionListener
         {
-            public override Task BeforeExecutionAwaitedAsync(TestContext userContext, CancellationToken token)
+            public Task AfterExecutionAsync(IDictionary<string, object> userContext, CancellationToken token) => Task.CompletedTask;
+
+            public Task AfterValidationAsync(IDictionary<string, object> userContext, IValidationResult validationResult, CancellationToken token) => Task.CompletedTask;
+
+            public Task BeforeExecutionAsync(IDictionary<string, object> userContext, CancellationToken token) => Task.CompletedTask;
+
+            public Task BeforeExecutionAwaitedAsync(IDictionary<string, object> userContext, CancellationToken token)
             {
-                userContext.Complete("bar");
+                ((TestContext)userContext).Complete("bar");
 
                 return Task.CompletedTask;
             }
+
+            public Task BeforeExecutionStepAwaitedAsync(IDictionary<string, object> userContext, CancellationToken token) => Task.CompletedTask;
         }
 
         public class TestContext: Dictionary<string, object>

--- a/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
+++ b/src/GraphQL/DataLoader/DataLoaderDocumentListener.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Execution;
@@ -18,12 +19,12 @@ namespace GraphQL.DataLoader
             _accessor = accessor;
         }
 
-        public Task AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token)
+        public Task AfterValidationAsync(IDictionary<string, object> userContext, IValidationResult validationResult, CancellationToken token)
         {
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionAsync(object userContext, CancellationToken token)
+        public Task BeforeExecutionAsync(IDictionary<string, object> userContext, CancellationToken token)
         {
             if (_accessor.Context == null)
                 _accessor.Context = new DataLoaderContext();
@@ -31,19 +32,19 @@ namespace GraphQL.DataLoader
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionAwaitedAsync(object userContext, CancellationToken token)
+        public Task BeforeExecutionAwaitedAsync(IDictionary<string, object> userContext, CancellationToken token)
         {
             return Task.CompletedTask;
         }
 
-        public Task AfterExecutionAsync(object userContext, CancellationToken token)
+        public Task AfterExecutionAsync(IDictionary<string, object> userContext, CancellationToken token)
         {
             _accessor.Context = null;
 
             return Task.CompletedTask;
         }
 
-        public Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token)
+        public Task BeforeExecutionStepAwaitedAsync(IDictionary<string, object> userContext, CancellationToken token)
         {
             var context = _accessor.Context;
             return context.DispatchAllAsync(token);

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -1,7 +1,8 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using GraphQL.Validation;
 using GraphQL.Resolvers;
+using GraphQL.Validation;
 
 namespace GraphQL.Execution
 {
@@ -11,61 +12,18 @@ namespace GraphQL.Execution
     public interface IDocumentExecutionListener
     {
         /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
-        Task AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token);
+        Task AfterValidationAsync(IDictionary<string, object> userContext, IValidationResult validationResult, CancellationToken token);
 
         /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
-        Task BeforeExecutionAsync(object userContext, CancellationToken token);
+        Task BeforeExecutionAsync(IDictionary<string, object> userContext, CancellationToken token);
 
         /// <summary>Executes before the <see cref="IDocumentExecuter"/> awaits the <see cref="Task"/> returned by <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/></summary>
-        Task BeforeExecutionAwaitedAsync(object userContext, CancellationToken token);
+        Task BeforeExecutionAwaitedAsync(IDictionary<string, object> userContext, CancellationToken token);
 
         /// <summary>Executes after the <see cref="IExecutionStrategy"/> has completed executing the request</summary>
-        Task AfterExecutionAsync(object userContext, CancellationToken token);
+        Task AfterExecutionAsync(IDictionary<string, object> userContext, CancellationToken token);
 
         /// <summary>Executes before each time the <see cref="IExecutionStrategy"/> awaits the <see cref="Task{TResult}"/> returned by <see cref="IFieldResolver.Resolve"/>. For parallel resolvers, this may execute a single time prior to awaiting multiple tasks.</summary>
-        Task BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token);
-    }
-
-    /// <inheritdoc cref="IDocumentExecutionListener"/>
-    public interface IDocumentExecutionListener<in T>
-    {
-        /// <inheritdoc cref="IDocumentExecutionListener.AfterValidationAsync(object, IValidationResult, CancellationToken)"/>
-        Task AfterValidationAsync(T userContext, IValidationResult validationResult, CancellationToken token);
-
-        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionAsync(object, CancellationToken)"/>
-        Task BeforeExecutionAsync(T userContext, CancellationToken token);
-
-        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionAwaitedAsync(object, CancellationToken)"/>
-        Task BeforeExecutionAwaitedAsync(T userContext, CancellationToken token);
-
-        /// <inheritdoc cref="IDocumentExecutionListener.AfterExecutionAsync(object, CancellationToken)"/>
-        Task AfterExecutionAsync(T userContext, CancellationToken token);
-
-        /// <inheritdoc cref="IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object, CancellationToken)"/>
-        Task BeforeExecutionStepAwaitedAsync(T userContext, CancellationToken token);
-    }
-
-    /// <inheritdoc cref="IDocumentExecutionListener"/>
-    public abstract class DocumentExecutionListenerBase<T> : IDocumentExecutionListener<T>, IDocumentExecutionListener
-    {
-        public virtual Task AfterValidationAsync(T userContext, IValidationResult validationResult, CancellationToken token) => Task.CompletedTask;
-
-        public virtual Task BeforeExecutionAsync(T userContext, CancellationToken token) => Task.CompletedTask;
-
-        public virtual Task BeforeExecutionAwaitedAsync(T userContext, CancellationToken token) => Task.CompletedTask;
-
-        public virtual Task AfterExecutionAsync(T userContext, CancellationToken token) => Task.CompletedTask;
-
-        public virtual Task BeforeExecutionStepAwaitedAsync(T userContext, CancellationToken token) => Task.CompletedTask;
-
-        Task IDocumentExecutionListener.AfterValidationAsync(object userContext, IValidationResult validationResult, CancellationToken token) => AfterValidationAsync((T)userContext, validationResult, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionAsync(object userContext, CancellationToken token) => BeforeExecutionAsync((T)userContext, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionAwaitedAsync(object userContext, CancellationToken token) => BeforeExecutionAwaitedAsync((T)userContext, token);
-
-        Task IDocumentExecutionListener.AfterExecutionAsync(object userContext, CancellationToken token) => AfterExecutionAsync((T)userContext, token);
-
-        Task IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object userContext, CancellationToken token) => BeforeExecutionStepAwaitedAsync((T)userContext, token);
+        Task BeforeExecutionStepAwaitedAsync(IDictionary<string, object> userContext, CancellationToken token);
     }
 }


### PR DESCRIPTION
See discussion in #1553

@joemcbride @Shane32 I propose changing the signature of all userContext params from object to `IDictionary<string, object>` and remove generic version of IDocumentExecutionListener.