### PR TITLE
Adds Join Monster .NET to the list of tools to use with GraphQL.NET

### DIFF
--- a/docs2/site/docs/getting-started/databases.md
+++ b/docs2/site/docs/getting-started/databases.md
@@ -13,3 +13,6 @@ This library will work with any data source that you provide.  Here are a few re
 
 ## Marten
 * [Marten + Nancy](https://github.com/joemcbride/marten/blob/graphql2/src/DinnerParty/Modules/GraphQLModule.cs) by [Joe McBride](https://github.com/joemcbride)
+
+## Join Monster
+* [Join Monster for .NET](https://github.com/umbraco/join-monster-dotnet) by [Rasmus Pedersen](https://github.com/rasmusjp) and [Morten Christensen](https://github.com/sitereactor) for [Umbraco](https://github.com/umbraco)


### PR DESCRIPTION
Join Monster for .NET is a query planner and batch data fetcher between GraphQL and SQL built for GraphQL for NET.

Adding it to the list as it could be valuable to people using GraphQL for NET.