### PR TITLE
Add ReadonlyResolveFieldContext "pool"

### DIFF
--- a/docs2/site/docs/guides/known-issues.md
+++ b/docs2/site/docs/guides/known-issues.md
@@ -235,6 +235,15 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+### Why does my saved `IResolveFieldContext` instance "change" after the field resolver executes?
+
+The `IResolveFieldContext` instance passed to field resolvers is re-used at the completion of the resolver. Be sure not to
+use this instance once the resolver finishes executing. To preserve a copy of the context, call `.Copy()` on the context
+to create a copy that is not re-used. Note that it is safe to use the field context within asynchronous field resolvers and
+data loaders. Once the asynchronous field resolver or data loader returns its final result, the context may be re-used.
+Also, any calls to the configured `UnhandledExceptionDelegate` will receive a field context copy that will not be re-used,
+so it is safe to preserve these instances without calling `.Copy()`.
+
 ## Known Issues
 
 `IResolveFieldContext.HasArgument` will return `true` for all arguments where `GetArgument` does not return `null`.

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -71,3 +71,9 @@
   and the variable resolves to its default value, then `HasArgument` returns `true` (since the field argument is successfully resolving to a variable).
 * Various `IEnumerable<T>` properties on schema and graph types have been changed to custom collections: `SchemaDirectives`, `SchemaTypes`, `TypeFields`, `PossibleTypes`, `ResolvedInterfaces`
 * `GraphTypesLookup` has been renamed to `SchemaTypes` with a significant decrease in public APIs 
+* The `IResolveFieldContext` instance passed to field resolvers is re-used at the completion of the resolver. Be sure not to
+  use this instance once the resolver finishes executing. To preserve a copy of the context, call `.Copy()` on the context
+  to create a copy that is not re-used. Note that it is safe to use the field context within asynchronous field resolvers and
+  data loaders. Once the asynchronous field resolver or data loader returns its final result, the context may be re-used.
+  Also, any calls to the configured `UnhandledExceptionDelegate` will receive a field context copy that will not be re-used,
+  so it is safe to preserve these instances without calling `.Copy()`.

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -309,6 +309,8 @@ namespace GraphQL
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
         public static object GetExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
+        public static void Preserve(this GraphQL.IResolveFieldContext context) { }
+        public static void Preserve<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
         public static void SetExtension(this GraphQL.IResolveFieldContext context, string path, object value) { }
     }
     public class ResolveFieldContext<TSource> : GraphQL.ResolveFieldContext, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<TSource>

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -309,8 +309,8 @@ namespace GraphQL
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
         public static object GetExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
-        public static void Copy(this GraphQL.IResolveFieldContext context) { }
-        public static void Copy<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
+        public static GraphQL.IResolveFieldContext Copy(this GraphQL.IResolveFieldContext context) { }
+        public static GraphQL.IResolveFieldContext<TSource> Copy<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
         public static void SetExtension(this GraphQL.IResolveFieldContext context, string path, object value) { }
     }
     public class ResolveFieldContext<TSource> : GraphQL.ResolveFieldContext, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<TSource>

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -305,12 +305,12 @@ namespace GraphQL
     {
         public static GraphQL.IResolveFieldContext<TSourceType> As<TSourceType>(this GraphQL.IResolveFieldContext context) { }
         public static GraphQL.Subscription.IResolveEventStreamContext<T> As<T>(this GraphQL.Subscription.IResolveEventStreamContext context) { }
+        public static GraphQL.IResolveFieldContext Copy(this GraphQL.IResolveFieldContext context) { }
+        public static GraphQL.IResolveFieldContext<TSource> Copy<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
         public static object GetArgument(this GraphQL.IResolveFieldContext context, System.Type argumentType, string name, object defaultValue = null) { }
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
         public static object GetExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
-        public static GraphQL.IResolveFieldContext Copy(this GraphQL.IResolveFieldContext context) { }
-        public static GraphQL.IResolveFieldContext<TSource> Copy<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
         public static void SetExtension(this GraphQL.IResolveFieldContext context, string path, object value) { }
     }
     public class ResolveFieldContext<TSource> : GraphQL.ResolveFieldContext, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<TSource>

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -309,8 +309,8 @@ namespace GraphQL
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
         public static object GetExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
