### PR TITLE
Prevent API tests from running twice

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
+++ b/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Any particular reason the API tests run for both net5 and net3.1 ?