### PR TITLE
Add xml comments to ExecutionResult

### DIFF
--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -39,7 +39,7 @@ namespace GraphQL
         public PerfRecord[] Perf { get; set; }
 
         /// <summary>
-        /// Indicates that unhandled <see cref="Exception"/> stack traces should be serialized into GraphQL query result json along with exception messages; defaults to only <see cref="Exception.Message"/>
+        /// Indicates that unhandled <see cref="Exception"/> stack traces should be serialized into GraphQL query result json along with exception messages; otherwise only <see cref="Exception.Message"/> should be serialized
         /// </summary>
         public bool ExposeExceptions { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -19,7 +19,7 @@ namespace GraphQL
         public ExecutionErrors Errors { get; set; }
 
         /// <summary>
-        /// Returns the original query.
+        /// Returns the original GraphQL query.
         /// </summary>
         public string Query { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -9,7 +9,7 @@ namespace GraphQL
     public class ExecutionResult
     {
         /// <summary>
-        /// Returns the data from the graph resolvers. This property is typically serialized as part of the GraphQL json response.
+        /// Returns the data from the graph resolvers. This property is serialized as part of the GraphQL json response.
         /// </summary>
         public object Data { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -39,7 +39,7 @@ namespace GraphQL
         public PerfRecord[] Perf { get; set; }
 
         /// <summary>
-        /// Indicates that unhandled <see cref="Exception"/> stack traces should be serialized into GraphQL query result json along with exception messages; otherwise only <see cref="Exception.Message"/> should be serialized
+        /// Indicates that unhandled <see cref="Exception"/> stack traces should be serialized into GraphQL response json along with exception messages; otherwise only <see cref="Exception.Message"/> should be serialized
         /// </summary>
         public bool ExposeExceptions { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -44,7 +44,7 @@ namespace GraphQL
         public bool ExposeExceptions { get; set; }
 
         /// <summary>
-        /// Returns additional user-defined data; see <see cref="IExecutionContext.Extensions"/> and <see cref="IResolveFieldContext.Extensions"/>. This property is typically serialized as part of the GraphQL json response.
+        /// Returns additional user-defined data; see <see cref="IExecutionContext.Extensions"/> and <see cref="IResolveFieldContext.Extensions"/>. This property is serialized as part of the GraphQL json response.
         /// </summary>
         public Dictionary<string, object> Extensions { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 
@@ -7,20 +8,44 @@ namespace GraphQL
 {
     public class ExecutionResult
     {
+        /// <summary>
+        /// Returns the data from the graph resolvers. This property is typically serialized as part of the GraphQL json response.
+        /// </summary>
         public object Data { get; set; }
 
+        /// <summary>
+        /// Returns a set of errors that occurred during processing. This property is typically serialized as part of the GraphQL json response.
+        /// </summary>
         public ExecutionErrors Errors { get; set; }
 
+        /// <summary>
+        /// Returns the original query.
+        /// </summary>
         public string Query { get; set; }
 
+        /// <summary>
+        /// Returns the parsed GraphQL request.
+        /// </summary>
         public Document Document { get; set; }
 
+        /// <summary>
+        /// Returns the GraphQL operation that is being executed.
+        /// </summary>
         public Operation Operation { get; set; }
 
+        /// <summary>
+        /// Returns the performance metrics (Apollo Tracing) when enabled by <see cref="ExecutionOptions.EnableMetrics"/>.
+        /// </summary>
         public PerfRecord[] Perf { get; set; }
 
+        /// <summary>
+        /// Indicates that unhandled <see cref="Exception"/> stack traces should be serialized into GraphQL query result json along with exception messages; defaults to only <see cref="Exception.Message"/>
+        /// </summary>
         public bool ExposeExceptions { get; set; }
 
+        /// <summary>
+        /// Returns additional user-defined data; see <see cref="IExecutionContext.Extensions"/> and <see cref="IResolveFieldContext.Extensions"/>. This property is typically serialized as part of the GraphQL json response.
+        /// </summary>
         public Dictionary<string, object> Extensions { get; set; }
 
         public ExecutionResult()

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -14,7 +14,7 @@ namespace GraphQL
         public object Data { get; set; }
 
         /// <summary>
-        /// Returns a set of errors that occurred during processing. This property is typically serialized as part of the GraphQL json response.
+        /// Returns a set of errors that occurred during any stage of processing (parsing, validating, executing, etc.). This property is serialized as part of the GraphQL json response.
         /// </summary>
         public ExecutionErrors Errors { get; set; }
 


### PR DESCRIPTION
These are mostly adaptations of xml comments in `ExecutionOptions`, `IExecutionContext` or `IResolveFieldContext`.  Since the use case by implementations is to typically read these values, the comments were adapted in that vein.