### PR TITLE
bugfix: Expected type "Decimal", found 39614081257132168796771975168.

### DIFF
--- a/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
+++ b/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Tests.Bugs
         {
             var query = @"
 mutation {
-  create(input: {id1:""8dfab389-a6f7-431d-ab4e-aa693cc53edf"", id2:""8dfab389-a6f7-431d-ab4e-aa693cc53ede"", uint: 3147483647, uintArray: [3147483640], short: -21000, shortArray: [20000] ushort: 61000, ushortArray: [65000], ulong: 4000000000000, ulongArray: [1234567890123456789], byte: 50, byteArray: [1,2,3], sbyte: -60, sbyteArray: [-1,2,-3] })
+  create(input: {id1:""8dfab389-a6f7-431d-ab4e-aa693cc53edf"", id2:""8dfab389-a6f7-431d-ab4e-aa693cc53ede"", uint: 3147483647, uintArray: [3147483640], short: -21000, shortArray: [20000] ushort: 61000, ushortArray: [65000], ulong: 4000000000000, ulongArray: [1234567890123456789], byte: 50, byteArray: [1,2,3], sbyte: -60, sbyteArray: [-1,2,-3], dec: 39614081257132168796771975168, decArray: [1,39614081257132168796771975168,3] })
   {
     id1
     id2
@@ -33,6 +33,9 @@ mutation {
 
     sbyte
     sbyteArray
+
+    dec
+    decArray
   }
   create_with_defaults(input: { })
   {
@@ -56,44 +59,93 @@ mutation {
 
     sbyte
     sbyteArray
+
+    dec
+    decArray
   }
 }
 ";
             var expected = @"{
-  ""create"": {
-    ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
-    ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
-    ""uint"": 3147483647,
-    ""uintArray"": [3147483640],
-    ""short"": -21000,
-    ""shortArray"": [20000],
-    ""ushort"": 61000,
-    ""ushortArray"": [65000],
-    ""ulong"": 4000000000000,
-    ""ulongArray"": [1234567890123456789],
-    ""byte"": 50,
-    ""byteArray"": [1,2,3],
-    ""sbyte"": -60,
-    ""sbyteArray"": [-1,2,-3]
-  },
-  ""create_with_defaults"": {
-    ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
-    ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
-    ""uint"": 3147483647,
-    ""uintArray"": [3147483640],
-    ""short"": -21000,
-    ""shortArray"": [20000],
-    ""ushort"": 61000,
-    ""ushortArray"": [65000],
-    ""ulong"": 4000000000000,
-    ""ulongArray"": [1234567890123456789],
-    ""byte"": 50,
-    ""byteArray"": [1,2,3],
-    ""sbyte"": -60,
-    ""sbyteArray"": [-1,2,-3]
+  ""data"": {
+    ""create"": {
+      ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
+      ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
+      ""uint"": 3147483647,
+      ""uintArray"": [
+        3147483640
+      ],
+      ""short"": -21000,
+      ""shortArray"": [
+        20000
+      ],
+      ""ushort"": 61000,
+      ""ushortArray"": [
+        65000
+      ],
+      ""ulong"": 4000000000000,
+      ""ulongArray"": [
+        1234567890123456789
+      ],
+      ""byte"": 50,
+      ""byteArray"": [
+        1,
+        2,
+        3
+      ],
+      ""sbyte"": -60,
+      ""sbyteArray"": [
+        -1,
+        2,
+        -3
+      ],
+      ""dec"": 39614081257132168796771975168,
+      ""decArray"": [
+        1,
+        39614081257132168796771975168,
+        3
+      ]
+    },
+    ""create_with_defaults"": {
+      ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
+      ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
+      ""uint"": 3147483647,
+      ""uintArray"": [
+        3147483640
+      ],
+      ""short"": -21000,
+      ""shortArray"": [
+        20000
+      ],
+      ""ushort"": 61000,
+      ""ushortArray"": [
+        65000
+      ],
+      ""ulong"": 4000000000000,
+      ""ulongArray"": [
+        1234567890123456789
+      ],
+      ""byte"": 50,
+      ""byteArray"": [
+        1,
+        2,
+        3
+      ],
+      ""sbyte"": -60,
+      ""sbyteArray"": [
+        -1,
+        2,
+        -3
+      ],
+      ""dec"": 39614081257132168796771975168,
+      ""decArray"": [
+        1,
+        39614081257132168796771975168,
+        3
+      ]
+    }
   }
 }";
-            AssertQuerySuccess(query, expected, null);
+            AssertQuery(query, expected, null, null);
         }
     }
 
@@ -128,6 +180,9 @@ mutation {
 
         public sbyte sByte { get; set; }
         public sbyte[] sbyteArray { get; set; }
+
+        public decimal dec { get; set; }
+        public decimal[] decArray { get; set; }
     }
 
     public class ScalarsInput : InputObjectGraphType<ScalarsModel>
@@ -144,6 +199,7 @@ mutation {
             Field("ulong", o => o.uLong, type: typeof(ULongGraphType));
             Field("byte", o => o.bYte, type: typeof(ByteGraphType));
             Field("sbyte", o => o.sByte, type: typeof(SByteGraphType));
+            Field("dec", o => o.dec, type: typeof(DecimalGraphType));
 
             Field(o => o.byteArray);
             Field(o => o.sbyteArray);
@@ -151,6 +207,7 @@ mutation {
             Field(o => o.uintArray);
             Field(o => o.shortArray);
             Field(o => o.ushortArray);
+            Field(o => o.decArray);
         }
     }
 
@@ -168,13 +225,15 @@ mutation {
             Field("ulong", o => o.uLong, type: typeof(NonNullGraphType<ULongGraphType>)).DefaultValue((ulong)4000000000000);
             Field("byte", o => o.bYte, type: typeof(NonNullGraphType<ByteGraphType>)).DefaultValue((byte)50);
             Field("sbyte", o => o.sByte, type: typeof(NonNullGraphType<SByteGraphType>)).DefaultValue((sbyte)-60);
+            Field("dec", o => o.dec, type: typeof(NonNullGraphType<DecimalGraphType>)).DefaultValue(39614081257132168796771975168m);
 
-            Field(o => o.byteArray, nullable: false).DefaultValue(new byte[] { 1,2,3 });
-            Field(o => o.sbyteArray, nullable: false).DefaultValue(new sbyte[] { -1,2,-3 });
+            Field(o => o.byteArray, nullable: false).DefaultValue(new byte[] { 1, 2, 3 });
+            Field(o => o.sbyteArray, nullable: false).DefaultValue(new sbyte[] { -1, 2, -3 });
             Field(o => o.ulongArray, nullable: false).DefaultValue(new ulong[] { 1234567890123456789 });
             Field(o => o.uintArray, nullable: false).DefaultValue(new uint[] { 3147483640 });
             Field(o => o.shortArray, nullable: false).DefaultValue(new short[] { 20000 });
             Field(o => o.ushortArray, nullable: false).DefaultValue(new ushort[] { 65000 });
+            Field(o => o.decArray, nullable: false).DefaultValue(new decimal[] { 1, 39614081257132168796771975168m, 3 });
         }
     }
 
