### PR TITLE
Fix serialization of SubscriptionExecutionResult for System.Text.Json

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.SystemTextJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.SystemTextJson.approved.txt
@@ -15,6 +15,7 @@ namespace GraphQL.SystemTextJson
     public class ExecutionResultJsonConverter : System.Text.Json.Serialization.JsonConverter<GraphQL.ExecutionResult>
     {
         public ExecutionResultJsonConverter(GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
+        public override bool CanConvert(System.Type typeToConvert) { }
         public override GraphQL.ExecutionResult Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { }
         public override void Write(System.Text.Json.Utf8JsonWriter writer, GraphQL.ExecutionResult value, System.Text.Json.JsonSerializerOptions options) { }
     }

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
@@ -109,6 +109,6 @@ namespace GraphQL.NewtonsoftJson
 
         public override bool CanRead => false;
 
-        public override bool CanConvert(Type objectType) => objectType == typeof(ExecutionResult);
+        public override bool CanConvert(Type objectType) => typeof(ExecutionResult).IsAssignableFrom(objectType);
     }
 }

--- a/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
@@ -198,5 +198,7 @@ namespace GraphQL.SystemTextJson
 
         public override ExecutionResult Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             => throw new NotImplementedException();
+
+        public override bool CanConvert(Type typeToConvert) => typeof(ExecutionResult).IsAssignableFrom(typeToConvert);
     }
 }


### PR DESCRIPTION
To reproduce just throw exception in the first line of `ChatSubscriptions.cs`:
```c#
 private IObservable<Message> Subscribe(IResolveEventStreamContext context)
        {
            throw new Exception("test");           //  <----------------------------------------
            var messageContext = context.UserContext.As<MessageHandlingContext>();
            var user = messageContext.Get<ClaimsPrincipal>("user");

            string sub = "Anonymous";
            if (user != null)
                sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;

            return _chat.Messages(sub);
        }
```
and then query
```graphql
subscription
{
  messageAdded
  {
    content
  }
}
```
Result: 
```
System.Text.Json.JsonException: 'A possible object cycle was detected which is not supported. This can either be due to a cycle or if the object depth is larger than the maximum allowed depth of 0.'
```
at `JsonSerializer.Serialize(writer, message.Payload, options);` and GraphQL Playground hang

After fix:
```
{
  "error": {
    "message": "GraphQL.ExecutionError: Error trying to resolve field 'messageAdded'.\r\n ---> System.Exception: test\r\n   at GraphQL.Samples.Schemas.Chat.ChatSubscriptions.Subscribe(IResolveEventStreamContext context) in C:\\_GIT_\\GitHub\\server\\samples\\Samples.Schemas.Chat\\ChatSubscriptions.cs:line 63\r\n   at GraphQL.Resolvers.EventStreamResolver`1.Subscribe(IResolveEventStreamContext context) in C:\\_GIT_\\GitHub\\graphql-dotnet\\src\\GraphQL\\Resolvers\\EventStreamResolver.cs:line 18\r\n   at GraphQL.Resolvers.EventStreamResolver`1.GraphQL.Resolvers.IEventStreamResolver.Subscribe(IResolveEventStreamContext context) in C:\\_GIT_\\GitHub\\graphql-dotnet\\src\\GraphQL\\Resolvers\\EventStreamResolver.cs:line 20\r\n   at GraphQL.Execution.SubscriptionExecutionStrategy.ResolveEventStreamAsync(ExecutionContext context, ExecutionNode node) in C:\\_GIT_\\GitHub\\graphql-dotnet\\src\\GraphQL\\Execution\\SubscriptionExecutionStrategy.cs:line 93\r\n   --- End of inner exception stack trace ---",
    "locations": [
      {
        "line": 2,
        "column": 3
      }
    ],
    "path": [
      "messageAdded"
    ],
    "extensions": {
      "code": "",
      "codes": [
        ""
      ]
    }
  }
}
```

Also see #1623 , https://github.com/graphql-dotnet/server/pull/321