### PR TITLE
Change Connection.TotalCount to nullable int

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -11,3 +11,4 @@
 * When used, Apollo tracing will now convert the starting timestamp to UTC so that `StartTime` and `EndTime` are properly serialized as UTC values.
 * `ApolloTracing.ConvertTime` is now private and `ResolverTrace.Path` does not initialize an empty list when created.
 * `LightweightCache.First` has been removed.
+* `Connection<TNode, TEdge>.TotalCount` has been changed from an `int` to an `int?`. This allows for returning `null` indicating that the total count is unknown.

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2312,7 +2312,7 @@ namespace GraphQL.Types.Relay.DataObjects
         public System.Collections.Generic.List<TEdge> Edges { get; set; }
         public System.Collections.Generic.List<TNode> Items { get; }
         public GraphQL.Types.Relay.DataObjects.PageInfo PageInfo { get; set; }
-        public int TotalCount { get; set; }
+        public int? TotalCount { get; set; }
     }
     public class Edge<TNode>
     {

--- a/src/GraphQL/Types/Relay/DataObjects/Connection.cs
+++ b/src/GraphQL/Types/Relay/DataObjects/Connection.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Types.Relay.DataObjects
         where TEdge : Edge<TNode>
     {
         /// <summary>
-        /// The total number of records available.
+        /// The total number of records available. Returns <see langword="null"/> if the total number is unknown.
         /// </summary>
         public int? TotalCount { get; set; }
 

--- a/src/GraphQL/Types/Relay/DataObjects/Connection.cs
+++ b/src/GraphQL/Types/Relay/DataObjects/Connection.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Types.Relay.DataObjects
         /// <summary>
         /// The total number of records available.
         /// </summary>
-        public int TotalCount { get; set; }
+        public int? TotalCount { get; set; }
 
         /// <summary>
         /// Additional pagination information for this result data set.


### PR DESCRIPTION
@sungam3r Any comments? Seems rather obvious to me when considering this existing code:

```cs
            Field<IntGraphType>()
                .Name("totalCount")
                .Description(
                    "A count of the total number of objects in this connection, ignoring pagination. " +
                    "This allows a client to fetch the first five objects by passing \"5\" as the argument " +
                    "to `first`, then fetch the total count so it could display \"5 of 83\", for example. " +
                    "In cases where we employ infinite scrolling or don't have an exact count of entries, " +
                    "this field will return `null`.");
```