### PR TITLE
Remove ResolveFieldContextExtensions.TryAsyncResolve

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -302,8 +302,6 @@ namespace GraphQL
         public static object GetExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
         public static void SetExtension(this GraphQL.IResolveFieldContext context, string path, object value) { }
-        public static System.Threading.Tasks.Task<object> TryAsyncResolve(this GraphQL.IResolveFieldContext context, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object>> resolve, System.Func<GraphQL.ExecutionErrors, System.Threading.Tasks.Task<object>> error = null) { }
-        public static System.Threading.Tasks.Task<TResult> TryAsyncResolve<TResult>(this GraphQL.IResolveFieldContext context, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<TResult>> resolve, System.Func<GraphQL.ExecutionErrors, System.Threading.Tasks.Task<TResult>> error = null) { }
     }
     public class ResolveFieldContext<TSource> : GraphQL.ResolveFieldContext, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<TSource>
     {

--- a/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
+++ b/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
@@ -281,7 +281,6 @@ namespace GraphQL.Tests.Execution
             One,
             Two
         }
-
     }
 
     public static class ResolveFieldContextExtensions

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -94,33 +94,6 @@ namespace GraphQL
             return new ResolveEventStreamContext<T>(context);
         }
 
-        public static Task<object> TryAsyncResolve(this IResolveFieldContext context, Func<IResolveFieldContext, Task<object>> resolve, Func<ExecutionErrors, Task<object>> error = null)
-            => TryAsyncResolve<object>(context, resolve, error);
-
-        public static async Task<TResult> TryAsyncResolve<TResult>(this IResolveFieldContext context, Func<IResolveFieldContext, Task<TResult>> resolve, Func<ExecutionErrors, Task<TResult>> error = null)
-        {
-            try
-            {
-                return await resolve(context).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                if (error == null)
-                {
-                    var er = new ExecutionError(ex.Message, ex);
-                    er.AddLocation(context.FieldAst, context.Document);
-                    er.Path = context.Path;
-                    context.Errors.Add(er);
-                    return default;
-                }
-                else
-                {
-                    var result = error(context.Errors);
-                    return result == null ? default : await result.ConfigureAwait(false);
-                }
-            }
-        }
-
         private static readonly char[] _separators = { '.' };
 
         /// <summary>


### PR DESCRIPTION
I propose to delete `ResolveFieldContextExtensions.TryAsyncResolve` from the main GraphQL library.  It is only used by `ResolveFieldContextTests.cs`, and seems a bit useless otherwise.  Also, the logic is designed for tests: if an error occurs and an exception handler was specified, it will completely ignore the exception (not adding it to the list of document errors), and call the exception handler with the list of errors from the context, returning a `TResult` from the exception handler.  This logic is obviously useful only to a test.