### PR TITLE
Unify scalar conversions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.2.0-preview</VersionPrefix>
+    <VersionPrefix>3.2.1-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
+++ b/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
@@ -12,8 +12,11 @@ namespace GraphQL.Tests.Bugs
         {
             var query = @"
 mutation {
-  create(input: {id1:""8dfab389-a6f7-431d-ab4e-aa693cc53edf"", id2:""8dfab389-a6f7-431d-ab4e-aa693cc53ede"", uint: 3147483647, uintArray: [3147483640], short: -21000, shortArray: [20000] ushort: 61000, ushortArray: [65000], ulong: 4000000000000, ulongArray: [1234567890123456789], byte: 50, byteArray: [1,2,3], sbyte: -60, sbyteArray: [-1,2,-3], dec: 39614081257132168796771975168, decZero: 12.10, decArray: [1,39614081257132168796771975168,3] })
+  create(input: {float1: 1.3, floatFromInt: 1, id1:""8dfab389-a6f7-431d-ab4e-aa693cc53edf"", id2:""8dfab389-a6f7-431d-ab4e-aa693cc53ede"", uint: 3147483647, uintArray: [3147483640], short: -21000, shortArray: [20000] ushort: 61000, ushortArray: [65000], ulong: 4000000000000, ulongArray: [1234567890123456789], byte: 50, byteArray: [1,2,3], sbyte: -60, sbyteArray: [-1,2,-3], dec: 39614081257132168796771975168, decZero: 12.10, decArray: [1,39614081257132168796771975168,3] })
   {
+    float1
+    floatFromInt
+
     id1
     id2
 
@@ -41,6 +44,9 @@ mutation {
   }
   create_with_defaults(input: { })
   {
+    float1
+    floatFromInt
+
     id1
     id2
 
@@ -71,6 +77,8 @@ mutation {
             var expected = @"{
   ""data"": {
     ""create"": {
+      ""float1"": 1.2999999523162842,
+      ""floatFromInt"": 1,
       ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
       ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
       ""uint"": 3147483647,
@@ -110,6 +118,8 @@ mutation {
       ]
     },
     ""create_with_defaults"": {
+      ""float1"": 1.2999999523162842,
+      ""floatFromInt"": 1,
       ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
       ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
       ""uint"": 3147483647,
@@ -164,6 +174,10 @@ mutation {
 
     public class ScalarsModel
     {
+        public float Float1 { get; set; }
+
+        public float FloatFromInt { get; set; }
+
         public Guid Id1 { get; set; }
 
         public Guid Id2 { get; set; }
@@ -197,6 +211,8 @@ mutation {
         {
             Name = "ScalarsInput";
 
+            Field("float1", o => o.Float1, type: typeof(FloatGraphType));
+            Field("floatFromInt", o => o.FloatFromInt, type: typeof(FloatGraphType));
             Field("id1", o => o.Id1, type: typeof(IdGraphType));
             Field("id2", o => o.Id2, type: typeof(GuidGraphType));
             Field("uint", o => o.uInt, type: typeof(UIntGraphType));
@@ -224,6 +240,8 @@ mutation {
         {
             Name = "ScalarsInputWithDefaults";
 
+            Field("float1", o => o.Float1, type: typeof(NonNullGraphType<FloatGraphType>)).DefaultValue(1.3f);
+            Field("floatFromInt", o => o.FloatFromInt, type: typeof(NonNullGraphType<FloatGraphType>)).DefaultValue(1);
             Field("id1", o => o.Id1, type: typeof(NonNullGraphType<IdGraphType>)).DefaultValue(new Guid("8dfab389-a6f7-431d-ab4e-aa693cc53edf"));
             Field("id2", o => o.Id2, type: typeof(NonNullGraphType<GuidGraphType>)).DefaultValue(new Guid("8dfab389-a6f7-431d-ab4e-aa693cc53ede"));
             Field("uint", o => o.uInt, type: typeof(NonNullGraphType<UIntGraphType>)).DefaultValue((uint)3147483647);
@@ -251,6 +269,8 @@ mutation {
         {
             Name = "ScalarsType";
 
+            Field("float1", o => o.Float1, type: typeof(FloatGraphType));
+            Field("floatFromInt", o => o.FloatFromInt, type: typeof(FloatGraphType));
             Field("id1", o => o.Id1, type: typeof(IdGraphType));
             Field("id2", o => o.Id2, type: typeof(GuidGraphType));
             Field("uint", o => o.uInt, type: typeof(UIntGraphType));

--- a/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
@@ -40,15 +40,15 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void coerces_int_to_value()
         {
-            type.ParseValue(1234567).ShouldBe(1234567);
-            type.ParseLiteral(new IntValue(1234567)).ShouldBe(1234567);
+            type.ParseValue(1234567).ShouldBe(1234567d);
+            type.ParseLiteral(new IntValue(1234567)).ShouldBe(1234567d);
         }
 
         [Fact]
         public void coerces_long_to_value()
         {
-            type.ParseValue(12345678901234).ShouldBe(12345678901234);
-            type.ParseLiteral(new LongValue(12345678901234)).ShouldBe(12345678901234);
+            type.ParseValue(12345678901234).ShouldBe(12345678901234d);
+            type.ParseLiteral(new LongValue(12345678901234)).ShouldBe(12345678901234d);
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Numerics;
+using GraphQL.Language.AST;
 using GraphQL.Types;
 using Shouldly;
 using Xunit;
@@ -12,7 +14,8 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void coerces_null_to_null()
         {
-            type.ParseValue(null).ShouldBe(null);
+            type.ParseValue(null).ShouldBeNull();
+            type.ParseLiteral(null).ShouldBeNull();
         }
 
         [Fact]
@@ -30,7 +33,36 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void coerces_double_to_value()
         {
-            type.ParseValue(1.79769313486231e308).ShouldBe(1.79769313486231e308);
+            type.ParseValue(1.79769313486231e308d).ShouldBe(1.79769313486231e308d);
+            type.ParseLiteral(new FloatValue(1.79769313486231e308d)).ShouldBe(1.79769313486231e308d);
+        }
+
+        [Fact]
+        public void coerces_int_to_value()
+        {
+            type.ParseValue(1234567).ShouldBe(1234567);
+            type.ParseLiteral(new IntValue(1234567)).ShouldBe(1234567);
+        }
+
+        [Fact]
+        public void coerces_long_to_value()
+        {
+            type.ParseValue(12345678901234).ShouldBe(12345678901234);
+            type.ParseLiteral(new LongValue(12345678901234)).ShouldBe(12345678901234);
+        }
+
+        [Fact]
+        public void coerces_decimal_to_value()
+        {
+            type.ParseValue(9223372036854775808m).ShouldBe(9223372036854775808d);
+            type.ParseLiteral(new DecimalValue(9223372036854775808m)).ShouldBe(9223372036854775808d);
+        }
+
+        [Fact]
+        public void coerces_bigint_to_value()
+        {
+            type.ParseValue(new BigInteger(9999999999)).ShouldBe(9999999999d);
+            type.ParseLiteral(new BigIntValue(9999999999)).ShouldBe(9999999999d);
         }
     }
 }

--- a/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
@@ -33,36 +33,36 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void coerces_double_to_value()
         {
-            type.ParseValue(1.79769313486231e308d).ShouldBe(1.79769313486231e308d);
-            type.ParseLiteral(new FloatValue(1.79769313486231e308d)).ShouldBe(1.79769313486231e308d);
+            type.ParseValue(1.79769313486231e308d).ShouldBeOfType<double>().ShouldBe(1.79769313486231e308d);
+            type.ParseLiteral(new FloatValue(1.79769313486231e308d)).ShouldBeOfType<double>().ShouldBe(1.79769313486231e308d);
         }
 
         [Fact]
         public void coerces_int_to_value()
         {
-            type.ParseValue(1234567).ShouldBe(1234567d);
-            type.ParseLiteral(new IntValue(1234567)).ShouldBe(1234567d);
+            type.ParseValue(1234567).ShouldBeOfType<double>().ShouldBe(1234567d);
+            type.ParseLiteral(new IntValue(1234567)).ShouldBeOfType<double>().ShouldBe(1234567d);
         }
 
         [Fact]
         public void coerces_long_to_value()
         {
-            type.ParseValue(12345678901234).ShouldBe(12345678901234d);
-            type.ParseLiteral(new LongValue(12345678901234)).ShouldBe(12345678901234d);
+            type.ParseValue(12345678901234).ShouldBeOfType<double>().ShouldBe(12345678901234d);
+            type.ParseLiteral(new LongValue(12345678901234)).ShouldBeOfType<double>().ShouldBe(12345678901234d);
         }
 
         [Fact]
         public void coerces_decimal_to_value()
         {
-            type.ParseValue(9223372036854775808m).ShouldBe(9223372036854775808d);
-            type.ParseLiteral(new DecimalValue(9223372036854775808m)).ShouldBe(9223372036854775808d);
+            type.ParseValue(9223372036854775808m).ShouldBeOfType<double>().ShouldBe(9223372036854775808d);
+            type.ParseLiteral(new DecimalValue(9223372036854775808m)).ShouldBeOfType<double>().ShouldBe(9223372036854775808d);
         }
 
         [Fact]
         public void coerces_bigint_to_value()
         {
-            type.ParseValue(new BigInteger(9999999999)).ShouldBe(9999999999d);
-            type.ParseLiteral(new BigIntValue(9999999999)).ShouldBe(9999999999d);
+            type.ParseValue(new BigInteger(9999999999)).ShouldBeOfType<double>().ShouldBe(9999999999d);
+            type.ParseLiteral(new BigIntValue(9999999999)).ShouldBeOfType<double>().ShouldBe(9999999999d);
         }
     }
 }

--- a/src/GraphQL/Conversion/ValueConverter.cs
+++ b/src/GraphQL/Conversion/ValueConverter.cs
@@ -57,58 +57,58 @@ namespace GraphQL
             Register<DateTimeOffset, DateTime>(value => value.UtcDateTime);
             Register<TimeSpan, long>(value => (long)value.TotalSeconds);
 
-            Register<int, sbyte>(value => { checked { return (sbyte)value; } });
-            Register<int, byte>(value => { checked { return (byte)value; } });
-            Register<int, short>(value => { checked { return (short)value; } });
-            Register<int, ushort>(value => { checked { return (ushort)value; } });
+            Register<int, sbyte>(value => checked((sbyte)value));
+            Register<int, byte>(value => checked((byte)value));
+            Register<int, short>(value => checked((short)value));
+            Register<int, ushort>(value => checked((ushort)value));
             Register(typeof(int), typeof(bool), value => Convert.ToBoolean(value, NumberFormatInfo.InvariantInfo).Boxed());
-            Register<int, uint>(value => { checked { return (uint)value; } });
+            Register<int, uint>(value => checked((uint)value));
             Register<int, long>(value => value);
-            Register<int, ulong>(value => { checked { return (ulong)value; } });
+            Register<int, ulong>(value => checked((ulong)value));
             Register<int, BigInteger>(value => new BigInteger(value));
             Register<int, double>(value => value);
             Register<int, float>(value => value);
             Register<int, decimal>(value => value);
             Register<int, TimeSpan>(value => TimeSpan.FromSeconds(value));
 
-            Register<long, sbyte>(value => { checked { return (sbyte)value; } });
-            Register<long, byte>(value => { checked { return (byte)value; } });
-            Register<long, short>(value => { checked { return (short)value; } });
-            Register<long, ushort>(value => { checked { return (ushort)value; } });
-            Register<long, int>(value => { checked { return (int)value; } });
-            Register<long, uint>(value => { checked { return (uint)value; } });
-            Register<long, ulong>(value => { checked { return (ulong)value; } });
+            Register<long, sbyte>(value => checked((sbyte)value));
+            Register<long, byte>(value => checked((byte)value));
+            Register<long, short>(value => checked((short)value));
+            Register<long, ushort>(value => checked((ushort)value));
+            Register<long, int>(value => checked((int)value));
+            Register<long, uint>(value => checked((uint)value));
+            Register<long, ulong>(value => checked((ulong)value));
             Register<long, BigInteger>(value => new BigInteger(value));
             Register<long, double>(value => value);
             Register<long, float>(value => value);
             Register<long, decimal>(value => value);
             Register<long, TimeSpan>(value => TimeSpan.FromSeconds(value));
 
-            Register<BigInteger, sbyte>(value => { checked { return (sbyte)value; } });
-            Register<BigInteger, byte>(value => { checked { return (byte)value; } });
-            Register<BigInteger, decimal>(value => { checked { return (decimal)value; } });
-            Register<BigInteger, double>(value => { checked { return (double)value; } });
-            Register<BigInteger, short>(value => { checked { return (short)value; } });
-            Register<BigInteger, long>(value => { checked { return (long)value; } });
-            Register<BigInteger, sbyte>(value => { checked { return (sbyte)value; } });
-            Register<BigInteger, ushort>(value => { checked { return (ushort)value; } });
-            Register<BigInteger, uint>(value => { checked { return (uint)value; } });
-            Register<BigInteger, ulong>(value => { checked { return (ulong)value; } });
-            Register<BigInteger, int>(value => { checked { return (int)value; } });
-            Register<BigInteger, float>(value => { checked { return (float)value; } });
+            Register<BigInteger, sbyte>(value => checked((sbyte)value));
+            Register<BigInteger, byte>(value => checked((byte)value));
+            Register<BigInteger, decimal>(value => checked((decimal)value));
+            Register<BigInteger, double>(value => checked((double)value));
+            Register<BigInteger, short>(value => checked((short)value));
+            Register<BigInteger, long>(value => checked((long)value));
+            Register<BigInteger, sbyte>(value => checked((sbyte)value));
+            Register<BigInteger, ushort>(value => checked((ushort)value));
+            Register<BigInteger, uint>(value => checked((uint)value));
+            Register<BigInteger, ulong>(value => checked((ulong)value));
+            Register<BigInteger, int>(value => checked((int)value));
+            Register<BigInteger, float>(value => checked((float)value));
 
-            Register<uint, sbyte>(value => { checked { return (sbyte)value; } });
-            Register<uint, byte>(value => { checked { return (byte)value; } });
-            Register<uint, int>(value => { checked { return (int)value; } });
+            Register<uint, sbyte>(value => checked((sbyte)value));
+            Register<uint, byte>(value => checked((byte)value));
+            Register<uint, int>(value => checked((int)value));
             Register<uint, long>(value => value);
             Register<uint, ulong>(value => value);
-            Register<uint, short>(value => { checked { return (short)value; } });
-            Register<uint, ushort>(value => { checked { return (ushort)value; } });
+            Register<uint, short>(value => checked((short)value));
+            Register<uint, ushort>(value => checked((ushort)value));
             Register<uint, BigInteger>(value => new BigInteger(value));
 
             Register<ulong, BigInteger>(value => new BigInteger(value));
 
-            Register<byte, sbyte>(value => { checked { return (sbyte)value; } });
+            Register<byte, sbyte>(value => checked((sbyte)value));
             Register<byte, int>(value => value);
             Register<byte, long>(value => value);
             Register<byte, ulong>(value => value);
@@ -116,25 +116,25 @@ namespace GraphQL
             Register<byte, ushort>(value => value);
             Register<byte, BigInteger>(value => new BigInteger(value));
 
-            Register<sbyte, byte>(value => { checked { return (byte)value; } });
+            Register<sbyte, byte>(value => checked((byte)value));
             Register<sbyte, int>(value => value);
             Register<sbyte, long>(value => value);
-            Register<sbyte, ulong>(value => { checked { return (ulong)value; } });
+            Register<sbyte, ulong>(value => checked((ulong)value));
             Register<sbyte, short>(value => value);
-            Register<sbyte, ushort>(value => { checked { return (ushort)value; } });
+            Register<sbyte, ushort>(value => checked((ushort)value));
             Register<sbyte, BigInteger>(value => new BigInteger(value));
 
             Register<float, double>(value => value);
-            Register<float, decimal>(value => { checked { return (decimal)value; } });
+            Register<float, decimal>(value => checked((decimal)value));
             Register<float, BigInteger>(value => new BigInteger(value));
 
-            Register<double, float>(value => { checked { return (float)value; } });
-            Register<double, decimal>(value => { checked { return (decimal)value; } });
+            Register<double, float>(value => checked((float)value));
+            Register<double, decimal>(value => checked((decimal)value));
 
-            Register<char, byte>(value => { checked { return (byte)value; } });
+            Register<char, byte>(value => checked((byte)value));
             Register<char, int>(value => value);
 
-            Register<decimal, double>(value => { checked { return (double)value; } });
+            Register<decimal, double>(value => checked((double)value));
         }
 
         /// <summary>

--- a/src/GraphQL/Conversion/ValueConverter.cs
+++ b/src/GraphQL/Conversion/ValueConverter.cs
@@ -57,56 +57,58 @@ namespace GraphQL
             Register<DateTimeOffset, DateTime>(value => value.UtcDateTime);
             Register<TimeSpan, long>(value => (long)value.TotalSeconds);
 
-            Register<int, sbyte>(value => Convert.ToSByte(value, NumberFormatInfo.InvariantInfo));
-            Register<int, byte>(value => Convert.ToByte(value, NumberFormatInfo.InvariantInfo));
-            Register<int, short>(value => Convert.ToInt16(value, NumberFormatInfo.InvariantInfo));
-            Register<int, ushort>(value => Convert.ToUInt16(value, NumberFormatInfo.InvariantInfo));
+            Register<int, sbyte>(value => { checked { return (sbyte)value; } });
+            Register<int, byte>(value => { checked { return (byte)value; } });
+            Register<int, short>(value => { checked { return (short)value; } });
+            Register<int, ushort>(value => { checked { return (ushort)value; } });
             Register(typeof(int), typeof(bool), value => Convert.ToBoolean(value, NumberFormatInfo.InvariantInfo).Boxed());
-            Register<int, uint>(value => Convert.ToUInt32(value, NumberFormatInfo.InvariantInfo));
+            Register<int, uint>(value => { checked { return (uint)value; } });
             Register<int, long>(value => value);
-            Register<int, ulong>(value => Convert.ToUInt64(value, NumberFormatInfo.InvariantInfo));
+            Register<int, ulong>(value => { checked { return (ulong)value; } });
             Register<int, BigInteger>(value => new BigInteger(value));
-            Register<int, double>(value => Convert.ToDouble(value, NumberFormatInfo.InvariantInfo));
-            Register<int, decimal>(value => Convert.ToDecimal(value, NumberFormatInfo.InvariantInfo));
+            Register<int, double>(value => value);
+            Register<int, float>(value => value);
+            Register<int, decimal>(value => value);
             Register<int, TimeSpan>(value => TimeSpan.FromSeconds(value));
 
-            Register<long, sbyte>(value => Convert.ToSByte(value, NumberFormatInfo.InvariantInfo));
-            Register<long, byte>(value => Convert.ToByte(value, NumberFormatInfo.InvariantInfo));
-            Register<long, short>(value => Convert.ToInt16(value, NumberFormatInfo.InvariantInfo));
-            Register<long, ushort>(value => Convert.ToUInt16(value, NumberFormatInfo.InvariantInfo));
-            Register<long, int>(value => Convert.ToInt32(value, NumberFormatInfo.InvariantInfo));
-            Register<long, uint>(value => Convert.ToUInt32(value, NumberFormatInfo.InvariantInfo));
-            Register<long, ulong>(value => Convert.ToUInt64(value, NumberFormatInfo.InvariantInfo));
+            Register<long, sbyte>(value => { checked { return (sbyte)value; } });
+            Register<long, byte>(value => { checked { return (byte)value; } });
+            Register<long, short>(value => { checked { return (short)value; } });
+            Register<long, ushort>(value => { checked { return (ushort)value; } });
+            Register<long, int>(value => { checked { return (int)value; } });
+            Register<long, uint>(value => { checked { return (uint)value; } });
+            Register<long, ulong>(value => { checked { return (ulong)value; } });
             Register<long, BigInteger>(value => new BigInteger(value));
             Register<long, double>(value => value);
+            Register<long, float>(value => value);
             Register<long, decimal>(value => value);
             Register<long, TimeSpan>(value => TimeSpan.FromSeconds(value));
 
-            Register<BigInteger, sbyte>(value => (sbyte)value);
-            Register<BigInteger, byte>(value => (byte)value);
-            Register<BigInteger, decimal>(value => (decimal)value);
-            Register<BigInteger, double>(value => (double)value);
-            Register<BigInteger, short>(value => (short)value);
-            Register<BigInteger, long>(value => (long)value);
-            Register<BigInteger, sbyte>(value => (sbyte)value);
-            Register<BigInteger, ushort>(value => (ushort)value);
-            Register<BigInteger, uint>(value => (uint)value);
-            Register<BigInteger, ulong>(value => (ulong)value);
-            Register<BigInteger, int>(value => (int)value);
-            Register<BigInteger, float>(value => (float)value);
+            Register<BigInteger, sbyte>(value => { checked { return (sbyte)value; } });
+            Register<BigInteger, byte>(value => { checked { return (byte)value; } });
+            Register<BigInteger, decimal>(value => { checked { return (decimal)value; } });
+            Register<BigInteger, double>(value => { checked { return (double)value; } });
+            Register<BigInteger, short>(value => { checked { return (short)value; } });
+            Register<BigInteger, long>(value => { checked { return (long)value; } });
+            Register<BigInteger, sbyte>(value => { checked { return (sbyte)value; } });
+            Register<BigInteger, ushort>(value => { checked { return (ushort)value; } });
+            Register<BigInteger, uint>(value => { checked { return (uint)value; } });
+            Register<BigInteger, ulong>(value => { checked { return (ulong)value; } });
+            Register<BigInteger, int>(value => { checked { return (int)value; } });
+            Register<BigInteger, float>(value => { checked { return (float)value; } });
 
-            Register<uint, sbyte>(value => (sbyte)value);
-            Register<uint, byte>(value => (byte)value);
-            Register<uint, int>(value => (int)value);
+            Register<uint, sbyte>(value => { checked { return (sbyte)value; } });
+            Register<uint, byte>(value => { checked { return (byte)value; } });
+            Register<uint, int>(value => { checked { return (int)value; } });
             Register<uint, long>(value => value);
             Register<uint, ulong>(value => value);
-            Register<uint, short>(value => (short)value);
-            Register<uint, ushort>(value => (ushort)value);
+            Register<uint, short>(value => { checked { return (short)value; } });
+            Register<uint, ushort>(value => { checked { return (ushort)value; } });
             Register<uint, BigInteger>(value => new BigInteger(value));
 
             Register<ulong, BigInteger>(value => new BigInteger(value));
 
-            Register<byte, sbyte>(value => (sbyte)value);
+            Register<byte, sbyte>(value => { checked { return (sbyte)value; } });
             Register<byte, int>(value => value);
             Register<byte, long>(value => value);
             Register<byte, ulong>(value => value);
@@ -114,22 +116,25 @@ namespace GraphQL
             Register<byte, ushort>(value => value);
             Register<byte, BigInteger>(value => new BigInteger(value));
 
-            Register<sbyte, byte>(value => (byte)value);
+            Register<sbyte, byte>(value => { checked { return (byte)value; } });
             Register<sbyte, int>(value => value);
             Register<sbyte, long>(value => value);
-            Register<sbyte, ulong>(value => (ulong)value);
+            Register<sbyte, ulong>(value => { checked { return (ulong)value; } });
             Register<sbyte, short>(value => value);
-            Register<sbyte, ushort>(value => (ushort)value);
+            Register<sbyte, ushort>(value => { checked { return (ushort)value; } });
             Register<sbyte, BigInteger>(value => new BigInteger(value));
 
-            Register<float, double>(value => (double)value);
-            Register<float, decimal>(value => Convert.ToDecimal(value, NumberFormatInfo.InvariantInfo));
+            Register<float, double>(value => value);
+            Register<float, decimal>(value => { checked { return (decimal)value; } });
             Register<float, BigInteger>(value => new BigInteger(value));
 
-            Register<double, decimal>(value => Convert.ToDecimal(value, NumberFormatInfo.InvariantInfo));
+            Register<double, float>(value => { checked { return (float)value; } });
+            Register<double, decimal>(value => { checked { return (decimal)value; } });
 
-            Register<char, byte>(value => Convert.ToByte(value));
-            Register<char, int>(value => Convert.ToInt32(value));
+            Register<char, byte>(value => { checked { return (byte)value; } });
+            Register<char, int>(value => value);
+
+            Register<decimal, double>(value => { checked { return (double)value; } });
         }
 
         /// <summary>

--- a/src/GraphQL/Types/Scalars/BooleanGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BooleanGraphType.cs
@@ -4,8 +4,8 @@ namespace GraphQL.Types
 {
     public class BooleanGraphType : ScalarGraphType
     {
-        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(bool));
-
         public override object ParseLiteral(IValue value) => ((value as BooleanValue)?.Value).Boxed();
+
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(bool));
     }
 }

--- a/src/GraphQL/Types/Scalars/DateGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateGraphType.cs
@@ -24,6 +24,21 @@ namespace GraphQL.Types
             return null;
         }
 
+        public override object ParseLiteral(IValue value)
+        {
+            if (value is DateTimeValue timeValue)
+            {
+                return timeValue.Value;
+            }
+
+            if (value is StringValue stringValue)
+            {
+                return ParseValue(stringValue.Value);
+            }
+
+            return null;
+        }
+
         public override object ParseValue(object value)
         {
             if (value is DateTime dateTime)
@@ -45,21 +60,6 @@ namespace GraphQL.Types
             }
 
             throw new FormatException($"Could not parse date. Expected either a string or a DateTime without time component. Value: {value}");
-        }
-
-        public override object ParseLiteral(IValue value)
-        {
-            if (value is DateTimeValue timeValue)
-            {
-                return timeValue.Value;
-            }
-
-            if (value is StringValue stringValue)
-            {
-                return ParseValue(stringValue.Value);
-            }
-
-            return null;
         }
     }
 }

--- a/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
@@ -12,8 +12,6 @@ namespace GraphQL.Types
                 "to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.";
         }
 
-        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTime));
-
         public override object ParseLiteral(IValue value)
         {
             if (value is DateTimeValue timeValue)
@@ -28,5 +26,7 @@ namespace GraphQL.Types
 
             return null;
         }
+
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTime));
     }
 }

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -12,13 +12,13 @@ namespace GraphQL.Types
                 "to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.";
         }
 
