### PR TITLE
[DRAFT] Change server-side errors to exceptions

### DIFF
--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -41,12 +41,12 @@ namespace GraphQL
         {
             if (options.Schema == null)
             {
-                throw new ExecutionError("A schema is required.");
+                throw new InvalidOperationException("A schema is required.");
             }
 
             if (string.IsNullOrWhiteSpace(options.Query))
             {
-                throw new ExecutionError("A query is required.");
+                throw new InvalidOperationException("A query is required.");
             }
         }
 
@@ -92,7 +92,7 @@ namespace GraphQL
 
                 if (operation == null)
                 {
-                    throw new ExecutionError("Unable to determine operation from query.");
+                    throw new InvalidOperationException("Unable to determine operation from query.");
                 }
 
                 IValidationResult validationResult;

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -95,8 +95,7 @@ namespace GraphQL.Execution
 
             if (!(parent.Result is IEnumerable data))
             {
-                var error = new ExecutionError("User error: expected an IEnumerable list though did not find one.");
-                throw error;
+                throw new InvalidOperationException("User error: expected an IEnumerable list though did not find one.");
             }
 
             var index = 0;
@@ -126,14 +125,9 @@ namespace GraphQL.Execution
                 {
                     if (listType.ResolvedType is NonNullGraphType)
                     {
-                        var error = new ExecutionError(
+                        throw new InvalidOperationException(
                             "Cannot return null for non-null type."
-                            + $" Field: {parent.Name}, Type: {parent.FieldDefinition.ResolvedType}.");
-
-                        error.AddLocation(parent.Field, context.Document);
-                        error.Path = parent.Path.Append(index.ToString());
-                        context.Errors.Add(error);
-                        return;
+                            + $" Field: {parent.Name}, Type: {parent.FieldDefinition.ResolvedType}, Path: '{parent.Path.Append(index.ToString())}'.");
                     }
 
                     var valueExecutionNode = new ValueExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, index++)
@@ -248,7 +242,7 @@ namespace GraphQL.Execution
             {
                 if (result == null)
                 {
-                    throw new ExecutionError("Cannot return null for non-null type."
+                    throw new InvalidOperationException("Cannot return null for non-null type."
                         + $" Field: {node.Name}, Type: {nonNullType}.");
                 }
 
@@ -266,7 +260,7 @@ namespace GraphQL.Execution
 
                 if (objectType == null)
                 {
-                    throw new ExecutionError(
+                    throw new InvalidOperationException(
                         $"Abstract type {abstractType.Name} must resolve to an Object type at " +
                         $"runtime for field {node.Parent.GraphType.Name}.{node.Name} " +
                         $"with value '{result}', received 'null'.");
@@ -274,13 +268,13 @@ namespace GraphQL.Execution
 
                 if (!abstractType.IsPossibleType(objectType))
                 {
-                    throw new ExecutionError($"Runtime Object type \"{objectType}\" is not a possible type for \"{abstractType}\".");
+                    throw new InvalidOperationException($"Runtime Object type \"{objectType}\" is not a possible type for \"{abstractType}\".");
                 }
             }
 
             if (objectType?.IsTypeOf != null && !objectType.IsTypeOf(result))
             {
-                throw new ExecutionError($"\"{result}\" value of type \"{result.GetType()}\" is not allowed for \"{objectType.Name}\". Either change IsTypeOf method of \"{objectType.Name}\" to accept this value or return another value from your resolver.");
+                throw new InvalidOperationException($"\"{result}\" value of type \"{result.GetType()}\" is not allowed for \"{objectType.Name}\". Either change IsTypeOf method of \"{objectType.Name}\" to accept this value or return another value from your resolver.");
             }
         }
 

--- a/src/GraphQL/Invariant.cs
+++ b/src/GraphQL/Invariant.cs
@@ -1,20 +1,22 @@
+using System;
+
 namespace GraphQL
 {
     public static class Invariant
     {
         /// <summary>
-        /// Throws an <see cref="ExecutionError"/> if <c>valid</c> is false or <c>message</c> is empty.
+        /// Throws an <see cref="InvalidOperationException"/> if <c>valid</c> is false or <c>message</c> is empty.
         /// </summary>
         public static void Check(bool valid, string message)
         {
             if (string.IsNullOrWhiteSpace(message))
             {
-                throw new ExecutionError("Invariant requires an error message.");
+                throw new InvalidOperationException("Invariant requires an error message.");
             }
 
             if (!valid)
             {
-                throw new ExecutionError(message);
+                throw new InvalidOperationException(message);
             }
         }
     }

--- a/src/GraphQL/Language/AST/Document.cs
+++ b/src/GraphQL/Language/AST/Document.cs
@@ -36,7 +36,7 @@ namespace GraphQL.Language.AST
             }
             else
             {
-                throw new ExecutionError("Unhandled document definition");
+                throw new ArgumentException("Unhandled document definition");
             }
         }
 

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -110,7 +110,7 @@ namespace GraphQL.Language
             }
             else if (source.DefaultValue != null && !(source.DefaultValue is GraphQLValue))
             {
-                throw new ExecutionError($"Unknown default value: {source.DefaultValue}");
+                throw new InvalidOperationException($"Unknown default value: {source.DefaultValue}");
             }
             return def;
         }
@@ -267,7 +267,7 @@ namespace GraphQL.Language
                 }
             }
 
-            throw new ExecutionError($"Unmapped value type {source.Kind}");
+            throw new InvalidOperationException($"Unmapped value type {source.Kind}");
         }
 
         public ObjectField ObjectField(GraphQLObjectField source)
