### PR TITLE
Change QueryArguments to implement IReadOnlyCollection and ICollection

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -597,7 +597,7 @@ namespace GraphQL.Execution
         public static object CoerceValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue input, GraphQL.Language.AST.Variables variables = null) { }
         public static System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> CollectFields(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IGraphType specificType, GraphQL.Language.AST.SelectionSet selectionSet) { }
         public static bool DoesFragmentConditionMatch(GraphQL.Execution.ExecutionContext context, string fragmentName, GraphQL.Types.IGraphType type) { }
-        public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, GraphQL.Types.QueryArguments definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
+        public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, System.Collections.Generic.IReadOnlyCollection<GraphQL.Types.QueryArgument> definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
         public static GraphQL.Types.FieldType GetFieldDefinition(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Types.IObjectGraphType parentType, GraphQL.Language.AST.Field field) { }
         public static GraphQL.Types.IObjectGraphType GetOperationRootType(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.Operation operation) { }
         public static object GetVariableValue(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinition variable, object input) { }
@@ -2004,7 +2004,7 @@ namespace GraphQL.Types
     {
         public QueryArgument() { }
     }
-    public class QueryArguments : System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument>, System.Collections.IEnumerable
+    public class QueryArguments : System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument>, System.Collections.Generic.IReadOnlyCollection<GraphQL.Types.QueryArgument>, System.Collections.ICollection, System.Collections.IEnumerable
     {
         public QueryArguments(params GraphQL.Types.QueryArgument[] args) { }
         public QueryArguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> list) { }

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -213,7 +213,7 @@ namespace GraphQL.Execution
             return scalar.ParseValue(input);
         }
 
-        public static Dictionary<string, object> GetArgumentValues(ISchema schema, QueryArguments definitionArguments, Arguments astArguments, Variables variables)
+        public static Dictionary<string, object> GetArgumentValues(ISchema schema, IReadOnlyCollection<QueryArgument> definitionArguments, Arguments astArguments, Variables variables)
         {
             if (definitionArguments == null || definitionArguments.Count == 0)
             {
@@ -222,7 +222,7 @@ namespace GraphQL.Execution
 
             var values = new Dictionary<string, object>(definitionArguments.Count);
 
-            foreach (var arg in definitionArguments.ArgumentsList)
+            foreach (var arg in definitionArguments)
             {
                 var value = astArguments?.ValueFor(arg.Name);
                 var type = arg.ResolvedType;

--- a/src/GraphQL/Types/QueryArguments.cs
+++ b/src/GraphQL/Types/QueryArguments.cs
@@ -5,7 +5,7 @@ using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
-    public class QueryArguments : IEnumerable<QueryArgument>
+    public class QueryArguments : IReadOnlyCollection<QueryArgument>, ICollection
     {
         public QueryArguments(params QueryArgument[] args)
         {
@@ -44,6 +44,10 @@ namespace GraphQL.Types
 
         public int Count => ArgumentsList?.Count ?? 0;
 
+        bool ICollection.IsSynchronized => false;
+
+        object ICollection.SyncRoot => this;
+
         public void Add(QueryArgument argument)
         {
             if (argument == null)
@@ -79,5 +83,7 @@ namespace GraphQL.Types
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        void ICollection.CopyTo(Array array, int index) => ((ICollection)ArgumentsList)?.CopyTo(array, index);
     }
 }


### PR DESCRIPTION
This facilitates changing `IFieldType` to a readonly interface in #1572 .

Implementing `IReadOnlyCollection` does not require any other code changes, as it only adds `Count` which already exists on the class.

Implementing `ICollection` facilitates short-circuit evaluation by `Enumerable.Count()`

There are no breaking changes, as `GetArgumentValues` is a static method and cannot be overriden.