### PR TITLE
XML comments for scalar graph types

### DIFF
--- a/src/GraphQL.Tests/Types/ULongGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ULongGraphTypeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using GraphQL.Language.AST;
 using GraphQL.Types;
 using Shouldly;
 using Xunit;
@@ -35,5 +36,11 @@ namespace GraphQL.Tests.Types
         [InlineData(65535, 65535)]
         public void Coerces_input_to_valid_ulong(object input, ulong expected)
             => type.ParseValue(input).ShouldBe(expected);
+
+        [Fact]
+        public void Reads_BigInt_Literals()
+        {
+            Assert.Equal(18446744073709551615ul, (ulong)type.ParseLiteral(new BigIntValue(System.Numerics.BigInteger.Parse("18446744073709551615"))));
+        }
     }
 }

--- a/src/GraphQL/Introspection/__EnumValue.cs
+++ b/src/GraphQL/Introspection/__EnumValue.cs
@@ -12,11 +12,11 @@ namespace GraphQL.Introspection
                 "a placeholder for a string or numeric value. However an Enum value is " +
                 "returned in a JSON response as a string.";
 
-            Field(f => f.Name);
-            Field(f => f.Description, nullable: true);
+            Field(f => f.Name).Description(null);
+            Field(f => f.Description, nullable: true).Description(null);
 
             Field<NonNullGraphType<BooleanGraphType>>("isDeprecated", resolve: context => (!string.IsNullOrWhiteSpace(context.Source?.DeprecationReason)).Boxed());
-            Field(f => f.DeprecationReason, nullable: true);
+            Field(f => f.DeprecationReason, nullable: true).Description(null);
         }
     }
 }

--- a/src/GraphQL/Types/Scalars/BigIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BigIntGraphType.cs
@@ -1,10 +1,12 @@
 using System.Numerics;
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The BigInt scalar graph type represents a signed integer with any number of digits.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="BigInteger"/> .NET values to this scalar graph type.
     /// </summary>
     public class BigIntGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/BigIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BigIntGraphType.cs
@@ -3,8 +3,12 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The BigInt scalar graph type represents a signed integer with any number of digits.
+    /// </summary>
     public class BigIntGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             BigIntValue bigIntValue => bigIntValue.Value,
@@ -13,6 +17,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(BigInteger));
     }
 }

--- a/src/GraphQL/Types/Scalars/BooleanGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BooleanGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The Boolean scalar graph type represents a boolean value.
+    /// The Boolean scalar graph type represents a boolean value. It is one of the five built-in scalars.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="bool"/> .NET values to this scalar graph type.
     /// </summary>
     public class BooleanGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/BooleanGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BooleanGraphType.cs
@@ -2,10 +2,15 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Boolean scalar graph type represents a boolean value.
+    /// </summary>
     public class BooleanGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(bool));
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => ((value as BooleanValue)?.Value).Boxed();
     }
 }

--- a/src/GraphQL/Types/Scalars/ByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ByteGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The Byte scalar graph type represents an unsigned 8-bit integer value.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="byte"/> .NET values to this scalar graph type.
     /// </summary>
     public class ByteGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/ByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ByteGraphType.cs
@@ -2,8 +2,12 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Byte scalar graph type represents an unsigned 8-bit integer value.
+    /// </summary>
     public class ByteGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             ByteValue byteValue => byteValue.Value,
@@ -11,6 +15,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(byte));
     }
 }

--- a/src/GraphQL/Types/Scalars/DateGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateGraphType.cs
@@ -4,14 +4,21 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Date scalar graph type represents a year, month and day.
+    /// </summary>
     public class DateGraphType : ScalarGraphType
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateGraphType"/> class
+        /// </summary>
         public DateGraphType()
         {
             Description = "The `Date` scalar type represents a year, month and day in accordance with the " +
                 "[ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.";
         }
 
+        /// <inheritdoc/>
         public override object Serialize(object value)
         {
             var date = ParseValue(value);
@@ -24,6 +31,7 @@ namespace GraphQL.Types
             return null;
         }
 
