### PR TITLE
Support UnhandledExceptionContext.ErrorMessage within DocumentExecuter

### DIFF
--- a/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
+++ b/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading.Tasks;
+using GraphQL.Execution;
 using GraphQL.Tests.Utilities;
 using Shouldly;
 using Xunit;
@@ -58,6 +60,72 @@ namespace GraphQL.Tests.Errors
             }, new ExecutionResult { Errors = new ExecutionErrors { expectedError }, Data = new { hello2 = (object)null } });
 
         }
+
+        [Fact]
+        public void unhandled_exception_delegate_can_rethrow_custom_message_from_field_resolver()
+        {
+            var def = @"
+                type Query {
+                  hello2: Int
+                }
+            ";
+
+            Builder.Types.Include<Query>();
+
+            var expectedError = new ExecutionError("Test error message", new ApplicationException());
+            expectedError.AddLocation(1, 3);
+            expectedError.Path = new[] { "hello2" };
+
+            AssertQuery(options =>
+            {
+                options.Schema = Builder.Build(def);
+                options.Query = "{ hello2 }";
+                options.UnhandledExceptionDelegate = ctx =>
+                {
+                    if (ctx.Exception is ApplicationException)
+                    {
+                        ctx.ErrorMessage = "Test error message";
+                    }
+                };
+            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError }, Data = new { hello2 = (object)null } });
+
+        }
+
+        [Fact]
+        public void unhandled_exception_delegate_can_rethrow_custom_message_from_document_listener()
+        {
+            var def = @"
+                type Query {
+                  hello2: Int
+                }
+            ";
+
+            Builder.Types.Include<Query>();
+
+            var expectedError = new ExecutionError("Test error message", new ApplicationException2());
+
+            AssertQuery(options =>
+            {
+                options.Schema = Builder.Build(def);
+                options.Query = "{ hello2 }";
+                options.Listeners.Add(new DocListener());
+                options.UnhandledExceptionDelegate = ctx =>
+                {
+                    if (ctx.Exception is ApplicationException2)
+                    {
+                        ctx.ErrorMessage = "Test error message";
+                    }
+                };
+            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError } });
+
+        }
+
+        public class DocListener : DocumentExecutionListenerBase
+        {
+            public override Task BeforeExecutionAsync(IExecutionContext context) => throw new ApplicationException2();
+        }
+
+        public class ApplicationException2 : Exception { }
 
         public class Query
         {

--- a/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
+++ b/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
@@ -117,7 +117,6 @@ namespace GraphQL.Tests.Errors
                     }
                 };
             }, new ExecutionResult { Errors = new ExecutionErrors { expectedError } });
-
         }
 
         public class DocListener : DocumentExecutionListenerBase

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -199,6 +199,9 @@ namespace GraphQL
             }
             catch (Exception ex)
             {
+                if (options.ThrowOnUnhandledException)
+                    throw;
+
                 UnhandledExceptionContext exceptionContext = null;
 
                 if (options.UnhandledExceptionDelegate != null)
@@ -207,9 +210,6 @@ namespace GraphQL
                     options.UnhandledExceptionDelegate(exceptionContext);
                     ex = exceptionContext.Exception;
                 }
-
-                if (options.ThrowOnUnhandledException && !(ex is ExecutionError))
-                    throw;
 
                 result = new ExecutionResult
                 {

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -203,7 +203,6 @@ namespace GraphQL
                     throw;
 
                 UnhandledExceptionContext exceptionContext = null;
-
                 if (options.UnhandledExceptionDelegate != null)
                 {
                     exceptionContext = new UnhandledExceptionContext(context, null, ex);

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -199,21 +199,23 @@ namespace GraphQL
             }
             catch (Exception ex)
             {
-                if (options.ThrowOnUnhandledException)
-                    throw;
+                UnhandledExceptionContext exceptionContext = null;
 
                 if (options.UnhandledExceptionDelegate != null)
                 {
-                    var exceptionContext = new UnhandledExceptionContext(context, null, ex);
+                    exceptionContext = new UnhandledExceptionContext(context, null, ex);
                     options.UnhandledExceptionDelegate(exceptionContext);
                     ex = exceptionContext.Exception;
                 }
+
+                if (options.ThrowOnUnhandledException && !(ex is ExecutionError))
+                    throw;
 
                 result = new ExecutionResult
                 {
                     Errors = new ExecutionErrors
                     {
-                        ex is ExecutionError executionError ? executionError : new UnhandledError("Error executing document.", ex)
+                        ex is ExecutionError executionError ? executionError : new UnhandledError(exceptionContext?.ErrorMessage ?? "Error executing document.", ex)
                     }
                 };
             }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -218,6 +218,9 @@ namespace GraphQL.Execution
             }
             catch (Exception ex)
             {
+                if (context.ThrowOnUnhandledException)
+                    throw;
+
                 UnhandledExceptionContext exceptionContext = null;
                 if (context.UnhandledExceptionDelegate != null)
                 {
@@ -225,9 +228,6 @@ namespace GraphQL.Execution
                     context.UnhandledExceptionDelegate(exceptionContext);
                     ex = exceptionContext.Exception;
                 }
-
-                if (context.ThrowOnUnhandledException && !(ex is ExecutionError))
-                    throw;
 
                 var error = ex is ExecutionError executionError ? executionError : new UnhandledError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve field '{node.Name}'.", ex);
                 error.AddLocation(node.Field, context.Document);

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -218,9 +218,6 @@ namespace GraphQL.Execution
             }
             catch (Exception ex)
             {
-                if (context.ThrowOnUnhandledException)
-                    throw;
-
                 UnhandledExceptionContext exceptionContext = null;
                 if (context.UnhandledExceptionDelegate != null)
                 {
@@ -228,6 +225,9 @@ namespace GraphQL.Execution
                     context.UnhandledExceptionDelegate(exceptionContext);
                     ex = exceptionContext.Exception;
                 }
+
+                if (context.ThrowOnUnhandledException && !(ex is ExecutionError))
+                    throw;
 
                 var error = ex is ExecutionError executionError ? executionError : new UnhandledError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve field '{node.Name}'.", ex);
                 error.AddLocation(node.Field, context.Document);


### PR DESCRIPTION
When setting `UnhandledExceptionContext.ErrorMessage` during an error caught in the `DocumentExecuter`, the error message is now overridden as it should be.

Added tests to verify this both for `DocumentExecuter` and `ExecutionStrategy`.
