### PR TITLE
Add lock for multithreaded initialization

### DIFF
--- a/src/GraphQL.Tests/Execution/MultithreadedTests.cs
+++ b/src/GraphQL.Tests/Execution/MultithreadedTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL.Instrumentation;
+using GraphQL.Tests.Introspection;
+using GraphQL.Tests.StarWars;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Execution
+{
+    public class MultithreadedTests
+    {
+        [Fact]
+        public async Task test()
+        {
+            // create a middleware that increments a variable when every field is resolved
+            var middleware = new FieldMiddlewareBuilder();
+            int count = 0;
+            middleware.Use((schema, d) => context => {
+                Interlocked.Increment(ref count);
+                return d(context);
+            });
+
+            // prep a test execution using that middleware
+            StarWarsTestBase starWarsTest = null;
+            Func<Task> testExecution = async () =>
+            {
+                var result = await starWarsTest.Executer.ExecuteAsync(new ExecutionOptions
+                {
+                    Query = SchemaIntrospection.IntrospectionQuery,
+                    Schema = starWarsTest.Schema,
+                    FieldMiddleware = middleware,
+                });
+                result.Errors.ShouldBeNull();
+            };
+
+            // run a single execution and record the number of times the resolver executed
+            starWarsTest = new StarWarsTestBase();
+            await testExecution();
+            var correctCount = count;
+
+            // test initializing the schema first, followed by 3 simultaneous executions
+            starWarsTest = new StarWarsTestBase();
+            await testExecution();
+            count = 0;
+            var t1 = Task.Run(testExecution);
+            var t2 = Task.Run(testExecution);
+            var t3 = Task.Run(testExecution);
+            await Task.WhenAll(t1, t2, t3);
+            count.ShouldBe(correctCount * 3, "Failed synchronized initialization");
+
+            // test three simultaneous executions on an uninitialized schema
+            count = 0;
+            starWarsTest = new StarWarsTestBase();
+            t1 = Task.Run(testExecution);
+            t2 = Task.Run(testExecution);
+            t3 = Task.Run(testExecution);
+            await Task.WhenAll(t1, t2, t3);
+            count.ShouldBe(correctCount * 3, "Failed multithreaded initialization");
+        }
+    }
+}

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -71,8 +71,14 @@ namespace GraphQL
                 {
                     using (metrics.Subject("schema", "Initializing schema"))
                     {
-                        options.FieldMiddleware.ApplyTo(options.Schema);
-                        options.Schema.Initialize();
+                        lock (options.Schema)
+                        {
+                            if (!options.Schema.Initialized)
+                            {
+                                options.FieldMiddleware.ApplyTo(options.Schema);
+                                options.Schema.Initialize();
+                            }
+                        }
                     }
                 }
 

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -23,6 +23,8 @@ namespace GraphQL.Types
         /// Initializes the schema. Called by <see cref="IDocumentExecuter"/> before validating or executing the request.
         /// <br/><br/>
         /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="ExecutionOptions.FieldMiddleware"/>.
+        /// <br/><br/>
+        /// This method is not safe to be called from multiple threads simultaneously.
         /// </summary>
         void Initialize();
 

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -24,7 +24,8 @@ namespace GraphQL.Types
         /// <br/><br/>
         /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="ExecutionOptions.FieldMiddleware"/>.
         /// <br/><br/>
-        /// This method is not safe to be called from multiple threads simultaneously.
+        /// This method should be safe to be called from multiple threads simultaneously. However, field middleware
+        /// must be applied in a thread-safe manner so that it is not applied to the schema multiple times.
         /// </summary>
         void Initialize();
 


### PR DESCRIPTION
Fixes #2208 

Adds test which proves bug exists and fails prior to this fix.