-        public static void Preserve(this GraphQL.IResolveFieldContext context) { }
-        public static void Preserve<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
+        public static void Copy(this GraphQL.IResolveFieldContext context) { }
+        public static void Copy<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
         public static void SetExtension(this GraphQL.IResolveFieldContext context, string path, object value) { }
     }
     public class ResolveFieldContext<TSource> : GraphQL.ResolveFieldContext, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<TSource>

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -90,7 +90,7 @@ namespace GraphQL.Execution
             // once a field resolver finishes executing. However, a ReadonlyResolveFieldContext instance is not re-used
             // when an exception within a field resolver is thrown, and the FAQ says that calls to UnhandledExceptionDelegate
             // will be provided with a context that is not re-used. If we clear or re-use execution contexts, we should
-            // at least provide UnhandledExecptionDelegate with a copy (e.g. create one with ReadonlyResolveFieldContext
+            // at least provide UnhandledExceptionDelegate with a copy (e.g. create one with ReadonlyResolveFieldContext
             // and then Copy it) so that it is unaffected by clearing the execution context. Also note that subscription
             // execution will be affected by clearing the execution context.
 

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -110,5 +110,12 @@ namespace GraphQL.Execution
                 _trackedArrays.Clear();
             }
         }
+
+        /// <summary>
+        /// Provides a method for an execution strategy to reuse an instance of <see cref="ReadonlyResolveFieldContext"/>.
+        /// Although in theory this field should not be accessed by multiple threads at the same time,
+        /// access is restricted to <see cref="System.Threading.Interlocked.Exchange{T}(ref T, T)"/>.
+        /// </summary>
+        internal ReadonlyResolveFieldContext ReusableReadonlyResolveFieldContext = null;
     }
 }

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -113,7 +113,7 @@ namespace GraphQL.Execution
 
         /// <summary>
         /// Allows for an execution strategy to reuse an instance of <see cref="ReadonlyResolveFieldContext"/>.
-        /// Although in theory this field should not be accessed by multiple threads at the same time,
+        /// This field may be accessed by multiple threads at the same time, so
         /// access is restricted to <see cref="System.Threading.Interlocked.Exchange{T}(ref T, T)"/>.
         /// </summary>
         internal ReadonlyResolveFieldContext ReusableReadonlyResolveFieldContext;

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -112,10 +112,10 @@ namespace GraphQL.Execution
         }
 
         /// <summary>
-        /// Provides a method for an execution strategy to reuse an instance of <see cref="ReadonlyResolveFieldContext"/>.
+        /// Allows for an execution strategy to reuse an instance of <see cref="ReadonlyResolveFieldContext"/>.
         /// Although in theory this field should not be accessed by multiple threads at the same time,
         /// access is restricted to <see cref="System.Threading.Interlocked.Exchange{T}(ref T, T)"/>.
         /// </summary>
-        internal ReadonlyResolveFieldContext ReusableReadonlyResolveFieldContext = null;
+        internal ReadonlyResolveFieldContext ReusableReadonlyResolveFieldContext;
     }
 }

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -114,7 +114,8 @@ namespace GraphQL.Execution
         /// <summary>
         /// Allows for an execution strategy to reuse an instance of <see cref="ReadonlyResolveFieldContext"/>.
         /// This field may be accessed by multiple threads at the same time, so
