### PR TITLE
Fix type registration for directive args

### DIFF
--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   NODE_VERSION: '10.x'   # Node 10 LTS
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
   pack:
@@ -46,13 +48,10 @@ jobs:
       - name: Install dependencies
         working-directory: src
         run: dotnet restore
-        env:
-          DOTNET_NOLOGO: true
-          DOTNET_CLI_TELEMETRY_OPTOUT: true
-      - name: Build solution (release config)
+      - name: Build solution [Release]
         working-directory: src
         run: dotnet build --no-restore -c Release -p:NoWarn=CS1591 -p:VersionSuffix=$GITHUB_RUN_NUMBER
-      - name: Pack solution (release config)
+      - name: Pack solution [Release]
         working-directory: src
         run: dotnet pack --no-restore -c Release -p:VersionSuffix=$GITHUB_RUN_NUMBER -o out
       - name: Publish artifacts

--- a/src/GraphQL/Types/GraphTypesLookup.cs
+++ b/src/GraphQL/Types/GraphTypesLookup.cs
@@ -140,10 +140,12 @@ namespace GraphQL.Types
                 {
                     if (arg.ResolvedType != null)
                     {
+                        lookup.AddTypeIfNotRegistered(arg.ResolvedType, ctx);
                         arg.ResolvedType = lookup.ConvertTypeReference(directive, arg.ResolvedType);
                     }
                     else
                     {
+                        lookup.AddTypeIfNotRegistered(arg.Type, ctx);
                         arg.ResolvedType = lookup.BuildNamedType(arg.Type, ctx.ResolveType);
                     }
                 }


### PR DESCRIPTION
This is regression. I found it while migrating on 3.1.2. No time to write tests but I can reproduce the bug with simple example.

Change StarWarsSchema.cs adding new directive
```c#
using System;
using GraphQL.Types;
using GraphQL.Utilities;

namespace GraphQL.StarWars
{
    public class StarWarsSchema : Schema
    {
        public StarWarsSchema(IServiceProvider serviceProvider)
            : base(serviceProvider)
        {
            Query = serviceProvider.GetRequiredService<StarWarsQuery>();
            Mutation = serviceProvider.GetRequiredService<StarWarsMutation>();
            RegisterDirective(new LinkDirective());
            Description = "Example StarWars universe schema";
        }
    }

    public class LinkDirective : DirectiveGraphType
    {
        public LinkDirective() : base("link", new[] { DirectiveLocation.FieldDefinition, DirectiveLocation.Object, DirectiveLocation.Interface })
        {
            Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<UriGraphType>> { Name = "url" });
        }
    }
}
```

This happens because directives have their own code branch and there is no type registration. I'm sure it was simply forgotten, because it was not intended to use custom scalars in directives.