### PR TITLE
Support for serialize custom ExecutionResult

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -96,7 +96,7 @@ namespace GraphQL
     public class ExecutionResult
     {
         public ExecutionResult() { }
-        protected ExecutionResult(GraphQL.ExecutionResult result) { }
+        public ExecutionResult(GraphQL.ExecutionResult result) { }
         public object Data { get; set; }
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultContractResolver.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultContractResolver.cs
@@ -10,7 +10,7 @@ namespace GraphQL.NewtonsoftJson
         private readonly CamelCaseNamingStrategy _camelCase = new CamelCaseNamingStrategy();
 
         protected override JsonConverter ResolveContractConverter(Type objectType) =>
-            objectType == typeof(ExecutionResult)
+            objectType == typeof(ExecutionResult) || objectType.IsSubclassOf(typeof(ExecutionResult))
                 ? new ExecutionResultJsonConverter()
                 : base.ResolveContractConverter(objectType);
 

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultContractResolver.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultContractResolver.cs
@@ -10,7 +10,7 @@ namespace GraphQL.NewtonsoftJson
         private readonly CamelCaseNamingStrategy _camelCase = new CamelCaseNamingStrategy();
 
         protected override JsonConverter ResolveContractConverter(Type objectType) =>
-            objectType == typeof(ExecutionResult) || objectType.IsSubclassOf(typeof(ExecutionResult))
+            typeof(ExecutionResult).IsAssignableFrom(objectType)
                 ? new ExecutionResultJsonConverter()
                 : base.ResolveContractConverter(objectType);
 

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -52,7 +52,7 @@ namespace GraphQL
         {
         }
 
-        protected ExecutionResult(ExecutionResult result)
+        public ExecutionResult(ExecutionResult result)
         {
             if (result == null)
                 throw new ArgumentNullException(nameof(result));


### PR DESCRIPTION
I ran into an error when serializing `class MyExecutionResult : ExecutionResult { ... }` led to `OutOfMemoryException` since custom converter for `ExecutionResult` was not used because of strict condition inside `ExecutionResultContractResolver`. Then serializer started to serialize all properties from `ExecutionResult`. I wanted to use the copy constructor, but I could not, because it is `protected`. So it is `public` now too.