### PR TITLE
Don't override argument null literals with default values

### DIFF
--- a/docs2/site/docs/guides/known-issues.md
+++ b/docs2/site/docs/guides/known-issues.md
@@ -183,7 +183,7 @@ data from your database within the fetch delegate, use an inner join to retrieve
 ## Known Issues
 
 `IResolveFieldContext.HasArgument` will return `true` for all arguments where `GetArgument` does not return `null`.
-It cannot identify which arguments have been provided a null value compared to arguments which were not provided.
+It cannot identify which arguments have been provided a `null` value compared to arguments which were not provided.
 
 ## Common Errors
 

--- a/docs2/site/docs/guides/known-issues.md
+++ b/docs2/site/docs/guides/known-issues.md
@@ -180,6 +180,11 @@ This is done within your database queries; it is not a function of the dataloade
 `CollectionBatchDataLoader` as you would for a one-to-many relationship; then when you are loading
 data from your database within the fetch delegate, use an inner join to retrieve the proper data.
 
+## Known Issues
+
+`IResolveFieldContext.HasArgument` will return `true` for all arguments where `GetArgument` does not return `null`.
+It cannot identify which arguments have been provided a null value compared to arguments which were not provided.
+
 ## Common Errors
 
 ### Synchronous operations are disallowed.

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1516,7 +1516,7 @@ namespace GraphQL.Language.AST
         public void Add(GraphQL.Language.AST.Variable variable) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Language.AST.Variable> GetEnumerator() { }
         public override string ToString() { }
-        public object ValueFor(string name, object defaultValue) { }
+        public object ValueFor(string name, object defaultValue = null) { }
     }
 }
 namespace GraphQL.Language

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -665,7 +665,7 @@ namespace GraphQL.Execution
     public static class ExecutionHelper
     {
         public static void AssertValidVariableValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, object input, string variableName, bool hasDefaultValue) { }
-        public static object CoerceValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue input, GraphQL.Language.AST.Variables variables = null) { }
+        public static object CoerceValue(GraphQL.Types.ISchema schema, GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue input, GraphQL.Language.AST.Variables variables = null, object fieldDefault = null) { }
         public static System.Collections.Generic.Dictionary<string, GraphQL.Language.AST.Field> CollectFields(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IGraphType specificType, GraphQL.Language.AST.SelectionSet selectionSet) { }
         public static bool DoesFragmentConditionMatch(GraphQL.Execution.ExecutionContext context, string fragmentName, GraphQL.Types.IGraphType type) { }
         public static System.Collections.Generic.Dictionary<string, object> GetArgumentValues(GraphQL.Types.ISchema schema, GraphQL.Types.QueryArguments definitionArguments, GraphQL.Language.AST.Arguments astArguments, GraphQL.Language.AST.Variables variables) { }
@@ -1479,6 +1479,7 @@ namespace GraphQL.Language.AST
         public Variable() { }
         public string Name { get; set; }
         public object Value { get; set; }
+        public bool ValueSpecified { get; }
     }
     public class VariableDefinition : GraphQL.Language.AST.AbstractNode
     {
@@ -1515,7 +1516,7 @@ namespace GraphQL.Language.AST
         public void Add(GraphQL.Language.AST.Variable variable) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Language.AST.Variable> GetEnumerator() { }
         public override string ToString() { }
-        public object ValueFor(string name) { }
+        public object ValueFor(string name, object defaultValue) { }
     }
 }
 namespace GraphQL.Language

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -93,8 +93,12 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void Input_Enum_OverrideDefault() => AssertQuerySuccess("{ inputWithDefault(arg: SLEEPY) }", @"{ ""inputWithDefault"": ""Sleepy"" }");
 
+        // For non-nullable struct types, GetArgument coerces null to default(T), which is Grumpy
         [Fact]
         public void Input_Enum_NullDefault() => AssertQuerySuccess("{ inputWithDefault(arg: null) }", @"{ ""inputWithDefault"": ""Grumpy"" }");
