### PR TITLE
Change IFieldType and IProvideMetadata to read-only interfaces

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -138,7 +138,7 @@ namespace GraphQL
         public static string NameOf<TSourceType, TProperty>(this System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
         public static string TrimGraphQLTypes(this string name) { }
         public static TMetadataProvider WithMetadata<TMetadataProvider>(this TMetadataProvider provider, string key, object value)
-            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+            where TMetadataProvider : GraphQL.Utilities.MetadataProvider { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.All)]
     public sealed class GraphQLMetadataAttribute : GraphQL.GraphQLAttribute
@@ -169,7 +169,7 @@ namespace GraphQL
         GraphQL.Language.AST.Document Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
         GraphQL.Language.AST.Field FieldAst { get; }
-        GraphQL.Types.FieldType FieldDefinition { get; }
+        GraphQL.Types.IFieldType FieldDefinition { get; }
         string FieldName { get; }
         GraphQL.Language.AST.Fragments Fragments { get; }
         GraphQL.Instrumentation.Metrics Metrics { get; }
@@ -247,7 +247,7 @@ namespace GraphQL
         public GraphQL.Language.AST.Document Document { get; }
         public GraphQL.ExecutionErrors Errors { get; }
         public GraphQL.Language.AST.Field FieldAst { get; }
-        public GraphQL.Types.FieldType FieldDefinition { get; }
+        public GraphQL.Types.IFieldType FieldDefinition { get; }
         public string FieldName { get; }
         public GraphQL.Language.AST.Fragments Fragments { get; }
         public GraphQL.Instrumentation.Metrics Metrics { get; }
@@ -271,7 +271,7 @@ namespace GraphQL
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
         public GraphQL.Language.AST.Field FieldAst { get; set; }
-        public GraphQL.Types.FieldType FieldDefinition { get; set; }
+        public GraphQL.Types.IFieldType FieldDefinition { get; set; }
         public string FieldName { get; set; }
         public GraphQL.Language.AST.Fragments Fragments { get; set; }
         public GraphQL.Instrumentation.Metrics Metrics { get; set; }
@@ -442,26 +442,26 @@ namespace GraphQL.Conversion
     {
         public static readonly GraphQL.Conversion.CamelCaseNameConverter Instance;
         public CamelCaseNameConverter() { }
-        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.FieldType field) { }
+        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.IFieldType field) { }
         public string NameForField(string fieldName, GraphQL.Types.IComplexGraphType parentGraphType) { }
     }
     public class DefaultNameConverter : GraphQL.Conversion.INameConverter
     {
         public static readonly GraphQL.Conversion.DefaultNameConverter Instance;
         public DefaultNameConverter() { }
-        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.FieldType field) { }
+        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.IFieldType field) { }
         public string NameForField(string fieldName, GraphQL.Types.IComplexGraphType parentGraphType) { }
     }
     public interface INameConverter
     {
-        string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.FieldType field);
+        string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.IFieldType field);
         string NameForField(string fieldName, GraphQL.Types.IComplexGraphType parentGraphType);
     }
     public class PascalCaseNameConverter : GraphQL.Conversion.INameConverter
     {
         public static readonly GraphQL.Conversion.PascalCaseNameConverter Instance;
         public PascalCaseNameConverter() { }
-        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.FieldType field) { }
+        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.IFieldType field) { }
         public string NameForField(string fieldName, GraphQL.Types.IComplexGraphType parentGraphType) { }
     }
 }
@@ -560,7 +560,7 @@ namespace GraphQL.Execution
 {
     public class ArrayExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {
-        public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode) { }
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode> Items { get; set; }
         public override object ToValue() { }
     }
@@ -598,7 +598,7 @@ namespace GraphQL.Execution
         public static System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> CollectFields(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IGraphType specificType, GraphQL.Language.AST.SelectionSet selectionSet) { }
         public static bool DoesFragmentConditionMatch(GraphQL.Execution.ExecutionContext context, string fragmentName, GraphQL.Types.IGraphType type) { }
         public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, GraphQL.Types.QueryArguments definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
