### PR TITLE
Remove set-env from workflow

### DIFF
--- a/.github/workflows/publish-code.yml
+++ b/.github/workflows/publish-code.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           ref="${github_ref:10}"
           echo $ref
-          echo "::set-env name=ref::$ref"
+          echo "ref=$ref" >> $GITHUB_ENV
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
