### PR TITLE
Fix all build warnings except CS1591 warnings

### DIFF
--- a/src/GraphQL.Tests/Validation/ValidationCodeTests.cs
+++ b/src/GraphQL.Tests/Validation/ValidationCodeTests.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Tests.Validation
     public class ValidationCodeTests
     {
         // be sure to update the documentation if any of these codes or numbers change - see errors.md
-        
+
         [Theory]
         [InlineData(typeof(ValidationError), "VALIDATION_ERROR")]
         [InlineData(typeof(ArgumentsOfCorrectTypeError), "ARGUMENTS_OF_CORRECT_TYPE")]
@@ -39,9 +39,7 @@ namespace GraphQL.Tests.Validation
         [InlineData(typeof(VariablesAreInputTypesError), "VARIABLES_ARE_INPUT_TYPES")]
         [InlineData(typeof(VariablesInAllowedPositionError), "VARIABLES_IN_ALLOWED_POSITION")]
         public void Verify_GetValidationErrorCode(Type type, string code)
-        {
-            ValidationError.GetValidationErrorCode(type).ShouldBe(code);
-        }
+            => ValidationError.GetValidationErrorCode(type).ShouldBe(code);
 
         [Theory]
         [InlineData(ArgumentsOfCorrectTypeError.NUMBER, "5.6.1")]
@@ -70,9 +68,8 @@ namespace GraphQL.Tests.Validation
         [InlineData(UniqueVariableNamesError.NUMBER, "5.8.1")]
         [InlineData(VariablesAreInputTypesError.NUMBER, "5.8.2")]
         [InlineData(VariablesInAllowedPositionError.NUMBER, "5.8.5")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1025:InlineData should be unique within the Theory it belongs to")]
         public void Verify_Validation_Number(string actualCode, string expectedCode)
-        {
-            actualCode.ShouldBe(expectedCode);
-        }
+            => actualCode.ShouldBe(expectedCode);
     }
 }

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -10,24 +10,18 @@ namespace GraphQL.Builders
     {
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : IGraphType
-        {
-            return ConnectionBuilder<TSourceType>.Create<TNodeType>();
-        }
+            => ConnectionBuilder<TSourceType>.Create<TNodeType>();
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
-        {
-            return ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>();
-        }
+            => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>();
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>
-        {
-            return ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType, TConnectionType>();
-        }
+            => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType, TConnectionType>();
     }
 
     public class ConnectionBuilder<TSourceType>
@@ -53,17 +47,12 @@ namespace GraphQL.Builders
         }
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
-            where TNodeType : IGraphType
-        {
-            return Create<TNodeType, EdgeType<TNodeType>>(name);
-        }
+            where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>(name);
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
-        {
-            return Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
-        }
+            => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
 
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
             where TNodeType : IGraphType

--- a/src/GraphQL/DataLoader/BatchDataLoader.cs
+++ b/src/GraphQL/DataLoader/BatchDataLoader.cs
@@ -38,7 +38,7 @@ namespace GraphQL.DataLoader
         /// <param name="fetchDelegate">An asynchronous delegate that is passed a list of keys and a cancellation token, which returns a list objects</param>
         /// <param name="keySelector">A selector for the key from the returned object</param>
         /// <param name="keyComparer">An optional equality comparer for the keys</param>
-        /// <param name="defaultValue">The value returned when no match is found in the dictionary, or default(T) if unspecified</param>
+        /// <param name="defaultValue">The value returned when no match is found in the list, or default(T) if unspecified</param>
         /// <param name="maxBatchSize">The maximum number of keys passed to the fetch delegate at a time</param>
         public BatchDataLoader(Func<IEnumerable<TKey>, CancellationToken, Task<IEnumerable<T>>> fetchDelegate,
             Func<T, TKey> keySelector,

--- a/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
+++ b/src/GraphQL/DataLoader/DataLoaderContextExtensions.cs
@@ -59,6 +59,7 @@ namespace GraphQL.DataLoader
         /// <param name="loaderKey">A unique key to identify the DataLoader instance</param>
         /// <param name="fetchFunc">A cancellable delegate to fetch data for some keys asynchronously</param>
         /// <param name="keyComparer">An <seealso cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <param name="defaultValue">The value returned when no match is found in the dictionary, or default(T) if unspecified</param>
         /// <returns>A new or existing DataLoader instance</returns>
         public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<IDictionary<TKey, T>>> fetchFunc,
             IEqualityComparer<TKey> keyComparer = null, T defaultValue = default)
