### PR TITLE
Add ISchema.Comparer

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -85,6 +85,7 @@ namespace GraphQL
         public System.IServiceProvider RequestServices { get; set; }
         public object Root { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
+        public GraphQL.Introspection.ISchemaComparer SchemaComparer { get; set; }
         public GraphQL.Introspection.ISchemaFilter SchemaFilter { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Action<GraphQL.Execution.UnhandledExceptionContext> UnhandledExceptionDelegate { get; set; }
@@ -974,6 +975,15 @@ namespace GraphQL.Instrumentation
 }
 namespace GraphQL.Introspection
 {
+    public class DefaultSchemaComparer : GraphQL.Introspection.ISchemaComparer
+    {
+        public DefaultSchemaComparer() { }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType> DirectiveComparer { get; }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.IGraphType> TypeComparer { get; }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument> ArgumentComparer(GraphQL.Types.IFieldType field) { }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition> EnumValueComparer(GraphQL.Types.EnumerationGraphType parent) { }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.IFieldType> FieldComparer(GraphQL.Types.IGraphType parent) { }
+    }
     public class DefaultSchemaFilter : GraphQL.Introspection.ISchemaFilter
     {
         public DefaultSchemaFilter() { }
@@ -982,6 +992,14 @@ namespace GraphQL.Introspection
         public virtual System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue) { }
         public virtual System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field) { }
         public virtual System.Threading.Tasks.Task<bool> AllowType(GraphQL.Types.IGraphType type) { }
+    }
+    public interface ISchemaComparer
+    {
+        System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType> DirectiveComparer { get; }
+        System.Collections.Generic.IComparer<GraphQL.Types.IGraphType> TypeComparer { get; }
+        System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument> ArgumentComparer(GraphQL.Types.IFieldType field);
+        System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition> EnumValueComparer(GraphQL.Types.EnumerationGraphType parent);
+        System.Collections.Generic.IComparer<GraphQL.Types.IFieldType> FieldComparer(GraphQL.Types.IGraphType parent);
     }
     public interface ISchemaFilter
     {
@@ -1991,6 +2009,7 @@ namespace GraphQL.Types
     {
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AllTypes { get; }
+        GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
         string Description { get; set; }
         System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> Directives { get; set; }
         GraphQL.Introspection.ISchemaFilter Filter { get; set; }
@@ -2149,6 +2168,7 @@ namespace GraphQL.Types
         public Schema(System.IServiceProvider services) { }
         public System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         public System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AllTypes { get; }
+        public GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
         public string Description { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> Directives { get; set; }
         public GraphQL.Introspection.ISchemaFilter Filter { get; set; }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -52,6 +52,7 @@ namespace GraphQL
 
             options.Schema.NameConverter = options.NameConverter;
             options.Schema.Filter = options.SchemaFilter;
+            options.Schema.Comparer = options.SchemaComparer;
 
             ExecutionResult result = null;
             ExecutionContext context = null;

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -77,8 +77,11 @@ namespace GraphQL
         /// <summary>If set, limits the maximum number of nodes executed in parallel</summary>
         public int? MaxParallelExecutionCount { get; set; }
 
-        /// <summary>Provides the ability to filter the schema upon introspection to hide types; by default no types are hidden.</summary>
+        /// <summary>Provides the ability to filter the schema upon introspection to hide types, fields, arguments, enum values, directives. By default nothing is hidden.</summary>
         public ISchemaFilter SchemaFilter { get; set; } = new DefaultSchemaFilter();
+
+        /// <summary>Provides the ability to order the schema elements upon introspection. By default only fields are ordered by their names within enclosing type.</summary>
+        public ISchemaComparer SchemaComparer { get; set; } = new DefaultSchemaComparer();
 
         /// <summary>
         /// The service provider for the executing request. Typically this is set to a scoped service provider

--- a/src/GraphQL/Introspection/ISchemaComparer.cs
+++ b/src/GraphQL/Introspection/ISchemaComparer.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using GraphQL.Types;
+
+namespace GraphQL.Introspection
+{
+    /// <summary>
+    /// Provides the ability to order the schema elements upon introspection.
+    /// </summary>
+    public interface ISchemaComparer
+    {
+        /// <summary>
+        /// Returns a comparer for GraphQL types.
+        /// </summary>
+        IComparer<IGraphType> TypeComparer { get; }
+
+        /// <summary>
+        /// Returns a comparer for fields withing enclosing type.
+        /// </summary>
+        /// <param name="parent"> Parent type to which the fields belong. </param>
+        IComparer<IFieldType> FieldComparer(IGraphType parent);
+
+        /// <summary>
+        /// Returns a comparer for field arguments.
+        /// </summary>
+        /// <param name="field"> The field to which the arguments belong. </param>
+        IComparer<QueryArgument> ArgumentComparer(IFieldType field);
+
+        /// <summary>
+        /// Returns a comparer for enum values.
+        /// </summary>
+        /// <param name="parent"> The enumeration to which the enum values belong. </param>
+        IComparer<EnumValueDefinition> EnumValueComparer(EnumerationGraphType parent);
+
+        /// <summary>
+        /// Returns a comparer for GraphQL directives.
+        /// </summary>
+        IComparer<DirectiveGraphType> DirectiveComparer { get; }
+    }
+
+    /// <summary>
+    /// Default schema comparer. By default only fields are ordered by their names within enclosing type.
+    /// </summary>
+    public class DefaultSchemaComparer : ISchemaComparer
+    {
+        private static readonly FieldByNameComparer _instance = new FieldByNameComparer();
+
+        private sealed class FieldByNameComparer : IComparer<IFieldType>
+        {
+            public int Compare(IFieldType x, IFieldType y) => x.Name.CompareTo(y.Name);
+        }
+
+        /// <inheritdoc/>
+        public virtual IComparer<IGraphType> TypeComparer => null;
+
+        /// <inheritdoc/>
+        public virtual IComparer<DirectiveGraphType> DirectiveComparer => null;
+
+        /// <inheritdoc/>
+        public virtual IComparer<QueryArgument> ArgumentComparer(IFieldType field) => null;
+
+        /// <inheritdoc/>
+        public virtual IComparer<EnumValueDefinition> EnumValueComparer(EnumerationGraphType parent) => null;
+
+        /// <inheritdoc/>
+        public virtual IComparer<IFieldType> FieldComparer(IGraphType parent) => _instance;
+    }
+}

--- a/src/GraphQL/Introspection/ISchemaFilter.cs
+++ b/src/GraphQL/Introspection/ISchemaFilter.cs
@@ -3,40 +3,65 @@ using GraphQL.Types;
 
 namespace GraphQL.Introspection
 {
+    /// <summary>
+    /// Provides the ability to filter the schema upon introspection to hide types, fields, arguments, enum values, directives.
+    /// </summary>
     public interface ISchemaFilter
     {
+        /// <summary>
+        /// Returns a value indicating whether to hide the specified type.
+        /// </summary>
+        /// <param name="type"> GraphQL type to consider. </param>
         Task<bool> AllowType(IGraphType type);
+
+        /// <summary>
+        /// Returns a value indicating whether to hide the specified field.
+        /// </summary>
+        /// <param name="parent"> Parent type to which the field belongs. </param>
+        /// <param name="field"> Field to consider. </param>
         Task<bool> AllowField(IGraphType parent, IFieldType field);
+
+        /// <summary>
+        /// Returns a value indicating whether to hide the specified field argument.
+        /// </summary>
+        /// <param name="field"> The field to which the argument belongs. </param>
+        /// <param name="argument"> Argument to consider. </param>
         Task<bool> AllowArgument(IFieldType field, QueryArgument argument);
+
+        /// <summary>
+        /// Returns a value indicating whether to hide the specified enum value.
+        /// </summary>
+        /// <param name="parent"> The enumeration to which the enum value belongs.  </param>
+        /// <param name="enumValue"> Enum value to consider. </param>
         Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue);
+
+        /// <summary>
+        /// Returns a value indicating whether to hide the specified directive.
+        /// </summary>
+        /// <param name="directive"> GraphQL directive to consider. </param>
         Task<bool> AllowDirective(DirectiveGraphType directive);
     }
 
+    /// <summary>
+    /// Default schema filter. By default nothing is hidden.
+    /// </summary>
     public class DefaultSchemaFilter : ISchemaFilter
     {
-        public virtual Task<bool> AllowType(IGraphType type)
-        {
-            return Task.FromResult(true);
-        }
+        private static readonly Task<bool> _completed = Task.FromResult(true);
 
-        public virtual Task<bool> AllowField(IGraphType parent, IFieldType field)
-        {
-            return Task.FromResult(true);
-        }
+        /// <inheritdoc/>
+        public virtual Task<bool> AllowType(IGraphType type) => _completed;
 
-        public virtual Task<bool> AllowArgument(IFieldType field, QueryArgument argument)
-        {
-            return Task.FromResult(true);
-        }
+        /// <inheritdoc/>
+        public virtual Task<bool> AllowField(IGraphType parent, IFieldType field) => _completed;
 
-        public virtual Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue)
-        {
-            return Task.FromResult(true);
-        }
+        /// <inheritdoc/>
+        public virtual Task<bool> AllowArgument(IFieldType field, QueryArgument argument) => _completed;
 
-        public virtual Task<bool> AllowDirective(DirectiveGraphType directive)
-        {
-            return Task.FromResult(true);
-        }
+        /// <inheritdoc/>
+        public virtual Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue) => _completed;
+
+        /// <inheritdoc/>
+        public virtual Task<bool> AllowDirective(DirectiveGraphType directive) => _completed;
     }
 }

