### PR TITLE
Move FieldMiddleware from ExecutionOptions to Schema

### DIFF
--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -99,7 +99,7 @@ Also, the middleware itself should be registered in DI:
 services.AddSingleton<InstrumentFieldsMiddleware>();
 ```
 
-Alternatively, you can use an enumerable in your constructor to add all DI-registered middleware:
+Alternatively, you can use an enumerable in your constructor to add all DI-registered middlewares:
 
 ```csharp
 public MySchema : Schema

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -99,6 +99,30 @@ Also, the middleware itself should be registered in DI:
 services.AddSingleton<InstrumentFieldsMiddleware>();
 ```
 
+Alternatively, you can use an enumerable in your constructor to add all DI-registered middleware:
+
+```csharp
+public MySchema : Schema
+{
+  public MySchema(
+    IServiceProvider services,
+    MyQuery query,
+    IEnumerable<IFieldMiddleware> middlewares)
+    : base(services)
+  {
+    Query = query;
+    foreach (var middleware in middlewares)
+      FieldMiddleware.Use(middleware);
+  }
+}
+
+// within Startup.cs
+services.AddSingleton<ISchema, MySchema>();
+services.AddSingleton<IFieldMiddleware, InstrumentFieldsMiddleware>();
+services.AddSingleton<IFieldMiddleware, MyMiddleware>();
+...
+```
+
 ## Known issues
 
 Perhaps the most important thing with Field Middlewares that you should be aware of is that the

--- a/docs2/site/docs/getting-started/field-middleware.md
+++ b/docs2/site/docs/getting-started/field-middleware.md
@@ -31,20 +31,18 @@ public class InstrumentFieldsMiddleware : IFieldMiddleware
 }
 ```
 
