### PR TITLE
Remove ExecutionNode.IsResultSet and memory for Source

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -96,3 +96,5 @@
 * `ISchema.FindDirective`, `ISchema.RegisterDirective`, `ISchema.RegisterDirectives` methods were moved into `SchemaDirectives` class
 * `ISchema.FindType` method was moved into `SchemaTypes[string typeName]` indexer
 * Some of the `ISchemaNodeVisitor` methods have been changes to better support schema traversal
+* `ExecutionNode.IsResultSet` has been removed
+* `ExecutionNode.Source` is read-only; additional derived classes have been added for subscriptions

--- a/src/GraphQL.ApiTests/GraphQL.SystemReactive.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.SystemReactive.approved.txt
@@ -4,6 +4,7 @@ namespace GraphQL.Execution
     {
         public SubscriptionExecutionStrategy() { }
         public static GraphQL.Execution.SubscriptionExecutionStrategy Instance { get; }
+        protected GraphQL.Execution.ExecutionNode BuildSubscriptionExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode, object source) { }
         public override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.Execution.ExecutionContext context) { }
         protected virtual System.Threading.Tasks.Task<System.IObservable<GraphQL.ExecutionResult>> ResolveEventStreamAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
     }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -742,13 +742,12 @@ namespace GraphQL.Execution
         public GraphQL.Types.FieldType FieldDefinition { get; }
         public GraphQL.Types.IGraphType GraphType { get; }
         public int? IndexInParentNode { get; }
-        public bool IsResultSet { get; }
         public string Name { get; }
         public GraphQL.Execution.ExecutionNode Parent { get; }
         public System.Collections.Generic.IEnumerable<object> Path { get; }
         public System.Collections.Generic.IEnumerable<object> ResponsePath { get; }
         public object Result { get; set; }
-        public object Source { get; set; }
+        public virtual object Source { get; }
         public GraphQL.Types.IObjectGraphType GetParentType(GraphQL.Types.ISchema schema) { }
         public abstract object ToValue();
     }
@@ -766,6 +765,7 @@ namespace GraphQL.Execution
         protected void SetNodeError(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, GraphQL.ExecutionError error) { }
         protected virtual void ValidateNodeResult(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
         public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode = default) { }
+        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode, object source) { }
         public static GraphQL.Execution.RootExecutionNode BuildExecutionRootNode(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IObjectGraphType rootType) { }
         public static void SetArrayItemNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ArrayExecutionNode parent) { }
         public static void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent) { }
@@ -875,6 +875,21 @@ namespace GraphQL.Execution
         public SerialExecutionStrategy() { }
         public static GraphQL.Execution.SerialExecutionStrategy Instance { get; }
         protected override System.Threading.Tasks.Task ExecuteNodeTreeAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode rootNode) { }
+    }
+    public class SubscriptionArrayExecutionNode : GraphQL.Execution.ArrayExecutionNode
+    {
+        public SubscriptionArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode, object source) { }
+        public override object Source { get; }
+    }
+    public class SubscriptionObjectExecutionNode : GraphQL.Execution.ObjectExecutionNode
+    {
+        public SubscriptionObjectExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode, object source) { }
+        public override object Source { get; }
+    }
+    public class SubscriptionValueExecutionNode : GraphQL.Execution.ValueExecutionNode
+    {
+        public SubscriptionValueExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.ScalarGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode, object source) { }
+        public override object Source { get; }
     }
     [System.Serializable]
     public class SyntaxError : GraphQL.Execution.DocumentError

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -771,7 +771,6 @@ namespace GraphQL.Execution
         protected void SetNodeError(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, GraphQL.ExecutionError error) { }
         protected virtual void ValidateNodeResult(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
         protected static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode = default) { }
-        public static GraphQL.Execution.ExecutionNode BuildExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQL.Language.AST.Field field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode, object source) { }
         protected static GraphQL.Execution.RootExecutionNode BuildExecutionRootNode(GraphQL.Execution.ExecutionContext context, GraphQL.Types.IObjectGraphType rootType) { }
     }
     public class GraphQLDocumentBuilder : GraphQL.Execution.IDocumentBuilder