-        public static GraphQL.Types.FieldType GetFieldDefinition(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Types.IObjectGraphType parentType, GraphQL.Language.AST.Field field) { }
+        public static GraphQL.Types.IFieldType GetFieldDefinition(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Types.IObjectGraphType parentType, GraphQL.Language.AST.Field field) { }
         public static GraphQL.Types.IObjectGraphType GetOperationRootType(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.Operation operation) { }
         public static object GetVariableValue(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinition variable, object input) { }
         public static GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions variableDefinitions, GraphQL.Inputs inputs) { }
@@ -607,9 +607,9 @@ namespace GraphQL.Execution
     }
     public abstract class ExecutionNode
     {
-        protected ExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        protected ExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode) { }
         public GraphQL.Language.AST.Field Field { get; }
-        public GraphQL.Types.FieldType FieldDefinition { get; }
+        public GraphQL.Types.IFieldType FieldDefinition { get; }
         public GraphQL.Types.IGraphType GraphType { get; }
         public int? IndexInParentNode { get; set; }
         public bool IsResultSet { get; }
@@ -629,7 +629,7 @@ namespace GraphQL.Execution
         protected abstract System.Threading.Tasks.Task ExecuteNodeTreeAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode rootNode);
         protected virtual System.Threading.Tasks.Task OnBeforeExecutionStepAwaitedAsync(GraphQL.Execution.ExecutionContext context) { }
         protected virtual void ValidateNodeResult(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
-        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode = default) { }
+        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode = default) { }
         public static GraphQL.Execution.RootExecutionNode BuildExecutionRootNode(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IObjectGraphType rootType) { }
         public static void SetArrayItemNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ArrayExecutionNode parent) { }
         public static void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent) { }
@@ -678,7 +678,7 @@ namespace GraphQL.Execution
     }
     public class ObjectExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {
-        public ObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode) { }
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ExecutionNode> SubFields { get; set; }
         public GraphQL.Types.IObjectGraphType GetObjectGraphType(GraphQL.Types.ISchema schema) { }
         public override object ToValue() { }
@@ -715,7 +715,7 @@ namespace GraphQL.Execution
     }
     public class ValueExecutionNode : GraphQL.Execution.ExecutionNode
     {
-        public ValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode) { }
         public override object ToValue() { }
     }
 }
@@ -1736,7 +1736,7 @@ namespace GraphQL.Types
         public GraphQL.Resolvers.IAsyncEventStreamResolver AsyncSubscriber { get; set; }
         public GraphQL.Resolvers.IEventStreamResolver Subscriber { get; set; }
     }
-    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
+    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
         public FieldType() { }
         public GraphQL.Types.QueryArguments Arguments { get; set; }
@@ -1828,17 +1828,15 @@ namespace GraphQL.Types
         GraphQL.Types.FieldType GetField(string name);
         bool HasField(string name);
     }
-    public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
+    public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
-        GraphQL.Types.QueryArguments Arguments { get; set; }
-        string DeprecationReason { get; set; }
-        string Description { get; set; }
-        string Name { get; set; }
+        GraphQL.Types.QueryArguments Arguments { get; }
+        string DeprecationReason { get; }
+        GraphQL.Resolvers.IFieldResolver Resolver { get; }
     }
     public interface IGraphType : GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
-        string DeprecationReason { get; set; }
-        string Description { get; set; }
+        string DeprecationReason { get; }
         string CollectTypes(GraphQL.Types.TypeCollectionContext context);
     }
     public interface IHaveDefaultValue
@@ -1856,7 +1854,8 @@ namespace GraphQL.Types
     public interface IInterfaceGraphType : GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata { }
     public interface INamedType
     {
-        string Name { get; set; }
+        string Description { get; }
+        string Name { get; }
     }
     public interface IObjectGraphType : GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
