### PR TITLE
Fix issue with custom subscription name

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>3.1.1-preview</VersionPrefix>
+    <VersionPrefix>3.1.2-preview</VersionPrefix>
     <PackageProjectUrl>https://github.com/graphql-dotnet/graphql-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL.Tests/Files/CustomSubscription.graphql
+++ b/src/GraphQL.Tests/Files/CustomSubscription.graphql
@@ -1,0 +1,17 @@
+schema {
+  query: CustomQuery
+  mutation: CustomMutation
+  subscription: CustomSubscription
+}
+
+type CustomQuery {
+  age: Int
+}
+
+type CustomMutation {
+  flag: Boolean
+}
+
+type CustomSubscription {
+  name: String
+}

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -10,6 +10,17 @@ namespace GraphQL.Tests.Utilities
 {
     public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     {
+        [Fact]
+        public void can_read_schema_with_custom_root_names()
+        {
+            var schema = Schema.For(ReadSchema("CustomSubscription.graphql"));
+
+            schema.Query.Name.ShouldBe("CustomQuery");
+            schema.Mutation.Name.ShouldBe("CustomMutation");
+            schema.Subscription.Name.ShouldBe("CustomSubscription");
+            schema.Subscription.Fields.All(f => f is EventStreamFieldType).ShouldBeTrue();
+        }
+
         [Theory]
         [InlineData("PetAfterAll.graphql", 15)]
         [InlineData("PetBeforeAll.graphql", 15)]

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -15,6 +15,7 @@ namespace GraphQL.Utilities
     {
         protected readonly IDictionary<string, IGraphType> _types = new Dictionary<string, IGraphType>();
         private readonly List<IVisitorSelector> _visitorSelectors = new List<IVisitorSelector>();
+        private GraphQLSchemaDefinition schemaDef;
 
         public IServiceProvider ServiceProvider { get; set; } = new DefaultServiceProvider();
 
@@ -90,8 +91,6 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             PreConfigure(schema);
 
             var directives = new List<DirectiveGraphType>();
-
-            GraphQLSchemaDefinition schemaDef = null;
 
             foreach (var def in document.Definitions)
             {
@@ -209,6 +208,15 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             return type;
         }
 
+        private bool IsSubscriptionType(ObjectGraphType type)
+        {
+            var operationDefinition = schemaDef?.OperationTypes?.FirstOrDefault(o => o.Operation == OperationType.Subscription);
+            if (operationDefinition == null)
+                return type.Name == "Subscription";
+
+            return type.Name == operationDefinition.Type.Name.Value;
+        }
+
         protected virtual IObjectGraphType ToObjectGraphType(GraphQLObjectTypeDefinition astType, bool isExtensionType = false)
         {
             var typeConfig = Types.For(astType.Name.Value);
@@ -232,7 +240,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             CopyMetadata(type, typeConfig);
 
             Func<string, GraphQLFieldDefinition, FieldType> constructFieldType;
-            if (type.Name == "Subscription")
+            if (IsSubscriptionType(type))
             {
                 constructFieldType = ToSubscriptionFieldType;
             }


### PR DESCRIPTION
Before this fix all subscription fields were created as `FieldType` (not `EventStreamFieldType`) if subscription root type has custom name != 'Subscription'.