--- a/src/GraphQL/Introspection/SchemaMetaFieldType.cs
+++ b/src/GraphQL/Introspection/SchemaMetaFieldType.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using GraphQL.Resolvers;
 using GraphQL.Types;
 
@@ -31,7 +32,14 @@ namespace GraphQL.Introspection
             FieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<__Type>>>>(
                 "types",
                 "A list of all types supported by this server.",
-                resolve: async context => await context.Schema.AllTypes.WhereAsync(x => context.Schema.Filter.AllowType(x)).ConfigureAwait(false));
+                resolve: async context =>
+                {
+                    var types = await context.Schema.AllTypes.WhereAsync(x => context.Schema.Filter.AllowType(x)).ConfigureAwait(false);
+                    if (context.Schema.Comparer.TypeComparer != null)
+                        types = types.OrderBy(t => t, context.Schema.Comparer.TypeComparer);
+                    return types;
+                });
+
 
             Field<NonNullGraphType<__Type>>(
                 "queryType",
@@ -65,7 +73,13 @@ namespace GraphQL.Introspection
             FieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<__Directive>>>>(
                 "directives",
                 "A list of all directives supported by this server.",
-                resolve: async context => await context.Schema.Directives.WhereAsync(d => context.Schema.Filter.AllowDirective(d)).ConfigureAwait(false));
+                resolve: async context =>
+                {
+                    var directives = await context.Schema.Directives.WhereAsync(d => context.Schema.Filter.AllowDirective(d)).ConfigureAwait(false);
+                    if (context.Schema.Comparer.DirectiveComparer != null)
+                        directives = directives.OrderBy(d => d, context.Schema.Comparer.DirectiveComparer);
+                    return directives;
+                });
         }
     }
 }