+
+        [Fact]
+        public void Input_Enum_NullDefault_Nullable() => AssertQuerySuccess("{ inputWithDefaultNullable(arg: null) }", @"{ ""inputWithDefaultNullable"": null }");
 
         [Fact]
         public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required for field \u0022inputRequired\u0022 but not provided.", 1, 3, (object[])null, code: "PROVIDED_NON_NULL_ARGUMENTS", number: ProvidedNonNullArgumentsError.NUMBER);
@@ -163,6 +167,10 @@ namespace GraphQL.Tests.Bugs
                 "inputWithDefault",
                 arguments: new QueryArguments(new QueryArgument<EnumerationGraphType<Bug1699Enum>> { Name = "arg", DefaultValue = Bug1699Enum.Happy }),
                 resolve: ctx => ctx.GetArgument<Bug1699Enum>("arg").ToString());
+            Field<StringGraphType>(
+                "inputWithDefaultNullable",
+                arguments: new QueryArguments(new QueryArgument<EnumerationGraphType<Bug1699Enum>> { Name = "arg", DefaultValue = Bug1699Enum.Happy }),
+                resolve: ctx => ctx.GetArgument<Bug1699Enum?>("arg")?.ToString());
             Field<StringGraphType>(
                 "inputRequired",
                 arguments: new QueryArguments(new QueryArgument<NonNullGraphType<EnumerationGraphType<Bug1699Enum>>> { Name = "arg" }),

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -94,6 +94,9 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_OverrideDefault() => AssertQuerySuccess("{ inputWithDefault(arg: SLEEPY) }", @"{ ""inputWithDefault"": ""Sleepy"" }");
 
         [Fact]
+        public void Input_Enum_NullDefault() => AssertQuerySuccess("{ inputWithDefault(arg: null) }", @"{ ""inputWithDefault"": ""Grumpy"" }");
+
+        [Fact]
         public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required for field \u0022inputRequired\u0022 but not provided.", 1, 3, (object[])null, code: "PROVIDED_NON_NULL_ARGUMENTS", number: ProvidedNonNullArgumentsError.NUMBER);
 
         [Fact]

--- a/src/GraphQL.Tests/Bugs/Bug2159.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2159.cs
@@ -1,0 +1,118 @@
+using System;
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Errors;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/2159
+    public class Bug2159 : QueryTestBase<Bug2159Schema>
+    {
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, string path, Exception exception = null, string code = null, string inputs = null, string number = null)
+            => AssertQueryWithError(query, result, message, line, column, new object[] { path }, exception, code, inputs, number);
+
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null, string number = null)
+        {
+            ExecutionError error;
+            if (number != null)
+                error = new ValidationError(null, number, message);
+            else
+                error = exception == null ? new ExecutionError(message) : new ExecutionError(message, exception);
+            if (line != 0)
+                error.AddLocation(line, column);
+            error.Path = path;
+            if (code != null)
+                error.Code = code;
+            var expected = CreateQueryResult(result, new ExecutionErrors { error });
+            AssertQueryIgnoreErrors(query, expected, inputs?.ToInputs(), renderErrors: true, expectedErrorCount: 1);
+        }
+
+        [Fact]
+        public void Direct_Literal_Default() => AssertQuerySuccess("{ testValue }", @"{ ""testValue"": ""defaultValue"" }");
+
+        [Fact]
+        public void Direct_Literal_Specified() => AssertQuerySuccess("{ testValue(arg: \"hello\") }", @"{ ""testValue"": ""hello"" }");
+
+        [Fact]
+        public void Direct_Literal_Null() => AssertQuerySuccess("{ testValue(arg: null) }", @"{ ""testValue"": null }");
+
+        // If a variable is provided for an input object field, the runtime value of that variable must be used.
+        // If the runtime value is null and the field type is non‐null, a field error must be thrown. If no runtime
+        // value is provided, the variable definition’s default value should be used. If the variable definition
+        // does not provide a default value, the input object field definition’s default value should be used.
+        [Fact]
+        public void Direct_Variable_FieldDefault() => AssertQuerySuccess("query($input: String) { testValue(arg: $input) }", @"{ ""testValue"": ""defaultValue"" }");
+
+        [Fact]
+        public void Direct_Variable_VarDefault() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", @"{ ""testValue"": ""varDefault"" }");
+
+        [Fact]
+        public void Direct_Variable_Specified() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", @"{ ""testValue"": ""hello"" }", "{\"input\":\"hello\"}".ToInputs());
+
+        [Fact]
+        public void Direct_Variable_Null() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", @"{ ""testValue"": null }", "{\"input\":null}".ToInputs());
+
+
+        [Fact]
+        public void Object_Literal_Default() => AssertQuerySuccess("{ testObject }", @"{ ""testObject"": ""defaultValue"" }");
+
+        [Fact]
+        public void Object_Literal_Specified() => AssertQuerySuccess("{ testObject(arg: {value:\"hello\"}) }", @"{ ""testObject"": ""hello"" }");
+
+        [Fact]
+        public void Object_Literal_Null() => AssertQuerySuccess("{ testObject(arg: {value:null}) }", @"{ ""testObject"": null }");
+
+        // If a variable is provided for an input object field, the runtime value of that variable must be used.
+        // If the runtime value is null and the field type is non‐null, a field error must be thrown. If no runtime
+        // value is provided, the variable definition’s default value should be used. If the variable definition
+        // does not provide a default value, the input object field definition’s default value should be used.
+        [Fact]
+        public void Object_Variable_Default() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", @"{ ""testObject"": ""defaultFieldValue"" }", "{\"input\":{}}".ToInputs());
+
+        [Fact]
+        public void Object_Variable_Specified() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", @"{ ""testObject"": ""hello"" }", "{\"input\":{\"value\":\"hello\"}}".ToInputs());
+
+        [Fact]
+        public void Object_Variable_Null() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", @"{ ""testObject"": null }", "{\"input\":{\"value\":null}}".ToInputs());
+    }
+
+    public class Bug2159Schema : Schema
+    {
+        public Bug2159Schema()
+        {
+            Query = new Bug2159Query();
+        }
+    }
+
+    public class Bug2159Query : ObjectGraphType
+    {
+        public Bug2159Query()
+        {
+            Field<StringGraphType>(
+                "testValue",
+                resolve: ctx => ctx.GetArgument<string>("arg"),
+                arguments: new QueryArguments(
+                    new QueryArgument(typeof(StringGraphType)) { Name = "arg", DefaultValue = "defaultValue" }));
+            Field<StringGraphType>(
+                "testObject",
+                resolve: ctx => ctx.GetArgument<Bug2159Object>("arg")?.Value,
+                arguments: new QueryArguments(
+                    new QueryArgument(typeof(Bug2159ObjectGraphType)) { Name = "arg", DefaultValue = new Bug2159Object { Value = "defaultValue" } }));
+        }
+    }
+
+    public class Bug2159Object
+    {
+        public string Value { get; set; }
+    }
+
+    public class Bug2159ObjectGraphType : InputObjectGraphType<Bug2159Object>
+    {
+        public Bug2159ObjectGraphType()
+        {
+            Field(x => x.Value, true).DefaultValue("defaultFieldValue");
+        }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug2159.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2159.cs
@@ -16,10 +16,6 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void Direct_Literal_Null() => AssertQuerySuccess("{ testValue(arg: null) }", @"{ ""testValue"": null }");
 
-        // If a variable is provided for an input object field, the runtime value of that variable must be used.
-        // If the runtime value is null and the field type is non‐null, a field error must be thrown. If no runtime
-        // value is provided, the variable definition’s default value should be used. If the variable definition
-        // does not provide a default value, the input object field definition’s default value should be used.
         [Fact]
         public void Direct_Variable_FieldDefault() => AssertQuerySuccess("query($input: String) { testValue(arg: $input) }", @"{ ""testValue"": ""defaultValue"" }");
 
@@ -42,10 +38,6 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void Object_Literal_Null() => AssertQuerySuccess("{ testObject(arg: {value:null}) }", @"{ ""testObject"": null }");
 
-        // If a variable is provided for an input object field, the runtime value of that variable must be used.
-        // If the runtime value is null and the field type is non‐null, a field error must be thrown. If no runtime
-        // value is provided, the variable definition’s default value should be used. If the variable definition
-        // does not provide a default value, the input object field definition’s default value should be used.
         [Fact]
         public void Object_Variable_Default() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", @"{ ""testObject"": ""defaultFieldValue"" }", "{\"input\":{}}".ToInputs());
 

--- a/src/GraphQL.Tests/Bugs/Bug2159.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2159.cs
@@ -1,8 +1,5 @@
-using System;
 using GraphQL.SystemTextJson;
 using GraphQL.Types;
-using GraphQL.Validation;
-using GraphQL.Validation.Errors;
 using Xunit;
 
 namespace GraphQL.Tests.Bugs
@@ -10,25 +7,6 @@ namespace GraphQL.Tests.Bugs
     // https://github.com/graphql-dotnet/graphql-dotnet/issues/2159
     public class Bug2159 : QueryTestBase<Bug2159Schema>
     {
-        private void AssertQueryWithError(string query, string result, string message, int line, int column, string path, Exception exception = null, string code = null, string inputs = null, string number = null)
-            => AssertQueryWithError(query, result, message, line, column, new object[] { path }, exception, code, inputs, number);
-
-        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null, string number = null)
-        {
-            ExecutionError error;
-            if (number != null)
-                error = new ValidationError(null, number, message);
-            else
-                error = exception == null ? new ExecutionError(message) : new ExecutionError(message, exception);
-            if (line != 0)
-                error.AddLocation(line, column);
-            error.Path = path;
-            if (code != null)
-                error.Code = code;
-            var expected = CreateQueryResult(result, new ExecutionErrors { error });
-            AssertQueryIgnoreErrors(query, expected, inputs?.ToInputs(), renderErrors: true, expectedErrorCount: 1);
-        }
-
         [Fact]
         public void Direct_Literal_Default() => AssertQuerySuccess("{ testValue }", @"{ ""testValue"": ""defaultValue"" }");
 

--- a/src/GraphQL.Tests/Bugs/Bug2159.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2159.cs
@@ -123,29 +123,29 @@ namespace GraphQL.Tests.Bugs
         {
             Field<StringGraphType>(
                 "testValue",
-                resolve: ctx => ctx.GetArgument<string>("arg"),
                 arguments: new QueryArguments(
-                    new QueryArgument(typeof(StringGraphType)) { Name = "arg", DefaultValue = "defaultValue" }));
+                    new QueryArgument(typeof(StringGraphType)) { Name = "arg", DefaultValue = "defaultValue" }),
+                resolve: ctx => ctx.GetArgument<string>("arg"));
             Field<StringGraphType>(
                 "testObject",
-                resolve: ctx => ctx.GetArgument<Bug2159Object>("arg")?.Value,
                 arguments: new QueryArguments(
-                    new QueryArgument(typeof(Bug2159ObjectGraphType)) { Name = "arg", DefaultValue = new Bug2159Object { Value = "defaultValue" } }));
+                    new QueryArgument(typeof(Bug2159ObjectGraphType)) { Name = "arg", DefaultValue = new Bug2159Object { Value = "defaultValue" } }),
+                resolve: ctx => ctx.GetArgument<Bug2159Object>("arg")?.Value);
             Field<BooleanGraphType>(
                 "hasArgumentNoDefault",
-                resolve: ctx => ctx.HasArgument("arg"),
                 arguments: new QueryArguments(
-                    new QueryArgument(typeof(BooleanGraphType)) { Name = "arg" }));
+                    new QueryArgument(typeof(BooleanGraphType)) { Name = "arg" }),
+                resolve: ctx => ctx.HasArgument("arg"));
             Field<BooleanGraphType>(
                 "hasArgumentWithDefault",
-                resolve: ctx => ctx.HasArgument("arg"),
                 arguments: new QueryArguments(
-                    new QueryArgument(typeof(BooleanGraphType)) { Name = "arg", DefaultValue = true }));
+                    new QueryArgument(typeof(BooleanGraphType)) { Name = "arg", DefaultValue = true }),
+                resolve: ctx => ctx.HasArgument("arg"));
             Field<StringGraphType>(
                 "testReqObjField",
-                resolve: ctx => "OK",
                 arguments: new QueryArguments(
-                    new QueryArgument(typeof(Bug2159ReqObjGraphType)) { Name = "arg" }));
+                    new QueryArgument(typeof(Bug2159ReqObjGraphType)) { Name = "arg" }),
+                resolve: ctx => "OK");
         }
     }
 

