### PR TITLE
Extension methods to configure authorization requirements for GraphQL elements: types, fields, schema.

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -2,6 +2,8 @@
 
 ## New Features
 
+* Extension methods to configure authorization requirements for GraphQL elements: types, fields, schema.
+
 ## Breaking Changes
 
 * `NameConverter` and `SchemaFilter` have been removed from `ExecutionOptions` and are now properties on the `Schema`.

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1,5 +1,15 @@
 namespace GraphQL
 {
+    public static class AuthorizationExtensions
+    {
+        public const string POLICY_KEY = "Authorization__Policies";
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
+        public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
+        public static System.Collections.Generic.List<string> GetPolicies(this GraphQL.Types.IProvideMetadata provider) { }
+        public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata provider) { }
+    }
     public static class BoolBox
     {
         public static readonly object False;

--- a/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
@@ -6,7 +6,11 @@ namespace GraphQL.Tests.Bugs
 {
     public class Bug138DecimalPrecisionTests : QueryTestBase<DecimalSchema>
     {
+#if NETCOREAPP3_1
         [Fact]
+#else
+        [Fact(Skip = "24.149999999999999 with .NET Core < 3.1")]
+#endif
         public void double_to_decimal_does_not_lose_precision()
         {
             var query = @"

--- a/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
@@ -1,4 +1,5 @@
 using GraphQL.Types;
+using Shouldly;
 using Xunit;
 
 namespace GraphQL.Tests.Bugs
@@ -38,6 +39,7 @@ namespace GraphQL.Tests.Bugs
                 resolve: context =>
                 {
                     var val = context.GetArgument<decimal>("request");
+                    val.ShouldBe(24.15m);
                     return val;
                 });
         }

--- a/src/GraphQL/AuthorizationExtensions.cs
+++ b/src/GraphQL/AuthorizationExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using GraphQL.Builders;
 using GraphQL.Types;
@@ -55,6 +56,9 @@ namespace GraphQL
         public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : IProvideMetadata
         {
+            if (policy == null)
+                throw new ArgumentNullException(nameof(policy));
+
             var list = GetPolicies(provider) ?? new List<string>();
 
             if (!list.Contains(policy))

--- a/src/GraphQL/AuthorizationExtensions.cs
+++ b/src/GraphQL/AuthorizationExtensions.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using GraphQL.Builders;
+using GraphQL.Types;
+
+namespace GraphQL
+{
+    /// <summary>
+    /// Extension methods to configure authorization requirements for GraphQL elements: types, fields, schema.
+    /// </summary>
+    public static class AuthorizationExtensions
+    {
+        /// <summary>
+        /// Metadata key name for storing authorization policy names. Value of this key
+        /// is a simple list of strings.
+        /// </summary>
+        public const string POLICY_KEY = "Authorization__Policies";
+
+        /// <summary>
+        /// Gets a list of authorization policy names for the specified metadata provider.
+        /// </summary>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <returns> List of authorization policy names applied to this metadata provider. </returns>
+        public static List<string> GetPolicies(this IProvideMetadata provider) => provider.GetMetadata<List<string>>(POLICY_KEY);
+
+        /// <summary>
+        /// Gets a boolean value that determines whether any authorization policy is applied to this metadata provider.
+        /// </summary>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <returns> <c>true</c> if any authorization policy is applied, otherwise <c>false</c>. </returns>
+        public static bool RequiresAuthorization(this IProvideMetadata provider)
+        {
+            var policies = GetPolicies(provider);
+            return policies != null && policies.Count > 0;
+        }
+
+        /// <summary>
+        /// Adds authorization policy to the specified metadata provider. If the provider already contains
+        /// a policy with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
+        /// let compiler infer the returning type to allow methods chaining.
+        /// </typeparam>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <param name="policy"> Authorization policy name. </param>
+        /// <returns> The reference to the specified <paramref name="provider"/>. </returns>
+        public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
+            where TMetadataProvider : IProvideMetadata
+        {
+            var list = GetPolicies(provider) ?? new List<string>();
+
+            if (!list.Contains(policy))
+                list.Add(policy);
+
+            provider.Metadata[POLICY_KEY] = list;
+            return provider;
+        }
+
+        /// <summary>
+        /// Adds authorization policy to the specified field builder. If the underlying field already contains
+        /// a policy with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TSourceType"></typeparam>
+        /// <typeparam name="TReturnType"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="policy"> Authorization policy name. </param>
+        /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
+        public static FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(
+            this FieldBuilder<TSourceType, TReturnType> builder, string policy)
+        {
+            builder.FieldType.AuthorizeWith(policy);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds authorization policy to the specified connection builder. If the underlying field already
+        /// contains a policy with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TSourceType"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="policy"> Authorization policy name. </param>
+        /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
+        public static ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(
+            this ConnectionBuilder<TSourceType> builder, string policy)
+        {
+            builder.FieldType.AuthorizeWith(policy);
+            return builder;
+        }
+    }
+}

--- a/src/GraphQL/Execution/SerialExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SerialExecutionStrategy.cs
@@ -67,7 +67,6 @@ namespace GraphQL.Execution
                     }
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
See https://github.com/graphql-dotnet/server/issues/293 and especially https://github.com/graphql-dotnet/server/issues/293#issuecomment-740469302 .I believe it would be correct to provide a base API for declaration of authorization requirements in the main project. In this case, the implementation will remain in the corresponding separate repositories.