### PR TITLE
[Discussion] Change interfaces to read-only

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -79,12 +79,10 @@ namespace GraphQL
         public GraphQL.Inputs Inputs { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
         public int? MaxParallelExecutionCount { get; set; }
-        public GraphQL.Conversion.INameConverter NameConverter { get; set; }
         public string OperationName { get; set; }
         public string Query { get; set; }
         public object Root { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
-        public GraphQL.Introspection.ISchemaFilter SchemaFilter { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Action<GraphQL.Execution.UnhandledExceptionContext> UnhandledExceptionDelegate { get; set; }
         public System.Collections.Generic.IDictionary<string, object> UserContext { get; set; }
@@ -138,7 +136,7 @@ namespace GraphQL
         public static string NameOf<TSourceType, TProperty>(this System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
         public static string TrimGraphQLTypes(this string name) { }
         public static TMetadataProvider WithMetadata<TMetadataProvider>(this TMetadataProvider provider, string key, object value)
-            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+            where TMetadataProvider : GraphQL.Utilities.MetadataProvider { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.All)]
     public sealed class GraphQLMetadataAttribute : GraphQL.GraphQLAttribute
@@ -169,7 +167,7 @@ namespace GraphQL
         GraphQL.Language.AST.Document Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
         GraphQL.Language.AST.Field FieldAst { get; }
-        GraphQL.Types.FieldType FieldDefinition { get; }
+        GraphQL.Types.IFieldType FieldDefinition { get; }
         string FieldName { get; }
         GraphQL.Language.AST.Fragments Fragments { get; }
         GraphQL.Instrumentation.Metrics Metrics { get; }
@@ -247,7 +245,7 @@ namespace GraphQL
         public GraphQL.Language.AST.Document Document { get; }
         public GraphQL.ExecutionErrors Errors { get; }
         public GraphQL.Language.AST.Field FieldAst { get; }
-        public GraphQL.Types.FieldType FieldDefinition { get; }
+        public GraphQL.Types.IFieldType FieldDefinition { get; }
         public string FieldName { get; }
         public GraphQL.Language.AST.Fragments Fragments { get; }
         public GraphQL.Instrumentation.Metrics Metrics { get; }
@@ -271,7 +269,7 @@ namespace GraphQL
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
         public GraphQL.Language.AST.Field FieldAst { get; set; }
-        public GraphQL.Types.FieldType FieldDefinition { get; set; }
+        public GraphQL.Types.IFieldType FieldDefinition { get; set; }
         public string FieldName { get; set; }
         public GraphQL.Language.AST.Fragments Fragments { get; set; }
         public GraphQL.Instrumentation.Metrics Metrics { get; set; }
@@ -348,12 +346,12 @@ namespace GraphQL.Builders
     public static class ConnectionBuilder
     {
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
-            where TNodeType : GraphQL.Types.IGraphType { }
+            where TNodeType : GraphQL.Types.GraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
-            where TNodeType : GraphQL.Types.IGraphType
+            where TNodeType : GraphQL.Types.GraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
-            where TNodeType : GraphQL.Types.IGraphType
+            where TNodeType : GraphQL.Types.GraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
@@ -374,12 +372,12 @@ namespace GraphQL.Builders
         public GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Unidirectional() { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
-            where TNodeType : GraphQL.Types.IGraphType { }
+            where TNodeType : GraphQL.Types.GraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")
-            where TNodeType : GraphQL.Types.IGraphType
+            where TNodeType : GraphQL.Types.GraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
-            where TNodeType : GraphQL.Types.IGraphType
+            where TNodeType : GraphQL.Types.GraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
@@ -442,26 +440,26 @@ namespace GraphQL.Conversion
     {
         public static readonly GraphQL.Conversion.CamelCaseNameConverter Instance;
         public CamelCaseNameConverter() { }
-        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.FieldType field) { }
+        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.IFieldType field) { }
         public string NameForField(string fieldName, GraphQL.Types.IComplexGraphType parentGraphType) { }
     }
     public class DefaultNameConverter : GraphQL.Conversion.INameConverter
     {
         public static readonly GraphQL.Conversion.DefaultNameConverter Instance;
         public DefaultNameConverter() { }
-        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.FieldType field) { }
+        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.IFieldType field) { }
         public string NameForField(string fieldName, GraphQL.Types.IComplexGraphType parentGraphType) { }
     }
     public interface INameConverter
     {
-        string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.FieldType field);
+        string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.IFieldType field);
         string NameForField(string fieldName, GraphQL.Types.IComplexGraphType parentGraphType);
     }
     public class PascalCaseNameConverter : GraphQL.Conversion.INameConverter
     {
         public static readonly GraphQL.Conversion.PascalCaseNameConverter Instance;
         public PascalCaseNameConverter() { }
-        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.FieldType field) { }
+        public string NameForArgument(string argumentName, GraphQL.Types.IComplexGraphType parentGraphType, GraphQL.Types.IFieldType field) { }
         public string NameForField(string fieldName, GraphQL.Types.IComplexGraphType parentGraphType) { }
     }
 }
@@ -560,7 +558,7 @@ namespace GraphQL.Execution
 {
     public class ArrayExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {
-        public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode) { }
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode> Items { get; set; }
         public override object ToValue() { }
     }
@@ -597,8 +595,8 @@ namespace GraphQL.Execution
         public static object CoerceValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue input, GraphQL.Language.AST.Variables variables = null) { }
         public static System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> CollectFields(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IGraphType specificType, GraphQL.Language.AST.SelectionSet selectionSet) { }
         public static bool DoesFragmentConditionMatch(GraphQL.Execution.ExecutionContext context, string fragmentName, GraphQL.Types.IGraphType type) { }
-        public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, GraphQL.Types.QueryArguments definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
-        public static GraphQL.Types.FieldType GetFieldDefinition(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Types.IObjectGraphType parentType, GraphQL.Language.AST.Field field) { }
+        public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, System.Collections.Generic.IEnumerable<GraphQL.Types.IQueryArgument> definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
+        public static GraphQL.Types.IFieldType GetFieldDefinition(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Types.IObjectGraphType parentType, GraphQL.Language.AST.Field field) { }
         public static GraphQL.Types.IObjectGraphType GetOperationRootType(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.Operation operation) { }
         public static object GetVariableValue(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinition variable, object input) { }
         public static GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions variableDefinitions, GraphQL.Inputs inputs) { }
@@ -607,9 +605,9 @@ namespace GraphQL.Execution
     }
     public abstract class ExecutionNode
     {
-        protected ExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        protected ExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode) { }
         public GraphQL.Language.AST.Field Field { get; }
-        public GraphQL.Types.FieldType FieldDefinition { get; }
+        public GraphQL.Types.IFieldType FieldDefinition { get; }
         public GraphQL.Types.IGraphType GraphType { get; }
         public int? IndexInParentNode { get; set; }
         public bool IsResultSet { get; }
@@ -629,7 +627,7 @@ namespace GraphQL.Execution
         protected abstract System.Threading.Tasks.Task ExecuteNodeTreeAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode rootNode);
         protected virtual System.Threading.Tasks.Task OnBeforeExecutionStepAwaitedAsync(GraphQL.Execution.ExecutionContext context) { }
         protected virtual void ValidateNodeResult(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
-        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode = default) { }
+        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode = default) { }
         public static GraphQL.Execution.RootExecutionNode BuildExecutionRootNode(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IObjectGraphType rootType) { }
         public static void SetArrayItemNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ArrayExecutionNode parent) { }
         public static void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent) { }
@@ -678,7 +676,7 @@ namespace GraphQL.Execution
     }
     public class ObjectExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {
-        public ObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode) { }
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ExecutionNode> SubFields { get; set; }
         public GraphQL.Types.IObjectGraphType GetObjectGraphType(GraphQL.Types.ISchema schema) { }
         public override object ToValue() { }
@@ -715,7 +713,7 @@ namespace GraphQL.Execution
     }
     public class ValueExecutionNode : GraphQL.Execution.ExecutionNode
     {
-        public ValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.IFieldType fieldDefinition, int? indexInParentNode) { }
         public override object ToValue() { }
     }
 }
