### PR TITLE
Update the Link for FAQ in Migration 2-> 3

### DIFF
--- a/docs2/site/docs/migrations/migration3.md
+++ b/docs2/site/docs/migrations/migration3.md
@@ -15,7 +15,7 @@ These .Net types now are automatically mapped to corresponding built-in custom s
 * BigInt
 
 There is also support for converting base-64 encoded strings to byte arrays. See
-the [FAQ](https://graphql-dotnet.github.io/docs/guides/known-issues#can-custom-scalars-serialize-non-null-data-to-a-null-value-and-vice-versa)
+the [FAQ](../guides/known-issues#can-custom-scalars-serialize-non-null-data-to-a-null-value-and-vice-versa)
 and the `ValueConverter` class for more details.
 
 See [Schema Types](https://graphql-dotnet.github.io/docs/getting-started/schema-types) for more details.

--- a/docs2/site/docs/migrations/migration3.md
+++ b/docs2/site/docs/migrations/migration3.md
@@ -15,7 +15,7 @@ These .Net types now are automatically mapped to corresponding built-in custom s
 * BigInt
 
 There is also support for converting base-64 encoded strings to byte arrays. See
-the [FAQ](known-issues#can-custom-scalars-serialize-non-null-data-to-a-null-value-and-vice-versa)
+the [FAQ](https://graphql-dotnet.github.io/docs/guides/known-issues#can-custom-scalars-serialize-non-null-data-to-a-null-value-and-vice-versa)
 and the `ValueConverter` class for more details.
 
 See [Schema Types](https://graphql-dotnet.github.io/docs/getting-started/schema-types) for more details.


### PR DESCRIPTION
Creating this PR to fix the link for FAQ documentation in Migration Guide [v2 ->v3]