### PR TITLE
ISchema inherits IProvideMetadata

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,7 @@
   - src/GraphQL.Dummy/**/*
   - src/GraphQL.Harness.Tests/**/*
   - src/GraphQL.Tests/**/*
+  - '!src/GraphQL.ApiTests/**/*.txt'
 
 "CI":
   - .github/workflows/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@
   - src/GraphQL.Dummy/**/*
   - src/GraphQL.Harness.Tests/**/*
   - src/GraphQL.Tests/**/*
-  - '!src/GraphQL.ApiTests/**/*.txt'
+  - !src/GraphQL.ApiTests/**/*.txt
 
 "CI":
   - .github/workflows/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,5 @@
 "test":
-  - src/GraphQL.ApiTests/**/*
-  - src/GraphQL.DataLoader.Tests/**/*
-  - src/GraphQL.Dummy/**/*
-  - src/GraphQL.Harness.Tests/**/*
-  - src/GraphQL.Tests/**/*
-  - '!src/GraphQL.ApiTests/**/*.txt'
+  - any: ['src/GraphQL.ApiTests/**/*', 'src/GraphQL.DataLoader.Tests/**/*', 'src/GraphQL.Dummy/**/*', 'src/GraphQL.Harness.Tests/**/*', 'src/GraphQL.Tests/**/*', '!src/GraphQL.ApiTests/**/*.txt']
 
 "CI":
   - .github/workflows/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@
   - src/GraphQL.Dummy/**/*
   - src/GraphQL.Harness.Tests/**/*
   - src/GraphQL.Tests/**/*
-  - !src/GraphQL.ApiTests/**/*.txt
+  - '!src/GraphQL.ApiTests/**/*.txt'
 
 "CI":
   - .github/workflows/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,6 +12,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/docs2/site/docs/migrations/migration3.md
+++ b/docs2/site/docs/migrations/migration3.md
@@ -472,3 +472,8 @@ public class MyConverter : INameConverter
 The three introspection field definitions for `__schema`, `__type`, and `__typename` have moved from static properties on the `SchemaIntrospection` class
 to properties of the `ISchema` interface, typically provided by the `Schema` class. Custom implementations of `ISchema` must implement three new properties:
 `SchemaMetaFieldType`, `TypeMetaFieldType`, and `TypeNameMetaFieldType`. These can be provided by the `GraphTypesLookup` class.
