### PR TITLE
CoreToVanillaConverter cleanup

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug1781.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1781.cs
@@ -1,0 +1,59 @@
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1781
+    public class Bug1781 : QueryTestBase<Bug1781Schema>
+    {
+        [Fact]
+        public async Task DocumentExecuter_really_big_double_valid()
+        {
+            var de = new DocumentExecuter();
+            var valid = await de.ExecuteAsync(new ExecutionOptions
+            {
+                Query = $"{{ test(arg:{double.MaxValue.ToString("0")}0.0) }}",
+                Schema = Schema,
+            });
+            valid.ShouldNotBeNull();
+            valid.Data.ShouldNotBeNull();
+            valid.Errors.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task DocumentExecuter_really_small_double_valid()
+        {
+            var de = new DocumentExecuter();
+            var valid = await de.ExecuteAsync(new ExecutionOptions
+            {
+                Query = $"{{ test(arg:{double.MinValue.ToString("0")}0.0) }}",
+                Schema = Schema,
+            });
+            valid.ShouldNotBeNull();
+            valid.Data.ShouldNotBeNull();
+            valid.Errors.ShouldBeNull();
+        }
+    }
+
+    public class Bug1781Schema : Schema
+    {
+        public Bug1781Schema()
+        {
+            Query = new Bug1781Query();
+        }
+    }
+
+    public class Bug1781Query : ObjectGraphType
+    {
+        public Bug1781Query()
+        {
+            Field<StringGraphType>("Test",
+                resolve: context => "ok",
+                arguments: new QueryArguments(
+                    new QueryArgument(typeof(FloatGraphType)) { Name = "arg" }
+                ));
+        }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug1781.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1781.cs
@@ -1,5 +1,8 @@
+using System.Numerics;
 using System.Threading.Tasks;
+using GraphQL.Language;
 using GraphQL.Types;
+using GraphQLParser.AST;
 using Shouldly;
 using Xunit;
 
@@ -34,6 +37,39 @@ namespace GraphQL.Tests.Bugs
             valid.ShouldNotBeNull();
             valid.Data.ShouldNotBeNull();
             valid.Errors.ShouldBeNull();
+        }
+
+        [Theory]
+        [InlineData(ASTNodeKind.IntValue, "1")]
+        [InlineData(ASTNodeKind.IntValue, "-1")]
+        [InlineData(ASTNodeKind.IntValue, "9223372036854775807")]
+        [InlineData(ASTNodeKind.IntValue, "-9223372036854775808")]
+        [InlineData(ASTNodeKind.IntValue, "79228162514264337593543950335")]
+        [InlineData(ASTNodeKind.IntValue, "-79228162514264337593543950335")]
+        [InlineData(ASTNodeKind.IntValue, "100000000000000000000000000000000")]
+        [InlineData(ASTNodeKind.IntValue, "-100000000000000000000000000000000")]
+        [InlineData(ASTNodeKind.FloatValue, "1.7976931348623157E+308")]
+        [InlineData(ASTNodeKind.FloatValue, "-1.7976931348623157E+308")]
+        [InlineData(ASTNodeKind.FloatValue, "1e+5")]
+        [InlineData(ASTNodeKind.FloatValue, "1e-5")]
+        [InlineData(ASTNodeKind.FloatValue, "1e5")]
+        [InlineData(ASTNodeKind.FloatValue, "1.0")]
+        [InlineData(ASTNodeKind.FloatValue, "1.")]
+        [InlineData(ASTNodeKind.FloatValue, "1.7976931348623157E+900")]
+        [InlineData(ASTNodeKind.FloatValue, "-1.7976931348623157E+900")]
+        [InlineData(ASTNodeKind.BooleanValue, "true")]
+        [InlineData(ASTNodeKind.BooleanValue, "false")]
+        public void Values_Parse_Successfully(ASTNodeKind kind, string valueString)
+        {
+            //note: thousand separators and/or culture-specific characters are invalid graphql literals, and will not be returned by graphql-parser
+            //uppercase TRUE and FALSE are also invalid graphql input data, and will not be returned by graphql-parser
+            //whitespace will not be returned by graphql-parser
+            var converter = new CoreToVanillaConverter("");
+            var value = new GraphQLScalarValue(kind)
+            {
+                Value = valueString
+            };
+            var ret = converter.Value(value);
         }
     }
 

