### PR TITLE
Validation optimizations

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -16,8 +16,6 @@
 * `IGraphType.CollectTypes` method has been removed.
 * `ExecutionHelper.SubFieldsFor` method has been removed.
 * `NodeExtensions`, `AstNodeExtensions` classes have been removed.
-* `ErrorLocation` struct became `readonly`.
-* `SourceLocation` class became `readonly struct`.
 * `CoreToVanillaConverter` class became `static` and most of its members have been removed.
 * `GraphQL.Language.AST.Field.MergeSelectionSet` method has been removed.
 * `CoreToVanillaConverter.Convert` method now requires only one `GraphQLDocument` argument.
@@ -47,7 +45,9 @@
 ```
 
 * `INode.IsEqualTo` and related methods have been removed.
-* `NameNode` has been changed to a readonly struct.
+* `void Visit<TState>(System.Action<INode, TState> action, TState state)` method has been added.
+* `SourceLocation`, `NameNode` and `BasicVisitor` have been changed to a `readonly struct`.
+* `ErrorLocation` struct became `readonly`.
 * `DebugNodeVisitor` class has been removed.
 * Most methods and classes within `OverlappingFieldsCanBeMerged` are now private.
 * `EnumerableExtensions.Apply` for dictionaries has been removed.

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1049,6 +1049,7 @@ namespace GraphQL.Language.AST
         public string Comment { get; }
         public GraphQL.Language.AST.CommentNode CommentNode { get; set; }
         public GraphQL.Language.AST.SourceLocation SourceLocation { get; set; }
+        public virtual void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class Argument : GraphQL.Language.AST.AbstractNode
     {
@@ -1059,6 +1060,7 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public GraphQL.Language.AST.IValue Value { get; set; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class Arguments : GraphQL.Language.AST.AbstractNode, System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Argument>, System.Collections.IEnumerable
     {
@@ -1068,6 +1070,7 @@ namespace GraphQL.Language.AST
         public System.Collections.Generic.IEnumerator<GraphQL.Language.AST.Argument> GetEnumerator() { }
         public override string ToString() { }
         public GraphQL.Language.AST.IValue ValueFor(string name) { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class BigIntValue : GraphQL.Language.AST.ValueNode<System.Numerics.BigInteger>
     {
@@ -1106,6 +1109,7 @@ namespace GraphQL.Language.AST
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; set; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class Directives : GraphQL.Language.AST.AbstractNode, System.Collections.Generic.ICollection<GraphQL.Language.AST.Directive>, System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Directive>, System.Collections.IEnumerable
     {
@@ -1122,6 +1126,7 @@ namespace GraphQL.Language.AST
         public System.Collections.Generic.IEnumerator<GraphQL.Language.AST.Directive> GetEnumerator() { }
         public bool Remove(GraphQL.Language.AST.Directive item) { }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class Document : GraphQL.Language.AST.AbstractNode
     {
@@ -1132,6 +1137,7 @@ namespace GraphQL.Language.AST
         public string OriginalQuery { get; set; }
         public void AddDefinition(GraphQL.Language.AST.IDefinition definition) { }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class EnumValue : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue
     {
@@ -1154,6 +1160,7 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class Fields : System.Collections.Generic.IEnumerable<GraphQL.Language.AST.Field>, System.Collections.IEnumerable
     {
@@ -1176,6 +1183,7 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
         public GraphQL.Language.AST.NamedType Type { get; set; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class FragmentSpread : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.IFragment, GraphQL.Language.AST.INode, GraphQL.Language.AST.ISelection
     {
@@ -1185,6 +1193,7 @@ namespace GraphQL.Language.AST
         public string Name { get; }
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class Fragments : System.Collections.Generic.IEnumerable<GraphQL.Language.AST.FragmentDefinition>, System.Collections.IEnumerable
     {
@@ -1208,6 +1217,7 @@ namespace GraphQL.Language.AST
     {
         System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         GraphQL.Language.AST.SourceLocation SourceLocation { get; }
+        void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state);
     }
     public interface ISelection : GraphQL.Language.AST.INode { }
     public interface IType : GraphQL.Language.AST.INode { }
@@ -1227,6 +1237,7 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
         public GraphQL.Language.AST.NamedType Type { get; set; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class IntValue : GraphQL.Language.AST.ValueNode<int>
     {
@@ -1238,14 +1249,17 @@ namespace GraphQL.Language.AST
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public GraphQL.Language.AST.IType Type { get; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class ListValue : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue
     {
         public ListValue(System.Collections.Generic.IEnumerable<GraphQL.Language.AST.IValue> values) { }
+        public ListValue(System.Collections.Generic.List<GraphQL.Language.AST.IValue> values) { }
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public object Value { get; }
         public System.Collections.Generic.IEnumerable<GraphQL.Language.AST.IValue> Values { get; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class LongValue : GraphQL.Language.AST.ValueNode<long>
     {
@@ -1257,6 +1271,7 @@ namespace GraphQL.Language.AST
         public NameNode(string name, GraphQL.Language.AST.SourceLocation location) { }
         public string Name { get; }
         public GraphQL.Language.AST.SourceLocation SourceLocation { get; }
+        public void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class NamedType : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IType
     {
@@ -1271,6 +1286,7 @@ namespace GraphQL.Language.AST
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public GraphQL.Language.AST.IType Type { get; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class NullValue : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue
     {
@@ -1286,16 +1302,19 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.NameNode NameNode { get; }
         public GraphQL.Language.AST.IValue Value { get; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class ObjectValue : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.INode, GraphQL.Language.AST.IValue
     {
         public ObjectValue(System.Collections.Generic.IEnumerable<GraphQL.Language.AST.ObjectField> fields) { }
+        public ObjectValue(System.Collections.Generic.List<GraphQL.Language.AST.ObjectField> fields) { }
         public override System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Children { get; }
         public System.Collections.Generic.IEnumerable<string> FieldNames { get; }
         public System.Collections.Generic.IEnumerable<GraphQL.Language.AST.ObjectField> ObjectFields { get; }
         public object Value { get; }
         public GraphQL.Language.AST.ObjectField Field(string name) { }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class Operation : GraphQL.Language.AST.AbstractNode, GraphQL.Language.AST.IDefinition, GraphQL.Language.AST.IHaveSelectionSet, GraphQL.Language.AST.INode
     {
@@ -1308,6 +1327,7 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.SelectionSet SelectionSet { get; set; }
         public GraphQL.Language.AST.VariableDefinitions Variables { get; set; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public enum OperationType
     {
@@ -1336,6 +1356,7 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.SelectionSet Merge(GraphQL.Language.AST.SelectionSet otherSelection) { }
         public void Prepend(GraphQL.Language.AST.ISelection selection) { }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class ShortValue : GraphQL.Language.AST.ValueNode<short>
     {
@@ -1397,6 +1418,7 @@ namespace GraphQL.Language.AST
         public GraphQL.Language.AST.NameNode NameNode { get; set; }
         public GraphQL.Language.AST.IType Type { get; set; }
         public override string ToString() { }
+        public override void Visit<TState>(System.Action<GraphQL.Language.AST.INode, TState> action, TState state) { }
     }
     public class VariableDefinitions : System.Collections.Generic.IEnumerable<GraphQL.Language.AST.VariableDefinition>, System.Collections.IEnumerable
     {
@@ -2513,7 +2535,7 @@ namespace GraphQL.Utilities.Federation
 }
 namespace GraphQL.Validation
 {
-    public class BasicVisitor
+    public readonly struct BasicVisitor
     {
         public BasicVisitor(params GraphQL.Validation.INodeVisitor[] visitors) { }
         public BasicVisitor(System.Collections.Generic.IList<GraphQL.Validation.INodeVisitor> visitors) { }
@@ -2585,8 +2607,8 @@ namespace GraphQL.Validation
         public System.Collections.Generic.IDictionary<string, object> UserContext { get; set; }
         public GraphQL.Language.AST.FragmentDefinition GetFragment(string name) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
-        public System.Collections.Generic.IEnumerable<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
-        public System.Collections.Generic.IEnumerable<GraphQL.Language.AST.FragmentDefinition> GetRecursivelyReferencedFragments(GraphQL.Language.AST.Operation operation) { }
+        public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
+        public System.Collections.Generic.List<GraphQL.Language.AST.FragmentDefinition> GetRecursivelyReferencedFragments(GraphQL.Language.AST.Operation operation) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetVariables(GraphQL.Language.AST.IHaveSelectionSet node) { }
         public string Print(GraphQL.Language.AST.INode node) { }
         public string Print(GraphQL.Types.IGraphType type) { }

--- a/src/GraphQL/Language/AST/AbstractNode.cs
+++ b/src/GraphQL/Language/AST/AbstractNode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -18,9 +19,12 @@ namespace GraphQL.Language.AST
         public CommentNode CommentNode { get; set; }
 
         /// <inheritdoc/>
+        public SourceLocation SourceLocation { get; set; }
+
+        /// <inheritdoc/>
         public virtual IEnumerable<INode> Children => null;
 
         /// <inheritdoc/>
-        public SourceLocation SourceLocation { get; set; }
+        public virtual void Visit<TState>(Action<INode, TState> action, TState state) { }
     }
 }

--- a/src/GraphQL/Language/AST/Argument.cs
+++ b/src/GraphQL/Language/AST/Argument.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -42,6 +43,9 @@ namespace GraphQL.Language.AST
         {
             get { yield return Value; }
         }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state) => action(Value, state);
 
         /// <inheritdoc />
         public override string ToString() => $"Argument{{name={Name},value={Value}}}";

--- a/src/GraphQL/Language/AST/Arguments.cs
+++ b/src/GraphQL/Language/AST/Arguments.cs
@@ -16,44 +16,41 @@ namespace GraphQL.Language.AST
         /// <inheritdoc/>
         public override IEnumerable<INode> Children => _arguments;
 
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            if (_arguments != null)
+            {
+                foreach (var arg in _arguments)
+                    action(arg, state);
+            }
+        }
+
         /// <summary>
         /// Adds an argument node to the list.
         /// </summary>
-        public void Add(Argument arg)
-        {
-            if (arg == null)
-                throw new ArgumentNullException(nameof(arg));
-
-            if (_arguments == null)
-                _arguments = new List<Argument>();
-
-            _arguments.Add(arg);
-        }
+        public void Add(Argument arg) => (_arguments ??= new List<Argument>()).Add(arg ?? throw new ArgumentNullException(nameof(arg)));
 
         /// <summary>
         /// Returns the value of an argument node, searching the list of argument nodes by the name of the argument.
         /// </summary>
         public IValue ValueFor(string name)
         {
-            if (_arguments == null)
-                return null;
-
             // DO NOT USE LINQ ON HOT PATH
-            foreach (var x in _arguments)
-                if (x.Name == name)
-                    return x.Value;
+            if (_arguments != null)
+            {
+                foreach (var x in _arguments)
+                {
+                    if (x.Name == name)
+                        return x.Value;
+                }
+            }
 
             return null;
         }
 
         /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<Argument> GetEnumerator()
-        {
-            if (_arguments == null)
-                return System.Linq.Enumerable.Empty<Argument>().GetEnumerator();
-
-            return _arguments.GetEnumerator();
-        }
+        public IEnumerator<Argument> GetEnumerator() => (_arguments ?? System.Linq.Enumerable.Empty<Argument>()).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/GraphQL/Language/AST/Directive.cs
+++ b/src/GraphQL/Language/AST/Directive.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -35,6 +36,9 @@ namespace GraphQL.Language.AST
         {
             get { yield return Arguments; }
         }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state) => action(Arguments, state);
 
         /// <inheritdoc />
         public override string ToString() => $"Directive{{name='{Name}',arguments={Arguments}}}";

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -15,18 +15,22 @@ namespace GraphQL.Language.AST
         /// <inheritdoc/>
         public override IEnumerable<INode> Children => _directives;
 
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            if (_directives != null)
+            {
+                foreach (var directive in _directives)
+                    action(directive, state);
+            }
+        }
+
         /// <summary>
         /// Adds a directive node to the list.
         /// </summary>
         public void Add(Directive directive)
         {
-            if (directive == null)
-                throw new ArgumentNullException(nameof(directive));
-
-            if (_directives == null)
-                _directives = new List<Directive>();
-
-            _directives.Add(directive);
+            (_directives ??= new List<Directive>()).Add(directive ?? throw new ArgumentNullException(nameof(directive)));
 
             if (!_unique.ContainsKey(directive.Name))
             {
@@ -53,13 +57,7 @@ namespace GraphQL.Language.AST
         public bool IsReadOnly => false;
 
         /// <inheritdoc/>
-        public IEnumerator<Directive> GetEnumerator()
-        {
-            if (_directives == null)
-                return System.Linq.Enumerable.Empty<Directive>().GetEnumerator();
-
-            return _directives.GetEnumerator();
-        }
+        public IEnumerator<Directive> GetEnumerator() => (_directives ?? System.Linq.Enumerable.Empty<Directive>()).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/GraphQL/Language/AST/Document.cs
+++ b/src/GraphQL/Language/AST/Document.cs
@@ -28,6 +28,13 @@ namespace GraphQL.Language.AST
         /// <inheritdoc/>
         public override IEnumerable<INode> Children => _definitions;
 
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            foreach (var definition in _definitions)
+                action(definition, state);
+        }
+
         /// <summary>
         /// Returns a list of operation nodes for this document.
         /// </summary>

--- a/src/GraphQL/Language/AST/Field.cs
+++ b/src/GraphQL/Language/AST/Field.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -79,6 +80,14 @@ namespace GraphQL.Language.AST
                     yield return SelectionSet;
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            action(Arguments, state);
+            action(Directives, state);
+            action(SelectionSet, state);
         }
 
         /// <inheritdoc />

--- a/src/GraphQL/Language/AST/FragmentDefinition.cs
+++ b/src/GraphQL/Language/AST/FragmentDefinition.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -47,14 +48,19 @@ namespace GraphQL.Language.AST
 
                 if (Directives != null)
                 {
-                    foreach (var directive in Directives)
-                    {
-                        yield return directive;
-                    }
+                    yield return Directives;
                 }
 
                 yield return SelectionSet;
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            action(Type, state);
+            action(Directives, state);
+            action(SelectionSet, state);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Language/AST/FragmentSpread.cs
+++ b/src/GraphQL/Language/AST/FragmentSpread.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -32,6 +33,9 @@ namespace GraphQL.Language.AST
 
         /// <inheritdoc/>
         public override IEnumerable<INode> Children => Directives;
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state) => action(Directives, state);
 
         /// <inheritdoc/>
         public override string ToString() => $"FragmentSpread{{name='{Name}', directives={Directives}}}";

--- a/src/GraphQL/Language/AST/Fragments.cs
+++ b/src/GraphQL/Language/AST/Fragments.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GraphQL.Language.AST
 {
@@ -9,15 +10,12 @@ namespace GraphQL.Language.AST
     /// </summary>
     public class Fragments : IEnumerable<FragmentDefinition>
     {
-        private readonly List<FragmentDefinition> _fragments = new List<FragmentDefinition>();
+        private List<FragmentDefinition> _fragments;
 
         /// <summary>
         /// Adds a fragment definition node to the list.
         /// </summary>
-        public void Add(FragmentDefinition fragment)
-        {
-            _fragments.Add(fragment ?? throw new ArgumentNullException(nameof(fragment)));
-        }
+        public void Add(FragmentDefinition fragment) => (_fragments ??= new List<FragmentDefinition>()).Add(fragment ?? throw new ArgumentNullException(nameof(fragment)));
 
         /// <summary>
         /// Returns the number of fragment definition nodes in the list.
@@ -30,18 +28,20 @@ namespace GraphQL.Language.AST
         public FragmentDefinition FindDefinition(string name)
         {
             // DO NOT USE LINQ ON HOT PATH
-            foreach (var f in _fragments)
-                if (f.Name == name)
-                    return f;
+            if (_fragments != null)
+            {
+                foreach (var f in _fragments)
+                {
+                    if (f.Name == name)
+                        return f;
+                }
+            }
 
             return null;
         }
 
         /// <inheritdoc/>
-        public IEnumerator<FragmentDefinition> GetEnumerator()
-        {
-            return _fragments.GetEnumerator();
-        }
+        public IEnumerator<FragmentDefinition> GetEnumerator() => (_fragments ?? Enumerable.Empty<FragmentDefinition>()).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/src/GraphQL/Language/AST/INode.cs
+++ b/src/GraphQL/Language/AST/INode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -8,13 +9,21 @@ namespace GraphQL.Language.AST
     public interface INode
     {
         /// <summary>
+        /// Returns the node's location within the source document.
+        /// </summary>
+        SourceLocation SourceLocation { get; }
+
+        /// <summary>
         /// Returns a list of children nodes. If the node doesn't have children, returns <see langword="null"/>.
         /// </summary>
         IEnumerable<INode> Children { get; }
 
         /// <summary>
-        /// Returns the node's location within the source document.
+        /// Visits every child node with the specified delegate and state. If the node doesn't have children, does nothing.
         /// </summary>
-        SourceLocation SourceLocation { get; }
+        /// <typeparam name="TState">Type of the provided state.</typeparam>
+        /// <param name="action">Delegate to execute on every child node of this node.</param>
+        /// <param name="state">An arbitrary state passed by the caller.</param>
+        void Visit<TState>(Action<INode, TState> action, TState state);
     }
 }

--- a/src/GraphQL/Language/AST/InlineFragment.cs
+++ b/src/GraphQL/Language/AST/InlineFragment.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -32,10 +33,7 @@ namespace GraphQL.Language.AST
 
                 if (Directives != null)
                 {
-                    foreach (var directive in Directives)
-                    {
-                        yield return directive;
-                    }
+                    yield return Directives;
                 }
 
                 if (SelectionSet != null)
@@ -43,6 +41,14 @@ namespace GraphQL.Language.AST
                     yield return SelectionSet;
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            action(Type, state);
+            action(Directives, state);
+            action(SelectionSet, state);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Language/AST/ListType.cs
+++ b/src/GraphQL/Language/AST/ListType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -25,6 +26,9 @@ namespace GraphQL.Language.AST
         {
             get { yield return Type; }
         }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state) => action(Type, state);
 
         /// <inheritdoc/>
         public override string ToString() => $"ListType{{type={Type}}}";

--- a/src/GraphQL/Language/AST/NameNode.cs
+++ b/src/GraphQL/Language/AST/NameNode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -30,9 +31,12 @@ namespace GraphQL.Language.AST
         /// </summary>
         public string Name { get; }
 
+        /// <inheritdoc/>
+        public SourceLocation SourceLocation { get; }
+
         IEnumerable<INode> INode.Children => null;
 
         /// <inheritdoc/>
-        public SourceLocation SourceLocation { get; }
+        public void Visit<TState>(Action<INode, TState> action, TState state) { }
     }
 }

--- a/src/GraphQL/Language/AST/NonNullType.cs
+++ b/src/GraphQL/Language/AST/NonNullType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -25,6 +26,9 @@ namespace GraphQL.Language.AST
         {
             get { yield return Type; }
         }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state) => action(Type, state);
 
         /// <inheritdoc/>
         public override string ToString() => $"NonNullType{{type={Type}}}";

--- a/src/GraphQL/Language/AST/Operation.cs
+++ b/src/GraphQL/Language/AST/Operation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -59,14 +60,25 @@ namespace GraphQL.Language.AST
 
                 if (Directives != null)
                 {
-                    foreach (var directive in Directives)
-                    {
-                        yield return directive;
-                    }
+                    yield return Directives;
                 }
 
                 yield return SelectionSet;
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            var variables = Variables?.VariablesList;
+            if (variables != null)
+            {
+                foreach (var variable in variables)
+                    action(variable, state);
+            }
+
+            action(Directives, state);
+            action(SelectionSet, state);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Language/AST/Operations.cs
+++ b/src/GraphQL/Language/AST/Operations.cs
@@ -10,39 +10,39 @@ namespace GraphQL.Language.AST
     /// </summary>
     public class Operations : IEnumerable<Operation>
     {
-        private readonly List<Operation> _operations = new List<Operation>();
+        private List<Operation> _operations;
 
         /// <summary>
         /// Returns the number of operation nodes the list contains.
         /// </summary>
-        public int Count => _operations.Count;
+        public int Count => _operations?.Count ?? 0;
 
         /// <summary>
         /// Adds an operation node to the list.
         /// </summary>
-        /// <param name="operation"></param>
-        public void Add(Operation operation)
-        {
-            _operations.Add(operation ?? throw new ArgumentNullException(nameof(operation)));
-        }
+        public void Add(Operation operation) => (_operations ??= new List<Operation>()).Add(operation ?? throw new ArgumentNullException(nameof(operation)));
 
         /// <summary>
         /// Returns the first operation in the list that matches the specified name, or <see langword="null"/> if none are matched.
         /// </summary>
         public Operation WithName(string operationName)
         {
-            return _operations.FirstOrDefault(op => op.Name == operationName);
+            // DO NOT USE LINQ ON HOT PATH
+            if (_operations != null)
+            {
+                foreach (var op in _operations)
+                {
+                    if (op.Name == operationName)
+                        return op;
+                }
+            }
+
+            return null;
         }
 
         /// <inheritdoc/>
-        public IEnumerator<Operation> GetEnumerator()
-        {
-            return _operations.GetEnumerator();
-        }
+        public IEnumerator<Operation> GetEnumerator() => (_operations ?? Enumerable.Empty<Operation>()).GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/GraphQL/Language/AST/SelectionSet.cs
+++ b/src/GraphQL/Language/AST/SelectionSet.cs
@@ -28,11 +28,21 @@ namespace GraphQL.Language.AST
         /// </summary>
         public IList<ISelection> Selections => SelectionsList;
 
-        // avoids List+Enumerator<ISelection> boxing on hot path
-        internal List<ISelection> SelectionsList { get; }
+        // avoids List+Enumerator<ISelection> boxing
+        internal List<ISelection> SelectionsList { get; private set; }
 
         /// <inheritdoc/>
         public override IEnumerable<INode> Children => SelectionsList;
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            if (SelectionsList != null)
+            {
+                foreach (var selection in SelectionsList)
+                    action(selection, state);
+            }
+        }
 
         /// <summary>
         /// Adds a node to the start of the list.

--- a/src/GraphQL/Language/AST/ValueNodes/ListValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ListValue.cs
@@ -14,21 +14,47 @@ namespace GraphQL.Language.AST
         /// </summary>
         public ListValue(IEnumerable<IValue> values)
         {
-            Values = values ?? Array.Empty<IValue>();
+            ValuesList = (values ?? throw new ArgumentNullException(nameof(values))).ToList();
+        }
+
+        /// <summary>
+        /// Initializes a new instance with the specified list of values.
+        /// </summary>
+        public ListValue(List<IValue> values)
+        {
+            ValuesList = values ?? throw new ArgumentNullException(nameof(values));
         }
 
         /// <summary>
         /// Returns a <see cref="List{T}">List&lt;object&gt;</see> containing the values of the list.
         /// </summary>
-        public object Value => Values.Select(x => x.Value).ToList();
+        public object Value
+        {
+            get
+            {
+                var list = new List<object>(ValuesList.Count);
+                foreach (var item in ValuesList)
+                    list.Add(item.Value);
+                return list;
+            }
+        }
 
         /// <summary>
         /// Returns a list of the child value nodes.
         /// </summary>
-        public IEnumerable<IValue> Values { get; }
+        public IEnumerable<IValue> Values => ValuesList;
+
+        internal List<IValue> ValuesList { get; private set; }
 
         /// <inheritdoc/>
-        public override IEnumerable<INode> Children => Values;
+        public override IEnumerable<INode> Children => ValuesList;
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            foreach (var value in ValuesList)
+                action(value, state);
+        }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -45,6 +46,9 @@ namespace GraphQL.Language.AST
         {
             get { yield return Value; }
         }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state) => action(Value, state);
 
         /// <inheritdoc/>
         public override string ToString() => $"ObjectField{{name='{Name}', value={Value}}}";

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectValue.cs
@@ -14,10 +14,15 @@ namespace GraphQL.Language.AST
         /// </summary>
         public ObjectValue(IEnumerable<ObjectField> fields)
         {
-            if (fields == null)
-                ObjectFields = Array.Empty<ObjectField>();
-            else
-                ObjectFields = fields;
+            ObjectFieldsList = (fields ?? throw new ArgumentNullException(nameof(fields))).ToList();
+        }
+
+        /// <summary>
+        /// Initializes a new instance that contains the specified field nodes.
+        /// </summary>
+        public ObjectValue(List<ObjectField> fields)
+        {
+            ObjectFieldsList = fields ?? throw new ArgumentNullException(nameof(fields));
         }
 
         /// <summary>
@@ -37,22 +42,47 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the field value nodes that are contained within this object value node.
         /// </summary>
-        public IEnumerable<ObjectField> ObjectFields { get; }
+        public IEnumerable<ObjectField> ObjectFields => ObjectFieldsList;
+
+        internal List<ObjectField> ObjectFieldsList { get; private set; }
 
         /// <summary>
         /// Returns a list of the names of the fields specified for this object value node.
         /// </summary>
-        public IEnumerable<string> FieldNames => ObjectFields.Select(x => x.Name).ToList();
+        public IEnumerable<string> FieldNames
+        {
+            get
+            {
+                var list = new List<string>(ObjectFieldsList.Count);
+                foreach (var item in ObjectFieldsList)
+                    list.Add(item.Name);
+                return list;
+            }
+        }
 
         /// <inheritdoc/>
-        public override IEnumerable<INode> Children => ObjectFields;
+        public override IEnumerable<INode> Children => ObjectFieldsList;
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            foreach (var field in ObjectFieldsList)
+                action(field, state);
+        }
 
         /// <summary>
         /// Returns the first matching field node contained within this object value node that matches the specified name, or <see langword="null"/> otherwise.
         /// </summary>
         public ObjectField Field(string name)
         {
-            return ObjectFields.FirstOrDefault(x => x.Name == name);
+            // DO NOT USE LINQ ON HOT PATH
+            foreach (var field in ObjectFieldsList)
+            {
+                if (field.Name == name)
+                    return field;
+            }
+
+            return null;
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Language/AST/VariableDefinition.cs
+++ b/src/GraphQL/Language/AST/VariableDefinition.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GraphQL.Language.AST
@@ -55,6 +56,13 @@ namespace GraphQL.Language.AST
                     yield return DefaultValue;
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Visit<TState>(Action<INode, TState> action, TState state)
+        {
+            action(Type, state);
+            action(DefaultValue, state);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Language/AST/VariableDefinitions.cs
+++ b/src/GraphQL/Language/AST/VariableDefinitions.cs
@@ -10,34 +10,19 @@ namespace GraphQL.Language.AST
     /// </summary>
     public class VariableDefinitions : IEnumerable<VariableDefinition>
     {
-        private List<VariableDefinition> _variables;
+        internal List<VariableDefinition> VariablesList { get; private set; }
 
         /// <summary>
         /// Adds a variable definition node to the list.
         /// </summary>
-        public void Add(VariableDefinition variable)
-        {
-            if (variable == null)
-                throw new ArgumentNullException(nameof(variable));
-
-            if (_variables == null)
-                _variables = new List<VariableDefinition>();
-
-            _variables.Add(variable);
-        }
+        public void Add(VariableDefinition variable) => (VariablesList ??= new List<VariableDefinition>()).Add(variable ?? throw new ArgumentNullException(nameof(variable)));
 
         /// <inheritdoc/>
-        public IEnumerator<VariableDefinition> GetEnumerator()
-        {
-            if (_variables == null)
-                return Enumerable.Empty<VariableDefinition>().GetEnumerator();
-
-            return _variables.GetEnumerator();
-        }
+        public IEnumerator<VariableDefinition> GetEnumerator() => (VariablesList ?? Enumerable.Empty<VariableDefinition>()).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <inheritdoc/>
-        public override string ToString() => _variables?.Count > 0 ? $"VariableDefinitions{{{string.Join(", ", _variables)}}}" : "VariableDefinitions(Empty)";
+        public override string ToString() => VariablesList?.Count > 0 ? $"VariableDefinitions{{{string.Join(", ", VariablesList)}}}" : "VariableDefinitions(Empty)";
     }
 }

--- a/src/GraphQL/Language/AST/Variables.cs
+++ b/src/GraphQL/Language/AST/Variables.cs
@@ -15,34 +15,28 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Adds a variable to the list.
         /// </summary>
-        public void Add(Variable variable)
-        {
-            if (variable == null)
-                throw new ArgumentNullException(nameof(variable));
-
-            if (_variables == null)
-                _variables = new List<Variable>();
-
-            _variables.Add(variable);
-        }
+        public void Add(Variable variable) => (_variables ??= new List<Variable>()).Add(variable ?? throw new ArgumentNullException(nameof(variable)));
 
         /// <summary>
         /// Returns the first variable with a matching name, or <see langword="null"/> if none are found.
         /// </summary>
         public object ValueFor(string name)
         {
-            var variable = _variables?.FirstOrDefault(v => v.Name == name);
-            return variable?.Value;
+            // DO NOT USE LINQ ON HOT PATH
+            if (_variables != null)
+            {
+                foreach (var v in _variables)
+                {
+                    if (v.Name == name)
+                        return v.Value;
+                }
+            }
+
+            return null;
         }
 
         /// <inheritdoc/>
-        public IEnumerator<Variable> GetEnumerator()
-        {
-            if (_variables == null)
-                return Enumerable.Empty<Variable>().GetEnumerator();
-
-            return _variables.GetEnumerator();
-        }
+        public IEnumerator<Variable> GetEnumerator() => (_variables ?? Enumerable.Empty<Variable>()).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -336,13 +336,13 @@ namespace GraphQL.Language
                 case ASTNodeKind.ObjectValue:
                 {
                     var obj = (GraphQLObjectValue)source;
-                    var fields = obj.Fields?.Select(ObjectField);
+                    var fields = obj.Fields?.Select(ObjectField) ?? Enumerable.Empty<ObjectField>();
                     return new ObjectValue(fields) { SourceLocation = Convert(obj.Location) };
                 }
                 case ASTNodeKind.ListValue:
                 {
                     var list = (GraphQLListValue)source;
-                    var values = list.Values?.Select(Value);
+                    var values = list.Values?.Select(Value) ?? Enumerable.Empty<IValue>();
                     return new ListValue(values) { SourceLocation = Convert(list.Location) };
                 }
                 case ASTNodeKind.NullValue:

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -68,13 +68,15 @@ namespace GraphQL.Types
         /// <inheritdoc/>
         public FieldType GetField(string name)
         {
-            if (string.IsNullOrWhiteSpace(name))
-                return null;
-
             // DO NOT USE LINQ ON HOT PATH
-            foreach (var x in _fields)
-                if (string.Equals(x.Name, name, StringComparison.Ordinal))
-                    return x;
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                foreach (var x in _fields)
+                {
+                    if (string.Equals(x.Name, name, StringComparison.Ordinal))
+                        return x;
+                }
+            }
 
             return null;
         }

--- a/src/GraphQL/Types/QueryArguments.cs
+++ b/src/GraphQL/Types/QueryArguments.cs
@@ -65,9 +65,12 @@ namespace GraphQL.Types
         /// </summary>
         public void Add(QueryArgument argument)
         {
+            if (argument == null)
+                throw new ArgumentNullException(nameof(argument));
+
             NameValidator.ValidateName(argument.Name, "argument");
 
-            (ArgumentsList ??= new List<QueryArgument>()).Add(argument ?? throw new ArgumentNullException(nameof(argument)));
+            (ArgumentsList ??= new List<QueryArgument>()).Add(argument);
         }
 
         /// <summary>

--- a/src/GraphQL/Types/QueryArguments.cs
+++ b/src/GraphQL/Types/QueryArguments.cs
@@ -65,15 +65,9 @@ namespace GraphQL.Types
         /// </summary>
         public void Add(QueryArgument argument)
         {
-            if (argument == null)
-                throw new ArgumentNullException(nameof(argument));
-
             NameValidator.ValidateName(argument.Name, "argument");
 
-            if (ArgumentsList == null)
-                ArgumentsList = new List<QueryArgument>();
-
-            ArgumentsList.Add(argument);
+            (ArgumentsList ??= new List<QueryArgument>()).Add(argument ?? throw new ArgumentNullException(nameof(argument)));
         }
 
         /// <summary>
@@ -81,13 +75,15 @@ namespace GraphQL.Types
         /// </summary>
         public QueryArgument Find(string name)
         {
-            if (ArgumentsList == null)
-                return null;
-
             // DO NOT USE LINQ ON HOT PATH
-            foreach (var arg in ArgumentsList)
-                if (arg.Name == name)
-                    return arg;
+            if (ArgumentsList != null)
+            {
+                foreach (var arg in ArgumentsList)
+                {
+                    if (arg.Name == name)
+                        return arg;
+                }
+            }
 
             return null;
         }

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -156,8 +156,10 @@ namespace GraphQL.Types
         {
             // DO NOT USE LINQ ON HOT PATH
             foreach (var def in _values)
+            {
                 if (def.Name.Equals(name, comparison))
                     return def;
+            }
 
             return null;
         }
@@ -174,8 +176,10 @@ namespace GraphQL.Types
 
             // DO NOT USE LINQ ON HOT PATH
             foreach (var def in _values)
+            {
                 if (def.UnderlyingValue.Equals(value))
                     return def;
+            }
 
             return null;
         }

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -490,8 +490,10 @@ namespace GraphQL.Utilities
         {
             // DO NOT USE LINQ ON HOT PATH
             foreach (var c in _configs)
+            {
                 if (c.Matches(node))
                     return c;
+            }
 
             return null;
         }

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
@@ -119,7 +119,7 @@ namespace GraphQL.Utilities.Federation
 
         private bool FindSelectionToAmend(SelectionSet selectionSet, Document document, out SelectionSet setToAlter)
         {
-            foreach (var selection in selectionSet.Selections)
+            foreach (var selection in selectionSet.SelectionsList)
             {
                 if (selection is Field childField && childField.Name == "__typename")
                 {

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -93,14 +93,11 @@ namespace GraphQL.Validation
 
             visitors.Insert(0, context.TypeInfo);
 
-            var basic = new BasicVisitor(visitors);
+            new BasicVisitor(visitors).Visit(document, context);
 
-            basic.Visit(document, context);
-
-            if (context.HasErrors)
-                return new ValidationResult(context.Errors);
-
-            return SuccessfullyValidatedResult.Instance;
+            return context.HasErrors
+                ? new ValidationResult(context.Errors)
+                : (IValidationResult)SuccessfullyValidatedResult.Instance;
         }
     }
 }

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -27,18 +27,16 @@ namespace GraphQL.Validation.Rules
             {
                 var fieldDef = context.TypeInfo.GetFieldDef();
 
-                if (fieldDef == null || fieldDef.Arguments == null)
+                if (fieldDef?.Arguments?.Count > 0)
                 {
-                    return;
-                }
-
-                foreach (var arg in fieldDef.Arguments)
-                {
-                    if (arg.DefaultValue == null &&
-                        arg.ResolvedType is NonNullGraphType &&
-                        node.Arguments?.ValueFor(arg.Name) == null)
+                    foreach (var arg in fieldDef.Arguments.ArgumentsList)
                     {
-                        context.ReportError(new ProvidedNonNullArgumentsError(context, node, arg));
+                        if (arg.DefaultValue == null &&
+                            arg.ResolvedType is NonNullGraphType &&
+                            node.Arguments?.ValueFor(arg.Name) == null)
+                        {
+                            context.ReportError(new ProvidedNonNullArgumentsError(context, node, arg));
+                        }
                     }
                 }
             }),


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.16299.726 (1709/FallCreatorsUpdate/Redstone3)
Intel Core i7 CPU 920 2.67GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
Frequency=2607421 Hz, Resolution=383.5207 ns, Timer=TSC
.NET Core SDK=5.0.101
  [Host]     : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT
  DefaultJob : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT

```
before/after

|        Method |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |----------:|---------:|---------:|-------:|------:|------:|----------:|
| Introspection | 446.98 μs | 0.481 μs | 0.402 μs | 4.3945 |     - |     - |  19.59 KB |
|     Fragments | 204.92 μs | 0.048 μs | 0.040 μs | 2.9297 |     - |     - |  12.31 KB |
|          Hero |  30.26 μs | 0.018 μs | 0.015 μs | 1.1902 |     - |     - |   4.95 KB |

|        Method |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |----------:|---------:|---------:|-------:|------:|------:|----------:|
| Introspection | 426.06 μs | 0.588 μs | 0.491 μs | 3.4180 |     - |     - |  14.16 KB |
|     Fragments | 193.79 μs | 0.123 μs | 0.115 μs | 2.4414 |     - |     - |  10.07 KB |
|          Hero |  29.66 μs | 0.055 μs | 0.051 μs | 1.0681 |     - |     - |   4.48 KB |

My main goal was to reduce the number of heap allocations. It's nice that the speed has also increased. The PR contains a lot of minor fixes, but the main idea is to stop visitors from allocating memory when iterating over children. This was achieved 100%.