### PR TITLE
Remove Schema.Services

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -2033,7 +2033,7 @@ namespace GraphQL.Types
         public bool Initialized { get; }
         public GraphQL.Types.IObjectGraphType Mutation { get; set; }
         public GraphQL.Types.IObjectGraphType Query { get; set; }
-        public System.IServiceProvider Services { get; set; }
+        public System.IServiceProvider Services { get; }
         public GraphQL.Types.IObjectGraphType Subscription { get; set; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -2033,7 +2033,6 @@ namespace GraphQL.Types
         public bool Initialized { get; }
         public GraphQL.Types.IObjectGraphType Mutation { get; set; }
         public GraphQL.Types.IObjectGraphType Query { get; set; }
-        public System.IServiceProvider Services { get; }
         public GraphQL.Types.IObjectGraphType Subscription { get; set; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -97,15 +97,6 @@ namespace GraphQL.Types
         /// </returns>
         object IServiceProvider.GetService(Type serviceType) => _services.GetService(serviceType);
 
-        /// <summary>
-        /// The service provider used to create objects, such as graph types, requested by the schema.
-        /// <br/><br/>
-        /// Note that most objects are created during schema initialization, which then have the same lifetime as the schema's lifetime.
-        /// <br/><br/>
-        /// Other types created by the service provider may include directives, middleware, validation rules, and name converters, among others.
-        /// </summary>
-        public IServiceProvider Services => _services;
-
         public ISchemaFilter Filter { get; set; } = new DefaultSchemaFilter();
 
         public IEnumerable<DirectiveGraphType> Directives

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -104,7 +104,7 @@ namespace GraphQL.Types
         /// <br/><br/>
         /// Other types created by the service provider may include directives, middleware, validation rules, and name converters, among others.
         /// </summary>
-        public IServiceProvider Services { get; set; }
+        public IServiceProvider Services => _services;
 
         public ISchemaFilter Filter { get; set; } = new DefaultSchemaFilter();
 


### PR DESCRIPTION
Somehow I didn't see this in my last review, but now Schema.Services points to ... nothing