### PR TITLE
Add checks for null DocumentExecuter parameters

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -62,7 +62,10 @@ namespace GraphQL.Tests.Bugs
         }
 
         [Fact]
-        public void query_is_empty() => AssertQueryWithError("", null, "Unable to determine operation from query.", 0, 0, (object[])null);
+        public void query_is_empty() => AssertQueryWithError("", null, "A query is required.", 0, 0, (object[])null);
+
+        [Fact]
+        public void query_is_whitespace() => AssertQueryWithError("\t \t \r\n", null, "A query is required.", 0, 0, (object[])null);
 
         [Fact]
         public void DocumentExecuter_cannot_have_null_constructor_parameters()

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -29,7 +29,7 @@ namespace GraphQL.Tests.Bugs
         public async Task DocumentExecuter_has_valid_options()
         {
             var de = new DocumentExecuter();
-            var valid = await de.ExecuteAsync(new ExecutionOptions()
+            var valid = await de.ExecuteAsync(new ExecutionOptions
             {
                 Query = "{test}",
                 Schema = Schema,

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -66,7 +66,8 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void DocumentExecuter_cannot_have_null_constructor_parameters()
         {
-            var valid = new DocumentExecuter(new GraphQLDocumentBuilder(), new DocumentValidator(), new ComplexityAnalyzer());
+            var valid1 = new DocumentExecuter();
+            var valid2 = new DocumentExecuter(new GraphQLDocumentBuilder(), new DocumentValidator(), new ComplexityAnalyzer());
             Assert.Throws<ArgumentNullException>(() => new DocumentExecuter(null, new DocumentValidator(), new ComplexityAnalyzer()));
             Assert.Throws<ArgumentNullException>(() => new DocumentExecuter(new GraphQLDocumentBuilder(), null, new ComplexityAnalyzer()));
             Assert.Throws<ArgumentNullException>(() => new DocumentExecuter(new GraphQLDocumentBuilder(), new DocumentValidator(), null));

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -1,0 +1,91 @@
+using GraphQL.Execution;
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
+using System;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1769
+    public class Bug1769 : QueryTestBase<Bug1769Schema>
+    {
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null)
+        {
+            var error = exception == null ? new ExecutionError(message) : new ExecutionError(message, exception);
+            if (line != 0) error.AddLocation(line, column);
+            error.Path = path;
+            if (code != null)
+                error.Code = code;
+            var expected = CreateQueryResult(result, new ExecutionErrors { error });
+            AssertQueryIgnoreErrors(query, expected, inputs?.ToInputs(), renderErrors: true, expectedErrorCount: 1);
+        }
+
+        [Fact]
+        public async Task DocumentExecuter_has_valid_options() {
+            var de = new DocumentExecuter();
+            var valid = await de.ExecuteAsync(new ExecutionOptions()
+            {
+                Query = "{test}",
+                Schema = Schema,
+            });
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await de.ExecuteAsync(new ExecutionOptions()
+                {
+                    Query = null,
+                    Schema = Schema,
+                });
+            });
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await de.ExecuteAsync(new ExecutionOptions()
+                {
+                    Query = "{test}",
+                    Schema = null,
+                });
+            });
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await de.ExecuteAsync(new ExecutionOptions()
+                {
+                    Query = "{test}",
+                    Schema = Schema,
+                    FieldMiddleware = null,
+                });
+            });
+        }
+
+        [Fact]
+        public void query_is_empty() => AssertQueryWithError("", null, "Unable to determine operation from query.", 0, 0, (object[])null);
+
+        [Fact]
+        public void DocumentExecuter_cannot_have_null_constructor_parameters()
+        {
+            var valid = new DocumentExecuter(new GraphQLDocumentBuilder(), new DocumentValidator(), new ComplexityAnalyzer());
+            Assert.Throws<ArgumentNullException>(() => new DocumentExecuter(null, new DocumentValidator(), new ComplexityAnalyzer()));
+            Assert.Throws<ArgumentNullException>(() => new DocumentExecuter(new GraphQLDocumentBuilder(), null, new ComplexityAnalyzer()));
+            Assert.Throws<ArgumentNullException>(() => new DocumentExecuter(new GraphQLDocumentBuilder(), new DocumentValidator(), null));
+        }
+    }
+
+    public class Bug1769Schema : Schema
+    {
+        public Bug1769Schema()
+        {
+            Query = new Bug1769Query();
+        }
+    }
+
+    public class Bug1769Query : ObjectGraphType
+    {
+        public Bug1769Query()
+        {
+            Field<StringGraphType>("Test", resolve: context => "ok");
+        }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -26,7 +26,8 @@ namespace GraphQL.Tests.Bugs
         }
 
         [Fact]
