### PR TITLE
Cleanup GraphTypesLookup exceptions

### DIFF
--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -83,7 +83,7 @@ namespace GraphQL.Tests.Types
         public void throw_error_on_missing_istypeof()
         {
             var schema = new InvalidUnionSchema();
-            //note: The exception occurs during CreateTypesLookup, not during FindType
+            //note: The exception occurs during Schema.CreateTypesLookup(), not during Schema.FindType()
             Should.Throw<InvalidOperationException>(() => schema.FindType("a"));
         }
 

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -83,7 +83,8 @@ namespace GraphQL.Tests.Types
         public void throw_error_on_missing_istypeof()
         {
             var schema = new InvalidUnionSchema();
-            Should.Throw<ExecutionError>(() => schema.FindType("a"));
+            //note: The exception occurs during CreateTypesLookup, not during FindType
+            Should.Throw<InvalidOperationException>(() => schema.FindType("a"));
         }
 
         [Fact]

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -276,7 +276,7 @@ namespace GraphQL.Types
             {
                 if (!union.Types.Any() && !union.PossibleTypes.Any())
                 {
-                    throw new ExecutionError("Must provide types for Union {0}.".ToFormat(union));
+                    throw new InvalidOperationException("Must provide types for Union {0}.".ToFormat(union));
                 }
 
                 foreach (var unionedType in union.PossibleTypes)
@@ -288,7 +288,7 @@ namespace GraphQL.Types
 
                     if (union.ResolveType == null && unionedType.IsTypeOf == null)
                     {
-                        throw new ExecutionError((
+                        throw new InvalidOperationException((
                             "Union type {0} does not provide a \"resolveType\" function " +
                             "and possible Type \"{1}\" does not provide a \"isTypeOf\" function. " +
                             "There is no way to resolve this possible type during execution.")
@@ -304,7 +304,7 @@ namespace GraphQL.Types
 
                     if (union.ResolveType == null && objType != null && objType.IsTypeOf == null)
                     {
-                        throw new ExecutionError((
+                        throw new InvalidOperationException((
                             "Union type {0} does not provide a \"resolveType\" function " +
                             "and possible Type \"{1}\" does not provide a \"isTypeOf\" function. " +
                             "There is no way to resolve this possible type during execution.")
@@ -458,7 +458,7 @@ Make sure that your ServiceProvider is configured correctly.");
 
                         if (objectType.IsTypeOf == null && interfaceType.ResolveType == null)
                         {
-                            throw new ExecutionError((
+                            throw new InvalidOperationException((
                                     "Interface type {0} does not provide a \"resolveType\" function " +
                                     "and possible Type \"{1}\" does not provide a \"isTypeOf\" function.  " +
                                     "There is no way to resolve this possible type during execution.")
@@ -482,7 +482,7 @@ Make sure that your ServiceProvider is configured correctly.");
 
                         if (union.ResolveType == null && unionType != null && unionType.IsTypeOf == null)
                         {
-                            throw new ExecutionError((
+                            throw new InvalidOperationException((
                                 "Union type {0} does not provide a \"resolveType\" function " +
                                 "and possible Type \"{1}\" does not provide a \"isTypeOf\" function. " +
                                 "There is no way to resolve this possible type during execution.")
@@ -514,7 +514,7 @@ Make sure that your ServiceProvider is configured correctly.");
 
             if (reference != null && result == null)
             {
-                throw new ExecutionError($"Unable to resolve reference to type '{reference.TypeName}' on '{parentType.Name}'");
+                throw new InvalidOperationException($"Unable to resolve reference to type '{reference.TypeName}' on '{parentType.Name}'");
             }
 
             return result;

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -232,7 +232,7 @@ namespace GraphQL.Types
 
             if (type is NonNullGraphType || type is ListGraphType)
             {
-                throw new ExecutionError("Only add root types.");
+                throw new ArgumentOutOfRangeException(nameof(type), "Only add root types.");
             }
 
             var name = type.CollectTypes(context).TrimGraphQLTypes();
@@ -262,7 +262,7 @@ namespace GraphQL.Types
 
                         if (interfaceInstance.ResolveType == null && obj.IsTypeOf == null)
                         {
-                            throw new ExecutionError((
+                            throw new InvalidOperationException((
                                 "Interface type {0} does not provide a \"resolveType\" function " +
                                 "and possible Type \"{1}\" does not provide a \"isTypeOf\" function. " +
                                 "There is no way to resolve this possible type during execution.")


### PR DESCRIPTION
All of the errors changed below should never occur during normal operation, but would represent a schema error. They can only occur while the `GraphTypesLookup` class is being built (during `Schema.Initialize`).  Any information contained within these errors could potentially represent privileged information.

These exceptions have been changed to a native exception type. If one of these exceptions were to occur, they would be wrapped into an ExecutionError inside the DocumentExecuter with a code that represents the inner error (since the schema is initialized during document execution, if it has not yet been initialized).