@@ -81,6 +82,7 @@ namespace GraphQL.DataLoader
         /// <param name="loaderKey">A unique key to identify the DataLoader instance</param>
         /// <param name="fetchFunc">A delegate to fetch data for some keys asynchronously</param>
         /// <param name="keyComparer">An <seealso cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <param name="defaultValue">The value returned when no match is found in the dictionary, or default(T) if unspecified</param>
         /// <returns>A new or existing DataLoader instance</returns>
         public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, Task<IDictionary<TKey, T>>> fetchFunc,
             IEqualityComparer<TKey> keyComparer = null, T defaultValue = default)
@@ -104,6 +106,7 @@ namespace GraphQL.DataLoader
         /// <param name="fetchFunc"></param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="keyComparer">An <seealso cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <param name="defaultValue">The value returned when no match is found in the list, or default(T) if unspecified</param>
         /// <returns>A new or existing DataLoader instance</returns>
         public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, CancellationToken, Task<IEnumerable<T>>> fetchFunc,
             Func<T, TKey> keySelector, IEqualityComparer<TKey> keyComparer = null, T defaultValue = default)
@@ -130,6 +133,7 @@ namespace GraphQL.DataLoader
         /// <param name="fetchFunc">A delegate to fetch data for some keys asynchronously</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="keyComparer">An <seealso cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <param name="defaultValue">The value returned when no match is found in the list, or default(T) if unspecified</param>
         /// <returns>A new or existing DataLoader instance</returns>
         public static IDataLoader<TKey, T> GetOrAddBatchLoader<TKey, T>(this DataLoaderContext context, string loaderKey, Func<IEnumerable<TKey>, Task<IEnumerable<T>>> fetchFunc,
             Func<T, TKey> keySelector, IEqualityComparer<TKey> keyComparer = null, T defaultValue = default)

--- a/src/GraphQL/EnumerableExtensions.cs
+++ b/src/GraphQL/EnumerableExtensions.cs
@@ -8,6 +8,7 @@ namespace GraphQL
         /// <summary>
         /// Performs the indicated action on each item.
         /// </summary>
+        /// <param name="items">The list of items to act on.</param>
         /// <param name="action">The action to be performed.</param>
         /// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
         public static void Apply<T>(this IEnumerable<T> items, Action<T> action)
@@ -21,6 +22,7 @@ namespace GraphQL
         /// <summary>
         /// Performs the indicated action on each item. Boxing free for <c>List+Enumerator{T}</c>.
         /// </summary>
+        /// <param name="items">The list of items to act on.</param>
         /// <param name="action">The action to be performed.</param>
         /// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
         public static void Apply<T>(this List<T> items, Action<T> action)
@@ -34,6 +36,7 @@ namespace GraphQL
         /// <summary>
         /// Performs the indicated action on each key-value pair.
         /// </summary>
+        /// <param name="items">The dictionary of items to act on.</param>
         /// <param name="action">The action to be performed.</param>
         /// <remarks>If an exception occurs, the action will not be performed on the remaining items.</remarks>
         public static void Apply(this System.Collections.IDictionary items, Action<object, object> action)

--- a/src/GraphQL/Execution/DocumentError.cs
+++ b/src/GraphQL/Execution/DocumentError.cs
@@ -14,8 +14,8 @@ namespace GraphQL.Execution
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DocumentError"/> class with a specified error message. Sets the
-        /// <see cref="ExecutionError.Code">Code</see> and <see cref="ExecutionError.Codes">Codes</see> properties based
-        /// on the inner exception(s). Loads any exception data from the inner exception into this instance.
+        /// <see cref="ExecutionError.Code">Code</see> property based on the inner exception. 
+        /// Loads any exception data from the inner exception into this instance.
         /// </summary>
         public DocumentError(string message, Exception innerException) : base(message, innerException) { }
     }

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -34,7 +34,7 @@ namespace GraphQL
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExecutionError"/> class with a specified error message. Sets the
-        /// <see cref="Code"/> and <see cref="Codes"/> properties based on the inner exception(s). Loads any exception data
+        /// <see cref="Code"/> property based on the inner exception. Loads any exception data
         /// from the inner exception into this instance.
         /// </summary>
         public ExecutionError(string message, Exception exception)

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -48,7 +48,7 @@ namespace GraphQL
         /// <summary>
         /// Note that field middlewares apply only to an uninitialized schema. If the schema is initialized
         /// then applying different middleware through options does nothing. The schema is initialized (if not yet)
