### PR TITLE
Add IQueryArgument interface

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -867,7 +867,7 @@ namespace GraphQL.Introspection
     public class DefaultSchemaFilter : GraphQL.Introspection.ISchemaFilter
     {
         public DefaultSchemaFilter() { }
-        public virtual System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.QueryArgument argument) { }
+        public virtual System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.IQueryArgument argument) { }
         public virtual System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.DirectiveGraphType directive) { }
         public virtual System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue) { }
         public virtual System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field) { }
@@ -875,7 +875,7 @@ namespace GraphQL.Introspection
     }
     public interface ISchemaFilter
     {
-        System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.QueryArgument argument);
+        System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.IQueryArgument argument);
         System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.DirectiveGraphType directive);
         System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue);
         System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field);
@@ -1870,6 +1870,7 @@ namespace GraphQL.Types
         TType GetMetadata<TType>(string key, TType defaultValue = default);
         bool HasMetadata(string key);
     }
+    public interface IQueryArgument : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata { }
     public interface ISchema
     {
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
@@ -1989,7 +1990,7 @@ namespace GraphQL.Types
         public void Interface<TInterface>()
             where TInterface : GraphQL.Types.IInterfaceGraphType { }
     }
-    public class QueryArgument : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IHaveDefaultValue
+    public class QueryArgument : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.INamedType, GraphQL.Types.IProvideMetadata, GraphQL.Types.IQueryArgument
     {
         public QueryArgument(GraphQL.Types.IGraphType type) { }
         public QueryArgument(System.Type type) { }
@@ -2237,7 +2238,7 @@ namespace GraphQL.Utilities
     public abstract class BaseSchemaNodeVisitor : GraphQL.Utilities.ISchemaNodeVisitor
     {
         protected BaseSchemaNodeVisitor() { }
-        public virtual void VisitArgumentDefinition(GraphQL.Types.QueryArgument argument) { }
+        public virtual void VisitArgumentDefinition(GraphQL.Types.IQueryArgument argument) { }
         public virtual void VisitEnum(GraphQL.Types.EnumerationGraphType type) { }
         public virtual void VisitEnumValue(GraphQL.Types.EnumValueDefinition value) { }
         public virtual void VisitFieldDefinition(GraphQL.Types.FieldType field) { }
@@ -2289,7 +2290,7 @@ namespace GraphQL.Utilities
     }
     public interface ISchemaNodeVisitor
     {
-        void VisitArgumentDefinition(GraphQL.Types.QueryArgument argument);
+        void VisitArgumentDefinition(GraphQL.Types.IQueryArgument argument);
         void VisitEnum(GraphQL.Types.EnumerationGraphType type);
         void VisitEnumValue(GraphQL.Types.EnumValueDefinition value);
         void VisitFieldDefinition(GraphQL.Types.FieldType field);

--- a/src/GraphQL/Introspection/ISchemaFilter.cs
+++ b/src/GraphQL/Introspection/ISchemaFilter.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Introspection
     {
         Task<bool> AllowType(IGraphType type);
         Task<bool> AllowField(IGraphType parent, IFieldType field);
-        Task<bool> AllowArgument(IFieldType field, QueryArgument argument);
+        Task<bool> AllowArgument(IFieldType field, IQueryArgument argument);
         Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue);
         Task<bool> AllowDirective(DirectiveGraphType directive);
     }
@@ -24,7 +24,7 @@ namespace GraphQL.Introspection
             return Task.FromResult(true);
         }
 
-        public virtual Task<bool> AllowArgument(IFieldType field, QueryArgument argument)
+        public virtual Task<bool> AllowArgument(IFieldType field, IQueryArgument argument)
         {
             return Task.FromResult(true);
         }

--- a/src/GraphQL/Introspection/__Directive.cs
+++ b/src/GraphQL/Introspection/__Directive.cs
@@ -23,7 +23,7 @@ namespace GraphQL.Introspection
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<__DirectiveLocation>>>>("locations");
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<__InputValue>>>>("args",
                 resolve: context =>
-                    context.Source.Arguments ?? Enumerable.Empty<QueryArgument>()
+                    context.Source.Arguments ?? Enumerable.Empty<IQueryArgument>()
             );
             Field<NonNullGraphType<BooleanGraphType>>("onOperation", deprecationReason: "Use 'locations'.",
                 resolve: context => context

--- a/src/GraphQL/Introspection/__Field.cs
+++ b/src/GraphQL/Introspection/__Field.cs
@@ -39,7 +39,7 @@ namespace GraphQL.Introspection
             FieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<__InputValue>>>>("args",
                 resolve: async context =>
                 {
-                    var arguments = context.Source.Arguments ?? Enumerable.Empty<QueryArgument>();
+                    var arguments = context.Source.Arguments ?? Enumerable.Empty<IQueryArgument>();
                     return await arguments.WhereAsync(x => context.Schema.Filter.AllowArgument(context.Source, x)).ConfigureAwait(false);
                 });
             Field<NonNullGraphType<__Type>>("type", resolve: ctx => ctx.Source.ResolvedType);

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -4,6 +4,10 @@ using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
+    public interface IQueryArgument : IProvideMetadata, IHaveDefaultValue, INamedType
+    {
+    }
+
     public class QueryArgument<TType> : QueryArgument
         where TType : IGraphType
     {
@@ -14,7 +18,7 @@ namespace GraphQL.Types
     }
 
     [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
-    public class QueryArgument : MetadataProvider, IHaveDefaultValue
+    public class QueryArgument : MetadataProvider, IQueryArgument
     {
         private Type _type;
         private IGraphType _resolvedType;

--- a/src/GraphQL/Utilities/ISchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/ISchemaNodeVisitor.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Utilities
 
         void VisitFieldDefinition(FieldType field);
 
-        void VisitArgumentDefinition(QueryArgument argument);
+        void VisitArgumentDefinition(IQueryArgument argument);
 
         void VisitInterface(InterfaceGraphType iface);
 
@@ -46,7 +46,7 @@ namespace GraphQL.Utilities
         {
         }
 
-        public virtual void VisitArgumentDefinition(QueryArgument argument)
+        public virtual void VisitArgumentDefinition(IQueryArgument argument)
         {
         }
 


### PR DESCRIPTION
In preparation for changing interfaces to read-only, this PR adds an `IQueryArgument` interface which will eventually be a read-only interface once the underlying interfaces are changed to read-only.

Since `ISchemaFilter.AllowArgument` now has an `IQueryArgument` parameter, this is a breaking change.

Once combined with the changes in #1572 and #1593 this will allow `IFieldType.Arguments` to be of type `IEnumerable<IQueryArguments>` or a similar read-only type, facilitating the transition of `IFieldType` to be a completely read-only interface, including its arguments.