### PR TITLE
Add Schema.Description property from draft spec

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -1883,6 +1883,7 @@ namespace GraphQL.Types
     {
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AllTypes { get; }
+        string Description { get; set; }
         System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> Directives { get; set; }
         GraphQL.Introspection.ISchemaFilter Filter { get; set; }
         bool Initialized { get; }
@@ -2040,6 +2041,7 @@ namespace GraphQL.Types
         public Schema(System.IServiceProvider services) { }
         public System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         public System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AllTypes { get; }
+        public string Description { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> Directives { get; set; }
         public GraphQL.Introspection.ISchemaFilter Filter { get; set; }
         public bool Initialized { get; }

--- a/src/GraphQL.StarWars/StarWarsSchema.cs
+++ b/src/GraphQL.StarWars/StarWarsSchema.cs
@@ -11,6 +11,8 @@ namespace GraphQL.StarWars
         {
             Query = serviceProvider.GetRequiredService<StarWarsQuery>();
             Mutation = serviceProvider.GetRequiredService<StarWarsMutation>();
+
+            Description = "Example StarWars universe schema";
         }
     }
 }

--- a/src/GraphQL.Tests/Files/PetComplex.graphql
+++ b/src/GraphQL.Tests/Files/PetComplex.graphql
@@ -1,3 +1,8 @@
+#Animals - cats and dogs
+schema {
+  query: Query
+}
+
 type Query {
     animal: Pet
     allAnimalsCount: [Int!] @deprecated(reason: "do not touch!")

--- a/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
+++ b/src/GraphQL.Tests/Introspection/IntrospectionResult.cs
@@ -6,6 +6,7 @@ namespace GraphQL.Tests.Introspection
 @"{
   ""data"": {
     ""__schema"": {
+      ""description"": null,
       ""queryType"": {
         ""name"": ""TestQuery""
       },
@@ -227,6 +228,18 @@ namespace GraphQL.Tests.Introspection
           ""name"": ""__Schema"",
           ""description"": ""A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."",
           ""fields"": [
+            {
+              ""name"": ""description"",
+              ""description"": null,
+              ""args"": [],
+              ""type"": {
+                ""kind"": ""SCALAR"",
+                ""name"": ""String"",
+                ""ofType"": null
+              },
+              ""isDeprecated"": false,
+              ""deprecationReason"": null
+            },
             {
               ""name"": ""directives"",
               ""description"": ""A list of all directives supported by this server."",

--- a/src/GraphQL.Tests/Introspection/SchemaIntrospection.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospection.cs
@@ -5,6 +5,7 @@ namespace GraphQL.Tests.Introspection
         public static readonly string IntrospectionQuery = @"
   query IntrospectionQuery {
     __schema {
+      description
       queryType { name }
       mutationType { name }
       subscriptionType { name }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -30,6 +30,7 @@ namespace GraphQL.Tests.Utilities
                 builder => builder.Types.ForAll(config => config.ResolveType = _ => null)
             );
 
+            schema.Description.ShouldBe("Animals - cats and dogs");
             schema.AllTypes.Count().ShouldBe(33);
 
             var cat = schema.AllTypes.OfType<IComplexGraphType>().First(t => t.Name == "Cat");

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -1027,6 +1027,7 @@ type __InputValue {
 # available types and directives on the server, as well as the entry points for
 # query, mutation, and subscription operations.
 type __Schema {
+  description: String
   # A list of all types supported by this server.
   types: [__Type!]!
   # The type that query operations will be rooted at.

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Introspection/SchemaMetaFieldType.cs
+++ b/src/GraphQL/Introspection/SchemaMetaFieldType.cs
@@ -24,6 +24,10 @@ namespace GraphQL.Introspection
                 "exposes all available types and directives on the server, as well as " +
                 "the entry points for query, mutation, and subscription operations.";
 
+            Field<StringGraphType>(
+                "description",
+                resolve: context => context.Schema.Description);
+
             FieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<__Type>>>>(
                 "types",
                 "A list of all types supported by this server.",

--- a/src/GraphQL/Language/AST/Directive.cs
+++ b/src/GraphQL/Language/AST/Directive.cs
@@ -11,6 +11,7 @@ namespace GraphQL.Language.AST
         }
 
         public string Name => NameNode.Name;
+
         public NameNode NameNode { get; set; }
 
         public Arguments Arguments { get; set; }

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -31,6 +31,8 @@ namespace GraphQL.Types
         /// </summary>
         INameConverter NameConverter { get; set; }
 
+        string Description { get; set; }
+
         /// <summary>
         /// The 'query' base graph type; required
         /// </summary>

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -70,6 +70,8 @@ namespace GraphQL.Types
             FindType("____");
         }
 
+        public string Description { get; set; }
+
         public IObjectGraphType Query { get; set; }
 
         public IObjectGraphType Mutation { get; set; }

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -159,6 +159,8 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
 
             if (schemaDef != null)
             {
+                schema.Description = schemaDef.Comment?.Text;
+
                 foreach (var operationTypeDef in schemaDef.OperationTypes)
                 {
                     var typeName = operationTypeDef.Type.Name.Value;


### PR DESCRIPTION
http://spec.graphql.org/draft/#sec-Schema-Introspection : 

```graphql
type __Schema {
  description: String   <---
  types: [__Type!]!
  queryType: __Type!
  mutationType: __Type
  subscriptionType: __Type
  directives: [__Directive!]!
}
```

GraphQL Playground, GraphiQL, Voyager, Altair - everything works fine with these changes.