### PR TITLE
Make ExecutionError.Code and related virtual

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -50,12 +50,13 @@ namespace GraphQL
         public ExecutionError(string message) { }
         public ExecutionError(string message, System.Collections.IDictionary data) { }
         public ExecutionError(string message, System.Exception exception) { }
-        public string Code { get; set; }
-        public System.Collections.Generic.IEnumerable<string> Codes { get; }
-        public bool HasCodes { get; }
+        public virtual System.Collections.Generic.IEnumerable<string> Codes { get; }
+        public virtual bool HasCodes { get; }
         public System.Collections.Generic.IEnumerable<GraphQL.ErrorLocation> Locations { get; }
         public System.Collections.Generic.IEnumerable<object> Path { get; set; }
+        public virtual string Code { get; set; }
         public void AddLocation(int line, int column) { }
+        protected static string GetErrorCode(System.Exception exception) { }
     }
     public static class ExecutionErrorExtensions
     {

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -35,11 +35,11 @@ namespace GraphQL
 
         public IEnumerable<ErrorLocation> Locations => _errorLocations;
 
-        public string Code { get; set; }
+        public virtual string Code { get; set; }
 
-        public bool HasCodes => InnerException != null || !string.IsNullOrWhiteSpace(Code);
+        public virtual bool HasCodes => InnerException != null || !string.IsNullOrWhiteSpace(Code);
 
-        public IEnumerable<string> Codes
+        public virtual IEnumerable<string> Codes
         {
             get
             {
@@ -92,7 +92,7 @@ namespace GraphQL
             }
         }
 
-        private static string GetErrorCode(Exception exception) => _exceptionErrorCodes.GetOrAdd(exception.GetType(), NormalizeErrorCode);
+        protected static string GetErrorCode(Exception exception) => _exceptionErrorCodes.GetOrAdd(exception.GetType(), NormalizeErrorCode);
 
         private static string NormalizeErrorCode(Type exceptionType)
         {


### PR DESCRIPTION
This marks the following properties `virtual` so they can be overridden by classes that inherit from `ExecutionError`:
* `Code`
* `Codes`
* `HasCodes`

It also marks the following a `protected` so that it can be used by an implementation that overrides `Codes`:
* `GetErrorCode`