@@ -867,7 +865,7 @@ namespace GraphQL.Introspection
     public class DefaultSchemaFilter : GraphQL.Introspection.ISchemaFilter
     {
         public DefaultSchemaFilter() { }
-        public virtual System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.QueryArgument argument) { }
+        public virtual System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.IQueryArgument argument) { }
         public virtual System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.DirectiveGraphType directive) { }
         public virtual System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue) { }
         public virtual System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field) { }
@@ -875,7 +873,7 @@ namespace GraphQL.Introspection
     }
     public interface ISchemaFilter
     {
-        System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.QueryArgument argument);
+        System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.IQueryArgument argument);
         System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.DirectiveGraphType directive);
         System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue);
         System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field);
@@ -1590,12 +1588,12 @@ namespace GraphQL.Types
         public System.Collections.Generic.IEnumerable<GraphQL.Types.FieldType> Fields { get; }
         public virtual GraphQL.Types.FieldType AddField(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>()
-            where TNodeType : GraphQL.Types.IGraphType { }
+            where TNodeType : GraphQL.Types.GraphType { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
-            where TNodeType : GraphQL.Types.IGraphType
+            where TNodeType : GraphQL.Types.GraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
-            where TNodeType : GraphQL.Types.IGraphType
+            where TNodeType : GraphQL.Types.GraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
         public GraphQL.Types.FieldType Field(System.Type type, string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, string deprecationReason = null) { }
@@ -1652,11 +1650,11 @@ namespace GraphQL.Types
         public static readonly GraphQL.Types.GraphQLDeprecatedDirective Deprecated;
         public static readonly GraphQL.Types.IncludeDirective Include;
         public static readonly GraphQL.Types.SkipDirective Skip;
-        public DirectiveGraphType(string name, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveLocation> locations) { }
-        public GraphQL.Types.QueryArguments Arguments { get; set; }
-        public string Description { get; set; }
-        public System.Collections.Generic.List<GraphQL.Types.DirectiveLocation> Locations { get; }
-        public string Name { get; set; }
+        public DirectiveGraphType(string name, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveLocation> locations, string description = null, System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments = null) { }
+        public virtual System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> Arguments { get; set; }
+        public virtual string Description { get; set; }
+        public virtual System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveLocation> Locations { get; set; }
+        public virtual string Name { get; set; }
     }
     public enum DirectiveLocation
     {
@@ -1736,7 +1734,7 @@ namespace GraphQL.Types
         public GraphQL.Resolvers.IAsyncEventStreamResolver AsyncSubscriber { get; set; }
         public GraphQL.Resolvers.IEventStreamResolver Subscriber { get; set; }
     }
-    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
+    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
         public FieldType() { }
         public GraphQL.Types.QueryArguments Arguments { get; set; }
@@ -1828,18 +1826,15 @@ namespace GraphQL.Types
         GraphQL.Types.FieldType GetField(string name);
         bool HasField(string name);
     }
-    public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
+    public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
-        GraphQL.Types.QueryArguments Arguments { get; set; }
-        string DeprecationReason { get; set; }
-        string Description { get; set; }
-        string Name { get; set; }
+        System.Collections.Generic.IEnumerable<GraphQL.Types.IQueryArgument> Arguments { get; }
+        string DeprecationReason { get; }
+        GraphQL.Resolvers.IFieldResolver Resolver { get; }
     }
     public interface IGraphType : GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
