### PR TITLE
Make sure error paths prefer aliases

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -178,6 +178,7 @@ namespace GraphQL
         GraphQL.Language.AST.Operation Operation { get; }
         GraphQL.Types.IObjectGraphType ParentType { get; }
         System.Collections.Generic.IEnumerable<object> Path { get; }
+        System.Collections.Generic.IEnumerable<object> ResponsePath { get; }
         GraphQL.Types.IGraphType ReturnType { get; }
         object RootValue { get; }
         GraphQL.Types.ISchema Schema { get; }
@@ -257,6 +258,7 @@ namespace GraphQL
         public GraphQL.Language.AST.Operation Operation { get; }
         public GraphQL.Types.IObjectGraphType ParentType { get; }
         public System.Collections.Generic.IEnumerable<object> Path { get; }
+        public System.Collections.Generic.IEnumerable<object> ResponsePath { get; }
         public GraphQL.Types.IGraphType ReturnType { get; }
         public object RootValue { get; }
         public GraphQL.Types.ISchema Schema { get; }
@@ -282,6 +284,7 @@ namespace GraphQL
         public GraphQL.Language.AST.Operation Operation { get; set; }
         public GraphQL.Types.IObjectGraphType ParentType { get; set; }
         public System.Collections.Generic.IEnumerable<object> Path { get; set; }
+        public System.Collections.Generic.IEnumerable<object> ResponsePath { get; set; }
         public GraphQL.Types.IGraphType ReturnType { get; set; }
         public object RootValue { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
@@ -617,6 +620,7 @@ namespace GraphQL.Execution
         public string Name { get; }
         public GraphQL.Execution.ExecutionNode Parent { get; }
         public System.Collections.Generic.IEnumerable<object> Path { get; }
+        public System.Collections.Generic.IEnumerable<object> ResponsePath { get; }
         public object Result { get; set; }
         public object Source { get; set; }
         public GraphQL.Types.IObjectGraphType GetParentType(GraphQL.Types.ISchema schema) { }

--- a/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Execution;
+using GraphQL.Types;
+using Xunit;
+
+using AST = GraphQL.Language.AST;
+
+namespace GraphQL.Tests.Execution
+{
+    public class ExecutionNodeTests
+    {
+        [Fact]
+        public void Path_Alias()
+        {
+            var objectGraphType = new AliasedFieldTestObject();
+
+            var node = new ValueExecutionNode(
+                new RootExecutionNode(objectGraphType),
+                new StringGraphType(),
+                new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name")),
+                objectGraphType.GetField("value"),
+                indexInParentNode: null);
+
+            var path = node.Path.ToList();
+            string pathSegment = Assert.Single(path) as string;
+            Assert.Equal("name", pathSegment);
+        }
+
+        [Fact]
+        public void Path_Name()
+        {
+            var objectGraphType = new AliasedFieldTestObject();
+
+            var node = new ValueExecutionNode(
+                new RootExecutionNode(objectGraphType),
+                new StringGraphType(),
+                new AST.Field(null, new AST.NameNode("name")),
+                objectGraphType.GetField("value"),
+                indexInParentNode: null);
+
+            var path = node.Path.ToList();
+            string pathSegment = Assert.Single(path) as string;
+            Assert.Equal("name", pathSegment);
+        }
+
+        [Fact]
+        public void ResponsePath_Alias()
+        {
+            var objectGraphType = new AliasedFieldTestObject();
+
+            var node = new ValueExecutionNode(
+                new RootExecutionNode(objectGraphType),
+                new StringGraphType(),
+                new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name")),
+                objectGraphType.GetField("value"),
+                indexInParentNode: null);
+
+            var path = node.ResponsePath.ToList();
+            string pathSegment = Assert.Single(path) as string;
+            Assert.Equal("alias", pathSegment);
+        }
+
+        [Fact]
+        public void ResponsePath_Name()
+        {
+            var objectGraphType = new AliasedFieldTestObject();
+
+            var node = new ValueExecutionNode(
+                new RootExecutionNode(objectGraphType),
+                new StringGraphType(),
+                new AST.Field(null, new AST.NameNode("name")),
+                objectGraphType.GetField("value"),
+                indexInParentNode: null);
+
+            var path = node.ResponsePath.ToList();
+            string pathSegment = Assert.Single(path) as string;
+            Assert.Equal("name", pathSegment);
+        }
+    }
+
+    public class AliasedFieldTestObject : ObjectGraphType
+    {
+        public AliasedFieldTestObject()
+        {
+            Field<StringGraphType>(
+                "value",
+                resolve: context => context.FieldAst.Alias ?? context.FieldAst.Name);
+        }
+    }
+}

--- a/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Execution;
 using GraphQL.Types;
+using Shouldly;
 using Xunit;
 
 using AST = GraphQL.Language.AST;
@@ -23,8 +23,7 @@ namespace GraphQL.Tests.Execution
                 indexInParentNode: null);
 
             var path = node.Path.ToList();
