### PR TITLE
SchemaPrinter can print inputobject default values

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.3.0-preview</VersionPrefix>
+    <VersionPrefix>3.3.1-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -581,6 +581,39 @@ union SingleUnion = Foo
         }
 
         [Fact]
+        public void prints_input_type_with_default()
+        {
+            var root = new ObjectGraphType { Name = "Query" };
+            root.Field<NonNullGraphType<StringGraphType>>(
+                "str",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<SomeInputType>> { Name = "argOne", DefaultValue = new SomeInput { Name = "Tom", Age = 42, IsDeveloper = true } },
+                    new QueryArgument<ListGraphType<SomeInputType>> { Name = "argTwo", DefaultValue = new[] { new SomeInput { Name = "Tom1", Age = 12 }, new SomeInput { Name = "Tom2", Age = 22, IsDeveloper = true } } })
+                );
+
+            var schema = new Schema { Query = root };
+
+            var expected = new Dictionary<string, string>
+            {
+                {
+                    "SomeInput",
+@"input SomeInput {
+  age: Int!
+  name: String!
+  isDeveloper: Boolean!
+}"
+                },
+                                {
+                    "Query",
+@"type Query {
+  str(argOne: SomeInput! = { age: 42, name: ""Tom"", isDeveloper: true }, argTwo: [SomeInput] = [{ age: 12, name: ""Tom1"", isDeveloper: false }, { age: 22, name: ""Tom2"", isDeveloper: true }]): String!
+}"
+                },
+            };
+            AssertEqual(print(schema), expected);
+        }
+
+        [Fact]
         public void prints_custom_scalar()
         {
             var root = new ObjectGraphType { Name = "Query" };
@@ -1013,6 +1046,26 @@ enum __TypeKind {
                 Name = "InputType";
                 Field<IntGraphType>("int");
             }
+        }
+
+        public class SomeInputType : InputObjectGraphType<SomeInput>
+        {
+            public SomeInputType()
+            {
+                Name = "SomeInput";
+                Field(x => x.Age);
+                Field(x => x.Name);
+                Field(x => x.IsDeveloper);
+            }
+        }
+
+        public class SomeInput
+        {
+            public string Name { get; set; }
+
+            public int Age { get; set; }
+
+            public bool IsDeveloper { get; set; }
         }
 
         public class OddType : ScalarGraphType

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using GraphQL.Introspection;
@@ -8,7 +9,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Utilities
 {
-    public class SchemaPrinter
+    public class SchemaPrinter //TODO: rewrite string concatenations to use buffer ?
     {
         protected SchemaPrinterOptions Options { get; }
 
@@ -165,7 +166,7 @@ namespace GraphQL.Utilities
                 IObjectGraphType objectGraphType => PrintObject(objectGraphType),
                 IInterfaceGraphType interfaceGraphType => PrintInterface(interfaceGraphType),
                 UnionGraphType unionGraphType => PrintUnion(unionGraphType),
-                DirectiveGraphType directiveGraphType => PrintDirective(directiveGraphType),
+                DirectiveGraphType directiveGraphType => PrintDirective(directiveGraphType),  //TODO: DirectiveGraphType does not inherit IGraphType
                 IInputObjectGraphType input => PrintInputObject(input),
                 _ => throw new InvalidOperationException($"Unknown GraphType '{type.GetType().Name}' with name '{type.Name}'")
             };
@@ -292,23 +293,59 @@ namespace GraphQL.Utilities
         {
             return graphType switch
             {
-                NonNullGraphType nullable => FormatDefaultValue(value, nullable.ResolvedType),
+                NonNullGraphType nonNull => FormatDefaultValue(value, nonNull.ResolvedType),
                 ListGraphType list => "[{0}]".ToFormat(string.Join(", ", ((IEnumerable<object>)value).Select(i => FormatDefaultValue(i, list.ResolvedType)))),
+                IInputObjectGraphType input => FormatInputObjectValue(value, input),
                 EnumerationGraphType enumeration => enumeration.Serialize(value).ToString(),
-                _ => value switch
+                ScalarGraphType scalar => value switch
                 {
                     string s => $"\"{s}\"",
                     bool b => b ? "true" : "false",
-                    _ => value.ToString()
-                }
+                    _ => value.ToString() // TODO: how to print custom scalars ("") ?
+                },
+                _ => throw new NotSupportedException($"Unsopported graph type '{graphType}'")
             };
+        }
+
+        private string FormatInputObjectValue(object value, IInputObjectGraphType input)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{ ");
+
+            foreach (var field in input.Fields)
+            {
+                string propertyName = field.GetMetadata<string>(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME) ?? field.Name;
+                PropertyInfo propertyInfo;
+
+                try
+                {
+                    propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                }
+                catch (AmbiguousMatchException)
+                {
+                    propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                }
+
+                object propertyValue = propertyInfo.GetValue(value);
+                if (propertyValue != null)
+                {
+                    sb.Append(field.Name)
+                       .Append(": ")
+                       .Append(FormatDefaultValue(propertyValue, field.ResolvedType))
+                       .Append(", ");
+                }
+            }
+
+            sb.Length -= 2;
+            sb.Append(" }");
+            return sb.ToString();
         }
 
         public static string ResolveName(IGraphType type)
         {
             return type switch
             {
-                NonNullGraphType nullable => $"{ResolveName(nullable.ResolvedType)}!",
+                NonNullGraphType nonNull => $"{ResolveName(nonNull.ResolvedType)}!",
                 ListGraphType list => $"[{ResolveName(list.ResolvedType)}]",
                 _ => type?.Name
             };

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -297,7 +297,7 @@ namespace GraphQL.Utilities
                 ListGraphType list => "[{0}]".ToFormat(string.Join(", ", ((IEnumerable<object>)value).Select(i => FormatDefaultValue(i, list.ResolvedType)))),
                 IInputObjectGraphType input => FormatInputObjectValue(value, input),
                 EnumerationGraphType enumeration => enumeration.Serialize(value).ToString(),
-                ScalarGraphType => value switch
+                ScalarGraphType _ => value switch
                 {
                     string s => $"\"{s}\"",
                     bool b => b ? "true" : "false",

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -297,7 +297,7 @@ namespace GraphQL.Utilities
                 ListGraphType list => "[{0}]".ToFormat(string.Join(", ", ((IEnumerable<object>)value).Select(i => FormatDefaultValue(i, list.ResolvedType)))),
                 IInputObjectGraphType input => FormatInputObjectValue(value, input),
                 EnumerationGraphType enumeration => enumeration.Serialize(value).ToString(),
-                ScalarGraphType scalar => value switch
+                ScalarGraphType => value switch
                 {
                     string s => $"\"{s}\"",
                     bool b => b ? "true" : "false",


### PR DESCRIPTION
before
```graphql

type Query {
  str(argOne: SomeInput! = GraphQL.Tests.Utilities.SchemaPrinterTests+SomeInput): String!
}

input SomeInput {
  age: Int!
  name: String!
  isDeveloper: Boolean!
}
```

after
```graphql
type Query {
  str(argOne: SomeInput! = { age: 42, name: "Tom", isDeveloper: true }): String!
}

input SomeInput {
  age: Int!
  name: String!
  isDeveloper: Boolean!
}
```