--- a/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
@@ -105,8 +105,7 @@ namespace GraphQL.Execution
                 return subscription
                     .Select(value =>
                     {
-                        var executionNode = BuildSubscriptionExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode, value);
-                        return executionNode;
+                        return BuildSubscriptionExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode, value);
                     })
                     .SelectMany(async executionNode =>
                     {

--- a/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
@@ -105,7 +105,7 @@ namespace GraphQL.Execution
                 return subscription
                     .Select(value =>
                     {
-                        var executionNode = BuildExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode, value);
+                        var executionNode = BuildSubscriptionExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode, value);
                         return executionNode;
                     })
                     .SelectMany(async executionNode =>
@@ -157,6 +157,24 @@ namespace GraphQL.Execution
                 context.Errors.Add(error);
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Builds an execution node with the specified parameters.
+        /// </summary>
+        protected ExecutionNode BuildSubscriptionExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode, object source)
+        {
+            if (graphType is NonNullGraphType nonNullFieldType)
+                graphType = nonNullFieldType.ResolvedType;
+
+            return graphType switch
+            {
+                ListGraphType _ => new SubscriptionArrayExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
+                IObjectGraphType _ => new SubscriptionObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
+                IAbstractGraphType _ => new SubscriptionObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
+                ScalarGraphType scalarGraphType => new SubscriptionValueExecutionNode(parent, scalarGraphType, field, fieldDefinition, indexInParentNode, source),
+                _ => throw new InvalidOperationException($"Unexpected type: {graphType}")
+            };
         }
 
         private ExecutionError GenerateError(

--- a/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
@@ -108,8 +108,7 @@ namespace GraphQL.Execution
                 return subscription
                     .Select(value =>
                     {
-                        var executionNode = BuildExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode);
-                        executionNode.Source = value;
+                        var executionNode = BuildExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode, value);
                         return executionNode;
                     })
                     .SelectMany(async executionNode =>

--- a/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
@@ -103,10 +103,7 @@ namespace GraphQL.Execution
                 }
 
                 return subscription
-                    .Select(value =>
-                    {
-                        return BuildSubscriptionExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode, value);
-                    })
+                    .Select(value => BuildSubscriptionExecutionNode(node.Parent, node.GraphType, node.Field, node.FieldDefinition, node.IndexInParentNode, value))
                     .SelectMany(async executionNode =>
                     {
                         if (context.Listeners != null)

--- a/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionNodeTests.cs
@@ -23,7 +23,6 @@ namespace GraphQL.Tests.Execution
             root.GetParentType(null).ShouldBeNull();
             root.GraphType.ShouldBe(type);
             root.IndexInParentNode.ShouldBeNull();
-            root.IsResultSet.ShouldBeFalse();
             root.Name.ShouldBeNull();
             root.Parent.ShouldBeNull();
             root.Path.ToArray().Length.ShouldBe(0);

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -211,6 +211,7 @@ namespace GraphQL.Execution
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
+            // these are the only conditions upon which a node has already been executed when this method is called
             if (node is RootExecutionNode || node.Parent is ArrayExecutionNode)
                 return;
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -207,6 +207,24 @@ namespace GraphQL.Execution
         }
 
         /// <summary>
+        /// Builds an execution node with the specified parameters.
+        /// </summary>
+        public static ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode, object source)
+        {
+            if (graphType is NonNullGraphType nonNullFieldType)
+                graphType = nonNullFieldType.ResolvedType;
+
+            return graphType switch
+            {
+                ListGraphType _ => new SubscriptionArrayExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
+                IObjectGraphType _ => new SubscriptionObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
+                IAbstractGraphType _ => new SubscriptionObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
+                ScalarGraphType scalarGraphType => new SubscriptionValueExecutionNode(parent, scalarGraphType, field, fieldDefinition, indexInParentNode, source),
+                _ => throw new InvalidOperationException($"Unexpected type: {graphType}")
+            };
+        }
+
+        /// <summary>
         /// Executes a single node. If the node does not return an <see cref="IDataLoaderResult"/>,
         /// it will pass execution to <see cref="CompleteNode(ExecutionContext, ExecutionNode)"/>.
         /// </summary>
