### PR TITLE
[WIP] ROM from parser - phase 2

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -749,6 +749,7 @@ namespace GraphQL.Execution
     public class GraphQLDocumentBuilder : GraphQL.Execution.IDocumentBuilder
     {
         public GraphQLDocumentBuilder() { }
+        public bool IgnoreComments { get; set; }
         public GraphQL.Language.AST.Document Build(string body) { }
     }
     public interface IDocumentBuilder
@@ -2419,6 +2420,7 @@ namespace GraphQL.Utilities
         protected readonly System.Collections.Generic.IDictionary<string, GraphQL.Types.IGraphType> _types;
         public SchemaBuilder() { }
         public System.Collections.Generic.IDictionary<string, System.Type> Directives { get; }
+        public bool IgnoreComments { get; set; }
         public System.IServiceProvider ServiceProvider { get; set; }
         public GraphQL.Utilities.TypeSettings Types { get; }
         public virtual GraphQL.Types.ISchema Build(string[] typeDefinitions) { }

--- a/src/GraphQL.Benchmarks/Properties/launchSettings.json
+++ b/src/GraphQL.Benchmarks/Properties/launchSettings.json
@@ -3,6 +3,9 @@
     "Profiler": {
       "commandName": "Project",
       "commandLineArgs": "test"
+    },
+    "Benchmarks": {
+      "commandName": "Project"
     }
   }
 }

--- a/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
@@ -61,7 +61,7 @@ namespace GraphQL.Execution
             {
                 var resolveContext = new ResolveEventStreamContext
                 {
-                    FieldName = node.Field.Name,
+                    FieldName = (string)node.Field.Name,
                     FieldAst = node.Field,
                     FieldDefinition = node.FieldDefinition,
                     ReturnType = node.FieldDefinition.ResolvedType,

--- a/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
@@ -107,7 +107,7 @@ namespace GraphQL.Tests.Execution
         {
             Field<StringGraphType>(
                 "value",
-                resolve: context => context.FieldAst.Alias ?? context.FieldAst.Name);
+                resolve: context => (string)(context.FieldAst.Alias.IsEmpty ? context.FieldAst.Name : context.FieldAst.Alias));
         }
     }
 }

--- a/src/GraphQL.Tests/Language/CommentTests.cs
+++ b/src/GraphQL.Tests/Language/CommentTests.cs
@@ -20,7 +20,7 @@ query _ {
 }";
 
             var document = CoreToVanillaConverter.Convert(query.Parse());
-            document.Operations.First().Comment.ShouldBeNull();
+            document.Operations.First().Comment.IsEmpty.ShouldBeTrue();
         }
 
         [Fact]
@@ -49,10 +49,10 @@ query _ {
 
             var document = CoreToVanillaConverter.Convert(query.Parse());
             document.Operations.First()
-                .SelectionSet.Selections.OfType<Field>().First().Comment.ShouldBeNull();
+                .SelectionSet.Selections.OfType<Field>().First().Comment.IsEmpty.ShouldBeTrue();
             document.Operations.First()
                 .SelectionSet.Selections.OfType<Field>().First()
-                .SelectionSet.Selections.OfType<Field>().First().Comment.ShouldBeNull();
+                .SelectionSet.Selections.OfType<Field>().First().Comment.IsEmpty.ShouldBeTrue();
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Language/CommentTests.cs
+++ b/src/GraphQL.Tests/Language/CommentTests.cs
@@ -9,13 +9,6 @@ namespace GraphQL.Tests.Language
 {
     public class CommentTests
     {
-        private readonly Parser _parser;
-
-        public CommentTests()
-        {
-            _parser = new Parser(new Lexer());
-        }
-
         [Fact]
         public void operation_comment_should_be_null()
         {
@@ -26,7 +19,7 @@ query _ {
     }
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse());
             document.Operations.First().Comment.ShouldBeNull();
         }
 
@@ -40,7 +33,7 @@ query _ {
     }
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse(ignoreComments: false));
             document.Operations.First().Comment.ShouldBe("comment");
         }
 
@@ -54,7 +47,7 @@ query _ {
     }
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse());
             document.Operations.First()
                 .SelectionSet.Selections.OfType<Field>().First().Comment.ShouldBeNull();
             document.Operations.First()
@@ -74,7 +67,7 @@ query _ {
     }
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse(ignoreComments: false));
             document.Operations.First()
                 .SelectionSet.Selections.OfType<Field>().First().Comment.ShouldBe("comment1");
             document.Operations.First()
@@ -97,7 +90,7 @@ fragment human on person {
         name
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse(ignoreComments: false));
             document.Fragments.First().Comment.ShouldBe("comment");
         }
 
@@ -116,7 +109,7 @@ fragment human on person {
         name
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse(ignoreComments: false));
             document.Operations.First()
                 .SelectionSet.Selections.OfType<Field>().First()
                 .SelectionSet.Selections.OfType<FragmentSpread>().First().Comment.ShouldBe("comment");
@@ -135,7 +128,7 @@ query _ {
     }
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse(ignoreComments: false));
             document.Operations.First()
                 .SelectionSet.Selections.OfType<Field>().First()
                 .SelectionSet.Selections.OfType<InlineFragment>().First().Comment.ShouldBe("comment");
@@ -153,7 +146,7 @@ query _ {
     }
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse(ignoreComments: false));
             document.Operations.First()
                 .SelectionSet.Selections.OfType<Field>().First()
                 .Arguments.First().Comment.ShouldBe("comment");
@@ -171,7 +164,7 @@ query _(
     }
 }";
 