--- a/src/GraphQL.Tests/Bugs/Bug2159.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2159.cs
@@ -61,6 +61,46 @@ namespace GraphQL.Tests.Bugs
 
         [Fact]
         public void HasArgument_NoDefault_SetVariable() => AssertQuerySuccess("query($input: Boolean) { hasArgumentNoDefault(arg: $input) }", @"{ ""hasArgumentNoDefault"": true }", "{\"input\":true}".ToInputs());
+
+        //todo: fix HasArgument so it returns false only when no value was supplied
+        [Fact(Skip = "HasArgument currently returns false if GetArgument returns null")]
+        public void HasArgument_NoDefault_SetNull() => AssertQuerySuccess("{ hasArgumentNoDefault(arg: null) }", @"{ ""hasArgumentNoDefault"": true }");
+
+        //todo: fix HasArgument so it returns false only when no value was supplied
+        [Fact(Skip = "HasArgument currently returns false if GetArgument returns null")]
+        public void HasArgument_NoDefault_DefaultVariableNull() => AssertQuerySuccess("query($input: Boolean = null) { hasArgumentNoDefault(arg: $input) }", @"{ ""hasArgumentNoDefault"": true }");
+
+        //todo: fix HasArgument so it returns false only when no value was supplied
+        [Fact(Skip = "HasArgument currently returns false if GetArgument returns null")]
+        public void HasArgument_NoDefault_SetVariableNull() => AssertQuerySuccess("query($input: Boolean) { hasArgumentNoDefault(arg: $input) }", @"{ ""hasArgumentNoDefault"": true }", "{\"input\":null}".ToInputs());
+
+        //todo: fix HasArgument so it returns false only when no value was supplied
+        [Fact(Skip = "HasArgument currently returns false if GetArgument returns null")]
+        public void HasArgument_WithDefault_None() => AssertQuerySuccess("{ hasArgumentDefault }", @"{ ""hasArgumentWithDefault"": false }");
+
+        //todo: fix HasArgument so it returns false only when no value was supplied
+        [Fact(Skip = "HasArgument currently returns false if GetArgument returns null")]
+        public void HasArgument_WithDefault_UnsetVariable() => AssertQuerySuccess("query($input: Boolean) { hasArgumentWithDefault(arg: $input) }", @"{ ""hasArgumentWithDefault"": false }");
+
+        [Fact]
+        public void HasArgument_WithDefault_Set() => AssertQuerySuccess("{ hasArgumentWithDefault(arg: true) }", @"{ ""hasArgumentWithDefault"": true }");
+
+        [Fact]
+        public void HasArgument_WithDefault_DefaultVariable() => AssertQuerySuccess("query($input: Boolean = true) { hasArgumentWithDefault(arg: $input) }", @"{ ""hasArgumentWithDefault"": true }");
+
+        [Fact]
+        public void HasArgument_WithDefault_SetVariable() => AssertQuerySuccess("query($input: Boolean) { hasArgumentWithDefault(arg: $input) }", @"{ ""hasArgumentWithDefault"": true }", "{\"input\":true}".ToInputs());
+
+        //todo: fix HasArgument so it returns false only when no value was supplied
+        [Fact(Skip = "HasArgument currently returns false if GetArgument returns null")]
+        public void HasArgument_WithDefault_SetNull() => AssertQuerySuccess("{ hasArgumentWithDefault(arg: null) }", @"{ ""hasArgumentWithDefault"": true }");
+
+        [Fact]
+        public void HasArgument_WithDefault_DefaultVariableNull() => AssertQuerySuccess("query($input: Boolean = null) { hasArgumentWithDefault(arg: $input) }", @"{ ""hasArgumentWithDefault"": true }");
+
+        //todo: fix HasArgument so it returns false only when no value was supplied
+        [Fact(Skip = "HasArgument currently returns false if GetArgument returns null")]
+        public void HasArgument_WithDefault_SetVariableNull() => AssertQuerySuccess("query($input: Boolean) { hasArgumentWithDefault(arg: $input) }", @"{ ""hasArgumentWithDefault"": true }", "{\"input\":null}".ToInputs());
     }
 
     public class Bug2159Schema : Schema