-        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTimeOffset));
-
         public override object ParseLiteral(IValue value) => value switch
         {
             DateTimeOffsetValue offsetValue => offsetValue.Value,
             StringValue stringValue => ParseValue(stringValue.Value),
             _ => null
         };
+
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTimeOffset));
     }
 }

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -4,17 +4,17 @@ namespace GraphQL.Types
 {
     public class DecimalGraphType : ScalarGraphType
     {
-        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(decimal));
-
         public override object ParseLiteral(IValue value) => value switch
         {
             DecimalValue decimalValue => decimalValue.Value,
             StringValue stringValue => ParseValue(stringValue.Value),
-            IntValue intValue => ParseValue(intValue.Value),
-            LongValue longValue => ParseValue(longValue.Value),
-            FloatValue floatValue => ParseValue(floatValue.Value),
-            BigIntValue bigIntValue => ParseValue(bigIntValue.Value),
+            IntValue intValue => checked((decimal)intValue.Value),
+            LongValue longValue => checked((decimal)longValue.Value),
+            FloatValue floatValue => checked((decimal)floatValue.Value),
+            BigIntValue bigIntValue => checked((decimal)bigIntValue.Value),
             _ => null
         };
+
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(decimal));
     }
 }

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -57,6 +57,8 @@ namespace GraphQL.Types
             return foundByValue?.Name;
         }
 