-        string DeprecationReason { get; set; }
-        string Description { get; set; }
-        string CollectTypes(GraphQL.Types.TypeCollectionContext context);
+        string DeprecationReason { get; }
     }
     public interface IHaveDefaultValue
     {
@@ -1856,7 +1851,8 @@ namespace GraphQL.Types
     public interface IInterfaceGraphType : GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata { }
     public interface INamedType
     {
-        string Name { get; set; }
+        string Description { get; }
+        string Name { get; }
     }
     public interface IObjectGraphType : GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata
     {
@@ -1865,37 +1861,30 @@ namespace GraphQL.Types
     }
     public interface IProvideMetadata
     {
-        System.Collections.Generic.IDictionary<string, object> Metadata { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object> Metadata { get; }
         TType GetMetadata<TType>(string key, System.Func<TType> defaultValueFactory);
         TType GetMetadata<TType>(string key, TType defaultValue = default);
         bool HasMetadata(string key);
     }
+    public interface IQueryArgument : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata { }
     public interface ISchema
     {
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AllTypes { get; }
-        System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> Directives { get; set; }
+        System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> Directives { get; }
         GraphQL.Introspection.ISchemaFilter Filter { get; set; }
         bool Initialized { get; }
-        GraphQL.Types.IObjectGraphType Mutation { get; set; }
-        GraphQL.Conversion.INameConverter NameConverter { get; set; }
-        GraphQL.Types.IObjectGraphType Query { get; set; }
-        GraphQL.Types.FieldType SchemaMetaFieldType { get; }
-        GraphQL.Types.IObjectGraphType Subscription { get; set; }
-        GraphQL.Types.FieldType TypeMetaFieldType { get; }
-        GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
+        GraphQL.Types.IObjectGraphType Mutation { get; }
+        GraphQL.Conversion.INameConverter NameConverter { get; }
+        GraphQL.Types.IObjectGraphType Query { get; }
+        GraphQL.Types.IFieldType SchemaMetaFieldType { get; }
+        GraphQL.Types.IObjectGraphType Subscription { get; }
+        GraphQL.Types.IFieldType TypeMetaFieldType { get; }
+        GraphQL.Types.IFieldType TypeNameMetaFieldType { get; }
         GraphQL.Types.DirectiveGraphType FindDirective(string name);
         GraphQL.Types.IGraphType FindType(string name);
         GraphQL.Types.IAstFromValueConverter FindValueConverter(object value, GraphQL.Types.IGraphType type);
         void Initialize();
-        void RegisterDirective(GraphQL.Types.DirectiveGraphType directive);
-        void RegisterDirectives(params GraphQL.Types.DirectiveGraphType[] directives);
-        void RegisterType(GraphQL.Types.IGraphType type);
-        void RegisterType<T>()
-            where T : GraphQL.Types.IGraphType;
-        void RegisterTypes(params GraphQL.Types.IGraphType[] types);
-        void RegisterTypes(params System.Type[] types);
-        void RegisterValueConverter(GraphQL.Types.IAstFromValueConverter converter);
     }
     public class IdGraphType : GraphQL.Types.ScalarGraphType
     {
@@ -1936,15 +1925,15 @@ namespace GraphQL.Types
     }
     public class ListGraphType : GraphQL.Types.GraphType
     {
-        public ListGraphType(GraphQL.Types.IGraphType type) { }
+        public ListGraphType(GraphQL.Types.GraphType type) { }
         protected ListGraphType(System.Type type) { }
-        public GraphQL.Types.IGraphType ResolvedType { get; set; }
+        public GraphQL.Types.GraphType ResolvedType { get; set; }
         public System.Type Type { get; }
         public override string CollectTypes(GraphQL.Types.TypeCollectionContext context) { }
         public override string ToString() { }
     }
     public class ListGraphType<T> : GraphQL.Types.ListGraphType
-        where T : GraphQL.Types.IGraphType
+        where T : GraphQL.Types.GraphType
     {
         public ListGraphType() { }
     }
@@ -1957,9 +1946,9 @@ namespace GraphQL.Types
     }
     public class NonNullGraphType : GraphQL.Types.GraphType
     {
-        public NonNullGraphType(GraphQL.Types.IGraphType type) { }
+        public NonNullGraphType(GraphQL.Types.GraphType type) { }
         protected NonNullGraphType(System.Type type) { }
-        public GraphQL.Types.IGraphType ResolvedType { get; set; }
+        public GraphQL.Types.GraphType ResolvedType { get; set; }
         public System.Type Type { get; }
         public override string CollectTypes(GraphQL.Types.TypeCollectionContext context) { }
         public override string ToString() { }
@@ -1989,7 +1978,7 @@ namespace GraphQL.Types
         public void Interface<TInterface>()
             where TInterface : GraphQL.Types.IInterfaceGraphType { }
     }
-    public class QueryArgument : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IHaveDefaultValue
+    public class QueryArgument : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata, GraphQL.Types.IQueryArgument
     {
         public QueryArgument(GraphQL.Types.IGraphType type) { }
         public QueryArgument(System.Type type) { }
@@ -2004,15 +1993,20 @@ namespace GraphQL.Types
     {
         public QueryArgument() { }
     }
-    public class QueryArguments : System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument>, System.Collections.IEnumerable
+    public class QueryArguments : System.Collections.Generic.List<GraphQL.Types.QueryArgument>
     {
         public QueryArguments(params GraphQL.Types.QueryArgument[] args) { }
         public QueryArguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> list) { }
-        public int Count { get; }
         public GraphQL.Types.QueryArgument this[int index] { get; set; }
         public void Add(GraphQL.Types.QueryArgument argument) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
         public GraphQL.Types.QueryArgument Find(string name) { }
-        public System.Collections.Generic.IEnumerator<GraphQL.Types.QueryArgument> GetEnumerator() { }
+        public void Insert(int index, GraphQL.Types.QueryArgument argument) { }
+        public void InsertRange(int index, System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
+    }
+    public static class QueryArgumentsExtensions
+    {
+        public static GraphQL.Types.IQueryArgument Find(this System.Collections.Generic.IEnumerable<GraphQL.Types.IQueryArgument> list, string name) { }
     }
     public class SByteGraphType : GraphQL.Types.ScalarGraphType
     {
@@ -2040,10 +2034,10 @@ namespace GraphQL.Types
         public GraphQL.Types.IObjectGraphType Mutation { get; set; }
         public GraphQL.Conversion.INameConverter NameConverter { get; set; }
         public GraphQL.Types.IObjectGraphType Query { get; set; }
-        public GraphQL.Types.FieldType SchemaMetaFieldType { get; }
+        public GraphQL.Types.IFieldType SchemaMetaFieldType { get; }
         public GraphQL.Types.IObjectGraphType Subscription { get; set; }
-        public GraphQL.Types.FieldType TypeMetaFieldType { get; }
-        public GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
+        public GraphQL.Types.IFieldType TypeMetaFieldType { get; }
+        public GraphQL.Types.IFieldType TypeNameMetaFieldType { get; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public GraphQL.Types.DirectiveGraphType FindDirective(string name) { }
@@ -2149,12 +2143,12 @@ namespace GraphQL.Types
 namespace GraphQL.Types.Relay
 {
     public class ConnectionType<TNodeType> : GraphQL.Types.Relay.ConnectionType<TNodeType, GraphQL.Types.Relay.EdgeType<TNodeType>>
-        where TNodeType : GraphQL.Types.IGraphType
+        where TNodeType : GraphQL.Types.GraphType
     {
         public ConnectionType() { }
     }
     public class ConnectionType<TNodeType, TEdgeType> : GraphQL.Types.ObjectGraphType<object>
-        where TNodeType : GraphQL.Types.IGraphType
+        where TNodeType : GraphQL.Types.GraphType
         where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
     {
         public ConnectionType() { }
@@ -2316,7 +2310,7 @@ namespace GraphQL.Utilities
     public class MetadataProvider : GraphQL.Types.IProvideMetadata
     {
         public MetadataProvider() { }
-        public System.Collections.Generic.IDictionary<string, object> Metadata { get; set; }
+        public System.Collections.Concurrent.ConcurrentDictionary<string, object> Metadata { get; set; }
         public TType GetMetadata<TType>(string key, System.Func<TType> defaultValueFactory) { }
         public TType GetMetadata<TType>(string key, TType defaultValue = default) { }
         public bool HasMetadata(string key) { }
@@ -2346,9 +2340,9 @@ namespace GraphQL.Utilities
         public System.Collections.Generic.IDictionary<string, System.Type> Directives { get; }
         public System.IServiceProvider ServiceProvider { get; set; }
         public GraphQL.Utilities.TypeSettings Types { get; }
-        public virtual GraphQL.Types.ISchema Build(string[] typeDefinitions) { }
-        public virtual GraphQL.Types.ISchema Build(string typeDefinitions) { }
-        protected virtual void CopyMetadata(GraphQL.Types.IProvideMetadata target, GraphQL.Types.IProvideMetadata source) { }
+        public virtual GraphQL.Types.Schema Build(string[] typeDefinitions) { }
+        public virtual GraphQL.Types.Schema Build(string typeDefinitions) { }
+        protected virtual void CopyMetadata(GraphQL.Utilities.MetadataProvider target, GraphQL.Types.IProvideMetadata source) { }
         protected virtual GraphQL.Types.IGraphType GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }
         public GraphQL.Utilities.SchemaBuilder RegisterDirectiveVisitor<T>(string name)
@@ -2500,7 +2494,7 @@ namespace GraphQL.Utilities.Federation
     public class FederatedSchemaBuilder : GraphQL.Utilities.SchemaBuilder
     {
         public FederatedSchemaBuilder() { }
-        public override GraphQL.Types.ISchema Build(string typeDefinitions) { }
+        public override GraphQL.Types.Schema Build(string typeDefinitions) { }
         protected override void PreConfigure(GraphQL.Types.Schema schema) { }
     }
     public class FederatedSchemaPrinter : GraphQL.Utilities.SchemaPrinter
@@ -2590,9 +2584,9 @@ namespace GraphQL.Validation
         public TypeInfo(GraphQL.Types.ISchema schema) { }
         public void Enter(GraphQL.Language.AST.INode node) { }
         public GraphQL.Language.AST.INode[] GetAncestors() { }
-        public GraphQL.Types.QueryArgument GetArgument() { }
+        public GraphQL.Types.IQueryArgument GetArgument() { }
         public GraphQL.Types.DirectiveGraphType GetDirective() { }
-        public GraphQL.Types.FieldType GetFieldDef() { }
+        public GraphQL.Types.IFieldType GetFieldDef() { }
         public GraphQL.Types.IGraphType GetInputType() { }
         public GraphQL.Types.IGraphType GetLastType() { }
         public GraphQL.Types.IGraphType GetParentType() { }

--- a/src/GraphQL.Tests/Conversion/FieldNameConverterTests.cs
+++ b/src/GraphQL.Tests/Conversion/FieldNameConverterTests.cs
@@ -60,7 +60,6 @@ namespace GraphQL.Tests.Conversion
             {
                 _.Schema = build_schema(converter);
                 _.Query = "{ PeRsoN { naME: Name } }";
-                _.NameConverter = converter;
             },
             @"{ ""PeRsoN"": { ""naME"": ""Quinn"" } }");
         }
@@ -73,7 +72,6 @@ namespace GraphQL.Tests.Conversion
             {
                 _.Schema = build_schema(converter);
                 _.Query = "{ PeRsoN { naME: Name } }";
-                _.NameConverter = converter;
             },
             @"{ ""PeRsoN"": { ""naME"": ""Quinn"" } }");
         }

--- a/src/GraphQL.Tests/Execution/Performance/ListPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/ListPerformanceTests.cs
@@ -107,6 +107,7 @@ namespace GraphQL.Tests.Execution.Performance
 
             smallListTimer.Start();
 
+            Schema.NameConverter = CamelCaseNameConverter.Instance;
             var runResult2 = await Executer.ExecuteAsync(_ =>
             {
                 _.EnableMetrics = false;
@@ -117,7 +118,6 @@ namespace GraphQL.Tests.Execution.Performance
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;
-                _.NameConverter = CamelCaseNameConverter.Instance;
             });
 
             smallListTimer.Stop();
@@ -153,7 +153,6 @@ namespace GraphQL.Tests.Execution.Performance
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;
-                _.NameConverter = CamelCaseNameConverter.Instance;
             });
 
             smallListTimer.Stop();
@@ -201,7 +200,6 @@ namespace GraphQL.Tests.Execution.Performance
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;
-                _.NameConverter = CamelCaseNameConverter.Instance;
             });
 
             smallListTimer.Stop();

--- a/src/GraphQL.Tests/Execution/Performance/StarWarsPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/StarWarsPerformanceTests.cs
@@ -51,7 +51,6 @@ namespace GraphQL.Tests.Execution.Performance
                     _.UserContext = null;
                     _.CancellationToken = default;
                     _.ValidationRules = null;
