### PR TITLE
Add format column, fix GraphQL.NET naming

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Usage question or discussion about GraphQL .NET.
+about: Usage question or discussion about GraphQL.NET.
 ---
 
 <!--
@@ -9,7 +9,7 @@ about: Usage question or discussion about GraphQL .NET.
   Useful Links:
   - Documentation: https://graphql-dotnet.github.io/
 
-  GraphQL .NET has community support channels, try asking your question on:
+  GraphQL.NET has community support channels, try asking your question on:
 
   - Gitter: https://gitter.im/graphql-dotnet/graphql-dotnet
   - Stack Overflow: https://stackoverflow.com/questions/tagged/graphql-dotnet

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ It supports the popular IDEs for managing GraphQL requests and exploring GraphQL
 
 ## Training
 
-* [API Development in .NET with GraphQL](https://www.lynda.com/NET-tutorials/API-Development-NET-GraphQL/664823-2.html) - [Glenn Block](https://twitter.com/gblock) demonstrates how to use the GraphQL .NET framework to build a fully functional GraphQL endpoint.
+* [API Development in .NET with GraphQL](https://www.lynda.com/NET-tutorials/API-Development-NET-GraphQL/664823-2.html) - [Glenn Block](https://twitter.com/gblock) demonstrates how to use the GraphQL.NET framework to build a fully functional GraphQL endpoint.
 * [Building GraphQL APIs with ASP.NET Core](https://app.pluralsight.com/library/courses/building-graphql-apis-aspdotnet-core/table-of-contents) by [Roland Guijt](https://github.com/RolandGuijt)
 
 ## Upgrade Guides

--- a/docs2/site/docs/getting-started/dependency-injection.md
+++ b/docs2/site/docs/getting-started/dependency-injection.md
@@ -1,6 +1,6 @@
 # Dependency Injection
 
-GraphQL .NET supports dependency injection through a `IServiceProvider` interface that is passed to the Schema class. Internally when trying to resolve a type the library will call the methods on this interface.
+GraphQL.NET supports dependency injection through a `IServiceProvider` interface that is passed to the Schema class. Internally when trying to resolve a type the library will call the methods on this interface.
 
 > The library resolves a `GraphType` only once and caches that type for the lifetime of the `Schema`.
 

--- a/docs2/site/docs/getting-started/introduction.md
+++ b/docs2/site/docs/getting-started/introduction.md
@@ -6,7 +6,7 @@
 
 > A GraphQL service is created by defining types and fields on those types, then providing functions for each field on each type.
 
-Here is a "Hello World" example for GraphQL .NET using the System.Text.Json serialization engine.
+Here is a "Hello World" example for GraphQL.NET using the System.Text.Json serialization engine.
 
 ```csharp
 using System;

--- a/docs2/site/docs/getting-started/relay.md
+++ b/docs2/site/docs/getting-started/relay.md
@@ -1,7 +1,7 @@
 # Relay
 
 The core project provides a few classes to help implement Facebook's [Relay](https://facebook.github.io/relay/).
-You can find more types and helpers in the [GraphQL .NET Relay project](https://github.com/graphql-dotnet/relay).
+You can find more types and helpers in the [GraphQL.NET Relay project](https://github.com/graphql-dotnet/relay).
 Also see the specification for the GraphQL "Connections" pattern [here](https://relay.dev/graphql/connections.htm).
 
 Example needed...

--- a/docs2/site/docs/getting-started/schema-types.md
+++ b/docs2/site/docs/getting-started/schema-types.md
@@ -6,9 +6,9 @@ A GraphQL object type has a name and fields, but at some point those fields have
 
 These are the scalars provided by the [GraphQL Specification](https://graphql.github.io/graphql-spec/June2018/#sec-Scalars).
 
-| GraphQL     | GraphQL .NET        | .NET                    |
-|-------------|---------------------|-------------------------|
-| `String`    | `StringGraphType`   | `string`                |
+| GraphQL | GraphQL.NET        | .NET                    |
+|----------|---------------------|-------------------------|
+| `String`   | `StringGraphType`   | `string`                |
 | `Int`       | `IntGraphType`      | `int`                   |
 | `Float`     | `FloatGraphType`    | `double`                |
 | `Boolean`   | `BooleanGraphType`  | `bool`                  |
@@ -18,28 +18,28 @@ These are the scalars provided by the [GraphQL Specification](https://graphql.gi
 
 These are additional scalars provided by this project.
 
-| GraphQL          | GraphQL .NET                    | .NET               |
-|------------------|---------------------------------|--------------------|
-| `Date`           | `DateGraphType`                 | `DateTime`         |
-| `DateTime`       | `DateTimeGraphType`             | `DateTime`         |
-| `DateTimeOffset` | `DateTimeOffsetGraphType`       | `DateTimeOffset`   |
-| `Seconds`        | `TimeSpanSecondsGraphType`      | `TimeSpan`         |
-| `Milliseconds`   | `TimeSpanMillisecondsGraphType` | `TimeSpan`         |
-| `Decimal` | `DecimalGraphType` | `decimal` |
-| `Uri` | `UriGraphType` | `Uri` |
-| `Guid` | `GuidGraphType` | `Guid` |
-| `Short` | `ShortGraphType` | `short` |
-| `UShort` | `UShortGraphType` | `ushort` |
-| `UInt` | `UIntGraphType` | `uint` |
-| `Long` | `LongGraphType` | `long` |
-| `ULong` | `ULongGraphType` | `ulong` |
-| `Byte` | `ByteGraphType` | `byte` |
-| `SByte` | `SByteGraphType` | `sbyte`
-| `BigInt` | `BigIntGraphType` | `BigInteger`
+| GraphQL          | GraphQL.NET                    | .NET               | Format |
+|------------------|---------------------------------|--------------------|-------|
+| `Date`           | `DateGraphType`                 | `DateTime`         | ISO-8601: yyyy-MM-dd |
+| `DateTime`       | `DateTimeGraphType`             | `DateTime`         | ISO-8601, assume UTC |
+| `DateTimeOffset` | `DateTimeOffsetGraphType`       | `DateTimeOffset`   | ISO-8601 |
+| `Seconds`        | `TimeSpanSecondsGraphType`      | `TimeSpan`         | number |
+| `Milliseconds`   | `TimeSpanMillisecondsGraphType` | `TimeSpan`         | number |
+| `Decimal` | `DecimalGraphType` | `decimal` | number |
+| `Uri` | `UriGraphType` | `Uri` | RFC 2396/2732/3986/3987 |
+| `Guid` | `GuidGraphType` | `Guid` | string |
+| `Short` | `ShortGraphType` | `short` | number |
+| `UShort` | `UShortGraphType` | `ushort` | number |
+| `UInt` | `UIntGraphType` | `uint` | number |
+| `Long` | `LongGraphType` | `long` | number |
+| `ULong` | `ULongGraphType` | `ulong` | number |
+| `Byte` | `ByteGraphType` | `byte` | number |
+| `SByte` | `SByteGraphType` | `sbyte` | number |
+| `BigInt` | `BigIntGraphType` | `BigInteger` | number |
 
 Lists of data are also supported with any Scalar or Object types.
 
-| GraphQL    | GraphQL .NET                        | .NET           |
+| GraphQL    | GraphQL.NET                        | .NET           |
 | -----------|-------------------------------------|----------------|
 | `[String]` | `ListGraphType<StringGraphType>`    | `List<string>` |
 | `[Boolean]` | `ListGraphType<BooleanGraphType>`    | `List<bool>` |
@@ -57,7 +57,7 @@ type Droid {
 }
 ```
 
-**GraphQL .NET**
+**GraphQL.NET**
 
 ```csharp
 public class DroidType : ObjectGraphType<Droid>
@@ -113,7 +113,7 @@ public enum Episodes
 
 Compare the two implementations. GraphQL does not specify backing values for members of its enums. The name of each member _is_ the value.
 
-**GraphQL .NET**
+**GraphQL.NET**
 
 GraphQL.NET provides two methods of defining GraphQL enums.
 

--- a/docs2/site/docs/guides/dataloader.md
+++ b/docs2/site/docs/guides/dataloader.md
@@ -1,6 +1,6 @@
 # DataLoader
 
-GraphQL .NET includes an implementation of Facebook's [DataLoader](https://github.com/facebook/dataloader).
+GraphQL.NET includes an implementation of Facebook's [DataLoader](https://github.com/facebook/dataloader).
 
 Consider a GraphQL query like this:
 

--- a/docs2/site/docs/guides/links.md
+++ b/docs2/site/docs/guides/links.md
@@ -1,6 +1,6 @@
 # Links
 
-* [API Development in .NET with GraphQL](https://www.lynda.com/NET-tutorials/API-Development-NET-GraphQL/664823-2.html) by [Glenn Block](https://twitter.com/gblock) - demonstrates how to use the GraphQL .NET framework to build a fully functional GraphQL endpoint.
+* [API Development in .NET with GraphQL](https://www.lynda.com/NET-tutorials/API-Development-NET-GraphQL/664823-2.html) by [Glenn Block](https://twitter.com/gblock) - demonstrates how to use the GraphQL.NET framework to build a fully functional GraphQL endpoint.
 * [ASP.NET Core GraphQL Boxed Project Template](https://github.com/Dotnet-Boxed/Templates/blob/master/Docs/GraphQL.md) - A fully featured GraphQL server project template with lots of optional features built on top of ASP.NET Core.
 * [GraphQL with .NET Core (11 Part Blog Series)](https://fiyazhasan.me/tag/graphql/) by [Fiyaz Hasan](https://github.com/fiyazbinhasan)
 * [Implementing pagination with GraphQL.NET and Relay](http://corstianboerman.com/2019-03-08/implementing-pagination-with-graphql-net-and-relay.html) by [Corstian Boerman](https://twitter.com/corstianboerman) - Article describing the details of implementing cursor based pagination (against SQL Server) and exposing this through connections in GraphQL.

--- a/docs2/site/docs/guides/schema-generation.md
+++ b/docs2/site/docs/guides/schema-generation.md
@@ -1,6 +1,6 @@
 ## Schema Generation
 
-Here are a few community projects built with GraphQL .NET which can generate a Schema based off of C# classes.
+Here are a few community projects built with GraphQL.NET which can generate a Schema based off of C# classes.
 
 * [GraphQL Conventions](https://github.com/graphql-dotnet/conventions) by [Tommy Lillehagen](https://github.com/tlil87)
 * [GraphQL Annotations](https://github.com/dlukez/graphql-dotnet-annotations) by [Daniel Zimmermann](https://github.com/dlukez)

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -1,4 +1,4 @@
-- title: GraphQL .NET
+- title: GraphQL.NET
   dir: ./
   url: /
   file: pages/landing.js


### PR DESCRIPTION
`GraphQL .NET` usages: 10
`GraphQL.NET` usages: 32   -> _winner_