### PR TITLE
Prevent unnecessary wrapping of ExecutionErrors in DocumentExecuter

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -63,10 +63,10 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_Valid_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum!) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", "{\"arg\":\"GRUMPY\"}".ToInputs());
 
         [Fact]
-        public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, inputs: "{\"arg\":\"DOPEY\"}");
+        public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}");
 
         [Fact]
-        public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, inputs: "{\"arg\":2}");
+        public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":2}");
 
         [Fact]
         public void Input_Enum_UndefinedDefault() => AssertQuerySuccess("{ input }", @"{ ""input"": ""Grumpy"" }");

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -63,10 +63,10 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_Valid_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum!) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", "{\"arg\":\"GRUMPY\"}".ToInputs());
 
         [Fact]
-        public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}");
+        public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, inputs: "{\"arg\":\"DOPEY\"}");
 
         [Fact]
-        public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 0, 0, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":2}");
+        public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, inputs: "{\"arg\":2}");
 
         [Fact]
         public void Input_Enum_UndefinedDefault() => AssertQuerySuccess("{ input }", @"{ ""input"": ""Grumpy"" }");

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -289,8 +289,7 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null variable.");
+            caughtError.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null variable.");
         }
 
         [Fact]
@@ -305,8 +304,7 @@ namespace GraphQL.Tests.Execution
             var caughtError = result.Errors.Single();
 
             caughtError.ShouldNotBeNull();
-            caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe(
+            caughtError.Message.ShouldBe(
                 "Variable '$input' is invalid. Unable to parse input as a 'TestInputObject' type. Did you provide a List or Scalar value accidentally?");
         }
 
@@ -321,8 +319,7 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null variable.");
+            caughtError.Message.ShouldBe("Variable '$input.c' is invalid. Received a null input for a non-null variable.");
         }
 
         [Fact]
@@ -336,8 +333,7 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError?.InnerException.ShouldNotBeNull();
-            caughtError?.InnerException.Message.ShouldBe("Variable '$input' is invalid. Unrecognized input fields 'e' for type 'TestInputObject'.");
+            caughtError.Message.ShouldBe("Variable '$input' is invalid. Unrecognized input fields 'e' for type 'TestInputObject'.");
         }
 
         [Fact]
@@ -509,8 +505,7 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError.InnerException.ShouldNotBeNull();
-            caughtError.InnerException.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null variable.");
+            caughtError.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null variable.");
         }
 
         [Fact]
@@ -530,8 +525,7 @@ namespace GraphQL.Tests.Execution
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
-            caughtError.InnerException.ShouldNotBeNull();
-            caughtError.InnerException.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null variable.");
+            caughtError.Message.ShouldBe("Variable '$value' is invalid. Received a null input for a non-null variable.");
         }
 
         [Fact]

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -208,7 +208,7 @@ namespace GraphQL
                 {
                     Errors = new ExecutionErrors
                     {
-                        new ExecutionError(ex.Message, ex)
+                        ex is ExecutionError executionError ? executionError : new ExecutionError(ex.Message, ex)
                     }
                 };
             }

--- a/src/GraphQL/Execution/InvalidValueException.cs
+++ b/src/GraphQL/Execution/InvalidValueException.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Execution
         public InvalidValueException(string variableName, string message) :
             base($"Variable '${variableName}' is invalid. {message}")
         {
-
+            Code = "INVALID_VALUE";
         }
     }
 }


### PR DESCRIPTION
Right now all unhandled `Exception`s are wrapped inside an `ExecutionError` within `DocumentExecuter` (unless `ThrowOnUnhandledException` is set).  This prevents additional data, such as location or codes, from being returned either from library code or from the `UnhandledExceptionDelegate`.  This can be seen in the `Input_Enum_InvalidEnum_Variable` test, as it can only return the location information with this change.