### PR TITLE
Set RequestServices in Harness sample

### DIFF
--- a/src/GraphQL.Harness/GraphQLMiddleware.cs
+++ b/src/GraphQL.Harness/GraphQLMiddleware.cs
@@ -63,6 +63,7 @@ namespace Example
                 options.Inputs = request.Variables.ToInputs();
                 options.UserContext = _settings.BuildUserContext?.Invoke(context);
                 options.EnableMetrics = _settings.EnableMetrics;
+                options.RequestServices = context.RequestServices;
                 if (_settings.EnableMetrics)
                 {
                     options.FieldMiddleware


### PR DESCRIPTION
Although there currently is no sample within the Harness sample project demonstrating scoped services, I feel that a proper demonstration of typical integration with Asp.Net Core should set the `RequestServices` property based on `HttpContext.RequestServices`.  Then people that use cut & paste from the `Harness` sample will already have the proper configuration for scoped services in their project, matching what's shown in the documentation.