### PR TITLE
Change ExecutionResult.Data internals from dictionaries to arrays

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -16,6 +16,9 @@
 ## Breaking Changes
 
 * GraphQL.NET now uses GraphQL-Parser v7 with new memory model
+* `ExecutionResult.Data` format breaking changes. Now objects are serialized as `ObjectProperty` lists, not object dictionaries.
+  Both `GraphQL.NewtonsoftJson` and `GraphQL.SystemTextJson` serializers received the necessary changes to produce the same JSON as before.
+  However, consumers using `ExecutionResult` instances directly most likely will not work correctly.
 * `NameConverter`, `SchemaFilter` and `FieldMiddleware` have been removed from `ExecutionOptions` and are now properties on the `Schema`.
   These properties can be set in the constructor of the `Schema` instance, or within your DI composition root, or at any time before
   any query is executed. Once a query has been executed, changes to these fields is not allowed, and adding middleware via the field middleware

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -100,4 +100,4 @@
 * `ISchema.FindType` method was moved into `SchemaTypes[string typeName]` indexer
 * Some of the `ISchemaNodeVisitor` methods have been changes to better support schema traversal
 * Most `ExecutionStrategy` methods are now `protected`
-* `ObjectExecutionNode.SubFields` property type was changed from `Dictionary<string, ExecutionNode> ` to `ExecutionNode[]`
+* `ObjectExecutionNode.SubFields` property type was changed from `Dictionary<string, ExecutionNode>` to `ExecutionNode[]`

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -16,7 +16,7 @@
 ## Breaking Changes
 
 * GraphQL.NET now uses GraphQL-Parser v7 with new memory model
-* `ExecutionResult.Data` format breaking changes. Now objects are serialized as `ObjectProperty` lists, not object dictionaries.
+* `ExecutionResult.Data` format breaking changes. Now objects are serialized as `ObjectProperty` arrays, not object dictionaries.
   Both `GraphQL.NewtonsoftJson` and `GraphQL.SystemTextJson` serializers received the necessary changes to produce the same JSON as before.
   However, consumers using `ExecutionResult` instances directly most likely will not work correctly.
 * `NameConverter`, `SchemaFilter` and `FieldMiddleware` have been removed from `ExecutionOptions` and are now properties on the `Schema`.

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -99,3 +99,5 @@
 * `ISchema.FindDirective`, `ISchema.RegisterDirective`, `ISchema.RegisterDirectives` methods were moved into `SchemaDirectives` class
 * `ISchema.FindType` method was moved into `SchemaTypes[string typeName]` indexer
 * Some of the `ISchemaNodeVisitor` methods have been changes to better support schema traversal
+* Most `ExecutionStrategy` methods are now `protected`
+* `ObjectExecutionNode.SubFields` property type was changed from `Dictionary<string, ExecutionNode> ` to `ExecutionNode[]`

--- a/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
@@ -26,6 +26,13 @@ namespace GraphQL.NewtonsoftJson
         public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { }
         public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
     }
