### PR TITLE
Fix build process

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -27,6 +27,9 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
+          source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Install dependencies
         working-directory: src
         run: dotnet restore


### PR DESCRIPTION
Problem started to occur around 12/20/2020.  See https://github.com/actions/virtual-environments/issues/1090#issuecomment-748432535 .  See https://www.hossambarakat.net/2020/06/24/fix-error-NU1101/ .  Fixed by adding Nuget.config file (automatically via the workflow).

- This is now occurring in `master` and `develop` branches.
- It is not due to code changes; rerunning old build check workflows now results in an error
- The build-artifacts and publish workflows are not affected as they already create a Nuget.config file within them (tested).
- It is not caused by installing both 2.1 and 3.1 SDKs, and the order of side-by-side SDK installation does not matter.

Once this PR is merged, `master` needs to be merged into `develop`, and from there into any open PRs.