-        /// access is restricted to <see cref="System.Threading.Interlocked.Exchange{T}(ref T, T)"/>.
+        /// access is restricted to <see cref="System.Threading.Interlocked.Exchange{T}(ref T, T)"/>
+        /// and <see cref="System.Threading.Interlocked.CompareExchange{T}(ref T, T, T)"/>.
         /// </summary>
         internal ReadonlyResolveFieldContext ReusableReadonlyResolveFieldContext;
     }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -220,7 +220,8 @@ namespace GraphQL.Execution
 
             try
             {
-                var resolveContext = new ReadonlyResolveFieldContext(node, context);
+                ReadonlyResolveFieldContext resolveContext = System.Threading.Interlocked.Exchange(ref context.ReusableReadonlyResolveFieldContext, null);
+                resolveContext = resolveContext != null ? resolveContext.Reset(node, context) : new ReadonlyResolveFieldContext(node, context);
 
                 var resolver = node.FieldDefinition.Resolver ?? NameFieldResolver.Instance;
                 var result = resolver.Resolve(resolveContext);
@@ -236,6 +237,8 @@ namespace GraphQL.Execution
                 if (!(result is IDataLoaderResult))
                 {
                     CompleteNode(context, node);
+                    // for non-dataloader nodes that completed without throwing an error, we can re-use the context
+                    System.Threading.Interlocked.Exchange(ref context.ReusableReadonlyResolveFieldContext, resolveContext);
                 }
             }
             catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -238,7 +238,7 @@ namespace GraphQL.Execution
                 {
                     CompleteNode(context, node);
                     // for non-dataloader nodes that completed without throwing an error, we can re-use the context
-                    System.Threading.Interlocked.Exchange(ref context.ReusableReadonlyResolveFieldContext, resolveContext);
+                    System.Threading.Interlocked.CompareExchange(ref context.ReusableReadonlyResolveFieldContext, resolveContext, null);
                 }
             }
             catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -358,6 +358,7 @@ namespace GraphQL.Execution
             UnhandledExceptionContext exceptionContext = null;
             if (context.UnhandledExceptionDelegate != null)
             {
+                // be sure not to re-use this instance of `IResolveFieldContext`
                 var resolveContext = new ReadonlyResolveFieldContext(node, context);
                 exceptionContext = new UnhandledExceptionContext(context, resolveContext, ex);
                 context.UnhandledExceptionDelegate(exceptionContext);

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -14,8 +14,8 @@ namespace GraphQL
     /// <summary>
     /// Contains parameters pertaining to the currently executing <see cref="IFieldResolver"/>.
     /// This object is only valid during the execution of the field; it is re-used once the field
-    /// has resolved. Use <see cref="ResolveFieldContextExtensions.Preserve(IResolveFieldContext)"/>
-    /// if you need to preserve a copy of the context for later use.
+    /// has resolved. Use <see cref="ResolveFieldContextExtensions.Copy(IResolveFieldContext)"/>
+    /// if you need to preserve a copy of the context for later use or copy required properties from the context.
     /// </summary>
     public interface IResolveFieldContext : IProvideUserContext
     {

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -13,6 +13,9 @@ namespace GraphQL
 {
     /// <summary>
     /// Contains parameters pertaining to the currently executing <see cref="IFieldResolver"/>.
+    /// This object is only valid during the execution of the field; it is re-used once the field
+    /// has resolved. Use <see cref="ResolveFieldContextExtensions.Preserve(IResolveFieldContext)"/>
+    /// if you need to preserve a copy of the context for later use.
     /// </summary>
     public interface IResolveFieldContext : IProvideUserContext
     {

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -13,8 +13,8 @@ namespace GraphQL
     /// </summary>
     public class ReadonlyResolveFieldContext : IResolveFieldContext<object>
     {
-        private readonly ExecutionNode _executionNode;
-        private readonly ExecutionContext _executionContext;
+        private ExecutionNode _executionNode;
+        private ExecutionContext _executionContext;
         private IDictionary<string, ArgumentValue> _arguments;
         private IDictionary<string, Field> _subFields;
 
@@ -25,6 +25,15 @@ namespace GraphQL
         {
             _executionNode = node ?? throw new ArgumentNullException(nameof(node));
             _executionContext = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        internal ReadonlyResolveFieldContext Reset(ExecutionNode node, ExecutionContext context)
+        {
+            _executionNode = node ?? throw new ArgumentNullException(nameof(node));
+            _executionContext = context ?? throw new ArgumentNullException(nameof(context));
+            _arguments = null;
+            _subFields = null;
+            return this;
         }
 
         private IDictionary<string, Field> GetSubFields()

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -186,15 +186,15 @@ namespace GraphQL
         }
 
         /// <summary>
-        /// Preserve a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
+        /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
         /// accessed at a later time.
         /// </summary>
-        public static void Preserve(this IResolveFieldContext context) => new ResolveFieldContext(context);
+        public static void Copy(this IResolveFieldContext context) => new ResolveFieldContext(context);
 
         /// <summary>
-        /// Preserve a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
+        /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
         /// accessed at a later time.
         /// </summary>
-        public static void Preserve<TSource>(this IResolveFieldContext<TSource> context) => new ResolveFieldContext<TSource>(context);
+        public static void Copy<TSource>(this IResolveFieldContext<TSource> context) => new ResolveFieldContext<TSource>(context);
     }
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -189,7 +189,7 @@ namespace GraphQL
         /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
         /// accessed at a later time.
         /// </summary>
-        public static void Copy(this IResolveFieldContext context) => new ResolveFieldContext(context);
+        public static IResolveFieldContext Copy(this IResolveFieldContext context) => new ResolveFieldContext(context);
 
         /// <summary>
         /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -195,6 +195,6 @@ namespace GraphQL
         /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
         /// accessed at a later time.
         /// </summary>
-        public static void Copy<TSource>(this IResolveFieldContext<TSource> context) => new ResolveFieldContext<TSource>(context);
+        public static IResolveFieldContext<TSource> Copy<TSource>(this IResolveFieldContext<TSource> context) => new ResolveFieldContext<TSource>(context);
     }
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -184,5 +184,17 @@ namespace GraphQL
                 }
             }
         }
