### PR TITLE
[proposal] code first federation

### DIFF
--- a/docs2/site/docs/guides/federation.md
+++ b/docs2/site/docs/guides/federation.md
@@ -1,0 +1,6 @@
+# Apollo Federation
+
+GraphQL .NET includes an implementation of [Apollo Federation](https://www.apollographql.com/docs/apollo-server/federation/introduction/).
+
+Federation works best when you have two or more teams working on two or more services
+

--- a/docs2/site/docs/guides/federation.md
+++ b/docs2/site/docs/guides/federation.md
@@ -1,6 +1,5 @@
 # Apollo Federation
 
-GraphQL .NET includes an implementation of [Apollo Federation](https://www.apollographql.com/docs/apollo-server/federation/introduction/).
+GraphQL.NET includes an implementation of [Apollo Federation](https://www.apollographql.com/docs/apollo-server/federation/introduction/).
 
 Federation works best when you have two or more teams working on two or more services
-

--- a/docs2/site/docs/guides/federation.md
+++ b/docs2/site/docs/guides/federation.md
@@ -2,4 +2,4 @@
 
 GraphQL.NET includes an implementation of [Apollo Federation](https://www.apollographql.com/docs/apollo-server/federation/introduction/).
 
-Federation works best when you have two or more teams working on two or more services
+Federation works best when you have two or more teams working on two or more services.

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -72,6 +72,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "guides", "guides", "{F279F263-BCEB-4738-9111-C85139BC63A7}"
 	ProjectSection(SolutionItems) = preProject
 		..\docs2\site\docs\guides\dataloader.md = ..\docs2\site\docs\guides\dataloader.md
+		..\docs2\site\docs\guides\federation.md = ..\docs2\site\docs\guides\federation.md
 		..\docs2\site\docs\guides\links.md = ..\docs2\site\docs\guides\links.md
 		..\docs2\site\docs\guides\migration.md = ..\docs2\site\docs\guides\migration.md
 		..\docs2\site\docs\guides\schema-generation.md = ..\docs2\site\docs\guides\schema-generation.md

--- a/src/GraphQL/Utilities/Federation/Proposal.cs
+++ b/src/GraphQL/Utilities/Federation/Proposal.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL.Builders;
+using GraphQL.Types;
+using GraphQLParser.AST;
+
+namespace GraphQL.Utilities.Federation
+{
+    public static class MySchemaBuilderExtensions
+    {
+        /// <summary>
+        /// Internal helper to build GraphQLDirective instance which is then used by FederationSchemaPrinter while printing federated schema sdl
+        /// Directives are stored in fields metadata under key "__AST_MetaField__" and does not used anywhere else
+        /// Additional properties like Location are added to avoid null ref exceptions only
+        /// </summary>
+        /// <param name="name">name of the directive, e.g. key, extend, provides, requires</param>
+        /// <param name="value">value for fields argument, e.g. @key(fields: "id")</param>
+        /// <param name="kind">for field directives - ASTNodeKind.StringValue, for type directives - ASTNodeKind.Argument</param>
+        /// <returns></returns>
+        private static GraphQLDirective BuildGraphQLDirective(string name, string value = null, ASTNodeKind kind = ASTNodeKind.StringValue) => new GraphQLDirective
+        {
+            Name = new GraphQLName
+            {
+                Value = name,
+                Location = new GraphQLLocation()
+            },
+            Arguments = string.IsNullOrEmpty(value) ? new List<GraphQLArgument>() : new List<GraphQLArgument>() {
+                        new GraphQLArgument
+                        {
+                            Name = new GraphQLName {
+                                Value = "fields",
+                                Location = new GraphQLLocation()
+                            },
+                            Value = new GraphQLScalarValue(kind) {
+                                Value = value,
+                                Location = new GraphQLLocation()
+                            },
+                            Location = new GraphQLLocation()
+                        }
+                    },
+            Location = new GraphQLLocation()
+        };
+
+        /// <summary>
+        /// The same as above
+        /// </summary>
+        /// <returns></returns>
+        private static GraphQLObjectTypeDefinition BuildGraphQLObjectTypeDefinition() => new GraphQLObjectTypeDefinition
+        {
+            Directives = new List<GraphQLDirective>(),
+            Location = new GraphQLLocation(),
+            Fields = new List<GraphQLFieldDefinition>()
+        };
+
+        private static void AddDirective(GraphQLObjectTypeDefinition definition, GraphQLDirective directive) => ((List<GraphQLDirective>)definition.Directives).Add(directive);
+
+        /// <summary>
+        /// Public helper which will allow us to set "__EXTENSION_AST_MetaField__" on a type which then will be used by FederatedSchemaPrinter
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        public static void BuildExtensionAstMeta(this IProvideMetadata type, string name, string value = null)
+        {
+            var definition = BuildGraphQLObjectTypeDefinition();
+            var directive = BuildGraphQLDirective(name, value, ASTNodeKind.Argument);
+            AddDirective(definition, directive);
+            // type.AddExtensionAstType(definition);
+            type.Metadata["__EXTENSION_AST_MetaField__"] = new List<ASTNode> { definition };
+        }
+
+        /// <summary>
+        /// Public helper which will allow us to set "__AST_MetaField__" on a field which then will be used by FederatedSchemaPrinter
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        public static void BuildAstMeta(this IProvideMetadata type, string name, string value = null)
+        {
+            // var definition = type.GetAstType<GraphQLObjectTypeDefinition>() ?? BuildGraphQLObjectTypeDefinition();
+            var definition = (GraphQLObjectTypeDefinition)type.GetMetadata<ASTNode>("__AST_MetaField__", () => BuildGraphQLObjectTypeDefinition());
+            var directive = BuildGraphQLDirective(name, value);
+            AddDirective(definition, directive);
+            //type.SetAstType(definition);
+            type.Metadata["__AST_MetaField__"] = definition;
+        }
+    }
+
+    /// <summary>
+    /// FieldBuillderExtensions, provide shortcuts for filling field metadata with expected objects, e.g. instead of:
+    /// Field().Name("foo").FieldType.Metadata["__AST_MetaField__"] = new GraphQLObjectTypeDefinition() {...};
+    /// we will have:
+    /// Field().Name("foo").Requires("bar");
+    /// </summary>
+    public static class FederatedFieldBuilderExtensions
+    {
+        private static FieldBuilder<TSourceType, TReturnType> BuildAstMeta<TSourceType, TReturnType>(FieldBuilder<TSourceType, TReturnType> fieldBuilder, string name, string value = null)
+        {
+            fieldBuilder.FieldType.BuildAstMeta(name, value);
+            return fieldBuilder;
+        }
+
+        public static FieldBuilder<TSourceType, TReturnType> Key<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields) => BuildAstMeta(fieldBuilder, "key", fields);
+        public static FieldBuilder<TSourceType, TReturnType> Requires<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields) => BuildAstMeta(fieldBuilder, "requires", fields);
+        public static FieldBuilder<TSourceType, TReturnType> Provides<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields) => BuildAstMeta(fieldBuilder, "provides", fields);
+        public static FieldBuilder<TSourceType, TReturnType> External<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder) => BuildAstMeta(fieldBuilder, "external");
+    }
+
+    /// <summary>
+    /// Can be replaced with ObjectGraphType extensions, the same as above - idea to allow us to define type directives, e.g.:
+    /// public class AcmeType: ObjectGraphType {
+    ///   public AcmeType() {
+    ///     // Metadata["__AST_MetaField__"] = new GraphQLObjectTypeDefinition() {...};
+    ///     Key("id");
+    ///   }
+    /// }
+    ///
+    /// TODO:
+    /// - there is only two cases: `type Account @key(fields:"id")` and `extend type Account @key(fields:"id")`
+    /// - will be nice to have to enforce declaration one of above
+    /// - will be nice to have to enforce resolve reference declaration
+    /// </summary>
+    /// <typeparam name="TSourceType"></typeparam>
+    public class FederatedObjectGraphType<TSourceType> : ObjectGraphType<TSourceType>
+    {
+        public void Key(string fields) => this.BuildAstMeta("key", fields);
+
+        public void ExtendByKey(string fields)
+        {
+            this.BuildExtensionAstMeta("key", fields);
+            Key(fields);
+        }
+
+        // Resolve reference is from schema first aproach
+        public void ResolveReferenceAsync(Func<FederatedResolveContext, Task<TSourceType>> resolver) => ResolveReferenceAsync(new FuncFederatedResolver<TSourceType>(resolver));
+
+        public void ResolveReferenceAsync(IFederatedResolver resolver)
+        {
+            // Metadata[FederatedSchemaBuilder.RESOLVER_METADATA_FIELD] = resolver;
+            Metadata["__FedResolver__"] = resolver;
+        }
+    }
+
+    // TODO: move me into separate project
+    //public static class FederatedGraphQLBuilderExtensions
+    //{
+    //    public static IGraphQLBuilder AddFederation(this IGraphQLBuilder builder)
+    //    {
+    //        builder.Services.AddSingleton<AnyScalarGraphType>();
+    //        builder.Services.AddSingleton<ServiceGraphType>();
+
+    //        return builder;
+    //    }
+    //}
+
+
+    /// <summary>
+    /// Small extensions just to hide registration of required types, can be extension instead
+    /// </summary>
+    public class FederatedSchemaProposal : Schema
+    {
+        public FederatedSchemaProposal() : this(new DefaultServiceProvider()) { }
+        public FederatedSchemaProposal(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+            RegisterValueConverter(new AnyValueConverter());
+            RegisterType<AnyScalarGraphType>();
+            RegisterType<ServiceGraphType>();
+            RegisterType<EntityType>();
+        }
+    }
+
+    /// <summary>
+    /// TODO:
+    /// - implicit vs explicit
+    /// </summary>
+    public class EntityType : UnionGraphType {
+        public EntityType()
+        {
+            Name = "_Entity";
+        }
+    }
+
+    /// <summary>
+    /// Small helper which does add Query._service and Query._entities
+    /// Resolvers are the same as in FederatedSchemaBuilder so can be reused
+    ///
+    /// TODO:
+    /// - extract resolvers into base class
+    /// - reuse resolvers in both FederatedQuery and FederatedSchemaBuilder
+    /// </summary>
+    public class FederatedQuery : ObjectGraphType
+    {
+        public FederatedQuery()
+        {
+            Field<NonNullGraphType<ServiceGraphType>>().Name("_service").Resolve(context => new { });
+
+            Field<NonNullGraphType<ListGraphType<EntityType>>>()
+                .Name("_entities")
+                .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<AnyScalarGraphType>>>>("representations")
+                .ResolveAsync(context =>
+                {
+                    var representations = context.GetArgument<List<Dictionary<string, object>>>("representations");
+                    var results = new List<Task<object>>();
+
+                    foreach (var representation in representations)
+                    {
+                        var typeName = representation["__typename"].ToString();
+                        var type = context.Schema.FindType(typeName);
+
+                        if (type != null)
+                        {
+                            // execute resolver
+                            var resolver = type.GetMetadata<IFederatedResolver>("__FedResolver__");
+                            if (resolver != null)
+                            {
+                                var resolveContext = new FederatedResolveContext
+                                {
+                                    Arguments = representation,
+                                    ParentFieldContext = (ResolveFieldContext)context
+                                };
+                                var result = resolver.Resolve(resolveContext);
+                                results.Add(result);
+                            }
+                            else
+                            {
+                                results.Add(Task.FromResult((object)representation));
+                            }
+                        }
+                        else
+                        {
+                            // otherwise return the representation
+                            results.Add(Task.FromResult((object)representation));
+                        }
+                    }
+
+                    var tasks = Task.WhenAll(results).ContinueWith(results => (object)results.Result);
+                    tasks.ConfigureAwait(false);
+                    return tasks;
+                });
+        }
+    }
+}