--- a/src/GraphQL.Tests/CoreToVanillaConverterTests.cs
+++ b/src/GraphQL.Tests/CoreToVanillaConverterTests.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using System.Threading.Tasks;
 using GraphQL.Language;
 using GraphQL.Types;
@@ -9,7 +8,7 @@ using Xunit;
 namespace GraphQL.Tests.Bugs
 {
     // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1781
-    public class Bug1781 : QueryTestBase<Bug1781Schema>
+    public class CoreToVanillaConverterTests : QueryTestBase<PR1781Schema>
     {
         [Fact]
         public async Task DocumentExecuter_really_big_double_valid()
@@ -17,7 +16,7 @@ namespace GraphQL.Tests.Bugs
             var de = new DocumentExecuter();
             var valid = await de.ExecuteAsync(new ExecutionOptions
             {
-                Query = $"{{ test(arg:{double.MaxValue.ToString("0")}0.0) }}",
+                Query = $"{{ test(arg:{double.MaxValue:0}0.0) }}",
                 Schema = Schema,
             });
             valid.ShouldNotBeNull();
@@ -31,7 +30,7 @@ namespace GraphQL.Tests.Bugs
             var de = new DocumentExecuter();
             var valid = await de.ExecuteAsync(new ExecutionOptions
             {
-                Query = $"{{ test(arg:{double.MinValue.ToString("0")}0.0) }}",
+                Query = $"{{ test(arg:{double.MinValue:0}0.0) }}",
                 Schema = Schema,
             });
             valid.ShouldNotBeNull();
@@ -73,17 +72,17 @@ namespace GraphQL.Tests.Bugs
         }
     }
 
-    public class Bug1781Schema : Schema
+    public class PR1781Schema : Schema
     {
-        public Bug1781Schema()
+        public PR1781Schema()
         {
-            Query = new Bug1781Query();
+            Query = new PR1781Query();
         }
     }
 