+
+        /// <summary>
+        /// Preserve a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
+        /// accessed at a later time.
+        /// </summary>
+        public static void Preserve(this IResolveFieldContext context) => new ResolveFieldContext(context);
+
+        /// <summary>
+        /// Preserve a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
+        /// accessed at a later time.
+        /// </summary>
+        public static void Preserve<TSource>(this IResolveFieldContext<TSource> context) => new ResolveFieldContext<TSource>(context);
     }
 }


### PR DESCRIPTION
Updated PR of #1584 

This re-uses `ReadonlyResolveFieldContext` for synchronous resolvers.


### `develop` branch (before)

|        Method | UseCaching |       Mean |     Error |    StdDev |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |----------- |-----------:|----------:|----------:|--------:|--------:|------:|----------:|
| Introspection |      False | 949.071 us | 3.9364 us | 3.6821 us | 87.8906 | 23.4375 |     - | 544.37 KB |
|          Hero |      False |  17.149 us | 0.0353 us | 0.0330 us |  1.4343 |       - |     - |   8.84 KB |
| Introspection |       True | 707.605 us | 6.1738 us | 5.7750 us | 82.0313 | 27.3438 |     - | 504.67 KB |
|          Hero |       True |   3.509 us | 0.0137 us | 0.0129 us |  0.6790 |  0.0038 |     - |   4.16 KB |

### `pool2` branch (after)

|        Method | UseCaching |       Mean |     Error |    StdDev |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |----------- |-----------:|----------:|----------:|--------:|--------:|------:|----------:|
| Introspection |      False | 938.379 us | 3.5908 us | 3.1832 us | 79.1016 | 24.4141 |     - | 487.07 KB |
|          Hero |      False |  16.611 us | 0.0504 us | 0.0472 us |  1.4038 |       - |     - |   8.75 KB |
| Introspection |       True | 709.847 us | 2.8191 us | 2.6370 us | 72.2656 | 22.4609 |     - | 447.38 KB |
|          Hero |       True |   3.480 us | 0.0160 us | 0.0150 us |  0.6638 |  0.0038 |     - |   4.08 KB |

### `tune` branch

|        Method | UseCaching |       Mean |     Error |    StdDev |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |----------- |-----------:|----------:|----------:|--------:|--------:|------:|----------:|
| Introspection |      False | 882.251 us | 4.0359 us | 3.7752 us | 81.0547 | 24.4141 |     - | 498.52 KB |
|          Hero |      False |  16.831 us | 0.0744 us | 0.0696 us |  1.4343 |       - |     - |   8.79 KB |
| Introspection |       True | 647.674 us | 2.8377 us | 2.6544 us | 74.2188 | 23.4375 |     - | 458.83 KB |
|          Hero |       True |   3.522 us | 0.0229 us | 0.0215 us |  0.6714 |  0.0038 |     - |   4.12 KB |
