### PR TITLE
Fix package upload workflow

### DIFF
--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -59,4 +59,4 @@ jobs:
             src/out/*
       - name: Publish Nuget packages to GitHub registry
         working-directory: src
-        run: dotnet nuget push out/*
+        run: dotnet nuget push out/* -k ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems the key must be added to the `dotnet nuget push` command.  (Tested in my fork.)  One of my other projects did not require this here as it was configured with the `actions/setup-dotnet` command as described in the documentation.  No idea why it is required here.  Perhaps the `Directory.Build.props` file's `<clear/>` is messing with it.