+        /// <inheritdoc/>
         public override object ParseValue(object value)
         {
             if (value is DateTime dateTime)
@@ -47,6 +55,7 @@ namespace GraphQL.Types
             throw new FormatException($"Could not parse date. Expected either a string or a DateTime without time component. Value: {value}");
         }
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value)
         {
             if (value is DateTimeValue timeValue)

--- a/src/GraphQL/Types/Scalars/DateGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateGraphType.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Types
     public class DateGraphType : ScalarGraphType
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DateGraphType"/> class
+        /// Initializes a new instance of the <see cref="DateGraphType"/> class.
         /// </summary>
         public DateGraphType()
         {

--- a/src/GraphQL/Types/Scalars/DateGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateGraphType.cs
@@ -5,7 +5,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The Date scalar graph type represents a year, month and day.
+    /// The Date scalar graph type represents a year, month and day in accordance with the ISO-8601 standard.
     /// </summary>
     public class DateGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
@@ -4,7 +4,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The DateTime scalar graph type represents a date and time.
+    /// The DateTime scalar graph type represents a date and time in accordance with the ISO-8601 standard.
     /// </summary>
     public class DateTimeGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
@@ -1,10 +1,12 @@
 using System;
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The DateTime scalar graph type represents a date and time in accordance with the ISO-8601 standard.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="DateTime"/> .NET values to this scalar graph type.
     /// </summary>
     public class DateTimeGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
@@ -3,8 +3,14 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The DateTime scalar graph type represents a date and time.
+    /// </summary>
     public class DateTimeGraphType : ScalarGraphType
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateTimeGraphType"/> class
+        /// </summary>
         public DateTimeGraphType()
         {
             Description =
@@ -12,8 +18,10 @@ namespace GraphQL.Types
                 "to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.";
         }
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTime));
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value)
         {
             if (value is DateTimeValue timeValue)

--- a/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Types
     public class DateTimeGraphType : ScalarGraphType
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DateTimeGraphType"/> class
+        /// Initializes a new instance of the <see cref="DateTimeGraphType"/> class.
         /// </summary>
         public DateTimeGraphType()
         {

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -1,10 +1,12 @@
 using System;
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The DateTimeOffset scalar graph type represents a date, time and offset from UTC.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="DateTimeOffset"/> .NET values to this scalar graph type.
     /// </summary>
     public class DateTimeOffsetGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Types
     public class DateTimeOffsetGraphType : ScalarGraphType
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DateTimeOffsetGraphType"/> class
+        /// Initializes a new instance of the <see cref="DateTimeOffsetGraphType"/> class.
         /// </summary>
         public DateTimeOffsetGraphType()
         {

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -3,8 +3,14 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The DateTimeOffset scalar graph type represents a date, time and offset from UTC.
+    /// </summary>
     public class DateTimeOffsetGraphType : ScalarGraphType
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateTimeOffsetGraphType"/> class
+        /// </summary>
         public DateTimeOffsetGraphType()
         {
             Description =
@@ -12,8 +18,10 @@ namespace GraphQL.Types
                 "to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.";
         }
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(DateTimeOffset));
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             DateTimeOffsetValue offsetValue => offsetValue.Value,

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The Decimal scalar graph type represents a decimal value.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="decimal"/> .NET values to this scalar graph type.
     /// </summary>
     public class DecimalGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -2,10 +2,15 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Decimal scalar graph type represents a decimal value.
+    /// </summary>
     public class DecimalGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(decimal));
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             DecimalValue decimalValue => decimalValue.Value,

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -184,7 +184,7 @@ namespace GraphQL.Types
     }
 
     /// <summary>
-    /// A class that represents an enumeratoin definition.
+    /// A class that represents an enumeration definition.
     /// </summary>
     public class EnumValueDefinition : MetadataProvider
     {
@@ -220,7 +220,7 @@ namespace GraphQL.Types
         }
 
         /// <summary>
