### PR TITLE
Add common status check for build checks

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -5,8 +5,6 @@ on:
     branches: 
       - master
       - develop
-    paths: 
-      - src/**
 
 jobs:
   test:
@@ -38,3 +36,7 @@ jobs:
       - name: Test solution (debug config)
         working-directory: src
         run: dotnet test --no-restore
+  buildcheck:
+    needs:
+      - test
+    runs-on: ubuntu-latest

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -5,6 +5,8 @@ on:
     branches: 
       - master
       - develop
+    paths:
+      - src/**
 
 jobs:
   test:

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -5,7 +5,7 @@ on:
     branches: 
       - master
       - develop
-    paths:
+    paths: 
       - src/**
 
 jobs:

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -40,3 +40,6 @@ jobs:
     needs:
       - test
     runs-on: ubuntu-latest
+    steps:
+      - name: Pass build check
+        run: exit 0

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -5,10 +5,6 @@ on:
     branches: 
       - master
       - develop
-    paths: 
-      - docs2/**
-      - package.json
-      - yarn.lock
 
 env:
   NODE_VERSION: '10.x'   # Node 10 LTS

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -14,7 +14,7 @@ env:
   NODE_VERSION: '10.x'   # Node 10 LTS
 
 jobs:
-  build-docs:
+  buildcheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -5,6 +5,10 @@ on:
     branches: 
       - master
       - develop
+    paths: 
+      - docs2/**
+      - package.json
+      - yarn.lock
 
 env:
   NODE_VERSION: '10.x'   # Node 10 LTS


### PR DESCRIPTION
With this change, both code and documentation build checks (which are in different workflows) will create a common "buildcheck" status which can be set in the branch protection options.

I imagine we want to turn off the old branch protection option (set for appveyor) and change to the 'buildcheck' status, which is triggered by either the `test-code.yml` or `test-documentation.yml` workflows.

Current configuration:
![image](https://user-images.githubusercontent.com/6377684/96968789-7c439b00-14df-11eb-987c-a51a0cf354af.png)