-        /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(Action{ExecutionOptions})">ExecuteAsync</see>.
+        /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)">ExecuteAsync</see>.
         /// </summary>
         public IFieldMiddlewareBuilder FieldMiddleware { get; set; } = new FieldMiddlewareBuilder();
 

--- a/src/GraphQL/Execution/IDocumentExecuter.cs
+++ b/src/GraphQL/Execution/IDocumentExecuter.cs
@@ -31,6 +31,7 @@ namespace GraphQL
         /// <summary>
         /// Executes a GraphQL request and returns the result
         /// </summary>
+        /// <param name="executer">An instance of <see cref="IDocumentExecuter"/> to use to execute the query</param>
         /// <param name="configure">A delegate which configures the execution options</param>
         public static Task<ExecutionResult> ExecuteAsync(this IDocumentExecuter executer, Action<ExecutionOptions> configure)
         {

--- a/src/GraphQL/Execution/IExecutionStrategy.cs
+++ b/src/GraphQL/Execution/IExecutionStrategy.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Execution
     /// <summary>
     /// Processes a parsed GraphQL request, resolving all the nodes and returning the result; exceptions
     /// are unhandled. Should not run any <see cref="IDocumentExecutionListener">IDocumentExecutionListener</see>s except
-    /// for <see cref="IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(object, System.Threading.CancellationToken)">BeforeExecutionStepAwaitedAsync</see>.
+    /// for <see cref="IDocumentExecutionListener.BeforeExecutionStepAwaitedAsync(IExecutionContext)">BeforeExecutionStepAwaitedAsync</see>.
     /// </summary>
     public interface IExecutionStrategy
     {

--- a/src/GraphQL/Execution/InputsExtensions.cs
+++ b/src/GraphQL/Execution/InputsExtensions.cs
@@ -7,7 +7,7 @@ namespace GraphQL
         /// <summary>
         /// Converts a dictionary into an <see cref="Inputs"/>.
         /// </summary>
-        /// <param name="json">A dictionary.</param>
+        /// <param name="dictionary">A dictionary.</param>
         /// <returns>Inputs.</returns>
         public static Inputs ToInputs(this Dictionary<string, object> dictionary)
             => dictionary?.Count > 0 ? new Inputs(dictionary) : Inputs.Empty;

--- a/src/GraphQL/Execution/InvalidVariableError.cs
+++ b/src/GraphQL/Execution/InvalidVariableError.cs
@@ -19,8 +19,7 @@ namespace GraphQL.Execution
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidVariableError"/> class for a specified variable
-        /// and error message. Sets the <see cref="ExecutionError.Codes">Codes</see> property based on the inner
-        /// exception(s). Loads any exception data from the inner exception into this instance.
+        /// and error message. Loads any exception data from the inner exception into this instance.
         /// </summary>
         public InvalidVariableError(string variableName, string message, Exception innerException) :
             base($"Variable '${variableName}' is invalid. {message}", innerException)

--- a/src/GraphQL/Execution/UnhandledError.cs
+++ b/src/GraphQL/Execution/UnhandledError.cs
@@ -10,8 +10,8 @@ namespace GraphQL.Execution
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnhandledError"/> class with a specified error message. Sets the
-        /// <see cref="ExecutionError.Code">Code</see> and <see cref="ExecutionError.Codes">Codes</see> properties based on
-        /// the inner exception(s). Loads any exception data from the inner exception into this instance.
+        /// <see cref="ExecutionError.Code">Code</see> property based on the inner exception.
+        /// Loads any exception data from the inner exception into this instance.
         /// </summary>
         public UnhandledError(string message, Exception innerException)
             : base(message, innerException)

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -23,6 +23,7 @@ namespace GraphQL.Instrumentation
         /// <br/><br/>
         /// This is a compatibility shim when compiling delegates without schema specified.
         /// </summary>
+        /// <param name="builder">Interface for connecting middlewares to a schema.</param>
         /// <param name="middleware">Middleware delegate.</param>
         /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
         public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)

--- a/src/GraphQL/LightweightCache.cs
+++ b/src/GraphQL/LightweightCache.cs
@@ -88,7 +88,7 @@ namespace GraphQL
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="TValue"/> with the specified key.
+        /// Gets or sets the <typeparamref name="TValue"/> with the specified key.
         /// </summary>
         /// <param name="key">The key.</param>
         public TValue this[TKey key]
@@ -142,10 +142,7 @@ namespace GraphQL
         /// If it does not already exist, it's created using the OnMissing action.
         /// </summary>
         /// <param name="key">The key.</param>
-        public void FillDefault(TKey key)
-        {
-            Fill(key, _onMissing(key));
-        }
+        public void FillDefault(TKey key) => Fill(key, _onMissing(key));
 
         /// <summary>
         /// Guarantees that the Cache has a value for a given key.
@@ -270,10 +267,7 @@ namespace GraphQL
         /// <summary>
         /// Clears this instance of all key/value pairs.
         /// </summary>
-        public void Clear()
-        {
-            _values.Clear();
-        }
+        public void Clear() => _values.Clear();
 
         /// <summary>
         /// If the dictionary contains the indicated key, performs the action with its value.
@@ -291,9 +285,6 @@ namespace GraphQL
         /// <summary>
         /// Equivalent to Clear()
         /// </summary>
-        public void ClearAll()
-        {
-            _values.Clear();
-        }
+        public void ClearAll() => _values.Clear();
     }
 }

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -143,7 +143,7 @@ namespace GraphQL
         /// <param name="propertyValue">The value to be converted.</param>
         /// <param name="fieldType">The desired type.</param>
         /// <param name="mappedType">