--- a/src/GraphQL.Tests/Bugs/Bug2159.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2159.cs
@@ -46,6 +46,21 @@ namespace GraphQL.Tests.Bugs
 
         [Fact]
         public void Object_Variable_Null() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", @"{ ""testObject"": null }", "{\"input\":{\"value\":null}}".ToInputs());
+
+        [Fact]
+        public void HasArgument_NoDefault_None() => AssertQuerySuccess("{ hasArgumentNoDefault }", @"{ ""hasArgumentNoDefault"": false }");
+
+        [Fact]
+        public void HasArgument_NoDefault_UnsetVariable() => AssertQuerySuccess("query($input: Boolean) { hasArgumentNoDefault(arg: $input) }", @"{ ""hasArgumentNoDefault"": false }");
+
+        [Fact]
+        public void HasArgument_NoDefault_Set() => AssertQuerySuccess("{ hasArgumentNoDefault(arg: true) }", @"{ ""hasArgumentNoDefault"": true }");
+
+        [Fact]
+        public void HasArgument_NoDefault_DefaultVariable() => AssertQuerySuccess("query($input: Boolean = true) { hasArgumentNoDefault(arg: $input) }", @"{ ""hasArgumentNoDefault"": true }");
+
+        [Fact]
+        public void HasArgument_NoDefault_SetVariable() => AssertQuerySuccess("query($input: Boolean) { hasArgumentNoDefault(arg: $input) }", @"{ ""hasArgumentNoDefault"": true }", "{\"input\":true}".ToInputs());
     }
 
     public class Bug2159Schema : Schema