-        /// When mapped to an <see cref="Enum"/> member, contains the underlying enumeration value; otherwise contains <see cref="Value" />.
+        /// When mapped to a member of an <see cref="Enum"/>, contains the underlying enumeration value; otherwise contains <see cref="Value" />.
         /// </summary>
         internal object UnderlyingValue { get; set; }
     }

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -188,7 +188,7 @@ namespace GraphQL.Types
     public class EnumValueDefinition : MetadataProvider
     {
         /// <summary>
-        /// The name of the enumeration member.
+        /// The name of the enumeration member, as exposed through the GraphQL endpoint (e.g. "RED").
         /// </summary>
         public string Name { get; set; }
 
@@ -204,7 +204,7 @@ namespace GraphQL.Types
 
         private object _value;
         /// <summary>
-        /// The value of the enumeration member.
+        /// The value of the enumeration member, as referenced by the code (e.g. <see cref="ConsoleColor.Red"/>).
         /// </summary>
         public object Value
         {

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -28,6 +28,10 @@ namespace GraphQL.Types
         /// <summary>
         /// Adds a value to the allowed set of enumeration values.
         /// </summary>
+        /// <param name="name">The name of the enumeration member, as exposed through the GraphQL endpoint (e.g. "RED").</param>
+        /// <param name="description">A description of the enumeration member.</param>
+        /// <param name="value">The value of the enumeration member, as referenced by the code (e.g. <see cref="ConsoleColor.Red"/>).</param>
+        /// <param name="deprecationReason">The reason this enumeration member has been deprecated; null if this member has not been deprecated.</param>
         public void AddValue(string name, string description, object value, string deprecationReason = null)
         {
             AddValue(new EnumValueDefinition

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -17,11 +17,17 @@ namespace GraphQL.Types
     /// </summary>
     public class EnumerationGraphType : ScalarGraphType
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationGraphType"/> class.
+        /// </summary>
         public EnumerationGraphType()
         {
             Values = new EnumValues();
         }
 
+        /// <summary>
+        /// Adds a value to the allowed set of enumeration values.
+        /// </summary>
         public void AddValue(string name, string description, object value, string deprecationReason = null)
         {
             AddValue(new EnumValueDefinition
@@ -33,6 +39,9 @@ namespace GraphQL.Types
             });
         }
 
+        /// <summary>
+        /// Adds a value to the allowed set of enumeration values.
+        /// </summary>
         public void AddValue(EnumValueDefinition value)
         {
             if (value == null)
@@ -42,8 +51,12 @@ namespace GraphQL.Types
             Values.Add(value);
         }
 
+        /// <summary>
+        /// Returns the allowed set of enumeration values.
+        /// </summary>
         public EnumValues Values { get; }
 
+        /// <inheritdoc/>
         public override object Serialize(object value)
         {
             var valueString = value.ToString();
@@ -57,6 +70,7 @@ namespace GraphQL.Types
             return foundByValue?.Name;
         }
 
+        /// <inheritdoc/>
         public override object ParseValue(object value)
         {
             if (value == null)
@@ -68,6 +82,7 @@ namespace GraphQL.Types
             return found?.Value;
         }
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value)
             => !(value is EnumValue enumValue) ? null : ParseValue(enumValue.Name);
     }
@@ -80,6 +95,9 @@ namespace GraphQL.Types
     /// <typeparam name="TEnum"> The enum to take values from. </typeparam>
     public class EnumerationGraphType<TEnum> : EnumerationGraphType where TEnum : Enum
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationGraphType"/> class.
+        /// </summary>
         public EnumerationGraphType()
         {
             var type = typeof(TEnum);
@@ -104,17 +122,33 @@ namespace GraphQL.Types
             }
         }
 
+        /// <summary>
+        /// Changes the case of the specified string to constant case (uppercase, using underscores to separate words).
+        /// </summary>
         protected virtual string ChangeEnumCase(string val) => StringUtils.ToConstantCase(val);
     }
 