### PR DESCRIPTION
Have prepared small video (i do belive that it is better see once rather than read many times)

[![demo](https://img.youtube.com/vi/Cdzo7HU_r-c/0.jpg)](https://www.youtube.com/watch?v=Cdzo7HU_r-c)

# Code First Federation

- [ ] directives
- [ ] _Service
- [ ] _Entity
- [ ] Query._service
- [ ] Query._entities
- [ ] resolve reference
- [ ] tests

We already have an schema first federation implementation and going to reuse as much as possible of its code in code first aproach

## directives

1. We do not have real directives at moment in graphql-dotnet
2. We do not need real directives for federation to work
3. We do need print directives in Query._service for gateway to be able to understand our graph (already have this code in `FederatedSchemaPrinter`)

**How does it work in schema first implementation:** `FederatedSchemaPrinter` expecting fields to have `AST_METAFIELD` and types to have `EXTENSION_AST_METAFIELD` with `GraphQLObjectTypeDefinition` inside, it does use this metadata to print directives in `_serivce { sdl }`

**Proposal:** instead of trying to provide real directives which in either case not required for federation to work (e.g. they are nor runtime nor generation) lets provide the same metadata

For this to work we will have to provide few `FieldBuilder` extensions methods which underneath will construct and set required metadata, e..g. in my code it looks like:

```csharp
public class AccountType: ObjectGraphType<Account> {
    public AccountType() {
        Field(x => x.Id).External();
    }
}
```

The same approach might be done for types, e.g. we can:

- make ObjectGraphType extensions to add key and extend directives
- make FederatedObjectGraphType which will hold this methods

# _Service & Query._service

There is already `ServiceType` defined which can be totally reused, underneath while resolving `sdl` it does creates `FederatedSchemaPrinter` and prints schema from context

All we have to do is to `RegisterType<ServiceGraphType>();` in our schema and inside our `Field<NonNullGraphType<ServiceGraphType>>().Name("_service").Resolve(context => new { });` inside our Query and everything will start to work

 # _Entity

In schema first aproach entities are generated on the fly, I did not found a way to do it dynamically and not really sure whether it should be implicit vs explicit

In my case I do have:

```csharp
public class EntityType : UnionGraphType
{
    public EntityType()
    {
        Name = "_Entity";
        Type<ArticleType>();
        Type<AccountType>();
    }
}
```

which is registered as type in my schema

# Query._entities

This one can be request from `FederatedSchemaBuilder` as is

# resolve references

In my case I have created

```csharp
public class FederatedObjectGraphType<TSourceType> : ObjectGraphType<TSourceType> {
  public void Key(string fields) => this.BuildAstMeta("key", fields);
  public void ExtendByKey(string fields) {
    this.BuildExtensionAstMeta("key", fields);
    Key(fields);
  }

  public void ResolveReferenceAsync(Func<FederatedResolveContext, Task<TSourceType>> resolver) => ResolveReferenceAsync(new FuncFederatedResolver<TSourceType>(resolver));

  public void ResolveReferenceAsync(IFederatedResolver resolver) {
    // Metadata[FederatedSchemaBuilder.RESOLVER_METADATA_FIELD] = resolver;
    Metadata["__FedResolver__"] = resolver;
  }
}
```

Which allows me to have something like this:

```csharp
public class AccountType: FederatedObjectGraphType<Account>
{
    public AccountType(InMemoryStorage storage)
    {
        ExtendByKey("id");
        Name = nameof(Account);
        
        Field(x => x.Id, type: typeof(NonNullGraphType<IdGraphType>)).External();

        Field<NonNullGraphType<ListGraphType<ArticleType>>>().Name("articles").Resolve(context => storage.articles.Where(article => article.AccountId == context.Source.Id));

        ResolveReferenceAsync(context => {
            var id = context.Arguments["id"].ToString();
            var account = new Account { Id = id };
            return Task.FromResult(account);
        });
    }
}
```

I have tested on following sample, where we have

**Accounts Service**

```graphql
type Account key(fields:"id") {
  id: ID!
  name: String!
  username: String!
}

type Query {
  account(id: ID!): Account
  accounts: [Account]!
}
```

**Articles Service**

```graphql
type Article key(fields:"id") {
  id: ID!
  title: String!
  account: Account!
}

extend type Account @key(fields: "id") {
  id: ID! @external
  articles: [Article]!
}
```

which are compatible with apollo gateway and apollo graph manager, e.g. can be connected to gateway and run queries like:

```
{
  article(id:"1") {
    title
    account {
      username
      articles {
        title
      }
    }
  }
  
  account(id:"1") {
    username
    articles {
      title
    }
  }
}
```

# Questions

- **Whether it is ok to reuse same metadata instead of trying to implement real directives - if so - can be first step**
- For me as a user will be nice to have something like `FederatedQuery` which will hide both `Query._service` and `Query._entities` implementations, also `FederatedSchema` which will hide  registration of required types
- Not sure which way to enforce `EntityType`
- Not sure how to enforce existance of `ResolveReference` in graph types