+    public class ObjectPropertyArrayJsonConverter : Newtonsoft.Json.JsonConverter
+    {
+        public ObjectPropertyArrayJsonConverter() { }
+        public override bool CanConvert(System.Type objectType) { }
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { }
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
     public static class SchemaExtensions
     {
         public static System.Threading.Tasks.Task<string> ExecuteAsync(this GraphQL.Types.ISchema schema, System.Action<GraphQL.ExecutionOptions> configure) { }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -265,6 +265,12 @@ namespace GraphQL
         public static T ToObject<T>(this System.Collections.Generic.IDictionary<string, object> source)
             where T :  class { }
     }
+    public struct ObjectProperty
+    {
+        public ObjectProperty(string key, object value) { }
+        public string Key { get; }
+        public object Value { get; }
+    }
     public class ReadonlyResolveFieldContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<object>
     {
         public ReadonlyResolveFieldContext(GraphQL.Execution.ExecutionNode node, GraphQL.Execution.ExecutionContext context) { }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -771,11 +771,8 @@ namespace GraphQL.Execution
         protected bool ProcessNodeUnhandledException(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, System.Exception ex) { }
         protected void SetNodeError(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, GraphQL.ExecutionError error) { }
         protected virtual void ValidateNodeResult(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
-        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode = default) { }
-        public static GraphQL.Execution.RootExecutionNode BuildExecutionRootNode(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IObjectGraphType rootType) { }
-        public static void SetArrayItemNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ArrayExecutionNode parent) { }
-        public static void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent) { }
-        public static void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent, GraphQL.Language.AST.Fields fields) { }
+        protected static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode = default) { }
+        protected static GraphQL.Execution.RootExecutionNode BuildExecutionRootNode(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IObjectGraphType rootType) { }
     }
     public class GraphQLDocumentBuilder : GraphQL.Execution.IDocumentBuilder
     {
@@ -860,7 +857,7 @@ namespace GraphQL.Execution
     public class ObjectExecutionNode : GraphQL.Execution.ExecutionNode, GraphQL.Execution.IParentExecutionNode
     {
         public ObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
-        public System.Collections.Generic.Dictionary<string, GraphQL.Execution.ExecutionNode> SubFields { get; set; }
+        public GraphQL.Execution.ExecutionNode[] SubFields { get; set; }
         public void ApplyToChildren<TState>(System.Action<GraphQL.Execution.ExecutionNode, TState> action, TState state, bool reverse = false) { }
         public GraphQL.Types.IObjectGraphType GetObjectGraphType(GraphQL.Types.ISchema schema) { }
         public override object ToValue() { }

--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -377,7 +377,7 @@ mutation {
         /// <summary>
         /// Exercises Execution.ExecutionNode.ResolvedType for children of children, verifying that
         /// <see cref="Execution.ExecutionNode.GraphType"/> is returning proper values. Without a dataloader,
-        /// <see cref="Execution.ExecutionStrategy.SetArrayItemNodes(Execution.ExecutionContext, Execution.ArrayExecutionNode)"/>
+        /// Execution.ExecutionStrategy.SetArrayItemNodes(Execution.ExecutionContext, Execution.ArrayExecutionNode)
         /// skips execution of <see cref="Execution.ExecutionStrategy.ValidateNodeResult(Execution.ExecutionContext, Execution.ExecutionNode)"/>
         /// because it is not relevant, and that method is the only one that calls Execution.ExecutionNode.ResolvedType.
         /// </summary>

--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -377,7 +377,7 @@ mutation {
         /// <summary>
         /// Exercises Execution.ExecutionNode.ResolvedType for children of children, verifying that
         /// <see cref="Execution.ExecutionNode.GraphType"/> is returning proper values. Without a dataloader,
-        /// <see cref="Execution.ExecutionStrategy.CompleteNode(Execution.ExecutionContext, Execution.ExecutionNode)"/>
+        /// <see cref="Execution.ExecutionStrategy.SetArrayItemNodes(Execution.ExecutionContext, Execution.ArrayExecutionNode)"/>
         /// skips execution of <see cref="Execution.ExecutionStrategy.ValidateNodeResult(Execution.ExecutionContext, Execution.ExecutionNode)"/>
         /// because it is not relevant, and that method is the only one that calls Execution.ExecutionNode.ResolvedType.
         /// </summary>

--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -377,7 +377,7 @@ mutation {
         /// <summary>
         /// Exercises Execution.ExecutionNode.ResolvedType for children of children, verifying that
         /// <see cref="Execution.ExecutionNode.GraphType"/> is returning proper values. Without a dataloader,
-        /// <see cref="Execution.ExecutionStrategy.SetArrayItemNodes(Execution.ExecutionContext, Execution.ArrayExecutionNode)"/>
+        /// <see cref="Execution.ExecutionStrategy.CompleteNode(Execution.ExecutionContext, Execution.ExecutionNode)"/>
         /// skips execution of <see cref="Execution.ExecutionStrategy.ValidateNodeResult(Execution.ExecutionContext, Execution.ExecutionNode)"/>
         /// because it is not relevant, and that method is the only one that calls Execution.ExecutionNode.ResolvedType.
         /// </summary>

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultContractResolver.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultContractResolver.cs
@@ -16,10 +16,16 @@ namespace GraphQL.NewtonsoftJson
             _errorInfoProvider = errorInfoProvider ?? throw new ArgumentNullException(nameof(errorInfoProvider));
         }
 
-        protected override JsonConverter ResolveContractConverter(Type objectType) =>
-            typeof(ExecutionResult).IsAssignableFrom(objectType)
-                ? new ExecutionResultJsonConverter(_errorInfoProvider)
-                : base.ResolveContractConverter(objectType);
+        protected override JsonConverter ResolveContractConverter(Type objectType)
+        {
+            if (objectType == typeof(ObjectProperty[]))
+                return new ObjectPropertyArrayJsonConverter();
+
+            if (typeof(ExecutionResult).IsAssignableFrom(objectType))
+                return new ExecutionResultJsonConverter(_errorInfoProvider);
+
+            return base.ResolveContractConverter(objectType);
+        }
 
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
@@ -5,6 +5,9 @@ using Newtonsoft.Json;
 
 namespace GraphQL.NewtonsoftJson
 {
+    /// <summary>
+    /// Converts an instance of <see cref="ExecutionResult"/> to JSON. Doesn't support read from JSON.
+    /// </summary>
     public class ExecutionResultJsonConverter : JsonConverter
     {
         private readonly IErrorInfoProvider _errorInfoProvider;
@@ -16,21 +19,20 @@ namespace GraphQL.NewtonsoftJson
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            if (value is ExecutionResult result)
-            {
-                writer.WriteStartObject();
+            var result = (ExecutionResult)value;
 
-                WriteErrors(result.Errors, writer, serializer);
-                WriteData(result, writer, serializer);
-                WriteExtensions(result, writer, serializer);
+            writer.WriteStartObject();
 
-                writer.WriteEndObject();
-            }
+            WriteErrors(result.Errors, writer, serializer);
+            WriteData(result, writer, serializer);
+            WriteExtensions(result, writer, serializer);
+
+            writer.WriteEndObject();
         }
 
         private void WriteData(ExecutionResult result, JsonWriter writer, JsonSerializer serializer)
         {
-            var data = result.Data;
+            object data = result.Data;
 
             if (result.Errors?.Count > 0 && data == null)
             {

--- a/src/GraphQL.NewtonsoftJson/ObjectPropertyArrayJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/ObjectPropertyArrayJsonConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using Newtonsoft.Json;
+
+namespace GraphQL.NewtonsoftJson
+{
+    /// <summary>
+    /// Converts an instance of <see cref="ObjectProperty"/> array to JSON. Doesn't support read from JSON.
+    /// <br/><br/>
+    /// Array of <see cref="ObjectProperty"/> is an analogy of Dictionary(string, object) which is naturally
+    /// handled by JSON.NET as an object. To write an array as a single object and not an array, this converter
+    /// is required. Working through arrays rather than dictionaries saves memory in the managed heap.
+    /// </summary>
+    public class ObjectPropertyArrayJsonConverter : JsonConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvert(Type objectType) => objectType == typeof(ObjectProperty[]);
+
+        /// <inheritdoc/>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+
+            var properties = (ObjectProperty[])value;
+
+            foreach (var property in properties)
+            {
+                writer.WritePropertyName(property.Key);
+                serializer.Serialize(writer, property.Value);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/GraphQL.NewtonsoftJson/StringExtensions.cs
+++ b/src/GraphQL.NewtonsoftJson/StringExtensions.cs
@@ -37,7 +37,7 @@ namespace GraphQL.NewtonsoftJson
         /// <returns>Returns a <c>null</c> if the object cannot be converted into a dictionary.</returns>
         public static Dictionary<string, object> ToDictionary(this string json)
         {
-            var values = JsonConvert.DeserializeObject(json,
+            object values = JsonConvert.DeserializeObject(json,
                 new JsonSerializerSettings
                 {
                     DateFormatHandling = DateFormatHandling.IsoDateFormat,
@@ -82,7 +82,7 @@ namespace GraphQL.NewtonsoftJson
 
             if (value is JValue rawValue)
             {
-                var val = rawValue.Value;
+                object val = rawValue.Value;
                 if (val is long l)
                 {
                     if (l >= int.MinValue && l <= int.MaxValue)

--- a/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
@@ -31,19 +31,16 @@ namespace GraphQL.Execution
             return result;
         }
 
-        private async Task<IDictionary<string, IObservable<ExecutionResult>>> ExecuteSubscriptionNodesAsync(ExecutionContext context, IDictionary<string, ExecutionNode> nodes)
+        private async Task<IDictionary<string, IObservable<ExecutionResult>>> ExecuteSubscriptionNodesAsync(ExecutionContext context, ExecutionNode[] nodes)
         {
             var streams = new Dictionary<string, IObservable<ExecutionResult>>();
 
-            foreach (var kvp in nodes)
+            foreach (var node in nodes)
             {
-                var name = kvp.Key;
-                var node = kvp.Value;
-
                 if (!(node.FieldDefinition is EventStreamFieldType))
                     continue;
 
-                streams[name] = await ResolveEventStreamAsync(context, node).ConfigureAwait(false);
+                streams[node.Name] = await ResolveEventStreamAsync(context, node).ConfigureAwait(false);
             }
 
             return streams;

--- a/src/GraphQL.SystemTextJson/ObjectDictionaryConverter.cs
+++ b/src/GraphQL.SystemTextJson/ObjectDictionaryConverter.cs
@@ -10,7 +10,7 @@ namespace GraphQL.SystemTextJson
 {
     /// <summary>
     /// A custom JsonConverter for reading a dictionary of objects of their real underlying type.
-    /// Does not support write.
+    /// Doesn't support write.
     /// </summary>
     public class ObjectDictionaryConverter : JsonConverter<Dictionary<string, object>>
     {

--- a/src/GraphQL.Tests/Bugs/Issue661.cs
+++ b/src/GraphQL.Tests/Bugs/Issue661.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Tests.Bugs
                 }).GetAwaiter().GetResult();
 
                 result.Errors.ShouldBeNull();
-                var data = result.Data.ToLightDictionary();
+                var data = result.Data.ToDict();
                 data.Count.ShouldBe(1);
                 data["get_cached"].ShouldBe("myvalue");
             }

--- a/src/GraphQL.Tests/Bugs/Issue661.cs
+++ b/src/GraphQL.Tests/Bugs/Issue661.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using GraphQL.SystemTextJson;
 using GraphQL.Types;
 using Microsoft.Extensions.Caching.Distributed;
@@ -38,7 +37,7 @@ namespace GraphQL.Tests.Bugs
                 }).GetAwaiter().GetResult();
 
                 result.Errors.ShouldBeNull();
-                var data = (Dictionary<string, object>)result.Data;
+                var data = result.Data.ToLightDictionary();
                 data.Count.ShouldBe(1);
                 data["get_cached"].ShouldBe("myvalue");
             }

--- a/src/GraphQL.Tests/Execution/Performance/ThreadPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/ThreadPerformanceTests.cs
@@ -125,7 +125,7 @@ namespace GraphQL.Tests.Execution.Performance
             });
 
             result.Errors.ShouldBeNull();
-            ((string)result.Data.ToLightDictionary()["m17"]).ShouldBe("5,5,1,1,1,5,5,5,5,1,5,1,5,1,5,1,5");
+            ((string)result.Data.ToDict()["m17"]).ShouldBe("5,5,1,1,1,5,5,5,5,1,5,1,5,1,5,1,5");
         }
     }
 }

--- a/src/GraphQL.Tests/Execution/Performance/ThreadPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/ThreadPerformanceTests.cs
@@ -118,15 +118,14 @@ namespace GraphQL.Tests.Execution.Performance
                 }
             ";
 
-            var runResult2 = await Executer.ExecuteAsync(_ =>
+            var result = await Executer.ExecuteAsync(_ =>
             {
                 _.Schema = Schema;
                 _.Query = query;
             });
 
-            var result = runResult2.Data as dynamic;
-            runResult2.Errors.ShouldBeNull();
-            ((string)result["m17"]).ShouldBe("5,5,1,1,1,5,5,5,5,1,5,1,5,1,5,1,5");
+            result.Errors.ShouldBeNull();
+            ((string)result.Data.ToLightDictionary()["m17"]).ShouldBe("5,5,1,1,1,5,5,5,5,1,5,1,5,1,5,1,5");
         }
     }
 }

--- a/src/GraphQL.Tests/Execution/UnionInterfaceTests.cs
+++ b/src/GraphQL.Tests/Execution/UnionInterfaceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GraphQL.Types;
 using GraphQL.Utilities;
 using GraphQL.Validation;
+using Shouldly;
 using Xunit;
 
 namespace GraphQL.Tests.Execution
@@ -118,7 +119,7 @@ namespace GraphQL.Tests.Execution
         [Fact]
         public void executes_using_union_types()
         {
-            // NOTE: This is an *invalid* query, but it should be an *executable* query.
+            // NOTE: This is an *invalid* query, but it should be an *executable* query.    <--- ???
 
             var query = @"
                 query AQuery {
@@ -137,14 +138,13 @@ namespace GraphQL.Tests.Execution
                 {
                   ""__typename"": ""Person"",
                   ""name"": ""John"",
-                  ""pets"": [
-                    { ""__typename"":  ""Cat"", ""name"": ""Garfield"", ""meows"": false },
-                    { ""__typename"":  ""Dog"", ""name"": ""Odie"", ""barks"": true }
-                  ]
+                  ""pets"": null
                 }
             ";
 
-            AssertQuerySuccess(query, expected, root: _john, rules: Enumerable.Empty<IValidationRule>());
+            var result = AssertQueryWithErrors(query, expected, root: _john, rules: Enumerable.Empty<IValidationRule>(), expectedErrorCount: 1);
+            result.Errors[0].Message.ShouldBe("Error trying to resolve field 'pets'.");
+            result.Errors[0].InnerException.Message.ShouldBe("Schema is not configured correctly to fetch field 'barks' from type 'Cat'.");
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace GraphQL.Tests.Execution
         [Fact]
         public void executes_using_interface_types()
         {
-            // NOTE: This is an *invalid* query, but it should be an *executable* query.
+            // NOTE: This is an *invalid* query, but it should be an *executable* query.    <--- ???
 
             var query = @"
                 query AQuery {
@@ -206,14 +206,13 @@ namespace GraphQL.Tests.Execution
                 {
                   ""__typename"": ""Person"",
                   ""name"": ""John"",
-                  ""friends"": [
-                    { ""__typename"":  ""Person"", ""name"": ""Liz"" },
-                    { ""__typename"":  ""Dog"", ""name"": ""Odie"", ""barks"": true }
-                  ]
+                  ""friends"": null
                 }
             ";
 
-            AssertQuerySuccess(query, expected, root: _john, rules: Enumerable.Empty<IValidationRule>());
+            var result = AssertQueryWithErrors(query, expected, root: _john, rules: Enumerable.Empty<IValidationRule>(), expectedErrorCount: 1);
+            result.Errors[0].Message.ShouldBe("Error trying to resolve field 'friends'.");
+            result.Errors[0].InnerException.Message.ShouldBe("Schema is not configured correctly to fetch field 'barks' from type 'Person'.");
         }
 
         [Fact]

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -66,6 +66,7 @@ namespace GraphQL.Tests
             object root = null,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
+            IEnumerable<IValidationRule> rules = null,
             int expectedErrorCount = 0,
             bool renderErrors = false,
             Action<UnhandledExceptionContext> unhandledExceptionDelegate = null)
@@ -78,6 +79,7 @@ namespace GraphQL.Tests
                 root,
                 userContext,
                 cancellationToken,
+                rules,
                 expectedErrorCount,
                 renderErrors,
                 unhandledExceptionDelegate);
@@ -90,6 +92,7 @@ namespace GraphQL.Tests
             object root = null,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
+            IEnumerable<IValidationRule> rules = null,
             int expectedErrorCount = 0,
             bool renderErrors = false,
             Action<UnhandledExceptionContext> unhandledExceptionDelegate = null)
@@ -102,6 +105,7 @@ namespace GraphQL.Tests
                 options.Inputs = inputs;
                 options.UserContext = userContext;
                 options.CancellationToken = cancellationToken;
+                options.ValidationRules = rules;
                 options.UnhandledExceptionDelegate = unhandledExceptionDelegate ?? (ctx => { });
             }).GetAwaiter().GetResult();
 

--- a/src/GraphQL.Tests/TestExtensions.cs
+++ b/src/GraphQL.Tests/TestExtensions.cs
@@ -1,56 +1,19 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GraphQL.Tests
 {
     internal static class TestExtensions
     {
-        public static LightDictionary ToLightDictionary(this object data)
+        public static Dictionary<string, object> ToDict(this object data)
         {
             if (data == null)
-                return LightDictionary.Empty;
+                return new Dictionary<string, object>();
 
             return data is ObjectProperty[] properties
-                ? new LightDictionary(properties)
+                ? properties.ToDictionary(x => x.Key, x => x.Value)
                 : throw new ArgumentException($"Unknown type {data.GetType()}. Parameter must be of type ObjectProperty[].", nameof(data));
-        }
-    }
-
-    /// <summary>
-    /// Lightweight analog for dictionary.
-    /// </summary>
-    internal struct LightDictionary
-    {
-        private readonly ObjectProperty[] _properties;
-
-        public static readonly LightDictionary Empty = new LightDictionary();
-
-        public LightDictionary(ObjectProperty[] properties)
-        {
-            _properties = properties;
-        }
-
-        public int Count => _properties?.Length ?? 0;
-
-        /// <summary>
-        /// Getsa property value by its key (name).
-        /// </summary>
-        /// <param name="key">Property name.</param>
-        /// <returns>Property value if exist.</returns>
-        public object this[string key]
-        {
-            get
-            {
-                if (_properties?.Length > 0)
-                {
-                    foreach (var property in _properties)
-                    {
-                        if (property.Key == key)
-                            return property.Value;
-                    }
-                }
-
-                return null;
-            }
         }
     }
 }

--- a/src/GraphQL.Tests/TestExtensions.cs
+++ b/src/GraphQL.Tests/TestExtensions.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace GraphQL.Tests
+{
+    internal static class TestExtensions
+    {
+        public static LightDictionary ToLightDictionary(this object data)
+        {
+            if (data == null)
+                return LightDictionary.Empty;
+
+            return data is ObjectProperty[] properties
+                ? new LightDictionary(properties)
+                : throw new ArgumentException($"Unknown type {data.GetType()}. Parameter must be of type ObjectProperty[].", nameof(data));
+        }
+    }
+
+    /// <summary>
+    /// Lightweight analog for dictionary.
+    /// </summary>
+    internal struct LightDictionary
+    {
+        private readonly ObjectProperty[] _properties;
+
+        public static readonly LightDictionary Empty = new LightDictionary();
+
+        public LightDictionary(ObjectProperty[] properties)
+        {
+            _properties = properties;
+        }
+
+        public int Count => _properties?.Length ?? 0;
+
+        /// <summary>
+        /// Getsa property value by its key (name).
+        /// </summary>
+        /// <param name="key">Property name.</param>
+        /// <returns>Property value if exist.</returns>
+        public object this[string key]
+        {
+            get
+            {
+                if (_properties?.Length > 0)
+                {
+                    foreach (var property in _properties)
+                    {
+                        if (property.Key == key)
+                            return property.Value;
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
@@ -163,12 +163,12 @@ type User @key(fields: ""id"") {
                 _.Query = query;
             }).GetAwaiter().GetResult();
 
-            var data = (Dictionary<string, object>)executionResult.Data;
-            var schema = (Dictionary<string, object>)data["__schema"];
-            var types = (List<object>)schema["types"];
-            var entityType = (Dictionary<string, object>)types.Single(t => (string)((Dictionary<string, object>)t)["name"] == "_Entity");
-            var possibleTypes = (List<object>)entityType["possibleTypes"];
-            var possibleType = (Dictionary<string, object>)possibleTypes[0];
+            var data = executionResult.Data.ToLightDictionary();
+            var schema = data["__schema"].ToLightDictionary();
+            var types = (object[])schema["types"];
+            var entityType = types.Single(t => (string)t.ToLightDictionary()["name"] == "_Entity").ToLightDictionary();
+            var possibleTypes = (object[])entityType["possibleTypes"];
+            var possibleType = possibleTypes[0].ToLightDictionary();
             var name = (string)possibleType["name"];
 
             Assert.Equal("User", name);

--- a/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
@@ -163,12 +163,12 @@ type User @key(fields: ""id"") {
                 _.Query = query;
             }).GetAwaiter().GetResult();
 
-            var data = executionResult.Data.ToLightDictionary();
-            var schema = data["__schema"].ToLightDictionary();
+            var data = executionResult.Data.ToDict();
+            var schema = data["__schema"].ToDict();
             var types = (object[])schema["types"];
-            var entityType = types.Single(t => (string)t.ToLightDictionary()["name"] == "_Entity").ToLightDictionary();
+            var entityType = types.Single(t => (string)t.ToDict()["name"] == "_Entity").ToDict();
             var possibleTypes = (object[])entityType["possibleTypes"];
-            var possibleType = possibleTypes[0].ToLightDictionary();
+            var possibleType = possibleTypes[0].ToDict();
             var name = (string)possibleType["name"];
 
             Assert.Equal("User", name);

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -145,7 +145,7 @@ namespace GraphQL.Tests.Utilities
 
             result.Errors.ShouldBeNull();
             var data = result.Data.ShouldBeOfType<ObjectProperty[]>();
-            var t = data.ToLightDictionary()["test"].ShouldBeOfType<ObjectProperty[]>().ToLightDictionary();
+            var t = data.ToDict()["test"].ShouldBeOfType<ObjectProperty[]>().ToDict();
             t["id"].ShouldBe("foo");
             t["name"].ShouldBe("bar");
         }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -144,8 +144,8 @@ namespace GraphQL.Tests.Utilities
             }).ConfigureAwait(false);
 
             result.Errors.ShouldBeNull();
-            var data = result.Data.ShouldBeOfType<Dictionary<string, object>>();
-            var t = data["test"].ShouldBeOfType<Dictionary<string, object>>();
+            var data = result.Data.ShouldBeOfType<ObjectProperty[]>();
+            var t = data.ToLightDictionary()["test"].ShouldBeOfType<ObjectProperty[]>().ToLightDictionary();
             t["id"].ShouldBe("foo");
             t["name"].ShouldBe("bar");
         }

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -74,7 +74,9 @@ namespace GraphQL
     /// <summary>
     /// Represents a property of an object as a pair of property name and its value. This struct is used
     /// in order to be able to store properties as arrays, not dictionaries. It allows more efficient use of
-    /// memory from the managed heap for the <see cref="ExecutionResult.Data"/> property.
+    /// memory from the managed heap for the <see cref="ExecutionResult.Data"/> property. The use of array
+    /// of <see cref="ObjectProperty"/> unambiguously indicates the need to convert the array into a json
+    /// object during serialization.
     /// </summary>
     public struct ObjectProperty
     {

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -70,4 +70,33 @@ namespace GraphQL
             Extensions = result.Extensions;
         }
     }
