### PR TITLE
DecimalValue check does not allocate memory

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -14,4 +14,5 @@ jobs:
     steps:
     - uses: actions/labeler@v3
       with:
+        sync-labels: ""
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/src/GraphQL.Tests/Types/DecimalGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DecimalGraphTypeTests.cs
@@ -52,5 +52,17 @@ namespace GraphQL.Tests.Types
             _type.ParseLiteral(new DecimalValue(12345.6579m)).ShouldBe(12345.6579m);
             _type.ParseLiteral(new DecimalValue(39614081257132168796771975168m)).ShouldBe(39614081257132168796771975168m);
         }
+
+        [Fact]
+        public void Unsafe_As_Does_Not_Allocate_Memory()
+        {
+            var allocated = GC.GetAllocatedBytesForCurrentThread();
+
+            var number = 12.10m;
+            for (int i = 0; i < 1000; i++)
+                _ = System.Runtime.CompilerServices.Unsafe.As<decimal, GraphQL.Language.DecimalData>(ref number);
+
+            GC.GetAllocatedBytesForCurrentThread().ShouldBe(allocated);
+        }
     }
 }

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -393,5 +393,4 @@ namespace GraphQL.Language
 
         internal bool Equals(ref DecimalData other) => Flags == other.Flags && Hi == other.Hi && Lo == other.Lo && Mid == other.Mid;
     }
-
 }

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -250,12 +250,13 @@ namespace GraphQL.Language
                         str.Value,
                         NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent,
                         CultureInfo.InvariantCulture,
-                        out var dec))
+                        out decimal dec))
                     {
-                        // TODO: make more efficient, current solution allocates memory
-                        int[] decBits = decimal.GetBits(dec);
-                        int[] dblAsDecBits = decimal.GetBits(new decimal(dbl));
-                        if (decBits[0] != dblAsDecBits[0] || decBits[1] != dblAsDecBits[1] || decBits[2] != dblAsDecBits[2] || decBits[3] != dblAsDecBits[3])
+                        // Cast the decimal to our struct to avoid the decimal.GetBits allocations.
+                        var decBits = System.Runtime.CompilerServices.Unsafe.As<decimal, DecimalData>(ref dec);
+                        decimal temp = new decimal(dbl);
+                        var dblAsDecBits = System.Runtime.CompilerServices.Unsafe.As<decimal, DecimalData>(ref temp);
+                        if (!decBits.Equals(dblAsDecBits))
                             return new DecimalValue(dec).WithLocation(str);
                     }
 
@@ -364,4 +365,33 @@ namespace GraphQL.Language
             return node.WithLocation(0, 0, astNode?.Location.Start ?? -1, astNode?.Location.End ?? -1);
         }
     }
+
+    // * DESCRIPTION TAKEN FROM MS REFERENCE SOURCE *
+    // https://github.com/microsoft/referencesource/blob/master/mscorlib/system/decimal.cs
+    // The lo, mid, hi, and flags fields contain the representation of the
+    // Decimal value. The lo, mid, and hi fields contain the 96-bit integer
+    // part of the Decimal. Bits 0-15 (the lower word) of the flags field are
+    // unused and must be zero; bits 16-23 contain must contain a value between
+    // 0 and 28, indicating the power of 10 to divide the 96-bit integer part
+    // by to produce the Decimal value; bits 24-30 are unused and must be zero;
+    // and finally bit 31 indicates the sign of the Decimal value, 0 meaning
+    // positive and 1 meaning negative.
+    internal readonly struct DecimalData
+    {
+        public readonly uint Flags;
+        public readonly uint Hi;
+        public readonly uint Lo;
+        public readonly uint Mid;
+
+        internal DecimalData(uint flags, uint hi, uint lo, uint mid)
+        {
+            Flags = flags;
+            Hi = hi;
+            Lo = lo;
+            Mid = mid;
+        }
+
+        internal bool Equals(ref DecimalData other) => Flags == other.Flags && Hi == other.Hi && Lo == other.Lo && Mid == other.Mid;
+    }
+
 }

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -391,6 +391,6 @@ namespace GraphQL.Language
             Mid = mid;
         }
 
-        internal bool Equals(ref DecimalData other) => Flags == other.Flags && Hi == other.Hi && Lo == other.Lo && Mid == other.Mid;
+        internal bool Equals(in DecimalData other) => Flags == other.Flags && Hi == other.Hi && Lo == other.Lo && Mid == other.Mid;
     }
 }


### PR DESCRIPTION
Inspired by https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/984.
Resolves old TODO with `decimal.GetBits`.