+        public override object ParseLiteral(IValue value) => !(value is EnumValue enumValue) ? null : ParseValue(enumValue.Name);
+
         public override object ParseValue(object value)
         {
             if (value == null)
@@ -67,9 +69,6 @@ namespace GraphQL.Types
             var found = Values.FindByName(value.ToString());
             return found?.Value;
         }
-
-        public override object ParseLiteral(IValue value)
-            => !(value is EnumValue enumValue) ? null : ParseValue(enumValue.Name);
     }
 
     /// <summary>

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -4,16 +4,16 @@ namespace GraphQL.Types
 {
     public class FloatGraphType : ScalarGraphType
     {
-        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(double));
-
         public override object ParseLiteral(IValue value) => value switch
         {
             FloatValue floatVal => floatVal.Value,
-            IntValue intVal => ParseValue(intVal.Value),
-            LongValue longVal => ParseValue(longVal.Value),
-            DecimalValue decVal => ParseValue(decVal.Value),
-            BigIntValue bigIntVal => ParseValue(bigIntVal.Value),
+            IntValue intVal => checked((double)intVal.Value),
+            LongValue longVal => checked((double)longVal.Value),
+            DecimalValue decVal => checked((double)decVal.Value),
+            BigIntValue bigIntVal => checked((double)bigIntVal.Value),
             _ => null
         };
+
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(double));
     }
 }

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -9,8 +9,10 @@ namespace GraphQL.Types
         public override object ParseLiteral(IValue value) => value switch
         {
             FloatValue floatVal => floatVal.Value,
-            IntValue intVal => intVal.Value,
-            LongValue longVal => longVal.Value,
+            IntValue intVal => ParseValue(intVal.Value),
+            LongValue longVal => ParseValue(longVal.Value),
+            DecimalValue decVal => ParseValue(decVal.Value),
+            BigIntValue bigIntVal => ParseValue(bigIntVal.Value),
             _ => null
         };
     }

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -16,8 +16,6 @@ namespace GraphQL.Types
 
         public override object Serialize(object value) => value?.ToString();
 
