### PR TITLE
Try to skip build on changes in docs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@ pull_requests:
   do_not_increment_build_number: true
 skip_tags: true
 skip_branch_with_pr: false
+skip_commits:
+  files:
+    - docs2/*
+    - README.md
 test: off
 
 os: Visual Studio 2019


### PR DESCRIPTION
I think it's time to suppress the build when we change the documentation only.