### PR TITLE
Update for setup-dotnet workflow changes

### DIFF
--- a/.github/workflows/pr-tests-code.yml
+++ b/.github/workflows/pr-tests-code.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches: 
       - develop
-#    paths: 
-#      - src/**
+    paths: 
+      - src/**
 
 jobs:
   ubuntu:

--- a/.github/workflows/pr-tests-code.yml
+++ b/.github/workflows/pr-tests-code.yml
@@ -21,19 +21,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
-      - name: Allow both runtimes
-        # https://github.com/actions/setup-dotnet/issues/25#issuecomment-646925506
-        shell: pwsh
-        run: |
-          $version = Split-Path (Split-Path $ENV:DOTNET_ROOT -Parent) -Leaf;
-          $root = Split-Path (Split-Path $ENV:DOTNET_ROOT -Parent) -Parent;
-          $directories = Get-ChildItem $root | Where-Object { $_.Name -ne $version };
-          foreach ($dir in $directories) {
-            $from = $dir.FullName;
-            $to = "$root/$version";
-            Write-Host Copying from $from to $to;
-            Copy-Item "$from\*" $to -Recurse -Force;
-          }
       - name: Install dependencies
         working-directory: src
         run: dotnet restore
@@ -61,19 +48,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
-      - name: Allow both runtimes
-        # https://github.com/actions/setup-dotnet/issues/25#issuecomment-646925506
-        shell: pwsh
-        run: |
-          $version = Split-Path (Split-Path $ENV:DOTNET_ROOT -Parent) -Leaf;
-          $root = Split-Path (Split-Path $ENV:DOTNET_ROOT -Parent) -Parent;
-          $directories = Get-ChildItem $root | Where-Object { $_.Name -ne $version };
-          foreach ($dir in $directories) {
-            $from = $dir.FullName;
-            $to = "$root/$version";
-            Write-Host Copying from $from to $to;
-            Copy-Item "$from\*" $to -Recurse -Force;
-          }
       - name: Install dependencies
         working-directory: src
         run: dotnet restore

--- a/.github/workflows/pr-tests-code.yml
+++ b/.github/workflows/pr-tests-code.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches: 
       - develop
-    paths: 
-      - src/**
+#    paths: 
+#      - src/**
 
 jobs:
   ubuntu:


### PR DESCRIPTION
Version `1.7.1` of the GitHub `actions/setup-dotnet` workflow contains the ability to configure multiple .NET SDKs for a test run.  This PR removes the hack previously necessary to be able to run tests against multiple versions of .NET Core.