-        public override object ParseValue(object value) => value?.ToString().Trim(' ', '"');
-
         public override object ParseLiteral(IValue value) => value switch
         {
             StringValue str => ParseValue(str.Value),
@@ -25,5 +23,7 @@ namespace GraphQL.Types
             LongValue longVal => longVal.Value,
             _ => null,
         };
+
+        public override object ParseValue(object value) => value?.ToString().Trim(' ', '"');
     }
 }

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Types
         public override object ParseLiteral(IValue value) => value switch
         {
             LongValue longValue => longValue.Value,
-            IntValue intValue => (long)intValue.Value,
+            IntValue intValue => ParseValue(intValue.Value),
             _ => null
         };
 

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Types
         public override object ParseLiteral(IValue value) => value switch
         {
             LongValue longValue => longValue.Value,
-            IntValue intValue => ParseValue(intValue.Value),
+            IntValue intValue => (long)intValue.Value,
             _ => null
         };
 

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -4,8 +4,8 @@ namespace GraphQL.Types
 {
     public class StringGraphType : ScalarGraphType
     {
-        public override object ParseValue(object value) => value?.ToString();
-
         public override object ParseLiteral(IValue value) => (value as StringValue)?.Value;
+
+        public override object ParseValue(object value) => value?.ToString();
     }
 }