+    /// <summary>
+    /// A class that represents a set of enumeration definitions.
+    /// </summary>
     public class EnumValues : IEnumerable<EnumValueDefinition>
     {
         private readonly List<EnumValueDefinition> _values = new List<EnumValueDefinition>();
 
+        /// <summary>
+        /// Returns an enumeration definition for the specified name.
+        /// </summary>
         public EnumValueDefinition this[string name] => FindByName(name);
 
+        /// <summary>
+        /// Adds an enumeration definition to the set.
+        /// </summary>
+        /// <param name="value"></param>
         public void Add(EnumValueDefinition value) => _values.Add(value ?? throw new ArgumentNullException(nameof(value)));
 
+        /// <summary>
+        /// Returns an enumeration definition for the specified name.
+        /// </summary>
         public EnumValueDefinition FindByName(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
             // DO NOT USE LINQ ON HOT PATH
@@ -125,6 +159,9 @@ namespace GraphQL.Types
             return null;
         }
 
+        /// <summary>
+        /// Returns an enumeration definition for the specified value.
+        /// </summary>
         public EnumValueDefinition FindByValue(object value)
         {
             if (value is Enum)
@@ -140,17 +177,36 @@ namespace GraphQL.Types
             return null;
         }
 
+        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
         public IEnumerator<EnumValueDefinition> GetEnumerator() => _values.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
+    /// <summary>
+    /// A class that represents an enumeratoin definition.
+    /// </summary>
     public class EnumValueDefinition : MetadataProvider
     {
+        /// <summary>
+        /// The name of the enumeration member.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// A description of the enumeration member.
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// The reason this enumeration member has been deprecated; null if this member has not been deprecated.
+        /// </summary>
         public string DeprecationReason { get; set; }
+
         private object _value;
+        /// <summary>
+        /// The value of the enumeration member.
+        /// </summary>
         public object Value
         {
             get => _value;
@@ -162,8 +218,9 @@ namespace GraphQL.Types
                 UnderlyingValue = value;
             }
         }
+
         /// <summary>
-        /// For enums, contains the underlying enumeration value; otherwise contains <see cref="Value" />.
+        /// When mapped to an <see cref="Enum"/> member, contains the underlying enumeration value; otherwise contains <see cref="Value" />.
         /// </summary>
         internal object UnderlyingValue { get; set; }
     }

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -123,7 +123,7 @@ namespace GraphQL.Types
         }
 
         /// <summary>
-        /// Changes the case of the specified string to constant case (uppercase, using underscores to separate words).
+        /// Changes the case of the specified enum name. By default changes it to constant case (uppercase, using underscores to separate words).
         /// </summary>
         protected virtual string ChangeEnumCase(string val) => StringUtils.ToConstantCase(val);
     }

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -2,10 +2,15 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Float scalar graph type represents an IEEE 754 double-precision floating point value.
+    /// </summary>
     public class FloatGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(double));
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             FloatValue floatVal => floatVal.Value,

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The Float scalar graph type represents an IEEE 754 double-precision floating point value.
+    /// The Float scalar graph type represents an IEEE 754 double-precision floating point value. It is one of the five built-in scalars.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="double"/> and <see cref="float"/> .NET values to this scalar graph type.
     /// </summary>
     public class FloatGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/GuidGraphType.cs
+++ b/src/GraphQL/Types/Scalars/GuidGraphType.cs
@@ -3,8 +3,12 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Guid scalar graph type represents a 128-bit globally unique identifier (GUID).
+    /// </summary>
     public class GuidGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             GuidValue guidValue => guidValue.Value,
@@ -12,6 +16,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(Guid));
     }
 }

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -1,10 +1,13 @@
+using System;
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The ID scalar graph type represents a string identifier, not intended to be human-readable.
-    /// When accepted as an input type, any string or integer input value will be accepted as an ID.
+    /// The ID scalar graph type represents a string identifier, not intended to be human-readable. It is one of the five built-in scalars.
+    /// When expected as an input type, any string or integer input value will be accepted as an ID.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="Guid"/> .NET values to this scalar graph type.
     /// </summary>
     public class IdGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -2,22 +2,32 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The ID scalar graph type represents a string identifier, not intended to be human-readable.
