### PR TITLE
Add location information to query parsing errors

### DIFF
--- a/src/GraphQL.Tests/Errors/QueryErrorTests.cs
+++ b/src/GraphQL.Tests/Errors/QueryErrorTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Errors
+{
+    public class QueryErrorTests : QueryTestBase<QueryErrorTests.TestSchema>
+    {
+        [Theory]
+        [InlineData("unknownoperation { firstAsync }", 1, 1)]
+        [InlineData("{ { firstAsync } }", 1, 3)]
+        [InlineData("{ firstAsync", 1, 13)]
+        [InlineData("{ firstAsync( }", 1, 15)]
+        public async Task parsing_error_for_bad_query(string query, int errorLine, int errorColumn)
+        {
+            var result = await Executer.ExecuteAsync(_ =>
+            {
+                _.Schema = Schema;
+                _.Query = query;
+            });
+
+            result.Errors.Count.ShouldBe(1);
+            var error = result.Errors.First();
+            error.Locations.ShouldNotBeNull();
+            error.Locations.Count().ShouldBe(1);
+            error.Locations.First().Line.ShouldBe(errorLine);
+            error.Locations.First().Column.ShouldBe(errorColumn);
+            error.Message.ShouldStartWith("Error parsing query:");
+            error.InnerException.ShouldBeOfType<GraphQLParser.Exceptions.GraphQLSyntaxErrorException>();
+        }
+
+        public class TestQuery : ObjectGraphType
+        {
+            public TestQuery()
+            {
+                Name = "Query";
+                Field<StringGraphType>(
+                    "firstSync",
+                    resolve: _ => "3"
+                );
+            }
+        }
+
+        public class TestSchema : Schema
+        {
+            public TestSchema()
+            {
+                Query = new TestQuery();
+            }
+        }
+    }
+}

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -1,7 +1,8 @@
-using System;
 using GraphQL.Language;
 using GraphQL.Language.AST;
 using GraphQLParser;
+using GraphQLParser.AST;
+using GraphQLParser.Exceptions;
 
 namespace GraphQL.Execution
 {
@@ -18,12 +19,12 @@ namespace GraphQL.Execution
         public Document Build(string body)
         {
             var source = new Source(body);
-            GraphQLParser.AST.GraphQLDocument result;
+            GraphQLDocument result;
             try
             {
                 result = _parser.Parse(source);
             }
-            catch (GraphQLParser.Exceptions.GraphQLSyntaxErrorException ex)
+            catch (GraphQLSyntaxErrorException ex)
             {
                 var e = new ExecutionError(ex.Description, ex);
                 e.AddLocation(ex.Line, ex.Column);

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using GraphQL.Language;
 using GraphQL.Language.AST;
 using GraphQLParser;
@@ -17,7 +18,41 @@ namespace GraphQL.Execution
         public Document Build(string body)
         {
             var source = new Source(body);
-            var result = _parser.Parse(source);
+            GraphQLParser.AST.GraphQLDocument result;
+            try
+            {
+                result = _parser.Parse(source);
+            }
+            catch (GraphQLParser.Exceptions.GraphQLSyntaxErrorException ex)
+            {
+                ExecutionError rethrowException = null;
+                try
+                {
+                    //e.g. message = "Syntax Error GraphQL (1:1) Unexpected Name \"unknownoperation\"\n1: unknownoperation { firstAsync }\n   ^\n"
+                    var message = ex.Message.Substring(0, ex.Message.IndexOf('\n'));
+                    var paren = ex.Message.IndexOf('(');
+                    var colon = ex.Message.IndexOf(':', paren);
+                    var paren2 = ex.Message.IndexOf(')', colon);
+                    var line = ex.Message.Substring(paren + 1, colon - paren - 1);
+                    var column = ex.Message.Substring(colon + 1, paren2 - colon - 1);
+                    var messageDescription = message.Substring(paren2 + 1).Trim();
+
+                    //e.g. newMessageDescription = "Error parsing query: Unexpected Name \"unknownoperation\""
+                    var newMessageDescription = "Error parsing query: " + messageDescription;
+
+                    rethrowException = new ExecutionError(newMessageDescription, ex);
+                    rethrowException.AddLocation(int.Parse(line), int.Parse(column));
+                    //rethrowException.Code will default to "SYNTAX_ERROR"
+                }
+                catch
+                {
+                }
+
+                if (rethrowException != null)
+                    throw rethrowException;
+
+                throw;
+            }
 
             var document = CoreToVanillaConverter.Convert(body, result);
             document.OriginalQuery = body;

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Execution
             }
             catch (GraphQLSyntaxErrorException ex)
             {
-                var e = new ExecutionError(ex.Description, ex);
+                var e = new ExecutionError("Error parsing query: " + ex.Description, ex);
                 e.AddLocation(ex.Line, ex.Column);
                 throw e;
             }

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -25,33 +25,9 @@ namespace GraphQL.Execution
             }
             catch (GraphQLParser.Exceptions.GraphQLSyntaxErrorException ex)
             {
-                ExecutionError rethrowException = null;
-                try
-                {
-                    //e.g. message = "Syntax Error GraphQL (1:1) Unexpected Name \"unknownoperation\"\n1: unknownoperation { firstAsync }\n   ^\n"
-                    var message = ex.Message.Substring(0, ex.Message.IndexOf('\n'));
-                    var paren = ex.Message.IndexOf('(');
-                    var colon = ex.Message.IndexOf(':', paren);
-                    var paren2 = ex.Message.IndexOf(')', colon);
-                    var line = ex.Message.Substring(paren + 1, colon - paren - 1);
-                    var column = ex.Message.Substring(colon + 1, paren2 - colon - 1);
-                    var messageDescription = message.Substring(paren2 + 1).Trim();
-
-                    //e.g. newMessageDescription = "Error parsing query: Unexpected Name \"unknownoperation\""
-                    var newMessageDescription = "Error parsing query: " + messageDescription;
-
-                    rethrowException = new ExecutionError(newMessageDescription, ex);
-                    rethrowException.AddLocation(int.Parse(line), int.Parse(column));
-                    //rethrowException.Code will default to "SYNTAX_ERROR"
-                }
-                catch
-                {
-                }
-
-                if (rethrowException != null)
-                    throw rethrowException;
-
-                throw;
+                var e = new ExecutionError(ex.Description, ex);
+                e.AddLocation(ex.Line, ex.Column);
+                throw e;
             }
 
             var document = CoreToVanillaConverter.Convert(body, result);

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="5.1.2" />
+    <PackageReference Include="GraphQL-Parser" Version="5.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />


### PR DESCRIPTION
Right now graphql syntax errors are passed through directly from the graphql parser library.  The error messages are multi-line and the location information is embedded inside the message string rather than attached to the graphql error response.  This PR parses the exception message from the graphql-parser library into the proper fields for the graphql response.

~~Note that this PR requires #1763 in order to work properly, as currently ExecutionErrors are wrapped, dropping location information.~~ Merged

The returned error code will not change with this PR (currently SYNTAX_ERROR).  In a separate PR, I will look at updating all of the error codes, including this one, that should be returned.