### PR TITLE
Fix code test workflow to always report buildcheck status

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -39,10 +39,16 @@ jobs:
       - name: Test solution (debug config)
         working-directory: src
         run: dotnet test --no-restore
+
   buildcheck:
     needs:
       - test
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - name: Pass build check
+        if: ${{ needs.test.result == 'success' }}
         run: exit 0
+      - name: Fail build check
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
With this change, a failed execution step will still cause the 'buildcheck' status to report.  So, if someone changes both code and docs in a single PR, and the docs pass (reporting a successful 'buildcheck' status), and the code fails, the failed code run will report a failed 'buildcheck' status, preventing the PR from being merged.