### PR TITLE
Move ValidateName calls after NameConverter is applied

### DIFF
--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -357,6 +357,24 @@ namespace GraphQL.Tests.Types
             schema.Initialize();
         }
 
+        [Fact]
+        public void throws_with_bad_namevalidator()
+        {
+            var exception = Should.Throw<ArgumentOutOfRangeException>(() =>
+            {
+                var type = new ObjectGraphType();
+                type.Field<StringGraphType>("hello");
+                var schema = new Schema
+                {
+                    Query = type,
+                    NameConverter = new TestNameConverter("hello", "hello$")
+                };
+                schema.Initialize();
+            });
+
+            exception.Message.ShouldStartWith($"A field name must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but hello$ does not.");
+        }
+
         private class TestNameConverter : INameConverter
         {
             private readonly string _from;

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -107,7 +107,8 @@ namespace GraphQL.Builders
 
         public ConnectionBuilder<TSourceType> Name(string name)
         {
-            NameValidator.ValidateName(name);
+            if (string.IsNullOrEmpty(name))
+                NameValidator.ValidateName(name);
 
             FieldType.Name = name;
             return this;

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -107,9 +107,6 @@ namespace GraphQL.Builders
 
         public ConnectionBuilder<TSourceType> Name(string name)
         {
-            if (string.IsNullOrEmpty(name))
-                NameValidator.ValidateName(name);
-
             FieldType.Name = name;
             return this;
         }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -55,9 +55,6 @@ namespace GraphQL.Builders
 
         public virtual FieldBuilder<TSourceType, TReturnType> Name(string name)
         {
-            if (string.IsNullOrEmpty(name))
-                NameValidator.ValidateName(name);
-
             FieldType.Name = name;
             return this;
         }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -55,7 +55,8 @@ namespace GraphQL.Builders
 
         public virtual FieldBuilder<TSourceType, TReturnType> Name(string name)
         {
-            NameValidator.ValidateName(name);
+            if (string.IsNullOrEmpty(name))
+                NameValidator.ValidateName(name);
 
             FieldType.Name = name;
             return this;

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -75,7 +75,8 @@ namespace GraphQL.Types
                 }
             }
 
-            if (string.IsNullOrEmpty(fieldType.Name)) NameValidator.ValidateName(fieldType.Name);
+            //check if fieldType.Name has never been set
+            NameValidator.ValidateNameNotNull(fieldType.Name);
 
             if (HasField(fieldType.Name))
             {

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -75,7 +75,7 @@ namespace GraphQL.Types
                 }
             }
 
-            NameValidator.ValidateName(fieldType.Name);
+            if (string.IsNullOrEmpty(fieldType.Name)) NameValidator.ValidateName(fieldType.Name);
 
             if (HasField(fieldType.Name))
             {

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -16,7 +16,8 @@ namespace GraphQL.Types
         public string Name
         {
             get => _name;
-            set {
+            set
+            {
                 NameValidator.ValidateNameNotNull(value);
                 _name = value;
             }

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -12,7 +12,15 @@ namespace GraphQL.Types
         private object _defaultValue;
         private IValue _defaultValueAST;
 
-        public string Name { get; set; }
+        private string _name;
+        public string Name
+        {
+            get => _name;
+            set {
+                NameValidator.ValidateNameNotNull(value);
+                _name = value;
+            }
+        }
 
         public string Description { get; set; }
 

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using GraphQL.Conversion;
 using GraphQL.Introspection;
 using GraphQL.Types.Relay;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
@@ -362,6 +363,7 @@ namespace GraphQL.Types
             if (applyNameConverter)
             {
                 field.Name = NameConverter.NameForField(field.Name, parentType);
+                NameValidator.ValidateName(field.Name);
             }
 
             if (field.ResolvedType == null)
@@ -382,6 +384,7 @@ namespace GraphQL.Types
                 if (applyNameConverter)
                 {
                     arg.Name = NameConverter.NameForArgument(arg.Name, parentType, field);
+                    NameValidator.ValidateName(arg.Name, "argument");
                 }
 
                 if (arg.ResolvedType != null)

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -37,7 +37,15 @@ namespace GraphQL.Types
             Type = type;
         }
 
-        public string Name { get; set; }
+        private string _name;
+        public string Name
+        {
+            get => _name;
+            set {
+                NameValidator.ValidateNameNotNull(value, "argument");
+                _name = value;
+            }
+        }
 
         public string Description { get; set; }
 

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -41,7 +41,8 @@ namespace GraphQL.Types
         public string Name
         {
             get => _name;
-            set {
+            set
+            {
                 NameValidator.ValidateNameNotNull(value, "argument");
                 _name = value;
             }

--- a/src/GraphQL/Types/QueryArguments.cs
+++ b/src/GraphQL/Types/QueryArguments.cs
@@ -28,7 +28,7 @@ namespace GraphQL.Types
             get => ArgumentsList != null ? ArgumentsList[index] : throw new IndexOutOfRangeException();
             set
             {
-                if (value != null)
+                if (value != null && string.IsNullOrEmpty(value.Name))
                 {
                     NameValidator.ValidateName(value.Name, "argument");
                 }
@@ -49,7 +49,8 @@ namespace GraphQL.Types
             if (argument == null)
                 throw new ArgumentNullException(nameof(argument));
 
-            NameValidator.ValidateName(argument.Name, "argument");
+            if (string.IsNullOrEmpty(argument.Name))
+                NameValidator.ValidateName(argument.Name, "argument");
 
             if (ArgumentsList == null)
                 ArgumentsList = new List<QueryArgument>();

--- a/src/GraphQL/Utilities/NameValidator.cs
+++ b/src/GraphQL/Utilities/NameValidator.cs
@@ -10,11 +10,7 @@ namespace GraphQL.Utilities
 
         public static void ValidateName(string name, string type = "field")
         {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                throw new ArgumentOutOfRangeException(nameof(name),
-                    $"A {type} name can not be null or empty.");
-            }
+            ValidateNameNotNull(name, type);
 
             if (name.Length > 1 && name.StartsWith(RESERVED_PREFIX, StringComparison.InvariantCulture))
             {
@@ -25,6 +21,15 @@ namespace GraphQL.Utilities
             {
                 throw new ArgumentOutOfRangeException(nameof(name),
                     $"A {type} name must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but {name} does not.");
+            }
+        }
+
+        internal static void ValidateNameNotNull(string name, string type = "field")
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentOutOfRangeException(nameof(name),
+                    $"A {type} name can not be null or empty.");
             }
         }
     }


### PR DESCRIPTION
Closes #1840 

The purpose of this PR is the following:
1. Allow invalid field and argument graphql names prior to schema initialization (not currently allowed)
2. Apply NameConverter to field and argument names during schema initialization (already exists)
3. Validate that the updated names are valid during schema initialization (currently does not happen)

The purpose of this PR is NOT:
1. Code cleanup / consolidation
2. Allow invalid field / argument names in an intialized schema