--- a/src/GraphQL/Introspection/__Field.cs
+++ b/src/GraphQL/Introspection/__Field.cs
@@ -40,7 +40,11 @@ namespace GraphQL.Introspection
                 resolve: async context =>
                 {
                     var arguments = context.Source.Arguments ?? Enumerable.Empty<QueryArgument>();
-                    return await arguments.WhereAsync(x => context.Schema.Filter.AllowArgument(context.Source, x)).ConfigureAwait(false);
+                    var args = await arguments.WhereAsync(x => context.Schema.Filter.AllowArgument(context.Source, x)).ConfigureAwait(false);
+                    var comparer = context.Schema.Comparer.ArgumentComparer(context.Source);
+                    if (comparer != null)
+                        args = args.OrderBy(a => a, comparer);
+                    return args; 
                 });
             Field<NonNullGraphType<__Type>>("type", resolve: ctx => ctx.Source.ResolvedType);
             Field<NonNullGraphType<BooleanGraphType>>("isDeprecated", resolve: context => (!string.IsNullOrWhiteSpace(context.Source.DeprecationReason)).Boxed());

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Types
     public interface ISchema
     {
         /// <summary>
-        /// Returns true once the schema has been initialized
+        /// Returns true once the schema has been initialized.
         /// </summary>
         bool Initialized { get; }
 
@@ -31,20 +31,23 @@ namespace GraphQL.Types
         /// </summary>
         INameConverter NameConverter { get; set; }
 
+        /// <summary>
+        /// Description of the provided schema.
+        /// </summary>
         string Description { get; set; }
 
         /// <summary>
-        /// The 'query' base graph type; required
+        /// The 'query' base graph type; required.
         /// </summary>
         IObjectGraphType Query { get; set; }
 
         /// <summary>
-        /// The 'mutation' base graph type; optional
+        /// The 'mutation' base graph type; optional.
         /// </summary>
         IObjectGraphType Mutation { get; set; }
 
         /// <summary>
-        /// The 'subscription' base graph type; optional
+        /// The 'subscription' base graph type; optional.
         /// </summary>
         IObjectGraphType Subscription { get; set; }
 
@@ -59,17 +62,17 @@ namespace GraphQL.Types
         IEnumerable<DirectiveGraphType> Directives { get; set; }
 
         /// <summary>
-        /// Returns a list of all the graph types utilized by this schema
+        /// Returns a list of all the graph types utilized by this schema.
         /// </summary>
         IEnumerable<IGraphType> AllTypes { get; }
 
         /// <summary>
-        /// Returns a <see cref="IGraphType"/> for a given name
+        /// Returns a <see cref="IGraphType"/> for a given name.
         /// </summary>
         IGraphType FindType(string name);
 
         /// <summary>
-        /// Returns a <see cref="DirectiveGraphType"/> for a given name
+        /// Returns a <see cref="DirectiveGraphType"/> for a given name.
         /// </summary>
         DirectiveGraphType FindDirective(string name);
 
@@ -137,25 +140,32 @@ namespace GraphQL.Types
         IAstFromValueConverter FindValueConverter(object value, IGraphType type);
 
         /// <summary>
-        /// Provides the ability to filter the schema upon introspection to hide types. This is set by <see cref="IDocumentExecuter"/>
-        /// to the filter passed to it within <see cref="ExecutionOptions.SchemaFilter"/>. By default, no types are hidden.
-        /// Note that this filter in fact does not prohibit the execution of queries that contain hidden types. To limit
-        /// access to the particular fields, you should use some authorization logic.
+        /// Provides the ability to filter the schema upon introspection to hide types, fields, arguments, enum values, directives.
+        /// This is set by <see cref="IDocumentExecuter"/> to the filter passed to it within <see cref="ExecutionOptions.SchemaFilter"/>.
+        /// By default nothing is hidden. Note that this filter in fact does not prohibit the execution of queries that contain
+        /// hidden types/fields. To limit access to the particular fields, you should use some authorization logic.
         /// </summary>
         ISchemaFilter Filter { get; set; }
 
         /// <summary>
-        /// Returns a reference to the __schema introspection field available on the query graph type
+        /// Provides the ability to order the schema elements upon introspection. This is set by <see cref="IDocumentExecuter"/>
+        /// to the comparer passed to it within <see cref="ExecutionOptions.SchemaComparer"/>. By default only fields are ordered by
+        /// their names within enclosing type.
+        /// </summary>
+        ISchemaComparer Comparer { get; set; }
+
+        /// <summary>
+        /// Returns a reference to the __schema introspection field available on the query graph type.
         /// </summary>
         FieldType SchemaMetaFieldType { get; }
 
         /// <summary>
-        /// Returns a reference to the __type introspection field available on the query graph type
+        /// Returns a reference to the __type introspection field available on the query graph type.
         /// </summary>
         FieldType TypeMetaFieldType { get; }
 
         /// <summary>
-        /// Returns a reference to the __typename introspection field available on any object, interface, or union graph type
+        /// Returns a reference to the __typename introspection field available on any object, interface, or union graph type.
         /// </summary>
         FieldType TypeNameMetaFieldType { get; }
     }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -59,8 +59,10 @@ namespace GraphQL.Types
             return builder.Build(typeDefinitions);
         }
 
