### PR TITLE
Update Migration 2-> 3 doc for the Dataloader link

### DIFF
--- a/docs2/site/docs/guides/migration3.md
+++ b/docs2/site/docs/guides/migration3.md
@@ -351,7 +351,7 @@ public class OrderType : ObjectGraphType<Order>
 
 If you need to process the data loader result before it is returned, additional refactoring will need to be done.
 The data loader also now supports chained data loaders, and asynchronous code prior to queuing the data loader. See
-[Data loader documentation](https://graphql-dotnet.github.io/docs/getting-started/dataloader) for more details.
+[Data loader documentation](https://graphql-dotnet.github.io/docs/guides/dataloader) for more details.
 
 ### DateGraphType parsing changes
 


### PR DESCRIPTION
Creating this PR to fixed the link for Dataloader documentation in Migration Guide [v2 ->v3]