### PR TITLE
Optimize metrics collection

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -8,6 +8,7 @@
 * New method `IParentExecutionNode.ApplyToChildren`
 * Document caching supported via `IDocumentCache` and a default implementation within `DefaultDocumentCache`.
   Within the `GraphQL.Caching` nuget package, a memory-backed implementation is available which is backed by `Microsoft.Extensions.Caching.Memory.IMemoryCache`.
+* `ExecutionOptions.EnableMetrics` is disabled by default
 
 ## Breaking Changes
 

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -944,7 +944,9 @@ namespace GraphQL.Instrumentation
     }
     public class Metrics
     {
+        public static readonly GraphQL.Instrumentation.Metrics Disabled;
         public Metrics(bool enabled = true) { }
+        public bool Enabled { get; }
         public GraphQL.Instrumentation.PerfRecord[] Finish() { }
         public GraphQL.Instrumentation.Metrics SetOperationName(string name) { }
         public GraphQL.Instrumentation.Metrics Start(string operationName) { }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -946,7 +946,7 @@ namespace GraphQL.Instrumentation
     {
         public Metrics(bool enabled = true) { }
         public bool Enabled { get; }
-        public static GraphQL.Instrumentation.Metrics Disabled { get; }
+        public static GraphQL.Instrumentation.Metrics None { get; }
         public GraphQL.Instrumentation.PerfRecord[] Finish() { }
         public GraphQL.Instrumentation.Metrics SetOperationName(string name) { }
         public GraphQL.Instrumentation.Metrics Start(string operationName) { }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -71,7 +71,7 @@ namespace GraphQL
             if (options.FieldMiddleware == null)
                 throw new InvalidOperationException("Cannot execute request if no middleware builder specified");
 
-            var metrics = new Metrics(options.EnableMetrics).Start(options.OperationName);
+            var metrics = (options.EnableMetrics ? new Metrics() : Metrics.Disabled).Start(options.OperationName);
 
             ExecutionResult result = null;
             ExecutionContext context = null;

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -71,7 +71,7 @@ namespace GraphQL
             if (options.FieldMiddleware == null)
                 throw new InvalidOperationException("Cannot execute request if no middleware builder specified");
 
-            var metrics = (options.EnableMetrics ? new Metrics() : Metrics.Disabled).Start(options.OperationName);
+            var metrics = (options.EnableMetrics ? new Metrics() : Metrics.None).Start(options.OperationName);
 
             ExecutionResult result = null;
             ExecutionContext context = null;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -120,7 +120,7 @@ namespace GraphQL.Execution
                     else if (graphType is NonNullGraphType)
                     {
                         ThrowNullError(variable.Name);
-                    } 
+                    }
 
                     // if the variable was not specified and no default was specified, do not set variable.Value
 
@@ -243,7 +243,7 @@ namespace GraphQL.Execution
                 if (value == null)
                     return null;
 
-                // note: a list can have a single child element which will automatically be intrepreted as a list of 1 elements. (see below rule)
+                // note: a list can have a single child element which will automatically be interpreted as a list of 1 elements. (see below rule)
                 // so, to prevent a string as being interpreted as a list of chars (which get converted to strings), we ignore considering a string as an IEnumerable
                 if (value is IEnumerable values && !(value is string))
                 {

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -61,7 +61,7 @@ namespace GraphQL
         public List<IDocumentExecutionListener> Listeners { get; } = new List<IDocumentExecutionListener>();
 
         /// <summary>This setting essentially allows Apollo Tracing. Disabling will increase performance.</summary>
-        public bool EnableMetrics { get; set; } = true;
+        public bool EnableMetrics { get; set; }
 
         /// <summary>When false, captures unhandled exceptions and returns them within <see cref="ExecutionResult.Errors">ExecutionResult.Errors</see></summary>
         public bool ThrowOnUnhandledException { get; set; }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -133,7 +133,7 @@ namespace GraphQL.Execution
             var arrayItems = (data is ICollection collection)
                 ? new List<ExecutionNode>(collection.Count)
                 : new List<ExecutionNode>();
-            
+
             if (data is IList list)
             {
                 for (int i=0; i<list.Count; ++i)

--- a/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
+++ b/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
@@ -12,18 +12,22 @@ namespace GraphQL.Instrumentation
         /// <inheritdoc/>
         public async Task<object> Resolve(IResolveFieldContext context, FieldMiddlewareDelegate next)
         {
-            var metadata = new Dictionary<string, object>
+            if (context.Metrics.Enabled)
             {
-                { "typeName", context.ParentType.Name },
-                { "fieldName", context.FieldName },
-                { "returnTypeName", SchemaPrinter.ResolveName(context.ReturnType) },
-                { "path", context.Path },
-            };
+                var metadata = new Dictionary<string, object>
+                {
+                    { "typeName", context.ParentType.Name },
+                    { "fieldName", context.FieldName },
+                    { "returnTypeName", SchemaPrinter.ResolveName(context.ReturnType) },
+                    { "path", context.Path },
+                };
 
-            using (context.Metrics.Subject("field", context.FieldName, metadata))
+                using (context.Metrics.Subject("field", context.FieldName, metadata))
+                    return await next(context).ConfigureAwait(false);
+            }
+            else
             {
-                var result = await next(context).ConfigureAwait(false);
-                return result;
+                return await next(context).ConfigureAwait(false);
             }
         }
     }

--- a/src/GraphQL/Instrumentation/Metrics.cs
+++ b/src/GraphQL/Instrumentation/Metrics.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace GraphQL.Instrumentation
 {
     /// <summary>
-    /// Records metrics during execution of a GraphQL document
+    /// Records metrics during execution of a GraphQL document.
     /// </summary>
     public class Metrics
     {
@@ -13,6 +13,8 @@ namespace GraphQL.Instrumentation
         private ValueStopwatch _stopwatch;
         private readonly List<PerfRecord> _records;
         private PerfRecord _main;
+
+        public static readonly Metrics Disabled = new Metrics(false);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Metrics"/> class.
@@ -24,6 +26,11 @@ namespace GraphQL.Instrumentation
             if (enabled)
                 _records = new List<PerfRecord>();
         }
+
+        /// <summary>
+        /// Shows whether metrics collection is enabled.
+        /// </summary>
+        public bool Enabled => _enabled;
 
         /// <summary>
         /// Logs the start of the execution.

--- a/src/GraphQL/Instrumentation/Metrics.cs
+++ b/src/GraphQL/Instrumentation/Metrics.cs
@@ -9,7 +9,6 @@ namespace GraphQL.Instrumentation
     /// </summary>
     public class Metrics
     {
-        private readonly bool _enabled;
         private ValueStopwatch _stopwatch;
         private readonly List<PerfRecord> _records;
         private PerfRecord _main;
@@ -22,7 +21,7 @@ namespace GraphQL.Instrumentation
         /// <param name="enabled">Indicates if metrics should be recorded for this execution.</param>
         public Metrics(bool enabled = true)
         {
-            _enabled = enabled;
+            Enabled = enabled;
             if (enabled)
                 _records = new List<PerfRecord>();
         }
@@ -30,7 +29,7 @@ namespace GraphQL.Instrumentation
         /// <summary>
         /// Shows whether metrics collection is enabled.
         /// </summary>
-        public bool Enabled => _enabled;
+        public bool Enabled { get; }
 
         /// <summary>
         /// Logs the start of the execution.
@@ -38,7 +37,7 @@ namespace GraphQL.Instrumentation
         /// <param name="operationName">The name of the GraphQL operation.</param>
         public Metrics Start(string operationName)
         {
-            if (_enabled)
+            if (Enabled)
             {
                 if (_main != null)
                     throw new InvalidOperationException("Metrics.Start has already been called");
@@ -56,7 +55,7 @@ namespace GraphQL.Instrumentation
         /// </summary>
         public Metrics SetOperationName(string name)
         {
-            if (_enabled && _main != null)
+            if (Enabled && _main != null)
                 _main.Subject = name;
 
             return this;
@@ -67,7 +66,7 @@ namespace GraphQL.Instrumentation
         /// </summary>
         public Marker Subject(string category, string subject, Dictionary<string, object> metadata = null)
         {
-            if (!_enabled)
+            if (!Enabled)
                 return Marker.Empty;
 
             if (_main == null)
@@ -84,7 +83,7 @@ namespace GraphQL.Instrumentation
         /// </summary>
         public PerfRecord[] Finish()
         {
-            if (!_enabled)
+            if (!Enabled)
                 return null;
 
             _main?.MarkEnd(_stopwatch.Elapsed.TotalMilliseconds);

--- a/src/GraphQL/Instrumentation/Metrics.cs
+++ b/src/GraphQL/Instrumentation/Metrics.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Instrumentation
         /// <summary>
         /// Gets an instance of the metrics for which metrics collection is disabled.
         /// </summary>
-        public static Metrics Disabled { get; } = new Metrics(false);
+        public static Metrics None { get; } = new Metrics(false);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Metrics"/> class.


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.14393.3986 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
Frequency=3515611 Hz, Resolution=284.4456 ns, Timer=TSC
.NET Core SDK=5.0.102
  [Host]     : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  DefaultJob : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT


```
before

|        Method | UseCaching |         Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |----------- |-------------:|----------:|----------:|---------:|--------:|------:|----------:|
| **Introspection** |      **False** | **1,112.457 μs** | **7.9694 μs** | **6.6548 μs** | **107.4219** | **33.2031** |     **-** | **487.09 KB** |
|          Hero |      False |    19.294 μs | 0.1714 μs | 0.1520 μs |   2.1057 |       - |     - |    8.7 KB |
| **Introspection** |       **True** |   **842.875 μs** | **6.8388 μs** | **5.7107 μs** | **106.4453** | **35.1563** |     **-** | **447.41 KB** |
|          Hero |       True |     3.722 μs | 0.0520 μs | 0.0487 μs |   0.9842 |       - |     - |   4.03 KB |

after

|        Method | UseCaching |         Mean |      Error |     StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------- |----------- |-------------:|-----------:|-----------:|---------:|--------:|------:|----------:|
| **Introspection** |      **False** | **1,112.892 μs** | **14.7801 μs** | **13.1022 μs** | **107.4219** | **33.2031** |     **-** | **486.28 KB** |
|          Hero |      False |    17.432 μs |  0.3071 μs |  0.2722 μs |   1.9226 |       - |     - |   7.89 KB |
| **Introspection** |       **True** |   **828.352 μs** | **14.5423 μs** | **13.6029 μs** | **104.4922** | **31.2500** |     **-** | **446.59 KB** |
|          Hero |       True |     3.211 μs |  0.0628 μs |  0.0588 μs |   0.7858 |       - |     - |   3.22 KB |


The results show improvement, but they are strange. A short `hero` request saves more memory than `introspection`.