+        /// <inheritdoc/>
         public INameConverter NameConverter { get; set; } = CamelCaseNameConverter.Instance;
 
+        /// <inheritdoc/>
         public bool Initialized => _lookup?.IsValueCreated == true;
 
         // TODO: It would be worthwhile to think at all about how to redo the design so that such a situation does not arise.
@@ -70,6 +72,7 @@ namespace GraphQL.Types
                 throw new InvalidOperationException("Schema is already initialized and sealed for modifications. You should call RegisterXXX methods only when Schema.Initialized = false.");
         }
 
+        /// <inheritdoc/>
         public void Initialize()
         {
             CheckDisposed();
@@ -77,12 +80,16 @@ namespace GraphQL.Types
             FindType("____");
         }
 
+        /// <inheritdoc/>
         public string Description { get; set; }
 
+        /// <inheritdoc/>
         public IObjectGraphType Query { get; set; }
 
+        /// <inheritdoc/>
         public IObjectGraphType Mutation { get; set; }
 
+        /// <inheritdoc/>
         public IObjectGraphType Subscription { get; set; }
 
         /// <summary>
@@ -106,8 +113,13 @@ namespace GraphQL.Types
         /// </returns>
         object IServiceProvider.GetService(Type serviceType) => _services.GetService(serviceType);
 