-                    _.NameConverter = CamelCaseNameConverter.Instance;
                 }).GetAwaiter().GetResult();
             }
 

--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -39,8 +39,8 @@ namespace GraphQL.Tests.Introspection
                 _.Schema = new Schema
                 {
                     Query = new TestQuery(),
+                    NameConverter = PascalCaseNameConverter.Instance,
                 };
-                _.NameConverter = PascalCaseNameConverter.Instance;
                 _.Query = SchemaIntrospection.IntrospectionQuery;
             });
 
@@ -59,8 +59,8 @@ namespace GraphQL.Tests.Introspection
                 _.Schema = new Schema
                 {
                     Query = new TestQuery(),
-                };
-                _.NameConverter = new TestNameConverter();
+                    NameConverter = new TestNameConverter(),
+            };
                 _.Query = SchemaIntrospection.IntrospectionQuery;
             });
 
@@ -71,7 +71,7 @@ namespace GraphQL.Tests.Introspection
 
         public class TestNameConverter : INameConverter
         {
-            public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => throw new Exception();
+            public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field) => throw new Exception();
 
             public string NameForField(string fieldName, IComplexGraphType parentGraphType) => throw new Exception();
         }

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -15,12 +15,12 @@ using Shouldly;
 namespace GraphQL.Tests
 {
     public class QueryTestBase<TSchema> : QueryTestBase<TSchema, GraphQLDocumentBuilder>
-        where TSchema : ISchema
+        where TSchema : Schema
     {
     }
 
     public class QueryTestBase<TSchema, TDocumentBuilder>
-        where TSchema : ISchema
+        where TSchema : Schema
         where TDocumentBuilder : IDocumentBuilder, new()
     {
         public QueryTestBase()
@@ -124,9 +124,11 @@ namespace GraphQL.Tests
             INameConverter nameConverter = null,
             IDocumentWriter writer = null)
         {
+            var schema = Schema;
+            schema.NameConverter = nameConverter ?? CamelCaseNameConverter.Instance;
             var runResult = Executer.ExecuteAsync(options =>
             {
-                options.Schema = Schema;
+                options.Schema = schema;
                 options.Query = query;
                 options.Root = root;
                 options.Inputs = inputs;
@@ -134,7 +136,6 @@ namespace GraphQL.Tests
                 options.CancellationToken = cancellationToken;
                 options.ValidationRules = rules;
                 options.UnhandledExceptionDelegate = unhandledExceptionDelegate ?? (ctx => { });
-                options.NameConverter = nameConverter ?? CamelCaseNameConverter.Instance;
             }).GetAwaiter().GetResult();
 
             writer ??= Writer;

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -9,20 +9,20 @@ namespace GraphQL.Builders
     public static class ConnectionBuilder
     {
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
         {
             return ConnectionBuilder<TSourceType>.Create<TNodeType>();
         }
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
             where TEdgeType : EdgeType<TNodeType>
         {
             return ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>();
         }
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>
         {
@@ -53,20 +53,20 @@ namespace GraphQL.Builders
         }
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
         {
             return Create<TNodeType, EdgeType<TNodeType>>(name);
         }
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
             where TEdgeType : EdgeType<TNodeType>
         {
             return Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
         }
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>
         {

--- a/src/GraphQL/Conversion/CamelCaseNameConverter.cs
+++ b/src/GraphQL/Conversion/CamelCaseNameConverter.cs
@@ -22,6 +22,6 @@ namespace GraphQL.Conversion
         /// <summary>
         /// Returns the argument name converted to camelCase.
         /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName.ToCamelCase();
+        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field) => argumentName.ToCamelCase();
     }
 }

--- a/src/GraphQL/Conversion/DefaultNameConverter.cs
+++ b/src/GraphQL/Conversion/DefaultNameConverter.cs
@@ -21,6 +21,6 @@ namespace GraphQL.Conversion
         /// <summary>
         /// Returns the argument name without modification
         /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName;
+        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field) => argumentName;
     }
 }

--- a/src/GraphQL/Conversion/INameConverter.cs
+++ b/src/GraphQL/Conversion/INameConverter.cs
@@ -21,6 +21,6 @@ namespace GraphQL.Conversion
         /// <summary>
         /// Sanitizes an argument name for a specified parent graph type and field definition; returns the updated field name
         /// </summary>
-        string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field);
+        string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field);
     }
 }

--- a/src/GraphQL/Conversion/PascalCaseNameConverter.cs
+++ b/src/GraphQL/Conversion/PascalCaseNameConverter.cs
@@ -21,6 +21,6 @@ namespace GraphQL.Conversion
         /// <summary>
         /// Returns the argument name converted to PascalCase.
         /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName.ToPascalCase();
+        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, IFieldType field) => argumentName.ToPascalCase();
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -65,9 +65,6 @@ namespace GraphQL
 
             var metrics = new Metrics(options.EnableMetrics).Start(options.OperationName);
 
-            options.Schema.NameConverter = options.NameConverter;
-            options.Schema.Filter = options.SchemaFilter;
-
             ExecutionResult result = null;
             ExecutionContext context = null;
 

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -50,19 +50,25 @@ namespace GraphQL.Execution
             return type;
         }
 
-        public static FieldType GetFieldDefinition(Document document, ISchema schema, IObjectGraphType parentType, Field field)
+        public static IFieldType GetFieldDefinition(Document document, ISchema schema, IObjectGraphType parentType, Field field)
         {
-            if (field.Name == schema.SchemaMetaFieldType.Name && schema.Query == parentType)
+            if (schema.Query == parentType)
             {
-                return schema.SchemaMetaFieldType;
+                var schemaMeta = schema.SchemaMetaFieldType;
+                if (field.Name == schemaMeta.Name && schema.Query == parentType)
+                {
+                    return schemaMeta;
+                }
+                var typeMeta = schema.TypeMetaFieldType;
+                if (field.Name == typeMeta.Name && schema.Query == parentType)
+                {
+                    return typeMeta;
+                }
             }
-            if (field.Name == schema.TypeMetaFieldType.Name && schema.Query == parentType)
+            var typeNameMeta = schema.TypeNameMetaFieldType;
+            if (field.Name == typeNameMeta.Name)
             {
-                return schema.TypeMetaFieldType;
-            }
-            if (field.Name == schema.TypeNameMetaFieldType.Name)
-            {
-                return schema.TypeNameMetaFieldType;
+                return typeNameMeta;
             }
 
             if (parentType == null)
@@ -213,16 +219,16 @@ namespace GraphQL.Execution
             return scalar.ParseValue(input);
         }
 