-            string pathSegment = Assert.Single(path) as string;
-            Assert.Equal("name", pathSegment);
+            path.ShouldHaveSingleItem().ShouldBeOfType<string>().ShouldBe("name");
         }
 
         [Fact]
@@ -40,8 +39,7 @@ namespace GraphQL.Tests.Execution
                 indexInParentNode: null);
 
             var path = node.Path.ToList();
-            string pathSegment = Assert.Single(path) as string;
-            Assert.Equal("name", pathSegment);
+            path.ShouldHaveSingleItem().ShouldBeOfType<string>().ShouldBe("name");
         }
 
         [Fact]
@@ -57,8 +55,7 @@ namespace GraphQL.Tests.Execution
                 indexInParentNode: null);
 
             var path = node.ResponsePath.ToList();
-            string pathSegment = Assert.Single(path) as string;
-            Assert.Equal("alias", pathSegment);
+            path.ShouldHaveSingleItem().ShouldBeOfType<string>().ShouldBe("alias");
         }
 
         [Fact]
@@ -74,8 +71,7 @@ namespace GraphQL.Tests.Execution
                 indexInParentNode: null);
 
             var path = node.ResponsePath.ToList();
-            string pathSegment = Assert.Single(path) as string;
-            Assert.Equal("name", pathSegment);
+            path.ShouldHaveSingleItem().ShouldBeOfType<string>().ShouldBe("name");
         }
     }
 

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -60,33 +60,15 @@ namespace GraphQL.Execution
             return null;
         }
 
-        public IEnumerable<object> Path
-        {
-            get
-            {
-                var node = this;
-                var count = 0;
-                while (!(node is RootExecutionNode))
-                {
-                    node = node.Parent;
-                    ++count;
-                }
+        /// <summary>
+        /// The path for the current node within the query.
+        /// </summary>
+        public IEnumerable<object> Path => GeneratePath(isForResponse: false);
 
-                var pathList = new object[count];
-                var index = count;
-                node = this;
-                while (!(node is RootExecutionNode))
-                {
-                    if (node.IndexInParentNode.HasValue)
-                        pathList[--index] = GetObjectIndex(node.IndexInParentNode.Value);
-                    else
-                        pathList[--index] = node.Field.Name;
-                    node = node.Parent;
-                }
-
-                return pathList;
-            }
-        }
+        /// <summary>
+        /// The path for the current node within the response.
+        /// </summary>
+        public IEnumerable<object> ResponsePath => GeneratePath(isForResponse: true);
 
         private static readonly object _num0 = 0;
         private static readonly object _num1 = 1;
@@ -124,6 +106,31 @@ namespace GraphQL.Execution
             15 => _num15,
             _ => index
         };