+        /// <inheritdoc/>
         public ISchemaFilter Filter { get; set; } = new DefaultSchemaFilter();
 
+        /// <inheritdoc/>
+        public ISchemaComparer Comparer { get; set; } = new DefaultSchemaComparer();
+
+        /// <inheritdoc/>
         public IEnumerable<DirectiveGraphType> Directives
         {
             get => _directives;
@@ -131,12 +143,16 @@ namespace GraphQL.Types
 
         public IEnumerable<Type> AdditionalTypes => _additionalTypes;
 
+        /// <inheritdoc/>
         public FieldType SchemaMetaFieldType => _lookup?.Value.SchemaMetaFieldType;
 
+        /// <inheritdoc/>
         public FieldType TypeMetaFieldType => _lookup?.Value.TypeMetaFieldType;
 
+        /// <inheritdoc/>
         public FieldType TypeNameMetaFieldType => _lookup?.Value.TypeNameMetaFieldType;
 
+        /// <inheritdoc/>
         public void RegisterType(IGraphType type)
         {
             CheckDisposed();
@@ -145,6 +161,7 @@ namespace GraphQL.Types
             _additionalInstances.Add(type ?? throw new ArgumentNullException(nameof(type)));
         }
 
+        /// <inheritdoc/>
         public void RegisterTypes(params IGraphType[] types)
         {
             CheckDisposed();
@@ -154,6 +171,7 @@ namespace GraphQL.Types
                 RegisterType(type);
         }
 
+        /// <inheritdoc/>
         public void RegisterTypes(params Type[] types)
         {
             CheckDisposed();
@@ -170,6 +188,7 @@ namespace GraphQL.Types
             }
         }
 
+        /// <inheritdoc/>
         public void RegisterType<T>() where T : IGraphType
         {
             CheckDisposed();
@@ -178,6 +197,7 @@ namespace GraphQL.Types
             RegisterType(typeof(T));
         }
 
+        /// <inheritdoc/>
         public void RegisterDirective(DirectiveGraphType directive)
         {
             CheckDisposed();
@@ -195,6 +215,7 @@ namespace GraphQL.Types
                 RegisterDirective(directive);
         }
 
+        /// <inheritdoc/>
         public void RegisterDirectives(params DirectiveGraphType[] directives)
         {
             CheckDisposed();
@@ -204,11 +225,13 @@ namespace GraphQL.Types
                 RegisterDirective(directive);
         }
 
+        /// <inheritdoc/>
         public DirectiveGraphType FindDirective(string name)
         {
             return _directives.FirstOrDefault(x => x.Name == name);
         }
 
+        /// <inheritdoc/>
         public void RegisterValueConverter(IAstFromValueConverter converter)
         {
             CheckDisposed();
@@ -216,11 +239,13 @@ namespace GraphQL.Types
             _converters.Add(converter ?? throw new ArgumentNullException(nameof(converter)));
         }
 
+        /// <inheritdoc/>
         public IAstFromValueConverter FindValueConverter(object value, IGraphType type)
         {
             return _converters.FirstOrDefault(x => x.Matches(value, type));
         }
 
+        /// <inheritdoc/>
         public IGraphType FindType(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -231,6 +256,7 @@ namespace GraphQL.Types
             return _lookup?.Value[name];
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
fixes #1905

Also adds a bunch of xml comments.

@Shane32 can we afford to make this change in 3.1 or should we wait for 4.0.0? Formally, there is one backward incompatible change here. I have extended the `ISchema` interface by adding a new `Comparer` property.