+
+    /// <summary>
+    /// Represents a property of an object as a pair of property name and its value. This struct is used
+    /// in order to be able to store properties as arrays, not dictionaries. It allows more efficient use of
+    /// memory from the managed heap for the <see cref="ExecutionResult.Data"/> property.
+    /// </summary>
+    public struct ObjectProperty
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="ObjectProperty"/>.
+        /// </summary>
+        /// <param name="key">Property key (name).</param>
+        /// <param name="value">Property value.</param>
+        public ObjectProperty(string key, object value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Property key (name).
+        /// </summary>
+        public string Key { get; }
+
+        /// <summary>
+        /// Property value.
+        /// </summary>
+        public object Value { get; }
+    }
 }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -29,7 +29,7 @@ namespace GraphQL.Execution
                 .ConfigureAwait(false);
 
             // After the entire node tree has been executed, get the values
-            var data = rootNode.ToValue();
+            object data = rootNode.ToValue();
 
             return new ExecutionResult
             {
@@ -50,7 +50,7 @@ namespace GraphQL.Execution
         /// <summary>
         /// Builds the root execution node.
         /// </summary>
-        public static RootExecutionNode BuildExecutionRootNode(ExecutionContext context, IObjectGraphType rootType)
+        protected static RootExecutionNode BuildExecutionRootNode(ExecutionContext context, IObjectGraphType rootType)
         {
             var root = new RootExecutionNode(rootType)
             {
@@ -71,7 +71,7 @@ namespace GraphQL.Execution
         /// Creates execution nodes for child fields of an object execution node. Only run if
         /// the object execution node result is not null.
         /// </summary>
-        public static void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent)
+        private static void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent)
         {
             var fields = System.Threading.Interlocked.Exchange(ref context.ReusableFields, null) ?? new Fields();
 
@@ -84,28 +84,25 @@ namespace GraphQL.Execution
         /// <summary>
         /// Creates specified child execution nodes of an object execution node.
         /// </summary>
-        public static void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent, Fields fields)
+        private static void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent, Fields fields)
         {
             var parentType = parent.GetObjectGraphType(context.Schema);
 
-            var subFields = new Dictionary<string, ExecutionNode>(fields.Count);
+            var subFields = new ExecutionNode[fields.Count];
 
+            int i = 0;
             foreach (var kvp in fields)
             {
-                var name = kvp.Key;
                 var field = kvp.Value;
 
                 var fieldDefinition = ExecutionHelper.GetFieldDefinition(context.Schema, parentType, field);
 
                 if (fieldDefinition == null)
-                    continue;
+                    throw new InvalidOperationException($"Schema is not configured correctly to fetch field '{field.Name}' from type '{parentType.Name}'.");
 
                 var node = BuildExecutionNode(parent, fieldDefinition.ResolvedType, field, fieldDefinition);
 
-                if (node == null)
-                    continue;
-
-                subFields[name] = node;
+                subFields[i++] = node;
             }
 
             parent.SubFields = subFields;
@@ -115,7 +112,7 @@ namespace GraphQL.Execution
         /// Creates execution nodes for array elements of an array execution node. Only run if
         /// the array execution node result is not null.
         /// </summary>
-        public static void SetArrayItemNodes(ExecutionContext context, ArrayExecutionNode parent)
+        private static void SetArrayItemNodes(ExecutionContext context, ArrayExecutionNode parent)
         {
             var listType = (ListGraphType)parent.GraphType;
             var itemType = listType.ResolvedType;
@@ -191,7 +188,7 @@ namespace GraphQL.Execution
         /// <summary>
         /// Builds an execution node with the specified parameters.
         /// </summary>
-        public static ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode = null)
+        protected static ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode = null)
         {
             if (graphType is NonNullGraphType nonNullFieldType)
                 graphType = nonNullFieldType.ResolvedType;

--- a/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
@@ -55,7 +55,7 @@ namespace GraphQL.Execution
 
             return items;
         }