@@ -1865,7 +1864,7 @@ namespace GraphQL.Types
     }
     public interface IProvideMetadata
     {
-        System.Collections.Generic.IDictionary<string, object> Metadata { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object> Metadata { get; }
         TType GetMetadata<TType>(string key, System.Func<TType> defaultValueFactory);
         TType GetMetadata<TType>(string key, TType defaultValue = default);
         bool HasMetadata(string key);
@@ -1880,10 +1879,10 @@ namespace GraphQL.Types
         GraphQL.Types.IObjectGraphType Mutation { get; set; }
         GraphQL.Conversion.INameConverter NameConverter { get; set; }
         GraphQL.Types.IObjectGraphType Query { get; set; }
-        GraphQL.Types.FieldType SchemaMetaFieldType { get; }
+        GraphQL.Types.IFieldType SchemaMetaFieldType { get; }
         GraphQL.Types.IObjectGraphType Subscription { get; set; }
-        GraphQL.Types.FieldType TypeMetaFieldType { get; }
-        GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
+        GraphQL.Types.IFieldType TypeMetaFieldType { get; }
+        GraphQL.Types.IFieldType TypeNameMetaFieldType { get; }
         GraphQL.Types.DirectiveGraphType FindDirective(string name);
         GraphQL.Types.IGraphType FindType(string name);
         GraphQL.Types.IAstFromValueConverter FindValueConverter(object value, GraphQL.Types.IGraphType type);
@@ -2040,10 +2039,10 @@ namespace GraphQL.Types
         public GraphQL.Types.IObjectGraphType Mutation { get; set; }
         public GraphQL.Conversion.INameConverter NameConverter { get; set; }
         public GraphQL.Types.IObjectGraphType Query { get; set; }
-        public GraphQL.Types.FieldType SchemaMetaFieldType { get; }
+        public GraphQL.Types.IFieldType SchemaMetaFieldType { get; }
         public GraphQL.Types.IObjectGraphType Subscription { get; set; }
-        public GraphQL.Types.FieldType TypeMetaFieldType { get; }
-        public GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
+        public GraphQL.Types.IFieldType TypeMetaFieldType { get; }
+        public GraphQL.Types.IFieldType TypeNameMetaFieldType { get; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public GraphQL.Types.DirectiveGraphType FindDirective(string name) { }
@@ -2316,7 +2315,7 @@ namespace GraphQL.Utilities
     public class MetadataProvider : GraphQL.Types.IProvideMetadata
     {
         public MetadataProvider() { }
-        public System.Collections.Generic.IDictionary<string, object> Metadata { get; set; }
+        public System.Collections.Concurrent.ConcurrentDictionary<string, object> Metadata { get; set; }
         public TType GetMetadata<TType>(string key, System.Func<TType> defaultValueFactory) { }
         public TType GetMetadata<TType>(string key, TType defaultValue = default) { }
         public bool HasMetadata(string key) { }
@@ -2348,7 +2347,7 @@ namespace GraphQL.Utilities
         public GraphQL.Utilities.TypeSettings Types { get; }
         public virtual GraphQL.Types.ISchema Build(string[] typeDefinitions) { }
         public virtual GraphQL.Types.ISchema Build(string typeDefinitions) { }
-        protected virtual void CopyMetadata(GraphQL.Types.IProvideMetadata target, GraphQL.Types.IProvideMetadata source) { }
+        protected virtual void CopyMetadata(GraphQL.Utilities.MetadataProvider target, GraphQL.Types.IProvideMetadata source) { }
         protected virtual GraphQL.Types.IGraphType GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }
         public GraphQL.Utilities.SchemaBuilder RegisterDirectiveVisitor<T>(string name)
@@ -2592,7 +2591,7 @@ namespace GraphQL.Validation
         public GraphQL.Language.AST.INode[] GetAncestors() { }
         public GraphQL.Types.QueryArgument GetArgument() { }
         public GraphQL.Types.DirectiveGraphType GetDirective() { }
-        public GraphQL.Types.FieldType GetFieldDef() { }
+        public GraphQL.Types.IFieldType GetFieldDef() { }
         public GraphQL.Types.IGraphType GetInputType() { }
         public GraphQL.Types.IGraphType GetLastType() { }
         public GraphQL.Types.IGraphType GetParentType() { }

--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -71,7 +71,7 @@ namespace GraphQL.Tests.Introspection
 
         public class TestNameConverter : INameConverter
         {
-            public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => throw new Exception();
+            public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field) => throw new Exception();
 
             public string NameForField(string fieldName, IComplexGraphType parentGraphType) => throw new Exception();
         }

--- a/src/GraphQL/Conversion/CamelCaseNameConverter.cs
+++ b/src/GraphQL/Conversion/CamelCaseNameConverter.cs
@@ -22,6 +22,6 @@ namespace GraphQL.Conversion
         /// <summary>
         /// Returns the argument name converted to camelCase.
         /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName.ToCamelCase();
+        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field) => argumentName.ToCamelCase();
     }
 }

