### PR TITLE
Stop escaping enum literals when used as default values

### DIFF
--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -920,6 +920,44 @@ scalar Uri
         }
 
         [Fact]
+        public void prints_enum_default_args()
+        {
+            var root = new ObjectGraphType { Name = "Query" };
+            
+            var f = new FieldType
+            {
+                Name = "bestColor",
+                Arguments = new QueryArguments(new QueryArgument<RgbEnum>
+                {
+                    Name = "color",
+                    DefaultValue = "RED"
+                }),
+                Type = typeof(RgbEnum)
+            };
+            root.AddField(f);
+            var schema = new Schema { Query = root };
+            schema.RegisterType<RgbEnum>();
+            var expected = new Dictionary<string, string>
+            {
+                {
+                    "Query",
+@"type Query {
+  bestColor(color: RGB = RED): RGB
+}"
+                },
+                {
+                    "RGB",
+@"enum RGB {
+  RED
+  GREEN
+  BLUE
+}"
+                },
+            };
+            AssertEqual(print(schema), expected);
+        }
+
+        [Fact]
         public void prints_introspection_schema()
         {
             var schema = new Schema

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -322,6 +322,11 @@ namespace GraphQL.Utilities
 
         public string FormatDefaultValue(object value, IGraphType graphType)
         {
+            if (IsEnumType(graphType))
+            {
+                return "{0}".ToFormat(SerializeEnumValue(graphType, value));
+            }
+
             if (value is string)
             {
                 return "\"{0}\"".ToFormat(value);
@@ -330,11 +335,6 @@ namespace GraphQL.Utilities
             if (value is bool)
             {
                 return value.ToString().ToLower(CultureInfo.InvariantCulture);
-            }
-
-            if (IsEnumType(graphType))
-            {
-                return "{0}".ToFormat(SerializeEnumValue(graphType, value));
             }
 
             return "{0}".ToFormat(value);


### PR DESCRIPTION
Co-Authored-By: Maria Miller <mariajmiller@users.noreply.github.com>

Enum values like `RED` were getting schema-printed as `"RED"` when used as default values, which is wrong. The fix is to just move the check of whether it is an enum first when printing.