### PR TITLE
Fix validation rule for required arguments

### DIFF
--- a/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
+++ b/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
@@ -34,10 +34,49 @@ mutation {
     sbyte
     sbyteArray
   }
+  create_with_defaults(input: { })
+  {
+    id1
+    id2
+
+    uint
+    uintArray
+
+    short
+    shortArray
+
+    ushort
+    ushortArray
+
+    ulong
+    ulongArray
+
+    byte
+    byteArray
+
+    sbyte
+    sbyteArray
+  }
 }
 ";
             var expected = @"{
   ""create"": {
+    ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
+    ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
+    ""uint"": 3147483647,
+    ""uintArray"": [3147483640],
+    ""short"": -21000,
+    ""shortArray"": [20000],
+    ""ushort"": 61000,
+    ""ushortArray"": [65000],
+    ""ulong"": 4000000000000,
+    ""ulongArray"": [1234567890123456789],
+    ""byte"": 50,
+    ""byteArray"": [1,2,3],
+    ""sbyte"": -60,
+    ""sbyteArray"": [-1,2,-3]
+  },
+  ""create_with_defaults"": {
     ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
     ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
     ""uint"": 3147483647,
@@ -96,6 +135,7 @@ mutation {
         public ScalarsInput()
         {
             Name = "ScalarsInput";
+
             Field("id1", o => o.Id1, type: typeof(IdGraphType));
             Field("id2", o => o.Id2, type: typeof(GuidGraphType));
             Field("uint", o => o.uInt, type: typeof(UIntGraphType));
@@ -114,11 +154,36 @@ mutation {
         }
     }
 
+    public class ScalarsInputWithDefaults : InputObjectGraphType<ScalarsModel>
+    {
+        public ScalarsInputWithDefaults()
+        {
+            Name = "ScalarsInputWithDefaults";
+
+            Field("id1", o => o.Id1, type: typeof(NonNullGraphType<IdGraphType>)).DefaultValue(new Guid("8dfab389-a6f7-431d-ab4e-aa693cc53edf"));
+            Field("id2", o => o.Id2, type: typeof(NonNullGraphType<GuidGraphType>)).DefaultValue(new Guid("8dfab389-a6f7-431d-ab4e-aa693cc53ede"));
+            Field("uint", o => o.uInt, type: typeof(NonNullGraphType<UIntGraphType>)).DefaultValue((uint)3147483647);
+            Field("short", o => o.sHort, type: typeof(NonNullGraphType<ShortGraphType>)).DefaultValue((short)-21000);
+            Field("ushort", o => o.uShort, type: typeof(NonNullGraphType<UShortGraphType>)).DefaultValue((ushort)61000);
+            Field("ulong", o => o.uLong, type: typeof(NonNullGraphType<ULongGraphType>)).DefaultValue((ulong)4000000000000);
+            Field("byte", o => o.bYte, type: typeof(NonNullGraphType<ByteGraphType>)).DefaultValue((byte)50);
+            Field("sbyte", o => o.sByte, type: typeof(NonNullGraphType<SByteGraphType>)).DefaultValue((sbyte)-60);
+
+            Field(o => o.byteArray, nullable: false).DefaultValue(new byte[] { 1,2,3 });
+            Field(o => o.sbyteArray, nullable: false).DefaultValue(new sbyte[] { -1,2,-3 });
+            Field(o => o.ulongArray, nullable: false).DefaultValue(new ulong[] { 1234567890123456789 });
+            Field(o => o.uintArray, nullable: false).DefaultValue(new uint[] { 3147483640 });
+            Field(o => o.shortArray, nullable: false).DefaultValue(new short[] { 20000 });
+            Field(o => o.ushortArray, nullable: false).DefaultValue(new ushort[] { 65000 });
+        }
+    }
+
     public class ScalarsType : ObjectGraphType<ScalarsModel>
     {
         public ScalarsType()
         {
             Name = "ScalarsType";
+
             Field("id1", o => o.Id1, type: typeof(IdGraphType));
             Field("id2", o => o.Id2, type: typeof(GuidGraphType));
             Field("uint", o => o.uInt, type: typeof(UIntGraphType));
@@ -142,9 +207,19 @@ mutation {
         public ScalarsMutation()
         {
             Name = "ScalarsMutation";
+
             Field<ScalarsType>(
                 "create",
                 arguments: new QueryArguments(new QueryArgument<ScalarsInput> { Name = "input" }),
+                resolve: ctx =>
+                {
+                    var arg = ctx.GetArgument<ScalarsModel>("input");
+                    return arg;
+                });
+
+            Field<ScalarsType>(
+                "create_with_defaults",
+                arguments: new QueryArguments(new QueryArgument<ScalarsInputWithDefaults> { Name = "input" }),
                 resolve: ctx =>
                 {
                     var arg = ctx.GetArgument<ScalarsModel>("input");

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -229,7 +229,7 @@ namespace GraphQL
                 foreach (var field in fields)
                 {
                     var fieldAst = fieldAsts.Find(x => x.Name == field.Name);
-                    var result = IsValidLiteralValue(field.ResolvedType, fieldAst?.Value, schema);
+                    var result = IsValidLiteralValue(field.ResolvedType, fieldAst?.Value ?? field.GetDefaultValueAST(schema), schema);
 
                     errors.AddRange(result.Select(err => $"In field \"{field.Name}\": {err}"));
                 }

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -2,19 +2,31 @@ using GraphQL.Resolvers;
 using System;
 using System.Diagnostics;
 using GraphQL.Utilities;
+using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
     [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
     public class FieldType : MetadataProvider, IFieldType
     {
+        private object _defaultValue;
+        private IValue _defaultValueAST;
+
         public string Name { get; set; }
 
         public string Description { get; set; }
 
         public string DeprecationReason { get; set; }
 
-        public object DefaultValue { get; set; }
+        public object DefaultValue
+        {
+            get => _defaultValue;
+            set
+            {
+                _defaultValue = value;
+                _defaultValueAST = null;
+            }
+        }
 
         public Type Type { get; set; }
 
@@ -23,5 +35,13 @@ namespace GraphQL.Types
         public QueryArguments Arguments { get; set; }
 
         public IFieldResolver Resolver { get; set; }
+
+        internal IValue GetDefaultValueAST(ISchema schema)
+        {
+            if (_defaultValueAST == null && _defaultValue != null)
+                _defaultValueAST = _defaultValue.AstFromValue(schema, ResolvedType);
+
+            return _defaultValueAST;
+        }
     }
 }

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using GraphQL.Language.AST;
 using GraphQL.Utilities;
 
 namespace GraphQL.Types
@@ -18,6 +19,8 @@ namespace GraphQL.Types
     {
         private Type _type;
         private IGraphType _resolvedType;
+        private object _defaultValue;
+        private IValue _defaultValueAST;
 
         public QueryArgument(IGraphType type)
         {
@@ -38,7 +41,15 @@ namespace GraphQL.Types
 
         public string Description { get; set; }
 
-        public object DefaultValue { get; set; }
+        public object DefaultValue
+        {
+            get => _defaultValue;
+            set
+            {
+                _defaultValue = value;
+                _defaultValueAST = null;
+            }
+        }
 
         public IGraphType ResolvedType
         {
@@ -70,5 +81,13 @@ namespace GraphQL.Types
 
         private ArgumentOutOfRangeException Create(string paramName, Type value) => new ArgumentOutOfRangeException(paramName,
             $"'{value.GetFriendlyName()}' is not a valid input type. QueryArgument must be one of the input types: ScalarGraphType, EnumerationGraphType or IInputObjectGraphType.");
+
+        internal IValue GetDefaultValueAST(ISchema schema)
+        {
+            if (_defaultValueAST == null && _defaultValue != null)
+                _defaultValueAST = _defaultValue.AstFromValue(schema, ResolvedType);
+
+            return _defaultValueAST;
+        }
     }
 }

--- a/src/GraphQL/Validation/Rules/ArgumentsOfCorrectType.cs
+++ b/src/GraphQL/Validation/Rules/ArgumentsOfCorrectType.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Validation.Rules
                     if (argDef == null) return;
 
                     var type = argDef.ResolvedType;
-                    var errors = type.IsValidLiteralValue(argAst.Value, context.Schema).ToList();
+                    var errors = type.IsValidLiteralValue(argAst.Value ?? argDef.GetDefaultValueAST(context.Schema), context.Schema).ToList();
                     if (errors.Count > 0)
                     {
                         var error = new ValidationError(


### PR DESCRIPTION
http://spec.graphql.org/June2018/#sec-Required-Arguments :
> Arguments can be required. An argument is required if the argument type is non‐null **and does not have a default value**. Otherwise, the argument is optional.

Given such a schema

```graphql
type Query
{
  a: A
}

type A
{
  field(p: Int! = 10): SomeType
}
```

and  query
```graphql
{
  a {
    field { <---- no args
    ...
  }
}
}
```

`ValidationError` occures: `$"Expected \"{ofType.Name}!\", found null."`