### PR TITLE
Change QueryArguments to IList and IEnumerable

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -597,7 +597,7 @@ namespace GraphQL.Execution
         public static object CoerceValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue input, GraphQL.Language.AST.Variables variables = null) { }
         public static System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> CollectFields(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IGraphType specificType, GraphQL.Language.AST.SelectionSet selectionSet) { }
         public static bool DoesFragmentConditionMatch(GraphQL.Execution.ExecutionContext context, string fragmentName, GraphQL.Types.IGraphType type) { }
-        public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, GraphQL.Types.QueryArguments definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
+        public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
         public static GraphQL.Types.FieldType GetFieldDefinition(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Types.IObjectGraphType parentType, GraphQL.Language.AST.Field field) { }
         public static GraphQL.Types.IObjectGraphType GetOperationRootType(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.Operation operation) { }
         public static object GetVariableValue(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinition variable, object input) { }
@@ -1598,23 +1598,23 @@ namespace GraphQL.Types
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
-        public GraphQL.Types.FieldType Field(System.Type type, string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, string deprecationReason = null) { }
+        public GraphQL.Types.FieldType Field(System.Type type, string name, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, string deprecationReason = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable = false, System.Type type = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable = false, System.Type type = null) { }
-        public GraphQL.Types.FieldType Field<TGraphType>(string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, string deprecationReason = null)
+        public GraphQL.Types.FieldType Field<TGraphType>(string name, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, string deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>(string name = "default") { }
-        public GraphQL.Types.FieldType FieldAsync(System.Type type, string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object>> resolve = null, string deprecationReason = null) { }
-        public GraphQL.Types.FieldType FieldAsync<TGraphType>(string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object>> resolve = null, string deprecationReason = null)
+        public GraphQL.Types.FieldType FieldAsync(System.Type type, string name, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object>> resolve = null, string deprecationReason = null) { }
+        public GraphQL.Types.FieldType FieldAsync<TGraphType>(string name, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object>> resolve = null, string deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
-        public GraphQL.Types.FieldType FieldAsync<TGraphType, TReturnType>(string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolve = null, string deprecationReason = null)
+        public GraphQL.Types.FieldType FieldAsync<TGraphType, TReturnType>(string name, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolve = null, string deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
-        public GraphQL.Types.FieldType FieldDelegate<TGraphType>(string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Delegate resolve = null, string deprecationReason = null)
+        public GraphQL.Types.FieldType FieldDelegate<TGraphType>(string name, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Delegate resolve = null, string deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
-        public GraphQL.Types.FieldType FieldSubscribe<TGraphType>(string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, System.Func<GraphQL.Subscription.IResolveEventStreamContext, System.IObservable<object>> subscribe = null, string deprecationReason = null)
+        public GraphQL.Types.FieldType FieldSubscribe<TGraphType>(string name, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, System.Func<GraphQL.Subscription.IResolveEventStreamContext, System.IObservable<object>> subscribe = null, string deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
-        public GraphQL.Types.FieldType FieldSubscribeAsync<TGraphType>(string name, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, System.Func<GraphQL.Subscription.IResolveEventStreamContext, System.Threading.Tasks.Task<System.IObservable<object>>> subscribeAsync = null, string deprecationReason = null)
+        public GraphQL.Types.FieldType FieldSubscribeAsync<TGraphType>(string name, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object> resolve = null, System.Func<GraphQL.Subscription.IResolveEventStreamContext, System.Threading.Tasks.Task<System.IObservable<object>>> subscribeAsync = null, string deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         public GraphQL.Types.FieldType GetField(string name) { }
         public bool HasField(string name) { }
@@ -1653,7 +1653,7 @@ namespace GraphQL.Types
         public static readonly GraphQL.Types.IncludeDirective Include;
         public static readonly GraphQL.Types.SkipDirective Skip;
         public DirectiveGraphType(string name, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveLocation> locations) { }
-        public GraphQL.Types.QueryArguments Arguments { get; set; }
+        public System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> Arguments { get; set; }
         public string Description { get; set; }
         public System.Collections.Generic.List<GraphQL.Types.DirectiveLocation> Locations { get; }
         public string Name { get; set; }
@@ -1739,7 +1739,7 @@ namespace GraphQL.Types
     public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
     {
         public FieldType() { }
-        public GraphQL.Types.QueryArguments Arguments { get; set; }
+        public System.Collections.Generic.IList<GraphQL.Types.QueryArgument> Arguments { get; set; }
         public object DefaultValue { get; set; }
         public string DeprecationReason { get; set; }
         public string Description { get; set; }
@@ -1830,7 +1830,7 @@ namespace GraphQL.Types
     }
     public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IProvideMetadata
     {
-        GraphQL.Types.QueryArguments Arguments { get; set; }
+        System.Collections.Generic.IList<GraphQL.Types.QueryArgument> Arguments { get; set; }
         string DeprecationReason { get; set; }
         string Description { get; set; }
         string Name { get; set; }
@@ -1975,8 +1975,8 @@ namespace GraphQL.Types
     }
     public static class ObjectGraphTypeExtensions
     {
-        public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext, object> resolve = null) { }
-        public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string description = null, GraphQL.Types.QueryArguments arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object>> resolve = null) { }
+        public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext, object> resolve = null) { }
+        public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string description = null, System.Collections.Generic.IList<GraphQL.Types.QueryArgument> arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object>> resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideMetadata
     {
@@ -2004,15 +2004,21 @@ namespace GraphQL.Types
     {
         public QueryArgument() { }
     }
-    public class QueryArguments : System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument>, System.Collections.IEnumerable
+    public class QueryArguments : System.Collections.Generic.List<GraphQL.Types.QueryArgument>
     {
         public QueryArguments(params GraphQL.Types.QueryArgument[] args) { }
         public QueryArguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> list) { }
-        public int Count { get; }
+        public new int Count { get; }
         public GraphQL.Types.QueryArgument this[int index] { get; set; }
         public void Add(GraphQL.Types.QueryArgument argument) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
         public GraphQL.Types.QueryArgument Find(string name) { }
-        public System.Collections.Generic.IEnumerator<GraphQL.Types.QueryArgument> GetEnumerator() { }
+        public void Insert(int index, GraphQL.Types.QueryArgument argument) { }
+        public void InsertRange(int index, System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
+    }
+    public static class QueryArgumentsExtensions
+    {
+        public static GraphQL.Types.QueryArgument Find(this System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> list, string name) { }
     }
     public class SByteGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -213,16 +213,22 @@ namespace GraphQL.Execution
             return scalar.ParseValue(input);
         }
 
-        public static Dictionary<string, object> GetArgumentValues(ISchema schema, QueryArguments definitionArguments, Arguments astArguments, Variables variables)
+        public static Dictionary<string, object> GetArgumentValues(ISchema schema, IEnumerable<QueryArgument> definitionArguments, Arguments astArguments, Variables variables)
         {
-            if (definitionArguments == null || definitionArguments.Count == 0)
-            {
+            if (definitionArguments.None())
                 return null;
+
+            Dictionary<string, object> values;
+            if (definitionArguments is ICollection collection)
+            {
+                values = new Dictionary<string, object>(collection.Count);
+            }
+            else
+            {
+                values = new Dictionary<string, object>();
             }
 
-            var values = new Dictionary<string, object>(definitionArguments.Count);
-
-            foreach (var arg in definitionArguments.ArgumentsList)
+            foreach (var arg in definitionArguments)
             {
                 var value = astArguments?.ValueFor(arg.Name);
                 var type = arg.ResolvedType;

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -106,7 +106,7 @@ namespace GraphQL.Types
             Type type,
             string name,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext<TSourceType>, object> resolve = null,
             string deprecationReason = null)
         {
@@ -126,7 +126,7 @@ namespace GraphQL.Types
         public FieldType Field<TGraphType>(
             string name,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext<TSourceType>, object> resolve = null,
             string deprecationReason = null)
             where TGraphType : IGraphType
@@ -147,7 +147,7 @@ namespace GraphQL.Types
         public FieldType FieldDelegate<TGraphType>(
             string name,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Delegate resolve = null,
             string deprecationReason = null)
             where TGraphType : IGraphType
@@ -169,7 +169,7 @@ namespace GraphQL.Types
             Type type,
             string name,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext<TSourceType>, Task<object>> resolve = null,
             string deprecationReason = null)
         {
@@ -189,7 +189,7 @@ namespace GraphQL.Types
         public FieldType FieldAsync<TGraphType>(
             string name,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext<TSourceType>, Task<object>> resolve = null,
             string deprecationReason = null)
             where TGraphType : IGraphType
@@ -210,7 +210,7 @@ namespace GraphQL.Types
         public FieldType FieldAsync<TGraphType, TReturnType>(
             string name,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext<TSourceType>, Task<TReturnType>> resolve = null,
             string deprecationReason = null)
             where TGraphType : IGraphType
@@ -231,7 +231,7 @@ namespace GraphQL.Types
         public FieldType FieldSubscribe<TGraphType>(
             string name,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext<TSourceType>, object> resolve = null,
             Func<IResolveEventStreamContext, IObservable<object>> subscribe = null,
             string deprecationReason = null)
@@ -256,7 +256,7 @@ namespace GraphQL.Types
         public FieldType FieldSubscribeAsync<TGraphType>(
             string name,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext<TSourceType>, object> resolve = null,
             Func<IResolveEventStreamContext, Task<IObservable<object>>> subscribeAsync = null,
             string deprecationReason = null)

--- a/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Resolvers;
 
@@ -11,7 +12,7 @@ namespace GraphQL.Types
             string name,
             IGraphType type,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext, object> resolve = null)
         {
             var field = new FieldType
@@ -30,7 +31,7 @@ namespace GraphQL.Types
             string name,
             IGraphType type,
             string description = null,
-            QueryArguments arguments = null,
+            IList<QueryArgument> arguments = null,
             Func<IResolveFieldContext, Task<object>> resolve = null)
         {
             var field = new FieldType

--- a/src/GraphQL/Types/DirectiveGraphType.cs
+++ b/src/GraphQL/Types/DirectiveGraphType.cs
@@ -76,7 +76,7 @@ namespace GraphQL.Types
 
         public string Description { get; set; }
 
-        public QueryArguments Arguments { get; set; }
+        public IEnumerable<QueryArgument> Arguments { get; set; }
 
         public List<DirectiveLocation> Locations { get; } = new List<DirectiveLocation>();
     }

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -2,6 +2,7 @@ using GraphQL.Resolvers;
 using System;
 using System.Diagnostics;
 using GraphQL.Utilities;
+using System.Collections.Generic;
 
 namespace GraphQL.Types
 {
@@ -20,7 +21,7 @@ namespace GraphQL.Types
 
         public IGraphType ResolvedType { get; set; }
 
-        public QueryArguments Arguments { get; set; }
+        public IList<QueryArgument> Arguments { get; set; }
 
         public IFieldResolver Resolver { get; set; }
     }

--- a/src/GraphQL/Types/Fields/IFieldType.cs
+++ b/src/GraphQL/Types/Fields/IFieldType.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace GraphQL.Types
 {
     public interface IFieldType : IHaveDefaultValue, IProvideMetadata
@@ -8,6 +10,6 @@ namespace GraphQL.Types
 
         string DeprecationReason { get; set; }
 
-        QueryArguments Arguments { get; set; }
+        IList<QueryArgument> Arguments { get; set; }
     }
 }

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -261,10 +261,8 @@ namespace GraphQL.Utilities
 
         public string PrintArgs(FieldType field)
         {
-            if (field.Arguments == null || field.Arguments.Count == 0)
-            {
+            if (field.Arguments.None())
                 return string.Empty;
-            }
 
             return "({0})".ToFormat(string.Join(", ", field.Arguments.Select(PrintInputValue)));
         }
@@ -308,9 +306,9 @@ namespace GraphQL.Utilities
             return builder.ToString().TrimStart();
         }
 
-        private string FormatDirectiveArguments(QueryArguments arguments)
+        private string FormatDirectiveArguments(IEnumerable<QueryArgument> arguments)
         {
-            if (arguments == null || arguments.Count == 0) return null;
+            if (arguments.None()) return null;
             return string.Join(Environment.NewLine, arguments.Select(arg=> $"  {PrintInputValue(arg)}"));
         }
 

--- a/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
+using GraphQL.Types;
 using GraphQL.Utilities;
 
 namespace GraphQL.Validation.Rules

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -58,12 +58,12 @@ namespace GraphQL.Validation.Rules
                 {
                     var directive = context.TypeInfo.GetDirective();
 
-                    if (directive?.Arguments?.ArgumentsList == null)
+                    if (directive == null || directive.Arguments.None())
                     {
                         return;
                     }
 
-                    foreach (var arg in directive.Arguments.ArgumentsList)
+                    foreach (var arg in directive.Arguments)
                     {
                         var argAst = node.Arguments?.ValueFor(arg.Name);
                         var type = arg.ResolvedType;


### PR DESCRIPTION
In preparation for changing interfaces to read-only, this PR changes `QueryArguments` to inherit from `List<QueryArgument>` and changes the `FieldType.Arguments` property to an `IList<QueryArgument>`.  This provides a few benefits:
1. `Field()` methods and similar can accept an array directly (yay!)
2. The `QueryArguments` can be cast directly to `IEnumerable<QueryArgument>`, so when #1572 is pulled, `IFieldType.Arguments` will return the list as an `IEnumerable<QueryArgument>`
3. `Enumerable` extension methods are all optimized with short-circuit evaluation, so `.Any()`, `.Count()` and so on do not execute an enumerator.
4. Since the `List` class is not necessary, there is one less object initialization when adding a value.

Also note that `List` already contains code to leave the underlying array null until at least one value is added.

I also added `.None()` as an internal optimization -- see the code for notes.

As an alternative, `IReadOnlyCollection<QueryArgument>` could be used in place of `IEnumerable<QueryArgument>`, which provides `.Count` as a property.  However, that interface is so infrequently used that I just stuck to `IEnumerable<QueryArgument>` with some short-circuit evaluation where needed.