-        /// GraphType for matching dictionary keys with <paramref name="type"/> property names.
+        /// GraphType for matching dictionary keys with <paramref name="fieldType"/> property names.
         /// GraphType contains information about this matching in Metadata property.
         /// In case of configuring field as Field(x => x.FName).Name("FirstName") source dictionary
         /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
@@ -280,14 +280,10 @@ namespace GraphQL
         /// <returns>The interface, or <c>null</c> if no matches were found.</returns>
         /// <remarks>If more than one interface matches, the returned interface is non-deterministic.</remarks>
         public static Type GetInterface(this Type type, string name)
-        {
-            return type.GetInterfaces().FirstOrDefault(x => x.Name == name);
-        }
+            => type.GetInterfaces().FirstOrDefault(x => x.Name == name);
 
         public static T GetPropertyValue<T>(this object value)
-        {
-            return (T)GetPropertyValue(value, typeof(T));
-        }
+            => (T)GetPropertyValue(value, typeof(T));
 
         /// <summary>
         /// Returns true is the value is null, value.ToString equals an empty string, or the value can be converted into a named enum value.

--- a/src/GraphQL/Reflection/ReflectionHelper.cs
+++ b/src/GraphQL/Reflection/ReflectionHelper.cs
@@ -41,6 +41,7 @@ namespace GraphQL.Reflection
         /// </summary>
         /// <param name="type">The type to check.</param>
         /// <param name="field">The desired field.</param>
