### PR TITLE
Rethrow canceled operations properly; do not call unhandled exception delegate

### DIFF
--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -185,6 +185,10 @@ namespace GraphQL
                     result.Errors = context.Errors;
                 }
             }
+            catch (OperationCanceledException) when (options.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (ExecutionError ex)
             {
                 result = new ExecutionResult

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -189,6 +189,10 @@ namespace GraphQL.Execution
                     CompleteNode(context, node);
                 }
             }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (ExecutionError error)
             {
                 SetNodeError(context, node, error);
@@ -218,6 +222,10 @@ namespace GraphQL.Execution
                 {
                     CompleteNode(context, node);
                 }
+            }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (ExecutionError error)
             {


### PR DESCRIPTION
Right now, if a request is canceled, pending async operations get caught as an `OperationCanceledException` and passed to the `UnhandledExceptionDelegate`.

Then when the next node is attempting to be resolved, the cancellation token is checked and thrown back to the `DocumentExecuter`, which then runs the `UnhandledExceptionDelegate` a second time and serializes a response.

This code change makes it so that when an operation is cancelled, the `OperationCanceledException` is immediately rethrown back to the caller of the `DocumentExecuter` -- no unhandled exception delegates are called, and no `ExecutionResult` is returned.

Without this change, the `UnhandledExceptionDelegate` often runs twice when a pending document is canceled.  With typical database logging code in the delegate, this would result in unnecessary database logs when something as simple as a browser is closed while loading.  (Of course the delegate could be coded to ignore these exceptions.)

In any case, I would expect this (canceled operations rethrow to the caller) to be the expected operation of any `Async` method, including `DocumentExecuter.ExecuteAsync`, and would be ideal for typical web server applications.