### PR TITLE
Retain stack traces and unwrap constructor exceptions

### DIFF
--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using GraphQL.Types;
 
 namespace GraphQL
@@ -107,7 +108,16 @@ namespace GraphQL
                 ctorArguments[i] = arg;
             }
 
-            object obj = targetCtor.Invoke(ctorArguments);
+            object obj;
+            try
+            {
+                obj = targetCtor.Invoke(ctorArguments);
+            }
+            catch (TargetInvocationException ex)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw ex.InnerException; //necessary only for intellisense
+            }
 
             foreach (var item in source)
             {

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -116,7 +116,7 @@ namespace GraphQL
             catch (TargetInvocationException ex)
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw ex.InnerException; //necessary only for intellisense
+                return null; // never executed, necessary only for intellisense
             }
 
             foreach (var item in source)

--- a/src/GraphQL/Reflection/SingleMethodAccessor.cs
+++ b/src/GraphQL/Reflection/SingleMethodAccessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 
 namespace GraphQL.Reflection
 {
@@ -29,7 +30,8 @@ namespace GraphQL.Reflection
             }
             catch (TargetInvocationException ex)
             {
-                throw ex.InnerException;
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw ex.InnerException; //necessary only for intellisense
             }
         }
     }

--- a/src/GraphQL/Reflection/SingleMethodAccessor.cs
+++ b/src/GraphQL/Reflection/SingleMethodAccessor.cs
@@ -31,7 +31,7 @@ namespace GraphQL.Reflection
             catch (TargetInvocationException ex)
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw ex.InnerException; //necessary only for intellisense
+                return null; // never executed, necessary only for intellisense
             }
         }
     }


### PR DESCRIPTION
This fixes two bugs:
- When using `SingleMethodAccessor`, exceptions are unwrapped but stack traces are not retained.
- When using the `ToObject` extension method (for instance, within `TryGetArgument`), constructor exceptions are not unwrapped.