- 
+
         IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes() => Items ?? Enumerable.Empty<ExecutionNode>();
 
         /// <inheritdoc/>

--- a/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
@@ -32,9 +32,10 @@ namespace GraphQL.Execution
             if (Items == null)
                 return null;
 
-            var items = new List<object>(Items.Count);
-            foreach (ExecutionNode item in Items)
+            var items = new object[Items.Count];
+            for (int i = 0; i < Items.Count; ++i)
             {
+                var item = Items[i];
                 object value = item.ToValue();
 
                 if (value == null)
@@ -49,12 +50,12 @@ namespace GraphQL.Execution
                     }
                 }
 
-                items.Add(value);
+                items[i] = value;
             }
 
             return items;
         }
-
+ 
         IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes() => Items ?? Enumerable.Empty<ExecutionNode>();
 
         /// <inheritdoc/>

--- a/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
@@ -12,9 +12,9 @@ namespace GraphQL.Execution
     public class ObjectExecutionNode : ExecutionNode, IParentExecutionNode
     {
         /// <summary>
-        /// Returns a dictionary of child execution nodes, with keys set to the names of the child fields that the child nodes represent.
+        /// Returns an array of child execution nodes.
         /// </summary>
-        public Dictionary<string, ExecutionNode> SubFields { get; set; }
+        public ExecutionNode[] SubFields { get; set; }
 
         /// <summary>
         /// Initializes an instance of <see cref="ObjectExecutionNode"/> with the specified values.
@@ -48,25 +48,25 @@ namespace GraphQL.Execution
             if (SubFields == null)
                 return null;
 
-            var fields = new ObjectProperty[SubFields.Count];
+            var fields = new ObjectProperty[SubFields.Length];
 
-            int i = 0;
-            foreach (var kvp in SubFields)
+            for (int i = 0; i < SubFields.Length; ++i)
             {
-                object value = kvp.Value.ToValue();
+                var child = SubFields[i];
+                object value = child.ToValue();
 
-                if (value == null && kvp.Value.FieldDefinition.ResolvedType is NonNullGraphType)
+                if (value == null && child.FieldDefinition.ResolvedType is NonNullGraphType)
                 {
                     return null;
                 }
 
-                fields[i++] = new ObjectProperty(kvp.Key, value);
+                fields[i] = new ObjectProperty(child.Name, value);
             }
 
             return fields;
         }
 