-        public static Dictionary<string, object> GetArgumentValues(ISchema schema, QueryArguments definitionArguments, Arguments astArguments, Variables variables)
+        public static Dictionary<string, object> GetArgumentValues(ISchema schema, IEnumerable<IQueryArgument> definitionArguments, Arguments astArguments, Variables variables)
         {
-            if (definitionArguments == null || definitionArguments.Count == 0)
+            if (definitionArguments == null || definitionArguments.Count() == 0)
             {
                 return null;
             }
 
-            var values = new Dictionary<string, object>(definitionArguments.Count);
+            var values = new Dictionary<string, object>(definitionArguments.Count());
 
-            foreach (var arg in definitionArguments.ArgumentsList)
+            foreach (var arg in definitionArguments)
             {
                 var value = astArguments?.ValueFor(arg.Name);
                 var type = arg.ResolvedType;

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Execution
         public ExecutionNode Parent { get; }
         public IGraphType GraphType { get; }
         public Field Field { get; }
-        public FieldType FieldDefinition { get; }
+        public IFieldType FieldDefinition { get; }
         public int? IndexInParentNode { get; protected set; }
 
         public string Name => Field?.Alias ?? Field?.Name;
@@ -36,7 +36,7 @@ namespace GraphQL.Execution
             set => _source = value;
         }
 
-        protected ExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        protected ExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode)
         {
             Parent = parent;
             GraphType = graphType;
@@ -119,7 +119,7 @@ namespace GraphQL.Execution
     {
         public IDictionary<string, ExecutionNode> SubFields { get; set; }
 
-        public ObjectExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        public ObjectExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode)
             : base(parent, graphType, field, fieldDefinition, indexInParentNode)
         {
         }
@@ -175,7 +175,7 @@ namespace GraphQL.Execution
     {
         public List<ExecutionNode> Items { get; set; }
 
-        public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode)
             : base(parent, graphType, field, fieldDefinition, indexInParentNode)
         {
 
@@ -217,7 +217,7 @@ namespace GraphQL.Execution
 
     public class ValueExecutionNode : ExecutionNode
     {
-        public ValueExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        public ValueExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode)
             : base(parent, graphType, field, fieldDefinition, indexInParentNode)
         {
 

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -58,9 +58,6 @@ namespace GraphQL
         /// <summary>A list of <see cref="IDocumentExecutionListener"/>s, enabling code to be executed at various points during the processing of the GraphQL query</summary>
         public List<IDocumentExecutionListener> Listeners { get; } = new List<IDocumentExecutionListener>();
 
-        /// <summary>Field and argument names are sanitized by the provided <see cref="INameConverter"/>; defaults to <see cref="CamelCaseNameConverter"/></summary>
-        public INameConverter NameConverter { get; set; } = CamelCaseNameConverter.Instance;
-
         /// <summary>Allows unhandled <see cref="Exception"/> stack traces to be serialized into GraphQL query result json along with exception messages; defaults to only <see cref="Exception.Message"/></summary>
         public bool ExposeExceptions { get; set; }
 
@@ -79,8 +76,5 @@ namespace GraphQL
 
         /// <summary>If set, limits the maximum number of nodes executed in parallel</summary>
         public int? MaxParallelExecutionCount { get; set; }
-
-        /// <summary>Provides the ability to filter the schema upon introspection to hide types; by default no types are hidden.</summary>
-        public ISchemaFilter SchemaFilter { get; set; } = new DefaultSchemaFilter();
     }
 }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -147,7 +147,7 @@ namespace GraphQL.Execution
             parent.Items = arrayItems;
         }
 
-        public static ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode = null)
+        public static ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, IFieldType fieldDefinition, int? indexInParentNode = null)
         {
             if (graphType is NonNullGraphType nonNullFieldType)
                 graphType = nonNullFieldType.ResolvedType;

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -134,14 +134,14 @@ namespace GraphQL
                 if (type.GetGenericTypeDefinition() == typeof(NonNullGraphType<>))
                 {
                     var nonNull = (NonNullGraphType)Activator.CreateInstance(type);
-                    nonNull.ResolvedType = BuildNamedType(type.GenericTypeArguments[0], resolve);
+                    nonNull.ResolvedType = (GraphType)BuildNamedType(type.GenericTypeArguments[0], resolve); //ugly hack
                     return nonNull;
                 }
 
                 if (type.GetGenericTypeDefinition() == typeof(ListGraphType<>))
                 {
                     var list = (ListGraphType)Activator.CreateInstance(type);
-                    list.ResolvedType = BuildNamedType(type.GenericTypeArguments[0], resolve);
+                    list.ResolvedType = (GraphType)BuildNamedType(type.GenericTypeArguments[0], resolve); //ugly hack
                     return list;
                 }
             }
@@ -277,7 +277,7 @@ namespace GraphQL
         }
 
         public static TMetadataProvider WithMetadata<TMetadataProvider>(this TMetadataProvider provider, string key, object value)
-            where TMetadataProvider : IProvideMetadata
+            where TMetadataProvider : MetadataProvider
         {
             provider.Metadata[key] = value;
             return provider;

--- a/src/GraphQL/Introspection/ISchemaFilter.cs
+++ b/src/GraphQL/Introspection/ISchemaFilter.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Introspection
     {
         Task<bool> AllowType(IGraphType type);
         Task<bool> AllowField(IGraphType parent, IFieldType field);
-        Task<bool> AllowArgument(IFieldType field, QueryArgument argument);
+        Task<bool> AllowArgument(IFieldType field, IQueryArgument argument);
         Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue);
         Task<bool> AllowDirective(DirectiveGraphType directive);
     }
@@ -24,7 +24,7 @@ namespace GraphQL.Introspection
             return Task.FromResult(true);
         }
 
-        public virtual Task<bool> AllowArgument(IFieldType field, QueryArgument argument)
+        public virtual Task<bool> AllowArgument(IFieldType field, IQueryArgument argument)
         {
             return Task.FromResult(true);
         }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -22,7 +22,7 @@ namespace GraphQL
         Field FieldAst { get; }
 
         /// <summary>The <see cref="FieldType"/> definition specified in the parent graph type</summary>
-        FieldType FieldDefinition { get; }
+        IFieldType FieldDefinition { get; }
 
         /// <summary>The return value's graph type</summary>
         IGraphType ReturnType { get; }

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -36,7 +36,7 @@ namespace GraphQL
 
         public Language.AST.Field FieldAst => _executionNode.Field;
 
-        public FieldType FieldDefinition => _executionNode.FieldDefinition;
+        public IFieldType FieldDefinition => _executionNode.FieldDefinition;
 
         public IGraphType ReturnType => _executionNode.FieldDefinition.ResolvedType;
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -18,7 +18,7 @@ namespace GraphQL
 
         public Field FieldAst { get; set; }
 
-        public FieldType FieldDefinition { get; set; }
+        public IFieldType FieldDefinition { get; set; }
 
         public IGraphType ReturnType { get; set; }
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -39,7 +39,7 @@ namespace GraphQL
 
         public Language.AST.Field FieldAst => _baseContext.FieldAst;
 
-        public FieldType FieldDefinition => _baseContext.FieldDefinition;
+        public IFieldType FieldDefinition => _baseContext.FieldDefinition;
 
         public IGraphType ReturnType => _baseContext.ReturnType;
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -72,7 +72,7 @@ namespace GraphQL
         /// <summary>
         /// Determines if this field is an introspection field (__schema, __type, __typename) -- but not if it is a field of an introspection type
         /// </summary>
-        private static bool IsIntrospectionField(this FieldType fieldType) => fieldType?.Name?.StartsWith("__") ?? false;
+        private static bool IsIntrospectionField(this IFieldType fieldType) => fieldType?.Name?.StartsWith("__") ?? false;
 
         /// <summary>Returns the <see cref="IResolveFieldContext"/> typed as an <see cref="IResolveFieldContext{TSource}"/></summary>
         /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -341,7 +341,7 @@ namespace GraphQL.Types
         }
 
         public ConnectionBuilder<TSourceType> Connection<TNodeType>()
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
         {
             var builder = ConnectionBuilder.Create<TNodeType, TSourceType>();
             AddField(builder.FieldType);
@@ -349,7 +349,7 @@ namespace GraphQL.Types
         }
 
         public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
             where TEdgeType : EdgeType<TNodeType>
         {
             var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TSourceType>();
@@ -358,7 +358,7 @@ namespace GraphQL.Types
         }
 
         public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
