### PR TITLE
Add a RelayBatchDataLoader to existing DataLoaders

### DIFF
--- a/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
+++ b/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GraphQL.Types.Relay.DataObjects;
 
 namespace GraphQL.DataLoader
 {
@@ -240,6 +241,28 @@ namespace GraphQL.DataLoader
                 throw new ArgumentNullException(nameof(keySelector));
 
             return context.GetOrAdd(loaderKey, () => new CollectionBatchDataLoader<TKey, T>(WrapNonCancellableFunc(fetchFunc), keySelector, keyComparer));
+        }
+
+        /// <summary>
+        /// Get or add a DataLoader instance for batching paginated data fetching operations.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key used to load data</typeparam>
+        /// <typeparam name="T">The type of data to be loaded</typeparam>
+        /// <param name="context">The <seealso cref="DataLoaderContext"/> to get or add a DataLoader to</param>
+        /// <param name="loaderKey">A unique key to identify the DataLoader instance</param>
+        /// <param name="fetchFunc">A delegate to fetch paginated data for some keys asynchronously</param>
+        /// <param name="keyComparer">An <seealso cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <returns>A new or existing DataLoader instance</returns>
+        public static IRelayDataLoader<TKey, T> GetOrAddRelayBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<PageRequest<TKey>>, CancellationToken, Task<IDictionary<TKey, Connection<T>>>> fetchFunc,
+            IEqualityComparer<PageRequest<TKey>> keyComparer = null)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            if (fetchFunc == null)
+                throw new ArgumentNullException(nameof(fetchFunc));
+
+            return context.GetOrAdd(loaderKey, () => new RelayBatchDataLoader<TKey, T>(fetchFunc, keyComparer));
         }
     }
 }

--- a/src/GraphQL/DataLoader/IRelayDataLoader.cs
+++ b/src/GraphQL/DataLoader/IRelayDataLoader.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using GraphQL.Types.Relay.DataObjects;
+
+namespace GraphQL.DataLoader
+{
+    public class PageArguments
+    {
+        public string After { get; set; }
+        public string Before { get; set; }
+        public int First { get; set; }
+        public int Last { get; set; }
+    }
+
+    public class PageRequest<TKey>
+    {
+        public TKey Key { get; set; }
+        public PageArguments PageArguments { get; set; }
+    }
+
+    public interface IRelayDataLoader<TKey, T>
+    {
+        Task<Connection<T>> LoadPageAsync(PageRequest<TKey> pagedKey);
+    }
+}

--- a/src/GraphQL/DataLoader/RelayBatchDataLoader.cs
+++ b/src/GraphQL/DataLoader/RelayBatchDataLoader.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL.Types.Relay.DataObjects;
+
+namespace GraphQL.DataLoader
+{
+    public class RelayBatchDataLoader<TKey, T> : DataLoaderBase<IDictionary<TKey, Connection<T>>>, IRelayDataLoader<TKey, T>
+    {
+        private readonly Func<IEnumerable<PageRequest<TKey>>, CancellationToken, Task<IDictionary<TKey, Connection<T>>>> _loader;
+        private readonly HashSet<PageRequest<TKey>> _pendingRequests;
+
+        public RelayBatchDataLoader(Func<IEnumerable<PageRequest<TKey>>, CancellationToken, Task<IDictionary<TKey, Connection<T>>>> loader, IEqualityComparer<PageRequest<TKey>> keyComparer = null)
+        {
+            _loader = loader ?? throw new ArgumentNullException(nameof(loader));
+
+            keyComparer ??= EqualityComparer<PageRequest<TKey>>.Default;
+            _pendingRequests = new HashSet<PageRequest<TKey>>(keyComparer);
+        }
+
+        protected override bool IsFetchNeeded()
+        {
+            lock (_pendingRequests)
+            {
+                return _pendingRequests.Count > 0;
+            }
+        }
+
+        protected override async Task<IDictionary<TKey, Connection<T>>> FetchAsync(CancellationToken cancellationToken)
+        {
+            IList<PageRequest<TKey>> pageRequests;
+
+            lock (_pendingRequests)
+            {
+                pageRequests = _pendingRequests.ToArray();
+                _pendingRequests.Clear();
+            }
+
+            var responses = await _loader(pageRequests, cancellationToken);
+
+            return responses;
+        }
+
+        public async Task<Connection<T>> LoadPageAsync(PageRequest<TKey> pageRequest)
+        {
+            lock (_pendingRequests)
+            {
+                _pendingRequests.Add(pageRequest);
+            }
+
+            var result = await DataLoaded.ConfigureAwait(false);
+            return result.TryGetValue(pageRequest.Key, out var value) ? value : default;
+        }
+    }
+}


### PR DESCRIPTION
### PULL REQUEST DESCRIPTION
This is a proposal for a new dataloader based on the Relay specification. The proposed code will be used to ease the development of GraphQL Relay servers by providing the required page information to the resolving (typically infrastructure) layer.

### RELATED TOPIC
In my opinion, using EntityFrameworkCore is the most natural way of resolving GraphQL .NET server requests. However, with the current solution, it is quite painful to fetch data from a DataSet<T> with a Relay implementation. To release the stress, I have coded a ToConnectionDictionary method that is an extension of IQueryable<T> with the following heading:
```
private static async Task<IDictionary<TKey, Connection<T>>> ToConnectionDictionary<T, TKey>(this IQueryable<T> query, IEnumerable<PageRequest<TKey>> pageRequests, Expression<Func<T, TKey>> keySelector, Expression<Func<T, string>> cursorSelector)
```
This method fits perfectly with the new RelayBatchDataLoader and relieves the pain of correctly coding it.