### PR TITLE
make SuccessfullyValidatedResult public

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -2599,6 +2599,12 @@ namespace GraphQL.Validation
     {
         public MatchingNodeVisitor(System.Action<TNode> enter = null, System.Action<TNode> leave = null) { }
     }
+    public sealed class SuccessfullyValidatedResult : GraphQL.Validation.IValidationResult
+    {
+        public static readonly GraphQL.Validation.SuccessfullyValidatedResult Instance;
+        public GraphQL.ExecutionErrors Errors { get; }
+        public bool IsValid { get; }
+    }
     public class TypeInfo : GraphQL.Validation.INodeVisitor
     {
         public TypeInfo(GraphQL.Types.ISchema schema) { }

--- a/src/GraphQL/Validation/ValidationResult.cs
+++ b/src/GraphQL/Validation/ValidationResult.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Validation
     /// <summary>
     /// Optimization for validation "green path" - does not allocate memory in managed heap.
     /// </summary>
-    internal sealed class SuccessfullyValidatedResult : IValidationResult
+    public sealed class SuccessfullyValidatedResult : IValidationResult
     {
         private SuccessfullyValidatedResult() { }
 


### PR DESCRIPTION
At the moment in consuming code I have to have

```
var result = new ValidationResult(Enumerable.Empty<ValidationError>());
```