@@ -70,6 +85,16 @@ namespace GraphQL.Tests.Bugs
                 resolve: ctx => ctx.GetArgument<Bug2159Object>("arg")?.Value,
                 arguments: new QueryArguments(
                     new QueryArgument(typeof(Bug2159ObjectGraphType)) { Name = "arg", DefaultValue = new Bug2159Object { Value = "defaultValue" } }));
+            Field<BooleanGraphType>(
+                "hasArgumentNoDefault",
+                resolve: ctx => ctx.HasArgument("arg"),
+                arguments: new QueryArguments(
+                    new QueryArgument(typeof(BooleanGraphType)) { Name = "arg" }));
+            Field<BooleanGraphType>(
+                "hasArgumentWithDefault",
+                resolve: ctx => ctx.HasArgument("arg"),
+                arguments: new QueryArguments(
+                    new QueryArgument(typeof(BooleanGraphType)) { Name = "arg", DefaultValue = true }));
         }
     }
 

--- a/src/GraphQL.Tests/Bugs/Issue1127.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1127.cs
@@ -49,11 +49,11 @@ query {
                 resolve: ctx =>
                 {
                     ctx.Arguments["s1"].ShouldBe("def1");
-                    ctx.Arguments["s2"].ShouldBe("def2");
+                    ctx.Arguments["s2"].ShouldBeNull();
                     ctx.Arguments["s3"].ShouldBe("aaa");
 
                     ctx.Arguments["input1"].ShouldBe(1);
-                    ctx.Arguments["input2"].ShouldBe(2);
+                    ctx.Arguments["input2"].ShouldBeNull();
                     ctx.Arguments["input3"].ShouldNotBeNull();
 
                     (ctx.Arguments["input3"] as Dictionary<string, object>)["name"].ShouldBe("struct");

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -276,12 +276,7 @@ namespace GraphQL.Execution
                 var value = astArguments?.ValueFor(arg.Name);
                 var type = arg.ResolvedType;
 
-                var coercedValue = CoerceValue(schema, type, value, variables, arg.DefaultValue);
-
-                if (coercedValue != null)
-                {
-                    values[arg.Name] = coercedValue;
-                }
+                values[arg.Name] = CoerceValue(schema, type, value, variables, arg.DefaultValue);
             }
 
             return values;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -132,9 +132,9 @@ namespace GraphQL.Execution
                 throw;
             }
 