--- a/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
@@ -20,19 +20,19 @@ namespace GraphQL.Types
             _ => null
         };
 
-        public override object ParseValue(object value) => value switch
+        public override object ParseLiteral(IValue value) => value switch
         {
-            int i => TimeSpan.FromMilliseconds(i),
-            long l => TimeSpan.FromMilliseconds(l),
-            TimeSpan t => t,
+            TimeSpanValue spanValue => spanValue.Value,
+            IntValue intValue => TimeSpan.FromMilliseconds(intValue.Value),
+            LongValue longValue => TimeSpan.FromMilliseconds(longValue.Value),
             _ => null
         };
 
-        public override object ParseLiteral(IValue value) => value switch
+        public override object ParseValue(object value) => value switch
         {
-            TimeSpanValue spanValue => ParseValue(spanValue.Value),
-            LongValue longValue => ParseValue(longValue.Value),
-            IntValue intValue => ParseValue(intValue.Value),
+            TimeSpan t => t,
+            int i => TimeSpan.FromMilliseconds(i),
+            long l => TimeSpan.FromMilliseconds(l),
             _ => null
         };
     }

--- a/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
@@ -20,19 +20,19 @@ namespace GraphQL.Types
             _ => null
         };
 
-        public override object ParseValue(object value) => value switch
+        public override object ParseLiteral(IValue value) => value switch
         {
-            int i => TimeSpan.FromSeconds(i),
-            long l => TimeSpan.FromSeconds(l),
-            TimeSpan t => t,
+            TimeSpanValue spanValue => spanValue.Value,
+            IntValue intValue => TimeSpan.FromSeconds(intValue.Value),
+            LongValue longValue => TimeSpan.FromSeconds(longValue.Value),
             _ => null
         };
 
