### PR TITLE
Publish merged PRs as nuget packages to GitHub Packages

### DIFF
--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -1,0 +1,63 @@
+name: Build artifacts
+
+# ==== NOTE: do not rename this yml file or the run_number will be reset ====
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    paths:
+      - src/**
+
+env:
+  NODE_VERSION: '10.x'   # Node 10 LTS
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: yarn
+        run: yarn
+      - name: yarn docs2
+        working-directory: docs2
+        run: yarn
+      - name: yarn gatsby build
+        working-directory: docs2
+        run: yarn gatsby build
+      - name: Publish docs artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Documentation
+          path: docs2/public/**
+          if-no-files-found: error
+      - name: Use .NET Core 3.1 SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+          source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Install dependencies
+        working-directory: src
+        run: dotnet restore
+      - name: Build solution (release config)
+        working-directory: src
+        run: dotnet build --no-restore -c Release -p:NoWarn=CS1591 -p:VersionSuffix=$GITHUB_RUN_NUMBER
+      - name: Pack solution (release config)
+        working-directory: src
+        run: dotnet pack --no-restore -c Release -p:VersionSuffix=$GITHUB_RUN_NUMBER -o out
+      - name: Publish artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Nuget packages
+          path: |
+            src/out/*
+      - name: Publish Nuget packages to GitHub registry
+        working-directory: src
+        run: dotnet nuget push out/* -k ${{ secrets.GITHUB_TOKEN }}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.0-preview</VersionPrefix>
     <PackageProjectUrl>https://github.com/graphql-dotnet/graphql-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.0.0-preview</VersionPrefix>
+    <VersionPrefix>3.1.0-preview</VersionPrefix>
     <PackageProjectUrl>https://github.com/graphql-dotnet/graphql-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>


### PR DESCRIPTION
This configures merged PRs to automatically publish nuget packages to GitHub Packages

This would be effective for both master and develop branches.  Version numbers will be different because `Directory.Build.props` contains a different version prefix for each.

- master branch: `3.0.0-preview.{build}`
- develop branch `4.0.0-preview.{build}`

Where `{build}` is incremented automatically with every execution of this GitHub Action.