+        /// <param name="resolverType">Indicates if a resolver or subscriber method is requested.</param>
         public static MethodInfo MethodForField(this Type type, string field, ResolverType resolverType)
         {
             var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -39,7 +39,7 @@ namespace GraphQL
         /// </summary>
         IDictionary<string, object> Arguments { get; }
 
-        /// <summary>The root value of the graph, as defined by <see cref="ExecutionContext.RootValue"/></summary>
+        /// <summary>The root value of the graph, as defined by <see cref="ExecutionOptions.Root"/></summary>
         object RootValue { get; }
 
         /// <summary>The value of the parent object in the graph</summary>

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -9,7 +9,7 @@ using Field = GraphQL.Language.AST.Field;
 namespace GraphQL
 {
     /// <summary>
-    /// A readonly implementation of <see cref="IResolveFieldContext{object}"/>
+    /// A readonly implementation of <see cref="IResolveFieldContext"/>
     /// </summary>
     public class ReadonlyResolveFieldContext : IResolveFieldContext<object>
     {

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -99,7 +99,7 @@ namespace GraphQL
         /// <summary>
         /// Clone the specified <see cref="IResolveFieldContext"/>
         /// </summary>
-        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to <see cref="TSource"/></exception>
+        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to <typeparamref name="TSource"/></exception>
         public ResolveFieldContext(IResolveFieldContext context) : base(context)
         {
             if (context.Source != null && !(context.Source is TSource))

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -85,7 +85,7 @@ namespace GraphQL
         }
 
         /// <summary>Returns the <see cref="IResolveEventStreamContext"/> typed as an <see cref="IResolveEventStreamContext{TSource}"/></summary>
-        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveEventStreamContext.Source"/> property cannot be cast to the specified type</exception>
+        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>
         public static IResolveEventStreamContext<T> As<T>(this IResolveEventStreamContext context)
         {
             if (context is IResolveEventStreamContext<T> typedContext)

--- a/src/GraphQL/Resolvers/IFieldResolver.cs
+++ b/src/GraphQL/Resolvers/IFieldResolver.cs
@@ -33,7 +33,7 @@ namespace GraphQL.Resolvers
     public interface IFieldResolver<out T> : IFieldResolver
     {
         /// <summary>
-        /// Returns an object or null for the specified field. If <see cref="T"/> is a <see cref="Task{TResult}"/>, then this task will be awaited to obtain the actual object.
+        /// Returns an object or null for the specified field. If <typeparamref name="T"/> is a <see cref="Task{TResult}"/>, then this task will be awaited to obtain the actual object.
         /// </summary>
         new T Resolve(IResolveFieldContext context);
     }

--- a/src/GraphQL/SchemaExtensions.cs
+++ b/src/GraphQL/SchemaExtensions.cs
@@ -9,6 +9,8 @@ namespace GraphQL
         /// <summary>
         /// Executes a GraphQL request with the default <see cref="DocumentExecuter"/>, serializes the result using the specified <see cref="IDocumentWriter"/>, and returns the result
         /// </summary>
+        /// <param name="schema">An instance of <see cref="ISchema"/> to use to execute the query</param>
+        /// <param name="documentWriter">An instance of <see cref="IDocumentExecuter"/> to use to serialize the result</param>
         /// <param name="configure">A delegate which configures the execution options</param>
         public static async Task<string> ExecuteAsync(this ISchema schema, IDocumentWriter documentWriter, Action<ExecutionOptions> configure)
         {

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -20,9 +20,7 @@ namespace GraphQL
         /// <returns><c>null</c> if the cast failed, otherwise item as T</returns>
         public static T As<T>(this object item)
             where T : class
-        {
-            return item as T;
-        }
+            => item as T;
 
         /// <summary>
         /// Determines whether this instance is a concrete type.
@@ -46,9 +44,7 @@ namespace GraphQL
         ///   <c>true</c> if the specified type is a subclass of Nullable&lt;T&gt;; otherwise, <c>false</c>.
         /// </returns>
         public static bool IsNullable(this Type type)
-        {
-            return type == typeof(string) || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
-        }
+            => type == typeof(string) || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
 
         public static bool IsPrimitive(this Type type)
         {
@@ -66,9 +62,7 @@ namespace GraphQL
         ///   <c>true</c> if the indicated type implements IGraphType; otherwise, <c>false</c>.
         /// </returns>
         public static bool IsGraphType(this Type type)
-        {
-            return type.GetInterfaces().Contains(typeof(IGraphType));
-        }
+            => type.GetInterfaces().Contains(typeof(IGraphType));
 
         /// <summary>
         /// Gets the GraphQL name of the type. This is derived from the type name and can be overridden by the GraphQLMetadata Attribute.
@@ -107,7 +101,6 @@ namespace GraphQL
         /// <param name="isNullable">if set to <c>false</c> if the type explicitly non-nullable.</param>
         /// <returns>A Type object representing a GraphType that matches the indicated type.</returns>
         /// <remarks>This can handle arrays, lists and other collections implementing IEnumerable.</remarks>
-        /// <example><see>IList<string></see> -> <see>ListGraphType<StringGraphType></see></example>
         public static Type GetGraphTypeFromType(this Type type, bool isNullable = false)
         {
             while (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDataLoaderResult<>))

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using GraphQL.Language.AST;
@@ -68,9 +69,7 @@ namespace GraphQL.Types
         }
 
         public override object ParseLiteral(IValue value)
-        {
-            return !(value is EnumValue enumValue) ? null : ParseValue(enumValue.Name);
-        }
+            => !(value is EnumValue enumValue) ? null : ParseValue(enumValue.Name);
     }
 
     /// <summary>


### PR DESCRIPTION
Mostly everything was one of the following:
* Incorrect xml comment syntax (missing member)
* Missing some, but not all, xml comments for parameters
* Shortcut syntax for methods and properties