### PR TITLE
Fix schema first issue - custom scalar with default value as GraphQLTypeReference!

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.1.4-preview</VersionPrefix>
+    <VersionPrefix>3.1.5-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -55,7 +55,7 @@ namespace GraphQL.Types
             get => _defaultValue;
             set
             {
-                if (!(ResolvedType is GraphQLTypeReference))
+                if (!(ResolvedType?.GetNamedType() is GraphQLTypeReference))
                     _ = value.AstFromValue(null, ResolvedType); // HACK: https://github.com/graphql-dotnet/graphql-dotnet/issues/1795
 
                 _defaultValue = value;


### PR DESCRIPTION
```c#
 if (!(type is ScalarGraphType inputType))
                throw new ArgumentOutOfRangeException(nameof(type), $"Must provide Input Type, cannot use: {type}");
```
->
```
System.ArgumentOutOfRangeException: 'Must provide Input Type, cannot use: __GraphQLTypeReference '
```

on
```
 productId: Long! = 0
```

because of
```c#
 public object DefaultValue
        {
            get => _defaultValue;
            set
            {
                if (!(ResolvedType is GraphQLTypeReference))
                    _ = value.AstFromValue(null, ResolvedType); // HACK: https://github.com/graphql-dotnet/graphql-dotnet/issues/1795

                _defaultValue = value;
                _defaultValueAST = null;
            }
        }
```