### PR TITLE
Remove LightweightCache.GetKey and .First

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -8,3 +8,4 @@
 
 * `NameConverter` and `SchemaFilter` have been removed from `ExecutionOptions` and are now properties on the `Schema`.
 * `GraphQL.Utilities.ServiceProviderExtensions` has been made internal. This affects usages of it's extension method `GetRequiredService`. Instead reference the `Microsoft.Extensions.DependencyInjection.Abstractions` NuGet package and use extension method from `Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions` class.
+* `LightweightCache.First` has been removed.

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -213,8 +213,6 @@ namespace GraphQL
         public LightweightCache(System.Func<TKey, TValue> onMissing) { }
         public LightweightCache(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Func<TKey, TValue> onMissing) { }
         public int Count { get; }
-        public TValue First { get; }
-        public System.Func<TValue, TKey> GetKey { get; set; }
         public TValue this[TKey key] { get; set; }
         public System.Collections.Generic.IEnumerable<TKey> Keys { get; }
         public System.Func<TKey, TValue> OnMissing { set; }

--- a/src/GraphQL/LightweightCache.cs
+++ b/src/GraphQL/LightweightCache.cs
@@ -67,25 +67,10 @@ namespace GraphQL
             set => _onMissing = value;
         }
 
-        public Func<TValue, TKey> GetKey { get; set; } = delegate { throw new NotImplementedException(); };
-
         /// <summary>
         /// Gets the count.
         /// </summary>
         public int Count => _values.Count;
-
-        public TValue First
-        {
-            get
-            {
-                foreach (var pair in _values)
-                {
-                    return pair.Value;
-                }
-
-                return default;
-            }
-        }
 
         /// <summary>
         /// Gets or sets the <typeparamref name="TValue"/> with the specified key.


### PR DESCRIPTION
`GetKey` isn't implemented and doesn't override a member.

`First` is not used and does not seem to fulfill a purpose.

Targeting `develop` of course.