--- a/src/GraphQL/Conversion/DefaultNameConverter.cs
+++ b/src/GraphQL/Conversion/DefaultNameConverter.cs
@@ -21,6 +21,6 @@ namespace GraphQL.Conversion
         /// <summary>
         /// Returns the argument name without modification
         /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName;
+        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field) => argumentName;
     }
 }

--- a/src/GraphQL/Conversion/INameConverter.cs
+++ b/src/GraphQL/Conversion/INameConverter.cs
@@ -21,6 +21,6 @@ namespace GraphQL.Conversion
         /// <summary>
         /// Sanitizes an argument name for a specified parent graph type and field definition; returns the updated field name
         /// </summary>
-        string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field);
+        string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field);
     }
 }

--- a/src/GraphQL/Conversion/PascalCaseNameConverter.cs
+++ b/src/GraphQL/Conversion/PascalCaseNameConverter.cs
@@ -21,6 +21,6 @@ namespace GraphQL.Conversion
         /// <summary>
         /// Returns the argument name converted to PascalCase.
         /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName.ToPascalCase();
+        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field) => argumentName.ToPascalCase();
     }
 }

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -50,19 +50,23 @@ namespace GraphQL.Execution
             return type;
         }
 
-        public static FieldType GetFieldDefinition(Document document, ISchema schema, IObjectGraphType parentType, Field field)
+        public static IFieldType GetFieldDefinition(Document document, ISchema schema, IObjectGraphType parentType, Field field)
         {
-            if (field.Name == schema.SchemaMetaFieldType.Name && schema.Query == parentType)
+            var schemaMeta = schema.SchemaMetaFieldType;
+            var typeMeta = schema.TypeMetaFieldType;
+            var typeNameMeta = schema.TypeNameMetaFieldType;
+
+            if (field.Name == schemaMeta.Name && schema.Query == parentType)
             {
-                return schema.SchemaMetaFieldType;
+                return schemaMeta;
             }
-            if (field.Name == schema.TypeMetaFieldType.Name && schema.Query == parentType)
+            if (field.Name == typeMeta.Name && schema.Query == parentType)
             {
-                return schema.TypeMetaFieldType;
+                return typeMeta;
             }
-            if (field.Name == schema.TypeNameMetaFieldType.Name)
+            if (field.Name == typeNameMeta.Name)
             {
-                return schema.TypeNameMetaFieldType;
+                return typeNameMeta;
             }
 
             if (parentType == null)

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -52,18 +52,20 @@ namespace GraphQL.Execution
 
         public static IFieldType GetFieldDefinition(Document document, ISchema schema, IObjectGraphType parentType, Field field)
         {
-            var schemaMeta = schema.SchemaMetaFieldType;
-            var typeMeta = schema.TypeMetaFieldType;
+            if (schema.Query == parentType)
+            {
+                var schemaMeta = schema.SchemaMetaFieldType;
+                if (field.Name == schemaMeta.Name && schema.Query == parentType)
+                {
+                    return schemaMeta;
+                }
+                var typeMeta = schema.TypeMetaFieldType;
+                if (field.Name == typeMeta.Name && schema.Query == parentType)
+                {
+                    return typeMeta;
+                }
+            }
             var typeNameMeta = schema.TypeNameMetaFieldType;
-
-            if (field.Name == schemaMeta.Name && schema.Query == parentType)
-            {
-                return schemaMeta;
-            }
-            if (field.Name == typeMeta.Name && schema.Query == parentType)
-            {
-                return typeMeta;
-            }
             if (field.Name == typeNameMeta.Name)
             {
                 return typeNameMeta;

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Execution
         public ExecutionNode Parent { get; }
         public IGraphType GraphType { get; }
         public Field Field { get; }
-        public FieldType FieldDefinition { get; }
+        public IFieldType FieldDefinition { get; }
         public int? IndexInParentNode { get; protected set; }
 
         public string Name => Field?.Alias ?? Field?.Name;
@@ -36,7 +36,7 @@ namespace GraphQL.Execution
             set => _source = value;
         }
 
-        protected ExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        protected ExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode)
         {
             Parent = parent;
             GraphType = graphType;
@@ -119,7 +119,7 @@ namespace GraphQL.Execution
     {
         public IDictionary<string, ExecutionNode> SubFields { get; set; }
 
-        public ObjectExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        public ObjectExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode)
             : base(parent, graphType, field, fieldDefinition, indexInParentNode)
         {
         }
@@ -175,7 +175,7 @@ namespace GraphQL.Execution
     {
         public List<ExecutionNode> Items { get; set; }
 
-        public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode)
             : base(parent, graphType, field, fieldDefinition, indexInParentNode)
         {
 
@@ -217,7 +217,7 @@ namespace GraphQL.Execution
 
     public class ValueExecutionNode : ExecutionNode
     {
-        public ValueExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        public ValueExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode)
             : base(parent, graphType, field, fieldDefinition, indexInParentNode)
         {
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -147,7 +147,7 @@ namespace GraphQL.Execution
             parent.Items = arrayItems;
         }
 
-        public static ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode = null)
+        public static ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode = null)
         {
             if (graphType is NonNullGraphType nonNullFieldType)
                 graphType = nonNullFieldType.ResolvedType;

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -277,7 +277,7 @@ namespace GraphQL
         }
 
         public static TMetadataProvider WithMetadata<TMetadataProvider>(this TMetadataProvider provider, string key, object value)
-            where TMetadataProvider : IProvideMetadata
+            where TMetadataProvider : MetadataProvider
         {
             provider.Metadata[key] = value;
             return provider;

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -22,7 +22,7 @@ namespace GraphQL
         Field FieldAst { get; }
 
         /// <summary>The <see cref="FieldType"/> definition specified in the parent graph type</summary>
-        FieldType FieldDefinition { get; }
+        IFieldType FieldDefinition { get; }
 
         /// <summary>The return value's graph type</summary>
         IGraphType ReturnType { get; }

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -36,7 +36,7 @@ namespace GraphQL
 
         public Language.AST.Field FieldAst => _executionNode.Field;
 
-        public FieldType FieldDefinition => _executionNode.FieldDefinition;
+        public IFieldType FieldDefinition => _executionNode.FieldDefinition;
 
         public IGraphType ReturnType => _executionNode.FieldDefinition.ResolvedType;
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -18,7 +18,7 @@ namespace GraphQL
 
         public Field FieldAst { get; set; }
 
-        public FieldType FieldDefinition { get; set; }
+        public IFieldType FieldDefinition { get; set; }
 
         public IGraphType ReturnType { get; set; }
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -39,7 +39,7 @@ namespace GraphQL
 
         public Language.AST.Field FieldAst => _baseContext.FieldAst;
 
-        public FieldType FieldDefinition => _baseContext.FieldDefinition;
+        public IFieldType FieldDefinition => _baseContext.FieldDefinition;
 
         public IGraphType ReturnType => _baseContext.ReturnType;
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -72,7 +72,7 @@ namespace GraphQL
         /// <summary>
         /// Determines if this field is an introspection field (__schema, __type, __typename) -- but not if it is a field of an introspection type
         /// </summary>
-        private static bool IsIntrospectionField(this FieldType fieldType) => fieldType?.Name?.StartsWith("__") ?? false;
+        private static bool IsIntrospectionField(this IFieldType fieldType) => fieldType?.Name?.StartsWith("__") ?? false;
 
         /// <summary>Returns the <see cref="IResolveFieldContext"/> typed as an <see cref="IResolveFieldContext{TSource}"/></summary>
         /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>

--- a/src/GraphQL/Types/Fields/IFieldType.cs
+++ b/src/GraphQL/Types/Fields/IFieldType.cs
@@ -1,13 +1,13 @@
+using GraphQL.Resolvers;
+
 namespace GraphQL.Types
 {
-    public interface IFieldType : IHaveDefaultValue, IProvideMetadata
+    public interface IFieldType : IHaveDefaultValue, IProvideMetadata, INamedType
     {
-        string Name { get; set; }
+        string DeprecationReason { get; }
 
-        string Description { get; set; }
+        QueryArguments Arguments { get; }
 
-        string DeprecationReason { get; set; }
-
-        QueryArguments Arguments { get; set; }
+        IFieldResolver Resolver { get; }
     }
 }

--- a/src/GraphQL/Types/IGraphType.cs
+++ b/src/GraphQL/Types/IGraphType.cs
@@ -1,14 +1,15 @@
-﻿namespace GraphQL.Types
+namespace GraphQL.Types
 {
     public interface INamedType
     {
-        string Name { get; set; }
+        string Name { get; }
+
+        string Description { get; }
     }
 
     public interface IGraphType : IProvideMetadata, INamedType
     {
-        string Description { get; set; }
-        string DeprecationReason { get; set; }
+        string DeprecationReason { get; }
 
         string CollectTypes(TypeCollectionContext context);
     }

--- a/src/GraphQL/Types/IProvideMetadata.cs
+++ b/src/GraphQL/Types/IProvideMetadata.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types
 {
     public interface IProvideMetadata
     {
-        IDictionary<string, object> Metadata { get; }
+        IReadOnlyDictionary<string, object> Metadata { get; }
         TType GetMetadata<TType>(string key, TType defaultValue = default);
         TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory);
         bool HasMetadata(string key);

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -145,16 +145,16 @@ namespace GraphQL.Types
         /// <summary>
         /// Returns a reference to the __schema introspection field available on the query graph type
         /// </summary>
-        FieldType SchemaMetaFieldType { get; }
+        IFieldType SchemaMetaFieldType { get; }
 
         /// <summary>
         /// Returns a reference to the __type introspection field available on the query graph type
         /// </summary>
-        FieldType TypeMetaFieldType { get; }
+        IFieldType TypeMetaFieldType { get; }
 
         /// <summary>
         /// Returns a reference to the __typename introspection field available on any object, interface, or union graph type
         /// </summary>
-        FieldType TypeNameMetaFieldType { get; }
+        IFieldType TypeNameMetaFieldType { get; }
     }
 }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -121,11 +121,20 @@ namespace GraphQL.Types
 
         public IEnumerable<Type> AdditionalTypes => _additionalTypes;
 
-        public FieldType SchemaMetaFieldType => _lookup?.Value.SchemaMetaFieldType;
+        /// <summary>
+        /// Returns a reference to the __schema introspection field available on the query graph type
+        /// </summary>
+        public IFieldType SchemaMetaFieldType => _lookup?.Value.SchemaMetaFieldType;
 
-        public FieldType TypeMetaFieldType => _lookup?.Value.TypeMetaFieldType;
+        /// <summary>
+        /// Returns a reference to the __type introspection field available on the query graph type
+        /// </summary>
+        public IFieldType TypeMetaFieldType => _lookup?.Value.TypeMetaFieldType;
 
-        public FieldType TypeNameMetaFieldType => _lookup?.Value.TypeNameMetaFieldType;
+        /// <summary>
+        /// Returns a reference to the __typename introspection field available on any graph type
+        /// </summary>
+        public IFieldType TypeNameMetaFieldType => _lookup?.Value.TypeNameMetaFieldType;
 
         public void RegisterType(IGraphType type)
         {

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -121,19 +121,10 @@ namespace GraphQL.Types
 
         public IEnumerable<Type> AdditionalTypes => _additionalTypes;
 
-        /// <summary>
-        /// Returns a reference to the __schema introspection field available on the query graph type
-        /// </summary>
         public IFieldType SchemaMetaFieldType => _lookup?.Value.SchemaMetaFieldType;
 
-        /// <summary>
-        /// Returns a reference to the __type introspection field available on the query graph type
-        /// </summary>
         public IFieldType TypeMetaFieldType => _lookup?.Value.TypeMetaFieldType;
 
-        /// <summary>
-        /// Returns a reference to the __typename introspection field available on any graph type
-        /// </summary>
         public IFieldType TypeNameMetaFieldType => _lookup?.Value.TypeNameMetaFieldType;
 
         public void RegisterType(IGraphType type)

--- a/src/GraphQL/Utilities/MetadataProvider.cs
+++ b/src/GraphQL/Utilities/MetadataProvider.cs
@@ -7,7 +7,9 @@ namespace GraphQL.Utilities
 {
     public class MetadataProvider : IProvideMetadata
     {
-        public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
+        public ConcurrentDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
+
+        IReadOnlyDictionary<string, object> IProvideMetadata.Metadata => Metadata;
 
         public TType GetMetadata<TType>(string key, TType defaultValue = default)
         {

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -495,7 +495,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             }
         }
 
-        protected virtual void CopyMetadata(IProvideMetadata target, IProvideMetadata source)
+        protected virtual void CopyMetadata(MetadataProvider target, IProvideMetadata source)
         {
             source.Metadata.Apply(kv => target.Metadata[kv.Key] = kv.Value);
         }

--- a/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
+++ b/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace GraphQL.Utilities
         }
 
         public static TMetadataProvider SetAstType<TMetadataProvider>(this TMetadataProvider provider, ASTNode node)
-            where TMetadataProvider : IProvideMetadata
+            where TMetadataProvider : MetadataProvider
             => provider.WithMetadata(AST_METAFIELD, node);
 
         public static bool HasExtensionAstTypes(this IProvideMetadata type)
@@ -40,7 +40,7 @@ namespace GraphQL.Utilities
             return GetExtensionAstTypes(type).Count > 0;
         }
 
-        public static void AddExtensionAstType<T>(this IProvideMetadata type, T astType) where T : ASTNode 
+        public static void AddExtensionAstType<T>(this MetadataProvider type, T astType) where T : ASTNode 
         {
             var types = GetExtensionAstTypes(type);
             types.Add(astType);

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Validation
         private readonly Stack<IGraphType> _typeStack = new Stack<IGraphType>();
         private readonly Stack<IGraphType> _inputTypeStack = new Stack<IGraphType>();
         private readonly Stack<IGraphType> _parentTypeStack = new Stack<IGraphType>();
-        private readonly Stack<FieldType> _fieldDefStack = new Stack<FieldType>();
+        private readonly Stack<IFieldType> _fieldDefStack = new Stack<IFieldType>();
         private readonly Stack<INode> _ancestorStack = new Stack<INode>();
         private DirectiveGraphType _directive;
         private QueryArgument _argument;
@@ -42,7 +42,7 @@ namespace GraphQL.Validation
             return _parentTypeStack.Count > 0 ? _parentTypeStack.Peek() : null;
         }
 
-        public FieldType GetFieldDef()
+        public IFieldType GetFieldDef()
         {
             return _fieldDefStack.Count > 0 ? _fieldDefStack.Peek() : null;
         }
@@ -212,25 +212,28 @@ namespace GraphQL.Validation
             }
         }
 