-Then register your Field Middleware in `ExecutionOptions`.
+Then register your Field Middleware on the schema.
 
 ```csharp
-await schema.ExecuteAsync(options =>
-{
-  options.Query = "...";
-  options.FieldMiddleware.Use<InstrumentFieldsMiddleware>();
-});
+var schema = new Schema();
+schema.Query = new MyQuery();
+schema.FieldMiddleware.Use(new InstrumentFieldsMiddleware());
 ```
 
 Or, you can register a middleware delegate directly:
 
 ```csharp
-_.FieldMiddleware.Use((schema, next) =>
+schema.FieldMiddleware.Use(next =>
 {
   return context =>
   {
@@ -75,11 +73,25 @@ public delegate Task<object> FieldMiddlewareDelegate(IResolveFieldContext contex
 
 First, you are advised to read the article about [Dependency Injection](Dependency-Injection).
 
-If you use `IFieldMiddlewareBuilder.Use` overloads which accept type parameter (that is,
-those that do not accept a `IFieldMiddleware` instance or a middleware delegate) then your
-middleware creation will be delegated to DI-container. Thus, you can pass any dependencies to
+Typically you will want to set the middleware within the schema constructor.
+
+```csharp
+public MySchema : Schema
+{
+  public MySchema(
+    IServiceProvider services,
+    MyQuery query,
+    InstrumentFieldsMiddleware middleware)
+    : base(services)
+  {
+    Query = query;
+    FieldMiddleware.Use(middleware);
+  }
+}
+```
+
+Then your middleware creation will be delegated to DI-container. Thus, you can pass any dependencies to
 the Field Middleware constructor, provided that you have registered them correctly in DI.
-Note that it is required to have a schema that inherits from `Schema` or implements `IServiceProvider`.
 
 Also, the middleware itself should be registered in DI:
 

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -15,6 +15,9 @@
   These properties can be set in the constructor of the `Schema` instance, or within your DI registration delegate, or at any time before
   any query is executed. Once a query has been executed, changes to these fields is not allowed, and adding middleware via the field middleware
   builder has no effect.
+* The signature of `IFieldMiddlewareBuilder.Use` has been changed to remove the schema from delegate. Since the schema is now known, there is no
+  need for it to be passed to the middleware builder.
+* The middleware `Use<T>` extension method has been removed. Please use the `Use` method with a middleware instance instead.
 * `GraphQL.Utilities.ServiceProviderExtensions` has been made internal. This affects usages of its extension method `GetRequiredService`. Instead, reference the `Microsoft.Extensions.DependencyInjection.Abstractions` NuGet package and use extension method from `Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions` class.
 * `GraphQL.Instrumentation.StatsReport` and its associated classes have been removed. Please copy the source code into your project if you require these classes.
 * When used, Apollo tracing will now convert the starting timestamp to UTC so that `StartTime` and `EndTime` are properly serialized as UTC values.

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -11,7 +11,10 @@
 
 ## Breaking Changes
 
-* `NameConverter` and `SchemaFilter` have been removed from `ExecutionOptions` and are now properties on the `Schema`.
+* `NameConverter`, `SchemaFilter` and `FieldMiddleware` have been removed from `ExecutionOptions` and are now properties on the `Schema`.
+  These properties can be set in the constructor of the `Schema` instance, or within your DI registration delegate, or at any time before
+  any query is executed. Once a query has been executed, changes to these fields is not allowed, and adding middleware via the field middleware
+  builder has no effect.
 * `GraphQL.Utilities.ServiceProviderExtensions` has been made internal. This affects usages of its extension method `GetRequiredService`. Instead, reference the `Microsoft.Extensions.DependencyInjection.Abstractions` NuGet package and use extension method from `Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions` class.
 * `GraphQL.Instrumentation.StatsReport` and its associated classes have been removed. Please copy the source code into your project if you require these classes.
 * When used, Apollo tracing will now convert the starting timestamp to UTC so that `StartTime` and `EndTime` are properly serialized as UTC values.

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -12,7 +12,7 @@
 ## Breaking Changes
 
 * `NameConverter`, `SchemaFilter` and `FieldMiddleware` have been removed from `ExecutionOptions` and are now properties on the `Schema`.
-  These properties can be set in the constructor of the `Schema` instance, or within your DI registration delegate, or at any time before
+  These properties can be set in the constructor of the `Schema` instance, or within your DI composition root, or at any time before
   any query is executed. Once a query has been executed, changes to these fields is not allowed, and adding middleware via the field middleware
   builder has no effect.
 * The signature of `IFieldMiddlewareBuilder.Use` has been changed to remove the schema from delegate. Since the schema is now known, there is no

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -913,7 +913,7 @@ namespace GraphQL.Instrumentation
     public class FieldMiddlewareBuilder : GraphQL.Instrumentation.IFieldMiddlewareBuilder
     {
         public FieldMiddlewareBuilder() { }
-        public void ApplyTo(GraphQL.Types.ISchema schema) { }
+        public System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> Build() { }
         public GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
     }
     public static class FieldMiddlewareBuilderExtensions
@@ -931,7 +931,7 @@ namespace GraphQL.Instrumentation
     }
     public interface IFieldMiddlewareBuilder
     {
-        void ApplyTo(GraphQL.Types.ISchema schema);
+        System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> Build();
         GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware);
     }
     public class InstrumentFieldsMiddleware : GraphQL.Instrumentation.IFieldMiddleware
@@ -2135,6 +2135,8 @@ namespace GraphQL.Types
     public class SchemaTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
     {
         public int Count { get; }
+        public void ApplyMiddleware(GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder, GraphQL.Types.ISchema schema) { }
+        public void ApplyMiddleware(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform, GraphQL.Types.ISchema schema) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Types.IGraphType> GetEnumerator() { }
         public static GraphQL.Types.SchemaTypes Create(System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> types, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> directives, System.Func<System.Type, GraphQL.Types.IGraphType> resolveType, GraphQL.Conversion.INameConverter nameConverter) { }
     }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2093,7 +2093,7 @@ namespace GraphQL.Types
         public GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
         public string Description { get; set; }
         public GraphQL.Types.SchemaDirectives Directives { get; }
-        public GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; set; }
+        public GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; }
         public GraphQL.Introspection.ISchemaFilter Filter { get; set; }
         public bool Initialized { get; }
         public GraphQL.Types.IObjectGraphType Mutation { get; set; }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -913,16 +913,12 @@ namespace GraphQL.Instrumentation
     public class FieldMiddlewareBuilder : GraphQL.Instrumentation.IFieldMiddlewareBuilder
     {
         public FieldMiddlewareBuilder() { }
-        public System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> Build() { }
-        public GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
+        public System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> Build() { }
+        public GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
     }
     public static class FieldMiddlewareBuilderExtensions
     {
         public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, GraphQL.Instrumentation.IFieldMiddleware middleware) { }
-        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware) { }
-        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder, System.Type middleware) { }
-        public static GraphQL.Instrumentation.IFieldMiddlewareBuilder Use<T>(this GraphQL.Instrumentation.IFieldMiddlewareBuilder builder)
-            where T : GraphQL.Instrumentation.IFieldMiddleware { }
     }
     public delegate System.Threading.Tasks.Task<object> FieldMiddlewareDelegate(GraphQL.IResolveFieldContext context);
     public interface IFieldMiddleware
@@ -931,8 +927,8 @@ namespace GraphQL.Instrumentation
     }
     public interface IFieldMiddlewareBuilder
     {
-        System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> Build();
-        GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware);
+        System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> Build();
+        GraphQL.Instrumentation.IFieldMiddlewareBuilder Use(System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> middleware);
     }
     public class InstrumentFieldsMiddleware : GraphQL.Instrumentation.IFieldMiddleware
     {
@@ -2135,8 +2131,8 @@ namespace GraphQL.Types
     public class SchemaTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
     {
         public int Count { get; }
-        public void ApplyMiddleware(GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder, GraphQL.Types.ISchema schema) { }
-        public void ApplyMiddleware(System.Func<GraphQL.Types.ISchema, GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform, GraphQL.Types.ISchema schema) { }
+        public void ApplyMiddleware(GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
+        public void ApplyMiddleware(System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Types.IGraphType> GetEnumerator() { }
         public static GraphQL.Types.SchemaTypes Create(System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> types, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> directives, System.Func<System.Type, GraphQL.Types.IGraphType> resolveType, GraphQL.Conversion.INameConverter nameConverter) { }
     }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -88,7 +88,6 @@ namespace GraphQL
         public GraphQL.Validation.Complexity.ComplexityConfiguration ComplexityConfiguration { get; set; }
         public GraphQL.Language.AST.Document Document { get; set; }
         public bool EnableMetrics { get; set; }
-        public GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; set; }
         public GraphQL.Inputs Inputs { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
         public int? MaxParallelExecutionCount { get; set; }
@@ -1925,6 +1924,7 @@ namespace GraphQL.Types
         GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
         string Description { get; set; }
         GraphQL.Types.SchemaDirectives Directives { get; }
+        GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; }
         GraphQL.Introspection.ISchemaFilter Filter { get; }
         bool Initialized { get; }
         GraphQL.Types.IObjectGraphType Mutation { get; set; }
@@ -2097,6 +2097,7 @@ namespace GraphQL.Types
         public GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
         public string Description { get; set; }
         public GraphQL.Types.SchemaDirectives Directives { get; }
+        public GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; set; }
         public GraphQL.Introspection.ISchemaFilter Filter { get; set; }
         public bool Initialized { get; }
         public GraphQL.Types.IObjectGraphType Mutation { get; set; }

--- a/src/GraphQL.Benchmarks/Properties/launchSettings.json
+++ b/src/GraphQL.Benchmarks/Properties/launchSettings.json
@@ -3,6 +3,9 @@
     "Profiler": {
       "commandName": "Project",
       "commandLineArgs": "test"
+    },
+    "Benchmarks": {
+      "commandName": "Project"
     }
   }
 }

--- a/src/GraphQL.Harness/GraphQLMiddleware.cs
+++ b/src/GraphQL.Harness/GraphQLMiddleware.cs
@@ -65,12 +65,6 @@ namespace Example
                 options.UserContext = _settings.BuildUserContext?.Invoke(context);
                 options.EnableMetrics = _settings.EnableMetrics;
                 options.RequestServices = context.RequestServices;
-                if (_settings.EnableMetrics)
-                {
-                    options.FieldMiddleware
-                        .Use<CountFieldMiddleware>()
-                        .Use<InstrumentFieldsMiddleware>();
-                }
             });
 
             if (_settings.EnableMetrics)

--- a/src/GraphQL.Harness/Startup.cs
+++ b/src/GraphQL.Harness/Startup.cs
@@ -56,8 +56,8 @@ namespace GraphQL.Harness
                 if (settings.Value.EnableMetrics)
                 {
                     schema.FieldMiddleware
-                        .Use<CountFieldMiddleware>()
-                        .Use<InstrumentFieldsMiddleware>();
+                        .Use(services.GetRequiredService<CountFieldMiddleware>())
+                        .Use(services.GetRequiredService<InstrumentFieldsMiddleware>());
                 }
                 return schema;
             });

--- a/src/GraphQL.Harness/Startup.cs
+++ b/src/GraphQL.Harness/Startup.cs
@@ -49,7 +49,18 @@ namespace GraphQL.Harness
             services.AddSingleton<EpisodeEnum>();
 
             // add schema
-            services.AddSingleton<ISchema, StarWarsSchema>();
+            services.AddSingleton<ISchema, StarWarsSchema>(services =>
+            {
+                var settings = services.GetRequiredService<IOptions<GraphQLSettings>>();
+                var schema = new StarWarsSchema(services);
+                if (settings.Value.EnableMetrics)
+                {
+                    schema.FieldMiddleware
+                        .Use<CountFieldMiddleware>()
+                        .Use<InstrumentFieldsMiddleware>();
+                }
+                return schema;
+            });
 
             // add infrastructure stuff
             services.AddHttpContextAccessor();

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -49,15 +49,6 @@ namespace GraphQL.Tests.Bugs
                     Schema = null,
                 });
             });
-            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            {
-                await de.ExecuteAsync(new ExecutionOptions()
-                {
-                    Query = "{test}",
-                    Schema = Schema,
-                    FieldMiddleware = null,
-                });
-            });
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
+++ b/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
@@ -31,9 +31,10 @@ namespace GraphQL.Tests.Bugs
         public void apply_to_not_called_without_execute()
         {
             var docExec = new DocumentExecuter();
-            var execOptions = new ExecutionOptions { Schema = new Schema() };
+            var schema = new Schema();
+            var execOptions = new ExecutionOptions { Schema = schema };
             var mockMiddleware = new ApplyCounterMiddlewareBuilder();
-            execOptions.FieldMiddleware = mockMiddleware;
+            schema.FieldMiddleware = mockMiddleware;
 
             // no execute in this test
             //docExec.ExecuteAsync(execOptions).Wait();
@@ -44,13 +45,14 @@ namespace GraphQL.Tests.Bugs
         public void apply_to_called_once()
         {
             var docExec = new DocumentExecuter();
+            var schema = new Schema();
             var execOptions = new ExecutionOptions
             {
-                Schema = new Schema(),
+                Schema = schema,
                 Query = "{ abcd }"
             };
             var mockMiddleware = new ApplyCounterMiddlewareBuilder();
-            execOptions.FieldMiddleware = mockMiddleware;
+            schema.FieldMiddleware = mockMiddleware;
 
             docExec.ExecuteAsync(execOptions).Wait();
 
@@ -61,13 +63,14 @@ namespace GraphQL.Tests.Bugs
         public void apply_to_called_once_with_multiple_execute()
         {
             var docExec = new DocumentExecuter();
+            var schema = new Schema();
             var execOptions = new ExecutionOptions
             {
-                Schema = new Schema(),
+                Schema = schema,
                 Query = "{ abcd }"
             };
             var mockMiddleware = new ApplyCounterMiddlewareBuilder();
-            execOptions.FieldMiddleware = mockMiddleware;
+            schema.FieldMiddleware = mockMiddleware;
 
             docExec.ExecuteAsync(execOptions).Wait();
             docExec.ExecuteAsync(execOptions).Wait();

--- a/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
+++ b/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
@@ -15,13 +15,13 @@ namespace GraphQL.Tests.Bugs
         public int AppliedCount;
         private readonly FieldMiddlewareBuilder overriddenBuilder = new FieldMiddlewareBuilder();
 
-        public Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build()
+        public Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build()
         {
             AppliedCount++;
             return overriddenBuilder.Build();
         }
 
-        public IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
+        public IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
             => overriddenBuilder.Use(middleware);
     }
 

--- a/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
+++ b/src/GraphQL.Tests/Bugs/Bug252ExecutorAppliesFIeldBuilderOnce.cs
@@ -15,10 +15,10 @@ namespace GraphQL.Tests.Bugs
         public int AppliedCount;
         private readonly FieldMiddlewareBuilder overriddenBuilder = new FieldMiddlewareBuilder();
 
-        public void ApplyTo(ISchema schema)
+        public Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build()
         {
             AppliedCount++;
-            overriddenBuilder.ApplyTo(schema);
+            return overriddenBuilder.Build();
         }
 
         public IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)

--- a/src/GraphQL.Tests/Execution/MultithreadedTests.cs
+++ b/src/GraphQL.Tests/Execution/MultithreadedTests.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Tests.Execution
             // create a middleware that increments a variable when every field is resolved
             var middleware = new FieldMiddlewareBuilder();
             int count = 0;
-            middleware.Use((d) => context => {
+            middleware.Use(d => context => {
                 Interlocked.Increment(ref count);
                 return d(context);
             });

--- a/src/GraphQL.Tests/Execution/MultithreadedTests.cs
+++ b/src/GraphQL.Tests/Execution/MultithreadedTests.cs
@@ -30,18 +30,19 @@ namespace GraphQL.Tests.Execution
                 {
                     Query = SchemaIntrospection.IntrospectionQuery,
                     Schema = starWarsTest.Schema,
-                    FieldMiddleware = middleware,
                 });
                 result.Errors.ShouldBeNull();
             };
 
             // run a single execution and record the number of times the resolver executed
             starWarsTest = new StarWarsTestBase();
+            starWarsTest.Schema.FieldMiddleware = middleware;
             await testExecution();
             var correctCount = count;
 
             // test initializing the schema first, followed by 3 simultaneous executions
             starWarsTest = new StarWarsTestBase();
+            starWarsTest.Schema.FieldMiddleware = middleware;
             await testExecution();
             count = 0;
             var t1 = Task.Run(testExecution);
@@ -53,6 +54,7 @@ namespace GraphQL.Tests.Execution
             // test three simultaneous executions on an uninitialized schema
             count = 0;
             starWarsTest = new StarWarsTestBase();
+            starWarsTest.Schema.FieldMiddleware = middleware;
             t1 = Task.Run(testExecution);
             t2 = Task.Run(testExecution);
             t3 = Task.Run(testExecution);

--- a/src/GraphQL.Tests/Execution/MultithreadedTests.cs
+++ b/src/GraphQL.Tests/Execution/MultithreadedTests.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Tests.Execution
             // create a middleware that increments a variable when every field is resolved
             var middleware = new FieldMiddlewareBuilder();
             int count = 0;
-            middleware.Use((schema, d) => context => {
+            middleware.Use((d) => context => {
                 Interlocked.Increment(ref count);
                 return d(context);
             });

--- a/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
@@ -25,7 +25,7 @@ query {
 }";
 
             var start = DateTime.UtcNow;
-            Schema.FieldMiddleware.Use<InstrumentFieldsMiddleware>();
+            Schema.FieldMiddleware.Use(new InstrumentFieldsMiddleware());
             var result = Executer.ExecuteAsync(_ =>
             {
                 _.Schema = Schema;

--- a/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
@@ -25,12 +25,12 @@ query {
 }";
 
             var start = DateTime.UtcNow;
+            Schema.FieldMiddleware.Use<InstrumentFieldsMiddleware>();
             var result = Executer.ExecuteAsync(_ =>
             {
                 _.Schema = Schema;
                 _.Query = query;
                 _.EnableMetrics = true;
-                _.FieldMiddleware.Use<InstrumentFieldsMiddleware>();
             }).Result;
             result.EnrichWithApolloTracing(start);
             var trace = (ApolloTrace)result.Extensions["tracing"];

--- a/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/FieldMiddlewareBuilderTests.cs
@@ -198,11 +198,5 @@ namespace GraphQL.Tests.Instrumentation
             var transform = builder.Build();
             return transform != null ? transform(null) : null;
         }
-
-        public static FieldMiddlewareDelegate BuildResolve(this FieldMiddlewareBuilder builder, FieldMiddlewareDelegate start)
-        {
-            var transform = builder.Build();
-            return transform(start);
-        }
     }
 }

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
+using GraphQL.StarWars.Types;
 using GraphQL.Types;
+using GraphQL.Utilities.Federation;
 using Shouldly;
 using Xunit;
 
@@ -175,6 +177,21 @@ namespace GraphQL.Tests.Types
                 };
             });
             schema.Initialize();
+        }
+
+        [Fact]
+        public void disposed_schema_throws_errors()
+        {
+            var schema = new Schema();
+            schema.Dispose();
+            Should.Throw<ObjectDisposedException>(() => schema.Initialize());
+            Should.Throw<ObjectDisposedException>(() => schema.RegisterType(new ObjectGraphType { Name = "test" }));
+            Should.Throw<ObjectDisposedException>(() => schema.RegisterTypes(new IGraphType[] { }));
+            Should.Throw<ObjectDisposedException>(() => schema.RegisterTypes(typeof(DroidType)));
+            Should.Throw<ObjectDisposedException>(() => schema.RegisterType<DroidType>());
+            Should.Throw<ObjectDisposedException>(() => schema.RegisterDirective(new DirectiveGraphType("test", new DirectiveLocation[] { DirectiveLocation.Field })));
+            Should.Throw<ObjectDisposedException>(() => schema.RegisterDirectives(new DirectiveGraphType[] { }));
+            Should.Throw<ObjectDisposedException>(() => schema.RegisterValueConverter(new AnyValueConverter()));
         }
     }
 

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -165,7 +165,7 @@ namespace GraphQL.Tests.Types
         public void middleware_can_reference_SchemaTypes()
         {
             var schema = new Schema() { Query = new SomeQuery() };
-            schema.FieldMiddleware.Use((schema, next) =>
+            schema.FieldMiddleware.Use((next) =>
             {
                 schema.AllTypes.Count.ShouldNotBe(0);
                 return async context =>

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -164,8 +164,8 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void middleware_can_reference_SchemaTypes()
         {
-            var schema = new Schema() { Query = new SomeQuery() };
-            schema.FieldMiddleware.Use((next) =>
+            var schema = new Schema { Query = new SomeQuery() };
+            schema.FieldMiddleware.Use(next =>
             {
                 schema.AllTypes.Count.ShouldNotBe(0);
                 return async context =>

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -193,6 +193,19 @@ namespace GraphQL.Tests.Types
             Should.Throw<ObjectDisposedException>(() => schema.RegisterDirectives(new DirectiveGraphType[] { }));
             Should.Throw<ObjectDisposedException>(() => schema.RegisterValueConverter(new AnyValueConverter()));
         }
+
+        [Fact]
+        public void initialized_schema_throws_errors()
+        {
+            var schema = new Schema();
+            schema.Initialize();
+            Should.Throw<InvalidOperationException>(() => schema.RegisterType(new ObjectGraphType { Name = "test" }));
+            Should.Throw<InvalidOperationException>(() => schema.RegisterTypes(new IGraphType[] { }));
+            Should.Throw<InvalidOperationException>(() => schema.RegisterTypes(typeof(DroidType)));
+            Should.Throw<InvalidOperationException>(() => schema.RegisterType<DroidType>());
+            Should.Throw<InvalidOperationException>(() => schema.RegisterDirective(new DirectiveGraphType("test", new DirectiveLocation[] { DirectiveLocation.Field })));
+            Should.Throw<InvalidOperationException>(() => schema.RegisterDirectives(new DirectiveGraphType[] { }));
+        }
     }
 
     public class MyDto

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -184,6 +184,7 @@ namespace GraphQL.Tests.Types
         {
             var schema = new Schema();
             schema.Dispose();
+            schema.Dispose();
             Should.Throw<ObjectDisposedException>(() => schema.Initialize());
             Should.Throw<ObjectDisposedException>(() => schema.RegisterType(new ObjectGraphType { Name = "test" }));
             Should.Throw<ObjectDisposedException>(() => schema.RegisterTypes(new IGraphType[] { }));

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -160,6 +160,22 @@ namespace GraphQL.Tests.Types
                 type.ShouldBe(null, $"Found {typeName} in type lookup.");
             });
         }
+
+        [Fact]
+        public void middleware_can_reference_SchemaTypes()
+        {
+            var schema = new Schema() { Query = new SomeQuery() };
+            schema.FieldMiddleware.Use((schema, next) =>
+            {
+                schema.AllTypes.Count.ShouldNotBe(0);
+                return async context =>
+                {
+                    var res = await next(context);
+                    return "One " + res.ToString();
+                };
+            });
+            schema.Initialize();
+        }
     }
 
     public class MyDto

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -68,8 +68,6 @@ namespace GraphQL
                 throw new InvalidOperationException("Cannot execute request if no schema is specified");
             if (options.Query == null)
                 throw new InvalidOperationException("Cannot execute request if no query is specified");
-            if (options.FieldMiddleware == null)
-                throw new InvalidOperationException("Cannot execute request if no middleware builder specified");
 
             var metrics = new Metrics(options.EnableMetrics).Start(options.OperationName);
 
@@ -82,14 +80,7 @@ namespace GraphQL
                 {
                     using (metrics.Subject("schema", "Initializing schema"))
                     {
-                        lock (options.Schema)
-                        {
-                            if (!options.Schema.Initialized)
-                            {
-                                options.FieldMiddleware.ApplyTo(options.Schema);
-                                options.Schema.Initialize();
-                            }
-                        }
+                        options.Schema.Initialize();
                     }
                 }
 

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -47,13 +47,6 @@ namespace GraphQL
         /// <inheritdoc/>
         public IDictionary<string, object> UserContext { get; set; } = new Dictionary<string, object>();
 
-        /// <summary>
-        /// Note that field middlewares apply only to an uninitialized schema. If the schema is initialized
-        /// then applying different middleware through options does nothing. The schema is initialized (if not yet)
-        /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)">ExecuteAsync</see>.
-        /// </summary>
-        public IFieldMiddlewareBuilder FieldMiddleware { get; set; } = new FieldMiddlewareBuilder();
-
         /// <summary>Complexity constraints for <see cref="IComplexityAnalyzer"/> to use to validate maximum query complexity</summary>
         public ComplexityConfiguration ComplexityConfiguration { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using GraphQL.Execution;
-using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using GraphQL.Types;
 using GraphQL.Validation;

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -24,13 +24,13 @@ namespace GraphQL.Instrumentation
             else
             {
                 var firstMiddleware = _middleware;
-                _middleware = (next) => firstMiddleware(middleware(next));
+                _middleware = next => firstMiddleware(middleware(next));
             }
 
             return this;
         }
 
-        private readonly FieldMiddlewareDelegate _defaultDelegate = context => Task.FromResult(NameFieldResolver.Instance.Resolve(context));
+        private static readonly FieldMiddlewareDelegate _defaultDelegate = context => Task.FromResult(NameFieldResolver.Instance.Resolve(context));
 
         /// <inheritdoc/>
         public Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build()
@@ -38,7 +38,7 @@ namespace GraphQL.Instrumentation
             if (_middleware == null)
                 return null;
 
-            return (start) => _middleware(start ?? _defaultDelegate);
+            return start => _middleware(start ?? _defaultDelegate);
         }
     }
 }

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Resolvers;
-using GraphQL.Types;
 
 namespace GraphQL.Instrumentation
 {
@@ -12,63 +9,39 @@ namespace GraphQL.Instrumentation
     /// </summary>
     public class FieldMiddlewareBuilder : IFieldMiddlewareBuilder
     {
-        private Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> _singleMiddleware;
-        private IList<Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate>> _middlewares;
+        private Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> _middleware;
 
         /// <inheritdoc/>
-        public IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
+        public IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
         {
-            middleware = middleware ?? throw new ArgumentNullException(nameof(middleware));
+            if (middleware == null)
+                throw new ArgumentNullException(nameof(middleware));
 
-            if (_singleMiddleware == null)
+            if (_middleware == null)
             {
-                // allocation free optimization for single middleware (InstrumentFieldsMiddleware)
-                _singleMiddleware = middleware;
-            }
-            else if (_middlewares == null)
-            {
-                _middlewares = new List<Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate>>
-                {
-                    _singleMiddleware,
-                    middleware
-                };
+                _middleware = middleware;
             }
             else
             {
-                _middlewares.Add(middleware);
+                var firstMiddleware = _middleware;
+                _middleware = (d) => firstMiddleware(middleware(d));
             }
 
             return this;
         }
 
-        private FieldMiddlewareDelegate Build(FieldMiddlewareDelegate start, ISchema schema)
-        {
-            var middlewareDelegate = start ?? (context => Task.FromResult(NameFieldResolver.Instance.Resolve(context)));
-
-            if (_middlewares != null)
-            {
-                foreach (var middleware in _middlewares.Reverse())
-                {
-                    middlewareDelegate = middleware(schema, middlewareDelegate);
-                }
-            }
-            else if (_singleMiddleware != null)
-            {
-                middlewareDelegate = _singleMiddleware(schema, middlewareDelegate);
-            }
-
-            return middlewareDelegate;
-        }
-
         /// <inheritdoc/>
-        public Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build()
+        public Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build()
         {
-            if (Empty)
+            if (_middleware == null)
                 return null;
 
-            return (schema, start) => Build(start, schema);
-        }
+            return (start) =>
+            {
+                start ??= (context => Task.FromResult(NameFieldResolver.Instance.Resolve(context)));
 
-        private bool Empty => _singleMiddleware == null;
+                return _middleware(start);
+            };
+        }
     }
 }

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -24,11 +24,13 @@ namespace GraphQL.Instrumentation
             else
             {
                 var firstMiddleware = _middleware;
-                _middleware = (d) => firstMiddleware(middleware(d));
+                _middleware = (next) => firstMiddleware(middleware(next));
             }
 
             return this;
         }
+
+        private readonly FieldMiddlewareDelegate _defaultDelegate = context => Task.FromResult(NameFieldResolver.Instance.Resolve(context));
 
         /// <inheritdoc/>
         public Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build()
@@ -36,12 +38,7 @@ namespace GraphQL.Instrumentation
             if (_middleware == null)
                 return null;
 
-            return (start) =>
-            {
-                start ??= (context => Task.FromResult(NameFieldResolver.Instance.Resolve(context)));
-
-                return _middleware(start);
-            };
+            return (start) => _middleware(start ?? _defaultDelegate);
         }
     }
 }

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using GraphQL.Types;
-using GraphQL.Utilities;
 
 namespace GraphQL.Instrumentation
 {

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using GraphQL.Types;
+using GraphQL.Utilities;
 
 namespace GraphQL.Instrumentation
 {
@@ -10,7 +11,7 @@ namespace GraphQL.Instrumentation
     public static class FieldMiddlewareBuilderExtensions
     {
         /// <summary>
-        /// Adds middleware to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
+        /// Adds middleware to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
         /// </summary>
         /// <param name="builder">Interface for connecting middlewares to a schema.</param>
         /// <param name="middleware">Middleware instance.</param>

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -5,68 +5,17 @@ namespace GraphQL.Instrumentation
 {
     /// <summary>
     /// Extension methods for <see cref="IFieldMiddlewareBuilder"/> to add middlewares.
-    /// These methods are built on top of <see cref="IFieldMiddlewareBuilder.Use(Func{ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate})"/>.
+    /// These methods are built on top of <see cref="IFieldMiddlewareBuilder.Use(Func{FieldMiddlewareDelegate, FieldMiddlewareDelegate})"/>.
     /// </summary>
     public static class FieldMiddlewareBuilderExtensions
     {
         /// <summary>
-        /// Adds middleware to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
+        /// Adds middleware to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
         /// </summary>
         /// <param name="builder">Interface for connecting middlewares to a schema.</param>
         /// <param name="middleware">Middleware instance.</param>
         /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
         public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, IFieldMiddleware middleware)
             => builder.Use(next => context => middleware.Resolve(context, next));
-
-        /// <summary>
-        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
-        /// <br/><br/>
-        /// This is a compatibility shim when compiling delegates without schema specified.
-        /// </summary>
-        /// <param name="builder">Interface for connecting middlewares to a schema.</param>
-        /// <param name="middleware">Middleware delegate.</param>
-        /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
-        public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
-            => builder.Use((_, next) => middleware(next));
-
-        /// <summary>
-        /// Adds middleware specified by its type to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
-        /// <br/><br/>
-        /// Middleware will be created using the DI container obtained from the <see cref="Schema"/>.
-        /// </summary>
-        /// <typeparam name="T">Middleware type.</typeparam>
-        /// <param name="builder">Interface for connecting middlewares to a schema.</param>
-        /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
-        public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) where T : IFieldMiddleware => Use(builder, typeof(T));
-
-        /// <summary>
-        /// Adds middleware specified by its type to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
-        /// <br/><br/>
-        /// Middleware will be created using the DI container obtained from the <see cref="Schema"/>.
-        /// </summary>
-        /// <param name="builder">Interface for connecting middlewares to a schema.</param>
-        /// <param name="middleware">Middleware type.</param>
-        /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
-        public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, System.Type middleware)
-        {
-            if (!typeof(IFieldMiddleware).IsAssignableFrom(middleware))
-                throw new ArgumentException($"Field middleware of type '{middleware.FullName}' must implement the {nameof(IFieldMiddleware)} interface", nameof(middleware));
-
-            return builder.Use((schema, next) =>
-            {
-                if (schema == null)
-                    throw new InvalidOperationException("Schema is null. Schema required for resolving middlewares from DI container.");
-
-                // Not an ideal solution, but at least it allows to work with custom schemas which are not inherited from Schema type
-                if (!(schema is IServiceProvider provider))
-                    throw new NotSupportedException($"'{schema.GetType().FullName}' should implement 'IServiceProvider' interface for resolving middlewares.");
-
-                var instance = (IFieldMiddleware)provider.GetService(middleware);
-                if (instance == null)
-                    throw new InvalidOperationException($"Field middleware of type '{middleware.FullName}' must be registered in the DI container.");
-
-                return context => instance.Resolve(context, next);
-            });
-        }
     }
 }

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Instrumentation
     public static class FieldMiddlewareBuilderExtensions
     {
         /// <summary>
-        /// Adds middleware to the list of delegates that will be applied to the schema when invoking <see cref="IFieldMiddlewareBuilder.ApplyTo(ISchema)"/>.
+        /// Adds middleware to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
         /// </summary>
         /// <param name="builder">Interface for connecting middlewares to a schema.</param>
         /// <param name="middleware">Middleware instance.</param>
@@ -19,7 +19,7 @@ namespace GraphQL.Instrumentation
             => builder.Use(next => context => middleware.Resolve(context, next));
 
         /// <summary>
-        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="IFieldMiddlewareBuilder.ApplyTo(ISchema)"/>.
+        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
         /// <br/><br/>
         /// This is a compatibility shim when compiling delegates without schema specified.
         /// </summary>
@@ -30,7 +30,7 @@ namespace GraphQL.Instrumentation
             => builder.Use((_, next) => middleware(next));
 
         /// <summary>
-        /// Adds middleware specified by its type to the list of delegates that will be applied to the schema when invoking <see cref="IFieldMiddlewareBuilder.ApplyTo(ISchema)"/>.
+        /// Adds middleware specified by its type to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
         /// <br/><br/>
         /// Middleware will be created using the DI container obtained from the <see cref="Schema"/>.
         /// </summary>
@@ -40,7 +40,7 @@ namespace GraphQL.Instrumentation
         public static IFieldMiddlewareBuilder Use<T>(this IFieldMiddlewareBuilder builder) where T : IFieldMiddleware => Use(builder, typeof(T));
 
         /// <summary>
-        /// Adds middleware specified by its type to the list of delegates that will be applied to the schema when invoking <see cref="IFieldMiddlewareBuilder.ApplyTo(ISchema)"/>.
+        /// Adds middleware specified by its type to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
         /// <br/><br/>
         /// Middleware will be created using the DI container obtained from the <see cref="Schema"/>.
         /// </summary>

--- a/src/GraphQL/Instrumentation/IFieldMiddleware.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddleware.cs
@@ -3,9 +3,7 @@ using System.Threading.Tasks;
 namespace GraphQL.Instrumentation
 {
     /// <summary>
-    /// Interface for field middleware. It doesn’t have to be implemented on your middleware.
-    /// Then a search will be made for such a method with a suitable signature. Nevertheless,
-    /// to improve performance, it is recommended to implement this interface.
+    /// Interface for field middleware.
     /// </summary>
     public interface IFieldMiddleware
     {

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -19,7 +19,7 @@ namespace GraphQL.Instrumentation
 
         /// <summary>
         /// Returns a transform for field resolvers, or <see langword="null"/> if no middleware is defined.
-        /// The transform is a cumulation of all middleware configured within this builder.
+        /// The transform is a cumulation of all middlewares configured within this builder.
         /// </summary>
         Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build();
     }

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Instrumentation
     public interface IFieldMiddlewareBuilder
     {
         /// <summary>
-        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="ApplyTo(ISchema)"/>.
+        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
         /// <br/><br/>
         /// The delegate is used to unify the different ways of specifying middleware. See additional methods in <see cref="FieldMiddlewareBuilderExtensions"/>.
         /// </summary>

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -9,18 +9,18 @@ namespace GraphQL.Instrumentation
     public interface IFieldMiddlewareBuilder
     {
         /// <summary>
-        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder, ISchema)"/>.
+        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
         /// <br/><br/>
         /// The delegate is used to unify the different ways of specifying middleware. See additional methods in <see cref="FieldMiddlewareBuilderExtensions"/>.
         /// </summary>
         /// <param name="middleware">Middleware delegate.</param>
         /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
-        IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware);
+        IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware);
 
         /// <summary>
         /// Returns a transform for field resolvers, or <see langword="null"/> if no middleware is defined.
         /// The transform is a cumulation of all middleware configured within this builder.
         /// </summary>
-        Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build();
+        Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build();
     }
 }

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -18,12 +18,9 @@ namespace GraphQL.Instrumentation
         IFieldMiddlewareBuilder Use(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware);
 
         /// <summary>
-        /// Applies all delegates specified by the <see cref="Use(Func{ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate})"/> method to the schema.
-        /// <br/><br/>
-        /// When applying to the schema, modifies the resolver of each field of each graph type adding required behavior.
-        /// Therefore, as a rule, this method should be called only once during schema initialization. See <see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)"/>.
+        /// Returns a transform for field resolvers, or <see langword="null"/> if no middleware is defined.
+        /// The transform is a cumulation of all middleware configured within this builder.
         /// </summary>
-        /// <param name="schema">The schema to which you want to apply middlewares.</param>
-        void ApplyTo(ISchema schema);
+        Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> Build();
     }
 }

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Instrumentation
     public interface IFieldMiddlewareBuilder
     {
         /// <summary>
-        /// Adds the specified delegate to the list of delegates that will be applied to the schema when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
+        /// Adds the specified delegate to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
         /// <br/><br/>
         /// The delegate is used to unify the different ways of specifying middleware. See additional methods in <see cref="FieldMiddlewareBuilderExtensions"/>.
         /// </summary>

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -191,14 +191,14 @@ namespace GraphQL.Types
         /// When applying to the schema, modifies the resolver of each field of each graph type adding required behavior.
         /// Therefore, as a rule, this method should be called only once during schema initialization.
         /// </summary>
-        public void ApplyMiddleware(IFieldMiddlewareBuilder fieldMiddlewareBuilder, ISchema schema)
+        public void ApplyMiddleware(IFieldMiddlewareBuilder fieldMiddlewareBuilder)
         {
             var transform = (fieldMiddlewareBuilder ?? throw new ArgumentNullException(nameof(fieldMiddlewareBuilder))).Build();
 
             // allocation free optimization if no middlewares are defined
             if (transform != null)
             {
-                ApplyMiddleware(transform, schema);
+                ApplyMiddleware(transform);
             }
         }
 
@@ -208,13 +208,10 @@ namespace GraphQL.Types
         /// When applying to the schema, modifies the resolver of each field of each graph type adding required behavior.
         /// Therefore, as a rule, this method should be called only once during schema initialization.
         /// </summary>
-        public void ApplyMiddleware(Func<ISchema, FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform, ISchema schema)
+        public void ApplyMiddleware(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform)
         {
             if (transform == null)
                 throw new ArgumentNullException(nameof(transform));
-
-            if (schema == null)
-                throw new ArgumentNullException(nameof(schema));
 
             foreach (var item in Dictionary)
             {
@@ -224,7 +221,7 @@ namespace GraphQL.Types
                     {
                         var inner = field.Resolver ?? NameFieldResolver.Instance;
 
-                        var fieldMiddlewareDelegate = transform(schema, context => inner.ResolveAsync(context));
+                        var fieldMiddlewareDelegate = transform(context => inner.ResolveAsync(context));
 
                         field.Resolver = new FuncFieldResolver<object>(fieldMiddlewareDelegate.Invoke);
                     }

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -189,7 +189,7 @@ namespace GraphQL.Types
         /// Applies all delegates specified by the middleware builder to the schema.
         /// <br/><br/>
         /// When applying to the schema, modifies the resolver of each field of each graph type adding required behavior.
-        /// Therefore, as a rule, this method should be called only once during schema initialization.
+        /// Therefore, as a rule, this method should be called only once - during schema initialization.
         /// </summary>
         public void ApplyMiddleware(IFieldMiddlewareBuilder fieldMiddlewareBuilder)
         {
@@ -203,10 +203,10 @@ namespace GraphQL.Types
         }
 
         /// <summary>
-        /// Applies the speicifed middleware transform delegate to the schema.
+        /// Applies the specified middleware transform delegate to the schema.
         /// <br/><br/>
         /// When applying to the schema, modifies the resolver of each field of each graph type adding required behavior.
-        /// Therefore, as a rule, this method should be called only once during schema initialization.
+        /// Therefore, as a rule, this method should be called only once - during schema initialization.
         /// </summary>
         public void ApplyMiddleware(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform)
         {

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using GraphQL.Conversion;
+using GraphQL.Instrumentation;
 using GraphQL.Introspection;
 
 namespace GraphQL.Types
@@ -24,8 +25,7 @@ namespace GraphQL.Types
         /// <br/><br/>
         /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="ExecutionOptions.FieldMiddleware"/>.
         /// <br/><br/>
-        /// This method should be safe to be called from multiple threads simultaneously. However, field middleware
-        /// must be applied in a thread-safe manner so that it is not applied to the schema multiple times.
+        /// This method should be safe to be called from multiple threads simultaneously.
         /// </summary>
         void Initialize();
 
@@ -33,6 +33,13 @@ namespace GraphQL.Types
         /// Field and argument names are sanitized by the provided <see cref="INameConverter"/>; defaults to <see cref="CamelCaseNameConverter"/>
         /// </summary>
         INameConverter NameConverter { get; }
+
+        /// <summary>
+        /// Note that field middlewares apply only to an uninitialized schema. If the schema is initialized
+        /// then adding additional middleware through the builder does nothing. The schema is initialized (if not yet)
+        /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)">ExecuteAsync</see>.
+        /// </summary>
+        IFieldMiddlewareBuilder FieldMiddleware { get; }
 
         /// <summary>
         /// Description of the schema.

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -35,7 +35,7 @@ namespace GraphQL.Types
         INameConverter NameConverter { get; }
 
         /// <summary>
-        /// Note that field middlewares apply only to an uninitialized schema. If the schema is initialized
+        /// Note that field middlewares from this property apply only to an uninitialized schema. If the schema is initialized
         /// then adding additional middleware through the builder does nothing. The schema is initialized (if not yet)
         /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)">ExecuteAsync</see>.
         /// </summary>

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -23,7 +23,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Initializes the schema. Called by <see cref="IDocumentExecuter"/> before validating or executing the request.
         /// <br/><br/>
-        /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="ExecutionOptions.FieldMiddleware"/>.
+        /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="FieldMiddleware"/>.
         /// <br/><br/>
         /// This method should be safe to be called from multiple threads simultaneously.
         /// </summary>

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -38,6 +38,7 @@ namespace GraphQL.Types
         /// Note that field middlewares from this property apply only to an uninitialized schema. If the schema is initialized
         /// then adding additional middleware through the builder does nothing. The schema is initialized (if not yet)
         /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)">ExecuteAsync</see>.
+        /// However, you can also apply middlewares at any time in runtime using SchemaTypes.ApplyMiddleware method.
         /// </summary>
         IFieldMiddlewareBuilder FieldMiddleware { get; }
 

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -76,7 +76,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public bool Initialized { get; private set; } = false;
+        public bool Initialized { get; private set; }
 
         // TODO: It would be worthwhile to think at all about how to redo the design so that such a situation does not arise.
         private void CheckInitialized([System.Runtime.CompilerServices.CallerMemberName] string name = "")
@@ -147,13 +147,12 @@ namespace GraphQL.Types
         public SchemaDirectives Directives { get; }
 
         /// <inheritdoc/>
-        public SchemaTypes AllTypes {
+        public SchemaTypes AllTypes
+        {
             get
             {
-                if (_allTypes != null)
-                    return _allTypes;
-
-                Initialize();
+                if (_allTypes == null)
+                    Initialize();
 
                 return _allTypes;
             }
@@ -286,7 +285,7 @@ namespace GraphQL.Types
         {
             if (disposing)
             {
-                if (_disposed)
+                if (!_disposed)
                 {
                     _services = null;
                     Query = null;
@@ -357,8 +356,8 @@ namespace GraphQL.Types
                 type => (IGraphType)_services.GetRequiredService(type),
                 NameConverter);
 
-            //at this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete
-            //however, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock
+            // At this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete.
+            // However, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock.
             _allTypes.ApplyMiddleware(FieldMiddleware);
         }
     }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -63,17 +63,8 @@ namespace GraphQL.Types
         /// <inheritdoc/>
         public INameConverter NameConverter { get; set; } = CamelCaseNameConverter.Instance;
 
-        private IFieldMiddlewareBuilder _fieldMiddlewareBuilder = new FieldMiddlewareBuilder();
         /// <inheritdoc/>
-        public IFieldMiddlewareBuilder FieldMiddleware
-        {
-            get => _fieldMiddlewareBuilder;
-            set
-            {
-                CheckInitialized();
-                _fieldMiddlewareBuilder = value ?? throw new ArgumentNullException();
-            }
-        }
+        public IFieldMiddlewareBuilder FieldMiddleware { get; internal set; } = new FieldMiddlewareBuilder();
 
         /// <inheritdoc/>
         public bool Initialized { get; private set; }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -101,8 +101,6 @@ namespace GraphQL.Types
                 CreateSchemaTypes();
 
                 Initialized = true;
-
-                FindType("____");
             }
         }
 

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -359,7 +359,7 @@ namespace GraphQL.Types
 
             //at this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete
             //however, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock
-            _allTypes.ApplyMiddleware(FieldMiddleware, this);
+            _allTypes.ApplyMiddleware(FieldMiddleware);
         }
     }
 }


### PR DESCRIPTION
Similar to how `NameConverter` and `SchemaFilter` were moved from `ExecutionOptions` to `Schema`, the same is now true for `FieldMiddleware`, since that also defines the schema configuration, rather than being an execution option.

Also simplifies middleware `Use` methods and overall design.