### PR TITLE
Clarify and unify conversion exceptions from resolver returned values

### DIFF
--- a/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
+++ b/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
@@ -106,9 +106,9 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = new List<string> {"text", null, null}};
             var errors = new[]
             {
-                new ExecutionError("Cannot return null for non-null type. Field: listOfNonNullable, Type: [String!].")
+                new ExecutionError("Error trying to resolve listOfNonNullable.")
                 {
-                    Path = new object[] {"nonNullableDataGraph", "listOfNonNullable", 1}
+                    Path = new object[] {"nonNullableDataGraph", "listOfNonNullable"}
                 }
             };
 
@@ -158,9 +158,9 @@ namespace GraphQL.Tests.Bugs
             var errors = new[]
             {
                 new ExecutionError(
-                    "Cannot return null for non-null type. Field: nonNullableListOfNonNullable, Type: [String!]!.")
+                    "Error trying to resolve nonNullableListOfNonNullable.")
                 {
-                    Path = new object[] {"nullableDataGraph", "nonNullableListOfNonNullable", 1}
+                    Path = new object[] {"nullableDataGraph", "nonNullableListOfNonNullable"}
                 }
             };
 

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -32,17 +32,17 @@ namespace GraphQL.Tests.Bugs
 
         // within C#, (int)Bug1699Enum.Happy does not equal Bug1699.Happy
         [Fact]
-        public void Int_Enum() => AssertQueryWithError("{ happy }", @"{ ""happy"": null }", "Unable to serialize '1' to \u0027Bug1699Enum\u0027", 1, 3, "happy");
+        public void Int_Enum() => AssertQueryWithError("{ happy }", @"{ ""happy"": null }", "Error trying to resolve happy.", 1, 3, "happy", exception: new InvalidOperationException());
 
         [Fact]
-        public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Unable to serialize '50' to \u0027Bug1699Enum\u0027", 1, 3, "invalidEnum");
+        public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Error trying to resolve invalidEnum.", 1, 3, "invalidEnum", exception: new InvalidOperationException());
 
         // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
         [Fact]
-        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Unable to serialize '50' to \u0027Bug1699Enum\u0027", 1, 3, "invalidEnumWithinList");
+        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Error trying to resolve invalidEnumWithinList.", 1, 3, "invalidEnumWithinList", exception: new InvalidOperationException());
 
         [Fact]
-        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Unable to serialize '50' to \u0027Bug1699Enum\u0027", 1, 3, "invalidEnumWithinNonNullList");
+        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Error trying to resolve invalidEnumWithinNonNullList.", 1, 3, "invalidEnumWithinNonNullList", exception: new InvalidOperationException());
 
         [Fact]
         public void Input_Enum_Valid() => AssertQuerySuccess("{ inputEnum(arg: SLEEPY) }", @"{ ""inputEnum"": ""SLEEPY"" }");

--- a/src/GraphQL.Tests/Bugs/Bug1773.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1773.cs
@@ -39,7 +39,8 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void list_throws_when_not_ienumerable()
         {
-            AssertQueryWithError("{testListInvalid}", "{\"testListInvalid\": null}", "Error trying to resolve testListInvalid.", 1, 2, new[] { "testListInvalid" }, new InvalidOperationException("Expected an IEnumerable list though did not find one."));
+            AssertQueryWithError("{testListInvalid}", "{\"testListInvalid\": null}", "Error trying to resolve testListInvalid.", 1, 2, new[] { "testListInvalid" },
+                new InvalidOperationException("Expected an IEnumerable list though did not find one."));
         }
 
         [Fact]