-            if (input == null/* && variable.DefaultValue != null*/)
+            if (input == null)
             {
-                return null /*variable.DefaultValue.Value*/;
+                return null;
             }
 
             return CoerceValue(schema, type, input.AstFromValue(schema, type));

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -117,6 +117,7 @@ namespace GraphQL.Execution
 
         /// <summary>
         /// Return the specified variable's value for the document from the attached <see cref="Inputs"/> object.
+        /// Since v3.3, returns null for variables set to null rather than the variable's default value.
         /// </summary>
         public static object GetVariableValue(Document document, ISchema schema, VariableDefinition variable, object input)
         {

--- a/src/GraphQL/Language/AST/Variable.cs
+++ b/src/GraphQL/Language/AST/Variable.cs
@@ -10,9 +10,23 @@ namespace GraphQL.Language.AST
         /// </summary>
         public string Name { get; set; }
 
+        private object _value;
         /// <summary>
         /// Gets or sets the value of the variable.
         /// </summary>
-        public object Value { get; set; }
+        public object Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                ValueSpecified = true;
+            }
+        }
+
+        /// <summary>
+        /// Indicates if the variable value has been set.
+        /// </summary>
+        public bool ValueSpecified { get; private set; }
     }
 }

--- a/src/GraphQL/Language/AST/Variables.cs
+++ b/src/GraphQL/Language/AST/Variables.cs
@@ -29,10 +29,12 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the first variable with a matching name, or <see langword="null"/> if none are found.
         /// </summary>