@@ -214,7 +232,7 @@ namespace GraphQL.Execution
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
-            if (node.IsResultSet)
+            if (node is RootExecutionNode || node.Parent is ArrayExecutionNode)
                 return;
 
             try
@@ -262,8 +280,6 @@ namespace GraphQL.Execution
         /// </summary>
         protected virtual async Task CompleteDataLoaderNodeAsync(ExecutionContext context, ExecutionNode node)
         {
-            if (!node.IsResultSet)
-                throw new InvalidOperationException("This execution node has not yet been executed");
             if (!(node.Result is IDataLoaderResult dataLoaderResult))
                 throw new InvalidOperationException("This execution node is not pending completion");
 
@@ -298,9 +314,6 @@ namespace GraphQL.Execution
         /// </summary>
         protected virtual void CompleteNode(ExecutionContext context, ExecutionNode node)
         {
-            if (!node.IsResultSet)
-                throw new InvalidOperationException("This execution node has not yet been executed");
-
             try
             {
                 ValidateNodeResult(context, node);

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -204,24 +204,6 @@ namespace GraphQL.Execution
         }
 
         /// <summary>
-        /// Builds an execution node with the specified parameters.
-        /// </summary>
-        public static ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode, object source)
-        {
-            if (graphType is NonNullGraphType nonNullFieldType)
-                graphType = nonNullFieldType.ResolvedType;
-
-            return graphType switch
-            {
-                ListGraphType _ => new SubscriptionArrayExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
-                IObjectGraphType _ => new SubscriptionObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
-                IAbstractGraphType _ => new SubscriptionObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode, source),
-                ScalarGraphType scalarGraphType => new SubscriptionValueExecutionNode(parent, scalarGraphType, field, fieldDefinition, indexInParentNode, source),
-                _ => throw new InvalidOperationException($"Unexpected type: {graphType}")
-            };
-        }
-
-        /// <summary>
         /// Executes a single node. If the node does not return an <see cref="IDataLoaderResult"/>,
         /// it will pass execution to <see cref="CompleteNode(ExecutionContext, ExecutionNode)"/>.
         /// </summary>

--- a/src/GraphQL/Execution/Nodes/ExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ExecutionNode.cs
@@ -69,7 +69,7 @@ namespace GraphQL.Execution
         public object Result { get; set; }
 
         /// <summary>
-        /// Returns the parent node's result. If set, the set value will override the parent node's result.
+        /// Returns the parent node's result.
         /// </summary>
         public virtual object Source => Parent?.Result;
 

--- a/src/GraphQL/Execution/Nodes/ExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ExecutionNode.cs
@@ -63,35 +63,15 @@ namespace GraphQL.Execution
         public string Name => Field?.Alias ?? Field?.Name;
 
         /// <summary>
-        /// Returns true if the result has been set. Also returns true when the result is temporarily set to an <see cref="IDataLoaderResult"/>
-        /// pending execution at a later time.
-        /// </summary>
-        public bool IsResultSet { get; private set; }
-
-        private object _result;
-        /// <summary>
         /// Sets or returns the result of the execution node. May return a <see cref="IDataLoaderResult"/> if a node returns a data loader
         /// result that has not yet finished executing.
         /// </summary>
-        public object Result
-        {
-            get => _result;
-            set
-            {
-                IsResultSet = true;
-                _result = value;
-            }
-        }
+        public object Result { get; set; }
 
-        private object _source;
         /// <summary>
         /// Returns the parent node's result. If set, the set value will override the parent node's result.
         /// </summary>
-        public object Source
-        {
-            get => _source ?? Parent?.Result;
-            set => _source = value;
-        }
+        public virtual object Source => Parent?.Result;
 
         /// <summary>
         /// Initializes an instance of <see cref="ExecutionNode"/> with the specified values
@@ -125,7 +105,7 @@ namespace GraphQL.Execution
             if (parentType is IObjectGraphType objectType)
                 return objectType;
 
-            if (parentType is IAbstractGraphType abstractType && Parent.IsResultSet)
+            if (parentType is IAbstractGraphType abstractType)
                 return abstractType.GetObjectType(Parent.Result, schema);
 
             return null;