-        private FieldType GetFieldDef(ISchema schema, IGraphType parentType, Field field)
+        private IFieldType GetFieldDef(ISchema schema, IGraphType parentType, Field field)
         {
             var name = field.Name;
+            var schemaMeta = schema.SchemaMetaFieldType;
+            var typeMeta = schema.TypeMetaFieldType;
+            var typeNameMeta = schema.TypeNameMetaFieldType;
 
-            if (name == schema.SchemaMetaFieldType.Name
+            if (name == schemaMeta.Name
                 && Equals(schema.Query, parentType))
             {
-                return schema.SchemaMetaFieldType;
+                return schemaMeta;
             }
 
-            if (name == schema.TypeMetaFieldType.Name
+            if (name == typeMeta.Name
                 && Equals(schema.Query, parentType))
             {
-                return schema.TypeMetaFieldType;
+                return typeMeta;
             }
 
-            if (name == schema.TypeNameMetaFieldType.Name && parentType.IsCompositeType())
+            if (name == typeNameMeta.Name && parentType.IsCompositeType())
             {
-                return schema.TypeNameMetaFieldType;
+                return typeNameMeta;
             }
 
             if (parentType is IObjectGraphType || parentType is IInterfaceGraphType)


### PR DESCRIPTION
Another conceptual draft to fix #1564 

Changes:
* `IFieldType` has changed from a read/write type to a read-only type
* `IProvideMetadata` is now a read-only type
* `ISchema` has a single additional method to access the introspection fields: `GetIntrospectionField<T>()` which returns an `IFieldType`
* `FieldType`, `MetadataProvider`, `GraphType` and other classes still provide read/write access to the underlying fields and metadata dictionary
* Various changes throughout the code base were changed from `FieldType` to `IFieldType` to support this change
* Due to the above changes, `IGraphType` (which inherits from `IProvideMetadata`) now has read-only access to metadata, although all classes that inherit from `GraphType` still have read/write access to the metadata

Thoughts:
* This concept could be applied to graph types as well.  `IGraphType` would change to read-only. 
 Many references to `IGraphType` would change to `GraphType`, as they would require read/write access (to set `ResolvedType` or apply middleware, for example).
* With these changes in place, marking certain fields `internal` is possible where it is not possible now (since `IGraphType` is used extensively, and interface members cannot be marked `internal`).
* I would endorse these changes across the entire project