### PR TITLE
Update ValidateNodeResult to throw InvalidOperationException

### DIFF
--- a/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
+++ b/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
@@ -243,6 +243,7 @@ namespace GraphQL.Tests.Bugs
                     else
                     {
                         actualError.InnerException.ShouldNotBeNull();
+                        actualError.InnerException.ShouldBeOfType(expectedError.InnerException.GetType());
                         actualError.InnerException.Message.ShouldBe(expectedError.InnerException.Message);
                     }
                 }

--- a/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
+++ b/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
@@ -38,7 +38,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {NonNullable = null};
             var errors = new[]
             {
-                new ExecutionError("Cannot return null for non-null type. Field: nonNullable, Type: String!.")
+                new ExecutionError("Error trying to resolve nonNullable.", new InvalidOperationException(
+                    "Cannot return null for non-null type. Field: nonNullable, Type: String!."))
                 {
                     Path = new[] {"nullableDataGraph", "nonNullable"}
                 }
@@ -55,7 +56,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {NullableNest = new Data {NonNullable = null}};
             var errors = new[]
             {
-                new ExecutionError("Cannot return null for non-null type. Field: nonNullable, Type: String!.")
+                new ExecutionError("Error trying to resolve nonNullable.", new InvalidOperationException(
+                    "Cannot return null for non-null type. Field: nonNullable, Type: String!."))
                 {
                     Path = new[] {"nullableDataGraph", "nullableNest", "nonNullable"}
                 }
@@ -72,7 +74,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {NonNullableNest = new Data {NonNullable = null}};
             var errors = new[]
             {
-                new ExecutionError("Cannot return null for non-null type. Field: nonNullable, Type: String!.")
+                new ExecutionError("Error trying to resolve nonNullable.", new InvalidOperationException(
+                    "Cannot return null for non-null type. Field: nonNullable, Type: String!."))
                 {
                     Path = new[] {"nullableDataGraph", "nonNullableNest", "nonNullable"}
                 }
@@ -89,7 +92,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {NonNullableNest = new Data {NonNullable = null}};
             var errors = new[]
             {
-                new ExecutionError("Cannot return null for non-null type. Field: nonNullable, Type: String!.")
+                new ExecutionError("Error trying to resolve nonNullable.", new InvalidOperationException(
+                    "Cannot return null for non-null type. Field: nonNullable, Type: String!."))
                 {
                     Path = new[] {"nonNullableDataGraph", "nonNullableNest", "nonNullable"}
                 }
@@ -106,7 +110,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = new List<string> {"text", null, null}};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve listOfNonNullable.")
+                new ExecutionError("Error trying to resolve listOfNonNullable.", new InvalidOperationException(
+                    "Cannot return a null member within a non-null list for list index 1."))
                 {
                     Path = new object[] {"nonNullableDataGraph", "listOfNonNullable"}
                 }
@@ -123,7 +128,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = null};
             var errors = new[]
             {
-                new ExecutionError("Cannot return null for non-null type. Field: nonNullableList, Type: [String]!.")
+                new ExecutionError("Error trying to resolve nonNullableList.", new InvalidOperationException(
+                    "Cannot return null for non-null type. Field: nonNullableList, Type: [String]!."))
                 {
                     Path = new[] {"nullableDataGraph", "nonNullableList"}
                 }
@@ -140,7 +146,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = null};
             var errors = new[]
             {
-                new ExecutionError("Cannot return null for non-null type. Field: nonNullableList, Type: [String]!.")
+                new ExecutionError("Error trying to resolve nonNullableList.", new InvalidOperationException(
+                    "Cannot return null for non-null type. Field: nonNullableList, Type: [String]!."))
                 {
                     Path = new[] {"nonNullableDataGraph", "nonNullableList"}
                 }
@@ -157,8 +164,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = new List<string> {"text", null, null}};
             var errors = new[]
             {
-                new ExecutionError(
-                    "Error trying to resolve nonNullableListOfNonNullable.")
+                new ExecutionError("Error trying to resolve nonNullableListOfNonNullable.", new InvalidOperationException(
+                    "Cannot return a null member within a non-null list for list index 1."))
                 {
                     Path = new object[] {"nullableDataGraph", "nonNullableListOfNonNullable"}
                 }
@@ -175,8 +182,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = null};
             var errors = new[]
             {
-                new ExecutionError(
-                    "Cannot return null for non-null type. Field: nonNullableListOfNonNullable, Type: [String!]!.")
+                new ExecutionError("Error trying to resolve nonNullableListOfNonNullable.", new InvalidOperationException(
+                    "Cannot return null for non-null type. Field: nonNullableListOfNonNullable, Type: [String!]!."))
                 {
                     Path = new[] {"nullableDataGraph", "nonNullableListOfNonNullable"}
                 }
@@ -193,8 +200,8 @@ namespace GraphQL.Tests.Bugs
             var data = new Data { ListOfStrings = new List<string> { "text", null, null } };
             var errors = new[]
             {
-                new ExecutionError(
-                    "Error trying to resolve nonNullableListOfNonNullableThrow.")
+                new ExecutionError("Error trying to resolve nonNullableListOfNonNullableThrow.", new Exception(
+                    "test"))
                 {
                     Path = new object[] { "nonNullableListOfNonNullableDataGraph", 0, "nonNullableListOfNonNullableThrow"}
                 }
@@ -229,6 +236,15 @@ namespace GraphQL.Tests.Bugs
 
                     actualError.Message.ShouldBe(expectedError.Message);
                     actualError.Path.ShouldBe(expectedError.Path);
+                    if (expectedError.InnerException == null)
+                    {
+                        actualError.InnerException.ShouldBeNull();
+                    }
+                    else
+                    {
+                        actualError.InnerException.ShouldNotBeNull();
+                        actualError.InnerException.Message.ShouldBe(expectedError.InnerException.Message);
+                    }
                 }
             }
         }

--- a/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
+++ b/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
@@ -12,7 +12,9 @@ namespace GraphQL.Tests.Execution
         {
             var result = AssertQueryWithErrors("{ pets { name } }", @"{ ""pets"": null }", expectedErrorCount: 1);
             var error = result.Errors.First();
-            error.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets with value '{ name = Eli }', received 'null'.");
+            error.Message.ShouldBe("Error trying to resolve pets.");
+            error.InnerException.ShouldNotBeNull();
+            error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets with value '{ name = Eli }', received 'null'.");
         }
     }
 