+
+### `ISchema` now implements `IProvideMetadata` (only for GraphQL.NET >= v3.2.0)
+
+Formally it is a breaking change but practically clients shouldn't run into problems, as hardly anyone creates their own `ISchema` implementations preferring
+to inherit from `Schema` class. 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.1.7-preview</VersionPrefix>
+    <VersionPrefix>3.2.0-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
@@ -12,7 +12,7 @@ namespace GraphQL.NewtonsoftJson
         public DocumentWriter(bool indent, GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
         public System.Threading.Tasks.Task WriteAsync<T>(System.IO.Stream stream, T value, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    public class ExecutionResultContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver1
+    public class ExecutionResultContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver
     {
         public ExecutionResultContractResolver(GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
         protected override Newtonsoft.Json.Serialization.JsonProperty CreateProperty(System.Reflection.MemberInfo member, Newtonsoft.Json.MemberSerialization memberSerialization) { }

--- a/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
@@ -12,7 +12,7 @@ namespace GraphQL.NewtonsoftJson
         public DocumentWriter(bool indent, GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
         public System.Threading.Tasks.Task WriteAsync<T>(System.IO.Stream stream, T value, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    public class ExecutionResultContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver
+    public class ExecutionResultContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver1
     {
         public ExecutionResultContractResolver(GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
         protected override Newtonsoft.Json.Serialization.JsonProperty CreateProperty(System.Reflection.MemberInfo member, Newtonsoft.Json.MemberSerialization memberSerialization) { }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1987,7 +1987,7 @@ namespace GraphQL.Types
     {
         GraphQL.Types.IGraphType ResolvedType { get; }
     }
-    public interface ISchema
+    public interface ISchema : GraphQL.Types.IProvideMetadata
     {
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AllTypes { get; }
@@ -2143,7 +2143,7 @@ namespace GraphQL.Types
         public abstract object ParseValue(object value);
         public virtual object Serialize(object value) { }
     }
-    public class Schema : GraphQL.Utilities.MetadataProvider, GraphQL.Types.ISchema, System.IDisposable, System.IServiceProvider
+    public class Schema : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IProvideMetadata, GraphQL.Types.ISchema, System.IDisposable, System.IServiceProvider
     {
         public Schema() { }
         public Schema(System.IServiceProvider services) { }

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -278,6 +278,14 @@ namespace GraphQL
                 : null;
         }
 
+        /// <summary>
+        /// Adds a key-value metadata pair to the specified provider.
+        /// </summary>
+        /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to let compiler infer the returning type to allow methods chaining. </typeparam>
+        /// <param name="provider"> Metadata provider which must implement <see cref="IProvideMetadata"/> interface. </param>
+        /// <param name="key"> String key. </param>
+        /// <param name="value"> Arbitrary value. </param>
+        /// <returns> The reference to the specified <paramref name="provider"/>. </returns>
         public static TMetadataProvider WithMetadata<TMetadataProvider>(this TMetadataProvider provider, string key, object value)
             where TMetadataProvider : IProvideMetadata
         {

--- a/src/GraphQL/Types/IGraphType.cs
+++ b/src/GraphQL/Types/IGraphType.cs
@@ -1,4 +1,4 @@
-﻿namespace GraphQL.Types
+namespace GraphQL.Types
 {
     public interface INamedType
     {
@@ -8,6 +8,7 @@
     public interface IGraphType : IProvideMetadata, INamedType
     {
         string Description { get; set; }
+
         string DeprecationReason { get; set; }
 
         string CollectTypes(TypeCollectionContext context);

--- a/src/GraphQL/Types/IProvideMetadata.cs
+++ b/src/GraphQL/Types/IProvideMetadata.cs
@@ -3,11 +3,41 @@ using System.Collections.Generic;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// Provides basic capabilities for getting and setting arbitrary meta information.
+    /// This interface is implemented by numerous descendants like <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </summary>
     public interface IProvideMetadata
     {
+        /// <summary>
+        /// Provides all meta information as a key-value dictionary.
+        /// </summary>
         IDictionary<string, object> Metadata { get; }
+
+        /// <summary>
+        /// Gets a value by a given key. If there is no value for the given key, returns <paramref name="defaultValue"/>.
+        /// </summary>
+        /// <typeparam name="TType"> Type of the value. </typeparam>
+        /// <param name="key"> String key. </param>
+        /// <param name="defaultValue"> It is used if there is no value for the given key. </param>
+        /// <returns> Value of the specified type. </returns>
         TType GetMetadata<TType>(string key, TType defaultValue = default);
+
+        /// <summary>
+        /// Gets a value by a given key. If there is no value for the given key, returns value obtained from <paramref name="defaultValueFactory"/>.
+        /// </summary>
+        /// <typeparam name="TType"> Type of the value. </typeparam>
+        /// <param name="key"> String key. </param>
+        /// <param name="defaultValueFactory"> It is used if there is no value for the given key. </param>
+        /// <returns> Value of the specified type. </returns>
         TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory);
+
+        /// <summary>
+        /// Indicates whether there is meta information with the given key.
+        /// </summary>
+        /// <param name="key"> String key. </param>
+        /// <returns> <c>true</c> if value for such key exists, otherwise <c>false</c>. </returns>
         bool HasMetadata(string key);
     }
 }

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Types
     /// <br/><br/>
     /// <see cref="Schema"/> only requires the <see cref="Schema.Query">Query</see> property to be set; although commonly the <see cref="Schema.Mutation">Mutation</see> and/or <see cref="Schema.Subscription">Subscription</see> properties are also set.
     /// </summary>
-    public interface ISchema
+    public interface ISchema : IProvideMetadata
     {
         /// <summary>
         /// Returns true once the schema has been initialized.

--- a/src/GraphQL/Utilities/MetadataProvider.cs
+++ b/src/GraphQL/Utilities/MetadataProvider.cs
@@ -5,21 +5,30 @@ using GraphQL.Types;
 
 namespace GraphQL.Utilities
 {
+    /// <summary>
+    /// Default implementation of <see cref="IProvideMetadata"/>. This is the base class for numerous
+    /// descendants like <see cref="GraphType"/>, <see cref="FieldType"/>, <see cref="Schema"/> and others.
+    /// </summary>
     public class MetadataProvider : IProvideMetadata
     {
+        /// <inheritdoc />
         public IDictionary<string, object> Metadata { get; set; } = new ConcurrentDictionary<string, object>();
 
+        /// <inheritdoc />
         public TType GetMetadata<TType>(string key, TType defaultValue = default)
         {
-            return GetMetadata(key, () => defaultValue);
+            var local = Metadata;
+            return local != null && local.TryGetValue(key, out object item) ? (TType)item : defaultValue;
         }
 
+        /// <inheritdoc />
         public TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory)
         {
             var local = Metadata;
-            return local != null && local.TryGetValue(key, out var item) ? (TType)item : defaultValueFactory();
+            return local != null && local.TryGetValue(key, out object item) ? (TType)item : defaultValueFactory();
         }
 
+        /// <inheritdoc />
         public bool HasMetadata(string key) => Metadata?.ContainsKey(key) ?? false;
     }
 }


### PR DESCRIPTION
@Shane32 Formally it is breaking change since I added a new requirement to `ISchema`. But I don't know anymore if it's worth worrying about this kind of change and postponing it until the next major version. See https://github.com/graphql-dotnet/server/pull/470#issuecomment-739498710