### PR TITLE
Raise errors upon failed coercion to meet graphql specifications

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -686,6 +686,11 @@ namespace GraphQL.Execution
     {
         public InvalidValueException(string variableName, string message) { }
     }
+    public class NullExecutionNode : GraphQL.Execution.ExecutionNode
+    {
+        public NullExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public override object ToValue() { }
+    }
     public class ObjectExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {
         public ObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
@@ -725,7 +730,8 @@ namespace GraphQL.Execution
     }
     public class ValueExecutionNode : GraphQL.Execution.ExecutionNode
     {
-        public ValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.ScalarGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public GraphQL.Types.ScalarGraphType GraphType { get; }
         public override object ToValue() { }
     }
 }

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -594,7 +594,7 @@ namespace GraphQL.Execution
     }
     public static class ExecutionHelper
     {
-        public static void AssertValidValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, object input, string fieldName) { }
+        public static void AssertValidVariableValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, object input, string variableName) { }
         public static object CoerceValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue input, GraphQL.Language.AST.Variables variables = null) { }
         public static System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> CollectFields(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IGraphType specificType, GraphQL.Language.AST.SelectionSet selectionSet) { }
         public static bool DoesFragmentConditionMatch(GraphQL.Execution.ExecutionContext context, string fragmentName, GraphQL.Types.IGraphType type) { }
@@ -684,7 +684,7 @@ namespace GraphQL.Execution
     }
     public class InvalidValueException : GraphQL.ExecutionError
     {
-        public InvalidValueException(string fieldName, string message) { }
+        public InvalidValueException(string variableName, string message) { }
     }
     public class ObjectExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {

--- a/src/GraphQL.Tests/Bugs/Bug1205VeryLongInt.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1205VeryLongInt.cs
@@ -13,7 +13,14 @@ namespace GraphQL.Tests.Bugs
         public void Very_Long_Number_Should_Return_Error_For_Int()
         {
             var query = "{ int }";
-            var expected = new ExecutionResult { Errors = new ExecutionErrors { new ExecutionError("Value was either too large or too small for an Int32.", new OverflowException()) } };
+            var error = new ExecutionError("Error trying to resolve int.", new OverflowException());
+            error.AddLocation(1, 3);
+            error.Path = new object[] { "int" };
+            var expected = new ExecutionResult {
+                Errors = new ExecutionErrors { error },
+                Data = new { @int = (object)null }
+            };
+            
             AssertQueryIgnoreErrors(query, expected, renderErrors: true, expectedErrorCount: 1);
         }
 
@@ -60,7 +67,15 @@ namespace GraphQL.Tests.Bugs
         public void Very_Very_Long_Number_Should_Return_Error_For_Long()
         {
             var query = "{ long_return_bigint }";
-            var expected = new ExecutionResult { Errors = new ExecutionErrors { new ExecutionError("Value was either too large or too small for an Int64.", new OverflowException()) } };
+            var error = new ExecutionError("Error trying to resolve long_return_bigint.", new OverflowException());
+            error.AddLocation(1, 3);
+            error.Path = new object[] { "long_return_bigint" };
+            var expected = new ExecutionResult
+            {
+                Errors = new ExecutionErrors { error },
+                Data = new { long_return_bigint = (object)null }
+            };
+
             AssertQueryIgnoreErrors(query, expected, renderErrors: true, expectedErrorCount: 1);
         }
 

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -35,7 +35,7 @@ namespace GraphQL.Tests.Bugs
         public void Int_Enum() => AssertQueryWithError("{ happy }", @"{ ""happy"": null }", "Unable to serialize '1' to \u0027Bug1699Enum\u0027", 1, 3, "happy");
 
         [Fact]
-        public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Unable to serialize '50'", 1, 3, "invalidEnum");
+        public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Unable to serialize '50' to \u0027Bug1699Enum\u0027", 1, 3, "invalidEnum");
 
         // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
         [Fact]

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -60,6 +60,9 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_InvalidInt() => AssertQueryWithError(@"{ input(arg: 2) }", null, "Argument \u0022arg\u0022 has invalid value 2.\nExpected type \u0022Bug1699Enum\u0022, found 2.", 1, 9, (object[])null, code: "5.3.3.1");
 
         [Fact]
+        public void Input_Enum_Valid_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum!) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", "{\"arg\":\"GRUMPY\"}".ToInputs());
+
+        [Fact]
         public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to Bug1699Enum", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}");
 
         [Fact]

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -63,7 +63,7 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_Valid_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum!) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", "{\"arg\":\"GRUMPY\"}".ToInputs());
 
         [Fact]
