### PR TITLE
Change ExposeExceptionStackTrace to only expose stack traces of UnhandledErrors

### DIFF
--- a/src/GraphQL.Tests/Errors/ErrorInfoProviderTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorInfoProviderTests.cs
@@ -131,7 +131,7 @@ namespace GraphQL.Tests.Errors
         public void exposeExceptions()
         {
             var innerException = new ArgumentNullException(null, new ArgumentOutOfRangeException());
-            var error = new ExecutionError(innerException.Message, innerException);
+            var error = new UnhandledError(innerException.Message, innerException);
 
             var info = new ErrorInfoProvider(new ErrorInfoProviderOptions { ExposeExceptionStackTrace = true }).GetInfo(error);
             info.Message.ShouldBe(error.ToString());
@@ -150,7 +150,7 @@ namespace GraphQL.Tests.Errors
                 }
                 catch (Exception innerException)
                 {
-                    throw new ExecutionError(innerException.Message, innerException);
+                    throw new UnhandledError(innerException.Message, innerException);
                 }
             }
             catch (ExecutionError e)
@@ -160,6 +160,24 @@ namespace GraphQL.Tests.Errors
 
             var info = new ErrorInfoProvider(new ErrorInfoProviderOptions { ExposeExceptionStackTrace = true }).GetInfo(error);
             info.Message.ShouldBe(error.ToString());
+        }
+
+        [Fact]
+        public void exposeExceptions_with_exposestacktrace_does_not_expose_execution_errors()
+        {
+            // generate a real stack trace to serialize
+            ExecutionError error;
+            try
+            {
+                throw new ExecutionError("An error has occurred!");
+            }
+            catch (ExecutionError e)
+            {
+                error = e;
+            }
+
+            var info = new ErrorInfoProvider(new ErrorInfoProviderOptions { ExposeExceptionStackTrace = true }).GetInfo(error);
+            info.Message.ShouldBe(error.Message);
         }
 
         [Fact]

--- a/src/GraphQL/Execution/ErrorInfoProvider.cs
+++ b/src/GraphQL/Execution/ErrorInfoProvider.cs
@@ -59,7 +59,8 @@ namespace GraphQL.Execution
 
             return new ErrorInfo
             {
-                Message = _options.ExposeExceptionStackTrace ? executionError.ToString() : executionError.Message,
+                Message = _options.ExposeExceptionStackTrace && executionError is UnhandledError ? executionError.ToString() : executionError.Message,
+                //Message = _options.ExposeExceptionStackTrace ? executionError.ToString() : executionError.Message,
                 Extensions = extensions,
             };
         }

--- a/src/GraphQL/Execution/ErrorInfoProvider.cs
+++ b/src/GraphQL/Execution/ErrorInfoProvider.cs
@@ -60,7 +60,6 @@ namespace GraphQL.Execution
             return new ErrorInfo
             {
                 Message = _options.ExposeExceptionStackTrace && executionError is UnhandledError ? executionError.ToString() : executionError.Message,
-                //Message = _options.ExposeExceptionStackTrace ? executionError.ToString() : executionError.Message,
                 Extensions = extensions,
             };
         }

--- a/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
+++ b/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Execution
     public class ErrorInfoProviderOptions
     {
         /// <summary>
-        /// Specifies whether stack traces should be serialized.
+        /// Specifies whether stack traces of unhandled exceptions should be serialized.
         /// </summary>
         public bool ExposeExceptionStackTrace { get; set; }
 


### PR DESCRIPTION
Regression fix: Originally the `ExposeExceptions` only exposed stack traces of unhandled exceptions.  Now it exposes stack traces of all errors, such as validation errors.  This PR fixes that.

Should the property name be changed to `ExposeUnhandledExceptionStackTrace`?  It seems rather long.