+    /// When accepted as an input type, any string or integer input value will be accepted as an ID.
+    /// </summary>
     public class IdGraphType : ScalarGraphType
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IdGraphType"/> class.
+        /// </summary>
         public IdGraphType()
         {
             Name = "ID";
             //Description =
             //    "The `ID` scalar type represents a unique identifier, often used to re-fetch an object or " +
             //    "as key for a cache. The `ID` type appears in a JSON response as a `String`; however, it " +
-            //    "is not intended to be human-readable. When expected as an input type, any string (such " +
+            //    "is not intended to be human-readable. When accepted as an input type, any string (such " +
             //    "as `\"4\"`) or integer (such as `4`) input value will be accepted as an `ID`.";
         }
 
+        /// <inheritdoc/>
         public override object Serialize(object value) => value?.ToString();
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => value?.ToString().Trim(' ', '"');
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             StringValue str => ParseValue(str.Value),

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Types
             //Description =
             //    "The `ID` scalar type represents a unique identifier, often used to re-fetch an object or " +
             //    "as key for a cache. The `ID` type appears in a JSON response as a `String`; however, it " +
-            //    "is not intended to be human-readable. When accepted as an input type, any string (such " +
+            //    "is not intended to be human-readable. When expected as an input type, any string (such " +
             //    "as `\"4\"`) or integer (such as `4`) input value will be accepted as an `ID`.";
         }
 

--- a/src/GraphQL/Types/Scalars/IntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IntGraphType.cs
@@ -6,7 +6,6 @@ namespace GraphQL.Types
     /// <summary>
     /// The Int scalar type represents a signed 32‐bit numeric non‐fractional value. It is one of the five built-in scalars.
     /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="int"/> .NET values to this scalar graph type.
-    /// https://graphql.github.io/graphql-spec/June2018/#sec-Int
     /// </summary>
     public class IntGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/IntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IntGraphType.cs
@@ -8,6 +8,7 @@ namespace GraphQL.Types
     /// </summary>
     public class IntGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value)
         {
             if (value is IntValue intValue)
@@ -18,6 +19,7 @@ namespace GraphQL.Types
             return null;
         }
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(int));
     }
 }

--- a/src/GraphQL/Types/Scalars/IntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IntGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The Int scalar type represents a signed 32‐bit numeric non‐fractional value.
+    /// The Int scalar type represents a signed 32‐bit numeric non‐fractional value. It is one of the five built-in scalars.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="int"/> .NET values to this scalar graph type.
     /// https://graphql.github.io/graphql-spec/June2018/#sec-Int
     /// </summary>
     public class IntGraphType : ScalarGraphType

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -2,8 +2,12 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Long scalar graph type represents a signed 64-bit integer value.
+    /// </summary>
     public class LongGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             LongValue longValue => longValue.Value,
@@ -11,6 +15,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(long));
     }
 }

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The Long scalar graph type represents a signed 64-bit integer value.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="long"/> .NET values to this scalar graph type.
     /// </summary>
     public class LongGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/SByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/SByteGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The SByte scalar graph type represents a signed 8-bit integer value.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="sbyte"/> .NET values to this scalar graph type.
     /// </summary>
     public class SByteGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/SByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/SByteGraphType.cs
@@ -2,8 +2,12 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The SByte scalar graph type represents a signed 8-bit integer value.
+    /// </summary>
     public class SByteGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             SByteValue sbyteValue => sbyteValue.Value,
@@ -11,6 +15,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(sbyte));
     }
 }

--- a/src/GraphQL/Types/Scalars/ShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ShortGraphType.cs
@@ -2,8 +2,12 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Short scalar graph type represents a signed 16-bit integer value.
+    /// </summary>
     public class ShortGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             ShortValue shortValue => shortValue.Value,
@@ -11,6 +15,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(short));
     }
 }

--- a/src/GraphQL/Types/Scalars/ShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ShortGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The Short scalar graph type represents a signed 16-bit integer value.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="short"/> .NET values to this scalar graph type.
     /// </summary>
     public class ShortGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -2,10 +2,15 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The String scalar graph type represents a string value