-        public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to Bug1699Enum", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}");
+        public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}");
 
         [Fact]
         public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to Bug1699Enum", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":2}");

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -32,7 +32,7 @@ namespace GraphQL.Tests.Bugs
 
         // within C#, (int)Bug1699Enum.Happy does not equal Bug1699.Happy
         [Fact]
-        public void Int_Enum() => AssertQueryWithError("{ happy }", @"{ ""happy"": null }", "Unable to serialize '1'", 1, 3, "happy");
+        public void Int_Enum() => AssertQueryWithError("{ happy }", @"{ ""happy"": null }", "Unable to serialize '1' to \u0027Bug1699Enum\u0027", 1, 3, "happy");
 
         [Fact]
         public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Unable to serialize '50'", 1, 3, "invalidEnum");

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -78,10 +78,10 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_OverrideDefault() => AssertQuerySuccess("{ inputWithDefault(arg: SLEEPY) }", @"{ ""inputWithDefault"": ""Sleepy"" }");
 
         [Fact]
-        public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Field \u0022inputRequired\u0022 argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required but not provided.", 1, 3, (object[])null, code: "5.3.3.2");
+        public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required for field \u0022inputRequired\u0022 but not provided.", 1, 3, (object[])null, code: "5.3.3.2");
 
         [Fact]
-        public void Input_Enum_RequiredWithDefault() => AssertQueryWithError(@"{ inputRequiredWithDefault }", null, "Field \u0022inputRequiredWithDefault\u0022 argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required but not provided.", 1, 3, (object[])null, code: "5.3.3.2");
+        public void Input_Enum_RequiredWithDefault() => AssertQueryWithError(@"{ inputRequiredWithDefault }", null, "Argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required for field \u0022inputRequiredWithDefault\u0022 but not provided.", 1, 3, (object[])null, code: "5.3.3.2");
     }
 
     public class Bug1699InvalidEnumSchema : Schema

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -39,7 +39,7 @@ namespace GraphQL.Tests.Bugs
 
         // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
         [Fact]
-        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Unable to serialize '50' to Bug1699Enum", 1, 3, "invalidEnumWithinList");
+        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Unable to serialize '50' to \u0027Bug1699Enum\u0027", 1, 3, "invalidEnumWithinList");
 
         [Fact]
         public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Unable to serialize '50' to \u0027Bug1699Enum\u0027", 1, 3, "invalidEnumWithinNonNullList");

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -39,10 +39,10 @@ namespace GraphQL.Tests.Bugs
 
         // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
         [Fact]
-        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Unable to serialize '50'", 1, 3, "invalidEnumWithinList");
+        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Unable to serialize '50' to Bug1699Enum", 1, 3, "invalidEnumWithinList");
 
         [Fact]
-        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Unable to serialize '50'", 1, 3, "invalidEnumWithinNonNullList");
+        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Unable to serialize '50' to Bug1699Enum", 1, 3, "invalidEnumWithinNonNullList");
 
         [Fact]
         public void Input_Enum_Valid() => AssertQuerySuccess("{ inputEnum(arg: SLEEPY) }", @"{ ""inputEnum"": ""SLEEPY"" }");

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Unable to serialize '50'", 1, 3, "invalidEnum");
 
-        // does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
+        // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
         [Fact]
         public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Unable to serialize '50'", 1, 3, "invalidEnumWithinList");
 

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -42,7 +42,7 @@ namespace GraphQL.Tests.Bugs
         public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Unable to serialize '50' to Bug1699Enum", 1, 3, "invalidEnumWithinList");
 
         [Fact]
