### PR TITLE
DocumentExecuter does not properly hide unhandled exception error messages

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug1156.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1156.cs
@@ -22,7 +22,8 @@ namespace GraphQL.Tests.Bugs
     }
 }";
             var result = AssertQueryWithErrors(query, null, expectedErrorCount: 1);
-            result.Errors[0].Message.ShouldBe(@"Unable to register GraphType 'GraphQL.Tests.Bugs.Type2' with the name 'MyType';
+            result.Errors[0].Message.ShouldBe("Error executing document.");
+            result.Errors[0].InnerException.Message.ShouldBe(@"Unable to register GraphType 'GraphQL.Tests.Bugs.Type2' with the name 'MyType';
 the name 'MyType' is already registered to 'GraphQL.Tests.Bugs.Type1'.");
         }
     }

--- a/src/GraphQL.Tests/Bugs/Bug1772.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1772.cs
@@ -45,9 +45,10 @@ namespace GraphQL.Tests.Bugs
             result.Data.ShouldBeNull();
             result.Errors.ShouldNotBeNull();
             result.Errors.Count.ShouldBe(1);
-            result.Errors[0].Message.ShouldBe($"Query does not contain operation '{operationName}'.");
+            result.Errors[0].Message.ShouldBe("Error executing document.");
             result.Errors[0].InnerException.ShouldNotBeNull();
             result.Errors[0].InnerException.ShouldBeOfType<InvalidOperationException>();
+            result.Errors[0].InnerException.Message.ShouldBe($"Query does not contain operation '{operationName}'.");
         }
     }
 

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -216,7 +216,7 @@ namespace GraphQL
                 {
                     Errors = new ExecutionErrors
                     {
-                        ex is ExecutionError executionError ? executionError : new ExecutionError(ex.Message, ex)
+                        ex is ExecutionError executionError ? executionError : new ExecutionError("Error executing document.", ex)
                     }
                 };
             }


### PR DESCRIPTION
The `DocumentExecuter` does not properly hide unhandled exception error messages, as unhandled errors that occur within a field resolver do.  This fixes that.  Inner exception codes are still returned as always.