### PR TITLE
Fix errors.path property to return numbers for list indexes

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -53,7 +53,7 @@ namespace GraphQL
         public System.Collections.Generic.IEnumerable<string> Codes { get; }
         public bool HasCodes { get; }
         public System.Collections.Generic.IEnumerable<GraphQL.ErrorLocation> Locations { get; }
-        public System.Collections.Generic.IEnumerable<string> Path { get; set; }
+        public System.Collections.Generic.IEnumerable<object> Path { get; set; }
         public void AddLocation(int line, int column) { }
     }
     public static class ExecutionErrorExtensions
@@ -177,7 +177,7 @@ namespace GraphQL
         GraphQL.Instrumentation.Metrics Metrics { get; }
         GraphQL.Language.AST.Operation Operation { get; }
         GraphQL.Types.IObjectGraphType ParentType { get; }
-        System.Collections.Generic.IEnumerable<string> Path { get; }
+        System.Collections.Generic.IEnumerable<object> Path { get; }
         GraphQL.Types.IGraphType ReturnType { get; }
         object RootValue { get; }
         GraphQL.Types.ISchema Schema { get; }
@@ -256,7 +256,7 @@ namespace GraphQL
         public GraphQL.Instrumentation.Metrics Metrics { get; }
         public GraphQL.Language.AST.Operation Operation { get; }
         public GraphQL.Types.IObjectGraphType ParentType { get; }
-        public System.Collections.Generic.IEnumerable<string> Path { get; }
+        public System.Collections.Generic.IEnumerable<object> Path { get; }
         public GraphQL.Types.IGraphType ReturnType { get; }
         public object RootValue { get; }
         public GraphQL.Types.ISchema Schema { get; }
@@ -281,7 +281,7 @@ namespace GraphQL
         public GraphQL.Instrumentation.Metrics Metrics { get; set; }
         public GraphQL.Language.AST.Operation Operation { get; set; }
         public GraphQL.Types.IObjectGraphType ParentType { get; set; }
-        public System.Collections.Generic.IEnumerable<string> Path { get; set; }
+        public System.Collections.Generic.IEnumerable<object> Path { get; set; }
         public GraphQL.Types.IGraphType ReturnType { get; set; }
         public object RootValue { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
@@ -622,7 +622,7 @@ namespace GraphQL.Execution
         public bool IsResultSet { get; }
         public string Name { get; }
         public GraphQL.Execution.ExecutionNode Parent { get; }
-        public System.Collections.Generic.IEnumerable<string> Path { get; }
+        public System.Collections.Generic.IEnumerable<object> Path { get; }
         public object Result { get; set; }
         public object Source { get; set; }
         public GraphQL.Types.IObjectGraphType GetParentType(GraphQL.Types.ISchema schema) { }

--- a/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
+++ b/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
@@ -108,7 +108,7 @@ namespace GraphQL.Tests.Bugs
             {
                 new ExecutionError("Cannot return null for non-null type. Field: listOfNonNullable, Type: [String!].")
                 {
-                    Path = new[] {"nonNullableDataGraph", "listOfNonNullable", "1"}
+                    Path = new object[] {"nonNullableDataGraph", "listOfNonNullable", 1}
                 }
             };
 
@@ -160,7 +160,7 @@ namespace GraphQL.Tests.Bugs
                 new ExecutionError(
                     "Cannot return null for non-null type. Field: nonNullableListOfNonNullable, Type: [String!]!.")
                 {
-                    Path = new[] {"nullableDataGraph", "nonNullableListOfNonNullable", "1"}
+                    Path = new object[] {"nullableDataGraph", "nonNullableListOfNonNullable", 1}
                 }
             };
 
@@ -196,7 +196,7 @@ namespace GraphQL.Tests.Bugs
                 new ExecutionError(
                     "Error trying to resolve nonNullableListOfNonNullableThrow.")
                 {
-                    Path = new[] { "nonNullableListOfNonNullableDataGraph", "0", "nonNullableListOfNonNullableThrow"}
+                    Path = new object[] { "nonNullableListOfNonNullableDataGraph", 0, "nonNullableListOfNonNullableThrow"}
                 }
             };
 

--- a/src/GraphQL.Tests/DocumentWriterTests.cs
+++ b/src/GraphQL.Tests/DocumentWriterTests.cs
@@ -112,5 +112,28 @@ namespace GraphQL.Tests
 
             actual.ShouldBeCrossPlatJson(expected);
         }