-        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Unable to serialize '50' to Bug1699Enum", 1, 3, "invalidEnumWithinNonNullList");
+        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Unable to serialize '50' to \u0027Bug1699Enum\u0027", 1, 3, "invalidEnumWithinNonNullList");
 
         [Fact]
         public void Input_Enum_Valid() => AssertQuerySuccess("{ inputEnum(arg: SLEEPY) }", @"{ ""inputEnum"": ""SLEEPY"" }");

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -1,0 +1,134 @@
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using System;
+using System.Linq;
+using System.Numerics;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/1699
+    public class Bug1699InvalidEnum : QueryTestBase<Bug1699InvalidEnumSchema>
+    {
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, string path, Exception exception = null, string code = null, string inputs = null)
+            => AssertQueryWithError(query, result, message, line, column, new object[] { path }, exception, code, inputs);
+
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null)
+        {
+            var error = exception == null ? new ExecutionError(message) : new ExecutionError(message, exception);
+            error.AddLocation(line, column);
+            error.Path = path;
+            if (code != null)
+                error.Code = code;
+            var expected = CreateQueryResult(result, new ExecutionErrors { error });
+            AssertQueryIgnoreErrors(query, expected, inputs?.ToInputs(), renderErrors: true, expectedErrorCount: 1);
+        }
+
+        [Fact]
+        public void Simple_Enum() => AssertQuerySuccess("{ grumpy }", @"{ ""grumpy"": ""GRUMPY"" }");
+
+        [Fact]
+        public void String_Enum() => AssertQuerySuccess("{ sleepy }", @"{ ""sleepy"": ""SLEEPY"" }");
+
+        // within C#, (int)Bug1699Enum.Happy does not equal Bug1699.Happy
+        [Fact]
+        public void Int_Enum() => AssertQueryWithError("{ happy }", @"{ ""happy"": null }", "Unable to serialize '1'", 1, 3, "happy");
+
+        [Fact]
+        public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Unable to serialize '50'", 1, 3, "invalidEnum");
+
+        // does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
+        [Fact]
+        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Unable to serialize '50'", 1, 3, "invalidEnumWithinList");
+
+        [Fact]
+        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Unable to serialize '50'", 1, 3, "invalidEnumWithinNonNullList");
+
+        [Fact]
+        public void Input_Enum_Valid() => AssertQuerySuccess("{ inputEnum(arg: SLEEPY) }", @"{ ""inputEnum"": ""SLEEPY"" }");
+
+        [Fact]
+        public void Input_Enum_Valid2() => AssertQuerySuccess("{ input(arg: SLEEPY) }", @"{ ""input"": ""Sleepy"" }");
+
+        [Fact]
+        public void Input_Enum_InvalidString() => AssertQueryWithError(@"{ input(arg: ""SLEEPY"") }", null, "Argument \u0022arg\u0022 has invalid value \u0022SLEEPY\u0022.\nExpected type \u0022Bug1699Enum\u0022, found \u0022SLEEPY\u0022.", 1, 9, (object[])null, code: "5.3.3.1");
+
+        [Fact]
+        public void Input_Enum_InvalidInt() => AssertQueryWithError(@"{ input(arg: 2) }", null, "Argument \u0022arg\u0022 has invalid value 2.\nExpected type \u0022Bug1699Enum\u0022, found 2.", 1, 9, (object[])null, code: "5.3.3.1");
+
+        [Fact]
+        public void Input_Enum_UndefinedDefault() => AssertQuerySuccess("{ input }", @"{ ""input"": ""Grumpy"" }");
+
+        [Fact]
+        public void Input_Enum_SetDefault() => AssertQuerySuccess("{ inputWithDefault }", @"{ ""inputWithDefault"": ""Happy"" }");
+
+        [Fact]
+        public void Input_Enum_OverrideDefault() => AssertQuerySuccess("{ inputWithDefault(arg: SLEEPY) }", @"{ ""inputWithDefault"": ""Sleepy"" }");
+
+        [Fact]
+        public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Field \u0022inputRequired\u0022 argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required but not provided.", 1, 3, (object[])null, code: "5.3.3.2");
+
+        [Fact]
+        public void Input_Enum_RequiredWithDefault() => AssertQueryWithError(@"{ inputRequiredWithDefault }", null, "Field \u0022inputRequiredWithDefault\u0022 argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required but not provided.", 1, 3, (object[])null, code: "5.3.3.2");
+    }
+
+    public class Bug1699InvalidEnumSchema : Schema
+    {
+        public Bug1699InvalidEnumSchema()
+        {
+            Query = new Bug1699InvalidEnumQuery();
+        }
+    }
+
+    public class Bug1699InvalidEnumQuery : ObjectGraphType
+    {
+        public Bug1699InvalidEnumQuery()
+        {
+            Field<EnumerationGraphType<Bug1699Enum>>(
+                "grumpy",
+                resolve: ctx => Bug1699Enum.Grumpy);
+            Field<EnumerationGraphType<Bug1699Enum>>(
+                "happy",
+                resolve: ctx => (int)Bug1699Enum.Happy);
+            Field<EnumerationGraphType<Bug1699Enum>>(
+                "sleepy",
+                resolve: ctx => Bug1699Enum.Sleepy.ToString());
+            Field<EnumerationGraphType<Bug1699Enum>>(
+                "invalidEnum",
+                resolve: ctx => 50);
+            Field<ListGraphType<EnumerationGraphType<Bug1699Enum>>>(
+                "invalidEnumWithinList",
+                resolve: ctx => new Bug1699Enum[] { Bug1699Enum.Happy, Bug1699Enum.Sleepy, (Bug1699Enum)50 });
+            Field<ListGraphType<NonNullGraphType<EnumerationGraphType<Bug1699Enum>>>>(
+                "invalidEnumWithinNonNullList",
+                resolve: ctx => new Bug1699Enum[] { Bug1699Enum.Happy, Bug1699Enum.Sleepy, (Bug1699Enum)50 });
+            Field<EnumerationGraphType<Bug1699Enum>>(
+                "inputEnum",
+                arguments: new QueryArguments(new QueryArgument<EnumerationGraphType<Bug1699Enum>> { Name = "arg" }),
+                resolve: ctx => ctx.GetArgument<Bug1699Enum>("arg"));
+            Field<StringGraphType>(
+                "input",
+                arguments: new QueryArguments(new QueryArgument<EnumerationGraphType<Bug1699Enum>> { Name = "arg" }),
+                resolve: ctx => ctx.GetArgument<Bug1699Enum>("arg").ToString());
+            Field<StringGraphType>(
+                "inputWithDefault",
+                arguments: new QueryArguments(new QueryArgument<EnumerationGraphType<Bug1699Enum>> { Name = "arg", DefaultValue = Bug1699Enum.Happy }),
+                resolve: ctx => ctx.GetArgument<Bug1699Enum>("arg").ToString());
+            Field<StringGraphType>(
+                "inputRequired",
+                arguments: new QueryArguments(new QueryArgument<NonNullGraphType<EnumerationGraphType<Bug1699Enum>>> { Name = "arg" }),
+                resolve: ctx => ctx.GetArgument<Bug1699Enum>("arg").ToString());
+            Field<StringGraphType>(
+                "inputRequiredWithDefault",
+                arguments: new QueryArguments(new QueryArgument<NonNullGraphType<EnumerationGraphType<Bug1699Enum>>> { Name = "arg", DefaultValue = Bug1699Enum.Happy }),
+                resolve: ctx => ctx.GetArgument<Bug1699Enum>("arg").ToString());
+        }
+    }
+
+    public enum Bug1699Enum
+    {
+        Grumpy,
+        Happy,
+        Sleepy,
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -81,7 +81,7 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required for field \u0022inputRequired\u0022 but not provided.", 1, 3, (object[])null, code: "5.3.3.2");
 
         [Fact]
-        public void Input_Enum_RequiredWithDefault() => AssertQueryWithError(@"{ inputRequiredWithDefault }", null, "Argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required for field \u0022inputRequiredWithDefault\u0022 but not provided.", 1, 3, (object[])null, code: "5.3.3.2");
+        public void Input_Enum_RequiredWithDefault() => AssertQuerySuccess("{ inputRequiredWithDefault }", @"{ ""inputRequiredWithDefault"": ""Happy"" }");
     }
 
     public class Bug1699InvalidEnumSchema : Schema

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -66,7 +66,7 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}");
 
         [Fact]
