### PR TITLE
Fixing and issue #1565 - data loader in federated schema

### DIFF
--- a/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
@@ -207,14 +207,13 @@ type User @key(fields: ""id"") {
 
             var expected = @"{ ""_entities"": [{ ""__typename"": ""User"", ""id"" : ""1"", ""username"": ""One"" }, { ""__typename"": ""User"", ""id"" : ""2"", ""username"": ""Two"" }] }";
 
-            var executionResult = Executer.ExecuteAsync(_ =>
+            AssertQuery(_ =>
             {
-                _.Schema = Builder.Build(definitions);
+                _.Definitions = definitions;
                 _.Query = query;
+                _.ExpectedResult = expected;
                 _.Listeners.Add(listener);
-            }).GetAwaiter().GetResult();
-
-            Assert.Equal(CreateQueryResult(expected).Data, executionResult.Data);
+            });
         }
     }
 }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTestBase.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTestBase.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GraphQL.Execution;
 using GraphQL.SystemTextJson;
 using GraphQL.Utilities;
 using GraphQLParser.Exceptions;
@@ -37,6 +39,7 @@ namespace GraphQL.Tests.Utilities
                     _.Inputs = config.Variables.ToInputs();
                     _.Root = config.Root;
                     _.ThrowOnUnhandledException = config.ThrowOnUnhandledException;
+                    _.Listeners.AddRange(config.Listeners);
                 },
                 queryResult);
         }
@@ -76,5 +79,6 @@ namespace GraphQL.Tests.Utilities
         public string ExpectedResult { get; set; }
         public object Root { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
+        public List<IDocumentExecutionListener> Listeners { get; set; } = new List<IDocumentExecutionListener>();
     }
 }


### PR DESCRIPTION
Hello, at moment I were able to run code first federation with gateway, metrics and apollo graph manager, except this one

Thanks to @ShadyNawara and his #1565 issue - this one needs to be fixed first before everything else, without working data loader federation makes no sense.

After taking a closer look it seems that problem is caused by `await resolver.Resolve(resolveContext)` in resolve reference, and indeed why should we await every and each reference instead of collecting all tasks and wait for them all?

I have added an test which to prevent regression on this with corresponding changes

BR
Alex