+
+        private IEnumerable<object> GeneratePath(bool isForResponse)
+        {
+            var node = this;
+            var count = 0;
+            while (!(node is RootExecutionNode))
+            {
+                node = node.Parent;
+                ++count;
+            }
+
+            var pathList = new object[count];
+            var index = count;
+            node = this;
+            while (!(node is RootExecutionNode))
+            {
+                if (node.IndexInParentNode.HasValue)
+                    pathList[--index] = GetObjectIndex(node.IndexInParentNode.Value);
+                else
+                    pathList[--index] = isForResponse ? node.Name : node.Field.Name;
+                node = node.Parent;
+            }
+
+            return pathList;
+        }
     }
 
     public interface IParentExecutionNode

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -62,12 +62,12 @@ namespace GraphQL.Execution
         /// <summary>
         /// The path for the current node within the query.
         /// </summary>
-        public IEnumerable<object> Path => GeneratePath(isForResponse: false);
+        public IEnumerable<object> Path => GeneratePath(preferAlias: false);
 
         /// <summary>
         /// The path for the current node within the response.
         /// </summary>
-        public IEnumerable<object> ResponsePath => GeneratePath(isForResponse: true);
+        public IEnumerable<object> ResponsePath => GeneratePath(preferAlias: true);
 
         private static readonly object _num0 = 0;
         private static readonly object _num1 = 1;
@@ -106,7 +106,7 @@ namespace GraphQL.Execution
             _ => index
         };
 
-        private IEnumerable<object> GeneratePath(bool isForResponse)
+        private IEnumerable<object> GeneratePath(bool preferAlias)
         {
             var node = this;
             var count = 0;
@@ -124,7 +124,7 @@ namespace GraphQL.Execution
                 if (node.IndexInParentNode.HasValue)
                     pathList[--index] = GetObjectIndex(node.IndexInParentNode.Value);
                 else
-                    pathList[--index] = isForResponse ? node.Name : node.Field.Name;
+                    pathList[--index] = preferAlias ? node.Name : node.Field.Name;
                 node = node.Parent;
             }
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -131,7 +131,7 @@ namespace GraphQL.Execution
                             + $" Field: {parent.Name}, Type: {parent.FieldDefinition.ResolvedType}.");
 
                         error.AddLocation(parent.Field, context.Document);
-                        error.Path = parent.Path.Append(index);
+                        error.Path = parent.ResponsePath.Append(index);
                         context.Errors.Add(error);
                         return;
                     }
@@ -210,7 +210,7 @@ namespace GraphQL.Execution
             catch (ExecutionError error)
             {
                 error.AddLocation(node.Field, context.Document);
-                error.Path = node.Path;
+                error.Path = node.ResponsePath;
                 context.Errors.Add(error);
 
                 node.Result = null;
@@ -230,7 +230,7 @@ namespace GraphQL.Execution
 
                 var error = new ExecutionError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve {node.Name}.", ex);
                 error.AddLocation(node.Field, context.Document);
-                error.Path = node.Path;
+                error.Path = node.ResponsePath;
                 context.Errors.Add(error);
 
                 node.Result = null;

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -79,7 +79,8 @@ namespace GraphQL.Execution
                     CancellationToken = context.CancellationToken,
                     Metrics = context.Metrics,
                     Errors = context.Errors,
-                    Path = node.Path
+                    Path = node.Path,
+                    ResponsePath = node.ResponsePath,
                 };
 
                 var eventStreamField = node.FieldDefinition as EventStreamFieldType;
@@ -144,7 +145,7 @@ namespace GraphQL.Execution
                                         context,
                                         $"Could not subscribe to field '{node.Field.Name}' in query '{context.Document.OriginalQuery}'",
                                         node.Field,
-                                        node.Path,
+                                        node.ResponsePath,
                                         exception)
                                 }
                             }.With(context)));
