### PR TITLE
[WIP]  Add pool for ReadonlyResolveFieldContext

### DIFF
--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -9,14 +9,16 @@ using GraphQL.Language.AST;
 using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQL.Validation.Complexity;
+using Microsoft.Extensions.ObjectPool;
 using static GraphQL.Execution.ExecutionHelper;
 using ExecutionContext = GraphQL.Execution.ExecutionContext;
 
 namespace GraphQL
 {
-
     public class DocumentExecuter : IDocumentExecuter
     {
+        private static readonly DefaultObjectPool<ReadonlyResolveFieldContext> _pool = new DefaultObjectPool<ReadonlyResolveFieldContext>(new ReadonlyResolveFieldContextPolicy());
+
         private readonly IDocumentBuilder _documentBuilder;
         private readonly IDocumentValidator _documentValidator;
         private readonly IComplexityAnalyzer _complexityAnalyzer;
@@ -247,6 +249,7 @@ namespace GraphQL
         {
             var context = new ExecutionContext
             {
+                Pool = _pool,
                 Document = document,
                 Schema = schema,
                 RootValue = root,

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -1,15 +1,17 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using GraphQL.Types;
+using Microsoft.Extensions.ObjectPool;
 
 namespace GraphQL.Execution
 {
     public class ExecutionContext : IProvideUserContext
     {
+        internal ObjectPool<ReadonlyResolveFieldContext> Pool { get; set; }
+
         public Document Document { get; set; }
 
         public ISchema Schema { get; set; }

--- a/src/GraphQL/Execution/ReadonlyResolveFieldContextPolicy.cs
+++ b/src/GraphQL/Execution/ReadonlyResolveFieldContextPolicy.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.ObjectPool;
+
+namespace GraphQL.Execution
+{
+    internal sealed class ReadonlyResolveFieldContextPolicy : IPooledObjectPolicy<ReadonlyResolveFieldContext>
+    {
+        public ReadonlyResolveFieldContext Create() => new ReadonlyResolveFieldContext();
+
+        public bool Return(ReadonlyResolveFieldContext obj)
+        {
+            obj.Clear();
+            return true;
+        }
+    }
+}

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="GraphQL-Parser" Version="5.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="3.1.1" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageReference Include="System.Reactive.Core" Version="4.0.0" />

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -13,15 +13,35 @@ namespace GraphQL
     /// </summary>
     public class ReadonlyResolveFieldContext : IResolveFieldContext<object>
     {
-        private readonly ExecutionNode _executionNode;
-        private readonly ExecutionContext _executionContext;
+        private ExecutionNode _executionNode;
+        private ExecutionContext _executionContext;
         private IDictionary<string, object> _arguments;
         private IDictionary<string, Field> _subFields;
+
+        internal ReadonlyResolveFieldContext()
+        {
+        }
 
         public ReadonlyResolveFieldContext(ExecutionNode node, ExecutionContext context)
         {
             _executionNode = node ?? throw new ArgumentNullException(nameof(node));
             _executionContext = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        internal ReadonlyResolveFieldContext Initialize(ExecutionNode node, ExecutionContext context)
+        {
+            _executionNode = node;
+            _executionContext = context;
+
+            return this;
+        }
+
+        internal void Clear()
+        {
+            _executionNode = null;
+            _executionContext = null;
+            _arguments = null;
+            _subFields = null;
         }
 
         private IDictionary<string, Field> GetSubFields()


### PR DESCRIPTION
Slight optimization over `ReadonlyResolveFieldContext`. No breaking changes, no public api changes, only internals. GraphQL package gets new dependency from `Microsoft.Extensions.ObjectPool` (netstandard2.0). I find it acceptable for internal things. One could do the cache himself, but why if there is a ready-made solution?

Before
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.17134.1304 (1803/April2018Update/Redstone4)
Intel Core i5-6200U CPU 2.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
Frequency=2343753 Hz, Resolution=426.6661 ns, Timer=TSC
.NET Core SDK=3.1.101
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X86 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X86 RyuJIT


```
|        Method |        Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |------------:|----------:|----------:|---------:|--------:|------:|----------:|
| Introspection | 2,607.83 us | 26.774 us | 23.735 us | 195.3125 | 54.6875 |     - | 486.71 KB |
|          Hero |    57.52 us |  0.308 us |  0.257 us |   8.8501 |       - |     - |  13.61 KB |

After
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.17134.1304 (1803/April2018Update/Redstone4)
Intel Core i5-6200U CPU 2.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
Frequency=2343753 Hz, Resolution=426.6661 ns, Timer=TSC
.NET Core SDK=3.1.101
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X86 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X86 RyuJIT


```
|        Method |        Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |------------:|----------:|----------:|---------:|--------:|------:|----------:|
| Introspection | 2,643.91 us | 14.938 us | 13.973 us | 171.8750 | 50.7813 |     - | 454.89 KB |
|          Hero |    58.63 us |  0.341 us |  0.319 us |   8.7891 |       - |     - |  13.55 KB |

~7% memory decrease on introspection test. There is some slowdown but it is not so significant.

@Shane32 Perhaps you will find the use of the pool in other places.