### PR TITLE
[WIP] 'Precompile' an execution tree to optimize performance on large requests

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -438,6 +438,32 @@ namespace GraphQL.Builders
         public int? PageSize { get; }
     }
 }
+namespace GraphQL.Compilation
+{
+    public class CompiledField
+    {
+        public CompiledField(GraphQL.Types.FieldType definition, GraphQL.Language.AST.Field field, System.Func<object, bool, GraphQL.Compilation.CompiledNode> resolve = null) { }
+        public GraphQL.Types.FieldType Definition { get; }
+        public GraphQL.Language.AST.Field Field { get; }
+        public System.Func<object, bool, GraphQL.Compilation.CompiledNode> Resolve { get; }
+    }
+    public class CompiledNode
+    {
+        public CompiledNode(GraphQL.Types.IGraphType graphType, System.Collections.Generic.Dictionary<string, GraphQL.Compilation.CompiledField> fields) { }
+        public System.Collections.Generic.Dictionary<string, GraphQL.Compilation.CompiledField> Fields { get; }
+        public GraphQL.Types.IGraphType GraphType { get; }
+    }
+    public class QueryCompilation
+    {
+        public QueryCompilation() { }
+        public static System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> CollectFields(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Variables variables, GraphQL.Language.AST.Document document, GraphQL.Types.IGraphType specificType, GraphQL.Language.AST.SelectionSet selectionSet) { }
+        public static GraphQL.Compilation.CompiledNode Compile(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.Variables variables, GraphQL.Language.AST.Operation operation) { }
+        public static bool DoesFragmentConditionMatch(GraphQL.Types.ISchema schema, string fragmentName, GraphQL.Types.IGraphType type) { }
+        public static GraphQL.Types.FieldType GetFieldDefinition(GraphQL.Types.ISchema schema, GraphQL.Types.IObjectGraphType parentType, GraphQL.Language.AST.Field field) { }
+        public static GraphQL.Types.IObjectGraphType GetOperationRootType(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.Operation operation) { }
+        public static bool ShouldIncludeNode(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Variables variables, GraphQL.Language.AST.Directives directives) { }
+    }
+}
 namespace GraphQL.Conversion
 {
     public class CamelCaseNameConverter : GraphQL.Conversion.INameConverter
@@ -596,7 +622,7 @@ namespace GraphQL.Execution
 {
     public class ArrayExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {
-        public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Compilation.CompiledField compiled, int? indexInParentNode) { }
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode> Items { get; set; }
         public override object ToValue() { }
     }
@@ -646,6 +672,7 @@ namespace GraphQL.Execution
     {
         public ExecutionContext() { }
         public System.Threading.CancellationToken CancellationToken { get; set; }
+        public GraphQL.Compilation.CompiledNode CompiledRootNode { get; set; }
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
         public System.Collections.Generic.Dictionary<string, object> Extensions { get; set; }
@@ -665,20 +692,16 @@ namespace GraphQL.Execution
     public static class ExecutionHelper
     {
         public static void AssertValidVariableValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, object input, string variableName, bool hasDefaultValue) { }
-        public static object CoerceValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue input, GraphQL.Language.AST.Variables variables = null, object fieldDefault = null) { }
-        public static System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> CollectFields(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IGraphType specificType, GraphQL.Language.AST.SelectionSet selectionSet) { }
-        public static bool DoesFragmentConditionMatch(GraphQL.Execution.ExecutionContext context, string fragmentName, GraphQL.Types.IGraphType type) { }
+        public static object CoerceValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue input, GraphQL.Language.AST.Variables variables = null) { }
         public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, GraphQL.Types.QueryArguments definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
-        public static GraphQL.Types.FieldType GetFieldDefinition(GraphQL.Types.ISchema schema, GraphQL.Types.IObjectGraphType parentType, GraphQL.Language.AST.Field field) { }
-        public static GraphQL.Types.IObjectGraphType GetOperationRootType(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.Operation operation) { }
         public static object GetVariableValue(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinition variable, object input) { }
         public static GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Language.AST.Document document, GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions variableDefinitions, GraphQL.Inputs inputs) { }
-        public static bool ShouldIncludeNode(GraphQL.Execution.ExecutionContext context, GraphQL.Language.AST.Directives directives) { }
         public static System.Collections.Generic.IDictionary<string, GraphQL.Language.AST.Field> SubFieldsFor(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IGraphType fieldType, GraphQL.Language.AST.Field field) { }
     }
     public abstract class ExecutionNode
     {
-        protected ExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        protected ExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Compilation.CompiledField compiled, int? indexInParentNode) { }
+        public GraphQL.Compilation.CompiledField CompiledField { get; }
         public GraphQL.Language.AST.Field Field { get; }
         public GraphQL.Types.FieldType FieldDefinition { get; }
         public GraphQL.Types.IGraphType GraphType { get; }
