### PR TITLE
fix issue #1189

### DIFF
--- a/src/GraphQL.Tests/Bugs/Issue1189.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1189.cs
@@ -1,0 +1,97 @@
+using System;
+using GraphQL.Tests.Utilities;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class Issue1189 : SchemaBuilderTestBase
+    {
+        private const string _typeDefinitions = @"
+                  type Droid {
+                    id: String!
+                    name: String!
+                    friend: Character
+                  }
+
+                  type Character {
+                    name: String!
+                  }
+
+                  type Query {
+                    hero: Droid
+                  }
+                ";
+
+        private const string _query = "{ hero { id name friend { name } } }";
+
+        [Theory]
+        [InlineData(typeof(Issue1189_DroidType_ExecutionError), "Error Message")]
+        [InlineData(typeof(Issue1189_DroidType_Exception), "Error trying to resolve friend.")]
+        public void Issue1189_Should_Work(Type resolverType, string errorMessage)
+        {
+            Builder.Types.Include<Issue1189_Query>();
+            Builder.Types.Include(resolverType);
+
+            var schema = Builder.Build(_typeDefinitions);
+            schema.Initialize();
+
+            var error = new ExecutionError(errorMessage);
+            error.AddLocation(1, 18);
+            error.Path = new string[] { "hero", "friend" };
+
+            var queryResult = new ExecutionResult()
+            {
+                Data = new { hero = new { id = "1", name = "R2-D2", friend = default(Issue1189_Character) } },
+                Errors = new ExecutionErrors { error }
+            };
+
+            AssertQuery(
+                _ =>
+                {
+                    _.Schema = schema;
+                    _.Query = _query;
+                    _.ThrowOnUnhandledException = false;
+                },
+                queryResult);
+        }
+    }
+
+    public class Issue1189_Droid
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Issue1189_Character
+    {
+        public string Name { get; set; }
+    }
+
+    [GraphQLMetadata("Query", IsTypeOf = typeof(Issue1189_Query))]
+    public class Issue1189_Query
+    {
+        [GraphQLMetadata("hero")]
+        public Issue1189_Droid GetHero()
+            => new Issue1189_Droid { Id = "1", Name = "R2-D2" };
+    }
+
+    [GraphQLMetadata("Droid", IsTypeOf = typeof(Issue1189_Droid))]
+    public class Issue1189_DroidType_ExecutionError
+    {
+        public string Id(Issue1189_Droid droid) => droid.Id;
+        public string Name(Issue1189_Droid droid) => droid.Name;
+
+        public Issue1189_Character Friend()
+            => throw new ExecutionError("Error Message");
+    }
+
+    [GraphQLMetadata("Droid", IsTypeOf = typeof(Issue1189_Droid))]
+    public class Issue1189_DroidType_Exception
+    {
+        public string Id(Issue1189_Droid droid) => droid.Id;
+        public string Name(Issue1189_Droid droid) => droid.Name;
+
+        public Issue1189_Character Friend()
+            => throw new Exception("Error Message");
+    }
+}

--- a/src/GraphQL/Reflection/SingleMethodAccessor.cs
+++ b/src/GraphQL/Reflection/SingleMethodAccessor.cs
@@ -23,7 +23,14 @@ namespace GraphQL.Reflection
 
         public object GetValue(object target, object[] arguments)
         {
-            return MethodInfo.Invoke(target, arguments);
+            try
+            {
+                return MethodInfo.Invoke(target, arguments);
+            }
+            catch (TargetInvocationException ex)
+            {
+                throw ex.InnerException;
+            }
         }
     }
 }


### PR DESCRIPTION
When using schema-first approach, resolvers are dynamically dispatched. This causes any exception raised inside resolver logic to be wrapped in a TargetInvocationException. As a result ExecutionError mechanism doesn't work properly (as described in #1189)