+
+        [Theory]
+        [ClassData(typeof(DocumentWritersTestData))]
+        public async void Writes_Path_Property_Correctly(IDocumentWriter writer)
+        {
+            var executionResult = new ExecutionResult
+            {
+                Data = null,
+                Errors = new ExecutionErrors(),
+                Extensions = null,
+            };
+            var executionError = new ExecutionError("Error testing index")
+            {
+                Path = new object[] { "parent", 23, "child" }
+            };
+            executionResult.Errors.Add(executionError);
+
+            var expected = @"{ ""errors"": [{ ""message"": ""Error testing index"", ""path"": [ ""parent"", 23, ""child"" ] }] }";
+
+            var actual = await writer.WriteToStringAsync(executionResult);
+
+            actual.ShouldBeCrossPlatJson(expected);
+        }
     }
 }

--- a/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
@@ -74,7 +74,7 @@ namespace GraphQL.Tests.Errors
 
             result.Errors.Count.ShouldBe(1);
             var error = result.Errors.First();
-            error.Path.ShouldBe(new[] { "testSubList", "0", "two" });
+            error.Path.ShouldBe(new object[] { "testSubList", 0, "two" });
         }
 
         [Fact]

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -57,7 +57,7 @@ namespace GraphQL
             }
         }
 
-        public IEnumerable<string> Path { get; set; }
+        public IEnumerable<object> Path { get; set; }
 
         public void AddLocation(int line, int column)
         {

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -88,24 +88,40 @@ namespace GraphQL.Execution
             }
         }
 
+        private static readonly object _num0 = 0;
+        private static readonly object _num1 = 1;
+        private static readonly object _num2 = 2;
+        private static readonly object _num3 = 3;
+        private static readonly object _num4 = 4;
+        private static readonly object _num5 = 5;
+        private static readonly object _num6 = 6;
+        private static readonly object _num7 = 7;
+        private static readonly object _num8 = 8;
+        private static readonly object _num9 = 9;
+        private static readonly object _num10 = 10;
+        private static readonly object _num11 = 11;
+        private static readonly object _num12 = 12;
+        private static readonly object _num13 = 13;
+        private static readonly object _num14 = 14;
+        private static readonly object _num15 = 15;
         private static object GetObjectIndex(int index) => index switch
         {
-            0 => 0,
-            1 => 1,
-            2 => 2,
-            3 => 3,
-            4 => 4,
-            5 => 5,
-            6 => 6,
-            7 => 7,
-            8 => 8,
-            9 => 9,
-            10 => 10,
-            11 => 11,
-            12 => 12,
-            13 => 13,
-            14 => 14,
-            15 => 15,
+            0 => _num0,
+            1 => _num1,
+            2 => _num2,
+            3 => _num3,
+            4 => _num4,
+            5 => _num5,
+            6 => _num6,
+            7 => _num7,
+            8 => _num8,
+            9 => _num9,
+            10 => _num10,
+            11 => _num11,
+            12 => _num12,
+            13 => _num13,
+            14 => _num14,
+            15 => _num15,
             _ => index
         };
     }

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -60,7 +60,7 @@ namespace GraphQL.Execution
             return null;
         }
 
-        public IEnumerable<string> Path
+        public IEnumerable<object> Path
         {
             get
             {
@@ -72,13 +72,13 @@ namespace GraphQL.Execution
                     ++count;
                 }
 
-                var pathList = new string[count];
+                var pathList = new object[count];
                 var index = count;
                 node = this;
                 while (!(node is RootExecutionNode))
                 {
                     if (node.IndexInParentNode.HasValue)
-                        pathList[--index] = GetStringIndex(node.IndexInParentNode.Value);
+                        pathList[--index] = GetObjectIndex(node.IndexInParentNode.Value);
                     else
                         pathList[--index] = node.Field.Name;
                     node = node.Parent;
@@ -88,25 +88,25 @@ namespace GraphQL.Execution
             }
         }
 
-        private static string GetStringIndex(int index) => index switch
+        private static object GetObjectIndex(int index) => index switch
         {
-            0 => "0",
-            1 => "1",
-            2 => "2",
-            3 => "3",
-            4 => "4",
-            5 => "5",
-            6 => "6",
-            7 => "7",
-            8 => "8",
-            9 => "9",
-            10 => "10",
-            11 => "11",
-            12 => "12",
-            13 => "13",
-            14 => "14",
-            15 => "15",
-            _ => index.ToString()
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            3 => 3,
+            4 => 4,
+            5 => 5,
+            6 => 6,
+            7 => 7,
+            8 => 8,
+            9 => 9,
+            10 => 10,
+            11 => 11,
+            12 => 12,
+            13 => 13,
+            14 => 14,
+            15 => 15,
+            _ => index
         };
     }
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -131,7 +131,7 @@ namespace GraphQL.Execution
                             + $" Field: {parent.Name}, Type: {parent.FieldDefinition.ResolvedType}.");
 
                         error.AddLocation(parent.Field, context.Document);