@@ -706,11 +729,10 @@ namespace GraphQL.Execution
         protected bool ProcessNodeUnhandledException(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, System.Exception ex) { }
         protected void SetNodeError(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, GraphQL.ExecutionError error) { }
         protected virtual void ValidateNodeResult(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
-        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode = default) { }
-        public static GraphQL.Execution.RootExecutionNode BuildExecutionRootNode(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IObjectGraphType rootType) { }
-        public static void SetArrayItemNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ArrayExecutionNode parent) { }
-        public static void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent) { }
-        public static void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent, System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> fields) { }
+        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Compilation.CompiledField compiled, int? indexInParentNode = default) { }
+        public static GraphQL.Execution.RootExecutionNode BuildExecutionRootNode(GraphQL.Execution.ExecutionContext context) { }
+        public static void SetArrayItemNodes(GraphQL.Execution.ArrayExecutionNode parent) { }
+        public static void SetSubFieldNodes(GraphQL.Execution.ObjectExecutionNode parent) { }
     }
     public class GraphQLDocumentBuilder : GraphQL.Execution.IDocumentBuilder
     {
@@ -738,6 +760,7 @@ namespace GraphQL.Execution
     public interface IExecutionContext : GraphQL.Execution.IProvideUserContext
     {
         System.Threading.CancellationToken CancellationToken { get; }
+        GraphQL.Compilation.CompiledNode CompiledRootNode { get; set; }
         GraphQL.Language.AST.Document Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
         System.Collections.Generic.Dictionary<string, object> Extensions { get; }
@@ -783,14 +806,13 @@ namespace GraphQL.Execution
     }
     public class NullExecutionNode : GraphQL.Execution.ExecutionNode
     {
-        public NullExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public NullExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Compilation.CompiledField compiled, int? indexInParentNode) { }
         public override object ToValue() { }
     }
     public class ObjectExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {
-        public ObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Compilation.CompiledField compiled, int? indexInParentNode) { }
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ExecutionNode> SubFields { get; set; }
-        public GraphQL.Types.IObjectGraphType GetObjectGraphType(GraphQL.Types.ISchema schema) { }
         public override object ToValue() { }
     }
     public class ParallelExecutionStrategy : GraphQL.Execution.ExecutionStrategy
@@ -835,7 +857,7 @@ namespace GraphQL.Execution
     }
     public class ValueExecutionNode : GraphQL.Execution.ExecutionNode
     {
-        public ValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.ScalarGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
+        public ValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.ScalarGraphType graphType, GraphQL.Compilation.CompiledField compiled, int? indexInParentNode) { }
         public GraphQL.Types.ScalarGraphType GraphType { get; }
         public override object ToValue() { }
     }

--- a/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
@@ -45,11 +45,10 @@ namespace GraphQL.Tests.Execution
             var node = new ValueExecutionNode(
                 new RootExecutionNode(objectGraphType),
                 new StringGraphType(),
-                new CompiledField
-                {
-                    Definition = objectGraphType.GetField("value"),
-                    Field = new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name"))
-                },
+                new CompiledField(
+                    objectGraphType.GetField("value"),
+                    new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name"))
+                ),
                 indexInParentNode: null);
 
             var path = node.Path.ToList();
@@ -64,11 +63,10 @@ namespace GraphQL.Tests.Execution
             var node = new ValueExecutionNode(
                 new RootExecutionNode(objectGraphType),
                 new StringGraphType(),
-                new CompiledField
-                {
-                    Definition = objectGraphType.GetField("value"),
-                    Field = new AST.Field(null, new AST.NameNode("name"))
-                },
+                new CompiledField(
+                    objectGraphType.GetField("value"),
+                    new AST.Field(null, new AST.NameNode("name"))
+                ),
                 indexInParentNode: null);
 
             var path = node.Path.ToList();
@@ -83,11 +81,10 @@ namespace GraphQL.Tests.Execution
             var node = new ValueExecutionNode(
                 new RootExecutionNode(objectGraphType),
                 new StringGraphType(),
-                new CompiledField
-                {
-                    Definition = objectGraphType.GetField("value"),
-                    Field = new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name"))
-                },
+                new CompiledField(
+                    objectGraphType.GetField("value"),
+                    new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name"))
+                ),
                 indexInParentNode: null);
 
             var path = node.ResponsePath.ToList();
@@ -102,11 +99,10 @@ namespace GraphQL.Tests.Execution
             var node = new ValueExecutionNode(
                 new RootExecutionNode(objectGraphType),
                 new StringGraphType(),
-                new CompiledField
-                {
-                    Definition = objectGraphType.GetField("value"),
-                    Field = new AST.Field(null, new AST.NameNode("name"))
-                },
+                new CompiledField(
+                    objectGraphType.GetField("value"),
+                    new AST.Field(null, new AST.NameNode("name"))
+                ),
                 indexInParentNode: null);
 
             var path = node.ResponsePath.ToList();

--- a/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using GraphQL.Compilation;
 using GraphQL.Execution;
 using GraphQL.Types;
 using Shouldly;
@@ -44,8 +45,11 @@ namespace GraphQL.Tests.Execution
             var node = new ValueExecutionNode(
                 new RootExecutionNode(objectGraphType),
                 new StringGraphType(),
-                new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name")),
-                objectGraphType.GetField("value"),
+                new CompiledField
+                {
+                    Definition = objectGraphType.GetField("value"),
+                    Field = new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name"))
+                },
                 indexInParentNode: null);
 
             var path = node.Path.ToList();
@@ -60,8 +64,11 @@ namespace GraphQL.Tests.Execution
             var node = new ValueExecutionNode(
                 new RootExecutionNode(objectGraphType),
                 new StringGraphType(),
-                new AST.Field(null, new AST.NameNode("name")),
-                objectGraphType.GetField("value"),
+                new CompiledField
+                {
+                    Definition = objectGraphType.GetField("value"),
+                    Field = new AST.Field(null, new AST.NameNode("name"))
+                },
                 indexInParentNode: null);
 
             var path = node.Path.ToList();
@@ -76,8 +83,11 @@ namespace GraphQL.Tests.Execution
             var node = new ValueExecutionNode(
                 new RootExecutionNode(objectGraphType),
                 new StringGraphType(),
-                new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name")),
-                objectGraphType.GetField("value"),
+                new CompiledField
+                {
+                    Definition = objectGraphType.GetField("value"),
+                    Field = new AST.Field(new AST.NameNode("alias"), new AST.NameNode("name"))
+                },
                 indexInParentNode: null);
 
             var path = node.ResponsePath.ToList();