-        public object ValueFor(string name)
+        public object ValueFor(string name, object defaultValue)
         {
             var variable = _variables?.FirstOrDefault(v => v.Name == name);
-            return variable?.Value;
+            if (variable != null && variable.ValueSpecified)
+                return variable.Value;
+            return defaultValue;
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Language/AST/Variables.cs
+++ b/src/GraphQL/Language/AST/Variables.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Language.AST
         }
 
         /// <summary>
-        /// Returns the first variable with a matching name, or <see langword="null"/> if none are found.
+        /// Returns the first variable with a matching name, or <paramref name="defaultValue"/> if none are found.
         /// </summary>
         public object ValueFor(string name, object defaultValue = null)
         {

--- a/src/GraphQL/Language/AST/Variables.cs
+++ b/src/GraphQL/Language/AST/Variables.cs
@@ -32,9 +32,9 @@ namespace GraphQL.Language.AST
         public object ValueFor(string name, object defaultValue = null)
         {
             var variable = _variables?.FirstOrDefault(v => v.Name == name);
-            if (variable != null && variable.ValueSpecified)
-                return variable.Value;
-            return defaultValue;
+            return variable != null && variable.ValueSpecified
+                ? variable.Value
+                : defaultValue;
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Language/AST/Variables.cs
+++ b/src/GraphQL/Language/AST/Variables.cs
@@ -29,7 +29,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the first variable with a matching name, or <see langword="null"/> if none are found.
         /// </summary>
-        public object ValueFor(string name, object defaultValue)
+        public object ValueFor(string name, object defaultValue = null)
         {
             var variable = _variables?.FirstOrDefault(v => v.Name == name);
             if (variable != null && variable.ValueSpecified)

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -63,7 +63,8 @@ namespace GraphQL
         {
             var isIntrospection = context.ParentType == null ? context.FieldDefinition.IsIntrospectionField() : context.ParentType.IsIntrospectionType();
             var argumentName = isIntrospection ? name : (context.Schema?.NameConverter.NameForArgument(name, context.ParentType, context.FieldDefinition) ?? name);
-            return context.Arguments?.ContainsKey(argumentName) ?? false;
+            object value = null;
+            return ((context.Arguments?.TryGetValue(argumentName, out value) ?? false) && value != null);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2159

Requires a signature change to CoerceValue and ValueFor.  They are added optional fields, so although not binary-compatible, it is "compile-compatible".

Changed one test that relied on incorrect behavior.  Added a number of tests that verify this fix.

Should note this behavior and signature change in the release notes.