### PR TITLE
Retarget System.Text.Json to netcoreapp3.1

### DIFF
--- a/src/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
+++ b/src/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>exe</OutputType>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/GraphQL.StarWars/GraphQL.StarWars.csproj
+++ b/src/GraphQL.StarWars/GraphQL.StarWars.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 

--- a/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
+++ b/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <RootNamespace>GraphQL.SystemTextJson</RootNamespace>
     <Description>System.Text.Json serializer for GraphQL.NET</Description>
     <PackageTags>GraphQL;json</PackageTags>

--- a/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
@@ -5,11 +5,7 @@ namespace GraphQL.Tests.Bugs
 {
     public class Bug138DecimalPrecisionTests : QueryTestBase<DecimalSchema>
     {
-#if NETCOREAPP3_1
         [Fact]
-#else
-        [Fact(Skip = "Deserialization error with .NET Core < 3.1")]
-#endif
         public void double_to_decimal_does_not_lose_precision()
         {
             var query = @"

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>GraphQL for .NET</Description>
     <Authors>Joe McBride</Authors>
     <Copyright>Copyright 2015-2017 Joseph T. McBride et al. All rights reserved.</Copyright>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>GraphQL;json;api</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
```
Warning	NETSDK1138	The target framework 'netcoreapp3.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.	GraphQL.SystemTextJson	C:\Program Files\dotnet\sdk\5.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets	28	
```
![изображение](https://user-images.githubusercontent.com/21261007/101214417-0f4e2400-368d-11eb-8f2e-7327257ae26b.png)

I suggest that we just change the patch version. `GraphQL.SystemTextJson` is already multitargeted for `netstandard2.0` so even old clients (netcoreapp3.0 as well) can continue to consume its bits.