### PR TITLE
Test for custom scalars in directives

### DIFF
--- a/src/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
+++ b/src/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <OutputType>exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.StarWars/GraphQL.StarWars.csproj
+++ b/src/GraphQL.StarWars/GraphQL.StarWars.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.StarWars/IoC/SimpleContainer.cs
+++ b/src/GraphQL.StarWars/IoC/SimpleContainer.cs
@@ -8,23 +8,23 @@ namespace GraphQL.StarWars.IoC
     {
         object Get(Type serviceType);
         T Get<T>();
-        void Register<TService>();
-        void Register<TService>(Func<TService> instanceCreator);
-        void Register<TService, TImpl>() where TImpl : TService;
-        void Singleton<TService>(TService instance);
-        void Singleton<TService>(Func<TService> instanceCreator);
+        void Register<TService>() where TService : class;
+        void Register<TService>(Func<TService> instanceCreator) where TService : class;
+        void Register<TService, TImpl>() where TService: class where TImpl : class, TService;
+        void Singleton<TService>(TService instance) where TService : class;
+        void Singleton<TService>(Func<TService> instanceCreator) where TService : class;
     }
 
     public class SimpleContainer : ISimpleContainer
     {
         private readonly Dictionary<Type, Func<object>> _registrations = new Dictionary<Type, Func<object>>();
 
-        public void Register<TService>()
+        public void Register<TService>() where TService : class
         {
             Register<TService, TService>();
         }
 
-        public void Register<TService, TImpl>() where TImpl : TService
+        public void Register<TService, TImpl>() where TService : class where TImpl : class, TService
         {
             _registrations.Add(typeof(TService),
                 () =>
@@ -36,17 +36,17 @@ namespace GraphQL.StarWars.IoC
                 });
         }
 
-        public void Register<TService>(Func<TService> instanceCreator)
+        public void Register<TService>(Func<TService> instanceCreator) where TService : class
         {
             _registrations.Add(typeof(TService), () => instanceCreator());
         }
 
-        public void Singleton<TService>(TService instance)
+        public void Singleton<TService>(TService instance) where TService : class
         {
             _registrations.Add(typeof(TService), () => instance);
         }
 
-        public void Singleton<TService>(Func<TService> instanceCreator)
+        public void Singleton<TService>(Func<TService> instanceCreator) where TService : class
         {
             var lazy = new Lazy<TService>(instanceCreator);
             Register(() => lazy.Value);

--- a/src/GraphQL.Tests/Bugs/BugWithCustomScalarsInDirective.cs
+++ b/src/GraphQL.Tests/Bugs/BugWithCustomScalarsInDirective.cs
@@ -1,0 +1,56 @@
+using System;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class BugWithCustomScalarsInDirective : QueryTestBase<BugWithCustomScalarsInDirectiveSchema, MsDiContainer>
+    {
+        public BugWithCustomScalarsInDirective()
+        {
+            Services.Register<BugWithCustomScalarsInDirectiveSchema>();
+            Services.Register<BugWithCustomScalarsInDirectiveQuery>();
+        }
+
+        [Fact]
+        public void schema_should_be_initialized()
+        {
+            Schema.Initialize();
+        }
+    }
+
+    public class BugWithCustomScalarsInDirectiveSchema : Schema
+    {
+        public BugWithCustomScalarsInDirectiveSchema(IServiceProvider provider, BugWithCustomScalarsInDirectiveQuery query)
+            : base(provider)
+        {
+            Query = query;
+            RegisterDirectives(new LinkDirective(), new SomeDirective());
+        }
+    }
+
+    public class BugWithCustomScalarsInDirectiveQuery : ObjectGraphType
+    {
+        public BugWithCustomScalarsInDirectiveQuery()
+        {
+            Name = "Query";
+            Field<StringGraphType>("str", resolve: _ => "aaa");
+        }
+    }
+
+    public class LinkDirective : DirectiveGraphType
+    {
+        public LinkDirective() : base("link", new[] { DirectiveLocation.FieldDefinition, DirectiveLocation.Object, DirectiveLocation.Interface })
+        {
+            Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<UriGraphType>> { Name = "url" });
+        }
+    }
+
+    public class SomeDirective : DirectiveGraphType
+    {
+        public SomeDirective() : base("some", new[] { DirectiveLocation.Scalar })
+        {
+            Arguments = new QueryArguments(new QueryArgument<GuidGraphType> { Name = "one" }, new QueryArgument<BigIntGraphType> { Name = "two" }, new QueryArgument<TimeSpanSecondsGraphType> { Name = "three" });
+        }
+    }
+}

