### PR TITLE
Prevent unnecessary wrapping of ExecutionErrors in ExecutionStrategy

### DIFF
--- a/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
+++ b/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
@@ -29,11 +29,46 @@ namespace GraphQL.Tests.Errors
             });
         }
 
+        [Fact]
+        public void unhandled_error_delegate_can_rethrow_custom_exception()
+        {
+            var def = @"
+                type Query {
+                  hello2: Int
+                }
+            ";
+
+            Builder.Types.Include<Query>();
+
+            var expectedError = new ExecutionError("Test error message");
+            expectedError.AddLocation(1, 3);
+            expectedError.Path = new[] { "hello2" };
+            
+            AssertQuery(options =>
+            {
+                options.Schema = Builder.Build(def);
+                options.Query = "{ hello2 }";
+                options.UnhandledExceptionDelegate = ctx =>
+                {
+                    if (ctx.Exception is ApplicationException)
+                    {
+                        ctx.Exception = new ExecutionError("Test error message");
+                    }
+                };
+            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError }, Data = new { hello2 = (object)null } });
+
+        }
+
         public class Query
         {
             public int Hello()
             {
                 throw new Exception("arrgh");
+            }
+
+            public int Hello2()
+            {
+                throw new ApplicationException("error!");
             }
         }
     }

--- a/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
+++ b/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
@@ -30,7 +30,7 @@ namespace GraphQL.Tests.Errors
         }
 
         [Fact]
-        public void unhandled_error_delegate_can_rethrow_custom_exception()
+        public void unhandled_exception_delegate_can_rethrow_custom_exception()
         {
             var def = @"
                 type Query {

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -228,7 +228,7 @@ namespace GraphQL.Execution
                     ex = exceptionContext.Exception;
                 }
 
-                var error = new ExecutionError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve {node.Name}.", ex);
+                var error = ex is ExecutionError executionError ? executionError : new ExecutionError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve {node.Name}.", ex);
                 error.AddLocation(node.Field, context.Document);
                 error.Path = node.Path;
                 context.Errors.Add(error);


### PR DESCRIPTION
This allows `UnhandledExceptionDelegate`s to return custom messages, just like throwing an `ExecutionError` directly from a resolver can already do.