@@ -51,35 +52,40 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void nonnull_list_throws_when_null()
         {
-            AssertQueryWithError("{testListNullInvalid}", "{\"testListNullInvalid\": null}", "Error trying to resolve testListNullInvalid.", 1, 2, new[] { "testListNullInvalid" }, new InvalidOperationException("Cannot return a null member within a non-null list for list index 0."));
+            AssertQueryWithError("{testListNullInvalid}", "{\"testListNullInvalid\": null}", "Error trying to resolve testListNullInvalid.", 1, 2, new[] { "testListNullInvalid" },
+                new InvalidOperationException("Cannot return a null member within a non-null list for list index 0."));
         }
 
         [Fact]
         public void list_throws_for_invalid_type()
         {
             // TODO: does not yet fully meet spec (does not return members of lists that are able to be serialized, with nulls and individual errors for unserializable values)
-            AssertQueryWithError("{testListInvalidType}", "{\"testListInvalidType\": null}", "Error trying to resolve testListInvalidType.", 1, 2, new[] { "testListInvalidType" }, new FormatException("Input string was not in a correct format."));
+            AssertQueryWithError("{testListInvalidType}", "{\"testListInvalidType\": null}", "Error trying to resolve testListInvalidType.", 1, 2, new[] { "testListInvalidType" },
+                new FormatException("Input string was not in a correct format."));
         }
 
         [Fact]
         public void list_throws_for_invalid_type_when_conversion_returns_null()
         {
             // TODO: does not yet fully meet spec (does not return members of lists that are able to be serialized, with nulls and individual errors for unserializable values)
-            AssertQueryWithError("{testListInvalidType2}", "{\"testListInvalidType2\": null}", "Error trying to resolve testListInvalidType2.", 1, 2, new[] { "testListInvalidType2" }, new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum' for list index 0."));
+            AssertQueryWithError("{testListInvalidType2}", "{\"testListInvalidType2\": null}", "Error trying to resolve testListInvalidType2.", 1, 2, new[] { "testListInvalidType2" },
+                new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum' for list index 0."));
         }
 
         [Fact]
         public void throws_for_invalid_type()
         {
             // in this case, the conversion threw a FormatException
-            AssertQueryWithError("{testInvalidType}", "{\"testInvalidType\": null}", "Error trying to resolve testInvalidType.", 1, 2, new[] { "testInvalidType" }, new FormatException("Input string was not in a correct format."));
+            AssertQueryWithError("{testInvalidType}", "{\"testInvalidType\": null}", "Error trying to resolve testInvalidType.", 1, 2, new[] { "testInvalidType" },
+                new FormatException("Input string was not in a correct format."));
         }
 
         [Fact]
         public void throws_for_invalid_type_when_conversion_returns_null()
         {
             // in this case, the converstion returned null, and GraphQL threw an InvalidOperationException
-            AssertQueryWithError("{testInvalidType2}", "{\"testInvalidType2\": null}", "Error trying to resolve testInvalidType2.", 1, 2, new[] { "testInvalidType2" }, new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum'"));
+            AssertQueryWithError("{testInvalidType2}", "{\"testInvalidType2\": null}", "Error trying to resolve testInvalidType2.", 1, 2, new[] { "testInvalidType2" },
+                new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum'"));
         }
 
     }

--- a/src/GraphQL.Tests/Bugs/Bug1773.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1773.cs
@@ -1,12 +1,6 @@
-using GraphQL.Execution;
+using System;
 using GraphQL.SystemTextJson;
 using GraphQL.Types;
-using GraphQL.Validation;
-using GraphQL.Validation.Complexity;
-using System;
-using System.Linq;
-using System.Numerics;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace GraphQL.Tests.Bugs

--- a/src/GraphQL.Tests/Bugs/Bug1773.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1773.cs
@@ -51,7 +51,7 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void nonnull_list_throws_when_null()
         {
-            AssertQueryWithError("{testListNullInvalid}", "{\"testListNullInvalid\": null}", "Error trying to resolve testListNullInvalid.", 1, 2, new[] { "testListNullInvalid" }, new InvalidOperationException("Cannot return a null member within a non-null list."));
+            AssertQueryWithError("{testListNullInvalid}", "{\"testListNullInvalid\": null}", "Error trying to resolve testListNullInvalid.", 1, 2, new[] { "testListNullInvalid" }, new InvalidOperationException("Cannot return a null member within a non-null list for list index 0."));
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace GraphQL.Tests.Bugs
         public void list_throws_for_invalid_type_when_conversion_returns_null()
         {
             // TODO: does not yet fully meet spec (does not return members of lists that are able to be serialized, with nulls and individual errors for unserializable values)
-            AssertQueryWithError("{testListInvalidType2}", "{\"testListInvalidType2\": null}", "Error trying to resolve testListInvalidType2.", 1, 2, new[] { "testListInvalidType2" }, new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum'"));
+            AssertQueryWithError("{testListInvalidType2}", "{\"testListInvalidType2\": null}", "Error trying to resolve testListInvalidType2.", 1, 2, new[] { "testListInvalidType2" }, new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum' for list index 0."));
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Bugs/Bug1773.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1773.cs
@@ -57,14 +57,14 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void list_throws_for_invalid_type()
         {
-            // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
+            // TODO: does not yet fully meet spec (does not return members of lists that are able to be serialized, with nulls and individual errors for unserializable values)
             AssertQueryWithError("{testListInvalidType}", "{\"testListInvalidType\": null}", "Error trying to resolve testListInvalidType.", 1, 2, new[] { "testListInvalidType" }, new FormatException("Input string was not in a correct format."));
         }
 
         [Fact]
         public void list_throws_for_invalid_type_when_conversion_returns_null()
         {
-            // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
+            // TODO: does not yet fully meet spec (does not return members of lists that are able to be serialized, with nulls and individual errors for unserializable values)
             AssertQueryWithError("{testListInvalidType2}", "{\"testListInvalidType2\": null}", "Error trying to resolve testListInvalidType2.", 1, 2, new[] { "testListInvalidType2" }, new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum'"));
         }
 

--- a/src/GraphQL.Tests/Bugs/Bug1773.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1773.cs
@@ -34,7 +34,7 @@ namespace GraphQL.Tests.Bugs
         public void list_throws_when_not_ienumerable()
         {
             AssertQueryWithError("{testListInvalid}", "{\"testListInvalid\": null}", "Error trying to resolve testListInvalid.", 1, 2, new[] { "testListInvalid" },
-                new InvalidOperationException("Expected an IEnumerable list though did not find one."));
+                new InvalidOperationException("Expected an IEnumerable list though did not find one. Found: Int32"));
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Bugs/Bug1773.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1773.cs
@@ -1,0 +1,116 @@
+using GraphQL.Execution;
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
+using System;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1773
+    public class Bug1773 : QueryTestBase<Bug1773Schema>
+    {
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null)
+        {
+            var error = exception == null ? new ExecutionError(message) : new ExecutionError(message, exception);
+            if (line != 0) error.AddLocation(line, column);
+            error.Path = path;
+            if (code != null)
+                error.Code = code;
+            var expected = CreateQueryResult(result, new ExecutionErrors { error });
+            var actualResult = AssertQueryIgnoreErrors(query, expected, inputs?.ToInputs(), renderErrors: true, expectedErrorCount: 1);
+            if (exception != null)
+            {
+                Assert.Equal(exception.GetType(), actualResult.Errors[0].InnerException.GetType());
+                Assert.Equal(exception.Message, actualResult.Errors[0].InnerException.Message);
+            }
+        }
+
+        [Fact]
+        public void list_valid()
+        {
+            AssertQuerySuccess("{testListValid}", "{\"testListValid\": [123]}");
+        }
+
+        [Fact]
+        public void list_throws_when_not_ienumerable()
+        {
+            AssertQueryWithError("{testListInvalid}", "{\"testListInvalid\": null}", "Error trying to resolve testListInvalid.", 1, 2, new[] { "testListInvalid" }, new InvalidOperationException("Expected an IEnumerable list though did not find one."));
+        }
+
+        [Fact]
+        public void nonnull_list_valid()
+        {
+            AssertQuerySuccess("{testListNullValid}", "{\"testListNullValid\": [123]}");
+        }
+
+        [Fact]
+        public void nonnull_list_throws_when_null()
+        {
+            AssertQueryWithError("{testListNullInvalid}", "{\"testListNullInvalid\": null}", "Error trying to resolve testListNullInvalid.", 1, 2, new[] { "testListNullInvalid" }, new InvalidOperationException("Cannot return a null member within a non-null list."));
+        }
+
+        [Fact]
+        public void list_throws_for_invalid_type()
+        {
+            // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
+            AssertQueryWithError("{testListInvalidType}", "{\"testListInvalidType\": null}", "Error trying to resolve testListInvalidType.", 1, 2, new[] { "testListInvalidType" }, new FormatException("Input string was not in a correct format."));
+        }
+
+        [Fact]
+        public void list_throws_for_invalid_type_when_conversion_returns_null()
+        {
+            // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
+            AssertQueryWithError("{testListInvalidType2}", "{\"testListInvalidType2\": null}", "Error trying to resolve testListInvalidType2.", 1, 2, new[] { "testListInvalidType2" }, new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum'"));
+        }
+
+        [Fact]
+        public void throws_for_invalid_type()
+        {
+            // in this case, the conversion threw a FormatException
+            AssertQueryWithError("{testInvalidType}", "{\"testInvalidType\": null}", "Error trying to resolve testInvalidType.", 1, 2, new[] { "testInvalidType" }, new FormatException("Input string was not in a correct format."));
+        }
+
+        [Fact]
+        public void throws_for_invalid_type_when_conversion_returns_null()
+        {
+            // in this case, the converstion returned null, and GraphQL threw an InvalidOperationException
+            AssertQueryWithError("{testInvalidType2}", "{\"testInvalidType2\": null}", "Error trying to resolve testInvalidType2.", 1, 2, new[] { "testInvalidType2" }, new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum'"));
+        }
+
+    }
+
+    public class Bug1773Schema : Schema
+    {
+        public Bug1773Schema()
+        {
+            Query = new Bug1773Query();
+        }
+    }
+
+    public class Bug1773Query : ObjectGraphType
+    {
+        public Bug1773Query()
+        {
+            Field<ListGraphType<IntGraphType>>("testListValid", resolve: context => new object[] { 123 });
+            Field<ListGraphType<IntGraphType>>("testListInvalid", resolve: context => 123);
+            Field<ListGraphType<IntGraphType>>("testListInvalidType", resolve: context => new object[] { "test" });
+            Field<ListGraphType<EnumerationGraphType<Bug1773Enum>>>("testListInvalidType2", resolve: context => new object[] { "test" });
+            Field<ListGraphType<NonNullGraphType<IntGraphType>>>("testListNullValid", resolve: context => new object[] { 123 });
+            Field<ListGraphType<NonNullGraphType<IntGraphType>>>("testListNullInvalid", resolve: context => new object[] { null });
+            Field<IntGraphType>("testNullValid", resolve: context => null);
+            Field<NonNullGraphType<IntGraphType>>("testNullInvalid", resolve: context => null);
+            Field<IntGraphType>("testInvalidType", resolve: context => "test");
+            Field<EnumerationGraphType<Bug1773Enum>>("testInvalidType2", resolve: context => "test");
+        }
+    }
+
+    public enum Bug1773Enum
+    {
+        Hello
+    }
+}

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -95,7 +95,7 @@ namespace GraphQL.Execution
 
             if (!(parent.Result is IEnumerable data))
             {
-                throw new InvalidOperationException("Expected an IEnumerable list though did not find one.");
+                throw new InvalidOperationException($"Expected an IEnumerable list though did not find one. Found: {parent.Result?.GetType().Name}");
             }
 
             var index = 0;

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -107,7 +107,7 @@ namespace GraphQL.Execution
             {
                 if (d != null)
                 {
-                    var node = BuildExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, index++);
+                    var node = BuildExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, index);
                     node.Result = d;
 
                     if (node is ObjectExecutionNode objectNode)
@@ -121,7 +121,7 @@ namespace GraphQL.Execution
                     else if (node is ValueExecutionNode valueNode)
                     {
                         node.Result = valueNode.GraphType.Serialize(d)
-                            ?? throw new InvalidOperationException($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}'");
+                            ?? throw new InvalidOperationException($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}' for list index {index}");
                     }
 
                     arrayItems.Add(node);
@@ -130,12 +130,14 @@ namespace GraphQL.Execution
                 {
                     if (listType.ResolvedType is NonNullGraphType)
                     {
-                        throw new InvalidOperationException("Cannot return a null member within a non-null list.");
+                        throw new InvalidOperationException($"Cannot return a null member within a non-null list for list index {index}.");
                     }
 
-                    var nullExecutionNode = new NullExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, index++);
+                    var nullExecutionNode = new NullExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, index);
                     arrayItems.Add(nullExecutionNode);
                 }
+
+                index++;
             }
 
             parent.Items = arrayItems;

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -95,8 +95,7 @@ namespace GraphQL.Execution
 
             if (!(parent.Result is IEnumerable data))
             {
-                var error = new ExecutionError("User error: expected an IEnumerable list though did not find one.");
-                throw error;
+                throw new InvalidOperationException("Expected an IEnumerable list though did not find one.");
             }
 
             var index = 0;
@@ -122,7 +121,7 @@ namespace GraphQL.Execution
                     else if (node is ValueExecutionNode valueNode)
                     {
                         node.Result = valueNode.GraphType.Serialize(d)
-                            ?? throw new ExecutionError($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}'");
+                            ?? throw new InvalidOperationException($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}'");
                     }
 
                     arrayItems.Add(node);
@@ -131,14 +130,7 @@ namespace GraphQL.Execution
                 {
                     if (listType.ResolvedType is NonNullGraphType)
                     {
-                        var error = new ExecutionError(
-                            "Cannot return null for non-null type."
-                            + $" Field: {parent.Name}, Type: {parent.FieldDefinition.ResolvedType}.");
-
-                        error.AddLocation(parent.Field, context.Document);
-                        error.Path = parent.ResponsePath.Append(index);
-                        context.Errors.Add(error);
-                        return;
+                        throw new InvalidOperationException("Cannot return a null member within a non-null list.");
                     }
 
                     var nullExecutionNode = new NullExecutionNode(parent, itemType, parent.Field, parent.FieldDefinition, index++);
@@ -210,7 +202,7 @@ namespace GraphQL.Execution
                     else if (node is ValueExecutionNode valueNode)
                     {
                         node.Result = valueNode.GraphType.Serialize(node.Result)
-                            ?? throw new ExecutionError($"Unable to serialize '{node.Result}' to '{valueNode.GraphType.Name}'");
+                            ?? throw new InvalidOperationException($"Unable to serialize '{node.Result}' to '{valueNode.GraphType.Name}'");
                     }
                 }
             }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -121,7 +121,7 @@ namespace GraphQL.Execution
                     else if (node is ValueExecutionNode valueNode)
                     {
                         node.Result = valueNode.GraphType.Serialize(d)
-                            ?? throw new InvalidOperationException($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}' for list index {index}");
+                            ?? throw new InvalidOperationException($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}' for list index {index}.");
                     }
 
                     arrayItems.Add(node);


### PR DESCRIPTION
Right now, after a resolver returns a value, the infrastructure attempts to convert it to the correct graph type.  For example, if the resolver returns a string of "1" for an IntGraphType, the infrastructure attempts to convert it to the number 1.  When this fails, the conversion throws an exception of FormatException which can be handled and logged by the UnhandledExceptionDelegate.  It is then wrapped in a generic "failure resolving {fieldname}" message, which is accurate - this is a server side code issue.  The ExecutionError also properly includes a code of "FORMAT" in this case.

However, if the resolver returns a string of "test" for an enumeration graph type (where "test" is invalid), the infrastructure throws a ExecutionError.  This cannot be caught or logged by the UnhandledExceptionDelegate, and the error inappropriately gets returned directly to the graphql client.  It does not have a code at all.

This PR fixes that so that any inappropriate returned value from a field resolver will:
* be able to be caught by the UnhandledExceptionDelegate
* wrapped and exact error message hidden from clients by default
* include a proper code

Note that, as was documented in #1699, the graphql infrastructure does not yet fully meet spec, where it will return members of lists that are able to be serialized, with nulls and individual errors for unserializable values.  This is not addressed in this PR.

Thanks to @GrangerAts for his work on #1658 which this is partially based off of.  Also see #1768

I will keep #1768 up to date, and in another PR we might create different exception classes rather than using InvalidOperationException for all of these cases, possibly wrapping serialization exceptions, similar to #1767.  This PR just contains the basic infrastructure and tests needed to continue this cleanup.