@@ -92,8 +102,11 @@ namespace GraphQL.Tests.Execution
             var node = new ValueExecutionNode(
                 new RootExecutionNode(objectGraphType),
                 new StringGraphType(),
-                new AST.Field(null, new AST.NameNode("name")),
-                objectGraphType.GetField("value"),
+                new CompiledField
+                {
+                    Definition = objectGraphType.GetField("value"),
+                    Field = new AST.Field(null, new AST.NameNode("name"))
+                },
                 indexInParentNode: null);
 
             var path = node.ResponsePath.ToList();

--- a/src/GraphQL.Tests/Execution/RepeatedSubfieldsTest.cs
+++ b/src/GraphQL.Tests/Execution/RepeatedSubfieldsTest.cs
@@ -1,3 +1,4 @@
+using GraphQL.Compilation;
 using GraphQL.Execution;
 using GraphQL.Language.AST;
 using GraphQL.Types;
@@ -40,7 +41,7 @@ namespace GraphQL.Tests.Execution
             outerSelection.Add(FirstTestField);
             outerSelection.Add(SecondTestField);
 
-            var fields = ExecutionHelper.CollectFields(new ExecutionContext(), null, outerSelection);
+            var fields = QueryCompilation.CollectFields(new Schema(), new Variables(), new Document(), null, outerSelection);
 
             fields.ContainsKey("test").ShouldBeTrue();
             fields["test"].SelectionSet.Selections.ShouldContain(x => x.IsEqualTo(FirstInnerField));
@@ -54,7 +55,7 @@ namespace GraphQL.Tests.Execution
             outerSelection.Add(FirstTestField);
             outerSelection.Add(AliasedTestField);
 
-            var fields = ExecutionHelper.CollectFields(new ExecutionContext(), null, outerSelection);
+            var fields = QueryCompilation.CollectFields(new Schema(), new Variables(), new Document(), null, outerSelection);
 
             fields["test"].SelectionSet.Selections.ShouldHaveSingleItem();
             fields["test"].SelectionSet.Selections.ShouldContain(x => x.IsEqualTo(FirstInnerField));
@@ -73,23 +74,21 @@ namespace GraphQL.Tests.Execution
                 new NameNode("Person"));
 
             var fragments = new Fragments { fragment };
+            var document = new Document();
+            document.AddDefinition(fragment);
 
             var schema = new Schema();
             schema.RegisterType(new PersonType());
-
-            var context = new ExecutionContext
-            {
-                Fragments = fragments,
-                Schema = schema
-            };
 
             var fragSpread = new FragmentSpread(new NameNode("fragment"));
             var outerSelection = new SelectionSet();
             outerSelection.Add(fragSpread);
             outerSelection.Add(SecondTestField);
 
