### PR TITLE
Expose Schema.CreateTypesLookup and related members as protected

### DIFF
--- a/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.PublicApi.GraphQL.approved.txt
@@ -1901,6 +1901,9 @@ namespace GraphQL.Types
     {
         public GraphTypesLookup() { }
         public GraphTypesLookup(GraphQL.Conversion.INameConverter nameConverter) { }
+        protected virtual System.Collections.Generic.IReadOnlyDictionary<System.Type, GraphQL.Types.IGraphType> BuiltInCustomScalars { get; }
+        protected virtual System.Collections.Generic.IReadOnlyDictionary<System.Type, GraphQL.Types.IGraphType> BuiltInScalars { get; }
+        protected virtual System.Collections.Generic.IReadOnlyDictionary<System.Type, GraphQL.Types.IGraphType> IntrospectionTypes { get; }
         public GraphQL.Types.IGraphType this[string typeName] { get; set; }
         public GraphQL.Types.IGraphType this[System.Type type] { get; }
         public GraphQL.Conversion.INameConverter NameConverter { get; set; }
@@ -1916,6 +1919,8 @@ namespace GraphQL.Types
         public void ApplyTypeReference(GraphQL.Types.IGraphType type) { }
         public void ApplyTypeReferences() { }
         public void Clear() { }
+        public virtual void Initialize(System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> types, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> directives, System.Func<System.Type, GraphQL.Types.IGraphType> resolveType, bool seal = false) { }
+        [System.Obsolete("Please use a constructor along with the Initialize method.")]
         public static GraphQL.Types.GraphTypesLookup Create(System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> types, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> directives, System.Func<System.Type, GraphQL.Types.IGraphType> resolveType, GraphQL.Conversion.INameConverter nameConverter, bool seal = false) { }
     }
     public class GuidGraphType : GraphQL.Types.ScalarGraphType
@@ -2160,6 +2165,7 @@ namespace GraphQL.Types
         public GraphQL.Types.IObjectGraphType Subscription { get; set; }
         public GraphQL.Types.FieldType TypeMetaFieldType { get; }
         public GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
+        protected virtual GraphQL.Types.GraphTypesLookup CreateTypesLookup(System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> types, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> directives, System.Func<System.Type, GraphQL.Types.IGraphType> graphTypeResolver) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public GraphQL.Types.DirectiveGraphType FindDirective(string name) { }

--- a/src/GraphQL.Tests/Bugs/Issue1952.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1952.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Conversion;
-using GraphQL.Introspection;
 using GraphQL.Types;
-using Shouldly;
 using Xunit;
 
 namespace GraphQL.Tests.Bugs
@@ -73,24 +71,6 @@ query {
 
                 return builtInScalars;
             }
-
-            // Introspection types http://spec.graphql.org/June2018/#sec-Schema-Introspection
-            private static readonly Dictionary<Type, IGraphType> _introspectionTypes = new IGraphType[]
-            {
-                new __DirectiveLocation(),
-                new __TypeKind(),
-                new __EnumValue(),
-                new __Directive(),
-                new __Field(),
-                new __InputValue(),
-                new __Type(),
-                new __Schema()
-            }
-            .ToDictionary(t => t.GetType());
-
-            // the standard introspection types are static, which would cause conflicts between the resolved
-            // instances of StringGraphType inside them and the custom StringGraphType in this class
-            protected override IReadOnlyDictionary<Type, IGraphType> IntrospectionTypes => _introspectionTypes;
         }
 
         [GraphQLMetadata("String")]