-        IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes() => SubFields?.Values ?? Enumerable.Empty<ExecutionNode>();
+        IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes() => SubFields ?? Enumerable.Empty<ExecutionNode>();
 
         /// <inheritdoc/>
         public void ApplyToChildren<TState>(Action<ExecutionNode, TState> action, TState state, bool reverse = false)
@@ -75,13 +75,13 @@ namespace GraphQL.Execution
             {
                 if (reverse)
                 {
-                    foreach (var item in SubFields.Reverse()) //TODO: write custom enumerator for reverse
-                        action(item.Value, state);
+                    for (int i = SubFields.Length - 1; i >= 0; --i)
+                        action(SubFields[i], state);
                 }
                 else
                 {
                     foreach (var item in SubFields)
-                        action(item.Value, state);
+                        action(item, state);
                 }
             }
         }

--- a/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
@@ -48,8 +48,9 @@ namespace GraphQL.Execution
             if (SubFields == null)
                 return null;
 
-            var fields = new Dictionary<string, object>(SubFields.Count);
+            var fields = new ObjectProperty[SubFields.Count];
 
+            int i = 0;
             foreach (var kvp in SubFields)
             {
                 object value = kvp.Value.ToValue();
@@ -59,7 +60,7 @@ namespace GraphQL.Execution
                     return null;
                 }
 
