### PR TITLE
Update exception types

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -698,10 +698,10 @@ namespace GraphQL.Execution
         public InvalidOperationError(string message) { }
     }
     [System.Serializable]
-    public class InvalidValueError : GraphQL.Execution.DocumentError
+    public class InvalidVariableError : GraphQL.Execution.DocumentError
     {
-        public InvalidValueError(string variableName, string message) { }
-        public InvalidValueError(string variableName, string message, System.Exception innerException) { }
+        public InvalidVariableError(string variableName, string message) { }
+        public InvalidVariableError(string variableName, string message, System.Exception innerException) { }
     }
     [System.Serializable]
     public class NoOperationError : GraphQL.Execution.DocumentError

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -750,7 +750,6 @@ namespace GraphQL.Execution
     [System.Serializable]
     public class UnhandledError : GraphQL.ExecutionError
     {
-        public UnhandledError(string message) { }
         public UnhandledError(string message, System.Exception innerException) { }
     }
     public class UnhandledExceptionContext

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -745,7 +745,6 @@ namespace GraphQL.Execution
     public class SyntaxError : GraphQL.Execution.DocumentError
     {
         public SyntaxError(GraphQLParser.Exceptions.GraphQLSyntaxErrorException ex) { }
-        public SyntaxError(string message, System.Exception innerException) { }
     }
     [System.Serializable]
     public class UnhandledError : GraphQL.ExecutionError

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -566,6 +566,11 @@ namespace GraphQL.Execution
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode> Items { get; set; }
         public override object ToValue() { }
     }
+    public abstract class DocumentError : GraphQL.ExecutionError
+    {
+        public DocumentError(string message) { }
+        public DocumentError(string message, System.Exception innerException) { }
+    }
     public abstract class DocumentExecutionListenerBase : GraphQL.Execution.IDocumentExecutionListener
     {
         protected DocumentExecutionListenerBase() { }
@@ -688,10 +693,20 @@ namespace GraphQL.Execution
         System.Collections.Generic.IDictionary<string, object> UserContext { get; }
     }
     [System.Serializable]
-    public class InvalidValueException : GraphQL.ExecutionError
+    public class InvalidOperationError : GraphQL.Execution.DocumentError
     {
-        public InvalidValueException(string variableName, string message) { }
-        public InvalidValueException(string variableName, string message, System.Exception innerException) { }
+        public InvalidOperationError(string message) { }
+    }
+    [System.Serializable]
+    public class InvalidValueError : GraphQL.Execution.DocumentError
+    {
+        public InvalidValueError(string variableName, string message) { }
+        public InvalidValueError(string variableName, string message, System.Exception innerException) { }
+    }
+    [System.Serializable]
+    public class NoOperationError : GraphQL.Execution.DocumentError
+    {
+        public NoOperationError() { }
     }
     public class NullExecutionNode : GraphQL.Execution.ExecutionNode
     {
@@ -725,6 +740,18 @@ namespace GraphQL.Execution
         public SubscriptionExecutionStrategy() { }
         public override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.Execution.ExecutionContext context) { }
         protected virtual System.Threading.Tasks.Task<System.IObservable<GraphQL.ExecutionResult>> ResolveEventStreamAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
+    }
+    [System.Serializable]
+    public class SyntaxError : GraphQL.Execution.DocumentError
+    {
+        public SyntaxError(GraphQLParser.Exceptions.GraphQLSyntaxErrorException ex) { }
+        public SyntaxError(string message, System.Exception innerException) { }
+    }
+    [System.Serializable]
+    public class UnhandledError : GraphQL.ExecutionError
+    {
+        public UnhandledError(string message) { }
+        public UnhandledError(string message, System.Exception innerException) { }
     }
     public class UnhandledExceptionContext
     {
@@ -2652,7 +2679,7 @@ namespace GraphQL.Validation
         public void ReportError(GraphQL.Validation.ValidationError error) { }
     }
     [System.Serializable]
-    public class ValidationError : GraphQL.ExecutionError
+    public class ValidationError : GraphQL.Execution.DocumentError
     {
         public ValidationError(string originalQuery, string errorCode, string message, params GraphQL.Language.AST.INode[] nodes) { }
         public ValidationError(string originalQuery, string errorCode, string message, System.Exception innerException, params GraphQL.Language.AST.INode[] nodes) { }

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -60,10 +60,10 @@ namespace GraphQL.Tests.Bugs
         }
 
         [Fact]