--- a/src/GraphQL.Tests/Types/NonNullGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/NonNullGraphTypeTests.cs
@@ -44,9 +44,12 @@ namespace GraphQL.Tests.Types
                 expectedErrorCount: 3);
 
             var errors = result.Errors.ToArray();
-            errors[0].Message.ShouldBe("Cannot return null for non-null type. Field: a, Type: Int!.");
-            errors[1].Message.ShouldBe("Cannot return null for non-null type. Field: b, Type: Boolean!.");
-            errors[2].Message.ShouldBe("Cannot return null for non-null type. Field: c, Type: String!.");
+            errors[0].Message.ShouldBe("Error trying to resolve a.");
+            errors[0].InnerException.Message.ShouldBe("Cannot return null for non-null type. Field: a, Type: Int!.");
+            errors[1].Message.ShouldBe("Error trying to resolve b.");
+            errors[1].InnerException.Message.ShouldBe("Cannot return null for non-null type. Field: b, Type: Boolean!.");
+            errors[2].Message.ShouldBe("Error trying to resolve c.");
+            errors[2].InnerException.Message.ShouldBe("Cannot return null for non-null type. Field: c, Type: String!.");
         }
     }
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -249,7 +249,7 @@ namespace GraphQL.Execution
             {
                 if (result == null)
                 {
-                    throw new ExecutionError("Cannot return null for non-null type."
+                    throw new InvalidOperationException("Cannot return null for non-null type."
                         + $" Field: {node.Name}, Type: {nonNullType}.");
                 }
 
@@ -267,7 +267,7 @@ namespace GraphQL.Execution
 
                 if (objectType == null)
                 {
-                    throw new ExecutionError(
+                    throw new InvalidOperationException(
                         $"Abstract type {abstractType.Name} must resolve to an Object type at " +
                         $"runtime for field {node.Parent.GraphType.Name}.{node.Name} " +
                         $"with value '{result}', received 'null'.");
@@ -275,13 +275,13 @@ namespace GraphQL.Execution
 
                 if (!abstractType.IsPossibleType(objectType))
                 {
-                    throw new ExecutionError($"Runtime Object type \"{objectType}\" is not a possible type for \"{abstractType}\".");
+                    throw new InvalidOperationException($"Runtime Object type \"{objectType}\" is not a possible type for \"{abstractType}\".");
                 }
             }
 
             if (objectType?.IsTypeOf != null && !objectType.IsTypeOf(result))
             {
-                throw new ExecutionError($"\"{result}\" value of type \"{result.GetType()}\" is not allowed for \"{objectType.Name}\". Either change IsTypeOf method of \"{objectType.Name}\" to accept this value or return another value from your resolver.");
+                throw new InvalidOperationException($"\"{result}\" value of type \"{result.GetType()}\" is not allowed for \"{objectType.Name}\". Either change IsTypeOf method of \"{objectType.Name}\" to accept this value or return another value from your resolver.");
             }
         }
 


### PR DESCRIPTION
In #1773 somehow I changed the exceptions thrown during `ExecutionStrategy.SetArrayItemNodes` but not `ExecutionStrategy.ValidateNodeResult`.  These represent the same basic changes - invalid results from the resolver (e.g. null for a non-null field) throw an `InvalidOperationException` rather than an `ExecutionError`.