### PR TITLE
Change DocumentExecuter to throw for invalid operation name

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug1770.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1770.cs
@@ -18,12 +18,14 @@ namespace GraphQL.Tests.Bugs
         [Theory]
         [InlineData("")]
         [InlineData((string)null)]
+        [InlineData("firstQuery")]
+        [InlineData("secondQuery")]
         public async Task DocumentExecuter_works_for_valid_operation(string operationName)
         {
             var de = new DocumentExecuter();
             var valid = await de.ExecuteAsync(new ExecutionOptions
             {
-                Query = "{test}",
+                Query = "query firstQuery {test} query secondQuery {test}",
                 Schema = Schema,
                 OperationName = operationName,
             });
@@ -33,15 +35,15 @@ namespace GraphQL.Tests.Bugs
         }
 
         [Theory]
-        [InlineData("mutation")]
-        [InlineData("subscription")]
+        [InlineData("thirdQuery")]
+        [InlineData("query")]
         [InlineData("test")]
         public async Task DocumentExecuter_throws_for_invalid_operation(string operationName)
         {
             var de = new DocumentExecuter();
             var result = await de.ExecuteAsync(new ExecutionOptions()
                 {
-                    Query = "{test}",
+                    Query = "query firstQuery {test} query secondQuery {test}",
                     Schema = Schema,
                     OperationName = operationName
                 });

--- a/src/GraphQL.Tests/Bugs/Bug1770.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1770.cs
@@ -1,0 +1,73 @@
+using GraphQL.Execution;
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
+using Shouldly;
+using System;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1770
+    public class Bug1770 : QueryTestBase<Bug1770Schema>
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData((string)null)]
+        public async Task DocumentExecuter_works_for_valid_operation(string operationName)
+        {
+            var de = new DocumentExecuter();
+            var valid = await de.ExecuteAsync(new ExecutionOptions
+            {
+                Query = "{test}",
+                Schema = Schema,
+                OperationName = operationName,
+            });
+            valid.ShouldNotBeNull();
+            valid.Data.ShouldNotBeNull();
+            valid.Errors.ShouldBeNull();
+        }
+
+        [Theory]
+        [InlineData("mutation")]
+        [InlineData("subscription")]
+        [InlineData("test")]
+        public async Task DocumentExecuter_throws_for_invalid_operation(string operationName)
+        {
+            var de = new DocumentExecuter();
+            var result = await de.ExecuteAsync(new ExecutionOptions()
+                {
+                    Query = "{test}",
+                    Schema = Schema,
+                    OperationName = operationName
+                });
+            result.ShouldNotBeNull();
+            result.Data.ShouldBeNull();
+            result.Errors.ShouldNotBeNull();
+            result.Errors.Count.ShouldBe(1);
+            result.Errors[0].Message.ShouldBe($"Query does not contain operation '{operationName}'.");
+            result.Errors[0].InnerException.ShouldNotBeNull();
+            result.Errors[0].InnerException.ShouldBeOfType<InvalidOperationException>();
+        }
+    }
+
+    public class Bug1770Schema : Schema
+    {
+        public Bug1770Schema()
+        {
+            Query = new Bug1770Query();
+        }
+    }
+
+    public class Bug1770Query : ObjectGraphType
+    {
+        public Bug1770Query()
+        {
+            Field<StringGraphType>("Test", resolve: context => "ok");
+        }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug1772.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1772.cs
@@ -1,13 +1,7 @@
-using GraphQL.Execution;
-using GraphQL.SystemTextJson;
-using GraphQL.Types;
-using GraphQL.Validation;
-using GraphQL.Validation.Complexity;
-using Shouldly;
 using System;
-using System.Linq;
-using System.Numerics;
 using System.Threading.Tasks;
+using GraphQL.Types;
+using Shouldly;
 using Xunit;
 
 namespace GraphQL.Tests.Bugs

--- a/src/GraphQL.Tests/Bugs/Bug1772.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1772.cs
@@ -12,8 +12,8 @@ using Xunit;
 
 namespace GraphQL.Tests.Bugs
 {
-    // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1770
-    public class Bug1770 : QueryTestBase<Bug1770Schema>
+    // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1772
+    public class Bug1772 : QueryTestBase<Bug1772Schema>
     {
         [Theory]
         [InlineData("")]
@@ -57,17 +57,17 @@ namespace GraphQL.Tests.Bugs
         }
     }
 
-    public class Bug1770Schema : Schema
+    public class Bug1772Schema : Schema
     {
-        public Bug1770Schema()
+        public Bug1772Schema()
         {
-            Query = new Bug1770Query();
+            Query = new Bug1772Query();
         }
     }
 
-    public class Bug1770Query : ObjectGraphType
+    public class Bug1772Query : ObjectGraphType
     {
-        public Bug1770Query()
+        public Bug1772Query()
         {
             Field<StringGraphType>("Test", resolve: context => "ok");
         }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -89,7 +89,7 @@ namespace GraphQL
 
                 if (operation == null)
                 {
-                    throw new ExecutionError("Unable to determine operation from query.");
+                    throw new InvalidOperationException($"Query does not contain operation '{options.OperationName}'.");
                 }
 
                 IValidationResult validationResult;


### PR DESCRIPTION
Right now, if `options.OperationName` is invalid, the `DocumentExecuter` treats this as a query error, whereas this should be an `InvalidOperationException` thrown back to the caller, since it is an invalid option passed to the `DocumentExecuter`.

However, the document needs to be parsed before this option can be validated, and document parsing takes place within the `try { }` block.  I propose we select one of the following options:

1. Throw `InvalidOperationException`, and let this get caught by the unhandled exception processing - for instance, throwing immedaitely when `ThrowOnUnhandledException` is true, or wrapping it when it is false.
2. Create a small amount of additional logic to throw this exception directly to the caller.

Another option (option 3) would be to leave it as a "query error" (rather than an invalid operation), but at least revise the error message to be more appropriate for the situation.

Old error message | New error message
-|-
Unable to determine operation from query. | Query does not contain operation 'firstOperation'

This PR currently is written for option 1.  Comments?