-                fields[kvp.Key] = value;
+                fields[i++] = new ObjectProperty(kvp.Key, value);
             }
 
             return fields;


### PR DESCRIPTION
NOTE: `ExecutionResult.Data` format breaking changes. Both serializers received the necessary changes to produce the same JSON as before. However, consumers using `ExecutionResult` instances directly will fail.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.14393.3986 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
Frequency=3515611 Hz, Resolution=284.4456 ns, Timer=TSC
.NET Core SDK=5.0.102
  [Host]     : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  DefaultJob : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT


```
develop -> 2cca930
|Method|Stage|Mean [base]|Mean [current]|Mean [% of base]|Allocated [base]|Allocated [current]|Allocated [% of base]|
|---|---|--:|--:|--:|--:|--:|--:|
|Introspection|Build|337,232.999 ns|329,409.298 ns|<span style="color:green">97</span>|96537 B|96512 B|<span style="color:green">99</span>|
|Introspection|Parse|20,686.241 ns|20,023.551 ns|<span style="color:green">96</span>|11920 B|11920 B|100|
|Introspection|Convert|11,329.900 ns|10,605.794 ns|<span style="color:green">93</span>|16552 B|16552 B|100|
|Introspection|Validate|204,554.089 ns|197,981.562 ns|<span style="color:green">96</span>|11104 B|11104 B|100|
|Introspection|DeserializeVars|1.864 ns|1.529 ns|<span style="color:green">82</span>|-|-|-|
|Introspection|ParseVariables|3.492 ns|3.302 ns|<span style="color:green">94</span>|-|-|-|
|Introspection|Execute|816,292.325 ns|745,128.630 ns|<span style="color:green">91</span>|322360 B|268887 B|<span style="color:green">83</span>|
|Introspection|Serialize|125,617.871 ns|120,827.945 ns|<span style="color:green">96</span>|27880 B|27880 B|100|
|||||||||
|Hero|Build|329,336.219 ns|319,597.950 ns|<span style="color:green">97</span>|96478 B|96512 B|100|
|Hero|Parse|983.678 ns|915.302 ns|<span style="color:green">93</span>|784 B|784 B|100|
|Hero|Convert|573.219 ns|533.714 ns|<span style="color:green">93</span>|1056 B|1056 B|100|
|Hero|Validate|12,885.186 ns|12,276.021 ns|<span style="color:green">95</span>|2464 B|2464 B|100|
|Hero|DeserializeVars|1.854 ns|1.794 ns|<span style="color:green">96</span>|-|-|-|
|Hero|ParseVariables|3.392 ns|3.450 ns|<span style="color:red">101</span>|-|-|-|
|Hero|Execute|2,583.273 ns|2,237.417 ns|<span style="color:green">86</span>|2264 B|1944 B|<span style="color:green">85</span>|
|Hero|Serialize|627.634 ns|597.467 ns|<span style="color:green">95</span>|504 B|504 B|100|
|||||||||
|Variables|Build|232,067.626 ns|218,214.758 ns|<span style="color:green">94</span>|65489 B|65524 B|100|
|Variables|Parse|1,827.924 ns|1,755.925 ns|<span style="color:green">96</span>|1008 B|1008 B|100|
|Variables|Convert|638.078 ns|598.966 ns|<span style="color:green">93</span>|1208 B|1208 B|100|
|Variables|Validate|23,736.276 ns|22,611.561 ns|<span style="color:green">95</span>|7705 B|7705 B|100|
|Variables|DeserializeVars|12,122.854 ns|10,753.568 ns|<span style="color:green">88</span>|8288 B|8288 B|100|
|Variables|ParseVariables|38,505.299 ns|34,291.993 ns|<span style="color:green">89</span>|13020 B|13020 B|100|
|Variables|Execute|3,674.601 ns|3,030.702 ns|<span style="color:green">82</span>|2025 B|1856 B|<span style="color:green">91</span>|
|Variables|Serialize|473.287 ns|454.584 ns|<span style="color:green">96</span>|504 B|504 B|100|
|||||||||
|Literal|Build|242,996.873 ns|217,030.702 ns|<span style="color:green">89</span>|65489 B|65583 B|100|
|Literal|Parse|23,324.517 ns|21,407.628 ns|<span style="color:green">91</span>|9016 B|9016 B|100|
|Literal|Convert|9,631.910 ns|8,551.997 ns|<span style="color:green">88</span>|12768 B|12768 B|100|
|Literal|Validate|170,517.856 ns|154,582.980 ns|<span style="color:green">90</span>|27200 B|27200 B|100|
|Literal|DeserializeVars|1.912 ns|1.521 ns|<span style="color:green">79</span>|-|-|-|
|Literal|ParseVariables|3.550 ns|3.575 ns|100|-|-|-|
|Literal|Execute|37,462.084 ns|32,904.648 ns|<span style="color:green">87</span>|13134 B|12966 B|<span style="color:green">98</span>|
|Literal|Serialize|494.283 ns|451.328 ns|<span style="color:green">91</span>|504 B|504 B|100|

2cca930 -> 9120557

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.14393.3986 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
Frequency=3515611 Hz, Resolution=284.4456 ns, Timer=TSC
.NET Core SDK=5.0.102
  [Host]     : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  DefaultJob : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT


```
|Method|Stage|Mean [base]|Mean [current]|Mean [% of base]|Allocated [base]|Allocated [current]|Allocated [% of base]|
|---|---|--:|--:|--:|--:|--:|--:|
|Introspection|Build|329,409.298 ns|317,720.646 ns|<span style="color:green">96</span>|96512 B|96516 B|100|
|Introspection|Parse|20,023.551 ns|19,646.200 ns|<span style="color:green">98</span>|11920 B|11920 B|100|
|Introspection|Convert|10,605.794 ns|10,606.806 ns|100|16552 B|16552 B|100|
|Introspection|Validate|197,981.562 ns|198,555.999 ns|100|11104 B|11104 B|100|
|Introspection|DeserializeVars|1.529 ns|2.035 ns|<span style="color:red">133</span>|-|-|-|
|Introspection|ParseVariables|3.302 ns|3.413 ns|<span style="color:red">103</span>|-|-|-|
|Introspection|Execute|745,128.630 ns|666,944.045 ns|<span style="color:green">89</span>|268887 B|207372 B|<span style="color:green">77</span>|
|Introspection|Serialize|120,827.945 ns|122,434.858 ns|<span style="color:red">101</span>|27880 B|27882 B|100|
|||||||||
|Hero|Build|319,597.950 ns|316,760.575 ns|<span style="color:green">99</span>|96512 B|96511 B|<span style="color:green">99</span>|
|Hero|Parse|915.302 ns|943.600 ns|<span style="color:red">103</span>|784 B|784 B|100|
|Hero|Convert|533.714 ns|551.079 ns|<span style="color:red">103</span>|1056 B|1056 B|100|
|Hero|Validate|12,276.021 ns|12,366.352 ns|100|2464 B|2464 B|100|
|Hero|DeserializeVars|1.794 ns|2.058 ns|<span style="color:red">114</span>|-|-|-|
|Hero|ParseVariables|3.450 ns|4.101 ns|<span style="color:red">118</span>|-|-|-|
|Hero|Execute|2,237.417 ns|2,035.015 ns|<span style="color:green">90</span>|1944 B|1600 B|<span style="color:green">82</span>|
|Hero|Serialize|597.467 ns|596.666 ns|<span style="color:green">99</span>|504 B|504 B|100|
|||||||||
|Variables|Build|218,214.758 ns|220,108.784 ns|100|65524 B|65524 B|100|
|Variables|Parse|1,755.925 ns|1,750.772 ns|<span style="color:green">99</span>|1008 B|1008 B|100|
|Variables|Convert|598.966 ns|598.362 ns|<span style="color:green">99</span>|1208 B|1208 B|100|
|Variables|Validate|22,611.561 ns|22,040.799 ns|<span style="color:green">97</span>|7705 B|7705 B|100|
|Variables|DeserializeVars|10,753.568 ns|10,790.941 ns|100|8288 B|8288 B|100|
|Variables|ParseVariables|34,291.993 ns|35,332.701 ns|<span style="color:red">103</span>|13020 B|13020 B|100|
|Variables|Execute|3,030.702 ns|3,066.137 ns|<span style="color:red">101</span>|1856 B|1680 B|<span style="color:green">90</span>|
|Variables|Serialize|454.584 ns|448.769 ns|<span style="color:green">98</span>|504 B|504 B|100|
|||||||||
|Literal|Build|217,030.702 ns|218,577.037 ns|100|65583 B|65489 B|<span style="color:green">99</span>|
|Literal|Parse|21,407.628 ns|21,451.090 ns|100|9016 B|9016 B|100|
|Literal|Convert|8,551.997 ns|8,639.705 ns|<span style="color:red">101</span>|12768 B|12768 B|100|
|Literal|Validate|154,582.980 ns|148,614.249 ns|<span style="color:green">96</span>|27200 B|27202 B|100|
|Literal|DeserializeVars|1.521 ns|1.749 ns|<span style="color:red">114</span>|-|-|-|
|Literal|ParseVariables|3.575 ns|3.636 ns|<span style="color:red">101</span>|-|-|-|
|Literal|Execute|32,904.648 ns|33,640.475 ns|<span style="color:red">102</span>|12966 B|12790 B|<span style="color:green">98</span>|
|Literal|Serialize|451.328 ns|436.704 ns|<span style="color:green">96</span>|504 B|504 B|100|

So, after two commits we can see 64 % of base for introspection query.