+    /// </summary>
     public class StringGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseValue(object value) => value?.ToString();
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => (value as StringValue)?.Value;
     }
 }

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -3,7 +3,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The String scalar graph type represents a string value.
+    /// The String scalar graph type represents a string value. It is one of the five built-in scalars. 
     /// </summary>
     public class StringGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -3,7 +3,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The String scalar graph type represents a string value
+    /// The String scalar graph type represents a string value.
     /// </summary>
     public class StringGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The String scalar graph type represents a string value. It is one of the five built-in scalars. 
+    /// The String scalar graph type represents a string value. It is one of the five built-in scalars.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="string"/> .NET values to this scalar graph type.
     /// </summary>
     public class StringGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Types
     public class TimeSpanMillisecondsGraphType : ScalarGraphType
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="TimeSpanMillisecondsGraphType"/> class
+        /// Initializes a new instance of the <see cref="TimeSpanMillisecondsGraphType"/> class.
         /// </summary>
         public TimeSpanMillisecondsGraphType()
         {

--- a/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
@@ -4,7 +4,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The Milliseconds scalar graph type represents a period of time represented as a total number of milliseconds.
+    /// The Milliseconds scalar graph type represents a period of time represented as an integer value of the total number of milliseconds.
     /// </summary>
     public class TimeSpanMillisecondsGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
@@ -3,8 +3,14 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Milliseconds scalar graph type represents a period of time represented as a total number of milliseconds.
+    /// </summary>
     public class TimeSpanMillisecondsGraphType : ScalarGraphType
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpanMillisecondsGraphType"/> class
+        /// </summary>
         public TimeSpanMillisecondsGraphType()
         {
             Name = "Milliseconds";
@@ -12,6 +18,7 @@ namespace GraphQL.Types
                 "The `Milliseconds` scalar type represents a period of time represented as the total number of milliseconds.";
         }
 
+        /// <inheritdoc/>
         public override object Serialize(object value) => value switch
         {
             TimeSpan timeSpan => (long)timeSpan.TotalMilliseconds,
@@ -20,6 +27,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => value switch
         {
             int i => TimeSpan.FromMilliseconds(i),
@@ -28,6 +36,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             TimeSpanValue spanValue => ParseValue(spanValue.Value),

--- a/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
@@ -3,8 +3,14 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Seconds scalar graph type represents a period of time represented as a total number of seconds.
+    /// </summary>
     public class TimeSpanSecondsGraphType : ScalarGraphType
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpanSecondsGraphType"/> class
+        /// </summary>
         public TimeSpanSecondsGraphType()
         {
             Name = "Seconds";
@@ -12,6 +18,7 @@ namespace GraphQL.Types
                 "The `Seconds` scalar type represents a period of time represented as the total number of seconds.";
         }
 
+        /// <inheritdoc/>
         public override object Serialize(object value) => value switch
         {
             TimeSpan timeSpan => (long)timeSpan.TotalSeconds,
@@ -20,6 +27,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => value switch
         {
             int i => TimeSpan.FromSeconds(i),
@@ -28,6 +36,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             TimeSpanValue spanValue => ParseValue(spanValue.Value),

--- a/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
@@ -1,10 +1,12 @@
 using System;
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The Seconds scalar graph type represents a period of time represented as an integer value of the total number of seconds.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="TimeSpan"/> .NET values to this scalar graph type.
     /// </summary>
     public class TimeSpanSecondsGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
@@ -4,7 +4,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The Seconds scalar graph type represents a period of time represented as a total number of seconds.
+    /// The Seconds scalar graph type represents a period of time represented as an integer value of the total number of seconds.
     /// </summary>
     public class TimeSpanSecondsGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Types
     public class TimeSpanSecondsGraphType : ScalarGraphType
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="TimeSpanSecondsGraphType"/> class
+        /// Initializes a new instance of the <see cref="TimeSpanSecondsGraphType"/> class.
         /// </summary>
         public TimeSpanSecondsGraphType()
         {

--- a/src/GraphQL/Types/Scalars/UIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UIntGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The UInt scalar graph type represents an unsigned 32-bit integer value.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="uint"/> .NET values to this scalar graph type.
     /// </summary>
     public class UIntGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/UIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UIntGraphType.cs
@@ -3,7 +3,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The ULong scalar graph type represents an unsigned 32-bit integer value.
+    /// The UInt scalar graph type represents an unsigned 32-bit integer value.
     /// </summary>
     public class UIntGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/UIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UIntGraphType.cs
@@ -2,8 +2,12 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The ULong scalar graph type represents an unsigned 32-bit integer value.
+    /// </summary>
     public class UIntGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             UIntValue uintValue => uintValue.Value,
@@ -12,6 +16,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(uint));
     }
 }

--- a/src/GraphQL/Types/Scalars/ULongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ULongGraphType.cs
@@ -2,16 +2,22 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The ULong scalar graph type represents an unsigned 64-bit integer value.
+    /// </summary>
     public class ULongGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             ULongValue ulongValue => ulongValue.Value,
             IntValue intValue => intValue.Value >= 0 ? (ulong?)intValue.Value : null,
             LongValue longValue => longValue.Value >= 0 ? (ulong?)longValue.Value : null,
+            BigIntValue bigIntValue => bigIntValue.Value >= 0 && bigIntValue.Value <= ulong.MaxValue ? (ulong?)bigIntValue.Value : null,
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(ulong));
     }
 }

