### PR TITLE
Enhancement: allows enumeration members to be specified by underlying value

### DIFF
--- a/src/GraphQL.Tests/Types/EnumGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/EnumGraphTypeTests.cs
@@ -87,7 +87,7 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void adds_values_from_enum_custom_casing()
         {
-            type.ParseValue("rED").ShouldBe(Colors.Red);
+            type.ParseValue("rED").ShouldBe((int)Colors.Red);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void parses_from_name()
         {
-            type.ParseValue("RED").ShouldBe(Colors.Red);
+            type.ParseValue("RED").ShouldBe((int)Colors.Red);
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Types/EnumGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/EnumGraphTypeTests.cs
@@ -87,7 +87,7 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void adds_values_from_enum_custom_casing()
         {
-            type.ParseValue("rED").ShouldBe((int)Colors.Red);
+            type.ParseValue("rED").ShouldBe(Colors.Red);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void parses_from_name()
         {
-            type.ParseValue("RED").ShouldBe((int)Colors.Red);
+            type.ParseValue("RED").ShouldBe(Colors.Red);
         }
 
         [Fact]

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -135,7 +135,7 @@ namespace GraphQL.Types
 
             // DO NOT USE LINQ ON HOT PATH
             foreach (var def in _values)
-                if (def.Value.Equals(value))
+                if (def.UnderlyingValue.Equals(value))
                     return def;
 
             return null;
@@ -156,13 +156,15 @@ namespace GraphQL.Types
         {
             get => _value;
             set {
+                _value = value;
                 if (value != null)
                 {
                     if (value is Enum)
                         value = Convert.ChangeType(value, Enum.GetUnderlyingType(value.GetType()));
                 }
-                _value = value;
+                UnderlyingValue = value;
             }
         }
+        internal object UnderlyingValue { get; set; }
     }
 }

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -114,14 +114,7 @@ namespace GraphQL.Types
 
         public EnumValueDefinition this[string name] => FindByName(name);
 
-        public void Add(EnumValueDefinition value)
-        {
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
-            if (value.Value is Enum enumValue)
-                value.Value = Convert.ChangeType(enumValue, Enum.GetUnderlyingType(enumValue.GetType()));
-            _values.Add(value);
-        }
+        public void Add(EnumValueDefinition value) => _values.Add(value ?? throw new ArgumentNullException(nameof(value)));
 
         public EnumValueDefinition FindByName(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
@@ -158,6 +151,18 @@ namespace GraphQL.Types
         public string Name { get; set; }
         public string Description { get; set; }
         public string DeprecationReason { get; set; }
-        public object Value { get; set; }
+        private object _value;
+        public object Value
+        {
+            get => _value;
+            set {
+                if (value != null)
+                {
+                    if (value is Enum)
+                        value = Convert.ChangeType(value, Enum.GetUnderlyingType(value.GetType()));
+                }
+                _value = value;
+            }
+        }
     }
 }

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -163,6 +163,9 @@ namespace GraphQL.Types
                 UnderlyingValue = value;
             }
         }
+        /// <summary>
+        /// For enums, contains the underlying enumeration value; otherwise contains <see cref="Value" />.
+        /// </summary>
         internal object UnderlyingValue { get; set; }
     }
 }

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -114,7 +114,14 @@ namespace GraphQL.Types
 
         public EnumValueDefinition this[string name] => FindByName(name);
 
-        public void Add(EnumValueDefinition value) => _values.Add(value ?? throw new ArgumentNullException(nameof(value)));
+        public void Add(EnumValueDefinition value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            if (value.Value is Enum enumValue)
+                value.Value = Convert.ChangeType(enumValue, Enum.GetUnderlyingType(enumValue.GetType()));
+            _values.Add(value);
+        }
 
         public EnumValueDefinition FindByName(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
@@ -128,6 +135,11 @@ namespace GraphQL.Types
 
         public EnumValueDefinition FindByValue(object value)
         {
+            if (value is Enum)
+            {
+                value = Convert.ChangeType(value, Enum.GetUnderlyingType(value.GetType()));
+            }
+
             // DO NOT USE LINQ ON HOT PATH
             foreach (var def in _values)
                 if (def.Value.Equals(value))

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -155,7 +155,8 @@ namespace GraphQL.Types
         public object Value
         {
             get => _value;
-            set {
+            set
+            {
                 _value = value;
                 if (value != null)
                 {

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -158,11 +158,8 @@ namespace GraphQL.Types
             set
             {
                 _value = value;
-                if (value != null)
-                {
-                    if (value is Enum)
-                        value = Convert.ChangeType(value, Enum.GetUnderlyingType(value.GetType()));
-                }
+                if (value is Enum)
+                    value = Convert.ChangeType(value, Enum.GetUnderlyingType(value.GetType()));
                 UnderlyingValue = value;
             }
         }


### PR DESCRIPTION
See #1832 and #1835 

Given:
```csharp
public enum IsSet
{
    NotSet = 0,
    Set = 1
}
```

Since C# does not consider `IsSet.NotSet` to equal `0`, an `EnumerationGraphType` must add values based on the enumeration member.  For example:

```csharp
public class AssignmentStateEnumType  : EnumerationGraphType {
    public AssignmentStateEnumType()
    {
        //this does not work
        AddValue(name: "NotAssigned", description: "There is no assignment", value: 0);
        AddValue(name: "Assigned", description: "There is an assignment", value: 1);
        //this is correct
        AddValue(name: "NotAssigned", description: "There is no assignment", value: IsSet.NotSet);
        AddValue(name: "Assigned", description: "There is an assignment", value: IsSet.Set);
    }
}
```

~~This did work in prior versions of `GraphQL.NET`.~~  This PR ~~reverts~~ **enhances** that behavior by converting the enum value to the underlying type when adding to the `EnumValues` collection, and then performing enum comparisons based on the underlying type.

There are a couple points worth of consideration here:

* It is strictly against GraphQL spec to allow enum arguments to be specified by number.  This PR does not change that.  So it's only a "server-side" change; the graphs do not function any different.
* Care was taken to prevent this from being a breaking change in any form besides the specified change.