@@ -98,7 +78,7 @@ query {
         {
             public override object Serialize(object value)
             {
-                return value.ToString().ToUpper();
+                return value?.ToString().ToUpper();
             }
         }
 

--- a/src/GraphQL.Tests/Bugs/Issue1952.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1952.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Conversion;
+using GraphQL.Introspection;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/1952
+    public class Issue1952 : QueryTestBase<Issue1952Schema>
+    {
+        [Fact]
+        public void Issue1952_Custom_Built_In_Scalar()
+        {
+            var query = @"
+query {
+  test
+}
+";
+            var expected = @"{
+  ""test"": ""HELLO""
+}";
+            AssertQuerySuccess(query, expected, null);
+        }
+    }
+
+    public class Issue1952Schema : Schema
+    {
+        public Issue1952Schema()
+        {
+            Query = new Issue1952Query();
+        }
+
+        protected override GraphTypesLookup CreateTypesLookup(IEnumerable<IGraphType> types, IEnumerable<DirectiveGraphType> directives, Func<Type, IGraphType> graphTypeResolver)
+        {
+            var lookup = new Issue1952GraphTypesLookup(NameConverter);
+
+            lookup.Initialize(
+                types,
+                directives,
+                graphTypeResolver,
+                seal: true);
+
+            return lookup;
+        }
+
+        private class Issue1952GraphTypesLookup : GraphTypesLookup
+        {
+            public Issue1952GraphTypesLookup(INameConverter nameConverter) : base(nameConverter)
+            {
+            }
+
+            private IReadOnlyDictionary<Type, IGraphType> _builtInScalars;
+
+            protected override IReadOnlyDictionary<Type, IGraphType> BuiltInScalars => _builtInScalars ??= GetBuiltInScalars();
+
+            private IReadOnlyDictionary<Type, IGraphType> GetBuiltInScalars()
+            {
+                // Standard scalars https://graphql.github.io/graphql-spec/June2018/#sec-Scalars
+                var builtInScalars = new IGraphType[]
+                {
+                    new BooleanGraphType(),
+                    new FloatGraphType(),
+                    new IntGraphType(),
+                    new IdGraphType(),
+                }
+                .ToDictionary(t => t.GetType());
+
+                builtInScalars.Add(typeof(StringGraphType), new Issue1952CustomStringGraphType());
+
+                return builtInScalars;
+            }
+
+            // Introspection types http://spec.graphql.org/June2018/#sec-Schema-Introspection
+            private static readonly Dictionary<Type, IGraphType> _introspectionTypes = new IGraphType[]
+            {
+                new __DirectiveLocation(),
+                new __TypeKind(),
+                new __EnumValue(),
+                new __Directive(),
+                new __Field(),
+                new __InputValue(),
+                new __Type(),
+                new __Schema()
+            }
+            .ToDictionary(t => t.GetType());
+
+            // the standard introspection types are static, which would cause conflicts between the resolved
+            // instances of StringGraphType inside them and the custom StringGraphType in this class
+            protected override IReadOnlyDictionary<Type, IGraphType> IntrospectionTypes => _introspectionTypes;
+        }
+
+        [GraphQLMetadata("String")]
+        private class Issue1952CustomStringGraphType : StringGraphType
+        {
+            public override object Serialize(object value)
+            {
+                return value.ToString().ToUpper();
+            }
+        }
+
+        private class Issue1952Query : ObjectGraphType
+        {
+            public Issue1952Query()
+            {
+                Field<StringGraphType>(
+                    "test",
+                    resolve: ctx => "hello");
+            }
+        }
+    }
+}

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Types
     public class GraphTypesLookup
     {
         // Introspection types http://spec.graphql.org/June2018/#sec-Schema-Introspection
-        private readonly Dictionary<Type, IGraphType> _introspectionTypes = new IGraphType[]
+        protected virtual IReadOnlyDictionary<Type, IGraphType> IntrospectionTypes { get; } = new IGraphType[]
         {
             new __DirectiveLocation(),
             new __TypeKind(),
@@ -27,10 +27,8 @@ namespace GraphQL.Types
         }
         .ToDictionary(t => t.GetType());
 
-        protected virtual IReadOnlyDictionary<Type, IGraphType> IntrospectionTypes => _introspectionTypes;
-
         // Standard scalars https://graphql.github.io/graphql-spec/June2018/#sec-Scalars
-        private readonly Dictionary<Type, IGraphType> _builtInScalars = new IGraphType[]
+        protected virtual IReadOnlyDictionary<Type, IGraphType> BuiltInScalars { get; } = new IGraphType[]
         {
             new StringGraphType(),
             new BooleanGraphType(),
@@ -40,10 +38,8 @@ namespace GraphQL.Types
         }
         .ToDictionary(t => t.GetType());
 
-        protected virtual IReadOnlyDictionary<Type, IGraphType> BuiltInScalars => _builtInScalars;
-
         // .NET custom scalars
-        private readonly Dictionary<Type, IGraphType> _builtInCustomScalars = new IGraphType[]
+        protected virtual IReadOnlyDictionary<Type, IGraphType> BuiltInCustomScalars { get; } = new IGraphType[]
         {
             new DateGraphType(),
             new DateTimeGraphType(),
@@ -63,8 +59,6 @@ namespace GraphQL.Types
             new SByteGraphType(),
         }
         .ToDictionary(t => t.GetType());
-
-        protected virtual IReadOnlyDictionary<Type, IGraphType> BuiltInCustomScalars => _builtInCustomScalars;
 
         private readonly IDictionary<string, IGraphType> _types = new Dictionary<string, IGraphType>();
         private readonly TypeCollectionContext _context;

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -308,12 +308,23 @@ namespace GraphQL.Types
                 .Union(GetRootTypes())
                 .Union(_additionalTypes.Select(type => (IGraphType)_services.GetRequiredService(type.GetNamedType())));
 
-            return GraphTypesLookup.Create(
+            return CreateTypesLookup(
                 types,
                 _directives,
-                type => (IGraphType)_services.GetRequiredService(type),
-                NameConverter,
+                type => (IGraphType)_services.GetRequiredService(type));
+        }
+
+        protected virtual GraphTypesLookup CreateTypesLookup(IEnumerable<IGraphType> types, IEnumerable<DirectiveGraphType> directives, Func<Type, IGraphType> graphTypeResolver)
+        {
+            var lookup = new GraphTypesLookup(NameConverter);
+
+            lookup.Initialize(
+                types,
+                directives,
+                graphTypeResolver,
                 seal: true);
+
+            return lookup;
         }
     }
 }


### PR DESCRIPTION
Possible fix for #1952 

Purpose:
- Allow changing behavior of built-in scalars such as `StringGraphType`

Challenges:
- Built-in scalar behaviors should probably be retained for introspection types
