### PR TITLE
remove Operation from ApolloTrace

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -777,7 +777,7 @@ namespace GraphQL.Instrumentation
     }
     public static class ApolloTracingExtensions
     {
-        public static GraphQL.Instrumentation.ApolloTrace CreateTrace(GraphQL.Language.AST.Operation operation, GraphQL.Instrumentation.PerfRecord[] perf, System.DateTime start) { }
+        public static GraphQL.Instrumentation.ApolloTrace CreateTrace(GraphQL.Instrumentation.PerfRecord[] perf, System.DateTime start) { }
         public static void EnrichWithApolloTracing(this GraphQL.ExecutionResult result, System.DateTime start) { }
     }
     public class Field

--- a/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using GraphQL.Language.AST;
 
 namespace GraphQL.Instrumentation
 {
@@ -15,7 +14,7 @@ namespace GraphQL.Instrumentation
                 return;
             }
 
-            var trace = CreateTrace(result.Operation, perf, start);
+            var trace = CreateTrace(perf, start);
             if (result.Extensions == null)
             {
                 result.Extensions = new Dictionary<string, object>();
@@ -23,10 +22,7 @@ namespace GraphQL.Instrumentation
             result.Extensions["tracing"] = trace;
         }
 
-        public static ApolloTrace CreateTrace(
-            Operation operation,
-            PerfRecord[] perf,
-            DateTime start)
+        public static ApolloTrace CreateTrace(PerfRecord[] perf, DateTime start)
         {
             var operationStat = perf.Single(x => x.Category == "operation"); // always exists
             var trace = new ApolloTrace(start, operationStat.Duration);
@@ -34,14 +30,14 @@ namespace GraphQL.Instrumentation
             var documentStats = perf.Where(x => x.Category == "document");
 
             var parsingStat = documentStats.FirstOrDefault(x => x.Subject == "Building document");
-            if (parsingStat != null) // can be null if exception occured
+            if (parsingStat != null) // can be null if exception occurred
             {
                 trace.Parsing.StartOffset = ApolloTrace.ConvertTime(parsingStat.Start);
                 trace.Parsing.Duration = ApolloTrace.ConvertTime(parsingStat.Duration);
             }
 
             var validationStat = documentStats.FirstOrDefault(x => x.Subject == "Validating document");
-            if (validationStat != null) // can be null if exception occured
+            if (validationStat != null) // can be null if exception occurred
             {
                 trace.Validation.StartOffset = ApolloTrace.ConvertTime(validationStat.Start);
                 trace.Validation.Duration = ApolloTrace.ConvertTime(validationStat.Duration);


### PR DESCRIPTION
apollo trace doesnt use operation. https://github.com/apollographql/apollo-tracing  so remove a redundant parameter 