-        public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to Bug1699Enum", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":2}");
+        public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":2}");
 
         [Fact]
         public void Input_Enum_UndefinedDefault() => AssertQuerySuccess("{ input }", @"{ ""input"": ""Grumpy"" }");

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -290,7 +290,7 @@ namespace GraphQL.Tests.Execution
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
             caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null field.");
+            caughtError?.InnerException.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null variable.");
         }
 
         [Fact]
@@ -322,7 +322,7 @@ namespace GraphQL.Tests.Execution
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
             caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null field.");
+            caughtError?.InnerException.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null variable.");
         }
 
         [Fact]
@@ -510,7 +510,7 @@ namespace GraphQL.Tests.Execution
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
             caughtError.InnerException.ShouldNotBeNull();
-            caughtError.InnerException.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null field.");
+            caughtError.InnerException.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null variable.");
         }
 
         [Fact]
@@ -531,7 +531,7 @@ namespace GraphQL.Tests.Execution
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
             caughtError.InnerException.ShouldNotBeNull();
-            caughtError.InnerException.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null field.");
+            caughtError.InnerException.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null variable.");
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -643,13 +643,15 @@ namespace GraphQL.Tests.Execution
             }
             ";
 
-            var expected = @"
+            var error = new ExecutionError("Argument \u0022input\u0022 has invalid value WRONG_TYPE.\nExpected type \u0022String\u0022, found WRONG_TYPE.");
+            error.AddLocation(3, 45);
+            error.Code = "5.3.3.1";
+            var expected = new ExecutionResult
             {
-              ""fieldWithDefaultArgumentValue"": ""\""Hello World\""""
-            }
-            ";
+                Errors = new ExecutionErrors { error },
+            };
 
-            AssertQuerySuccess(query, expected, rules:Enumerable.Empty<IValidationRule>());
+            AssertQueryIgnoreErrors(query, expected, renderErrors: true, expectedErrorCount: 1);
         }
     }
 }

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -111,7 +111,7 @@ namespace GraphQL.Execution
             catch (InvalidValueException error)
             {
                 error.AddLocation(variable, document);
-                throw error;
+                throw;
             }
 
             if (input == null && variable.DefaultValue != null)

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -144,7 +144,7 @@ namespace GraphQL.Execution
 
             if (type is ScalarGraphType scalar)
             {
-                // validate value can be parsed correctly
+                // verify value can be converted successfully
 
                 if (input is IValue value)
                 {

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -301,7 +301,7 @@ namespace GraphQL.Execution
 
             if (type is ScalarGraphType scalarType)
             {
-                return scalarType.ParseLiteral(input) ?? throw new ArgumentException($"Unable to convert '{input}' to {type.Name}");
+                return scalarType.ParseLiteral(input) ?? throw new ArgumentException($"Unable to convert '{input}' to '{type.Name}'");
             }
 
             return null;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -300,7 +300,7 @@ namespace GraphQL.Execution
 
             if (type is ScalarGraphType scalarType)
             {
-                return scalarType.ParseLiteral(input) ?? throw new ArgumentException($"Unable to convert '{input}'");
+                return scalarType.ParseLiteral(input) ?? throw new InvalidValueException($"Unable to convert '{input}' to {type.Name}");
             }
 
             return null;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -155,7 +155,7 @@ namespace GraphQL.Execution
                 else
                 {
                     if (scalar.ParseValue(input) == null)
-                        throw new InvalidValueException(variableName, $"Unable to convert '{input}' to {type.Name}");
+                        throw new InvalidValueException(variableName, $"Unable to convert '{input}' to '{type.Name}'");
                 }
 
                 return;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -150,7 +150,7 @@ namespace GraphQL.Execution
                 if (input is IValue value)
                 {
                     if (scalar.ParseLiteral(value) == null)
-                        throw new InvalidValueException(variableName, $"Unable to convert '{value.Value}' to {type.Name}");
+                        throw new InvalidValueException(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'");
                 }
                 else
                 {

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -124,6 +124,7 @@ namespace GraphQL.Execution
 
         public static void AssertValidVariableValue(ISchema schema, IGraphType type, object input, string variableName)
         {
+            // see also GraphQLExtensions.IsValidLiteralValue
             if (type is NonNullGraphType graphType)
             {
                 var nonNullType = graphType.ResolvedType;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -300,7 +300,7 @@ namespace GraphQL.Execution
 
             if (type is ScalarGraphType scalarType)
             {
-                return scalarType.ParseLiteral(input) ?? throw new InvalidValueException($"Unable to convert '{input}' to {type.Name}");
+                return scalarType.ParseLiteral(input) ?? throw new ArgumentException($"Unable to convert '{input}' to {type.Name}");
             }
 
             return null;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -1,6 +1,7 @@
 using GraphQL.Introspection;
 using GraphQL.Language.AST;
 using GraphQL.Types;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -207,10 +208,10 @@ namespace GraphQL.Execution
         {
             if (input is IValue value)
             {
-                return scalar.ParseLiteral(value);
+                return scalar.ParseLiteral(value) ?? throw new ArgumentException($"Unable to convert '{value.Value}'");
             }
 
-            return scalar.ParseValue(input);
+            return scalar.ParseValue(input) ?? throw new ArgumentException($"Unable to convert '{input}'");
         }
 
         public static Dictionary<string, object> GetArgumentValues(ISchema schema, QueryArguments definitionArguments, Arguments astArguments, Variables variables)
@@ -299,7 +300,7 @@ namespace GraphQL.Execution
 
             if (type is ScalarGraphType scalarType)
             {
-                return scalarType.ParseLiteral(input);
+                return scalarType.ParseLiteral(input) ?? throw new ArgumentException($"Unable to convert '{input}'");
             }
 
             return null;

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -241,11 +241,8 @@ namespace GraphQL.Execution
 
         public override object ToValue()
         {
-            if (Result == null)
-                return null;
-
-            var scalarType = GraphType as ScalarGraphType;
-            return scalarType?.Serialize(Result);
+            // result has already been serialized within ExecuteNodeAsync / SetArrayItemNodes
+            return Result;
         }
     }
 }

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -233,7 +233,7 @@ namespace GraphQL.Execution
 
     public class ValueExecutionNode : ExecutionNode
     {
-        public ValueExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        public ValueExecutionNode(ExecutionNode parent, ScalarGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
             : base(parent, graphType, field, fieldDefinition, indexInParentNode)
         {
 
@@ -244,5 +244,18 @@ namespace GraphQL.Execution
             // result has already been serialized within ExecuteNodeAsync / SetArrayItemNodes
             return Result;
         }
+
+        public new ScalarGraphType GraphType => (ScalarGraphType)base.GraphType;
+    }
+
+    public class NullExecutionNode : ExecutionNode
+    {
+        public NullExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+        {
+            Result = null;
+        }
+
+        public override object ToValue() => null;
     }
 }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -122,7 +122,7 @@ namespace GraphQL.Execution
                     else if (node is ValueExecutionNode valueNode)
                     {
                         node.Result = valueNode.GraphType.Serialize(d)
-                            ?? throw new ExecutionError($"Unable to serialize '{d}' to {valueNode.GraphType.Name}");
+                            ?? throw new ExecutionError($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}'");
                     }
 
                     arrayItems.Add(node);

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -119,6 +119,11 @@ namespace GraphQL.Execution
                     {
                         SetArrayItemNodes(context, arrayNode);
                     }
+                    else if (node is ValueExecutionNode valueNode)
+                    {
+                        node.Result = ((ScalarGraphType)itemType).Serialize(d)
+                            ?? throw new ExecutionError($"Unable to serialize '{d}'");
+                    }
 
                     arrayItems.Add(node);
                 }
@@ -204,6 +209,11 @@ namespace GraphQL.Execution
                     else if (node is ArrayExecutionNode arrayNode)
                     {
                         SetArrayItemNodes(context, arrayNode);
+                    }
+                    else if (node is ValueExecutionNode valueNode)
+                    {
+                        node.Result = ((ScalarGraphType)valueNode.GraphType).Serialize(node.Result)
+                            ?? throw new ExecutionError($"Unable to serialize '{node.Result}'");
                     }
                 }
             }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -121,7 +121,7 @@ namespace GraphQL.Execution
                     }
                     else if (node is ValueExecutionNode valueNode)
                     {
-                        node.Result = ((ScalarGraphType)itemType).Serialize(d)
+                        node.Result = valueNode.GraphType.Serialize(d)
                             ?? throw new ExecutionError($"Unable to serialize '{d}' to {valueNode.GraphType.Name}");
                     }
 
@@ -141,11 +141,8 @@ namespace GraphQL.Execution
                         return;
                     }
 
-                    var valueExecutionNode = new ValueExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, index++)
-                    {
-                        Result = null
-                    };
-                    arrayItems.Add(valueExecutionNode);
+                    var nullExecutionNode = new NullExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, index++);
+                    arrayItems.Add(nullExecutionNode);
                 }
             }
 
@@ -162,7 +159,7 @@ namespace GraphQL.Execution
                 ListGraphType _ => new ArrayExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
                 IObjectGraphType _ => new ObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
                 IAbstractGraphType _ => new ObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
-                ScalarGraphType _ => new ValueExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
+                ScalarGraphType scalarGraphType => new ValueExecutionNode(parent, scalarGraphType, field, fieldDefinition, indexInParentNode),
                 _ => throw new InvalidOperationException($"Unexpected type: {graphType}")
             };
         }
@@ -212,7 +209,7 @@ namespace GraphQL.Execution
                     }
                     else if (node is ValueExecutionNode valueNode)
                     {
-                        node.Result = ((ScalarGraphType)valueNode.GraphType).Serialize(node.Result)
+                        node.Result = valueNode.GraphType.Serialize(node.Result)
                             ?? throw new ExecutionError($"Unable to serialize '{node.Result}'");
                     }
                 }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -122,7 +122,7 @@ namespace GraphQL.Execution
                     else if (node is ValueExecutionNode valueNode)
                     {
                         node.Result = ((ScalarGraphType)itemType).Serialize(d)
-                            ?? throw new ExecutionError($"Unable to serialize '{d}'");
+                            ?? throw new ExecutionError($"Unable to serialize '{d}' to {valueNode.GraphType.Name}");
                     }
 
                     arrayItems.Add(node);

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -210,7 +210,7 @@ namespace GraphQL.Execution
                     else if (node is ValueExecutionNode valueNode)
                     {
                         node.Result = valueNode.GraphType.Serialize(node.Result)
-                            ?? throw new ExecutionError($"Unable to serialize '{node.Result}'");
+                            ?? throw new ExecutionError($"Unable to serialize '{node.Result}' to '{valueNode.GraphType.Name}'");
                     }
                 }
             }

--- a/src/GraphQL/Execution/InvalidValueException.cs
+++ b/src/GraphQL/Execution/InvalidValueException.cs
@@ -5,8 +5,8 @@ namespace GraphQL.Execution
     [Serializable]
     public class InvalidValueException : ExecutionError
     {
-        public InvalidValueException(string fieldName, string message) :
-            base($"Variable '${fieldName}' is invalid. {message}")
+        public InvalidValueException(string variableName, string message) :
+            base($"Variable '${variableName}' is invalid. {message}")
         {
 
         }

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -153,6 +153,7 @@ namespace GraphQL
 
         public static IEnumerable<string> IsValidLiteralValue(this IGraphType type, IValue valueAst, ISchema schema)
         {
+            // see also ExecutionHelper.AssertValidVariableValue
             if (type is NonNullGraphType nonNull)
             {
                 var ofType = nonNull.ResolvedType;

--- a/src/GraphQL/Types/Scalars/ScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ScalarGraphType.cs
@@ -23,7 +23,7 @@ namespace GraphQL.Types
         /// The returned value of a the result coercion is part of the overall execution result.
         /// Normally this value is a primitive value like String or Integer to make it easy for
         /// the serialization layer. For complex types like a Date or Money Scalar this involves
-        /// formatting the value.
+        /// formatting the value. Returning null indicates a failed conversion.
         /// </returns>
         public virtual object Serialize(object value) => ParseValue(value);
 
@@ -35,7 +35,7 @@ namespace GraphQL.Types
         /// String but rather complex ones when appropriate.
         /// </summary>
         /// <param name="value"> AST value node. </param>
-        /// <returns> Internal scalar representation. </returns>
+        /// <returns> Internal scalar representation. Returning null indicates a failed conversion. </returns>
         public abstract object ParseLiteral(IValue value);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace GraphQL.Types
         /// always be expressed in GraphQL query syntax, variable format is transport-specific (usually JSON).
         /// </summary>
         /// <param name="value"> Runtime object from variables. </param>
-        /// <returns> Internal scalar representation. </returns>
+        /// <returns> Internal scalar representation. Returning null indicates a failed conversion. </returns>
         public abstract object ParseValue(object value);
     }
 }

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -39,16 +39,15 @@ namespace GraphQL.Validation.Rules
 
                     foreach (var arg in fieldDef.Arguments)
                     {
-                        var argAst = node.Arguments?.ValueFor(arg.Name);
-                        var type = arg.ResolvedType;
-
-                        if (argAst == null && type is NonNullGraphType)
+                        if (arg.DefaultValue == null &&
+                            arg.ResolvedType is NonNullGraphType &&
+                            node.Arguments?.ValueFor(arg.Name) == null)
                         {
                             context.ReportError(
                                 new ValidationError(
                                     context.OriginalQuery,
                                     "5.3.3.2",
-                                    MissingFieldArgMessage(node.Name, arg.Name, context.Print(type)),
+                                    MissingFieldArgMessage(node.Name, arg.Name, context.Print(arg.ResolvedType)),
                                     node));
                         }
                     }

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -14,12 +14,12 @@ namespace GraphQL.Validation.Rules
     {
         public string MissingFieldArgMessage(string fieldName, string argName, string type)
         {
-            return $"Field \"{fieldName}\" argument \"{argName}\" of type \"{type}\" is required but not provided.";
+            return $"Argument \"{argName}\" of type \"{type}\" is required for field \"{fieldName}\" but not provided.";
         }
 
         public string MissingDirectiveArgMessage(string directiveName, string argName, string type)
         {
-            return $"Directive \"{directiveName}\" argument \"{argName}\" of type \"{type}\" is required but not provided.";
+            return $"Argument \"{argName}\" of type \"{type}\" is required for directive \"{directiveName}\" but not provided.";
         }
 
         public static readonly ProvidedNonNullArguments Instance = new ProvidedNonNullArguments();


### PR DESCRIPTION
Fixes #1699 

Fixes both input and output serialization coercion to meet these graphql requirements:

Scalars:
> 3.5 Result Coercion: A GraphQL server, when preparing a field of a given scalar type, must uphold the contract the scalar type describes, either by coercing the value or producing a field error if a value cannot be coerced or if coercion may result in data loss.

> 3.5 Input Coercion: If a GraphQL server expects a scalar type as input to an argument, coercion is observable and the rules must be well defined. If an input value does not match a coercion rule, a query error must be raised.

Enums:

> 3.9 Result Coercion: GraphQL servers must return one of the defined set of possible values. If a reasonable coercion is not possible they must raise a field error.

> 3.9 Input Coercion: GraphQL has a constant literal to represent enum input values. GraphQL string literals must not be accepted as an enum input and instead raise a query error.

Errors:
> 6.6.4 If an error is thrown while resolving a field, it should be treated as though the field returned null, and an error must be added to the "errors" list in the response.

Notes:
* The `when_argument_provided_cannot_be_parsed` test explicitly tested for incorrect behavior.  This has been fixed.
* The `Very_Long_Number_Should_Return_Error_For_Int` and `Very_Long_Number_In_Input_Should_Work_For_Long` test violated rule 6.6.4 as they did not return null to the field and add the error to the result.  Rather, they did not return any data, and only the one error.  This has been fixed.
* Although there are no enum-specific changes in this PR, I have added a number of tests for enums to test coercion properties.
* No breaking changes for applications which meet the graphql specification (passing valid values as arguments to queries, and returning valid values from field resolvers).  Can potentially break applications that rely on the incorrect behavior demonstrated within `when_argument_provided_cannot_be_parsed`, or applications that return invalid values from field resolvers, as these will now cause a query error.

Limitations of this PR:
* When returning a list of scalars, and one of the scalars causes a coercion error, an error is reported for the entire list, rather than the single member that caused the coercion error.  Nulls are properly bubbled up (starting with the entire list, rather than the member that caused the error).  Tests are in place to demonstrate this functionality, along with an appropriate comment.  This can possibly be addressed in a future PR, but would require notable refactoring or redesign, due to the design of the exception processing in place.