-                        error.Path = parent.Path.Append(index.ToString());
+                        error.Path = parent.Path.Append(index);
                         context.Errors.Add(error);
                         return;
                     }

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -162,7 +162,7 @@ namespace GraphQL.Execution
             ExecutionContext context,
             string message,
             Field field,
-            IEnumerable<string> path,
+            IEnumerable<object> path,
             Exception ex = null)
         {
             var error = new ExecutionError(message, ex);

--- a/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
@@ -50,12 +50,11 @@ namespace GraphQL.Instrumentation
             var fieldStats = perf.Where(x => x.Category == "field");
             foreach (var fieldStat in fieldStats)
             {
-                var stringPath = fieldStat.MetaField<IEnumerable<string>>("path");
                 trace.Execution.Resolvers.Add(
                     new ApolloTrace.ResolverTrace
                     {
                         FieldName = fieldStat.MetaField<string>("fieldName"),
-                        Path = ConvertPath(stringPath).ToList(),
+                        Path = fieldStat.MetaField<IEnumerable<object>>("path").ToList(),
                         ParentType = fieldStat.MetaField<string>("typeName"),
                         ReturnType = fieldStat.MetaField<string>("returnTypeName"),
                         StartOffset = ApolloTrace.ConvertTime(fieldStat.Start),
@@ -64,21 +63,6 @@ namespace GraphQL.Instrumentation
             }
 
             return trace;
-        }
-
-        private static IEnumerable<object> ConvertPath(IEnumerable<string> stringPath)
-        {
-            foreach (var step in stringPath)
-            {
-                if (int.TryParse(step, out var arrayIndex))
-                {
-                    yield return arrayIndex;
-                }
-                else
-                {
-                    yield return step;
-                }
-            }
         }
     }
 }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -69,7 +69,7 @@ namespace GraphQL
         ExecutionErrors Errors { get; }
 
         /// <summary>The path to the current executing field from the request root</summary>
-        IEnumerable<string> Path { get; }
+        IEnumerable<object> Path { get; }
 
         /// <summary>Returns a list of child fields requested for the current field</summary>
         IDictionary<string, Field> SubFields { get; }

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -62,7 +62,7 @@ namespace GraphQL
 
         public ExecutionErrors Errors => _executionContext.Errors;
 
-        public IEnumerable<string> Path => _executionNode.Path;
+        public IEnumerable<object> Path => _executionNode.Path;
 
         public IDictionary<string, Language.AST.Field> SubFields => _subFields ?? (_subFields = GetSubFields());
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -48,7 +48,7 @@ namespace GraphQL
 
         public ExecutionErrors Errors { get; set; }
 
-        public IEnumerable<string> Path { get; set; }
+        public IEnumerable<object> Path { get; set; }
 
         public IDictionary<string, Field> SubFields { get; set; }
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -65,7 +65,7 @@ namespace GraphQL
 
         public ExecutionErrors Errors => _baseContext.Errors;
 
-        public IEnumerable<string> Path => _baseContext.Path;
+        public IEnumerable<object> Path => _baseContext.Path;
 
         public IDictionary<string, Language.AST.Field> SubFields => _baseContext.SubFields;
 


### PR DESCRIPTION
Currently the `errors[].path` property returned in the graphql response returns strings to indicate positions within an array.  According to the spec it should return numbers.  This fixes that error.

See https://spec.graphql.org/June2018/#sec-Errors

> This field should be a list of path segments starting at the root of the response and ending with the field associated with the error. Path segments that represent fields should be strings, and path segments that represent list indices should be 0‐indexed integers. If the error happens in an aliased field, the path to the error should use the aliased name, since it represents a path in the response, not in the query.
>
> For example, if fetching one of the friends’ names fails in the following query:
> ```
> {
>   hero(episode: $episode) {
>     name
>     heroFriends: friends {
>       id
>       name
>     }
>   }
> }
> ```
> The response might look like:
> ```
> {
>   "errors": [
>     {
>       "message": "Name for character with ID 1002 could not be fetched.",
>       "locations": [ { "line": 6, "column": 7 } ],
>       "path": [ "hero", "heroFriends", 1, "name" ]
>     }
>   ],
>   "data": {
>     "hero": {
>       "name": "R2-D2",
>       "heroFriends": [
>         {
>           "id": "1000",
>           "name": "Luke Skywalker"
>         },
>         {
>           "id": "1002",
>           "name": null
>         },
>         {
>           "id": "1003",
>           "name": "Leia Organa"
>         }
>       ]
>     }
>   }
> }
> ```