-            var fields = ExecutionHelper.CollectFields(
-                context,
+            var fields = QueryCompilation.CollectFields(
+                schema,
+                new Variables(),
+                document,
                 new PersonType(),
                 outerSelection);
 

--- a/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
@@ -90,7 +90,6 @@ type User @key(fields: ""id"") {
         }
 
         [Theory]
-        [InlineData("...on User { id }", false)]
         [InlineData("__typename ...on User { id }", false)]
         [InlineData("...on User { __typename id }", false)]
         [InlineData("...on User { ...TypeAndId }", true)]

--- a/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
@@ -78,7 +78,7 @@ type User @key(fields: ""id"") {
                 }";
 
             var variables = @"{ ""_representations"": [{ ""__typename"": ""User"", ""id"": ""123"" }] }";
-            var expected = @"{ ""_entities"": [{ ""__typename"": ""User"", ""id"" : ""123"", ""username"": ""Quinn"" }] }";
+            var expected = @"{ ""_entities"": [{ ""id"" : ""123"", ""username"": ""Quinn"" }] }";
 
             AssertQuery(_ =>
             {
@@ -221,7 +221,7 @@ type User @key(fields: ""id"") {
                     }
                 }";
 
-            var expected = @"{ ""_entities"": [{ ""__typename"": ""User"", ""id"" : ""1"", ""username"": ""One"" }, { ""__typename"": ""User"", ""id"" : ""2"", ""username"": ""Two"" }] }";
+            var expected = @"{ ""_entities"": [{ ""id"" : ""1"", ""username"": ""One"" }, { ""id"" : ""2"", ""username"": ""Two"" }] }";
 
             AssertQuery(_ =>
             {

--- a/src/GraphQL/Compilation/Compilation.cs
+++ b/src/GraphQL/Compilation/Compilation.cs
@@ -44,7 +44,7 @@ namespace GraphQL.Compilation
             return new CompiledField(definition, value, resolve);
         }
 
-        private static Func<object, bool, CompiledNode>? GetResolve(ISchema schema, Document document, Variables variables, FieldType definition,Field field)
+        private static Func<object, bool, CompiledNode> GetResolve(ISchema schema, Document document, Variables variables, FieldType definition,Field field)
         {
             var unwrapped = definition?.ResolvedType;
             while(unwrapped is IProvideResolvedType provideResolvedType)

--- a/src/GraphQL/Compilation/Compilation.cs
+++ b/src/GraphQL/Compilation/Compilation.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GraphQL.Execution;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+
+namespace GraphQL.Compilation
+{
+    public class QueryCompilation
+    {
+        public static CompiledNode Compile(ISchema schema, Document document, Variables variables, Operation operation)
+        {
+            var rootOperationType = GetOperationRootType(document, schema, operation);
+            var fields = CollectFieldsRecursive(schema, document, variables, operation.SelectionSet, rootOperationType);
+            var rootNode = new CompiledNode(rootOperationType, fields);
+            return rootNode;
+        }
+
+        private static Dictionary<string, CompiledField> CollectFieldsRecursive(ISchema schema, Document document, Variables variables, SelectionSet selectionSet, IObjectGraphType rootOperationType)
+        {
+            var fields = new Dictionary<string, CompiledField>();
+            var collected = CollectFields(schema, variables, document, rootOperationType, selectionSet);
+            foreach (var kv in collected)
+            {
+                var field = CompileFieldRecursive(schema, document, variables, rootOperationType, kv.Value);
+                fields.Add(kv.Key, field);
+            }
+
+            return fields;
+        }
+
+        private static CompiledField CompileFieldRecursive(ISchema schema, Document document, Variables variables, IObjectGraphType graphType, Field value)
+        {
+            var definition = GetFieldDefinition(schema, graphType, value);
+            var resolve = GetResolve(schema, document, variables,  definition, value);
+            var field = new CompiledField
+            {
+                Field = value,
+                Definition = definition,
+                Resolve = resolve
+            };
+
+            return field;
+        }
+
+        private static Func<object, bool, CompiledNode>? GetResolve(ISchema schema, Document document, Variables variables, FieldType definition,Field field)
+        {
+            var unwrapped = definition?.ResolvedType;
+            while(unwrapped is IProvideResolvedType provideResolvedType)
+            {
+                unwrapped = provideResolvedType.ResolvedType;
+            }
+            switch (unwrapped)
+            {
+                case IAbstractGraphType abstractType:
+                {
+                    var gqlToNode = new Dictionary<IObjectGraphType, CompiledNode>();
+                    foreach (var possilbe in abstractType.PossibleTypes)
+                    {
+                        var fields = CollectFieldsRecursive(schema, document, variables, field.SelectionSet, possilbe);
+                        var rootNode = new CompiledNode(possilbe, fields);
+                        gqlToNode.Add(possilbe, rootNode);
+                    }
+                    var defaultType = new CompiledNode(abstractType, new Dictionary<string, CompiledField>());
+                    //if(gqlToNode.Count == 1)
+                    //{
+                    //    var type = gqlToNode.Values.Single();
+                    //    return (value, isResolved) => type;
+                    //}
+                    return (value, isResolved) =>
+                    {
+                        var objType = abstractType.GetObjectType(value, schema);
+                        return objType is { } && gqlToNode.TryGetValue(objType, out var foundType)
+                            ? foundType
+                            : defaultType;
+                    };
+                }
+                case IObjectGraphType objectType:
+                {
+                    var fields = CollectFieldsRecursive(schema, document, variables, field.SelectionSet, objectType);
+                    var rootNode = new CompiledNode(objectType, fields);
+                    return (value, isResolved) => rootNode;
+                }
+                case ScalarGraphType scalar:
+                default:
+                    return null;
+            }
+            
+        }
+
+        /// <summary>
+        /// Returns the root graph type for the execution -- for a specified schema and operation type.
+        /// </summary>
+        public static IObjectGraphType GetOperationRootType(Document document, ISchema schema, Operation operation)
+        {
+            IObjectGraphType type;
+
+            ExecutionError error;
+
+            switch (operation.OperationType)
+            {
+                case OperationType.Query:
+                    type = schema.Query;
+                    break;
+
+                case OperationType.Mutation:
+                    type = schema.Mutation;
+                    if (type == null)
+                    {
+                        error = new InvalidOperationError("Schema is not configured for mutations");
+                        error.AddLocation(operation, document);
+                        throw error;
+                    }
+                    break;
+
+                case OperationType.Subscription:
+                    type = schema.Subscription;
+                    if (type == null)
+                    {
+                        error = new InvalidOperationError("Schema is not configured for subscriptions");
+                        error.AddLocation(operation, document);
+                        throw error;
+                    }
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(operation), "Can only execute queries, mutations and subscriptions.");
+            }
+
+            return type;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="FieldType"/> for the specified AST <see cref="Field"/> within a specified parent
+        /// output graph type within a given schema. For meta-fields, returns the proper meta-field field type.
+        /// </summary>
+        public static FieldType GetFieldDefinition(ISchema schema, IObjectGraphType parentType, Field field)
+        {
+            if (field.Name == schema.SchemaMetaFieldType.Name && schema.Query == parentType)
+            {
+                return schema.SchemaMetaFieldType;
+            }
+            if (field.Name == schema.TypeMetaFieldType.Name && schema.Query == parentType)
+            {
+                return schema.TypeMetaFieldType;
+            }
+            if (field.Name == schema.TypeNameMetaFieldType.Name)
+            {
+                return schema.TypeNameMetaFieldType;
+            }
+
+            if (parentType == null)
+            {
+                throw new ArgumentNullException(nameof(parentType), $"Schema is not configured correctly to fetch field '{field.Name}'. Are you missing a root type?");
+            }
+
+            return parentType.GetField(field.Name);
+        }
+
+
+        private static Fields CollectFields(
+            ISchema schema,
+            Variables variables,
+            Document document,
+            IGraphType specificType,
+            SelectionSet selectionSet,
+            Fields fields,
+            List<string> visitedFragmentNames)
+        {
+            if (selectionSet != null)
+            {
+                foreach (var selection in selectionSet.SelectionsList)
+                {
+                    if (selection is Field field)
+                    {
+                        if (!ShouldIncludeNode(schema, variables, field.Directives))
+                        {
+                            continue;
+                        }
+
+                        fields.Add(field);
+                    }
+                    else if (selection is FragmentSpread spread)
+                    {
+                        if (visitedFragmentNames.Contains(spread.Name)
+                            || !ShouldIncludeNode(schema, variables, spread.Directives))
+                        {
+                            continue;
+                        }
+                        visitedFragmentNames.Add(spread.Name);
+
+                        var fragment = document.Fragments.FindDefinition(spread.Name);
+                        if (fragment == null
+                            || !ShouldIncludeNode(schema, variables, fragment.Directives)
+                            || !DoesFragmentConditionMatch(schema, fragment.Type.Name, specificType))
+                        {
+                            continue;
+                        }
+
+                        CollectFields(schema, variables, document, specificType, fragment.SelectionSet, fields, visitedFragmentNames);
+                    }
+                    else if (selection is InlineFragment inline)
+                    {
+                        var name = inline.Type != null ? inline.Type.Name : specificType.Name;
+
+                        if (!ShouldIncludeNode(schema, variables, inline.Directives)
+                          || !DoesFragmentConditionMatch(schema, name, specificType))
+                        {
+                            continue;
+                        }
+
+                        CollectFields(schema, variables, document, specificType, inline.SelectionSet, fields, visitedFragmentNames);
+                    }
+                }
+            }
+
+            return fields;
+        }
+        
+        /// <summary>
+        /// Before execution, the selection set is converted to a grouped field set by calling CollectFields().
+        /// Each entry in the grouped field set is a list of fields that share a response key (the alias if defined,
+        /// otherwise the field name). This ensures all fields with the same response key included via referenced
+        /// fragments are executed at the same time.
+        /// <br/><br/>
+        /// See http://spec.graphql.org/June2018/#sec-Field-Collection and http://spec.graphql.org/June2018/#CollectFields()
+        /// </summary>
+        public static Dictionary<string, Field> CollectFields(
+            ISchema schema,
+            Variables variables,
+            Document document,
+            IGraphType specificType,
+            SelectionSet selectionSet)
+        {
+            return CollectFields(schema, variables, document,  specificType, selectionSet, Fields.Empty(), new List<string>());
+        }
+
+        /// <summary>
+        /// Examines @skip and @include directives for a node and returns a value indicating if the node should be included or not.
+        /// <br/><br/>
+        /// Note: Neither @skip nor @include has precedence over the other. In the case that both the @skip and @include
+        /// directives are provided on the same field or fragment, it must be queried only if the @skip condition
+        /// is false and the @include condition is true. Stated conversely, the field or fragment must not be queried
+        /// if either the @skip condition is true or the @include condition is false.
+        /// </summary>
+        public static bool ShouldIncludeNode(ISchema schema, Variables variables, Directives directives)
+        {
+            if (directives != null)
+            {
+                var directive = directives.Find(DirectiveGraphType.Skip.Name);
+                if (directive != null)
+                {
+                    var values = ExecutionHelper.GetArgumentValues(
+                        schema,
+                        DirectiveGraphType.Skip.Arguments,
+                        directive.Arguments,
+                        variables);
+
+                    if (values.TryGetValue("if", out object ifObj) && bool.TryParse(ifObj?.ToString() ?? string.Empty, out bool ifVal) && ifVal)
+                        return false;
+                }
+
+                directive = directives.Find(DirectiveGraphType.Include.Name);
+                if (directive != null)
+                {
+                    var values = ExecutionHelper.GetArgumentValues(
+                        schema,
+                        DirectiveGraphType.Include.Arguments,
+                        directive.Arguments,
+                        variables);
+
+                    return values.TryGetValue("if", out object ifObj) && bool.TryParse(ifObj?.ToString() ?? string.Empty, out bool ifVal) && ifVal;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// This method calculates the criterion for matching fragment definition (spread or inline) to a given graph type.
+        /// This criterion determines the need to fill the resulting selection set with fields from such a fragment.
+        /// <br/><br/>
+        /// See http://spec.graphql.org/June2018/#DoesFragmentTypeApply()
+        /// </summary>
+        public static bool DoesFragmentConditionMatch(ISchema schema, string fragmentName, IGraphType type)
+        {
+            if (string.IsNullOrWhiteSpace(fragmentName))
+            {
+                return true;
+            }
+
+            var conditionalType = schema.FindType(fragmentName);
+
+            if (conditionalType == null)
+            {
+                return false;
+            }
+
+            if (conditionalType.Equals(type))
+            {
+                return true;
+            }
+
+            if (conditionalType is IAbstractGraphType abstractType)
+            {
+                return abstractType.IsPossibleType(type);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/GraphQL/Compilation/Compilation.cs
+++ b/src/GraphQL/Compilation/Compilation.cs
@@ -18,7 +18,12 @@ namespace GraphQL.Compilation
             return rootNode;
         }
 
-        private static Dictionary<string, CompiledField> CollectFieldsRecursive(ISchema schema, Document document, Variables variables, SelectionSet selectionSet, IObjectGraphType rootOperationType)
+        private static Dictionary<string, CompiledField> CollectFieldsRecursive(
+            ISchema schema,
+            Document document,
+            Variables variables,
+            SelectionSet selectionSet,
+            IObjectGraphType rootOperationType)
         {
             var fields = new Dictionary<string, CompiledField>();
             var collected = CollectFields(schema, variables, document, rootOperationType, selectionSet);
@@ -35,14 +40,8 @@ namespace GraphQL.Compilation
         {
             var definition = GetFieldDefinition(schema, graphType, value);
             var resolve = GetResolve(schema, document, variables,  definition, value);
-            var field = new CompiledField
-            {
-                Field = value,
-                Definition = definition,
-                Resolve = resolve
-            };
 
-            return field;
+            return new CompiledField(definition, value, resolve);
         }
 
         private static Func<object, bool, CompiledNode>? GetResolve(ISchema schema, Document document, Variables variables, FieldType definition,Field field)
@@ -64,11 +63,7 @@ namespace GraphQL.Compilation
                         gqlToNode.Add(possilbe, rootNode);
                     }
                     var defaultType = new CompiledNode(abstractType, new Dictionary<string, CompiledField>());
-                    //if(gqlToNode.Count == 1)
-                    //{
-                    //    var type = gqlToNode.Values.Single();
-                    //    return (value, isResolved) => type;
-                    //}
+
                     return (value, isResolved) =>
                     {
                         var objType = abstractType.GetObjectType(value, schema);
@@ -81,6 +76,7 @@ namespace GraphQL.Compilation
                 {
                     var fields = CollectFieldsRecursive(schema, document, variables, field.SelectionSet, objectType);
                     var rootNode = new CompiledNode(objectType, fields);
+
                     return (value, isResolved) => rootNode;
                 }
                 case ScalarGraphType scalar:

--- a/src/GraphQL/Compilation/CompiledField.cs
+++ b/src/GraphQL/Compilation/CompiledField.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+
+namespace GraphQL.Compilation
+{
+    public class CompiledField
+    {
+        public FieldType Definition { get; set; }
+        public Field Field { get; set; }
+
+        internal Func<object, bool, CompiledNode> Resolve { get; set; }
+        //{
+        //    var GraphType = Definition.ResolvedType;
+        //    var objectGraphType = GraphType as IObjectGraphType;
+
+        //    if (GraphType is IAbstractGraphType abstractGraphType && isResultSet)
+        //        objectGraphType = abstractGraphType.GetObjectType(result, Schema);
+
+        //    return new CompiledNode(objectGraphType, new Dictionary<string, CompiledField>());
+        //}
+    }
+}

--- a/src/GraphQL/Compilation/CompiledField.cs
+++ b/src/GraphQL/Compilation/CompiledField.cs
@@ -8,18 +8,15 @@ namespace GraphQL.Compilation
 {
     public class CompiledField
     {
-        public FieldType Definition { get; set; }
-        public Field Field { get; set; }
+        public FieldType Definition { get; }
+        public Field Field { get; }
+        public Func<object, bool, CompiledNode> Resolve { get; }
 
-        internal Func<object, bool, CompiledNode> Resolve { get; set; }
-        //{
-        //    var GraphType = Definition.ResolvedType;
-        //    var objectGraphType = GraphType as IObjectGraphType;
-
-        //    if (GraphType is IAbstractGraphType abstractGraphType && isResultSet)
-        //        objectGraphType = abstractGraphType.GetObjectType(result, Schema);
-
-        //    return new CompiledNode(objectGraphType, new Dictionary<string, CompiledField>());
-        //}
+        public CompiledField(FieldType definition, Field field, Func<object, bool, CompiledNode> resolve)
+        {
+            Definition = definition;
+            Field = field;
+            Resolve = resolve;
+        }
     }
 }

--- a/src/GraphQL/Compilation/CompiledField.cs
+++ b/src/GraphQL/Compilation/CompiledField.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Compilation
         public Field Field { get; }
         public Func<object, bool, CompiledNode> Resolve { get; }
 
-        public CompiledField(FieldType definition, Field field, Func<object, bool, CompiledNode> resolve)
+        public CompiledField(FieldType definition, Field field, Func<object, bool, CompiledNode> resolve = null)
         {
             Definition = definition;
             Field = field;

--- a/src/GraphQL/Compilation/CompiledNode.cs
+++ b/src/GraphQL/Compilation/CompiledNode.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using GraphQL.Types;
+
+namespace GraphQL.Compilation
+{
+    public class CompiledNode
+    {
+        public CompiledNode(IGraphType graphType, Dictionary<string, CompiledField> fields)
+        {
+            GraphType = graphType;
+            Fields = fields;
+        }
+
+        public Dictionary<string, CompiledField> Fields { get; }
+        public IGraphType GraphType { get; }
+    }
+}

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GraphQL.Compilation;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
@@ -305,6 +306,9 @@ namespace GraphQL
             int? maxParallelExecutionCount,
             IServiceProvider requestServices)
         {
+            var variables = inputs == null ? null : GetVariableValues(document, schema, operation?.Variables, inputs);
+            var compiled = QueryCompilation.Compile(schema, document, variables, operation);
+                
             var context = new ExecutionContext
             {
                 Document = document,
@@ -313,8 +317,9 @@ namespace GraphQL
                 UserContext = userContext,
 
                 Operation = operation,
-                Variables = inputs == null ? null : GetVariableValues(document, schema, operation?.Variables, inputs),
+                Variables = variables,
                 Fragments = document.Fragments,
+                CompiledRootNode = compiled,
                 CancellationToken = cancellationToken,
 
                 Metrics = metrics,

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using GraphQL.Compilation;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using GraphQL.Types;
@@ -59,5 +60,7 @@ namespace GraphQL.Execution
 
         /// <inheritdoc/>
         public IServiceProvider RequestServices { get; set; }
+
+        public CompiledNode CompiledRootNode { get; set; }
     }
 }

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -61,6 +61,7 @@ namespace GraphQL.Execution
         /// <inheritdoc/>
         public IServiceProvider RequestServices { get; set; }
 
+        /// <inheritdoc/>
         public CompiledNode CompiledRootNode { get; set; }
     }
 }

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -34,6 +34,8 @@ namespace GraphQL.Execution
         /// </summary>
         public FieldType FieldDefinition => CompiledField.Definition;
 
+        public CompiledField CompiledField { get; }
+
         /// <summary>
         /// Returns performance optimized field of this node.
         /// </summary>

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQL.Compilation;
 using GraphQL.DataLoader;
 using GraphQL.Language.AST;
 using GraphQL.Types;
@@ -26,12 +27,17 @@ namespace GraphQL.Execution
         /// <summary>
         /// Returns the AST field of this node.
         /// </summary>
-        public Field Field { get; }
+        public Field Field  => CompiledField.Field;
 
         /// <summary>
         /// Returns the graph's field type of this node.
         /// </summary>
-        public FieldType FieldDefinition { get; }
+        public FieldType FieldDefinition => CompiledField.Definition;
+
+        /// <summary>
+        /// Returns performance optimized field of this node.
+        /// </summary>
+        public CompiledField CompiledField { get; set; }
 
         /// <summary>
         /// For child array item nodes of a <see cref="ListGraphType"/>, returns the index of this array item within the field; otherwise, null.
@@ -99,15 +105,15 @@ namespace GraphQL.Execution
         /// </summary>
         /// <param name="parent">The parent node, or null if this is the root node</param>
         /// <param name="graphType">The graph type of this node, unwrapped if it is a <see cref="NonNullGraphType"/>. Array nodes will be a <see cref="ListGraphType"/> instance.</param>
-        /// <param name="field">The AST field of this node</param>
-        /// <param name="fieldDefinition">The graph's field type of this node</param>
+        /// <param name="compiled">The optimized compiled field of this node</param>
         /// <param name="indexInParentNode">For child array item nodes of a <see cref="ListGraphType"/>, the index of this array item within the field; otherwise, null</param>
-        protected ExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
+        protected ExecutionNode(ExecutionNode parent, IGraphType graphType, CompiledField compiled, int? indexInParentNode)
         {
             Parent = parent;
             GraphType = graphType;
-            Field = field;
-            FieldDefinition = fieldDefinition;
+            //Field = field;
+            //FieldDefinition = fieldDefinition;
+            CompiledField = compiled;
             IndexInParentNode = indexInParentNode;
         }
 
@@ -232,24 +238,9 @@ namespace GraphQL.Execution
         /// <summary>
         /// Initializes an instance of <see cref="ObjectExecutionNode"/> with the specified values.
         /// </summary>
-        public ObjectExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+        public ObjectExecutionNode(ExecutionNode parent, IGraphType graphType, CompiledField compiled, int? indexInParentNode)
+            : base(parent, graphType, compiled, indexInParentNode)
         {
-        }
-
-        /// <summary>
-        /// For execution nodes that represent a field that is an <see cref="IAbstractGraphType"/>, returns the
-        /// proper <see cref="IObjectGraphType"/> based on the set <see cref="ExecutionNode.Result"/>.
-        /// Otherwise returns the value of <see cref="ExecutionNode.GraphType"/>.
-        /// </summary>
-        public IObjectGraphType GetObjectGraphType(ISchema schema)
-        {
-            var objectGraphType = GraphType as IObjectGraphType;
-
-            if (GraphType is IAbstractGraphType abstractGraphType && IsResultSet)
-                objectGraphType = abstractGraphType.GetObjectType(Result, schema);
-
-            return objectGraphType;
         }
 
         /// <summary>
@@ -293,7 +284,7 @@ namespace GraphQL.Execution
         /// Initializes a new instance for the specified root graph type.
         /// </summary>
         public RootExecutionNode(IObjectGraphType graphType)
-            : base(null, graphType, null, null, null)
+            : base(null, graphType, null, null)
         {
 
         }
@@ -312,8 +303,8 @@ namespace GraphQL.Execution
         /// <summary>
         /// Initializes an <see cref="ArrayExecutionNode"/> instance with the specified values.
         /// </summary>
-        public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+        public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, CompiledField compiled, int? indexInParentNode)
+            : base(parent, graphType, compiled, indexInParentNode)
         {
 
         }
@@ -363,8 +354,8 @@ namespace GraphQL.Execution
         /// <summary>
         /// Initializes an instance of <see cref="ValueExecutionNode"/> with the specified values.
         /// </summary>
-        public ValueExecutionNode(ExecutionNode parent, ScalarGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+        public ValueExecutionNode(ExecutionNode parent, ScalarGraphType graphType, CompiledField compiled, int? indexInParentNode)
+            : base(parent, graphType, compiled, indexInParentNode)
         {
 
         }
@@ -391,8 +382,8 @@ namespace GraphQL.Execution
         /// <summary>
         /// Initializes an instance of <see cref="NullExecutionNode"/> with the specified values.
         /// </summary>
-        public NullExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+        public NullExecutionNode(ExecutionNode parent, IGraphType graphType, CompiledField compiled, int? indexInParentNode)
+            : base(parent, graphType, compiled, indexInParentNode)
         {
             Result = null;
         }

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -34,8 +34,6 @@ namespace GraphQL.Execution
         /// </summary>
         public FieldType FieldDefinition => CompiledField.Definition;
 
-        public CompiledField CompiledField { get; }
-
         /// <summary>
         /// Returns performance optimized field of this node.
         /// </summary>

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -127,16 +127,19 @@ namespace GraphQL.Execution
 
                     if (!(d is IDataLoaderResult))
                     {
-                        SetSubFieldNodes(objectNode);
-                    }
-                    else if (node is ArrayExecutionNode arrayNode)
-                    {
-                        SetArrayItemNodes(arrayNode);
-                    }
-                    else if (node is ValueExecutionNode valueNode)
-                    {
-                        node.Result = valueNode.GraphType.Serialize(d)
-                            ?? throw new InvalidOperationException($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}' for list index {index}.");
+                        if (node is ObjectExecutionNode objectNode)
+                        {
+                            SetSubFieldNodes(objectNode);
+                        }
+                        else if (node is ArrayExecutionNode arrayNode)
+                        {
+                            SetArrayItemNodes(arrayNode);
+                        }
+                        else if (node is ValueExecutionNode valueNode)
+                        {
+                            node.Result = valueNode.GraphType.Serialize(d)
+                                ?? throw new InvalidOperationException($"Unable to serialize '{d}' to '{valueNode.GraphType.Name}' for list index {index}.");
+                        }
                     }
 
                     arrayItems.Add(node);

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -96,42 +96,6 @@ namespace GraphQL.Execution
              SetSubFieldNodes(parent, compiledNode.Fields);
         }
 
-        //public static void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent)
-        //{
-        //    var fields = CollectFields(context, parent.GetObjectGraphType(context.Schema), parent.Field?.SelectionSet);
-        //    SetSubFieldNodes(context, parent, fields);
-        //}
-
-        //public static void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent, Dictionary<string, Field> fields)
-        //{
-        //    var parentType = parent.GetObjectGraphType(context.Schema);
-
-        //    var subFields = new Dictionary<string, ExecutionNode>(fields.Count);
-
-        //    foreach (var kvp in fields)
-        //    {
-        //        var name = kvp.Key;
-        //        var field = kvp.Value;
-
-        //        if (!ShouldIncludeNode(context, field.Directives))
-        //            continue;
-
-        //        var fieldDefinition = GetFieldDefinition(context.Schema, parentType, field);
-
-        //        if (fieldDefinition == null)
-        //            continue;
-
-        //        var node = BuildExecutionNode(parent, fieldDefinition.ResolvedType, field, fieldDefinition);
-
-        //        if (node == null)
-        //            continue;
-
-        //        subFields[name] = node;
-        //    }
-
-        //    parent.SubFields = subFields;
-        //}
-        
         /// <summary>
         /// Creates execution nodes for array elements of an array execution node. Only run if
         /// the array execution node result is not null.

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using GraphQL.Compilation;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using GraphQL.Types;
@@ -90,5 +91,11 @@ namespace GraphQL.Execution
         /// from your dependency injection framework.
         /// </summary>
         IServiceProvider RequestServices { get; }
+
+        /// <summary>
+        /// A performance-optimized preprocessed representation of <see cref="IResolveFieldContext.Document"/> tied with
+        /// <see cref="IResolveFieldContext"/> used for an actual query execution
+        /// </summary>
+        CompiledNode CompiledRootNode { get; set; }
     }
 }

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -13,8 +13,7 @@ namespace GraphQL.Execution
     {
         public override async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
         {
-            var rootType = GetOperationRootType(context.Document, context.Schema, context.Operation);
-            var rootNode = BuildExecutionRootNode(context, rootType);
+            var rootNode = BuildExecutionRootNode(context);
 
             var streams = await ExecuteSubscriptionNodesAsync(context, rootNode.SubFields).ConfigureAwait(false);
 
@@ -104,7 +103,7 @@ namespace GraphQL.Execution
                 return subscription
                     .Select(value =>
                     {
-                        var executionNode = BuildExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode);
+                        var executionNode = BuildExecutionNode(node.Parent, node.GraphType, node.CompiledField, node.IndexInParentNode);
                         executionNode.Source = value;
                         return executionNode;
                     })

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQL.Compilation;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;


### PR DESCRIPTION
### A little bit of context
I have an app with ~300 of graphql types and using graphql-dotnet and have a couple of places where there is heavy use of union types. I was looking for overall performance of app and noticed that there is big performance impact created by the library in case where a lot of data is returned. The schema is looking like following:
```graphql
 type Query {
    list(id: String!): List
 }
 type List {
        items(query: String, sortFields: [SortField],  groupByFields: [String], fieldKeys: [String]): [Item]
 }
 type Item {
        props:  [FieldValue]
        rights: Crud
 }
union FieldValue =
        NumberFieldValue
        | IntFieldValue
        | PercentageFieldValue
        | StringFieldValue
       """ 
       and 15+ more types like that 
       """
 
```

 It takes ~300ms to return a big table with 500 rows and 20 columns (~10k objects) whenever time spend in sql and app code that process it takes a 36ms and 30ms respectively, which is huge (5 times) difference compared to graphql-dotnet. The digging of code yielded couple of problems:

1. An internal graphql api `ISchema.FindType` and methods around it called too many times
2. Snowballing GC pressure

this pool requests fully addresses (1) and partially addresses (2) and making it easier to solve in future, but please keep in mind its a POC and names of newly added classes are far from being easy to understand 👼 and feedback on them is welcomed.

## Changes and idea behind them
Major objective of this rework was to make sure we prepare all fields and types before an actual request evaluation. It achieved by evaluating all selections sets for all possible (with regard to type system limitations) `IGraphType`s. 

In essence the code is reworked in a way that its 'evaluate' Document in current context of current Variables and Schema in order to produce data structure that is optimized for future repeated use by a `QueryCompilation` class. Also couple of methods that was used at ExecutionHelper moved to `QueryCompilation` because with exception of unit tests they havent being used anywhere else. The classes `CompiledField` and `CompiledNode` was added. `CompiledField` represents a ready-to-resolve object that have info about its original field. `CompiledNode` represents a `CompiledField` resolved for a specific field value type and have information about subfields. `QueryCompilation` is called right before context creation and creates a `CompiledField` for a root node. 

## Performance improvement evaluation
### CPU
The result of changes is substantial (~2.5x times) improvement in execution times , avoiding calling `ISchema.FindType` and relevant `lock()` and `Regex.Replace` each time we evaluate type of an object.

Here is analysis of running query 200x times under CPU profiler:
#### Before CPU
![before-cpu](https://user-images.githubusercontent.com/10799080/99656563-1a3e6d00-2a6e-11eb-9704-f1b92c0d98a9.png)
#### After CPU
![after-cpu](https://user-images.githubusercontent.com/10799080/99657119-c8e2ad80-2a6e-11eb-8113-ab111f1b688d.png)


### Memory & GC pressure
From a memory perspective you may see a noticeable reduction of live objects and substantial decreases of memory allocation of graphql internal objects. You also may have noticed that JIT_NEW from previous pictures looks like it takes more % of time (about 2 times) but since the query is running ~2.5x times faster it actually tells that allocations are slightly decreased. External code is most likely a GC time, so I'm planning to do another PR to solve issues with GC pressure specifically.

Here is analysis of allocation for running query 5x times (cant run more because running on space on NVME)
#### Before memory
![before-mem](https://user-images.githubusercontent.com/10799080/99656514-07c43380-2a6e-11eb-9493-85985611fdc6.png)
#### After memory
![after-mem](https://user-images.githubusercontent.com/10799080/99656547-11e63200-2a6e-11eb-898f-8848357dbf40.png)

## Tests
Since no new functionality was added, no new tests or documentation has being added

There are only some side changes to questionable unit tests for federation functionality which expects for federated query to return an `__typename` field which wasn't requested in query.

This PR is POC and me was having hard time giving stuff proper names so any feedback on class/members names is welcomed.