-            where TNodeType : IGraphType
+            where TNodeType : GraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>
         {

--- a/src/GraphQL/Types/Composite/ListGraphType.cs
+++ b/src/GraphQL/Types/Composite/ListGraphType.cs
@@ -3,7 +3,7 @@ using System;
 namespace GraphQL.Types
 {
     public class ListGraphType<T> : ListGraphType
-        where T : IGraphType
+        where T : GraphType
     {
         public ListGraphType()
             : base(typeof(T))
@@ -13,7 +13,7 @@ namespace GraphQL.Types
 
     public class ListGraphType : GraphType
     {
-        public ListGraphType(IGraphType type)
+        public ListGraphType(GraphType type)
         {
             ResolvedType = type;
         }
@@ -25,13 +25,13 @@ namespace GraphQL.Types
 
         public Type Type { get; private set; }
 
-        public IGraphType ResolvedType { get; set; }
+        public GraphType ResolvedType { get; set; }
 
         public override string CollectTypes(TypeCollectionContext context)
         {
             var innerType = context.ResolveType(Type);
-            ResolvedType = innerType;
-            var name = innerType.CollectTypes(context);
+            ResolvedType = (GraphType)innerType; //ugly hack
+            var name = ResolvedType.CollectTypes(context);
             context.AddType(name, innerType, context);
             return "[{0}]".ToFormat(name);
         }

--- a/src/GraphQL/Types/Composite/NonNullGraphType.cs
+++ b/src/GraphQL/Types/Composite/NonNullGraphType.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Types
 
     public class NonNullGraphType : GraphType
     {
-        public NonNullGraphType(IGraphType type)
+        public NonNullGraphType(GraphType type)
         {
             if (type is NonNullGraphType)
             {
@@ -35,13 +35,13 @@ namespace GraphQL.Types
 
         public Type Type { get; private set; }
 
-        public IGraphType ResolvedType { get; set; }
+        public GraphType ResolvedType { get; set; }
 
         public override string CollectTypes(TypeCollectionContext context)
         {
             var innerType = context.ResolveType(Type);
-            ResolvedType = innerType;
-            var name = innerType.CollectTypes(context);
+            ResolvedType = (GraphType)innerType; //ugly hack
+            var name = ResolvedType.CollectTypes(context);
             context.AddType(name, innerType, context);
             return "{0}!".ToFormat(name);
         }

--- a/src/GraphQL/Types/DirectiveGraphType.cs
+++ b/src/GraphQL/Types/DirectiveGraphType.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace GraphQL.Types
 {
@@ -63,22 +64,24 @@ namespace GraphQL.Types
         public static readonly SkipDirective Skip = new SkipDirective();
         public static readonly GraphQLDeprecatedDirective Deprecated = new GraphQLDeprecatedDirective();
 
-        public DirectiveGraphType(string name, IEnumerable<DirectiveLocation> locations)
+        public DirectiveGraphType(string name, IEnumerable<DirectiveLocation> locations, string description = null, IEnumerable<QueryArgument> arguments = null)
         {
-            Name = name;
-            Locations.AddRange(locations);
-
-            if (Locations.Count == 0)
+            if (locations.Count() == 0)
                 throw new ArgumentException("Directive must have locations", nameof(locations));
+
+            Name = name;
+            Locations = locations;
+            Description = description;
+            Arguments = arguments;
         }
 
-        public string Name { get; set; }
+        public virtual string Name { get; protected set; }
 
-        public string Description { get; set; }
+        public virtual string Description { get; protected set; }
 
-        public QueryArguments Arguments { get; set; }
+        public virtual IEnumerable<QueryArgument> Arguments { get; protected set; }
 
-        public List<DirectiveLocation> Locations { get; } = new List<DirectiveLocation>();
+        public virtual IEnumerable<DirectiveLocation> Locations { get; protected set; }
     }
 
     /// <summary>

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -2,6 +2,7 @@ using GraphQL.Resolvers;
 using System;
 using System.Diagnostics;
 using GraphQL.Utilities;
+using System.Collections.Generic;
 
 namespace GraphQL.Types
 {
@@ -23,5 +24,7 @@ namespace GraphQL.Types
         public QueryArguments Arguments { get; set; }
 
         public IFieldResolver Resolver { get; set; }
+
+        IEnumerable<IQueryArgument> IFieldType.Arguments => Arguments;
     }
 }

--- a/src/GraphQL/Types/Fields/IFieldType.cs
+++ b/src/GraphQL/Types/Fields/IFieldType.cs
@@ -1,13 +1,14 @@
+using System.Collections.Generic;
+using GraphQL.Resolvers;
+
 namespace GraphQL.Types
 {
-    public interface IFieldType : IHaveDefaultValue, IProvideMetadata
+    public interface IFieldType : IHaveDefaultValue, IProvideMetadata, INamedType
     {
-        string Name { get; set; }
+        string DeprecationReason { get; }
 
-        string Description { get; set; }
+        IEnumerable<IQueryArgument> Arguments { get; }
 
-        string DeprecationReason { get; set; }
-
-        QueryArguments Arguments { get; set; }
+        IFieldResolver Resolver { get; }
     }
 }

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -235,7 +235,8 @@ namespace GraphQL.Types
                 throw new ExecutionError("Only add root types.");
             }
 
-            var name = type.CollectTypes(context).TrimGraphQLTypes();
+            var graphType = (GraphType)type; //ugly hack
+            var name = graphType.CollectTypes(context).TrimGraphQLTypes();
             lock (_lock)
             {
                 SetGraphType(name, type);
@@ -500,13 +501,13 @@ Make sure that your ServiceProvider is configured correctly.");
         {
             if (type is NonNullGraphType nonNull)
             {
-                nonNull.ResolvedType = ConvertTypeReference(parentType, nonNull.ResolvedType);
+                nonNull.ResolvedType = (GraphType)ConvertTypeReference(parentType, nonNull.ResolvedType); //ugly hack
                 return nonNull;
             }
 
             if (type is ListGraphType list)
             {
-                list.ResolvedType = ConvertTypeReference(parentType, list.ResolvedType);
+                list.ResolvedType = (GraphType)ConvertTypeReference(parentType, list.ResolvedType); //ugly hack
                 return list;
             }
 

--- a/src/GraphQL/Types/IGraphType.cs
+++ b/src/GraphQL/Types/IGraphType.cs
@@ -1,15 +1,7 @@
-﻿namespace GraphQL.Types
+namespace GraphQL.Types
 {
-    public interface INamedType
-    {
-        string Name { get; set; }
-    }
-
     public interface IGraphType : IProvideMetadata, INamedType
     {
-        string Description { get; set; }
-        string DeprecationReason { get; set; }
-
-        string CollectTypes(TypeCollectionContext context);
+        string DeprecationReason { get; }
     }
 }

--- a/src/GraphQL/Types/INamedType.cs
+++ b/src/GraphQL/Types/INamedType.cs
@@ -1,0 +1,9 @@
+namespace GraphQL.Types
+{
+    public interface INamedType
+    {
+        string Name { get; }
+
+        string Description { get; }
+    }
+}

--- a/src/GraphQL/Types/IProvideMetadata.cs
+++ b/src/GraphQL/Types/IProvideMetadata.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types
 {
     public interface IProvideMetadata
     {
-        IDictionary<string, object> Metadata { get; }
+        IReadOnlyDictionary<string, object> Metadata { get; }
         TType GetMetadata<TType>(string key, TType defaultValue = default);
         TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory);
         bool HasMetadata(string key);

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -29,22 +29,22 @@ namespace GraphQL.Types
         /// <summary>
         /// The <see cref="INameConverter"/> used by the schema. This is set by <see cref="IDocumentExecuter"/> to the converter passed to it within <see cref="ExecutionOptions.NameConverter"/>.
         /// </summary>
-        INameConverter NameConverter { get; set; }
+        INameConverter NameConverter { get; }
 
         /// <summary>
         /// The 'query' base graph type; required
         /// </summary>
-        IObjectGraphType Query { get; set; }
+        IObjectGraphType Query { get; }
 
         /// <summary>
         /// The 'mutation' base graph type; optional
         /// </summary>
-        IObjectGraphType Mutation { get; set; }
+        IObjectGraphType Mutation { get; }
 
         /// <summary>
         /// The 'subscription' base graph type; optional
         /// </summary>
-        IObjectGraphType Subscription { get; set; }
+        IObjectGraphType Subscription { get; }
 
         /// <summary>
         /// Returns a list of directives supported by the schema.
@@ -54,7 +54,7 @@ namespace GraphQL.Types
         /// <br/><br/>
         /// <see cref="Schema"/> initializes the list to include <see cref="DirectiveGraphType.Include"/>, <see cref="DirectiveGraphType.Skip"/> and <see cref="DirectiveGraphType.Deprecated"/> by default.
         /// </summary>
-        IEnumerable<DirectiveGraphType> Directives { get; set; }
+        IEnumerable<DirectiveGraphType> Directives { get; }
 
         /// <summary>
         /// Returns a list of all the graph types utilized by this schema
@@ -77,59 +77,6 @@ namespace GraphQL.Types
         IEnumerable<Type> AdditionalTypes { get; }
 
         /// <summary>
-        /// Add a specific instance of an <see cref="IGraphType"/> to the schema.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
-        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        void RegisterType(IGraphType type);
-
-        /// <summary>
-        /// Add specific instances of <see cref="IGraphType"/>s to the schema.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
-        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        void RegisterTypes(params IGraphType[] types);
-
-        /// <summary>
-        /// Add specific graph types to the schema. Each type must implement <see cref="IGraphType"/>.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
-        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        void RegisterTypes(params Type[] types);
-
-        /// <summary>
-        /// Add a specific graph type to the schema.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
-        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        void RegisterType<T>() where T : IGraphType;
-
-        /// <summary>
-        /// Add a specific directive to the schema.
-        /// <br/><br/>
-        /// Directives are used by the GraphQL runtime as a way of modifying execution
-        /// behavior. Type system creators do not usually create them directly.
-        /// </summary>
-        void RegisterDirective(DirectiveGraphType directive);
-
-        /// <summary>
-        /// Add specific directives to the schema.
-        /// <br/><br/>
-        /// Directives are used by the GraphQL runtime as a way of modifying execution
-        /// behavior. Type system creators do not usually create them directly.
-        /// </summary>
-        void RegisterDirectives(params DirectiveGraphType[] directives);
-
-        /// <summary>
-        /// Register a custom value converter to the schema.
-        /// </summary>
-        void RegisterValueConverter(IAstFromValueConverter converter);
-
-        /// <summary>
         /// Search the schema for a <see cref="IAstFromValueConverter"/> that matches the provided object and graph type, and return the converter.
         /// </summary>
         IAstFromValueConverter FindValueConverter(object value, IGraphType type);
@@ -145,16 +92,16 @@ namespace GraphQL.Types
         /// <summary>
         /// Returns a reference to the __schema introspection field available on the query graph type
         /// </summary>
-        FieldType SchemaMetaFieldType { get; }
+        IFieldType SchemaMetaFieldType { get; }
 
         /// <summary>
         /// Returns a reference to the __type introspection field available on the query graph type
         /// </summary>
-        FieldType TypeMetaFieldType { get; }
+        IFieldType TypeMetaFieldType { get; }
 
         /// <summary>
         /// Returns a reference to the __typename introspection field available on any object, interface, or union graph type
         /// </summary>
-        FieldType TypeNameMetaFieldType { get; }
+        IFieldType TypeNameMetaFieldType { get; }
     }
 }

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -4,6 +4,10 @@ using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
+    public interface IQueryArgument : IProvideMetadata, IHaveDefaultValue, INamedType
+    {
+    }
+
     public class QueryArgument<TType> : QueryArgument
         where TType : IGraphType
     {
@@ -14,7 +18,7 @@ namespace GraphQL.Types
     }
 
     [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
-    public class QueryArgument : MetadataProvider, IHaveDefaultValue
+    public class QueryArgument : MetadataProvider, IHaveDefaultValue, IQueryArgument
     {
         private Type _type;
         private IGraphType _resolvedType;

--- a/src/GraphQL/Types/Relay/ConnectionType.cs
+++ b/src/GraphQL/Types/Relay/ConnectionType.cs
@@ -1,7 +1,7 @@
 namespace GraphQL.Types.Relay
 {
     public class ConnectionType<TNodeType, TEdgeType> : ObjectGraphType<object>
-        where TNodeType : IGraphType
+        where TNodeType : GraphType
         where TEdgeType : EdgeType<TNodeType>
     {
         public ConnectionType()
@@ -39,7 +39,7 @@ namespace GraphQL.Types.Relay
     }
 
     public class ConnectionType<TNodeType> : ConnectionType<TNodeType, EdgeType<TNodeType>>
-        where TNodeType : IGraphType
+        where TNodeType : GraphType
     {
 
     }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -121,11 +121,11 @@ namespace GraphQL.Types
 
         public IEnumerable<Type> AdditionalTypes => _additionalTypes;
 
-        public FieldType SchemaMetaFieldType => _lookup?.Value.SchemaMetaFieldType;
+        public IFieldType SchemaMetaFieldType => _lookup?.Value.SchemaMetaFieldType;
 
-        public FieldType TypeMetaFieldType => _lookup?.Value.TypeMetaFieldType;
+        public IFieldType TypeMetaFieldType => _lookup?.Value.TypeMetaFieldType;
 
-        public FieldType TypeNameMetaFieldType => _lookup?.Value.TypeNameMetaFieldType;
+        public IFieldType TypeNameMetaFieldType => _lookup?.Value.TypeNameMetaFieldType;
 
         public void RegisterType(IGraphType type)
         {
@@ -134,6 +134,12 @@ namespace GraphQL.Types
             _additionalInstances.Add(type ?? throw new ArgumentNullException(nameof(type)));
         }
 
+        /// <summary>
+        /// Add specific instances of <see cref="IGraphType"/>s to the schema.
+        /// <br/><br/>
+        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+        /// </summary>
         public void RegisterTypes(params IGraphType[] types)
         {
             CheckDisposed();
@@ -142,6 +148,12 @@ namespace GraphQL.Types
                 RegisterType(type);
         }
 
+        /// <summary>
+        /// Add specific graph types to the schema. Each type must implement <see cref="IGraphType"/>.
+        /// <br/><br/>
+        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+        /// </summary>
         public void RegisterTypes(params Type[] types)
         {
             CheckDisposed();
@@ -157,6 +169,12 @@ namespace GraphQL.Types
             }
         }
 
+        /// <summary>
+        /// Add a specific graph type to the schema.
+        /// <br/><br/>
+        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+        /// </summary>
         public void RegisterType<T>() where T : IGraphType
         {
             CheckDisposed();
@@ -164,6 +182,12 @@ namespace GraphQL.Types
             RegisterType(typeof(T));
         }
 
+        /// <summary>
+        /// Add a specific directive to the schema.
+        /// <br/><br/>
+        /// Directives are used by the GraphQL runtime as a way of modifying execution
+        /// behavior. Type system creators do not usually create them directly.
+        /// </summary>
         public void RegisterDirective(DirectiveGraphType directive)
         {
             CheckDisposed();
@@ -171,6 +195,12 @@ namespace GraphQL.Types
             _directives.Add(directive ?? throw new ArgumentNullException(nameof(directive)));
         }
 
+        /// <summary>
+        /// Add specific directives to the schema.
+        /// <br/><br/>
+        /// Directives are used by the GraphQL runtime as a way of modifying execution
+        /// behavior. Type system creators do not usually create them directly.
+        /// </summary>
         public void RegisterDirectives(IEnumerable<DirectiveGraphType> directives)
         {
             CheckDisposed();
@@ -179,6 +209,12 @@ namespace GraphQL.Types
                 RegisterDirective(directive);
         }
 
+        /// <summary>
+        /// Add specific directives to the schema.
+        /// <br/><br/>
+        /// Directives are used by the GraphQL runtime as a way of modifying execution
+        /// behavior. Type system creators do not usually create them directly.
+        /// </summary>
         public void RegisterDirectives(params DirectiveGraphType[] directives)
         {
             CheckDisposed();
@@ -192,6 +228,9 @@ namespace GraphQL.Types
             return _directives.FirstOrDefault(x => x.Name == name);
         }
 
+        /// <summary>
+        /// Register a custom value converter to the schema.
+        /// </summary>
         public void RegisterValueConverter(IAstFromValueConverter converter)
         {
             CheckDisposed();

--- a/src/GraphQL/Types/TypeExtensions.cs
+++ b/src/GraphQL/Types/TypeExtensions.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Types
                 }
                 var nonnullGraphType = typeof(NonNullGraphType<>).MakeGenericType(ofType.GetType());
                 var instance = (NonNullGraphType)Activator.CreateInstance(nonnullGraphType);
-                instance.ResolvedType = ofType;
+                instance.ResolvedType = (GraphType)ofType; //ugly hack
                 return instance;
             }
 
@@ -31,7 +31,7 @@ namespace GraphQL.Types
                 }
                 var listGraphType = typeof(ListGraphType<>).MakeGenericType(ofType.GetType());
                 var instance = (ListGraphType)Activator.CreateInstance(listGraphType);
-                instance.ResolvedType = ofType;
+                instance.ResolvedType = (GraphType)ofType; //ugly hack
                 return instance;
             }
 

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
@@ -40,7 +40,7 @@ namespace GraphQL.Utilities.Federation
         {
         }
 
-        public override ISchema Build(string typeDefinitions)
+        public override Schema Build(string typeDefinitions)
         {
             var schema = base.Build($"{FEDERATED_SDL}{Environment.NewLine}{typeDefinitions}");
             schema.RegisterType(BuildEntityGraphType(schema));
@@ -55,7 +55,7 @@ namespace GraphQL.Utilities.Federation
             schema.RegisterValueConverter(new AnyValueConverter());
         }
 
-        private void AddRootEntityFields(ISchema schema)
+        private void AddRootEntityFields(Schema schema)
         {
             var query = schema.Query;
 

--- a/src/GraphQL/Utilities/MetadataProvider.cs
+++ b/src/GraphQL/Utilities/MetadataProvider.cs
@@ -7,7 +7,9 @@ namespace GraphQL.Utilities
 {
     public class MetadataProvider : IProvideMetadata
     {
-        public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
+        public ConcurrentDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
+
+        IReadOnlyDictionary<string, object> IProvideMetadata.Metadata => Metadata;
 
         public TType GetMetadata<TType>(string key, TType defaultValue = default)
         {

--- a/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
+++ b/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace GraphQL.Utilities
         }
 
         public static TMetadataProvider SetAstType<TMetadataProvider>(this TMetadataProvider provider, ASTNode node)
-            where TMetadataProvider : IProvideMetadata
+            where TMetadataProvider : MetadataProvider
             => provider.WithMetadata(AST_METAFIELD, node);
 
         public static bool HasExtensionAstTypes(this IProvideMetadata type)
@@ -40,7 +40,7 @@ namespace GraphQL.Utilities
             return GetExtensionAstTypes(type).Count > 0;
         }
 
-        public static void AddExtensionAstType<T>(this IProvideMetadata type, T astType) where T : ASTNode 
+        public static void AddExtensionAstType<T>(this MetadataProvider type, T astType) where T : ASTNode 
         {
             var types = GetExtensionAstTypes(type);
             types.Add(astType);

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -308,9 +308,9 @@ namespace GraphQL.Utilities
             return builder.ToString().TrimStart();
         }
 
-        private string FormatDirectiveArguments(QueryArguments arguments)
+        private string FormatDirectiveArguments(IEnumerable<QueryArgument> arguments)
         {
-            if (arguments == null || arguments.Count == 0) return null;
+            if (arguments == null || arguments.Count() == 0) return null;
             return string.Join(Environment.NewLine, arguments.Select(arg=> $"  {PrintInputValue(arg)}"));
         }
 

--- a/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
+using GraphQL.Types;
 using GraphQL.Utilities;
 
 namespace GraphQL.Validation.Rules

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -58,12 +58,12 @@ namespace GraphQL.Validation.Rules
                 {
                     var directive = context.TypeInfo.GetDirective();
 
-                    if (directive?.Arguments?.ArgumentsList == null)
+                    if (directive?.Arguments == null)
                     {
                         return;
                     }
 
-                    foreach (var arg in directive.Arguments.ArgumentsList)
+                    foreach (var arg in directive.Arguments)
                     {
                         var argAst = node.Arguments?.ValueFor(arg.Name);
                         var type = arg.ResolvedType;

--- a/src/GraphQL/Validation/Rules/VariablesInAllowedPosition.cs
+++ b/src/GraphQL/Validation/Rules/VariablesInAllowedPosition.cs
@@ -82,7 +82,7 @@ namespace GraphQL.Validation.Rules
             var genericType = typeof(NonNullGraphType<>).MakeGenericType(type);
 
             var nonNull = (NonNullGraphType)Activator.CreateInstance(genericType);
-            nonNull.ResolvedType = varType;
+            nonNull.ResolvedType = (GraphType)varType; //ugly hack
             return nonNull;
         }
     }

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -12,10 +12,10 @@ namespace GraphQL.Validation
         private readonly Stack<IGraphType> _typeStack = new Stack<IGraphType>();
         private readonly Stack<IGraphType> _inputTypeStack = new Stack<IGraphType>();
         private readonly Stack<IGraphType> _parentTypeStack = new Stack<IGraphType>();
-        private readonly Stack<FieldType> _fieldDefStack = new Stack<FieldType>();
+        private readonly Stack<IFieldType> _fieldDefStack = new Stack<IFieldType>();
         private readonly Stack<INode> _ancestorStack = new Stack<INode>();
         private DirectiveGraphType _directive;
-        private QueryArgument _argument;
+        private IQueryArgument _argument;
 
         public TypeInfo(ISchema schema)
         {
@@ -42,7 +42,7 @@ namespace GraphQL.Validation
             return _parentTypeStack.Count > 0 ? _parentTypeStack.Peek() : null;
         }
 
-        public FieldType GetFieldDef()
+        public IFieldType GetFieldDef()
         {
             return _fieldDefStack.Count > 0 ? _fieldDefStack.Peek() : null;
         }
@@ -52,7 +52,7 @@ namespace GraphQL.Validation
             return _directive;
         }
 
-        public QueryArgument GetArgument()
+        public IQueryArgument GetArgument()
         {
             return _argument;
         }
@@ -124,7 +124,7 @@ namespace GraphQL.Validation
 
             if (node is Argument argAst)
             {
-                QueryArgument argDef = null;
+                IQueryArgument argDef = null;
                 IGraphType argType = null;
 
                 var args = GetDirective() != null ? GetDirective()?.Arguments : GetFieldDef()?.Arguments;
@@ -212,25 +212,28 @@ namespace GraphQL.Validation
             }
         }
 
-        private FieldType GetFieldDef(ISchema schema, IGraphType parentType, Field field)
+        private IFieldType GetFieldDef(ISchema schema, IGraphType parentType, Field field)
         {
             var name = field.Name;
+            var schemaMeta = schema.SchemaMetaFieldType;
+            var typeMeta = schema.TypeMetaFieldType;
+            var typeNameMeta = schema.TypeNameMetaFieldType;
 
-            if (name == schema.SchemaMetaFieldType.Name
+            if (name == schemaMeta.Name
                 && Equals(schema.Query, parentType))
             {
-                return schema.SchemaMetaFieldType;
+                return schemaMeta;
             }
 
-            if (name == schema.TypeMetaFieldType.Name
+            if (name == typeMeta.Name
                 && Equals(schema.Query, parentType))
             {
-                return schema.TypeMetaFieldType;
+                return typeMeta;
             }
 
-            if (name == schema.TypeNameMetaFieldType.Name && parentType.IsCompositeType())
+            if (name == typeNameMeta.Name && parentType.IsCompositeType())
             {
-                return schema.TypeNameMetaFieldType;
+                return typeNameMeta;
             }
 
             if (parentType is IObjectGraphType || parentType is IInterfaceGraphType)


### PR DESCRIPTION
See #1572 

This is testing the changes required to have the entire schema represented both in read/write classes started with `Schema` (and `GraphType` and `FieldType`, etc), and read-only interfaces via `ISchema` (and `IGraphType`, `IFieldType`, etc).  Execution strategies and similar classes should only need access to the interfaces.  `Schema` initialization support code, such as middleware building and `GraphTypesLookup` would all be based on the classes.

Changing `FieldType` to `IFieldType` was easy.  Changing `IGraphType` to `GraphType` is proving to be quite a challenge.

The `QueryArguments` was rewritten to inherit from `List<QueryArgument>` and thereby be able to be cast to `IEnumerable<IQueryArgument>`.  Since the class also implements `ICollection<QueryArgument>`, the .Net `Enumerable.Count()` extension method will use short-circuit evaluation to return the number of elements in the collection.  So we can safely use `.Count()` at will with no ill effects.  I'll have to check the MS source, but `.Any()` might even be a better choice, just in case somehow it isn't a `List<T>`.

`ExecutionOptions.SchemaFilter` and `ExecutionOptions.FieldNameConverter` have been moved to the schema.  They belong either in `Schema`, or in both `ExecutionOptions` and `ExecutionContext` -- but the `ExecutionOptions` should not modify the schema properties.

With each commit, I've verified that all tests pass.  So you can check the code changes and API diff at each step.

I'll add additional notes here as I play with this code.