-        public void query_is_empty1() => AssertQueryWithError("", null, "Cannot execute query if no operation is specified.", 0, 0, (object[])null, code: "NO_OPERATION");
+        public void query_is_empty1() => AssertQueryWithError("", null, "Document does not contain any operations.", 0, 0, (object[])null, code: "NO_OPERATION");
 
         [Fact]
-        public void query_is_whitespace2() => AssertQueryWithError("\t \t \r\n", null, "Cannot execute query if no operation is specified.", 0, 0, (object[])null, code: "NO_OPERATION");
+        public void query_is_whitespace2() => AssertQueryWithError("\t \t \r\n", null, "Document does not contain any operations.", 0, 0, (object[])null, code: "NO_OPERATION");
 
         [Fact]
         public void DocumentExecuter_cannot_have_null_constructor_parameters()

--- a/src/GraphQL/Execution/DocumentError.cs
+++ b/src/GraphQL/Execution/DocumentError.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace GraphQL.Execution
+{
+    public abstract class DocumentError : ExecutionError
+    {
+        public DocumentError(string message) : base(message) { }
+        public DocumentError(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/GraphQL/Execution/DocumentError.cs
+++ b/src/GraphQL/Execution/DocumentError.cs
@@ -5,6 +5,7 @@ namespace GraphQL.Execution
     public abstract class DocumentError : ExecutionError
     {
         public DocumentError(string message) : base(message) { }
+        
         public DocumentError(string message, Exception innerException) : base(message, innerException) { }
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -213,7 +213,7 @@ namespace GraphQL
                 {
                     Errors = new ExecutionErrors
                     {
-                        ex is ExecutionError executionError ? executionError : new UnhandledError(ex.Message, ex)
+                        ex is ExecutionError executionError ? executionError : new UnhandledError("Error executing document.", ex)
                     }
                 };
             }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -213,7 +213,7 @@ namespace GraphQL
                 {
                     Errors = new ExecutionErrors
                     {
-                        ex is ExecutionError executionError ? executionError : new UnhandledError("Error executing document.", ex)
+                        ex is ExecutionError executionError ? executionError : new UnhandledError(ex.Message, ex)
                     }
                 };
             }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -78,10 +78,7 @@ namespace GraphQL
 
                 if (document.Operations.Count == 0)
                 {
-                    throw new ExecutionError("Cannot execute query if no operation is specified.")
-                    {
-                        Code = "NO_OPERATION"
-                    };
+                    throw new NoOperationError();
                 }
 
                 var operation = GetOperation(options.OperationName, document);
@@ -216,7 +213,7 @@ namespace GraphQL
                 {
                     Errors = new ExecutionErrors
                     {
-                        ex is ExecutionError executionError ? executionError : new ExecutionError(ex.Message, ex)
+                        ex is ExecutionError executionError ? executionError : new UnhandledError(ex.Message, ex)
                     }
                 };
             }

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -25,7 +25,7 @@ namespace GraphQL.Execution
                     type = schema.Mutation;
                     if (type == null)
                     {
-                        error = new ExecutionError("Schema is not configured for mutations");
+                        error = new InvalidOperationError("Schema is not configured for mutations");
                         error.AddLocation(operation, document);
                         throw error;
                     }
@@ -35,16 +35,14 @@ namespace GraphQL.Execution
                     type = schema.Subscription;
                     if (type == null)
                     {
-                        error = new ExecutionError("Schema is not configured for subscriptions");
+                        error = new InvalidOperationError("Schema is not configured for subscriptions");
                         error.AddLocation(operation, document);
                         throw error;
                     }
                     break;
 
                 default:
-                    error = new ExecutionError("Can only execute queries, mutations and subscriptions.");
-                    error.AddLocation(operation, document);
-                    throw error;
+                    throw new ArgumentOutOfRangeException(nameof(operation), "Can only execute queries, mutations and subscriptions.");
             }
 
             return type;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -105,7 +105,7 @@ namespace GraphQL.Execution
             {
                 AssertValidVariableValue(schema, type, input, variable.Name);
             }