@@ -303,7 +303,7 @@ namespace GraphQL.Language
                 }
             }
 
-            throw new ExecutionError($"Unmapped type {type.Kind}");
+            throw new InvalidOperationException($"Unmapped type {type.Kind}");
         }
 
         public NameNode Name(GraphQLName name)
@@ -324,7 +324,7 @@ namespace GraphQL.Language
             OperationTypeParser.Query => OperationType.Query,
             OperationTypeParser.Mutation => OperationType.Mutation,
             OperationTypeParser.Subscription => OperationType.Subscription,
-            _ => throw new ExecutionError($"Unmapped operation type {type}")
+            _ => throw new InvalidOperationException($"Unmapped operation type {type}")
         };
     }
 

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -232,7 +232,7 @@ namespace GraphQL.Types
 
             if (type is NonNullGraphType || type is ListGraphType)
             {
-                throw new ExecutionError("Only add root types.");
+                throw new InvalidOperationException("Only add root types.");
             }
 
             var name = type.CollectTypes(context).TrimGraphQLTypes();
@@ -262,7 +262,7 @@ namespace GraphQL.Types
 
                         if (interfaceInstance.ResolveType == null && obj.IsTypeOf == null)
                         {
-                            throw new ExecutionError((
+                            throw new InvalidOperationException((
                                 "Interface type {0} does not provide a \"resolveType\" function " +
                                 "and possible Type \"{1}\" does not provide a \"isTypeOf\" function. " +
                                 "There is no way to resolve this possible type during execution.")
@@ -276,7 +276,7 @@ namespace GraphQL.Types
             {
                 if (!union.Types.Any() && !union.PossibleTypes.Any())
                 {
-                    throw new ExecutionError("Must provide types for Union {0}.".ToFormat(union));
+                    throw new InvalidOperationException("Must provide types for Union {0}.".ToFormat(union));
                 }
 
                 foreach (var unionedType in union.PossibleTypes)
@@ -288,7 +288,7 @@ namespace GraphQL.Types
 
                     if (union.ResolveType == null && unionedType.IsTypeOf == null)
                     {
-                        throw new ExecutionError((
+                        throw new InvalidOperationException((
                             "Union type {0} does not provide a \"resolveType\" function " +
                             "and possible Type \"{1}\" does not provide a \"isTypeOf\" function. " +
                             "There is no way to resolve this possible type during execution.")
@@ -304,7 +304,7 @@ namespace GraphQL.Types
 
                     if (union.ResolveType == null && objType != null && objType.IsTypeOf == null)
                     {
-                        throw new ExecutionError((
+                        throw new InvalidOperationException((
                             "Union type {0} does not provide a \"resolveType\" function " +
                             "and possible Type \"{1}\" does not provide a \"isTypeOf\" function. " +
                             "There is no way to resolve this possible type during execution.")
@@ -458,7 +458,7 @@ Make sure that your ServiceProvider is configured correctly.");
 
                         if (objectType.IsTypeOf == null && interfaceType.ResolveType == null)
                         {
-                            throw new ExecutionError((
+                            throw new InvalidOperationException((
                                     "Interface type {0} does not provide a \"resolveType\" function " +
                                     "and possible Type \"{1}\" does not provide a \"isTypeOf\" function.  " +
                                     "There is no way to resolve this possible type during execution.")
@@ -482,7 +482,7 @@ Make sure that your ServiceProvider is configured correctly.");
 
                         if (union.ResolveType == null && unionType != null && unionType.IsTypeOf == null)
                         {
-                            throw new ExecutionError((
+                            throw new InvalidOperationException((
                                 "Union type {0} does not provide a \"resolveType\" function " +
                                 "and possible Type \"{1}\" does not provide a \"isTypeOf\" function. " +
                                 "There is no way to resolve this possible type during execution.")
@@ -514,7 +514,7 @@ Make sure that your ServiceProvider is configured correctly.");
 
             if (reference != null && result == null)
             {
-                throw new ExecutionError($"Unable to resolve reference to type '{reference.TypeName}' on '{parentType.Name}'");
+                throw new InvalidOperationException($"Unable to resolve reference to type '{reference.TypeName}' on '{parentType.Name}'");
             }
 
             return result;

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -35,7 +35,7 @@ namespace GraphQL.Utilities
         {
             if (FieldsList.Exists(x => x.Name == field.Name))
             {
-                throw new ExecutionError($"A field with name \"{field.Name}\" already exists!");
+                throw new InvalidOperationException($"A field with name \"{field.Name}\" already exists!");
             }
 
             FieldsList.Add(field);

--- a/src/GraphQL/Validation/MatchingNodeVisitor.cs
+++ b/src/GraphQL/Validation/MatchingNodeVisitor.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation
         {
             if (enter == null && leave == null)
             {
-                throw new ExecutionError("Must provide an enter or leave function.");
+                throw new InvalidOperationException("Must provide an enter or leave function.");
             }
 
             _enter = enter;


### PR DESCRIPTION
This is in regards to #1650, and is a starting-point. I don't know the code well enough to feel like I got it right, but it should be enough to clarify my intent.

Were this sort of change to be made, it should make no significant difference to a developer using `ExceptionOptions.ThrowOnUnhandledException = false`. GraphQL.Net would wrap them into `ExecutionError` objects like all the other existing non-`ExecutionError` exceptions that are possibly thrown. 

But for a developer using `ExceptionOptions.ThrowOnUnhandledException = true`, they would have the ability to manually handle those server-side errors in whatever way they felt necessary. For example, they could use custom FieldMiddleware and change the exception into an `ExecutionError` that they were more comfortable with.