--- a/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
@@ -33,7 +33,7 @@ namespace GraphQL.Execution
         {
             var objectGraphType = GraphType as IObjectGraphType;
 
-            if (GraphType is IAbstractGraphType abstractGraphType && IsResultSet)
+            if (GraphType is IAbstractGraphType abstractGraphType)
                 objectGraphType = abstractGraphType.GetObjectType(Result, schema);
 
             return objectGraphType;

--- a/src/GraphQL/Execution/Nodes/SubscriptionArrayExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionArrayExecutionNode.cs
@@ -1,0 +1,21 @@
+using GraphQL.Language.AST;
+using GraphQL.Types;
+
+namespace GraphQL.Execution
+{
+    /// <inheritdoc/>
+    public class SubscriptionArrayExecutionNode : ArrayExecutionNode
+    {
+        /// <summary>
+        /// Initializes an <see cref="SubscriptionArrayExecutionNode"/> instance with the specified values.
+        /// </summary>
+        public SubscriptionArrayExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode, object source)
+            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+        {
+            Source = source;
+        }
+
+        /// <inheritdoc/>
+        public override object Source { get; }
+    }
+}

--- a/src/GraphQL/Execution/Nodes/SubscriptionObjectExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionObjectExecutionNode.cs
@@ -1,0 +1,21 @@
+using GraphQL.Language.AST;
+using GraphQL.Types;
+
+namespace GraphQL.Execution
+{
+    /// <inheritdoc/>
+    public class SubscriptionObjectExecutionNode : ObjectExecutionNode
+    {
+        /// <summary>
+        /// Initializes an instance of <see cref="SubscriptionObjectExecutionNode"/> with the specified values.
+        /// </summary>
+        public SubscriptionObjectExecutionNode(ExecutionNode parent, IGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode, object source)
+            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+        {
+            Source = source;
+        }
+
+        /// <inheritdoc/>
+        public override object Source { get; }
+    }
+}

--- a/src/GraphQL/Execution/Nodes/SubscriptionValueExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionValueExecutionNode.cs
@@ -1,0 +1,21 @@
+using GraphQL.Language.AST;
+using GraphQL.Types;
+
+namespace GraphQL.Execution
+{
+    /// <inheritdoc/>
+    public class SubscriptionValueExecutionNode : ValueExecutionNode
+    {
+        /// <summary>
+        /// Initializes an <see cref="SubscriptionValueExecutionNode"/> instance with the specified values.
+        /// </summary>
+        public SubscriptionValueExecutionNode(ExecutionNode parent, ScalarGraphType graphType, Field field, FieldType fieldDefinition, int? indexInParentNode, object source)
+            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+        {
+            Source = source;
+        }
+
+        /// <inheritdoc/>
+        public override object Source { get; }
+    }
+}


### PR DESCRIPTION
Should provide 16 bytes of savings for every instance of ExecutionNode, including ValueExecutionNode instances.  Have not yet run benchmarks

### Concept

* `Source` is only set during subscription execution.  It is left `null` for any other execution.  To reduce memory, `_source` has been removed from `ExecutionNode` along with the setter, and for subscriptions, another class is used that overrides the source property.
* `IsResultSet` is unnecessary, since the execution strategy almost always is required to process nodes like this: 1. create node 2. execute node 3. execute data loader, if any.   The only exception is that root nodes are not executed, and children of array nodes are not executed.  A simple type check (`node is RootExecutionNode` or `node.Parent is ArrayExecutionNode`) can determine this and skip execution.  Step 3 (execute data loader, if any) does not use `IsResultSet` but simply performs a type check on the result (`result is IDataLoaderResult`).  So, `IsResultSet` is unnecessary.  In order to verify this concept, I added `if (!IsResultSet) throw new Exception();` code to all the locations where `IsResultSet` was accessed, ran all the tests, and none of the exceptions were triggered.
* These two properties consumes 9 bytes on a 64-bit machine, and probably saves 16 bytes due to alignment.
* As `ValueExecutionNode` is one of the most memory-consuming objects overall during execution (per #2237), this represents a significant savings during execution.