@@ -192,6 +251,7 @@ mutation {
             Field("ulong", o => o.uLong, type: typeof(ULongGraphType));
             Field("byte", o => o.bYte, type: typeof(ByteGraphType));
             Field("sbyte", o => o.sByte, type: typeof(SByteGraphType));
+            Field("dec", o => o.dec, type: typeof(DecimalGraphType));
 
             Field(o => o.byteArray);
             Field(o => o.sbyteArray);
@@ -199,6 +259,7 @@ mutation {
             Field(o => o.uintArray);
             Field(o => o.shortArray);
             Field(o => o.ushortArray);
+            Field(o => o.decArray);
         }
     }
 

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -114,7 +114,7 @@ namespace GraphQL.Tests
 
         public ExecutionResult AssertQuery(
             string query,
-            ExecutionResult expectedExecutionResult,
+            object expectedExecutionResultOrJson,
             Inputs inputs,
             object root,
             IDictionary<string, object> userContext = null,
@@ -140,7 +140,7 @@ namespace GraphQL.Tests
             writer ??= Writer;
 
             var writtenResult = Writer.WriteToStringAsync(runResult).GetAwaiter().GetResult();
-            var expectedResult = Writer.WriteToStringAsync(expectedExecutionResult).GetAwaiter().GetResult();
+            var expectedResult = expectedExecutionResultOrJson is string s ? s : Writer.WriteToStringAsync((ExecutionResult)expectedExecutionResultOrJson).GetAwaiter().GetResult();
 
             string additionalInfo = null;
 

--- a/src/GraphQL.Tests/Types/DecimalGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DecimalGraphTypeTests.cs
@@ -49,7 +49,8 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void converts_DecimalValue_to_decimal()
         {
-            _type.ParseLiteral(new DecimalValue(12345.6579m)).ShouldBe((decimal)12345.6579);
+            _type.ParseLiteral(new DecimalValue(12345.6579m)).ShouldBe(12345.6579m);
+            _type.ParseLiteral(new DecimalValue(39614081257132168796771975168m)).ShouldBe(39614081257132168796771975168m);
         }
     }
 }

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -214,7 +214,13 @@ namespace GraphQL.Language
                         return new LongValue(longResult).WithLocation(str, _body);
                     }
 
-                    // If the value doesn't fit in an long, revert to using BigInteger...
+                    // If the value doesn't fit in an long, revert to using decimal...
+                    if (decimal.TryParse(str.Value, out var decimalResult))
+                    {
+                        return new DecimalValue(decimalResult).WithLocation(str, _body);
+                    }
+
+                    // If the value doesn't fit in an decimal, revert to using BigInteger...
                     if (BigInteger.TryParse(str.Value, out var bigIntegerResult))
                     {
                         return new BigIntValue(bigIntegerResult).WithLocation(str, _body);

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -8,11 +8,12 @@ namespace GraphQL.Types
 
         public override object ParseLiteral(IValue value) => value switch
         {
+            DecimalValue decimalValue => decimalValue.Value,
             StringValue stringValue => ParseValue(stringValue.Value),
             IntValue intValue => ParseValue(intValue.Value),
             LongValue longValue => ParseValue(longValue.Value),
             FloatValue floatValue => ParseValue(floatValue.Value),
-            DecimalValue decimalValue => decimalValue.Value,
+            BigIntValue bigIntValue => ParseValue(bigIntValue.Value),
             _ => null
         };
     }

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -566,7 +566,13 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
                         return longResult;
                     }
 
-                    // If the value doesn't fit in an long, revert to using BigInteger...
+                    // If the value doesn't fit in an long, revert to using decimal...
+                    if (decimal.TryParse(str.Value, out var decimalResult))
+                    {
+                        return decimalResult;
+                    }
+
+                    // If the value doesn't fit in an decimal, revert to using BigInteger...
                     if (BigInteger.TryParse(str.Value, out var bigIntegerResult))
                     {
                         return bigIntegerResult;


### PR DESCRIPTION
Now `decimal` takes priority over `BigInteger`. Also `DecimalGraphType` now can parse from `BigIntValue` literal.