### PR TITLE
make ServiceProviderExtensions internal

### DIFF
--- a/docs2/site/docs/guides/migration4.md
+++ b/docs2/site/docs/guides/migration4.md
@@ -5,3 +5,4 @@
 ## Breaking Changes
 
 * `NameConverter` and `SchemaFilter` have been removed from `ExecutionOptions` and are now properties on the `Schema`.
+* `GraphQL.Utilities.ServiceProviderExtensions` has been made internal. This effects usages of it's extensions method `GetRequiredService`. Instead reference the `Microsoft.Extensions.DependencyInjection.Abstractions` NuGet and use `Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions`.

--- a/docs2/site/docs/guides/migration4.md
+++ b/docs2/site/docs/guides/migration4.md
@@ -5,4 +5,4 @@
 ## Breaking Changes
 
 * `NameConverter` and `SchemaFilter` have been removed from `ExecutionOptions` and are now properties on the `Schema`.
-* `GraphQL.Utilities.ServiceProviderExtensions` has been made internal. This effects usages of it's extensions method `GetRequiredService`. Instead reference the `Microsoft.Extensions.DependencyInjection.Abstractions` NuGet and use `Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions`.
+* `GraphQL.Utilities.ServiceProviderExtensions` has been made internal. This affects usages of it's extension method `GetRequiredService`. Instead reference the `Microsoft.Extensions.DependencyInjection.Abstractions` NuGet package and use extension method from `Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions` class.

--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -2526,11 +2526,6 @@ namespace GraphQL.Utilities
         public bool IncludeDescriptions { get; set; }
         public bool OldImplementsSyntax { get; set; }
     }
-    public static class ServiceProviderExtensions
-    {
-        public static object GetRequiredService(this System.IServiceProvider provider, System.Type serviceType) { }
-        public static T GetRequiredService<T>(this System.IServiceProvider provider) { }
-    }
     public static class StringUtils
     {
         public static string Capitalize(string str) { }

--- a/src/GraphQL.StarWars/GraphQL.StarWars.csproj
+++ b/src/GraphQL.StarWars/GraphQL.StarWars.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQL.StarWars/StarWarsSchema.cs
+++ b/src/GraphQL.StarWars/StarWarsSchema.cs
@@ -1,6 +1,6 @@
 using System;
 using GraphQL.Types;
-using GraphQL.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.StarWars
 {

--- a/src/GraphQL/Utilities/ServiceProviderExtensions.cs
+++ b/src/GraphQL/Utilities/ServiceProviderExtensions.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace GraphQL.Utilities
 {
-    public static class ServiceProviderExtensions
+    static class ServiceProviderExtensions
     {
         /// <summary>
         /// Get service of type <typeparamref name="T"/> from the <see cref="IServiceProvider"/>.

--- a/src/GraphQL/Utilities/ServiceProviderExtensions.cs
+++ b/src/GraphQL/Utilities/ServiceProviderExtensions.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace GraphQL.Utilities
 {
-    static class ServiceProviderExtensions
+    internal static class ServiceProviderExtensions
     {
         /// <summary>
         /// Get service of type <typeparamref name="T"/> from the <see cref="IServiceProvider"/>.


### PR DESCRIPTION
The majority of things consuming will already reference `Microsoft.Extensions.DependencyInjection.Abstractions`. Which means ServiceProviderExtensions regularly causes type conflicts when using as an extension method

```
Severity	Code	Description	Project	File	Line	Suppression State
Error	CS0121	The call is ambiguous between the following methods or properties: 
'GraphQL.Utilities.ServiceProviderExtensions.GetRequiredService<T>(System.IServiceProvider)' and 
'Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<T>(System.IServiceProvider)'	
```

So this PR makes ServiceProviderExtensions internal

replaces #1929