### PR TITLE
Allow full manipulation of Directives in AST node

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -1049,17 +1049,22 @@ namespace GraphQL.Language.AST
         public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
-    public class Directives : GraphQL.Language.AST.AbstractNode, System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Directive>, System.Collections.IEnumerable
+    public class Directives : GraphQL.Language.AST.AbstractNode, System.Collections.Generic.ICollection<GraphQL.Language.AST.Directive>, System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Directive>, System.Collections.IEnumerable
     {
         public Directives() { }
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public int Count { get; }
         public bool HasDuplicates { get; }
+        public bool IsReadOnly { get; }
         public void Add(GraphQL.Language.AST.Directive directive) { }
+        public void Clear() { }
+        public bool Contains(GraphQL.Language.AST.Directive item) { }
+        public void CopyTo(GraphQL.Language.AST.Directive[] array, int arrayIndex) { }
         protected bool Equals(GraphQL.Language.AST.Directives directives) { }
         public GraphQL.Language.AST.Directive Find(string name) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Language.AST.Directive> GetEnumerator() { }
         public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
+        public bool Remove(GraphQL.Language.AST.Directive item) { }
     }
     public class Document : GraphQL.Language.AST.AbstractNode
     {

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -33,7 +33,7 @@ namespace GraphQL.Language.AST
 
         public bool HasDuplicates => _directives?.Count != _unique.Count;
 
-        public bool IsReadOnly => ((ICollection<Directive>)_directives).IsReadOnly;
+        public bool IsReadOnly => false;
 
         public IEnumerator<Directive> GetEnumerator()
         {

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
 {
-    public class Directives : AbstractNode, IEnumerable<Directive>, ICollection<Directive>
+    public class Directives : AbstractNode, ICollection<Directive>
     {
         private List<Directive> _directives;
         private readonly Dictionary<string, Directive> _unique = new Dictionary<string, Directive>(StringComparer.Ordinal);

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
 {
-    public class Directives : AbstractNode, IEnumerable<Directive>
+    public class Directives : AbstractNode, IEnumerable<Directive>, ICollection<Directive>
     {
         private List<Directive> _directives;
         private readonly Dictionary<string, Directive> _unique = new Dictionary<string, Directive>(StringComparer.Ordinal);
@@ -33,6 +33,8 @@ namespace GraphQL.Language.AST
 
         public bool HasDuplicates => _directives?.Count != _unique.Count;
 
+        public bool IsReadOnly => ((ICollection<Directive>)_directives).IsReadOnly;
+
         public IEnumerator<Directive> GetEnumerator()
         {
             if (_directives == null)
@@ -52,5 +54,17 @@ namespace GraphQL.Language.AST
             if (obj.GetType() != GetType()) return false;
             return Equals((Directives)obj);
         }
+
+        public void Clear()
+        {
+            _directives.Clear();
+            _unique.Clear();
+        }
+
+        public bool Contains(Directive item) => _directives.Contains(item);
+
+        public void CopyTo(Directive[] array, int arrayIndex) => _directives.CopyTo(array, arrayIndex);
+
+        public bool Remove(Directive item) => _directives.Remove(item) && _unique.Remove(item.Name);
     }
 }


### PR DESCRIPTION
This was one of the few (only?) exceptions to the AST being
full read-write, and prevented some processing of docs to
sanitize directives, for example, prior to execution.

There was really no apparent reason to introduce this limitation
at the AST level, so we implement `ICollection<Directive>` to
allow full mutation of this collection.