-            var document = CoreToVanillaConverter.Convert(_parser.Parse(new Source(query)));
+            var document = CoreToVanillaConverter.Convert(query.Parse(ignoreComments: false));
             document.Operations.First()
                 .Variables.First().Comment.ShouldBe("comment");
         }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -179,7 +179,11 @@ namespace GraphQL.Tests.Utilities
         {
             var schema = Schema.For(
                 ReadSchema("PetComplex.graphql"),
-                builder => builder.Types.ForAll(config => config.ResolveType = _ => null)
+                builder =>
+                {
+                    builder.Types.ForAll(config => config.ResolveType = _ => null);
+                    builder.IgnoreComments = false;
+                }
             );
 
             schema.Description.ShouldBe("Animals - cats and dogs");

--- a/src/GraphQL/Conversion/ValueConverter.cs
+++ b/src/GraphQL/Conversion/ValueConverter.cs
@@ -25,6 +25,16 @@ namespace GraphQL
         /// </summary>
         static ValueConverter()
         {
+#if NETSTANDARD2_1
+            Register<GraphQLParser.ROM, double>(value => double.Parse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
+            Register<GraphQLParser.ROM, float>(value => float.Parse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
+            Register<GraphQLParser.ROM, bool>(value => bool.Parse(value));
+#else //TODO: optimize
+            Register<GraphQLParser.ROM, double>(value => double.Parse((string)value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
+            Register<GraphQLParser.ROM, float>(value => float.Parse((string)value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
+            Register<GraphQLParser.ROM, bool>(value => bool.Parse((string)value));
+#endif
+
             Register<string, sbyte>(value => sbyte.Parse(value, NumberFormatInfo.InvariantInfo));
             Register<string, byte>(value => byte.Parse(value, NumberFormatInfo.InvariantInfo));
             Register<string, short>(value => short.Parse(value, NumberFormatInfo.InvariantInfo));

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -115,7 +115,6 @@ namespace GraphQL
 
                 var operation = GetOperation(options.OperationName, document);
                 metrics.SetOperationName(operation == null ? null : (string)operation.Name);
-                GraphQLParser.ROM z;
 
                 if (operation == null)
                 {

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -114,7 +114,8 @@ namespace GraphQL
                 }
 
                 var operation = GetOperation(options.OperationName, document);
-                metrics.SetOperationName(operation?.Name);
+                metrics.SetOperationName(operation == null ? null : (string)operation.Name);
+                GraphQLParser.ROM z;
 
                 if (operation == null)
                 {

--- a/src/GraphQL/Execution/ExecutionNode.cs
+++ b/src/GraphQL/Execution/ExecutionNode.cs
@@ -61,7 +61,7 @@ namespace GraphQL.Execution
         /// <summary>
         /// Returns the AST field alias, if specified, or AST field name otherwise.
         /// </summary>
-        public string Name => Field?.Alias ?? Field?.Name;
+        public string Name => Field == null ? null : Field.Alias.IsEmpty ? (string)Field.Name : (string)Field.Alias;
 
         /// <summary>
         /// Returns true if the result has been set. Also returns true when the result is temporarily set to an <see cref="IDataLoaderResult"/>

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -6,6 +6,7 @@ using GraphQL.DataLoader;
 using GraphQL.Language.AST;
 using GraphQL.Resolvers;
 using GraphQL.Types;
+using GraphQLParser;
 using static GraphQL.Execution.ExecutionHelper;
 
 namespace GraphQL.Execution
@@ -82,7 +83,7 @@ namespace GraphQL.Execution
         /// <summary>
         /// Creates specified child execution nodes of an object execution node.
         /// </summary>
-        public static void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent, Dictionary<string, Field> fields)
+        public static void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent, Dictionary<ROM, Field> fields)
         {
             var parentType = parent.GetObjectGraphType(context.Schema);
 
@@ -106,7 +107,7 @@ namespace GraphQL.Execution
                 if (node == null)
                     continue;
 
-                subFields[name] = node;
+                subFields[fieldDefinition.Name == name ? fieldDefinition.Name : (string)name] = node;
             }
 
             parent.SubFields = subFields;

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -13,25 +13,19 @@ namespace GraphQL.Execution
     /// </summary>
     public class GraphQLDocumentBuilder : IDocumentBuilder
     {
-        private readonly Parser _parser;
-
         /// <summary>
-        /// Initializes a new instance.
+        /// Specifies whether to ignore comments when parsing GraphQL document.
+        /// By default, all comments are ignored
         /// </summary>
-        public GraphQLDocumentBuilder()
-        {
-            var lexer = new Lexer();
-            _parser = new Parser(lexer);
-        }
+        public bool IgnoreComments { get; set; } = true;
 
         /// <inheritdoc/>
         public Document Build(string body)
         {
-            var source = new Source(body);
             GraphQLDocument result;
             try
             {
-                result = _parser.Parse(source);
+                result = Parser.Parse(body, ignoreComments: IgnoreComments);
             }
             catch (GraphQLSyntaxErrorException ex)
             {

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="7.0.0-preview-8" />
+    <PackageReference Include="GraphQL-Parser" Version="7.0.0-preview-19" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <Description>GraphQL for .NET</Description>
     <Authors>Joe McBride</Authors>
     <Copyright>Copyright 2015-2017 Joseph T. McBride et al. All rights reserved.</Copyright>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="6.0.0" />
+    <PackageReference Include="GraphQL-Parser" Version="7.0.0-preview-8" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />

--- a/src/GraphQL/Language/AST/AbstractNode.cs
+++ b/src/GraphQL/Language/AST/AbstractNode.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -11,7 +12,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the comment associated with the node.
         /// </summary>
-        public string Comment => CommentNode?.Value;
+        public ROM Comment => CommentNode?.Value ?? default;
 
         /// <summary>
         /// Returns the comment node associated with the node.

--- a/src/GraphQL/Language/AST/Argument.cs
+++ b/src/GraphQL/Language/AST/Argument.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -26,7 +27,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of this argument.
         /// </summary>
-        public string Name => NameNode.Name;
+        public ROM Name => NameNode.Name;
 
         /// <summary>
         /// Returns a <see cref="NameNode"/> containing the name of this argument.

--- a/src/GraphQL/Language/AST/CommentNode.cs
+++ b/src/GraphQL/Language/AST/CommentNode.cs
@@ -1,3 +1,5 @@
+using GraphQLParser;
+
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -8,7 +10,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Initializes a new instance with the specified comment value.
         /// </summary>
-        public CommentNode(string value)
+        public CommentNode(ROM value)
         {
             Value = value;
         }
@@ -16,6 +18,6 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the comment stored in this node.
         /// </summary>
-        public string Value { get; }
+        public ROM Value { get; }
     }
 }

--- a/src/GraphQL/Language/AST/Directive.cs
+++ b/src/GraphQL/Language/AST/Directive.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -19,7 +20,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of this directive.
         /// </summary>
-        public string Name => NameNode.Name;
+        public ROM Name => NameNode.Name;
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> which contains the name of this directive.

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -10,7 +11,7 @@ namespace GraphQL.Language.AST
     public class Directives : AbstractNode, ICollection<Directive>
     {
         private List<Directive> _directives;
-        private readonly Dictionary<string, Directive> _unique = new Dictionary<string, Directive>(StringComparer.Ordinal);
+        private readonly Dictionary<ROM, Directive> _unique = new Dictionary<ROM, Directive>();
 
         /// <inheritdoc/>
         public override IEnumerable<INode> Children => _directives;

--- a/src/GraphQL/Language/AST/Field.cs
+++ b/src/GraphQL/Language/AST/Field.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -28,7 +29,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of the field.
         /// </summary>
-        public string Name => NameNode.Name;
+        public ROM Name => NameNode.Name;
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> containing the name of this field.
@@ -38,7 +39,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the alias for this field, if any.
         /// </summary>
-        public string Alias { get; set; }
+        public ROM Alias { get; set; }
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> containing the alias of this field, if any.

--- a/src/GraphQL/Language/AST/Fields.cs
+++ b/src/GraphQL/Language/AST/Fields.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -8,9 +9,9 @@ namespace GraphQL.Language.AST
     /// </summary>
     public class Fields : IEnumerable<Field>
     {
-        private readonly Dictionary<string, Field> _fields;
+        private readonly Dictionary<ROM, Field> _fields;
 
-        private Fields(Dictionary<string, Field> fields)
+        private Fields(Dictionary<ROM, Field> fields)
         {
             _fields = fields;
         }
@@ -18,14 +19,14 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns a new instance that contains no field nodes.
         /// </summary>
-        public static Fields Empty() => new Fields(new Dictionary<string, Field>());
+        public static Fields Empty() => new Fields(new Dictionary<ROM, Field>());
 
         /// <summary>
         /// Adds a field node to the list.
         /// </summary>
         public void Add(Field field)
         {
-            var name = field.Alias ?? field.Name;
+            var name = field.Alias.IsEmpty ? field.Name : field.Alias;
 
             if (_fields.TryGetValue(name, out Field original))
             {
@@ -49,7 +50,7 @@ namespace GraphQL.Language.AST
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public static implicit operator Dictionary<string, Field>(Fields fields) => fields._fields;
+        public static implicit operator Dictionary<ROM, Field>(Fields fields) => fields._fields;
     }
 }
 

--- a/src/GraphQL/Language/AST/FragmentDefinition.cs
+++ b/src/GraphQL/Language/AST/FragmentDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -19,7 +20,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of this fragment definition.
         /// </summary>
-        public string Name => NameNode.Name;
+        public ROM Name => NameNode.Name;
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> containing the name of this fragment definition.

--- a/src/GraphQL/Language/AST/FragmentSpread.cs
+++ b/src/GraphQL/Language/AST/FragmentSpread.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -19,7 +20,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of this fragment spread.
         /// </summary>
-        public string Name => NameNode.Name;
+        public ROM Name => NameNode.Name;
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> containing the name of this fragment spread.

--- a/src/GraphQL/Language/AST/Fragments.cs
+++ b/src/GraphQL/Language/AST/Fragments.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -25,7 +26,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Searches the list by name and returns the first matching fragment definition, or <see langword="null"/> if none is found.
         /// </summary>
-        public FragmentDefinition FindDefinition(string name)
+        public FragmentDefinition FindDefinition(ROM name)
         {
             // DO NOT USE LINQ ON HOT PATH
             if (_fragments != null)

--- a/src/GraphQL/Language/AST/NameNode.cs
+++ b/src/GraphQL/Language/AST/NameNode.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -11,7 +12,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Initializes a new instance with the specified name.
         /// </summary>
-        public NameNode(string name, SourceLocation location)
+        public NameNode(ROM name, SourceLocation location)
         {
             Name = name;
             SourceLocation = location;
@@ -20,7 +21,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Initializes a new instance with the specified name.
         /// </summary>
-        public NameNode(string name)
+        public NameNode(ROM name)
         {
             Name = name;
             SourceLocation = default;
@@ -29,7 +30,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the contained name.
         /// </summary>
-        public string Name { get; }
+        public ROM Name { get; }
 
         /// <inheritdoc/>
         public SourceLocation SourceLocation { get; }

--- a/src/GraphQL/Language/AST/NamedType.cs
+++ b/src/GraphQL/Language/AST/NamedType.cs
@@ -1,3 +1,5 @@
+using GraphQLParser;
+
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -16,7 +18,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of the named type node.
         /// </summary>
-        public string Name => NameNode.Name;
+        public ROM Name => NameNode.Name;
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> containing the name of the type.

--- a/src/GraphQL/Language/AST/Operation.cs
+++ b/src/GraphQL/Language/AST/Operation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -20,7 +21,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of the operation, if any.
         /// </summary>
-        public string Name => NameNode.Name;
+        public ROM Name => NameNode.Name;
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> containing the name of the operation, if any.

--- a/src/GraphQL/Language/AST/ValueNodes/EnumValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/EnumValue.cs
@@ -1,3 +1,5 @@
+using GraphQLParser;
+
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -27,7 +29,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the string representation of the enumeration value.
         /// </summary>
-        public string Name { get; }
+        public ROM Name { get; }
 
         /// <summary>
         /// Returns a <see cref="NameNode"/> containing the string representation of the enumeration value.

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -20,7 +21,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Initializes a new instance for the specified field name and value.
         /// </summary>
-        public ObjectField(string name, IValue value)
+        public ObjectField(ROM name, IValue value)
         {
             Name = name;
             Value = value;
@@ -29,7 +30,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of the field.
         /// </summary>
-        public string Name { get; }
+        public ROM Name { get; }
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> containing the name of the field, if initialized with the <see cref="ObjectField.ObjectField(NameNode, IValue)"/> constructor.

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectValue.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -34,7 +35,7 @@ namespace GraphQL.Language.AST
             get
             {
                 var obj = new Dictionary<string, object>();
-                FieldNames.Apply(name => obj.Add(name, Field(name).Value.Value));
+                FieldNames.Apply(name => obj.Add((string)name, Field(name).Value.Value));
                 return obj;
             }
         }
@@ -49,11 +50,11 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns a list of the names of the fields specified for this object value node.
         /// </summary>
-        public IEnumerable<string> FieldNames
+        public IEnumerable<ROM> FieldNames
         {
             get
             {
-                var list = new List<string>(ObjectFieldsList.Count);
+                var list = new List<ROM>(ObjectFieldsList.Count);
                 foreach (var item in ObjectFieldsList)
                     list.Add(item.Name);
                 return list;
@@ -73,7 +74,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the first matching field node contained within this object value node that matches the specified name, or <see langword="null"/> otherwise.
         /// </summary>
-        public ObjectField Field(string name)
+        public ObjectField Field(ROM name)
         {
             // DO NOT USE LINQ ON HOT PATH
             foreach (var field in ObjectFieldsList)

--- a/src/GraphQL/Language/AST/Variable.cs
+++ b/src/GraphQL/Language/AST/Variable.cs
@@ -1,3 +1,5 @@
+using GraphQLParser;
+
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -8,7 +10,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Gets or sets the name of the variable.
         /// </summary>
-        public string Name { get; set; }
+        public ROM Name { get; set; }
 
         private object _value;
         /// <summary>

--- a/src/GraphQL/Language/AST/VariableDefinition.cs
+++ b/src/GraphQL/Language/AST/VariableDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -26,7 +27,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of the variable.
         /// </summary>
-        public string Name => NameNode.Name;
+        public ROM Name => NameNode.Name;
 
         /// <summary>
         /// Gets or sets the <see cref="NameNode"/> containing the name of the variable.

--- a/src/GraphQL/Language/AST/VariableReference.cs
+++ b/src/GraphQL/Language/AST/VariableReference.cs
@@ -1,3 +1,5 @@
+using GraphQLParser;
+
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of the variable being referenced.
         /// </summary>
-        public string Name { get; }
+        public ROM Name { get; }
 
         /// <summary>
         /// Returns a <see cref="NameNode"/> containing the name of the variable being referenced.

--- a/src/GraphQL/Language/AST/Variables.cs
+++ b/src/GraphQL/Language/AST/Variables.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Execution;
+using GraphQLParser;
 
 namespace GraphQL.Language.AST
 {
@@ -33,7 +34,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the first variable with a matching name, or <paramref name="defaultValue"/> if none are found.
         /// </summary>
-        public object ValueFor(string name, object defaultValue = null)
+        public object ValueFor(ROM name, object defaultValue = null)
         {
             return ValueFor(name, out var value) ? value.Value : defaultValue;
         }
@@ -41,7 +42,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Gets the first variable with a matching name. Returns <see langword="true"/> if a match is found.
         /// </summary>
-        public bool ValueFor(string name, out ArgumentValue value)
+        public bool ValueFor(ROM name, out ArgumentValue value)
         {
             // DO NOT USE LINQ ON HOT PATH
             if (_variables != null)

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -433,7 +433,7 @@ namespace GraphQL.Language
         private static NameNode Name(GraphQLName name)
         {
             if (name == null) return default;
-            return new NameNode(name.ValueString, Convert(name.Location));
+            return new NameNode(name.Value, Convert(name.Location));
         }
 
         /// <summary>

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -254,31 +254,46 @@ namespace GraphQL.Language
                 case ASTNodeKind.StringValue:
                 {
                     var str = (GraphQLScalarValue)source;
-                    return new StringValue(str.Value) { SourceLocation = Convert(str.Location) };
+                    return new StringValue(str.ValueString) { SourceLocation = Convert(str.Location) };
                 }
                 case ASTNodeKind.IntValue:
                 {
                     var str = (GraphQLScalarValue)source;
-
+#if NETSTANDARD2_1
                     if (int.TryParse(str.Value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var intResult))
+#else
+                    if (int.TryParse(str.ValueString, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var intResult))
+#endif
                     {
                         return new IntValue(intResult) { SourceLocation = Convert(str.Location) };
                     }
 
                     // If the value doesn't fit in an integer, revert to using long...
+#if NETSTANDARD2_1
                     if (long.TryParse(str.Value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var longResult))
+#else
+                    if (long.TryParse(str.ValueString, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var longResult))
+#endif
                     {
                         return new LongValue(longResult) { SourceLocation = Convert(str.Location) };
                     }
 
                     // If the value doesn't fit in an long, revert to using decimal...
+#if NETSTANDARD2_1
                     if (decimal.TryParse(str.Value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var decimalResult))
+#else
+                    if (decimal.TryParse(str.ValueString, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var decimalResult))
+#endif
                     {
                         return new DecimalValue(decimalResult) { SourceLocation = Convert(str.Location) };
                     }
 
                     // If the value doesn't fit in an decimal, revert to using BigInteger...
+#if NETSTANDARD2_1
                     if (BigInteger.TryParse(str.Value, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var bigIntegerResult))
+#else
+                    if (BigInteger.TryParse(str.ValueString, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var bigIntegerResult))
+#endif
                     {
                         return new BigIntValue(bigIntegerResult) { SourceLocation = Convert(str.Location) };
                     }
@@ -293,17 +308,25 @@ namespace GraphQL.Language
                     // the idea is to see if there is a loss of accuracy of value
                     // for example, 12.1 or 12.11 is double but 12.10 is decimal
                     if (double.TryParse(
+#if NETSTANDARD2_1
                         str.Value,
+#else
+                        str.ValueString,
+#endif
                         NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent,
                         CultureInfo.InvariantCulture,
                         out var dbl) == false)
                     {
-                        dbl = str.Value[0] == '-' ? double.NegativeInfinity : double.PositiveInfinity;
+                        dbl = str.Value.Span[0] == '-' ? double.NegativeInfinity : double.PositiveInfinity;
                     }
 
                     //it is possible for a FloatValue to overflow a decimal; however, with a double, it just returns Infinity or -Infinity
                     if (decimal.TryParse(
+#if NETSTANDARD2_1
                         str.Value,
+#else
+                         str.ValueString,
+#endif
                         NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent,
                         CultureInfo.InvariantCulture,
                         out decimal dec))
@@ -321,12 +344,16 @@ namespace GraphQL.Language
                 case ASTNodeKind.BooleanValue:
                 {
                     var str = (GraphQLScalarValue)source;
+#if NETSTANDARD2_1
                     return new BooleanValue(bool.Parse(str.Value)) { SourceLocation = Convert(str.Location) };
+#else
+                    return new BooleanValue(bool.Parse(str.ValueString)) { SourceLocation = Convert(str.Location) }; //TODO: rewrite
+#endif
                 }
                 case ASTNodeKind.EnumValue:
                 {
                     var str = (GraphQLScalarValue)source;
-                    return new EnumValue(str.Value) { SourceLocation = Convert(str.Location) };
+                    return new EnumValue(str.ValueString) { SourceLocation = Convert(str.Location) };
                 }
                 case ASTNodeKind.Variable:
                 {
@@ -406,7 +433,7 @@ namespace GraphQL.Language
         private static NameNode Name(GraphQLName name)
         {
             if (name == null) return default;
-            return new NameNode(name.Value, Convert(name.Location));
+            return new NameNode(name.ValueString, Convert(name.Location));
         }
 
         /// <summary>
@@ -416,7 +443,7 @@ namespace GraphQL.Language
         {
             return comment == null
                 ? null
-                : new CommentNode(comment.Text) { SourceLocation = Convert(comment.Location) };
+                : new CommentNode(comment.TextString) { SourceLocation = Convert(comment.Location) };
         }
 
         /// <summary>

--- a/src/GraphQL/ROMExtensions.cs
+++ b/src/GraphQL/ROMExtensions.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using GraphQLParser;
+
+namespace GraphQL
+{
+    public static class ROMExtensions
+    {
+        public static bool Contains(this List<string> list, ROM rom)
+        {
+            foreach(var l in list)
+            {
+                if (l == rom)
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -7,6 +7,7 @@ using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using GraphQL.Resolvers;
 using GraphQL.Types;
+using GraphQLParser;
 using Field = GraphQL.Language.AST.Field;
 
 namespace GraphQL
@@ -79,7 +80,7 @@ namespace GraphQL
         IEnumerable<object> ResponsePath { get; }
 
         /// <summary>Returns a list of child fields requested for the current field.</summary>
-        IDictionary<string, Field> SubFields { get; }
+        IDictionary<ROM, Field> SubFields { get; }
 
         /// <summary>
         /// The response map may also contain an entry with key extensions. This entry is reserved for implementors to extend the

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -4,6 +4,7 @@ using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using GraphQL.Types;
+using GraphQLParser;
 using Field = GraphQL.Language.AST.Field;
 
 namespace GraphQL
@@ -16,7 +17,7 @@ namespace GraphQL
         private ExecutionNode _executionNode;
         private ExecutionContext _executionContext;
         private IDictionary<string, ArgumentValue> _arguments;
-        private IDictionary<string, Field> _subFields;
+        private IDictionary<ROM, Field> _subFields;
 
         /// <summary>
         /// Initializes an instance with the specified <see cref="ExecutionNode"/> and <see cref="ExecutionContext"/>.
@@ -36,7 +37,7 @@ namespace GraphQL
             return this;
         }
 
-        private IDictionary<string, Field> GetSubFields()
+        private IDictionary<ROM, Field> GetSubFields()
         {
             return _executionNode.Field?.SelectionSet?.Selections?.Count > 0
                 ? ExecutionHelper.CollectFields(_executionContext, _executionNode.FieldDefinition.ResolvedType, _executionNode.Field.SelectionSet)
@@ -50,7 +51,7 @@ namespace GraphQL
         public object Source => _executionNode.Source;
 
         /// <inheritdoc/>
-        public string FieldName => _executionNode.Field.Name;
+        public string FieldName => (string)_executionNode.Field.Name;
 
         /// <inheritdoc/>
         public Field FieldAst => _executionNode.Field;
@@ -101,7 +102,7 @@ namespace GraphQL
         public IEnumerable<object> ResponsePath => _executionNode.ResponsePath;
 
         /// <inheritdoc/>
-        public IDictionary<string, Field> SubFields => _subFields ??= GetSubFields();
+        public IDictionary<ROM, Field> SubFields => _subFields ??= GetSubFields();
 
         /// <inheritdoc/>
         public IDictionary<string, object> UserContext => _executionContext.UserContext;

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -5,6 +5,7 @@ using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using GraphQL.Types;
+using GraphQLParser;
 using Field = GraphQL.Language.AST.Field;
 
 namespace GraphQL
@@ -72,7 +73,7 @@ namespace GraphQL
         public IEnumerable<object> ResponsePath { get; set; }
 
         /// <inheritdoc/>
-        public IDictionary<string, Field> SubFields { get; set; }
+        public IDictionary<ROM, Field> SubFields { get; set; }
 
         /// <inheritdoc/>
         public IServiceProvider RequestServices { get; set; }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -5,6 +5,7 @@ using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using GraphQL.Types;
+using GraphQLParser;
 
 namespace GraphQL
 {
@@ -74,7 +75,7 @@ namespace GraphQL
 
         public IEnumerable<object> ResponsePath => _baseContext.ResponsePath;
 
-        public IDictionary<string, Language.AST.Field> SubFields => _baseContext.SubFields;
+        public IDictionary<ROM, Language.AST.Field> SubFields => _baseContext.SubFields;
 
         public IDictionary<string, object> UserContext => _baseContext.UserContext;
 

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -25,7 +25,7 @@ namespace GraphQL.Resolvers
         public static NameFieldResolver Instance { get; } = new NameFieldResolver();
 
         /// <inheritdoc/>
-        public object Resolve(IResolveFieldContext context) => Resolve(context?.Source, context?.FieldAst?.Name);
+        public object Resolve(IResolveFieldContext context) => Resolve(context.Source, context.FieldDefinition.Name);
 
         private static object Resolve(object source, string name)
         {

--- a/src/GraphQL/Types/Collections/QueryArguments.cs
+++ b/src/GraphQL/Types/Collections/QueryArguments.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using GraphQL.Utilities;
+using GraphQLParser;
 
 namespace GraphQL.Types
 {
@@ -77,6 +78,21 @@ namespace GraphQL.Types
         /// Finds an argument by its name from the list.
         /// </summary>
         public QueryArgument Find(string name)
+        {
+            // DO NOT USE LINQ ON HOT PATH
+            if (List != null)
+            {
+                foreach (var arg in List)
+                {
+                    if (arg.Name == name)
+                        return arg;
+                }
+            }
+
+            return null;
+        }
+
+        public QueryArgument Find(ROM name)
         {
             // DO NOT USE LINQ ON HOT PATH
             if (List != null)

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -6,6 +6,7 @@ using GraphQL.Resolvers;
 using GraphQL.Subscription;
 using GraphQL.Types.Relay;
 using GraphQL.Utilities;
+using GraphQLParser;
 
 namespace GraphQL.Types
 {
@@ -29,11 +30,15 @@ namespace GraphQL.Types
         /// </summary>
         bool HasField(string name);
 
+        bool HasField(ROM name);
+
         /// <summary>
         /// Returns the <see cref="FieldType"/> for the field matching the specified name that
         /// is configured for this graph type, or <see langword="null"/> if none is found.
         /// </summary>
         FieldType GetField(string name);
+
+        FieldType GetField(ROM name);
     }
 
     /// <summary>
@@ -69,6 +74,21 @@ namespace GraphQL.Types
             return false;
         }
 
+        public bool HasField(ROM name)
+        {
+            if (name.IsEmpty)
+                return false;
+
+            // DO NOT USE LINQ ON HOT PATH
+            foreach (var field in Fields.List)
+            {
+                if (field.Name == name)
+                    return true;
+            }
+
+            return false;
+        }
+
         /// <inheritdoc/>
         public FieldType GetField(string name)
         {
@@ -78,6 +98,20 @@ namespace GraphQL.Types
                 foreach (var field in Fields.List)
                 {
                     if (string.Equals(field.Name, name, StringComparison.Ordinal))
+                        return field;
+                }
+            }
+
+            return null;
+        }
+
+        public FieldType GetField(ROM name)
+        {
+            if (!name.IsEmpty)
+            {
+                foreach (var field in Fields.List)
+                {
+                    if (field.Name == name)
                         return field;
                 }
             }

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using GraphQL.Conversion;
 using GraphQL.Introspection;
+using GraphQLParser;
 
 namespace GraphQL.Types
 {
@@ -71,11 +72,14 @@ namespace GraphQL.Types
         /// </summary>
         IGraphType FindType(string name);
 
+        IGraphType FindType(ROM rom);
+
         /// <summary>
         /// Returns a <see cref="DirectiveGraphType"/> for a given name.
         /// </summary>
         DirectiveGraphType FindDirective(string name);
 
+        DirectiveGraphType FindDirective(ROM name);
         /// <summary>
         /// A list of additional graph types manually added to the schema by RegisterType call.
         /// </summary>

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GraphQL.Conversion;
 using GraphQL.Introspection;
 using GraphQL.Utilities;
+using GraphQLParser;
 
 namespace GraphQL.Types
 {
@@ -215,6 +216,11 @@ namespace GraphQL.Types
             return Directives.FirstOrDefault(x => x.Name == name);
         }
 
+        public DirectiveGraphType FindDirective(ROM name)
+        {
+            return Directives.FirstOrDefault(x => x.Name == name);
+        }
+
         /// <inheritdoc/>
         public void RegisterValueConverter(IAstFromValueConverter converter)
         {
@@ -238,6 +244,14 @@ namespace GraphQL.Types
             }
 
             return _allTypes?.Value[name];
+        }
+
+        public IGraphType FindType(ROM rom)
+        {
+            if (rom.IsEmpty)
+                throw new ArgumentOutOfRangeException(nameof(rom), "A type name is required to lookup.");
+
+            return _allTypes?.Value[rom];
         }
 
         /// <inheritdoc/>
@@ -267,6 +281,7 @@ namespace GraphQL.Types
                     if (_allTypes.IsValueCreated)
                     {
                         _allTypes.Value.Dictionary.Clear();
+                        _allTypes.Value.Dictionary2.Clear();
                     }
 
                     _allTypes = null;

--- a/src/GraphQL/Types/TypeExtensions.cs
+++ b/src/GraphQL/Types/TypeExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using GraphQL.Language.AST;
+using GraphQLParser;
 
 namespace GraphQL.Types
 {
@@ -56,7 +57,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Returns the name of an AST type after unwrapping any <see cref="NonNullType"/> or <see cref="ListType"/> layers.
         /// </summary>
-        public static string Name(this IType type) => type switch
+        public static ROM Name(this IType type) => type switch
         {
             NonNullType nonnull => Name(nonnull.Type),
             ListType list => Name(list.Type),
@@ -71,7 +72,7 @@ namespace GraphQL.Types
         {
             NonNullType nonnull => $"{FullName(nonnull.Type)}!",
             ListType list => $"[{FullName(list.Type)}]",
-            _ => ((NamedType)type).Name
+            _ => (string)((NamedType)type).Name
         };
     }
 }

--- a/src/GraphQL/Utilities/DirectiveVisitorSelector.cs
+++ b/src/GraphQL/Utilities/DirectiveVisitorSelector.cs
@@ -35,10 +35,10 @@ namespace GraphQL.Utilities
 
         private IEnumerable<ISchemaNodeVisitor> BuildVisitors(IEnumerable<GraphQLDirective> directives)
         {
-            foreach (var dir in directives.Where(x => _directiveVisitors.ContainsKey(x.Name.Value)))
+            foreach (var dir in directives.Where(x => _directiveVisitors.ContainsKey(x.Name.ValueString)))
             {
-                var visitor = _typeResolver(_directiveVisitors[dir.Name.Value]);
-                visitor.Name = dir.Name.Value;
+                var visitor = _typeResolver(_directiveVisitors[dir.Name.ValueString]);
+                visitor.Name = dir.Name.ValueString;
                 if (dir.Arguments != null)
                     visitor.Arguments = ToArguments(dir.Arguments);
                 yield return visitor;
@@ -47,7 +47,7 @@ namespace GraphQL.Utilities
 
         private Dictionary<string, object> ToArguments(List<GraphQLArgument> arguments)
         {
-            return arguments.ToDictionary(x => x.Name.Value, x => x.Value.ToValue());
+            return arguments.ToDictionary(x => x.Name.ValueString, x => x.Value.ToValue());
         }
     }
 }

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -47,7 +47,7 @@ namespace GraphQL.Utilities.Federation
             var dirs = string.Join(
                 " ",
                 astDirectives
-                    .Where(x => IsFederatedDirective(x.Name.Value))
+                    .Where(x => IsFederatedDirective(x.Name.ValueString))
                     .Select(PrintAstDirective)
             );
 

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalyzer.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using GraphQL.Language.AST;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Complexity
 {
@@ -22,7 +23,7 @@ namespace GraphQL.Validation.Complexity
             public ComplexityResult Result { get; } = new ComplexityResult();
             public int LoopCounter { get; set; }
             public int MaxRecursionCount { get; set; }
-            public Dictionary<string, FragmentComplexity> FragmentMap { get; } = new Dictionary<string, FragmentComplexity>();
+            public Dictionary<ROM, FragmentComplexity> FragmentMap { get; } = new Dictionary<ROM, FragmentComplexity>();
 
             public void AssertRecursion()
             {

--- a/src/GraphQL/Validation/Errors/ArgumentsOfCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/ArgumentsOfCorrectTypeError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ArgumentsOfCorrectTypeError(ValidationContext context, Argument node, IEnumerable<string> verboseErrors)
-            : base(context.OriginalQuery, NUMBER, BadValueMessage(node.Name, context.Print(node.Value), verboseErrors), node)
+            : base(context.OriginalQuery, NUMBER, BadValueMessage((string)node.Name, context.Print(node.Value), verboseErrors), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/DefaultValuesOfCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/DefaultValuesOfCorrectTypeError.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public DefaultValuesOfCorrectTypeError(ValidationContext context, VariableDefinition varDefAst, IGraphType inputType, IEnumerable<string> verboseErrors)
-            : base(context.OriginalQuery, NUMBER, BadValueForDefaultArgMessage(varDefAst.Name, context.Print(inputType), context.Print(varDefAst.DefaultValue), verboseErrors), varDefAst.DefaultValue)
+            : base(context.OriginalQuery, NUMBER, BadValueForDefaultArgMessage((string)varDefAst.Name, context.Print(inputType), context.Print(varDefAst.DefaultValue), verboseErrors), varDefAst.DefaultValue)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/FieldsOnCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/FieldsOnCorrectTypeError.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public FieldsOnCorrectTypeError(ValidationContext context, Field node, IGraphType type, IEnumerable<string> suggestedTypeNames, IEnumerable<string> suggestedFieldNames)
-            : base(context.OriginalQuery, NUMBER, UndefinedFieldMessage(node.Name, type.Name, suggestedTypeNames, suggestedFieldNames), node)
+            : base(context.OriginalQuery, NUMBER, UndefinedFieldMessage((string)node.Name, type.Name, suggestedTypeNames, suggestedFieldNames), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/FragmentsOnCompositeTypesError.cs
+++ b/src/GraphQL/Validation/Errors/FragmentsOnCompositeTypesError.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public FragmentsOnCompositeTypesError(ValidationContext context, FragmentDefinition node)
-            : base(context.OriginalQuery, NUMBER, FragmentOnNonCompositeErrorMessage(node.Name, context.Print(node.Type)), node.Type)
+            : base(context.OriginalQuery, NUMBER, FragmentOnNonCompositeErrorMessage((string)node.Name, context.Print(node.Type)), node.Type)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
@@ -18,10 +18,10 @@ namespace GraphQL.Validation.Errors
         public KnownArgumentNamesError(ValidationContext context, Argument node, FieldType fieldDef, IGraphType parentType)
             : base(context.OriginalQuery, NUMBER,
                 UnknownArgMessage(
-                    node.Name,
+                    (string)node.Name,
                     fieldDef.Name,
                     context.Print(parentType),
-                    StringUtils.SuggestionList(node.Name, fieldDef.Arguments?.List?.Select(q => q.Name))),
+                    StringUtils.SuggestionList((string)node.Name, fieldDef.Arguments?.List?.Select(q => q.Name))),
                 node)
         {
         }
@@ -32,9 +32,9 @@ namespace GraphQL.Validation.Errors
         public KnownArgumentNamesError(ValidationContext context, Argument node, DirectiveGraphType directive)
             : base(context.OriginalQuery, NUMBER,
                 UnknownDirectiveArgMessage(
-                    node.Name,
+                    (string)node.Name,
                     directive.Name,
-                    StringUtils.SuggestionList(node.Name, directive.Arguments?.Select(q => q.Name))),
+                    StringUtils.SuggestionList((string)node.Name, directive.Arguments?.Select(q => q.Name))),
                 node)
         {
         }

--- a/src/GraphQL/Validation/Errors/KnownDirectivesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownDirectivesError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public KnownDirectivesError(ValidationContext context, Directive node)
-            : base(context.OriginalQuery, NUMBER, UnknownDirectiveMessage(node.Name), node)
+            : base(context.OriginalQuery, NUMBER, UnknownDirectiveMessage((string)node.Name), node)
         {
         }
 
@@ -22,7 +22,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public KnownDirectivesError(ValidationContext context, Directive node, DirectiveLocation candidateLocation)
-            : base(context.OriginalQuery, NUMBER, MisplacedDirectiveMessage(node.Name, candidateLocation.ToString()), node)
+            : base(context.OriginalQuery, NUMBER, MisplacedDirectiveMessage((string)node.Name, candidateLocation.ToString()), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/KnownTypeNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownTypeNamesError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public KnownTypeNamesError(ValidationContext context, NamedType node, string[] suggestedTypes)
-            : base(context.OriginalQuery, NUMBER, UnknownTypeMessage(node.Name, suggestedTypes), node)
+            : base(context.OriginalQuery, NUMBER, UnknownTypeMessage((string)node.Name, suggestedTypes), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/NoUndefinedVariablesError.cs
+++ b/src/GraphQL/Validation/Errors/NoUndefinedVariablesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public NoUndefinedVariablesError(ValidationContext context, Operation node, VariableReference variableReference)
-            : base(context.OriginalQuery, NUMBER, UndefinedVarMessage(variableReference.Name, node.Name), variableReference, node)
+            : base(context.OriginalQuery, NUMBER, UndefinedVarMessage((string)variableReference.Name, (string)node.Name), variableReference, node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/NoUnusedFragmentsError.cs
+++ b/src/GraphQL/Validation/Errors/NoUnusedFragmentsError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public NoUnusedFragmentsError(ValidationContext context, FragmentDefinition node)
-            : base(context.OriginalQuery, NUMBER, UnusedFragMessage(node.Name), node)
+            : base(context.OriginalQuery, NUMBER, UnusedFragMessage((string)node.Name), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/NoUnusedVariablesError.cs
+++ b/src/GraphQL/Validation/Errors/NoUnusedVariablesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public NoUnusedVariablesError(ValidationContext context, VariableDefinition node, Operation op)
-            : base(context.OriginalQuery, NUMBER, UnusedVariableMessage(node.Name, op.Name), node)
+            : base(context.OriginalQuery, NUMBER, UnusedVariableMessage((string)node.Name, (string)op.Name), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/PossibleFragmentSpreadsError.cs
+++ b/src/GraphQL/Validation/Errors/PossibleFragmentSpreadsError.cs
@@ -22,7 +22,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public PossibleFragmentSpreadsError(ValidationContext context, FragmentSpread node, IGraphType parentType, IGraphType fragType)
-            : base(context.OriginalQuery, NUMBER, TypeIncompatibleSpreadMessage(node.Name, context.Print(parentType), context.Print(fragType)), node)
+            : base(context.OriginalQuery, NUMBER, TypeIncompatibleSpreadMessage((string)node.Name, context.Print(parentType), context.Print(fragType)), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/ProvidedNonNullArgumentsError.cs
+++ b/src/GraphQL/Validation/Errors/ProvidedNonNullArgumentsError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ProvidedNonNullArgumentsError(ValidationContext context, Field node, QueryArgument arg)
-            : base(context.OriginalQuery, NUMBER, MissingFieldArgMessage(node.Name, arg.Name, context.Print(arg.ResolvedType)), node)
+            : base(context.OriginalQuery, NUMBER, MissingFieldArgMessage((string)node.Name, arg.Name, context.Print(arg.ResolvedType)), node)
         {
         }
 
@@ -22,7 +22,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ProvidedNonNullArgumentsError(ValidationContext context, Directive node, QueryArgument arg)
-            : base(context.OriginalQuery, NUMBER, MissingDirectiveArgMessage(node.Name, arg.Name, context.Print(arg.ResolvedType)), node)
+            : base(context.OriginalQuery, NUMBER, MissingDirectiveArgMessage((string)node.Name, arg.Name, context.Print(arg.ResolvedType)), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/ScalarLeafsError.cs
+++ b/src/GraphQL/Validation/Errors/ScalarLeafsError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ScalarLeafsError(ValidationContext context, SelectionSet node, Field field, IGraphType type)
-            : base(context.OriginalQuery, NUMBER, NoSubselectionAllowedMessage(field.Name, context.Print(type)), node)
+            : base(context.OriginalQuery, NUMBER, NoSubselectionAllowedMessage((string)field.Name, context.Print(type)), node)
         {
         }
 
@@ -22,7 +22,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ScalarLeafsError(ValidationContext context, Field node, IGraphType type)
-            : base(context.OriginalQuery, NUMBER, RequiredSubselectionMessage(node.Name, context.Print(type)), node)
+            : base(context.OriginalQuery, NUMBER, RequiredSubselectionMessage((string)node.Name, context.Print(type)), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/SingleRootFieldSubscriptionsError.cs
+++ b/src/GraphQL/Validation/Errors/SingleRootFieldSubscriptionsError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public SingleRootFieldSubscriptionsError(ValidationContext context, Operation operation, params ISelection[] nodes)
-            : base(context.OriginalQuery, NUMBER, InvalidNumberOfRootFieldMessage(operation.Name), nodes)
+            : base(context.OriginalQuery, NUMBER, InvalidNumberOfRootFieldMessage((string)operation.Name), nodes)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueArgumentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueArgumentNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueArgumentNamesError(ValidationContext context, Argument node, Argument otherNode)
-            : base(context.OriginalQuery, NUMBER, DuplicateArgMessage(node.Name), node, otherNode)
+            : base(context.OriginalQuery, NUMBER, DuplicateArgMessage((string)node.Name), node, otherNode)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueDirectivesPerLocationError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueDirectivesPerLocationError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueDirectivesPerLocationError(ValidationContext context, Directive node, Directive altNode)
-            : base(context.OriginalQuery, NUMBER, DuplicateDirectiveMessage(node.Name), node, altNode)
+            : base(context.OriginalQuery, NUMBER, DuplicateDirectiveMessage((string)node.Name), node, altNode)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueFragmentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueFragmentNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueFragmentNamesError(ValidationContext context, FragmentDefinition node, FragmentDefinition altNode)
-            : base(context.OriginalQuery, NUMBER, DuplicateFragmentNameMessage(node.Name), node, altNode)
+            : base(context.OriginalQuery, NUMBER, DuplicateFragmentNameMessage((string)node.Name), node, altNode)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueInputFieldNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueInputFieldNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueInputFieldNamesError(ValidationContext context, IValue node, ObjectField altNode)
-            : base(context.OriginalQuery, NUMBER, DuplicateInputField(altNode.Name), node, altNode.Value)
+            : base(context.OriginalQuery, NUMBER, DuplicateInputField((string)altNode.Name), node, altNode.Value)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueOperationNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueOperationNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueOperationNamesError(ValidationContext context, Operation node)
-            : base(context.OriginalQuery, NUMBER, DuplicateOperationNameMessage(node.Name), node)
+            : base(context.OriginalQuery, NUMBER, DuplicateOperationNameMessage((string)node.Name), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueVariableNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueVariableNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueVariableNamesError(ValidationContext context, VariableDefinition node, VariableDefinition altNode)
-            : base(context.OriginalQuery, NUMBER, DuplicateVariableMessage(node.Name), node, altNode)
+            : base(context.OriginalQuery, NUMBER, DuplicateVariableMessage((string)node.Name), node, altNode)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/VariablesAreInputTypesError.cs
+++ b/src/GraphQL/Validation/Errors/VariablesAreInputTypesError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public VariablesAreInputTypesError(ValidationContext context, VariableDefinition node, IGraphType type)
-            : base(context.OriginalQuery, NUMBER, UndefinedVarMessage(node.Name, type != null ? context.Print(type) : node.Type.Name()), node)
+            : base(context.OriginalQuery, NUMBER, UndefinedVarMessage((string)node.Name, type != null ? context.Print(type) : (string)node.Type.Name()), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/VariablesInAllowedPositionError.cs
+++ b/src/GraphQL/Validation/Errors/VariablesInAllowedPositionError.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public VariablesInAllowedPositionError(ValidationContext context, VariableDefinition varDef, IGraphType varType, VariableUsage usage)
-            : base(context.OriginalQuery, NUMBER, BadVarPosMessage(usage.Node.Name, context.Print(varType), context.Print(usage.Type)))
+            : base(context.OriginalQuery, NUMBER, BadVarPosMessage((string)usage.Node.Name, context.Print(varType), context.Print(usage.Type)))
         {
             var varDefPos = new Location(context.OriginalQuery, varDef.SourceLocation.Start);
             var usagePos = new Location(context.OriginalQuery, usage.Node.SourceLocation.Start);

--- a/src/GraphQL/Validation/Rules/FieldsOnCorrectType.cs
+++ b/src/GraphQL/Validation/Rules/FieldsOnCorrectType.cs
@@ -6,6 +6,7 @@ using GraphQL.Language.AST;
 using GraphQL.Types;
 using GraphQL.Utilities;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -39,12 +40,12 @@ namespace GraphQL.Validation.Rules
                     var fieldName = node.Name;
 
                     // First determine if there are any suggested types to condition on.
-                    var suggestedTypeNames = GetSuggestedTypeNames(type, fieldName).ToList();
+                    var suggestedTypeNames = GetSuggestedTypeNames(type, (string)fieldName).ToList();
 
                     // If there are no suggested types, then perhaps this was a typo?
                     var suggestedFieldNames = suggestedTypeNames.Count > 0
                         ? Array.Empty<string>()
-                        : GetSuggestedFieldNames(type, fieldName);
+                        : GetSuggestedFieldNames(type, (string)fieldName);
 
                     // Report an error, including helpful suggestions.
                     context.ReportError(new FieldsOnCorrectTypeError(context, node, type, suggestedTypeNames, suggestedFieldNames));

--- a/src/GraphQL/Validation/Rules/KnownFragmentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownFragmentNames.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Validation.Rules
             var fragment = context.GetFragment(fragmentName);
             if (fragment == null)
             {
-                context.ReportError(new KnownFragmentNamesError(context, node, fragmentName));
+                context.ReportError(new KnownFragmentNamesError(context, node, (string)fragmentName));
             }
         }).ToTask();
     }

--- a/src/GraphQL/Validation/Rules/KnownTypeNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownTypeNames.cs
@@ -29,7 +29,7 @@ namespace GraphQL.Validation.Rules
             if (type == null)
             {
                 var typeNames = context.Schema.AllTypes.Dictionary.Values.Select(x => x.Name).ToArray();
-                var suggestionList = StringUtils.SuggestionList(node.Name, typeNames);
+                var suggestionList = StringUtils.SuggestionList((string)node.Name, typeNames);
                 context.ReportError(new KnownTypeNamesError(context, node, suggestionList));
             }
         }).ToTask();

--- a/src/GraphQL/Validation/Rules/LoneAnonymousOperation.cs
+++ b/src/GraphQL/Validation/Rules/LoneAnonymousOperation.cs
@@ -23,7 +23,7 @@ namespace GraphQL.Validation.Rules
 
         private static readonly Task<INodeVisitor> _nodeVisitor = new MatchingNodeVisitor<Operation>((op, context) =>
         {
-            if (string.IsNullOrWhiteSpace(op.Name)
+            if (op.Name.IsEmpty
                 && context.Document.Operations.Count > 1)
             {
                 context.ReportError(new LoneAnonymousOperationError(context, op));

--- a/src/GraphQL/Validation/Rules/NoFragmentCycles.cs
+++ b/src/GraphQL/Validation/Rules/NoFragmentCycles.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -24,9 +25,9 @@ namespace GraphQL.Validation.Rules
 
         private static readonly Task<INodeVisitor> _nodeVisitor = new MatchingNodeVisitor<FragmentDefinition>((node, context) =>
         {
-            var visitedFrags = context.TypeInfo.NoFragmentCycles_VisitedFrags ??= new HashSet<string>();
+            var visitedFrags = context.TypeInfo.NoFragmentCycles_VisitedFrags ??= new HashSet<ROM>();
             var spreadPath = context.TypeInfo.NoFragmentCycles_SpreadPath ??= new Stack<FragmentSpread>();
-            var spreadPathIndexByName = context.TypeInfo.NoFragmentCycles_SpreadPathIndexByName ??= new Dictionary<string, int>();
+            var spreadPathIndexByName = context.TypeInfo.NoFragmentCycles_SpreadPathIndexByName ??= new Dictionary<ROM, int>();
             if (!visitedFrags.Contains(node.Name))
             {
                 detectCycleRecursive(node, spreadPath, visitedFrags, spreadPathIndexByName, context);
@@ -36,8 +37,8 @@ namespace GraphQL.Validation.Rules
         private static void detectCycleRecursive(
             FragmentDefinition fragment,
             Stack<FragmentSpread> spreadPath,
-            HashSet<string> visitedFrags,
-            Dictionary<string, int> spreadPathIndexByName,
+            HashSet<ROM> visitedFrags,
+            Dictionary<ROM, int> spreadPathIndexByName,
             ValidationContext context)
         {
             var fragmentName = fragment.Name;
@@ -79,7 +80,7 @@ namespace GraphQL.Validation.Rules
                     var cyclePath = spreadPath.Reverse().Skip(cycleIndex).ToArray();
                     var nodes = cyclePath.OfType<INode>().Concat(new[] { spreadNode }).ToArray();
 
-                    context.ReportError(new NoFragmentCyclesError(context, spreadName, cyclePath.Select(x => x.Name).ToArray(), nodes));
+                    context.ReportError(new NoFragmentCyclesError(context, (string)spreadName, cyclePath.Select(x => (string)x.Name).ToArray(), nodes));
                 }
             }
 

--- a/src/GraphQL/Validation/Rules/NoUndefinedVariables.cs
+++ b/src/GraphQL/Validation/Rules/NoUndefinedVariables.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -25,7 +26,7 @@ namespace GraphQL.Validation.Rules
         private static readonly Task<INodeVisitor> _nodeVisitor = new NodeVisitors(
             new MatchingNodeVisitor<VariableDefinition>((varDef, context) =>
             {
-                var varNameDef = context.TypeInfo.NoUndefinedVariables_VariableNameDefined ??= new HashSet<string>();
+                var varNameDef = context.TypeInfo.NoUndefinedVariables_VariableNameDefined ??= new HashSet<ROM>();
                 varNameDef.Add(varDef.Name);
             }),
 

--- a/src/GraphQL/Validation/Rules/PossibleFragmentSpreads.cs
+++ b/src/GraphQL/Validation/Rules/PossibleFragmentSpreads.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Types;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -37,7 +38,7 @@ namespace GraphQL.Validation.Rules
 
             new MatchingNodeVisitor<FragmentSpread>((node, context) =>
             {
-                string fragName = node.Name;
+                var fragName = node.Name;
                 var fragType = getFragmentType(context, fragName);
                 var parentType = context.TypeInfo.GetParentType().GetNamedType();
 
@@ -48,7 +49,7 @@ namespace GraphQL.Validation.Rules
             })
         ).ToTask();
 
-        private static IGraphType getFragmentType(ValidationContext context, string name)
+        private static IGraphType getFragmentType(ValidationContext context, ROM name)
         {
             var frag = context.GetFragment(name);
             return frag?.Type?.GraphTypeFromType(context.Schema);

--- a/src/GraphQL/Validation/Rules/UniqueArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueArgumentNames.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -27,8 +28,8 @@ namespace GraphQL.Validation.Rules
             new MatchingNodeVisitor<Directive>((__, context) => context.TypeInfo.UniqueArgumentNames_KnownArgs?.Clear()),
             new MatchingNodeVisitor<Argument>((argument, context) =>
             {
-                var knownArgs = context.TypeInfo.UniqueArgumentNames_KnownArgs ??= new Dictionary<string, Argument>();
-                string argName = argument.Name;
+                var knownArgs = context.TypeInfo.UniqueArgumentNames_KnownArgs ??= new Dictionary<ROM, Argument>();
+                var argName = argument.Name;
                 if (knownArgs.ContainsKey(argName))
                 {
                     context.ReportError(new UniqueArgumentNamesError(context, knownArgs[argName], argument));

--- a/src/GraphQL/Validation/Rules/UniqueDirectivesPerLocation.cs
+++ b/src/GraphQL/Validation/Rules/UniqueDirectivesPerLocation.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -42,7 +43,7 @@ namespace GraphQL.Validation.Rules
             if (!directives.HasDuplicates)
                 return;
 
-            var knownDirectives = new Dictionary<string, Directive>(directives.Count);
+            var knownDirectives = new Dictionary<ROM, Directive>(directives.Count);
 
             foreach (var directive in directives)
             {

--- a/src/GraphQL/Validation/Rules/UniqueFragmentNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueFragmentNames.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -23,7 +24,7 @@ namespace GraphQL.Validation.Rules
 
         private static readonly Task<INodeVisitor> _nodeVisitor = new MatchingNodeVisitor<FragmentDefinition>((fragmentDefinition, context) =>
             {
-                var knownFragments = context.TypeInfo.UniqueFragmentNames_KnownFragments ??= new Dictionary<string, FragmentDefinition>();
+                var knownFragments = context.TypeInfo.UniqueFragmentNames_KnownFragments ??= new Dictionary<ROM, FragmentDefinition>();
 
                 var fragmentName = fragmentDefinition.Name;
                 if (knownFragments.ContainsKey(fragmentName)) // .NET 2.2+ has TryAdd

--- a/src/GraphQL/Validation/Rules/UniqueInputFieldNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueInputFieldNames.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -26,7 +27,7 @@ namespace GraphQL.Validation.Rules
                 new MatchingNodeVisitor<ObjectValue>(
                     enter: (objVal, context) =>
                     {
-                        var knownNameStack = context.TypeInfo.UniqueInputFieldNames_KnownNameStack ??= new Stack<Dictionary<string, IValue>>();
+                        var knownNameStack = context.TypeInfo.UniqueInputFieldNames_KnownNameStack ??= new Stack<Dictionary<ROM, IValue>>();
 
                         knownNameStack.Push(context.TypeInfo.UniqueInputFieldNames_KnownNames);
                         context.TypeInfo.UniqueInputFieldNames_KnownNames = null;
@@ -36,7 +37,7 @@ namespace GraphQL.Validation.Rules
                 new MatchingNodeVisitor<ObjectField>(
                     leave: (objField, context) =>
                     {
-                        var knownNames = context.TypeInfo.UniqueInputFieldNames_KnownNames ??= new Dictionary<string, IValue>();
+                        var knownNames = context.TypeInfo.UniqueInputFieldNames_KnownNames ??= new Dictionary<ROM, IValue>();
 
                         if (knownNames.ContainsKey(objField.Name))
                         {

--- a/src/GraphQL/Validation/Rules/UniqueOperationNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueOperationNames.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -23,12 +24,12 @@ namespace GraphQL.Validation.Rules
 
         private static readonly Task<INodeVisitor> _nodeVisitor = new MatchingNodeVisitor<Operation>((op, context) =>
         {
-            if (string.IsNullOrWhiteSpace(op.Name))
+            if (op.Name.IsEmpty)
             {
                 return;
             }
 
-            var frequency = context.TypeInfo.UniqueOperationNames_Frequency ??= new HashSet<string>();
+            var frequency = context.TypeInfo.UniqueOperationNames_Frequency ??= new HashSet<ROM>();
 
             if (!frequency.Add(op.Name))
             {

--- a/src/GraphQL/Validation/Rules/UniqueVariableNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueVariableNames.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -25,7 +26,7 @@ namespace GraphQL.Validation.Rules
             new MatchingNodeVisitor<Operation>((__, context) => context.TypeInfo.UniqueVariableNames_KnownVariables?.Clear()),
             new MatchingNodeVisitor<VariableDefinition>((variableDefinition, context) =>
             {
-                var knownVariables = context.TypeInfo.UniqueVariableNames_KnownVariables ??= new Dictionary<string, VariableDefinition>();
+                var knownVariables = context.TypeInfo.UniqueVariableNames_KnownVariables ??= new Dictionary<ROM, VariableDefinition>();
 
                 var variableName = variableDefinition.Name;
 

--- a/src/GraphQL/Validation/Rules/VariablesInAllowedPosition.cs
+++ b/src/GraphQL/Validation/Rules/VariablesInAllowedPosition.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Types;
 using GraphQL.Validation.Errors;
+using GraphQLParser;
 
 namespace GraphQL.Validation.Rules
 {
@@ -24,7 +25,7 @@ namespace GraphQL.Validation.Rules
         private static readonly Task<INodeVisitor> _nodeVisitor = new NodeVisitors(
             new MatchingNodeVisitor<VariableDefinition>(
                 (varDefAst, context) => {
-                    var varDefMap = context.TypeInfo.VariablesInAllowedPosition_VarDefMap ??= new Dictionary<string, VariableDefinition>();
+                    var varDefMap = context.TypeInfo.VariablesInAllowedPosition_VarDefMap ??= new Dictionary<ROM, VariableDefinition>();
                     varDefMap[varDefAst.Name] = varDefAst;
                 }
             ),

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using GraphQL.Language.AST;
 using GraphQL.Types;
+using GraphQLParser;
 
 namespace GraphQL.Validation
 {
@@ -253,7 +254,7 @@ namespace GraphQL.Validation
         /// Tracks already visited fragments to maintain O(N) and to ensure that cycles
         /// are not redundantly reported.
         /// </summary>
-        internal HashSet<string> NoFragmentCycles_VisitedFrags;
+        internal HashSet<ROM> NoFragmentCycles_VisitedFrags;
         /// <summary>
         /// Array of AST nodes used to produce meaningful errors
         /// </summary>
@@ -261,26 +262,26 @@ namespace GraphQL.Validation
         /// <summary>
         /// Position in the spread path
         /// </summary>
-        internal Dictionary<string, int> NoFragmentCycles_SpreadPathIndexByName;
+        internal Dictionary<ROM, int> NoFragmentCycles_SpreadPathIndexByName;
 
-        internal HashSet<string> NoUndefinedVariables_VariableNameDefined;
+        internal HashSet<ROM> NoUndefinedVariables_VariableNameDefined;
 
         internal List<Operation> NoUnusedFragments_OperationDefs;
         internal List<FragmentDefinition> NoUnusedFragments_FragmentDefs;
 
         internal List<VariableDefinition> NoUnusedVariables_VariableDefs;
 
-        internal Dictionary<string, Argument> UniqueArgumentNames_KnownArgs;
+        internal Dictionary<ROM, Argument> UniqueArgumentNames_KnownArgs;
 
-        internal Dictionary<string, FragmentDefinition> UniqueFragmentNames_KnownFragments;
+        internal Dictionary<ROM, FragmentDefinition> UniqueFragmentNames_KnownFragments;
 
-        internal Stack<Dictionary<string, IValue>> UniqueInputFieldNames_KnownNameStack;
-        internal Dictionary<string, IValue> UniqueInputFieldNames_KnownNames;
+        internal Stack<Dictionary<ROM, IValue>> UniqueInputFieldNames_KnownNameStack;
+        internal Dictionary<ROM, IValue> UniqueInputFieldNames_KnownNames;
 
-        internal HashSet<string> UniqueOperationNames_Frequency;
+        internal HashSet<ROM> UniqueOperationNames_Frequency;
 
-        internal Dictionary<string, VariableDefinition> UniqueVariableNames_KnownVariables;
+        internal Dictionary<ROM, VariableDefinition> UniqueVariableNames_KnownVariables;
 
-        internal Dictionary<string, VariableDefinition> VariablesInAllowedPosition_VarDefMap;
+        internal Dictionary<ROM, VariableDefinition> VariablesInAllowedPosition_VarDefMap;
     }
 }

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -4,6 +4,7 @@ using GraphQL.Execution;
 using GraphQL.Language.AST;
 using GraphQL.Types;
 using GraphQL.Utilities;
+using GraphQLParser;
 
 namespace GraphQL.Validation
 {
@@ -105,7 +106,7 @@ namespace GraphQL.Validation
         /// <summary>
         /// Searches the document for a fragment definition by name and returns it.
         /// </summary>
-        public FragmentDefinition GetFragment(string name)
+        public FragmentDefinition GetFragment(ROM name)
         {
             return Document.Fragments.FindDefinition(name);
         }
@@ -156,7 +157,7 @@ namespace GraphQL.Validation
             var fragments = new List<FragmentDefinition>();
             var nodesToVisit = new Stack<SelectionSet>();
             nodesToVisit.Push(operation.SelectionSet);
-            var collectedNames = new Dictionary<string, bool>();
+            var collectedNames = new Dictionary<ROM, bool>();
 
             while (nodesToVisit.Count > 0)
             {
@@ -164,7 +165,7 @@ namespace GraphQL.Validation
 
                 foreach (var spread in GetFragmentSpreads(node))
                 {
-                    string fragName = spread.Name;
+                    var fragName = spread.Name;
                     if (!collectedNames.ContainsKey(fragName))
                     {
                         collectedNames[fragName] = true;


### PR DESCRIPTION
Continuation of #2198 

Draft to change validation and execution code to use ROM.  Initial reports are not looking good.  I have not spent enough time to figure out why.  I'm guessing the memory usage is because every reference to a ROM now takes 16 bytes instead of 8 bytes for a string.  Interestingly, with caching (and hence no validation), it still uses more memory.  It's very possible (or even likely) that I missed something and everything is getting converted to strings anyway.


BEFORE

|        Method | UseCaching |       Mean |     Error |    StdDev |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |----------- |-----------:|----------:|----------:|--------:|--------:|------:|----------:|
| Introspection |      False | 960.426 us | 5.2523 us | 4.9130 us | 78.1250 | 23.4375 |     - | 487.05 KB |
|          Hero |      False |  16.958 us | 0.0787 us | 0.0698 us |  1.4038 |       - |     - |   8.73 KB |
| Introspection |       True | 722.193 us | 5.4136 us | 5.0639 us | 72.2656 | 22.4609 |     - | 447.35 KB |
|          Hero |       True |   3.530 us | 0.0144 us | 0.0135 us |  0.6599 |  0.0038 |     - |   4.05 KB |



AFTER


|        Method | UseCaching |         Mean |     Error |    StdDev |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |----------- |-------------:|----------:|----------:|--------:|--------:|------:|----------:|
| Introspection |      False | 1,033.944 us | 4.2911 us | 4.0139 us | 82.0313 | 25.3906 |     - | 507.89 KB |
|          Hero |      False |    17.279 us | 0.0773 us | 0.0723 us |  1.4343 |       - |     - |   8.79 KB |
| Introspection |       True |   799.612 us | 4.8677 us | 4.5532 us | 76.1719 | 24.4141 |     - | 468.61 KB |
|          Hero |       True |     3.611 us | 0.0090 us | 0.0084 us |  0.6676 |  0.0038 |     - |    4.1 KB |