--- a/src/GraphQL/Types/Scalars/ULongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ULongGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The ULong scalar graph type represents an unsigned 64-bit integer value.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="ulong"/> .NET values to this scalar graph type.
     /// </summary>
     public class ULongGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/UShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UShortGraphType.cs
@@ -2,8 +2,12 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The UShort scalar graph type represents an unsigned 16-bit integer value.
+    /// </summary>
     public class UShortGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             UShortValue ushortValue => ushortValue.Value,
@@ -11,6 +15,7 @@ namespace GraphQL.Types
             _ => null
         };
 
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(ushort));
     }
 }

--- a/src/GraphQL/Types/Scalars/UShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UShortGraphType.cs
@@ -1,9 +1,11 @@
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The UShort scalar graph type represents an unsigned 16-bit integer value.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="ushort"/> .NET values to this scalar graph type.
     /// </summary>
     public class UShortGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -3,10 +3,15 @@ using GraphQL.Language.AST;
 
 namespace GraphQL.Types
 {
+    /// <summary>
+    /// The Uri scalar graph type represents an Uri represented as a string value
+    /// </summary>
     public class UriGraphType : ScalarGraphType
     {
+        /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(Uri));
 
+        /// <inheritdoc/>
         public override object ParseLiteral(IValue value) => value switch
         {
             UriValue uriValue => uriValue.Value,

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -1,10 +1,12 @@
 using System;
 using GraphQL.Language.AST;
+using GraphQL.Utilities;
 
 namespace GraphQL.Types
 {
     /// <summary>
     /// The Uri scalar graph type represents a string Uri specified in RFC 2396, RFC 2732, RFC 3986, and RFC 3987.
+    /// By default <see cref="GraphTypeTypeRegistry"/> maps all <see cref="Uri"/> .NET values to this scalar graph type.
     /// </summary>
     public class UriGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -4,7 +4,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The Uri scalar graph type represents an Uri represented as a string value
+    /// The Uri scalar graph type represents an Uri represented as a string value.
     /// </summary>
     public class UriGraphType : ScalarGraphType
     {

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -4,7 +4,7 @@ using GraphQL.Language.AST;
 namespace GraphQL.Types
 {
     /// <summary>
-    /// The Uri scalar graph type represents an Uri represented as a string value.
+    /// The Uri scalar graph type represents a string Uri specified in RFC 2396, RFC 2732, RFC 3986, and RFC 3987.
     /// </summary>
     public class UriGraphType : ScalarGraphType
     {


### PR DESCRIPTION
Also fixes a bug:
- `ULongGraphType` cannot parse integer literals greater than `long.MaxValue` and less than or equal to `ulong.MaxValue`.