### PR TITLE
Remove INode.IsEqualTo

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -20,6 +20,7 @@
 * `IHaveDefaultValue.Type` has been moved to `IProvideResolvedType.Type`
 * `Connection<TNode, TEdge>.TotalCount` has been changed from an `int` to an `int?`. This allows for returning `null` indicating that the total count is unknown.
 * By default fields returned by introspection query are no longer sorted by their names. `LegacyV3SchemaComparer` can be used to switch to the old behavior.
+* `INode.IsEqualTo` and related methods have been removed.
 
 ```c#
     /// <summary>

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1161,7 +1161,6 @@ namespace GraphQL.Language.AST
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
-        public GraphQL.Language.AST.Field MergeSelectionSet(GraphQL.Language.AST.Field other) { }
         public override string ToString() { }
     }
     public class Fields : System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Field>, System.Collections.IEnumerable

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1057,7 +1057,6 @@ namespace GraphQL.Language.AST
         public string Comment { get; }
         public GraphQL.Language.AST.CommentNode CommentNode { get; set; }
         public GraphQL.Language.AST.SourceLocation SourceLocation { get; set; }
-        public abstract bool IsEqualTo(GraphQL.Language.AST.INode node);
     }
     public class Argument : GraphQL.Language.AST.AbstractNode
     {
@@ -1067,8 +1066,6 @@ namespace GraphQL.Language.AST
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public GraphQL.Language.AST.IValue Value { get; set; }
-        protected bool Equals(GraphQL.Language.AST.Argument other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class Arguments : GraphQL.Language.AST.AbstractNode, System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Argument>, System.Collections.IEnumerable
@@ -1077,46 +1074,37 @@ namespace GraphQL.Language.AST
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public void Add(GraphQL.Language.AST.Argument arg) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Language.AST.Argument> GetEnumerator() { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
         public GraphQL.Language.AST.IValue ValueFor(string name) { }
     }
     public class BigIntValue : GraphQL.Language.AST.ValueNode<System.Numerics.BigInteger>
     {
         public BigIntValue(System.Numerics.BigInteger value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<System.Numerics.BigInteger> other) { }
     }
     public class BooleanValue : GraphQL.Language.AST.ValueNode<bool>
     {
         public BooleanValue(bool value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<bool> other) { }
     }
     public class ByteValue : GraphQL.Language.AST.ValueNode<byte>
     {
         public ByteValue(byte value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<byte> other) { }
     }
     public class CommentNode : GraphQL.Language.AST.AbstractNode
     {
         public CommentNode(string value) { }
         public string Value { get; }
-        protected bool Equals(GraphQL.Language.AST.CommentNode other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
     }
     public class DateTimeOffsetValue : GraphQL.Language.AST.ValueNode<System.DateTimeOffset>
     {
         public DateTimeOffsetValue(System.DateTimeOffset value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<System.DateTimeOffset> other) { }
     }
     public class DateTimeValue : GraphQL.Language.AST.ValueNode<System.DateTime>
     {
         public DateTimeValue(System.DateTime value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<System.DateTime> other) { }
     }
     public class DecimalValue : GraphQL.Language.AST.ValueNode<decimal>
     {
         public DecimalValue(decimal value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<decimal> other) { }
     }
     public class Directive : GraphQL.Language.AST.AbstractNode
     {
@@ -1125,8 +1113,6 @@ namespace GraphQL.Language.AST
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; set; }
-        protected bool Equals(GraphQL.Language.AST.Directive other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class Directives : GraphQL.Language.AST.AbstractNode, System.Collections.Generic.ICollection<GraphQL.Language.AST.Directive>, System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Directive>, System.Collections.IEnumerable
@@ -1142,7 +1128,6 @@ namespace GraphQL.Language.AST
         public void CopyTo(GraphQL.Language.AST.Directive[] array, int arrayIndex) { }
         public GraphQL.Language.AST.Directive Find(string name) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Language.AST.Directive> GetEnumerator() { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public bool Remove(GraphQL.Language.AST.Directive item) { }
         public override string ToString() { }
     }
@@ -1154,7 +1139,6 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.Operations Operations { get; }
         public string OriginalQuery { get; set; }
         public void AddDefinition(GraphQL.Language.AST.IDefinition definition) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode node) { }
         public override string ToString() { }
     }
     public class EnumValue : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue
@@ -1163,8 +1147,6 @@ namespace GraphQL.Language.AST
         public EnumValue(string name) { }
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
-        protected bool Equals(GraphQL.Language.AST.EnumValue other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class Field : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.IHaveSelectionSet, GraphQL.Language.AST.INode, GraphQL.Language.AST.ISelection
@@ -1179,8 +1161,6 @@ namespace GraphQL.Language.AST
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
-        protected bool Equals(GraphQL.Language.AST.Field other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public GraphQL.Language.AST.Field MergeSelectionSet(GraphQL.Language.AST.Field other) { }
         public override string ToString() { }
     }
@@ -1194,7 +1174,6 @@ namespace GraphQL.Language.AST
     public class FloatValue : GraphQL.Language.AST.ValueNode<double>
     {
         public FloatValue(double value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<double> other) { }
     }
     public class FragmentDefinition : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.IDefinition, GraphQL.Language.AST.IHaveSelectionSet, GraphQL.Language.AST.INode
     {
@@ -1205,8 +1184,6 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
         public GraphQL.Language.AST.NamedType Type { get; set; }
-        protected bool Equals(GraphQL.Language.AST.FragmentDefinition other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class FragmentSpread : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.IFragment, GraphQL.Language.AST.INode, GraphQL.Language.AST.ISelection
@@ -1216,8 +1193,6 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.Directives Directives { get; set; }
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
-        protected bool Equals(GraphQL.Language.AST.FragmentSpread other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class Fragments : System.Collections.Generic.IEnumerable<GraphQL.Language.AST.FragmentDefinition>, System.Collections.IEnumerable
@@ -1230,7 +1205,6 @@ namespace GraphQL.Language.AST
     public class GuidValue : GraphQL.Language.AST.ValueNode<System.Guid>
     {
         public GuidValue(System.Guid value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<System.Guid> other) { }
     }
     public interface IDefinition : GraphQL.Language.AST.INode { }
     public interface IFragment : GraphQL.Language.AST.INode, GraphQL.Language.AST.ISelection { }
@@ -1242,7 +1216,6 @@ namespace GraphQL.Language.AST
     {
         System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         GraphQL.Language.AST.SourceLocation SourceLocation { get; }
-        bool IsEqualTo(GraphQL.Language.AST.INode node);
     }
     public interface ISelection : GraphQL.Language.AST.INode { }
     public interface IType : GraphQL.Language.AST.INode { }
@@ -1261,20 +1234,17 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.Directives Directives { get; set; }
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
         public GraphQL.Language.AST.NamedType Type { get; set; }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class IntValue : GraphQL.Language.AST.ValueNode<int>
     {
         public IntValue(int value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<int> other) { }
     }
     public class ListType : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IType
     {
         public ListType(GraphQL.Language.AST.IType type) { }
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public GraphQL.Language.AST.IType Type { get; }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode node) { }
         public override string ToString() { }
     }
     public class ListValue : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue
@@ -1283,27 +1253,22 @@ namespace GraphQL.Language.AST
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public object Value { get; }
         public System.Collections.Generic.IEnumerable<GraphQL.Language.AST.IValue> Values { get; }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class LongValue : GraphQL.Language.AST.ValueNode<long>
     {
         public LongValue(long value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<long> other) { }
     }
     public class NameNode : GraphQL.Language.AST.AbstractNode
     {
         public NameNode(string name) { }
         public string Name { get; }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode node) { }
     }
     public class NamedType : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IType
     {
         public NamedType(GraphQL.Language.AST.NameNode node) { }
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
-        protected bool Equals(GraphQL.Language.AST.NamedType other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class NonNullType : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IType
@@ -1311,13 +1276,11 @@ namespace GraphQL.Language.AST
         public NonNullType(GraphQL.Language.AST.IType type) { }
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public GraphQL.Language.AST.IType Type { get; }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode node) { }
         public override string ToString() { }
     }
     public class NullValue : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue
     {
         public NullValue() { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class ObjectField : GraphQL.Language.AST.AbstractNode
@@ -1328,8 +1291,6 @@ namespace GraphQL.Language.AST
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public GraphQL.Language.AST.IValue Value { get; }
-        protected bool Equals(GraphQL.Language.AST.ObjectField other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class ObjectValue : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue
@@ -1340,7 +1301,6 @@ namespace GraphQL.Language.AST
         public System.Collections.Generic.IEnumerable<GraphQL.Language.AST.ObjectField> ObjectFields { get; }
         public object Value { get; }
         public GraphQL.Language.AST.ObjectField Field(string name) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class Operation : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.IDefinition, GraphQL.Language.AST.IHaveSelectionSet, GraphQL.Language.AST.INode
@@ -1353,8 +1313,6 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.OperationType OperationType { get; set; }
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
         public GraphQL.Language.AST.VariableDefinitions Variables { get; set; }
-        protected bool Equals(GraphQL.Language.AST.Operation other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode node) { }
         public override string ToString() { }
     }
     public enum OperationType
@@ -1374,7 +1332,6 @@ namespace GraphQL.Language.AST
     public class SByteValue : GraphQL.Language.AST.ValueNode<sbyte>
     {
         public SByteValue(sbyte value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<sbyte> other) { }
     }
     public class SelectionSet : GraphQL.Language.AST.AbstractNode
     {
@@ -1382,7 +1339,6 @@ namespace GraphQL.Language.AST
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public System.Collections.Generic.IList<GraphQL.Language.AST.ISelection> Selections { get; }
         public void Add(GraphQL.Language.AST.ISelection selection) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public GraphQL.Language.AST.SelectionSet Merge(GraphQL.Language.AST.SelectionSet otherSelection) { }
         public void Prepend(GraphQL.Language.AST.ISelection selection) { }
         public override string ToString() { }
@@ -1390,7 +1346,6 @@ namespace GraphQL.Language.AST
     public class ShortValue : GraphQL.Language.AST.ValueNode<short>
     {
         public ShortValue(short value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<short> other) { }
     }
     public class SourceLocation
     {
@@ -1407,39 +1362,31 @@ namespace GraphQL.Language.AST
     public class StringValue : GraphQL.Language.AST.ValueNode<string>
     {
         public StringValue(string value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<string> other) { }
     }
     public class TimeSpanValue : GraphQL.Language.AST.ValueNode<System.TimeSpan>
     {
         public TimeSpanValue(System.TimeSpan value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<System.TimeSpan> other) { }
     }
     public class UIntValue : GraphQL.Language.AST.ValueNode<uint>
     {
         public UIntValue(uint value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<uint> other) { }
     }
     public class ULongValue : GraphQL.Language.AST.ValueNode<ulong>
     {
         public ULongValue(ulong value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<ulong> other) { }
     }
     public class UShortValue : GraphQL.Language.AST.ValueNode<ushort>
     {
         public UShortValue(ushort value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<ushort> other) { }
     }
     public class UriValue : GraphQL.Language.AST.ValueNode<System.Uri>
     {
         public UriValue(System.Uri value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<System.Uri> other) { }
     }
     public abstract class ValueNode<T> : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue, GraphQL.Language.AST.IValue<T>
     {
         protected ValueNode() { }
         public T Value { get; set; }
-        protected abstract bool Equals(GraphQL.Language.AST.ValueNode<T> node);
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class Variable
@@ -1457,8 +1404,6 @@ namespace GraphQL.Language.AST
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; set; }
         public GraphQL.Language.AST.IType Type { get; set; }
-        protected bool Equals(GraphQL.Language.AST.VariableDefinition other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class VariableDefinitions : System.Collections.Generic.IEnumerable<GraphQL.Language.AST.VariableDefinition>, System.Collections.IEnumerable
@@ -1473,8 +1418,6 @@ namespace GraphQL.Language.AST
         public VariableReference(GraphQL.Language.AST.NameNode name) { }
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
-        protected bool Equals(GraphQL.Language.AST.VariableReference other) { }
-        public override bool IsEqualTo(GraphQL.Language.AST.INode obj) { }
         public override string ToString() { }
     }
     public class Variables : System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Variable>, System.Collections.IEnumerable
@@ -2548,7 +2491,6 @@ namespace GraphQL.Utilities.Federation
     public class AnyValue : GraphQL.Language.AST.ValueNode<object>
     {
         public AnyValue(object value) { }
-        protected override bool Equals(GraphQL.Language.AST.ValueNode<object> node) { }
     }
     public class AnyValueConverter : GraphQL.Types.IAstFromValueConverter
     {

--- a/src/GraphQL.Tests/Execution/RepeatedSubfieldsTest.cs
+++ b/src/GraphQL.Tests/Execution/RepeatedSubfieldsTest.cs
@@ -43,8 +43,8 @@ namespace GraphQL.Tests.Execution
             var fields = ExecutionHelper.CollectFields(new ExecutionContext(), null, outerSelection);
 
             fields.ContainsKey("test").ShouldBeTrue();
-            fields["test"].SelectionSet.Selections.ShouldContain(x => x.IsEqualTo(FirstInnerField));
-            fields["test"].SelectionSet.Selections.ShouldContain(x => x.IsEqualTo(SecondInnerField));
+            fields["test"].SelectionSet.Selections.ShouldContain(x => x == FirstInnerField);
+            fields["test"].SelectionSet.Selections.ShouldContain(x => x == SecondInnerField);
         }
 
         [Fact]
@@ -57,9 +57,9 @@ namespace GraphQL.Tests.Execution
             var fields = ExecutionHelper.CollectFields(new ExecutionContext(), null, outerSelection);
 
             fields["test"].SelectionSet.Selections.ShouldHaveSingleItem();
-            fields["test"].SelectionSet.Selections.ShouldContain(x => x.IsEqualTo(FirstInnerField));
+            fields["test"].SelectionSet.Selections.ShouldContain(x => x == FirstInnerField);
             fields["alias"].SelectionSet.Selections.ShouldHaveSingleItem();
-            fields["alias"].SelectionSet.Selections.ShouldContain(x => x.IsEqualTo(SecondInnerField));
+            fields["alias"].SelectionSet.Selections.ShouldContain(x => x == SecondInnerField);
         }
 
         [Fact]
@@ -94,8 +94,8 @@ namespace GraphQL.Tests.Execution
                 outerSelection);
 
             fields.ShouldHaveSingleItem();
-            fields["test"].SelectionSet.Selections.ShouldContain(x => x.IsEqualTo(FirstInnerField));
-            fields["test"].SelectionSet.Selections.ShouldContain(x => x.IsEqualTo(SecondInnerField));
+            fields["test"].SelectionSet.Selections.ShouldContain(x => x == FirstInnerField);
+            fields["test"].SelectionSet.Selections.ShouldContain(x => x == SecondInnerField);
         }
     }
 }

--- a/src/GraphQL/Language/AST/AbstractNode.cs
+++ b/src/GraphQL/Language/AST/AbstractNode.cs
@@ -22,8 +22,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public SourceLocation SourceLocation { get; set; }
-
-        /// <inheritdoc/>
-        public abstract bool IsEqualTo(INode node);
     }
 }

--- a/src/GraphQL/Language/AST/Argument.cs
+++ b/src/GraphQL/Language/AST/Argument.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -46,25 +45,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc />
         public override string ToString() => $"Argument{{name={Name},value={Value}}}";
-
-        /// <summary>
-        /// Compares another node to this node by name.
-        /// </summary>
-        protected bool Equals(Argument other)
-        {
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-        }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((Argument)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/Arguments.cs
+++ b/src/GraphQL/Language/AST/Arguments.cs
@@ -46,9 +46,6 @@ namespace GraphQL.Language.AST
             return null;
         }
 
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj) => ReferenceEquals(this, obj);
-
         /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
         public IEnumerator<Argument> GetEnumerator()
         {

--- a/src/GraphQL/Language/AST/CommentNode.cs
+++ b/src/GraphQL/Language/AST/CommentNode.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -19,22 +17,5 @@ namespace GraphQL.Language.AST
         /// Returns the comment stored in this node.
         /// </summary>
         public string Value { get; }
-
-        /// <summary>
-        /// Compares this instance to another <see cref="CommentNode"/> by comment value.
-        /// </summary>
-        protected bool Equals(CommentNode other) => string.Equals(Value, other.Value, StringComparison.InvariantCulture);
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((CommentNode)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/Directive.cs
+++ b/src/GraphQL/Language/AST/Directive.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -39,28 +38,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc />
         public override string ToString() => $"Directive{{name='{Name}',arguments={Arguments}}}";
-
-        /// <summary>
-        /// Compares this instance with another instance by name.
-        /// </summary>
-        protected bool Equals(Directive other)
-        {
-            if (other == null)
-                return false;
-
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-        }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((Directive)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -64,9 +64,6 @@ namespace GraphQL.Language.AST
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj) => ReferenceEquals(this, obj);
-
-        /// <inheritdoc/>
         public void Clear()
         {
             _directives.Clear();

--- a/src/GraphQL/Language/AST/Document.cs
+++ b/src/GraphQL/Language/AST/Document.cs
@@ -61,18 +61,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc />
         public override string ToString() => $"Document{{definitions={string.Join(", ", _definitions)}}}";
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode node)
-        {
-            if (node is null)
-                return false;
-            if (ReferenceEquals(this, node))
-                return true;
-            if (node.GetType() != GetType())
-                return false;
-
-            return true;
-        }
     }
 }

--- a/src/GraphQL/Language/AST/Field.cs
+++ b/src/GraphQL/Language/AST/Field.cs
@@ -84,31 +84,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc />
         public override string ToString() => $"Field{{name='{Name}', alias='{Alias}', arguments={Arguments}, directives={Directives}, selectionSet={SelectionSet}}}";
-
-        /// <summary>
-        /// Determines if this instance is equal to another instance by comparing the <see cref="Name"/> and <see cref="Alias"/> properties.
-        /// </summary>
-        private bool Equals(Field other)
-        {
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture) && string.Equals(Alias, other.Alias, StringComparison.InvariantCulture);
-        }
-
-        /// <summary>
-        /// Returns a new field selection node with the child field selection nodes merged with another field's child field selection nodes.
-        /// </summary>
-        public Field MergeSelectionSet(Field other)
-        {
-            if (Equals(other)) //TODO: is this check necessary?
-            {
-                return new Field(AliasNode, NameNode)
-                {
-                    Arguments = Arguments,
-                    SelectionSet = SelectionSet.Merge(other.SelectionSet),
-                    Directives = Directives,
-                    SourceLocation = SourceLocation,
-                };
-            }
-            return this;
-        }
     }
 }

--- a/src/GraphQL/Language/AST/Field.cs
+++ b/src/GraphQL/Language/AST/Field.cs
@@ -88,21 +88,9 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Determines if this instance is equal to another instance by comparing the <see cref="Name"/> and <see cref="Alias"/> properties.
         /// </summary>
-        protected bool Equals(Field other)
+        private bool Equals(Field other)
         {
             return string.Equals(Name, other.Name, StringComparison.InvariantCulture) && string.Equals(Alias, other.Alias, StringComparison.InvariantCulture);
-        }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((Field)obj);
         }
 
         /// <summary>
@@ -110,7 +98,7 @@ namespace GraphQL.Language.AST
         /// </summary>
         public Field MergeSelectionSet(Field other)
         {
-            if (Equals(other))
+            if (Equals(other)) //TODO: is this check necessary?
             {
                 return new Field(AliasNode, NameNode)
                 {

--- a/src/GraphQL/Language/AST/Field.cs
+++ b/src/GraphQL/Language/AST/Field.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST

--- a/src/GraphQL/Language/AST/Fields.cs
+++ b/src/GraphQL/Language/AST/Fields.cs
@@ -29,7 +29,13 @@ namespace GraphQL.Language.AST
 
             if (_fields.TryGetValue(name, out Field original))
             {
-                _fields[name] = original.MergeSelectionSet(field);
+                _fields[name] = new Field(original.AliasNode, original.NameNode)
+                {
+                    Arguments = original.Arguments,
+                    SelectionSet = original.SelectionSet.Merge(field.SelectionSet),
+                    Directives = original.Directives,
+                    SourceLocation = original.SourceLocation,
+                };
             }
             else
             {

--- a/src/GraphQL/Language/AST/FragmentDefinition.cs
+++ b/src/GraphQL/Language/AST/FragmentDefinition.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -60,25 +59,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"FragmentDefinition{{name='{Name}', typeCondition={Type}, directives={Directives}, selectionSet={SelectionSet}}}";
-
-        /// <summary>
-        /// Compares this instance to another instance by name.
-        /// </summary>
-        protected bool Equals(FragmentDefinition other)
-        {
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-        }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((FragmentDefinition)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/FragmentSpread.cs
+++ b/src/GraphQL/Language/AST/FragmentSpread.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -36,25 +35,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"FragmentSpread{{name='{Name}', directives={Directives}}}";
-
-        /// <summary>
-        /// Compares this instance to another instance by name.
-        /// </summary>
-        protected bool Equals(FragmentSpread other)
-        {
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-        }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((FragmentSpread)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/INode.cs
+++ b/src/GraphQL/Language/AST/INode.cs
@@ -16,11 +16,5 @@ namespace GraphQL.Language.AST
         /// Returns the node's location within the source document.
         /// </summary>
         SourceLocation SourceLocation { get; }
-
-        /// <summary>
-        /// Determines if the node is equal to another node.
-        /// This typically returns <see langword="true"/> if the node type and the node name matches.
-        /// </summary>
-        bool IsEqualTo(INode node);
     }
 }

--- a/src/GraphQL/Language/AST/InlineFragment.cs
+++ b/src/GraphQL/Language/AST/InlineFragment.cs
@@ -47,17 +47,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"InlineFragment{{typeCondition={Type}, directives={Directives}, selections={SelectionSet}}}";
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals(Type, ((InlineFragment)obj).Type);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/ListType.cs
+++ b/src/GraphQL/Language/AST/ListType.cs
@@ -28,18 +28,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"ListType{{type={Type}}}";
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode node)
-        {
-            if (node is null)
-                return false;
-            if (ReferenceEquals(this, node))
-                return true;
-            if (node.GetType() != GetType())
-                return false;
-
-            return true;
-        }
     }
 }

--- a/src/GraphQL/Language/AST/NameNode.cs
+++ b/src/GraphQL/Language/AST/NameNode.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -19,11 +17,5 @@ namespace GraphQL.Language.AST
         /// Returns the contained name.
         /// </summary>
         public string Name { get; }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode node)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/GraphQL/Language/AST/NamedType.cs
+++ b/src/GraphQL/Language/AST/NamedType.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -27,26 +25,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"NamedType{{name={Name}}}";
-
-        /// <summary>
-        /// Compares this instance to another instance by comparing the name of the type.
-        /// </summary>
-        protected bool Equals(NamedType other)
-        {
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-        }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-
-            return Equals((NamedType)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/NonNullType.cs
+++ b/src/GraphQL/Language/AST/NonNullType.cs
@@ -28,18 +28,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"NonNullType{{type={Type}}}";
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode node)
-        {
-            if (node is null)
-                return false;
-            if (ReferenceEquals(this, node))
-                return true;
-            if (node.GetType() != GetType())
-                return false;
-
-            return true;
-        }
     }
 }

--- a/src/GraphQL/Language/AST/NullValue.cs
+++ b/src/GraphQL/Language/AST/NullValue.cs
@@ -9,15 +9,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => "null";
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return true;
-            if (ReferenceEquals(this, obj))
-                return true;
-            return obj.GetType() == GetType();
-        }
     }
 }

--- a/src/GraphQL/Language/AST/Operation.cs
+++ b/src/GraphQL/Language/AST/Operation.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -72,25 +71,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"OperationDefinition{{name='{Name}', operation={OperationType}, variableDefinitions={Variables}, directives={Directives}, selectionSet={SelectionSet}}}";
-
-        /// <summary>
-        /// Compares this instance to another instance by name.
-        /// </summary>
-        protected bool Equals(Operation other)
-        {
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture) && OperationType == other.OperationType;
-        }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode node)
-        {
-            if (node is null)
-                return false;
-            if (ReferenceEquals(this, node))
-                return true;
-            if (node.GetType() != GetType())
-                return false;
-            return Equals((Operation)node);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/SelectionSet.cs
+++ b/src/GraphQL/Language/AST/SelectionSet.cs
@@ -60,9 +60,6 @@ namespace GraphQL.Language.AST
         }
 
         /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj) => ReferenceEquals(this, obj);
-
-        /// <inheritdoc/>
         public override string ToString()
         {
             string sel = string.Join(", ", SelectionsList.Select(s => s.ToString()));

--- a/src/GraphQL/Language/AST/ValueNodes/BigIntValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/BigIntValue.cs
@@ -14,8 +14,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<BigInteger> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/BooleanValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/BooleanValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<bool> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/ByteValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ByteValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<byte> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/DateTimeOffsetValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/DateTimeOffsetValue.cs
@@ -14,8 +14,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<DateTimeOffset> other) => DateTimeOffset.Equals(Value, other.Value);
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/DateTimeValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/DateTimeValue.cs
@@ -14,8 +14,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<DateTime> other) => DateTime.Equals(Value, other.Value);
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/DecimalValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/DecimalValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<decimal> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/EnumValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/EnumValue.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -38,23 +36,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"EnumValue{{name={Name}}}";
-
-        /// <summary>
-        /// Compares this instance to another instance by comparing the string representation of the enumeration value.
-        /// </summary>
-        protected bool Equals(EnumValue other) => string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-
-            return Equals((EnumValue)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<double> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/GuidValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/GuidValue.cs
@@ -14,8 +14,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<Guid> other) => Value.Equals(other.Value);
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/IntValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/IntValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<int> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/ListValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ListValue.cs
@@ -36,18 +36,5 @@ namespace GraphQL.Language.AST
             string values = string.Join(", ", Values.Select(x => x.ToString()));
             return $"ListValue{{values={values}}}";
         }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-
-            return true;
-        }
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/LongValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/LongValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<long> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -49,23 +48,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"ObjectField{{name='{Name}', value={Value}}}";
-
-        /// <summary>
-        /// Compares this instance to another instance by name.
-        /// </summary>
-        protected bool Equals(ObjectField other) => string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-
-            return Equals((ObjectField)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectValue.cs
@@ -61,18 +61,5 @@ namespace GraphQL.Language.AST
             string fields = string.Join(", ", ObjectFields.Select(x => x.ToString()));
             return $"ObjectValue{{objectFields={fields}}}";
         }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-
-            return true;
-        }
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/SByteValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/SByteValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<sbyte> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/ShortValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ShortValue.cs
@@ -13,8 +13,5 @@ namespace GraphQL.Language.AST
             Value = value;
         }
 
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<short> other) => Value == other.Value;
-
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/StringValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/StringValue.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -14,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<string> other) => string.Equals(Value, other.Value, StringComparison.InvariantCulture);
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/TimeSpanValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/TimeSpanValue.cs
@@ -14,8 +14,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<TimeSpan> other) => TimeSpan.Equals(Value, other.Value);
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/UIntValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/UIntValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<uint> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/ULongValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ULongValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<ulong> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/UShortValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/UShortValue.cs
@@ -12,8 +12,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<ushort> other) => Value == other.Value;
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/UriValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/UriValue.cs
@@ -14,8 +14,5 @@ namespace GraphQL.Language.AST
         {
             Value = value;
         }
-
-        /// <inheritdoc/>
-        protected override bool Equals(ValueNode<Uri> other) => Equals(Value, other.Value);
     }
 }

--- a/src/GraphQL/Language/AST/ValueNodes/ValueNode.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ValueNode.cs
@@ -12,22 +12,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"{GetType().Name}{{value={Value}}}";
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((T)obj);
-        }
-
-        /// <summary>
-        /// Compares the value of this instance to another instance.
-        /// </summary>
-        protected abstract bool Equals(ValueNode<T> node);
     }
 }

--- a/src/GraphQL/Language/AST/VariableDefinition.cs
+++ b/src/GraphQL/Language/AST/VariableDefinition.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -60,25 +59,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override string ToString() => $"VariableDefinition{{name={Name},type={Type},defaultValue={DefaultValue}}}";
-
-        /// <summary>
-        /// Compares this instance to another instance by name.
-        /// </summary>
-        protected bool Equals(VariableDefinition other)
-        {
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-        }
-
-        /// <inheritdoc/>
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((VariableDefinition)obj);
-        }
     }
 }

--- a/src/GraphQL/Language/AST/VariableReference.cs
+++ b/src/GraphQL/Language/AST/VariableReference.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GraphQL.Language.AST
 {
     public class VariableReference : AbstractNode, IValue
@@ -16,21 +14,5 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc />
         public override string ToString() => $"VariableReference{{name={Name}}}";
-
-        protected bool Equals(VariableReference other)
-        {
-            return string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-        }
-
-        public override bool IsEqualTo(INode obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((VariableReference)obj);
-        }
     }
 }

--- a/src/GraphQL/Utilities/Federation/AnyValue.cs
+++ b/src/GraphQL/Utilities/Federation/AnyValue.cs
@@ -8,7 +8,5 @@ namespace GraphQL.Utilities.Federation
         {
             Value = value;
         }
-
-        protected override bool Equals(ValueNode<object> node) => false;
     }
 }


### PR DESCRIPTION
`IsEqualTo` is never used, and the various protected overloaded `Equals` members are only there to assist `IsEqualTo`.  They don't affect the system-provided `Equals` method.