@@ -152,7 +153,7 @@ namespace GraphQL.Execution
             catch (Exception ex)
             {
                 var message = $"Error trying to resolve {node.Field.Name}.";
-                var error = GenerateError(context, message, node.Field, node.Path, ex);
+                var error = GenerateError(context, message, node.Field, node.ResponsePath, ex);
                 context.Errors.Add(error);
                 return null;
             }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -68,8 +68,11 @@ namespace GraphQL
         /// <summary>Can be used to return specific errors back to the GraphQL request caller</summary>
         ExecutionErrors Errors { get; }
 
-        /// <summary>The path to the current executing field from the request root</summary>
+        /// <summary>The path to the current executing field from the request root as it would appear in the query</summary>
         IEnumerable<object> Path { get; }
+
+        /// <summary>The path to the current executing field from the request root as it would appear in the response</summary>
+        IEnumerable<object> ResponsePath { get; }
 
         /// <summary>Returns a list of child fields requested for the current field</summary>
         IDictionary<string, Field> SubFields { get; }

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -64,6 +64,8 @@ namespace GraphQL
 
         public IEnumerable<object> Path => _executionNode.Path;
 
+        public IEnumerable<object> ResponsePath => _executionNode.ResponsePath;
+
         public IDictionary<string, Language.AST.Field> SubFields => _subFields ?? (_subFields = GetSubFields());
 
         public IDictionary<string, object> UserContext => _executionContext.UserContext;

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -68,8 +68,6 @@ namespace GraphQL
 
         public IEnumerable<object> ResponsePath => _executionNode.ResponsePath;
 
-        public IDictionary<string, Language.AST.Field> SubFields => _subFields ?? (_subFields = GetSubFields());
-
         public IDictionary<string, object> UserContext => _executionContext.UserContext;
 
         object IResolveFieldContext.Source => _executionNode.Source;

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -64,9 +64,9 @@ namespace GraphQL
 
         public IEnumerable<object> Path => _executionNode.Path;
 
-        public IDictionary<string, Field> SubFields => _subFields ?? (_subFields = GetSubFields());
-
         public IEnumerable<object> ResponsePath => _executionNode.ResponsePath;
+
+        public IDictionary<string, Field> SubFields => _subFields ?? (_subFields = GetSubFields());
 
         public IDictionary<string, object> UserContext => _executionContext.UserContext;
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -50,6 +50,8 @@ namespace GraphQL
 
         public IEnumerable<object> Path { get; set; }
 
+        public IEnumerable<object> ResponsePath { get; set; }
+
         public IDictionary<string, Field> SubFields { get; set; }
 
         public IDictionary<string, object> Extensions { get; set; }
@@ -80,6 +82,7 @@ namespace GraphQL
             Errors = context.Errors;
             SubFields = context.SubFields;
             Path = context.Path;
+            ResponsePath = context.ResponsePath;
             Extensions = context.Extensions;
         }
     }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -67,6 +67,8 @@ namespace GraphQL
 
         public IEnumerable<object> Path => _baseContext.Path;
 
+        public IEnumerable<object> ResponsePath => _baseContext.ResponsePath;
+
         public IDictionary<string, Language.AST.Field> SubFields => _baseContext.SubFields;
 
         public IDictionary<string, object> UserContext => _baseContext.UserContext;


### PR DESCRIPTION
According to [the GraphQL spec](http://spec.graphql.org/June2018/#sec-Errors) the path in an error, when a field is aliased, should include the alias and not the name. Specifically:
```
If the error happens in an aliased field, the path to the error should use the aliased name, since it represents a path in the response, not in the query.
```
My first thought was to simply change `ExecutionNode.Path` to prefer the alias since it is only used to populate error paths, however I quickly decided that could be a breaking change for consumers that are accessing the path in their resolvers and are expecting the "query" path.

So instead I've implemented a new `ResponsePath` property that is now used to populate `ExecutionError.Path`. It's also exposed in the `ResolveFieldContext` for any resolvers that want the path to contain aliases as well.