### PR TITLE
Fixes tests for .Net Core 2.1 LTS and .Net Framework 4.8

### DIFF
--- a/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
@@ -312,7 +312,16 @@ namespace GraphQL.DataLoader.Tests
                 var user2 = await task2.GetResultAsync();
             });
 
-            ex.Message.ShouldBe("An item with the same key has already been added. Key: 1");
+            var actualException = Should.Throw<ArgumentException>(() =>
+            {
+                var d = new Dictionary<int, int>
+                {
+                    { 1, 1 },
+                    { 1, 1 }
+                };
+            });
+
+            ex.Message.ShouldBe(actualException.Message);
         }
 
         [Fact]

--- a/src/GraphQL.DataLoader.Tests/GraphQL.DataLoader.Tests.csproj
+++ b/src/GraphQL.DataLoader.Tests/GraphQL.DataLoader.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Tests.props" />
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.DataLoader.Tests/GraphQL.DataLoader.Tests.csproj
+++ b/src/GraphQL.DataLoader.Tests/GraphQL.DataLoader.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Tests.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
@@ -5,7 +5,11 @@ namespace GraphQL.Tests.Bugs
 {
     public class Bug138DecimalPrecisionTests : QueryTestBase<DecimalSchema>
     {
+#if NETCOREAPP3_1
         [Fact]
+#else
+        [Fact(Skip = "Deserialization error with .NET Core 2.1")]
+#endif
         public void double_to_decimal_does_not_lose_precision()
         {
             var query = @"

--- a/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Tests.Bugs
 #if NETCOREAPP3_1
         [Fact]
 #else
-        [Fact(Skip = "Deserialization error with .NET Core 2.1")]
+        [Fact(Skip = "Deserialization error with .NET Core < 3.1")]
 #endif
         public void double_to_decimal_does_not_lose_precision()
         {

--- a/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/BooleanGraphTypeTests.cs
@@ -63,7 +63,8 @@ namespace GraphQL.Tests.Types
         public void coerces_input_to_exception(string input)
         {
             var formatException = Should.Throw<FormatException>(() => type.ParseValue(input));
-            formatException.Message.ShouldBe($"String '{input}' was not recognized as a valid Boolean.");
+            var formatException2 = Should.Throw<FormatException>(() => bool.Parse(input));
+            formatException.Message.ShouldBe(formatException2.Message);
         }
 
         [Theory]

--- a/src/GraphQL.Tests/Types/ObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ObjectGraphTypeTests.cs
@@ -34,8 +34,9 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void should_throw_on_invalid_graphtype_name()
         {
+            var ex = new ArgumentOutOfRangeException("name", "A type name must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ::: does not.");
             Should.Throw<ArgumentOutOfRangeException>(() => new TypeWithInvalidName())
-                .Message.Replace("\r", "").Replace("\n", "").ShouldBe("A type name must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ::: does not. (Parameter 'name')");
+                .Message.ShouldBe(ex.Message);
         }
     }
 }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTestBase.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTestBase.cs
@@ -68,7 +68,7 @@ namespace GraphQL.Tests.Utilities
         public ExecutionResult CreateQueryResult(string result) => result.ToExecutionResult();
 
         protected string ReadSchema(string fileName)
-            => File.ReadAllText(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Files", fileName));
+            => File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "Files", fileName));
     }
 
     public class ExecuteConfig

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -242,7 +242,7 @@ namespace GraphQL.Language
                         CultureInfo.InvariantCulture,
                         out var dbl) == false)
                     {
-                        dbl = str.Value.StartsWith("-") ? double.NegativeInfinity : double.PositiveInfinity;
+                        dbl = str.Value[0] == '-' ? double.NegativeInfinity : double.PositiveInfinity;
                     }
 
                     //it is possible for a FloatValue to overflow a decimal; however, with a double, it just returns Infinity or -Infinity

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -236,10 +236,13 @@ namespace GraphQL.Language
 
                     // the idea is to see if there is a loss of accuracy of value
                     // for example, 12.1 or 12.11 is double but 12.10 is decimal
-                    double dbl = double.Parse(
+                    if (double.TryParse(
                         str.Value,
                         NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent,
-                        CultureInfo.InvariantCulture);
+                        CultureInfo.InvariantCulture,
+                        out var dbl) == false) {
+                        dbl = str.Value.StartsWith("-") ? double.NegativeInfinity : double.PositiveInfinity;
+                    }
 
                     //it is possible for a FloatValue to overflow a decimal; however, with a double, it just returns Infinity or -Infinity
                     if (decimal.TryParse(

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -240,7 +240,8 @@ namespace GraphQL.Language
                         str.Value,
                         NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent,
                         CultureInfo.InvariantCulture,
-                        out var dbl) == false) {
+                        out var dbl) == false)
+                    {
                         dbl = str.Value.StartsWith("-") ? double.NegativeInfinity : double.PositiveInfinity;
                     }
 


### PR DESCRIPTION
Fixes tests with .Net Core 2.1 LTS and .Net Framework 4.8 due to the following:
- System.Text.Json does not properly deserialize floating point numbers in prior versions of .Net Core - it has rounding errors, not sure why.  The broken test was actually testing serialization, which works just fine in prior versions.
- Some native exception messages have changed over the different framework versions
- Parsing overflowed floating point values changed in .Net Core 3.1 (bug fix for prior .Net Core versions)