-    public class Bug1781Query : ObjectGraphType
+    public class PR1781Query : ObjectGraphType
     {
-        public Bug1781Query()
+        public PR1781Query()
         {
             Field<StringGraphType>("Test",
                 resolve: context => "ok",

--- a/src/GraphQL.Tests/CoreToVanillaConverterTests.cs
+++ b/src/GraphQL.Tests/CoreToVanillaConverterTests.cs
@@ -19,7 +19,7 @@ namespace GraphQL.Tests.Bugs
                 // create a floating-point value that is larger than double.MaxValue
                 // in the expression "{double.MaxValue:0}0.0" below, the 0.0 effectively
                 // multiplies double.MaxValue by 10 and the .0 forces the parser to
-                //   assume it is a floating point value rather than a large integer
+                // assume it is a floating point value rather than a large integer
                 Query = $"{{ test(arg:{double.MaxValue:0}0.0) }}",
                 Schema = Schema,
             });

--- a/src/GraphQL.Tests/CoreToVanillaConverterTests.cs
+++ b/src/GraphQL.Tests/CoreToVanillaConverterTests.cs
@@ -16,6 +16,10 @@ namespace GraphQL.Tests.Bugs
             var de = new DocumentExecuter();
             var valid = await de.ExecuteAsync(new ExecutionOptions
             {
+                // create a floating-point value that is larger than double.MaxValue
+                // in the expression "{double.MaxValue:0}0.0" below, the 0.0 effectively
+                //   multiplies double.MaxValue by 10 and the .0 forces the parser to
+                //   assume it is a floating point value rather than a large integer
                 Query = $"{{ test(arg:{double.MaxValue:0}0.0) }}",
                 Schema = Schema,
             });

--- a/src/GraphQL.Tests/CoreToVanillaConverterTests.cs
+++ b/src/GraphQL.Tests/CoreToVanillaConverterTests.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Tests.Bugs
             {
                 // create a floating-point value that is larger than double.MaxValue
                 // in the expression "{double.MaxValue:0}0.0" below, the 0.0 effectively
-                //   multiplies double.MaxValue by 10 and the .0 forces the parser to
+                // multiplies double.MaxValue by 10 and the .0 forces the parser to
                 //   assume it is a floating point value rather than a large integer
                 Query = $"{{ test(arg:{double.MaxValue:0}0.0) }}",
                 Schema = Schema,

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -226,7 +226,7 @@ namespace GraphQL.Language
                         return new BigIntValue(bigIntegerResult).WithLocation(str, _body);
                     }
 
-                    // Since BigInteger can contain any valid integer (arbitrarily large), this is impossible to trigger
+                    // Since BigInteger can contain any valid integer (arbitrarily large), this is impossible to trigger via an invalid query
                     throw new InvalidOperationException($"Invalid number {str.Value}");
                 }
                 case ASTNodeKind.FloatValue:

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using GraphQL.Language.AST;
@@ -203,25 +204,25 @@ namespace GraphQL.Language
                 {
                     var str = (GraphQLScalarValue)source;
 
-                    if (int.TryParse(str.Value, out var intResult))
+                    if (int.TryParse(str.Value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var intResult))
                     {
                         return new IntValue(intResult).WithLocation(str, _body);
                     }
 
                     // If the value doesn't fit in an integer, revert to using long...
-                    if (long.TryParse(str.Value, out var longResult))
+                    if (long.TryParse(str.Value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var longResult))
                     {
                         return new LongValue(longResult).WithLocation(str, _body);
                     }
 
                     // If the value doesn't fit in an long, revert to using decimal...
-                    if (decimal.TryParse(str.Value, out var decimalResult))
+                    if (decimal.TryParse(str.Value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var decimalResult))
                     {
                         return new DecimalValue(decimalResult).WithLocation(str, _body);
                     }
 
                     // If the value doesn't fit in an decimal, revert to using BigInteger...
-                    if (BigInteger.TryParse(str.Value, out var bigIntegerResult))
+                    if (BigInteger.TryParse(str.Value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var bigIntegerResult))
                     {
                         return new BigIntValue(bigIntegerResult).WithLocation(str, _body);
                     }
@@ -235,10 +236,17 @@ namespace GraphQL.Language
 
                     // the idea is to see if there is a loss of accuracy of value
                     // for example, 12.1 or 12.11 is double but 12.10 is decimal
-                    double dbl = double.Parse(str.Value);
+                    double dbl = double.Parse(
+                        str.Value,
+                        NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent,
+                        CultureInfo.InvariantCulture);
 
                     //it is possible for a FloatValue to overflow a decimal; however, with a double, it just returns Infinity or -Infinity
-                    if (decimal.TryParse(str.Value, out var dec))
+                    if (decimal.TryParse(
+                        str.Value,
+                        NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent,
+                        CultureInfo.InvariantCulture,
+                        out var dec))
                     {
                         // TODO: make more efficient, current solution allocates memory
                         int[] decBits = decimal.GetBits(dec);


### PR DESCRIPTION
As indicated in #1778 I went back to review the last `ExecutionError` within `CoreToVanillaConverter`.  I determined that it is impossible for an `ASTNodeKind.IntValue` to produce a value that cannot be cast to a `BigInteger`.  So I changed that exception to an `InvalidOperationException`, as if it was triggered, it would indicate a parsing problem within graphql-parser.

Then I reviewed `ASTNodeKind.FloatValue` and determined that for values beyond the range of a `decimal`, an overflow/parsing exception can occur.  This I fixed by using `decimal.TryParse`.  I also determined that values beyond the range of a `double` are simply interpreted as `Infinity` and `-Infinity` so there is no possibility of a failed conversion.  I added a test (which would have previously failed) to verify this change.

Finally, I noticed that `ValueConverter` was used to transliterate these strings to certain types of values.  I don't feel that's an appropriate use of the `ValueConverter` in this instance.  Note that the `ValueConverter` was not used for `ASTNodeKind.IntValue`.  So I changed the parsing code to use `double.Parse`, `decimal.TryParse` and `bool.Parse` in the appropriate locations.

Due to a well-designed parser, I was unable to trigger any other exceptions within this code.

Note that if we do want to use `ValueConverter`, it should be wrapped in a `try..catch` block and it should throw an `ExecutionError` upon a failed conversion.