-            catch (InvalidValueError error)
+            catch (InvalidVariableError error)
             {
                 error.AddLocation(variable, document);
                 throw;
@@ -128,7 +128,7 @@ namespace GraphQL.Execution
 
                 if (input == null)
                 {
-                    throw new InvalidValueError(variableName, "Received a null input for a non-null variable.");
+                    throw new InvalidVariableError(variableName, "Received a null input for a non-null variable.");
                 }
 
                 AssertValidVariableValue(schema, nonNullType, input, variableName);
@@ -149,11 +149,11 @@ namespace GraphQL.Execution
                     try
                     {
                         if (scalar.ParseLiteral(value) == null)
-                            throw new InvalidValueError(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'");
+                            throw new InvalidVariableError(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'");
                     }
                     catch (Exception ex)
                     {
-                        throw new InvalidValueError(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'", ex);
+                        throw new InvalidVariableError(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'", ex);
                     }
                 }
                 else
@@ -161,11 +161,11 @@ namespace GraphQL.Execution
                     try
                     {
                         if (scalar.ParseValue(input) == null)
-                            throw new InvalidValueError(variableName, $"Unable to convert '{input}' to '{type.Name}'");
+                            throw new InvalidVariableError(variableName, $"Unable to convert '{input}' to '{type.Name}'");
                     }
                     catch (Exception ex)
                     {
-                        throw new InvalidValueError(variableName, $"Unable to convert '{input}' to '{type.Name}'", ex);
+                        throw new InvalidVariableError(variableName, $"Unable to convert '{input}' to '{type.Name}'", ex);
                     }
                 }
 
@@ -195,7 +195,7 @@ namespace GraphQL.Execution
 
                 if (!(input is Dictionary<string, object> dict))
                 {
-                    throw new InvalidValueError(variableName,
+                    throw new InvalidVariableError(variableName,
                         $"Unable to parse input as a '{type.Name}' type. Did you provide a List or Scalar value accidentally?");
                 }
 
@@ -211,7 +211,7 @@ namespace GraphQL.Execution
 
                 if (unknownFields?.Count > 0)
                 {
-                    throw new InvalidValueError(variableName,
+                    throw new InvalidVariableError(variableName,
                         $"Unrecognized input fields {string.Join(", ", unknownFields.Select(k => $"'{k}'"))} for type '{type.Name}'.");
                 }
 
@@ -223,7 +223,7 @@ namespace GraphQL.Execution
                 return;
             }
 
-            throw new InvalidValueError(variableName ?? "input", "Invalid input");
+            throw new InvalidVariableError(variableName ?? "input", "Invalid input");
         }
 
         public static Dictionary<string, object> GetArgumentValues(ISchema schema, QueryArguments definitionArguments, Arguments astArguments, Variables variables)

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -107,7 +107,7 @@ namespace GraphQL.Execution
             {
                 AssertValidVariableValue(schema, type, input, variable.Name);
             }
-            catch (InvalidValueException error)
+            catch (InvalidValueError error)
             {
                 error.AddLocation(variable, document);
                 throw;
@@ -130,7 +130,7 @@ namespace GraphQL.Execution
 
                 if (input == null)
                 {
-                    throw new InvalidValueException(variableName, "Received a null input for a non-null variable.");
+                    throw new InvalidValueError(variableName, "Received a null input for a non-null variable.");
                 }
 
                 AssertValidVariableValue(schema, nonNullType, input, variableName);
@@ -151,11 +151,11 @@ namespace GraphQL.Execution
                     try
                     {
                         if (scalar.ParseLiteral(value) == null)
-                            throw new InvalidValueException(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'");
+                            throw new InvalidValueError(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'");
                     }
                     catch (Exception ex)
                     {
-                        throw new InvalidValueException(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'", ex);
+                        throw new InvalidValueError(variableName, $"Unable to convert '{value.Value}' to '{type.Name}'", ex);
                     }
                 }
                 else
@@ -163,11 +163,11 @@ namespace GraphQL.Execution
                     try
                     {
                         if (scalar.ParseValue(input) == null)
-                            throw new InvalidValueException(variableName, $"Unable to convert '{input}' to '{type.Name}'");
+                            throw new InvalidValueError(variableName, $"Unable to convert '{input}' to '{type.Name}'");
                     }
                     catch (Exception ex)
                     {
-                        throw new InvalidValueException(variableName, $"Unable to convert '{input}' to '{type.Name}'", ex);
+                        throw new InvalidValueError(variableName, $"Unable to convert '{input}' to '{type.Name}'", ex);
                     }
                 }
 
@@ -197,7 +197,7 @@ namespace GraphQL.Execution
 
                 if (!(input is Dictionary<string, object> dict))
                 {
-                    throw new InvalidValueException(variableName,
+                    throw new InvalidValueError(variableName,
                         $"Unable to parse input as a '{type.Name}' type. Did you provide a List or Scalar value accidentally?");
                 }
 
@@ -213,7 +213,7 @@ namespace GraphQL.Execution
 
                 if (unknownFields?.Count > 0)
                 {
-                    throw new InvalidValueException(variableName,
+                    throw new InvalidValueError(variableName,
                         $"Unrecognized input fields {string.Join(", ", unknownFields.Select(k => $"'{k}'"))} for type '{type.Name}'.");
                 }
 
@@ -225,7 +225,7 @@ namespace GraphQL.Execution
                 return;
             }
 
-            throw new InvalidValueException(variableName ?? "input", "Invalid input");
+            throw new InvalidValueError(variableName ?? "input", "Invalid input");
         }
 
         public static Dictionary<string, object> GetArgumentValues(ISchema schema, QueryArguments definitionArguments, Arguments astArguments, Variables variables)

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -229,7 +229,7 @@ namespace GraphQL.Execution
                     ex = exceptionContext.Exception;
                 }
 
-                var error = ex is ExecutionError executionError ? executionError : new ExecutionError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve {node.Name}.", ex);
+                var error = ex is ExecutionError executionError ? executionError : new UnhandledError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve {node.Name}.", ex);
                 error.AddLocation(node.Field, context.Document);
                 error.Path = node.ResponsePath;
                 context.Errors.Add(error);

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -26,9 +26,7 @@ namespace GraphQL.Execution
             }
             catch (GraphQLSyntaxErrorException ex)
             {
-                var e = new ExecutionError("Error parsing query: " + ex.Description, ex);
-                e.AddLocation(ex.Line, ex.Column);
-                throw e;
+                throw new SyntaxError(ex);
             }
 
             var document = CoreToVanillaConverter.Convert(body, result);

--- a/src/GraphQL/Execution/InvalidOperationError.cs
+++ b/src/GraphQL/Execution/InvalidOperationError.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GraphQL.Execution
 {

--- a/src/GraphQL/Execution/InvalidOperationError.cs
+++ b/src/GraphQL/Execution/InvalidOperationError.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GraphQL.Execution
+{
+    [Serializable]
+    public class InvalidOperationError : DocumentError
+    {
+        public InvalidOperationError(string message)
+            : base(message)
+        {
+            Code = "INVALID_OPERATION";
+        }
+    }
+}

--- a/src/GraphQL/Execution/InvalidValueError.cs
+++ b/src/GraphQL/Execution/InvalidValueError.cs
@@ -3,15 +3,15 @@ using System;
 namespace GraphQL.Execution
 {
     [Serializable]
-    public class InvalidValueException : ExecutionError
+    public class InvalidValueError : DocumentError
     {
-        public InvalidValueException(string variableName, string message) :
+        public InvalidValueError(string variableName, string message) :
             base($"Variable '${variableName}' is invalid. {message}")
         {
             Code = "INVALID_VALUE";
         }
 
-        public InvalidValueException(string variableName, string message, Exception innerException) :
+        public InvalidValueError(string variableName, string message, Exception innerException) :
             base($"Variable '${variableName}' is invalid. {message}", innerException)
         {
             Code = "INVALID_VALUE";

--- a/src/GraphQL/Execution/InvalidVariableError.cs
+++ b/src/GraphQL/Execution/InvalidVariableError.cs
@@ -3,15 +3,15 @@ using System;
 namespace GraphQL.Execution
 {
     [Serializable]
-    public class InvalidValueError : DocumentError
+    public class InvalidVariableError : DocumentError
     {
-        public InvalidValueError(string variableName, string message) :
+        public InvalidVariableError(string variableName, string message) :
             base($"Variable '${variableName}' is invalid. {message}")
         {
             Code = "INVALID_VALUE";
         }
 
-        public InvalidValueError(string variableName, string message, Exception innerException) :
+        public InvalidVariableError(string variableName, string message, Exception innerException) :
             base($"Variable '${variableName}' is invalid. {message}", innerException)
         {
             Code = "INVALID_VALUE";

--- a/src/GraphQL/Execution/NoOperationError.cs
+++ b/src/GraphQL/Execution/NoOperationError.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace GraphQL.Execution
+{
+    [Serializable]
+    public class NoOperationError : DocumentError
+    {
+        public NoOperationError()
+            : base("Document does not contain any operations.")
+        {
+            Code = "NO_OPERATION";
+        }
+    }
+}

--- a/src/GraphQL/Execution/SyntaxError.cs
+++ b/src/GraphQL/Execution/SyntaxError.cs
@@ -13,6 +13,7 @@ namespace GraphQL.Execution
             AddLocation(ex.Line, ex.Column);
         }
 
+        // available for use with third-party parsing engines
         public SyntaxError(string message, Exception innerException)
             : base("Error parsing query: " + message, innerException)
         {

--- a/src/GraphQL/Execution/SyntaxError.cs
+++ b/src/GraphQL/Execution/SyntaxError.cs
@@ -12,6 +12,5 @@ namespace GraphQL.Execution
             // Code will contain SYNTAX_ERROR due to inner exception
             AddLocation(ex.Line, ex.Column);
         }
-
     }
 }

--- a/src/GraphQL/Execution/SyntaxError.cs
+++ b/src/GraphQL/Execution/SyntaxError.cs
@@ -13,12 +13,5 @@ namespace GraphQL.Execution
             AddLocation(ex.Line, ex.Column);
         }
 
-        // available for use with third-party parsing engines
-        public SyntaxError(string message, Exception innerException)
-            : base("Error parsing query: " + message, innerException)
-        {
-            // the inner exception is of an unknown type, so set the code
-            Code = "SYNTAX_ERROR";
-        }
     }
 }

--- a/src/GraphQL/Execution/SyntaxError.cs
+++ b/src/GraphQL/Execution/SyntaxError.cs
@@ -1,0 +1,23 @@
+using System;
+using GraphQLParser.Exceptions;
+
+namespace GraphQL.Execution
+{
+    [Serializable]
+    public class SyntaxError : DocumentError
+    {
+        public SyntaxError(GraphQLSyntaxErrorException ex)
+            : base("Error parsing query: " + ex.Description, ex)
+        {
+            // Code will contain SYNTAX_ERROR due to inner exception
+            AddLocation(ex.Line, ex.Column);
+        }
+
+        public SyntaxError(string message, Exception innerException)
+            : base("Error parsing query: " + message, innerException)
+        {
+            // the inner exception is of an unknown type, so set the code
+            Code = "SYNTAX_ERROR";
+        }
+    }
+}

--- a/src/GraphQL/Execution/UnhandledError.cs
+++ b/src/GraphQL/Execution/UnhandledError.cs
@@ -5,7 +5,10 @@ namespace GraphQL.Execution
     [Serializable]
     public class UnhandledError : ExecutionError
     {
-        public UnhandledError(string message) : base(message) { }
-        public UnhandledError(string message, Exception innerException) : base(message, innerException) { }
+        public UnhandledError(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            // do not set another code by default; only inner exception's codes will be returned
+        }
     }
 }

--- a/src/GraphQL/Execution/UnhandledError.cs
+++ b/src/GraphQL/Execution/UnhandledError.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GraphQL.Execution
+{
+    [Serializable]
+    public class UnhandledError : ExecutionError
+    {
+        public UnhandledError(string message) : base(message) { }
+        public UnhandledError(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/GraphQL/Validation/ValidationError.cs
+++ b/src/GraphQL/Validation/ValidationError.cs
@@ -1,12 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using GraphQL.Execution;
 using GraphQL.Language.AST;
 using GraphQLParser;
 
 namespace GraphQL.Validation
 {
     [Serializable]
-    public class ValidationError : ExecutionError
+    public class ValidationError : DocumentError
     {
         private readonly List<INode> _nodes = new List<INode>();
 


### PR DESCRIPTION
* Add abstract `DocumentError`, which inherits `ExecutionError` and has these implementations:
  * `NoOperationError` (code `NO_OPERATION`)
  * `InvalidOperationError` (code `INVALID_OPERATION`)
  * `SyntaxError` (code `SYNTAX_ERROR`)
  * `InvalidVariableError` (renamed from `InvalidValueException`; unchanged code `INVALID_VALUE`)
  * `ValidationError` (code depends on which validation rule failed)
* Add `UnhandledError`, which inherits from `ExecutionError`, which is created when an unhandled error occurs.  No additional code is set for this error type; only the inner exception's codes are returned.

By convention, errors that inherit from `ExecutionError` now all end with the word `Error`, and regular exceptions end with `Exception`.

See #1768 

I also changed this error message: "Cannot execute query if no operation is specified." to "Document does not contain any operations.", which applies when there is an empty document (for the `NoOperationError`)