### PR TITLE
Change default field resolver message

### DIFF
--- a/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
+++ b/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
@@ -38,7 +38,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {NonNullable = null};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullable.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'nonNullable'.", new InvalidOperationException(
                     "Cannot return null for non-null type. Field: nonNullable, Type: String!."))
                 {
                     Path = new[] {"nullableDataGraph", "nonNullable"}
@@ -56,7 +56,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {NullableNest = new Data {NonNullable = null}};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullable.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'nonNullable'.", new InvalidOperationException(
                     "Cannot return null for non-null type. Field: nonNullable, Type: String!."))
                 {
                     Path = new[] {"nullableDataGraph", "nullableNest", "nonNullable"}
@@ -74,7 +74,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {NonNullableNest = new Data {NonNullable = null}};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullable.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'nonNullable'.", new InvalidOperationException(
                     "Cannot return null for non-null type. Field: nonNullable, Type: String!."))
                 {
                     Path = new[] {"nullableDataGraph", "nonNullableNest", "nonNullable"}
@@ -92,7 +92,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {NonNullableNest = new Data {NonNullable = null}};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullable.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'nonNullable'.", new InvalidOperationException(
                     "Cannot return null for non-null type. Field: nonNullable, Type: String!."))
                 {
                     Path = new[] {"nonNullableDataGraph", "nonNullableNest", "nonNullable"}
@@ -110,7 +110,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = new List<string> {"text", null, null}};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve listOfNonNullable.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'listOfNonNullable'.", new InvalidOperationException(
                     "Cannot return a null member within a non-null list for list index 1."))
                 {
                     Path = new object[] {"nonNullableDataGraph", "listOfNonNullable"}
@@ -128,7 +128,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = null};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullableList.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'nonNullableList'.", new InvalidOperationException(
                     "Cannot return null for non-null type. Field: nonNullableList, Type: [String]!."))
                 {
                     Path = new[] {"nullableDataGraph", "nonNullableList"}
@@ -146,7 +146,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = null};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullableList.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'nonNullableList'.", new InvalidOperationException(
                     "Cannot return null for non-null type. Field: nonNullableList, Type: [String]!."))
                 {
                     Path = new[] {"nonNullableDataGraph", "nonNullableList"}
@@ -164,7 +164,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = new List<string> {"text", null, null}};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullableListOfNonNullable.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'nonNullableListOfNonNullable'.", new InvalidOperationException(
                     "Cannot return a null member within a non-null list for list index 1."))
                 {
                     Path = new object[] {"nullableDataGraph", "nonNullableListOfNonNullable"}
@@ -182,7 +182,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data {ListOfStrings = null};
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullableListOfNonNullable.", new InvalidOperationException(
+                new ExecutionError("Error trying to resolve field 'nonNullableListOfNonNullable'.", new InvalidOperationException(
                     "Cannot return null for non-null type. Field: nonNullableListOfNonNullable, Type: [String!]!."))
                 {
                     Path = new[] {"nullableDataGraph", "nonNullableListOfNonNullable"}
@@ -200,7 +200,7 @@ namespace GraphQL.Tests.Bugs
             var data = new Data { ListOfStrings = new List<string> { "text", null, null } };
             var errors = new[]
             {
-                new ExecutionError("Error trying to resolve nonNullableListOfNonNullableThrow.", new Exception(
+                new ExecutionError("Error trying to resolve field 'nonNullableListOfNonNullableThrow'.", new Exception(
                     "test"))
                 {
                     Path = new object[] { "nonNullableListOfNonNullableDataGraph", 0, "nonNullableListOfNonNullableThrow"}

--- a/src/GraphQL.Tests/Bugs/Bug1205VeryLongInt.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1205VeryLongInt.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Tests.Bugs
         public void Very_Long_Number_Should_Return_Error_For_Int()
         {
             var query = "{ int }";
-            var error = new ExecutionError("Error trying to resolve int.", new OverflowException());
+            var error = new ExecutionError("Error trying to resolve field 'int'.", new OverflowException());
             error.AddLocation(1, 3);
             error.Path = new object[] { "int" };
             var expected = new ExecutionResult {
@@ -67,7 +67,7 @@ namespace GraphQL.Tests.Bugs
         public void Very_Very_Long_Number_Should_Return_Error_For_Long()
         {
             var query = "{ long_return_bigint }";
-            var error = new ExecutionError("Error trying to resolve long_return_bigint.", new OverflowException());
+            var error = new ExecutionError("Error trying to resolve field 'long_return_bigint'.", new OverflowException());
             error.AddLocation(1, 3);
             error.Path = new object[] { "long_return_bigint" };
             var expected = new ExecutionResult

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -30,17 +30,17 @@ namespace GraphQL.Tests.Bugs
 
         // within C#, (int)Bug1699Enum.Happy does not equal Bug1699.Happy
         [Fact]
-        public void Int_Enum() => AssertQueryWithError("{ happy }", @"{ ""happy"": null }", "Error trying to resolve happy.", 1, 3, "happy", exception: new InvalidOperationException());
+        public void Int_Enum() => AssertQueryWithError("{ happy }", @"{ ""happy"": null }", "Error trying to resolve field 'happy'.", 1, 3, "happy", exception: new InvalidOperationException());
 
         [Fact]
-        public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Error trying to resolve invalidEnum.", 1, 3, "invalidEnum", exception: new InvalidOperationException());
+        public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Error trying to resolve field 'invalidEnum'.", 1, 3, "invalidEnum", exception: new InvalidOperationException());
 
         // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
         [Fact]
-        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Error trying to resolve invalidEnumWithinList.", 1, 3, "invalidEnumWithinList", exception: new InvalidOperationException());
+        public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": null }", "Error trying to resolve field 'invalidEnumWithinList'.", 1, 3, "invalidEnumWithinList", exception: new InvalidOperationException());
 
         [Fact]
-        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Error trying to resolve invalidEnumWithinNonNullList.", 1, 3, "invalidEnumWithinNonNullList", exception: new InvalidOperationException());
+        public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Error trying to resolve field 'invalidEnumWithinNonNullList'.", 1, 3, "invalidEnumWithinNonNullList", exception: new InvalidOperationException());
 
         [Fact]
         public void Input_Enum_Valid() => AssertQuerySuccess("{ inputEnum(arg: SLEEPY) }", @"{ ""inputEnum"": ""SLEEPY"" }");

--- a/src/GraphQL.Tests/Bugs/Bug1773.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1773.cs
@@ -33,7 +33,7 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void list_throws_when_not_ienumerable()
         {
-            AssertQueryWithError("{testListInvalid}", "{\"testListInvalid\": null}", "Error trying to resolve testListInvalid.", 1, 2, new[] { "testListInvalid" },
+            AssertQueryWithError("{testListInvalid}", "{\"testListInvalid\": null}", "Error trying to resolve field 'testListInvalid'.", 1, 2, new[] { "testListInvalid" },
                 new InvalidOperationException("Expected an IEnumerable list though did not find one. Found: Int32"));
         }
 
@@ -46,7 +46,7 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void nonnull_list_throws_when_null()
         {
-            AssertQueryWithError("{testListNullInvalid}", "{\"testListNullInvalid\": null}", "Error trying to resolve testListNullInvalid.", 1, 2, new[] { "testListNullInvalid" },
+            AssertQueryWithError("{testListNullInvalid}", "{\"testListNullInvalid\": null}", "Error trying to resolve field 'testListNullInvalid'.", 1, 2, new[] { "testListNullInvalid" },
                 new InvalidOperationException("Cannot return a null member within a non-null list for list index 0."));
         }
 
@@ -54,7 +54,7 @@ namespace GraphQL.Tests.Bugs
         public void list_throws_for_invalid_type()
         {
             // TODO: does not yet fully meet spec (does not return members of lists that are able to be serialized, with nulls and individual errors for unserializable values)
-            AssertQueryWithError("{testListInvalidType}", "{\"testListInvalidType\": null}", "Error trying to resolve testListInvalidType.", 1, 2, new[] { "testListInvalidType" },
+            AssertQueryWithError("{testListInvalidType}", "{\"testListInvalidType\": null}", "Error trying to resolve field 'testListInvalidType'.", 1, 2, new[] { "testListInvalidType" },
                 new FormatException("Input string was not in a correct format."));
         }
 
@@ -62,7 +62,7 @@ namespace GraphQL.Tests.Bugs
         public void list_throws_for_invalid_type_when_conversion_returns_null()
         {
             // TODO: does not yet fully meet spec (does not return members of lists that are able to be serialized, with nulls and individual errors for unserializable values)
-            AssertQueryWithError("{testListInvalidType2}", "{\"testListInvalidType2\": null}", "Error trying to resolve testListInvalidType2.", 1, 2, new[] { "testListInvalidType2" },
+            AssertQueryWithError("{testListInvalidType2}", "{\"testListInvalidType2\": null}", "Error trying to resolve field 'testListInvalidType2'.", 1, 2, new[] { "testListInvalidType2" },
                 new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum' for list index 0."));
         }
 
@@ -70,7 +70,7 @@ namespace GraphQL.Tests.Bugs
         public void throws_for_invalid_type()
         {
             // in this case, the conversion threw a FormatException
-            AssertQueryWithError("{testInvalidType}", "{\"testInvalidType\": null}", "Error trying to resolve testInvalidType.", 1, 2, new[] { "testInvalidType" },
+            AssertQueryWithError("{testInvalidType}", "{\"testInvalidType\": null}", "Error trying to resolve field 'testInvalidType'.", 1, 2, new[] { "testInvalidType" },
                 new FormatException("Input string was not in a correct format."));
         }
 
@@ -78,7 +78,7 @@ namespace GraphQL.Tests.Bugs
         public void throws_for_invalid_type_when_conversion_returns_null()
         {
             // in this case, the converstion returned null, and GraphQL threw an InvalidOperationException
-            AssertQueryWithError("{testInvalidType2}", "{\"testInvalidType2\": null}", "Error trying to resolve testInvalidType2.", 1, 2, new[] { "testInvalidType2" },
+            AssertQueryWithError("{testInvalidType2}", "{\"testInvalidType2\": null}", "Error trying to resolve field 'testInvalidType2'.", 1, 2, new[] { "testInvalidType2" },
                 new InvalidOperationException("Unable to serialize 'test' to 'Bug1773Enum'"));
         }
 

--- a/src/GraphQL.Tests/Bugs/Issue1189.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1189.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Tests.Bugs
 
         [Theory]
         [InlineData(typeof(Issue1189_DroidType_ExecutionError), "Error Message")]
-        [InlineData(typeof(Issue1189_DroidType_Exception), "Error trying to resolve friend.")]
+        [InlineData(typeof(Issue1189_DroidType_Exception), "Error trying to resolve field 'friend'.")]
         public void Issue1189_Should_Work(Type resolverType, string errorMessage)
         {
             Builder.Types.Include<Issue1189_Query>();

--- a/src/GraphQL.Tests/Errors/ErrorExtensionsTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Tests.Errors
             });
 
             var errors = new ExecutionErrors();
-            var error = new ValidationError(query, code, "Error trying to resolve firstSync.", new SystemException("Just inner exception 1", new DllNotFoundException("just inner exception 2")));
+            var error = new ValidationError(query, code, "Error trying to resolve field 'firstSync'.", new SystemException("Just inner exception 1", new DllNotFoundException("just inner exception 2")));
             error.AddLocation(1, 3);
             error.Path = new[] { "firstSync" };
             errors.Add(error);
@@ -43,7 +43,7 @@ namespace GraphQL.Tests.Errors
             });
 
             var errors = new ExecutionErrors();
-            var error = new ExecutionError("Error trying to resolve uncodedSync.");
+            var error = new ExecutionError("Error trying to resolve field 'uncodedSync'.");
             error.AddLocation(1, 3);
             error.Path = new[] { "uncodedSync" };
             errors.Add(error);

--- a/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
@@ -80,7 +80,7 @@ namespace GraphQL.Tests.Errors
         [Fact]
         public void async_field_with_errors()
         {
-            var error = new ExecutionError("Error trying to resolve testasync.");
+            var error = new ExecutionError("Error trying to resolve field 'testasync'.");
             error.AddLocation(1, 3);
             error.Path = new[] { "testasync" };
 

--- a/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
+++ b/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Tests.Execution
         {
             var result = AssertQueryWithErrors("{ pets { name } }", @"{ ""pets"": null }", expectedErrorCount: 1);
             var error = result.Errors.First();
-            error.Message.ShouldBe("Error trying to resolve pets.");
+            error.Message.ShouldBe("Error trying to resolve field 'pets'.");
             error.InnerException.ShouldNotBeNull();
             error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets with value '{ name = Eli }', received 'null'.");
         }

--- a/src/GraphQL.Tests/Types/NonNullGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/NonNullGraphTypeTests.cs
@@ -44,11 +44,11 @@ namespace GraphQL.Tests.Types
                 expectedErrorCount: 3);
 
             var errors = result.Errors.ToArray();
-            errors[0].Message.ShouldBe("Error trying to resolve a.");
+            errors[0].Message.ShouldBe("Error trying to resolve field 'a'.");
             errors[0].InnerException.Message.ShouldBe("Cannot return null for non-null type. Field: a, Type: Int!.");
-            errors[1].Message.ShouldBe("Error trying to resolve b.");
+            errors[1].Message.ShouldBe("Error trying to resolve field 'b'.");
             errors[1].InnerException.Message.ShouldBe("Cannot return null for non-null type. Field: b, Type: Boolean!.");
-            errors[2].Message.ShouldBe("Error trying to resolve c.");
+            errors[2].Message.ShouldBe("Error trying to resolve field 'c'.");
             errors[2].InnerException.Message.ShouldBe("Cannot return null for non-null type. Field: c, Type: String!.");
         }
     }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -229,7 +229,7 @@ namespace GraphQL.Execution
                     ex = exceptionContext.Exception;
                 }
 
-                var error = ex is ExecutionError executionError ? executionError : new ExecutionError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve {node.Name}.", ex);
+                var error = ex is ExecutionError executionError ? executionError : new ExecutionError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve field '{node.Name}'.", ex);
                 error.AddLocation(node.Field, context.Document);
                 error.Path = node.ResponsePath;
                 context.Errors.Add(error);

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -98,7 +98,7 @@ namespace GraphQL.Execution
                 }
                 else
                 {
-                    throw new InvalidOperationException($"Subscriber not set for field {node.Field.Name}");
+                    throw new InvalidOperationException($"Subscriber not set for field '{node.Field.Name}'.");
                 }
 
                 return subscription
@@ -143,7 +143,7 @@ namespace GraphQL.Execution
                                 {
                                     GenerateError(
                                         context,
-                                        $"Could not subscribe to field '{node.Field.Name}' in query '{context.Document.OriginalQuery}'",
+                                        $"Could not subscribe to field '{node.Field.Name}' in query '{context.Document.OriginalQuery}'.",
                                         node.Field,
                                         node.ResponsePath,
                                         exception)
@@ -152,7 +152,7 @@ namespace GraphQL.Execution
             }
             catch (Exception ex)
             {
-                var message = $"Error trying to resolve {node.Field.Name}.";
+                var message = $"Error trying to resolve field '{node.Field.Name}'.";
                 var error = GenerateError(context, message, node.Field, node.ResponsePath, ex);
                 context.Errors.Add(error);
                 return null;


### PR DESCRIPTION
* Changes `Error trying to resolve {node.Name}.` to `Error trying to resolve field '{node.Name}'.`, and same for subscriptions
* Changes `Subscriber not set for field {node.Field.Name}` to `Subscriber not set for field '{node.Field.Name}'.`
* Changes `Could not subscribe to field '{node.Field.Name}' in query '{context.Document.OriginalQuery}'` to include period at end