### PR TITLE
Eliminate double conversion of date within DateGraphType

### DIFF
--- a/src/GraphQL/Types/Scalars/DateGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateGraphType.cs
@@ -37,9 +37,9 @@ namespace GraphQL.Types
 
             if (value is string valueAsString)
             {
-                if (DateTime.TryParseExact(valueAsString, "yyyy-MM-dd", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out var date))
+                if (DateTime.TryParseExact(valueAsString, "yyyy-MM-dd", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var date))
                 {
-                    return date.ToUniversalTime();
+                    return date;
                 }
                 throw new FormatException($"Could not parse date. Expected yyyy-MM-dd. Value: {valueAsString}");
             }


### PR DESCRIPTION
No functional change.  Tests already validate everything needed - for example, that it returns a DateTime.Kind of DateTimeKind.Utc.