--- a/src/GraphQL.Tests/MsDiContainer.cs
+++ b/src/GraphQL.Tests/MsDiContainer.cs
@@ -1,0 +1,66 @@
+using System;
+using GraphQL.StarWars.IoC;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Tests
+{
+    public class MsDiContainer : ISimpleContainer
+    {
+        private readonly ServiceCollection _services = new ServiceCollection();
+        private ServiceProvider _provider;
+
+        private void AssertNotCreated()
+        {
+            if (_provider != null)
+                throw new InvalidOperationException();
+        }
+
+        public object Get(Type serviceType)
+        {
+            _provider ??= _services.BuildServiceProvider();
+            return _provider.GetService(serviceType);
+        }
+
+        public T Get<T>()
+        {
+            _provider ??= _services.BuildServiceProvider();
+            return _provider.GetService<T>();
+        }
+
+        public void Register<TService>() where TService : class
+        {
+            AssertNotCreated();
+            _services.AddTransient<TService>();
+        }
+
+        public void Register<TService>(Func<TService> instanceCreator) where TService : class
+        {
+            AssertNotCreated();
+            _services.AddTransient(provider => instanceCreator());
+        }
+
+        public void Register<TService, TImpl>() where TService : class where TImpl : class, TService
+        {
+            AssertNotCreated();
+            _services.AddTransient<TService, TImpl>();
+        }
+
+        public void Singleton<TService>(TService instance) where TService : class
+        {
+            AssertNotCreated();
+            _services.AddSingleton<TService>(instance);
+        }
+
+        public void Singleton<TService>(Func<TService> instanceCreator) where TService : class
+        {
+            AssertNotCreated();
+            _services.AddSingleton<TService>(provider => instanceCreator());
+        }
+
+        public void Dispose()
+        {
+            _provider.Dispose();
+            _provider = null;
+        }
+    }
+}

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -14,18 +14,25 @@ using Shouldly;
 
 namespace GraphQL.Tests
 {
-    public class QueryTestBase<TSchema> : QueryTestBase<TSchema, GraphQLDocumentBuilder>
+    public class QueryTestBase<TSchema> : QueryTestBase<TSchema, GraphQLDocumentBuilder, SimpleContainer>
         where TSchema : ISchema
     {
     }
 
-    public class QueryTestBase<TSchema, TDocumentBuilder>
+    public class QueryTestBase<TSchema, TIocContainer> : QueryTestBase<TSchema, GraphQLDocumentBuilder, TIocContainer>
+       where TSchema : ISchema
+       where TIocContainer : ISimpleContainer, new()
+    {
+    }
+
+    public class QueryTestBase<TSchema, TDocumentBuilder, TIocContainer>
         where TSchema : ISchema
         where TDocumentBuilder : IDocumentBuilder, new()
+        where TIocContainer : ISimpleContainer, new()
     {
         public QueryTestBase()
         {
-            Services = new SimpleContainer();
+            Services = new TIocContainer();
             Executer = new DocumentExecuter(new TDocumentBuilder(), new DocumentValidator(), new ComplexityAnalyzer());
             Writer = new DocumentWriter(indent: true);
         }

--- a/src/GraphQL.Tests/StarWars/StarWarsTestBase.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsTestBase.cs
@@ -1,10 +1,9 @@
-﻿using GraphQL.Execution;
 using GraphQL.StarWars;
 using GraphQL.StarWars.Types;
 
 namespace GraphQL.Tests.StarWars
 {
-    public class StarWarsTestBase : QueryTestBase<StarWarsSchema, GraphQLDocumentBuilder>
+    public class StarWarsTestBase : QueryTestBase<StarWarsSchema>
     {
         public StarWarsTestBase()
         {

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Utilities
     {
         protected readonly IDictionary<string, IGraphType> _types = new Dictionary<string, IGraphType>();
         private readonly List<IVisitorSelector> _visitorSelectors = new List<IVisitorSelector>();
-        private GraphQLSchemaDefinition schemaDef;
+        private GraphQLSchemaDefinition _schemaDef;
 
         public IServiceProvider ServiceProvider { get; set; } = new DefaultServiceProvider();
 
@@ -98,8 +98,8 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
                 {
                     case ASTNodeKind.SchemaDefinition:
                     {
-                        schemaDef = def as GraphQLSchemaDefinition;
-                        schema.SetAstType(schemaDef);
+                        _schemaDef = def as GraphQLSchemaDefinition;
+                        schema.SetAstType(_schemaDef);
 
                         VisitNode(schema, v => v.VisitSchema(schema));
                         break;
@@ -156,11 +156,11 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
                 }
             }
 
-            if (schemaDef != null)
+            if (_schemaDef != null)
             {
-                schema.Description = schemaDef.Comment?.Text;
+                schema.Description = _schemaDef.Comment?.Text;
 
-                foreach (var operationTypeDef in schemaDef.OperationTypes)
+                foreach (var operationTypeDef in _schemaDef.OperationTypes)
                 {
                     var typeName = operationTypeDef.Type.Name.Value;
                     var type = GetType(typeName) as IObjectGraphType;
@@ -210,7 +210,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
 
         private bool IsSubscriptionType(ObjectGraphType type)
         {
-            var operationDefinition = schemaDef?.OperationTypes?.FirstOrDefault(o => o.Operation == OperationType.Subscription);
+            var operationDefinition = _schemaDef?.OperationTypes?.FirstOrDefault(o => o.Operation == OperationType.Subscription);
             if (operationDefinition == null)
                 return type.Name == "Subscription";
 


### PR DESCRIPTION
fixes #1977

You can comment out two lines in `GraphTypesLookup` to see that test fails
```c#
 foreach (var arg in directive.Arguments)
                {
                    if (arg.ResolvedType != null)
                    {
                        lookup.AddTypeIfNotRegistered(arg.ResolvedType, ctx);  <-----------------------------------
                        arg.ResolvedType = lookup.ConvertTypeReference(directive, arg.ResolvedType);
                    }
                    else
                    {
                        lookup.AddTypeIfNotRegistered(arg.Type, ctx); <-----------------------------------
                        arg.ResolvedType = lookup.BuildNamedType(arg.Type, ctx.ResolveType);
                    }
                }
```