-        public async Task DocumentExecuter_has_valid_options() {
+        public async Task DocumentExecuter_has_valid_options()
+        {
             var de = new DocumentExecuter();
             var valid = await de.ExecuteAsync(new ExecutionOptions()
             {

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -62,10 +62,10 @@ namespace GraphQL.Tests.Bugs
         }
 
         [Fact]
-        public void query_is_empty() => AssertQueryWithError("", null, "A query is required.", 0, 0, (object[])null);
+        public void query_is_empty1() => AssertQueryWithError("", null, "A query is required.", 0, 0, (object[])null, code: "SYNTAX_ERROR");
 
         [Fact]
-        public void query_is_whitespace() => AssertQueryWithError("\t \t \r\n", null, "A query is required.", 0, 0, (object[])null);
+        public void query_is_whitespace2() => AssertQueryWithError("\t \t \r\n", null, "A query is required.", 0, 0, (object[])null, code: "SYNTAX_ERROR");
 
         [Fact]
         public void DocumentExecuter_cannot_have_null_constructor_parameters()

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -62,10 +62,10 @@ namespace GraphQL.Tests.Bugs
         }
 
         [Fact]
-        public void query_is_empty1() => AssertQueryWithError("", null, "A query is required.", 0, 0, (object[])null, code: "SYNTAX_ERROR");
+        public void query_is_empty1() => AssertQueryWithError("", null, "Cannot execute query if no operation is specified.", 0, 0, (object[])null, code: "NO_OPERATION");
 
         [Fact]
-        public void query_is_whitespace2() => AssertQueryWithError("\t \t \r\n", null, "A query is required.", 0, 0, (object[])null, code: "SYNTAX_ERROR");
+        public void query_is_whitespace2() => AssertQueryWithError("\t \t \r\n", null, "Cannot execute query if no operation is specified.", 0, 0, (object[])null, code: "NO_OPERATION");
 
         [Fact]
         public void DocumentExecuter_cannot_have_null_constructor_parameters()

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -78,7 +78,7 @@ namespace GraphQL
 
                 if (document.Operations.Count == 0)
                 {
-                    throw new ExecutionError("A query is required.")
+                    throw new ExecutionError("Cannot execute query if no operation is specified.")
                     {
                         Code = "SYNTAX_ERROR"
                     };

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -80,7 +80,7 @@ namespace GraphQL
                 {
                     throw new ExecutionError("Cannot execute query if no operation is specified.")
                     {
-                        Code = "SYNTAX_ERROR"
+                        Code = "NO_OPERATION"
                     };
                 }
 

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -32,22 +32,9 @@ namespace GraphQL
 
         public DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IComplexityAnalyzer complexityAnalyzer)
         {
-            _documentBuilder = documentBuilder;
-            _documentValidator = documentValidator;
-            _complexityAnalyzer = complexityAnalyzer;
-        }
-
-        private void ValidateOptions(ExecutionOptions options)
-        {
-            if (options.Schema == null)
-            {
-                throw new ExecutionError("A schema is required.");
-            }
-
-            if (string.IsNullOrWhiteSpace(options.Query))
-            {
-                throw new ExecutionError("A query is required.");
-            }
+            _documentBuilder = documentBuilder ?? throw new ArgumentNullException(nameof(documentBuilder));
+            _documentValidator = documentValidator ?? throw new ArgumentNullException(nameof(documentValidator));
+            _complexityAnalyzer = complexityAnalyzer ?? throw new ArgumentNullException(nameof(complexityAnalyzer));
         }
 
         public async Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)
@@ -56,6 +43,10 @@ namespace GraphQL
                 throw new ArgumentNullException(nameof(options));
             if (options.Schema == null)
                 throw new InvalidOperationException("Cannot execute request if no schema is specified");
+            if (options.Query == null)
+                throw new InvalidOperationException("Cannot execute request if no query is specified");
+            if (options.FieldMiddleware == null)
+                throw new InvalidOperationException("Cannot execute request if no middleware builder specified");
 
             var metrics = new Metrics(options.EnableMetrics).Start(options.OperationName);
 
@@ -67,8 +58,6 @@ namespace GraphQL
 
             try
             {
-                ValidateOptions(options);
-
                 if (!options.Schema.Initialized)
                 {
                     using (metrics.Subject("schema", "Initializing schema"))

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -76,6 +76,14 @@ namespace GraphQL
                     }
                 }
 
+                if (document.Operations.Count == 0)
+                {
+                    throw new ExecutionError("A query is required.")
+                    {
+                        Code = "SYNTAX_ERROR"
+                    };
+                }
+
                 var operation = GetOperation(options.OperationName, document);
                 metrics.SetOperationName(operation?.Name);
 


### PR DESCRIPTION
With these changes, if `options.Query` or `options.Schema` is `null`, an exception is raised back to the caller, rather than a graphql result being returned.  This also validates that the constructor parameters are valid.

If `options.Query` is an empty string or only consists of whitespace, a ~~`SYNTAX_ERROR`~~ `NO_OPERATION` graphql error result is returned to the caller.