### PR TITLE
Misleading variable name in example

### DIFF
--- a/docs2/site/docs/getting-started/mutations.md
+++ b/docs2/site/docs/getting-started/mutations.md
@@ -47,8 +47,8 @@ public class StarWarsSchema : Schema
   public StarWarsSchema(IServiceProvider provider)
     : base(provider)
   {
-    Query = resolver.Resolve<StarWarsQuery>();
-    Mutation = resolver.Resolve<StarWarsMutation>();
+    Query = provider.Resolve<StarWarsQuery>();
+    Mutation = provider.Resolve<StarWarsMutation>();
   }
 }
 ```


### PR DESCRIPTION
Changed resolver to provider in mutation example as it read misleading to me at first. I see provider being injected and another variable name is then used to resolve the services called resolver.