-        public override object ParseLiteral(IValue value) => value switch
+        public override object ParseValue(object value) => value switch
         {
-            TimeSpanValue spanValue => ParseValue(spanValue.Value),
-            LongValue longValue => ParseValue(longValue.Value),
-            IntValue intValue => ParseValue(intValue.Value),
+            TimeSpan t => t,
+            int i => TimeSpan.FromSeconds(i),
+            long l => TimeSpan.FromSeconds(l),
             _ => null
         };
     }

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -5,13 +5,13 @@ namespace GraphQL.Types
 {
     public class UriGraphType : ScalarGraphType
     {
-        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(Uri));
-
         public override object ParseLiteral(IValue value) => value switch
         {
             UriValue uriValue => uriValue.Value,
             StringValue stringValue => ParseValue(stringValue.Value),
             _ => null
         };
+
+        public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(Uri));
     }
 }


### PR DESCRIPTION
Fixes #2047 . Also fixes bug when `FloatGraphType.Value` cannot be casted to `float` even when fractional part was specified.
I decided to remove all `Convert.To` calls and use the `checked` operator explicitly. First, this is how our intentions are more clearly expressed. Secondly, it turned out that we left unchecked context (C# uses unchecked by default) in some places. Examples:
```
 Register<sbyte, byte>(value => (byte)value);
 Register<sbyte, ulong>(value => (ulong)value);
```

I didn't add tests for all cases, because it is very expensive. I became convinced that some existing tests started failing when I changed `Convert.To` calls to explicit cast operator. So I added `checked` in every line with downcast.