### PR TITLE
Move IHaveDefaultValue.Type to IProvideResolvedType.Type

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -11,3 +11,4 @@
 * When used, Apollo tracing will now convert the starting timestamp to UTC so that `StartTime` and `EndTime` are properly serialized as UTC values.
 * `ApolloTracing.ConvertTime` is now private and `ResolverTrace.Path` does not initialize an empty list when created.
 * `LightweightCache.First` has been removed.
+* `IHaveDefaultValue.Type` has been moved to `IProvideResolvedType.Type`

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1978,7 +1978,6 @@ namespace GraphQL.Types
     public interface IHaveDefaultValue : GraphQL.Types.IProvideResolvedType
     {
         object DefaultValue { get; }
-        System.Type Type { get; }
     }
     public interface IImplementInterfaces
     {
@@ -2006,6 +2005,7 @@ namespace GraphQL.Types
     public interface IProvideResolvedType
     {
         GraphQL.Types.IGraphType ResolvedType { get; }
+        System.Type Type { get; }
     }
     public interface ISchema : GraphQL.Types.IProvideMetadata
     {

--- a/src/GraphQL/Types/IHaveDefaultValue.cs
+++ b/src/GraphQL/Types/IHaveDefaultValue.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GraphQL.Types
 {
     /// <summary>
@@ -11,10 +9,5 @@ namespace GraphQL.Types
         /// Returns the default value of this argument or field.
         /// </summary>
         object DefaultValue { get; }
-
-        /// <summary>
-        /// Returns the graph type of this argument or field.
-        /// </summary>
-        Type Type { get; }
     }
 }

--- a/src/GraphQL/Types/IProvideResolvedType.cs
+++ b/src/GraphQL/Types/IProvideResolvedType.cs
@@ -1,7 +1,14 @@
+using System;
+
 namespace GraphQL.Types
 {
     public interface IProvideResolvedType
     {
         IGraphType ResolvedType { get; }
+
+        /// <summary>
+        /// Returns the graph type of this argument or field.
+        /// </summary>
+        Type Type { get; }
     }
 }


### PR DESCRIPTION
As you can see, no code changes were necessary.  But perhaps we should rename `IProvideResolvedType` to `IProvideType` ?  I'd probably leave it as-is.

Note: xml comments to be done in separate PR targeting the `master` branch