### PR TITLE
The ExecutionResult.Data property is serialized only if the request was executed.

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -114,10 +114,13 @@ namespace GraphQL
         public object Data { get; set; }
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
+        public bool Executed { get; set; }
         public System.Collections.Generic.Dictionary<string, object> Extensions { get; set; }
         public GraphQL.Language.AST.Operation Operation { get; set; }
         public GraphQL.Instrumentation.PerfRecord[] Perf { get; set; }
         public string Query { get; set; }
+        public GraphQL.ExecutionResult AddError(GraphQL.ExecutionError error) { }
+        public GraphQL.ExecutionResult AddErrors(GraphQL.ExecutionErrors errors) { }
     }
     public class ExperimentalFeatures
     {
@@ -2791,6 +2794,7 @@ namespace GraphQL.Validation
     }
     public class ValidationResult : GraphQL.Validation.IValidationResult
     {
+        public ValidationResult(params GraphQL.Validation.ValidationError[] errors) { }
         public ValidationResult(System.Collections.Generic.IEnumerable<GraphQL.Validation.ValidationError> errors) { }
         public GraphQL.ExecutionErrors Errors { get; }
         public bool IsValid { get; }

--- a/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
+++ b/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
@@ -144,10 +144,10 @@ namespace GraphQL.DataLoader.Tests
                 expectedExecutionResult);
         }
 
-        public ExecutionResult CreateQueryResult(string result)
+        public ExecutionResult CreateQueryResult(string result, bool executed = true)
         {
             object expected = string.IsNullOrWhiteSpace(result) ? null : result.ToDictionary();
-            return new ExecutionResult { Data = expected };
+            return new ExecutionResult { Data = expected, Executed = executed };
         }
     }
 }

--- a/src/GraphQL.Harness.Tests/GraphQLAssertion.cs
+++ b/src/GraphQL.Harness.Tests/GraphQLAssertion.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Harness.Tests
     {
         public abstract void Assert(Scenario scenario, HttpContext context, ScenarioAssertionException ex);
 
-        protected ExecutionResult CreateQueryResult(string result, ExecutionErrors errors = null)
-            => result.ToExecutionResult(errors);
+        protected ExecutionResult CreateQueryResult(string result, ExecutionErrors errors = null, bool executed = true)
+            => result.ToExecutionResult(errors, executed);
     }
 }

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
@@ -32,15 +32,11 @@ namespace GraphQL.NewtonsoftJson
 
         private void WriteData(ExecutionResult result, JsonWriter writer, JsonSerializer serializer)
         {
-            object data = result.Data;
-
-            if (result.Errors?.Count > 0 && data == null)
+            if (result.Executed)
             {
-                return;
+                writer.WritePropertyName("data");
+                serializer.Serialize(writer, result.Data);
             }
-
-            writer.WritePropertyName("data");
-            serializer.Serialize(writer, data);
         }
 
         private void WriteErrors(ExecutionErrors errors, JsonWriter writer, JsonSerializer serializer)

--- a/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
@@ -25,6 +25,7 @@ namespace GraphQL.Execution
 
             ExecutionResult result = new SubscriptionExecutionResult
             {
+                Executed = true,
                 Streams = streams
             }.With(context);
 

--- a/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
@@ -38,14 +38,10 @@ namespace GraphQL.SystemTextJson
 
         private static void WriteData(Utf8JsonWriter writer, ExecutionResult result, JsonSerializerOptions options)
         {
-            object data = result.Data;
-
-            if (result.Errors?.Count > 0 && data == null)
+            if (result.Executed)
             {
-                return;
+                WriteProperty(writer, "data", result.Data, options);
             }
-
-            WriteProperty(writer, "data", data, options);
         }
 
         private static void WriteProperty(Utf8JsonWriter writer, string propertyName, object propertyValue, JsonSerializerOptions options)

--- a/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
+++ b/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
@@ -210,14 +210,15 @@ namespace GraphQL.Tests.Bugs
             AssertResult(QUERY, EXPECTED, data, errors);
         }
 
-        private void AssertResult(string query, string expected, Data data, IReadOnlyList<ExecutionError> errors)
+        private void AssertResult(string query, string expected, Data data, IReadOnlyList<ExecutionError> errors, bool executed = true)
         {
             ExecutionResult result =
                 AssertQueryWithErrors(
                     query,
                     expected,
                     root: data,
-                    expectedErrorCount: errors.Count);
+                    expectedErrorCount: errors.Count,
+                    executed: executed);
 
             ExecutionErrors actualErrors = result.Errors;
 

--- a/src/GraphQL.Tests/Bugs/Bug1156.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1156.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Tests.Bugs
         field2B
     }
 }";
-            var result = AssertQueryWithErrors(query, null, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(query, null, expectedErrorCount: 1, executed: false);
             result.Errors[0].Message.ShouldBe("Error executing document.");
             result.Errors[0].InnerException.Message.ShouldBe(@"Unable to register GraphType 'GraphQL.Tests.Bugs.Type2' with the name 'MyType';
 the name 'MyType' is already registered to 'GraphQL.Tests.Bugs.Type1'.");

--- a/src/GraphQL.Tests/Bugs/Bug1205VeryLongInt.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1205VeryLongInt.cs
@@ -20,6 +20,7 @@ namespace GraphQL.Tests.Bugs
             error.Path = new object[] { "int" };
             var expected = new ExecutionResult
             {
+                Executed = true,
                 Errors = new ExecutionErrors { error },
                 Data = new { @int = (object)null }
             };
@@ -28,7 +29,7 @@ namespace GraphQL.Tests.Bugs
         }
 
         [Fact]
-        public void Very_Long_Number_In_Input_Should_Return_Error_For_Int()
+        public void Very_Long_Number_In_Input_Should_Return_Error_Without_Data_For_Int()
         {
             var query = "{ int_with_arg(in:636474637870330463) }";
             var expected = new ExecutionResult
@@ -51,7 +52,7 @@ namespace GraphQL.Tests.Bugs
         {
             var query = "{ long }";
             var expected = @"{
-  ""long"": 636474637870330463 
+  ""long"": 636474637870330463
 }";
             AssertQuerySuccess(query, expected);
         }
@@ -61,7 +62,7 @@ namespace GraphQL.Tests.Bugs
         {
             var query = "{ long_with_arg(in:636474637870330463) }";
             var expected = @"{
-  ""long_with_arg"": 636474637870330463 
+  ""long_with_arg"": 636474637870330463
 }";
             AssertQuerySuccess(query, expected);
         }
@@ -75,6 +76,7 @@ namespace GraphQL.Tests.Bugs
             error.Path = new object[] { "long_return_bigint" };
             var expected = new ExecutionResult
             {
+                Executed = true,
                 Errors = new ExecutionErrors { error },
                 Data = new { long_return_bigint = (object)null }
             };
@@ -106,7 +108,7 @@ namespace GraphQL.Tests.Bugs
         {
             var query = "{ bigint }";
             var expected = @"{
-  ""bigint"": 636474637870330463636474637870330463636474637870330463 
+  ""bigint"": 636474637870330463636474637870330463636474637870330463
 }";
             AssertQuerySuccess(query, expected);
         }
@@ -116,7 +118,7 @@ namespace GraphQL.Tests.Bugs
         {
             var query = "{ bigint_with_arg(in:636474637870330463636474637870330463636474637870330463) }";
             var expected = @"{
-  ""bigint_with_arg"": 636474637870330463636474637870330463636474637870330463 
+  ""bigint_with_arg"": 636474637870330463636474637870330463636474637870330463
 }";
             AssertQuerySuccess(query, expected);
         }

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Tests.Bugs
         private void AssertQueryWithError(string query, string result, string message, int line, int column, string path, Exception exception = null, string code = null, string inputs = null, string number = null)
             => AssertQueryWithError(query, result, message, line, column, new object[] { path }, exception, code, inputs, number);
 
-        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null, string number = null)
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null, string number = null, bool executed = true)
         {
             ExecutionError error;
             if (number != null)
@@ -25,7 +25,7 @@ namespace GraphQL.Tests.Bugs
             error.Path = path;
             if (code != null)
                 error.Code = code;
-            var expected = CreateQueryResult(result, new ExecutionErrors { error });
+            var expected = CreateQueryResult(result, new ExecutionErrors { error }, executed: executed);
             AssertQueryIgnoreErrors(query, expected, inputs?.ToInputs(), renderErrors: true, expectedErrorCount: 1);
         }
 
@@ -61,13 +61,13 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_Valid2() => AssertQuerySuccess("{ input(arg: SLEEPY) }", @"{ ""input"": ""Sleepy"" }");
 
         [Fact]
-        public void Input_Enum_InvalidEnum() => AssertQueryWithError("{ input(arg: DOPEY) }", null, "Argument \u0022arg\u0022 has invalid value DOPEY.\nExpected type \u0022Bug1699Enum\u0022, found DOPEY.", 1, 9, (object[])null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER);
+        public void Input_Enum_InvalidEnum() => AssertQueryWithError("{ input(arg: DOPEY) }", null, "Argument \u0022arg\u0022 has invalid value DOPEY.\nExpected type \u0022Bug1699Enum\u0022, found DOPEY.", 1, 9, (object[])null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
 
         [Fact]
-        public void Input_Enum_InvalidString() => AssertQueryWithError(@"{ input(arg: ""SLEEPY"") }", null, "Argument \u0022arg\u0022 has invalid value \u0022SLEEPY\u0022.\nExpected type \u0022Bug1699Enum\u0022, found \u0022SLEEPY\u0022.", 1, 9, (object[])null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER);
+        public void Input_Enum_InvalidString() => AssertQueryWithError(@"{ input(arg: ""SLEEPY"") }", null, "Argument \u0022arg\u0022 has invalid value \u0022SLEEPY\u0022.\nExpected type \u0022Bug1699Enum\u0022, found \u0022SLEEPY\u0022.", 1, 9, (object[])null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
 
         [Fact]
-        public void Input_Enum_InvalidInt() => AssertQueryWithError(@"{ input(arg: 2) }", null, "Argument \u0022arg\u0022 has invalid value 2.\nExpected type \u0022Bug1699Enum\u0022, found 2.", 1, 9, (object[])null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER);
+        public void Input_Enum_InvalidInt() => AssertQueryWithError(@"{ input(arg: 2) }", null, "Argument \u0022arg\u0022 has invalid value 2.\nExpected type \u0022Bug1699Enum\u0022, found 2.", 1, 9, (object[])null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
 
         [Fact]
         public void Input_Enum_Valid_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum!) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", "{\"arg\":\"GRUMPY\"}".ToInputs());
@@ -79,10 +79,10 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_Valid_Default_Required_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum! = GRUMPY) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", null);
 
         [Fact]
-        public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}");
+        public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}", executed: false);
 
         [Fact]
-        public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":2}");
+        public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 1, 7, (object[])null, code: "INVALID_VALUE", inputs: "{\"arg\":2}", executed: false);
 
         [Fact]
         public void Input_Enum_UndefinedDefault() => AssertQuerySuccess("{ input }", @"{ ""input"": ""Grumpy"" }");
@@ -101,7 +101,7 @@ namespace GraphQL.Tests.Bugs
         public void Input_Enum_NullDefault_Nullable() => AssertQuerySuccess("{ inputWithDefaultNullable(arg: null) }", @"{ ""inputWithDefaultNullable"": null }");
 
         [Fact]
-        public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required for field \u0022inputRequired\u0022 but not provided.", 1, 3, (object[])null, code: "PROVIDED_NON_NULL_ARGUMENTS", number: ProvidedNonNullArgumentsError.NUMBER);
+        public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Argument \u0022arg\u0022 of type \u0022Bug1699Enum!\u0022 is required for field \u0022inputRequired\u0022 but not provided.", 1, 3, (object[])null, code: "PROVIDED_NON_NULL_ARGUMENTS", number: ProvidedNonNullArgumentsError.NUMBER, executed: false);
 
         [Fact]
         public void Input_Enum_RequiredWithDefault() => AssertQuerySuccess("{ inputRequiredWithDefault }", @"{ ""inputRequiredWithDefault"": ""Happy"" }");

--- a/src/GraphQL.Tests/Bugs/Bug1767InvalidByte.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1767InvalidByte.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Tests.Bugs
     // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1767
     public class Bug1767InvalidByte : QueryTestBase<Bug1767Schema>
     {
-        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null, string number = null)
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null, string number = null, bool executed = true)
         {
             ExecutionError error;
             if (number != null)
@@ -22,7 +22,7 @@ namespace GraphQL.Tests.Bugs
             error.Path = path;
             if (code != null)
                 error.Code = code;
-            var expected = CreateQueryResult(result, new ExecutionErrors { error });
+            var expected = CreateQueryResult(result, new ExecutionErrors { error }, executed);
             AssertQueryIgnoreErrors(query, expected, inputs?.ToInputs(), renderErrors: true, expectedErrorCount: 1);
         }
 
@@ -33,10 +33,10 @@ namespace GraphQL.Tests.Bugs
         public void Input_Byte_Valid_Argument() => AssertQuerySuccess("query { input(arg: 2) }", @"{ ""input"": ""2"" }", "{\"arg\":2}".ToInputs());
 
         [Fact]
-        public void Input_Byte_Invalid_Variable() => AssertQueryWithError("query($arg: Byte!) { input(arg: $arg) }", null, "Variable '$arg' is invalid. Unable to convert '300' to 'Byte'", 1, 7, null, new OverflowException(), "INVALID_VALUE", "{\"arg\":300}");
+        public void Input_Byte_Invalid_Variable() => AssertQueryWithError("query($arg: Byte!) { input(arg: $arg) }", null, "Variable '$arg' is invalid. Unable to convert '300' to 'Byte'", 1, 7, null, new OverflowException(), "INVALID_VALUE", "{\"arg\":300}", executed: false);
 
         [Fact]
-        public void Input_Byte_Invalid_Argument() => AssertQueryWithError("query { input(arg: 300) }", null, "Argument \"arg\" has invalid value 300.\nExpected type \"Byte\", found 300.", 1, 15, null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER);
+        public void Input_Byte_Invalid_Argument() => AssertQueryWithError("query { input(arg: 300) }", null, "Argument \"arg\" has invalid value 300.\nExpected type \"Byte\", found 300.", 1, 15, null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
     }
 
     public class Bug1767Schema : Schema

--- a/src/GraphQL.Tests/Bugs/Bug1769.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1769.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Tests.Bugs
     // https://github.com/graphql-dotnet/graphql-dotnet/pulls/1769
     public class Bug1769 : QueryTestBase<Bug1769Schema>
     {
-        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null)
+        private void AssertQueryWithError(string query, string result, string message, int line, int column, object[] path, Exception exception = null, string code = null, string inputs = null, bool executed = true)
         {
             var error = exception == null ? new ExecutionError(message) : new ExecutionError(message, exception);
             if (line != 0)
@@ -20,7 +20,7 @@ namespace GraphQL.Tests.Bugs
             error.Path = path;
             if (code != null)
                 error.Code = code;
-            var expected = CreateQueryResult(result, new ExecutionErrors { error });
+            var expected = CreateQueryResult(result, new ExecutionErrors { error }, executed);
             AssertQueryIgnoreErrors(query, expected, inputs?.ToInputs(), renderErrors: true, expectedErrorCount: 1);
         }
 
@@ -52,10 +52,10 @@ namespace GraphQL.Tests.Bugs
         }
 
         [Fact]
-        public void query_is_empty1() => AssertQueryWithError("", null, "Document does not contain any operations.", 0, 0, (object[])null, code: "NO_OPERATION");
+        public void query_is_empty1() => AssertQueryWithError("", null, "Document does not contain any operations.", 0, 0, null, code: "NO_OPERATION", executed: false);
 
         [Fact]
-        public void query_is_whitespace2() => AssertQueryWithError("\t \t \r\n", null, "Document does not contain any operations.", 0, 0, (object[])null, code: "NO_OPERATION");
+        public void query_is_whitespace2() => AssertQueryWithError("\t \t \r\n", null, "Document does not contain any operations.", 0, 0, null, code: "NO_OPERATION", executed: false);
 
         [Fact]
         public void DocumentExecuter_cannot_have_null_constructor_parameters()

--- a/src/GraphQL.Tests/Bugs/Bug1831.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1831.cs
@@ -35,7 +35,7 @@ namespace GraphQL.Tests.Bugs
                 Code = "KNOWN_TYPE_NAMES"
             };
             error2.AddLocation(1, 13);
-            var expected = CreateQueryResult(null, new ExecutionErrors { error1, error2 });
+            var expected = CreateQueryResult(null, new ExecutionErrors { error1, error2 }, executed: false);
             AssertQueryIgnoreErrors("query($arg: abcdefg) { test1 (arg: $arg) }", expected, inputs: $"{{ \"arg\": {param} }}".ToInputs(), expectedErrorCount: 2, renderErrors: true);
         }
     }

--- a/src/GraphQL.Tests/Bugs/Bug2159.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2159.cs
@@ -96,10 +96,10 @@ namespace GraphQL.Tests.Bugs
         public void HasArgument_WithDefault_SetVariableNull() => AssertQuerySuccess("query($input: Boolean) { hasArgumentWithDefault(arg: $input) }", @"{ ""hasArgumentWithDefault"": true }", "{\"input\":null}".ToInputs());
 
         [Fact]
-        public void CheckRequiredObjectFieldAreRequired_Variable() => AssertQueryWithErrors("query($input: Bug2159ReqObj) { testReqObjField(arg: $input) }", "null", "{\"input\":{\"value2\":null}}".ToInputs(), expectedErrorCount: 1);
+        public void CheckRequiredObjectFieldAreRequired_Variable() => AssertQueryWithErrors("query($input: Bug2159ReqObj) { testReqObjField(arg: $input) }", "null", "{\"input\":{\"value2\":null}}".ToInputs(), expectedErrorCount: 1, executed: false);
 
         [Fact]
-        public void CheckRequiredObjectFieldAreRequired_Literal() => AssertQueryWithErrors("{ testReqObjField(arg: { value2: null }) }", "null", expectedErrorCount: 1);
+        public void CheckRequiredObjectFieldAreRequired_Literal() => AssertQueryWithErrors("{ testReqObjField(arg: { value2: null }) }", "null", expectedErrorCount: 1, executed: false);
     }
 
     public class Bug2159Schema : Schema

--- a/src/GraphQL.Tests/Bugs/Issue1189.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1189.cs
@@ -40,8 +40,9 @@ namespace GraphQL.Tests.Bugs
             error.Path = new string[] { "hero", "friend" };
             error.Code = code;
 
-            var queryResult = new ExecutionResult()
+            var queryResult = new ExecutionResult
             {
+                Executed = true,
                 Data = new { hero = new { id = "1", name = "R2-D2", friend = default(Issue1189_Character) } },
                 Errors = new ExecutionErrors { error }
             };

--- a/src/GraphQL.Tests/Bugs/NullArguments.cs
+++ b/src/GraphQL.Tests/Bugs/NullArguments.cs
@@ -30,7 +30,7 @@ mutation {
 }
 ";
 
-            var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
@@ -47,7 +47,7 @@ mutation {
 }
 ";
 
-            var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
@@ -64,7 +64,7 @@ mutation {
 }
 ";
 
-            var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();

--- a/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
+++ b/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
@@ -177,7 +177,7 @@ mutation {
         {
             var query = @"mutation { long(number: ""100"") }";
             string expected = null;
-            AssertQueryWithErrors(query, expected, expectedErrorCount: 1);
+            AssertQueryWithErrors(query, expected, expectedErrorCount: 1, executed: false);
         }
 
         // TODO: rework to throw exception

--- a/src/GraphQL.Tests/DocumentWriterTests.cs
+++ b/src/GraphQL.Tests/DocumentWriterTests.cs
@@ -16,6 +16,7 @@ namespace GraphQL.Tests
         {
             var executionResult = new ExecutionResult
             {
+                Executed = true,
                 Data = @"{ ""someType"": { ""someProperty"": ""someValue"" } }".ToDictionary(),
                 Errors = new ExecutionErrors
                 {
@@ -59,7 +60,7 @@ namespace GraphQL.Tests
         [ClassData(typeof(DocumentWritersTestData))]
         public async void Writes_Correct_Execution_Result_With_Null_Data_And_Null_Errors(IDocumentWriter writer)
         {
-            var executionResult = new ExecutionResult();
+            var executionResult = new ExecutionResult { Executed = true };
 
             var expected = @"{
               ""data"": null
@@ -97,16 +98,36 @@ namespace GraphQL.Tests
 
         [Theory]
         [ClassData(typeof(DocumentWritersTestData))]
-        public async void Writes_Correct_Execution_Result_With_Empty_Data_Errors_And_Extensions(IDocumentWriter writer)
+        public async void Writes_Correct_Execution_Result_With_Empty_Data_Errors_And_Extensions_When_Executed(IDocumentWriter writer)
         {
             var executionResult = new ExecutionResult
             {
                 Data = new Dictionary<string, object>(),
                 Errors = new ExecutionErrors(),
-                Extensions = new Dictionary<string, object>()
+                Extensions = new Dictionary<string, object>(),
+                Executed = true
             };
 
             var expected = @"{ ""data"": {} }";
+
+            var actual = await writer.WriteToStringAsync(executionResult);
+
+            actual.ShouldBeCrossPlatJson(expected);
+        }
+
+        [Theory]
+        [ClassData(typeof(DocumentWritersTestData))]
+        public async void Writes_Correct_Execution_Result_With_Empty_Data_Errors_And_Extensions_When_Not_Executed(IDocumentWriter writer)
+        {
+            var executionResult = new ExecutionResult
+            {
+                Data = new Dictionary<string, object>(),
+                Errors = new ExecutionErrors(),
+                Extensions = new Dictionary<string, object>(),
+                Executed = false
+            };
+
+            var expected = @"{ }";
 
             var actual = await writer.WriteToStringAsync(executionResult);
 

--- a/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
+++ b/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
@@ -57,7 +57,7 @@ namespace GraphQL.Tests.Errors
                         ctx.Exception = new ExecutionError("Test error message");
                     }
                 };
-            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError }, Data = new { hello2 = (object)null } });
+            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError }, Data = new { hello2 = (object)null }, Executed = true });
 
         }
 
@@ -87,7 +87,7 @@ namespace GraphQL.Tests.Errors
                         ctx.ErrorMessage = "Test error message";
                     }
                 };
-            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError }, Data = new { hello2 = (object)null } });
+            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError }, Data = new { hello2 = (object)null }, Executed = true });
 
         }
 
@@ -116,7 +116,7 @@ namespace GraphQL.Tests.Errors
                         ctx.ErrorMessage = "Test error message";
                     }
                 };
-            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError } });
+            }, new ExecutionResult { Errors = new ExecutionErrors { expectedError }, Executed = true });
         }
 
         public class DocListener : DocumentExecutionListenerBase

--- a/src/GraphQL.Tests/Execution/LongTests.cs
+++ b/src/GraphQL.Tests/Execution/LongTests.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Execution
+{
+    public class LongTests
+    {
+        [Theory]
+        [ClassData(typeof(DocumentWritersTestData))]
+        public async Task LongMaxValueShouldBeSerialized(IDocumentWriter documentWriter)
+        {
+            var documentExecuter = new DocumentExecuter();
+            var executionResult = await documentExecuter.ExecuteAsync(_ =>
+            {
+                _.Schema = new LongSchema();
+                _.Query = "{ testField }";
+            });
+
+            var json = await documentWriter.WriteToStringAsync(executionResult);
+            executionResult.Errors.ShouldBeNull();
+
+            json.ShouldBe(@"{
+  ""data"": {
+    ""testField"": 9223372036854775807
+  }
+}");
+        }
+
+        private class LongSchema : Schema
+        {
+            public LongSchema()
+            {
+                Query = new Query();
+            }
+        }
+
+        private class Query : ObjectGraphType<object>
+        {
+            public Query()
+            {
+                Field<NonNullGraphType<LongGraphType>>("TestField", resolve: _ => long.MaxValue);
+            }
+        }
+    }
+}

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -286,7 +286,7 @@ namespace GraphQL.Tests.Execution
 
             var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": ""bar"", ""c"": null } }".ToInputs();
 
-            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
@@ -300,7 +300,7 @@ namespace GraphQL.Tests.Execution
 
             var inputs = @"{ ""input"": ""foo bar"" }".ToInputs();
 
-            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
 
@@ -316,7 +316,7 @@ namespace GraphQL.Tests.Execution
 
             var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": ""bar"" } }".ToInputs();
 
-            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
@@ -330,7 +330,7 @@ namespace GraphQL.Tests.Execution
 
             var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": ""bar"", ""c"": ""baz"", ""e"": ""dog"" } }".ToInputs();
 
-            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
@@ -502,7 +502,7 @@ namespace GraphQL.Tests.Execution
 
             string expected = null;
 
-            var result = AssertQueryWithErrors(query, expected, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(query, expected, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();
@@ -522,7 +522,7 @@ namespace GraphQL.Tests.Execution
 
             var inputs = @"{""value"": null}".ToInputs();
 
-            var result = AssertQueryWithErrors(query, expected, inputs, expectedErrorCount: 1);
+            var result = AssertQueryWithErrors(query, expected, inputs, expectedErrorCount: 1, executed: false);
 
             var caughtError = result.Errors.Single();
             caughtError.ShouldNotBeNull();

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -69,9 +69,10 @@ namespace GraphQL.Tests
             IEnumerable<IValidationRule> rules = null,
             int expectedErrorCount = 0,
             bool renderErrors = false,
-            Action<UnhandledExceptionContext> unhandledExceptionDelegate = null)
+            Action<UnhandledExceptionContext> unhandledExceptionDelegate = null,
+            bool executed = true)
         {
-            var queryResult = CreateQueryResult(expected);
+            var queryResult = CreateQueryResult(expected, executed: executed);
             return AssertQueryIgnoreErrors(
                 query,
                 queryResult,
@@ -109,7 +110,7 @@ namespace GraphQL.Tests
                 options.UnhandledExceptionDelegate = unhandledExceptionDelegate ?? (ctx => { });
             }).GetAwaiter().GetResult();
 
-            var renderResult = renderErrors ? runResult : new ExecutionResult { Data = runResult.Data };
+            var renderResult = renderErrors ? runResult : new ExecutionResult { Data = runResult.Data, Executed = runResult.Executed };
 
             var writtenResult = Writer.WriteToStringAsync(renderResult).GetAwaiter().GetResult();
             var expectedResult = Writer.WriteToStringAsync(expectedExecutionResult).GetAwaiter().GetResult();
@@ -168,7 +169,7 @@ namespace GraphQL.Tests
             return runResult;
         }
 
-        public static ExecutionResult CreateQueryResult(string result, ExecutionErrors errors = null)
-            => result.ToExecutionResult(errors);
+        public static ExecutionResult CreateQueryResult(string result, ExecutionErrors errors = null, bool executed = true)
+            => result.ToExecutionResult(errors, executed);
     }
 }

--- a/src/GraphQL.Tests/Shared/JsonStringExtensions.cs
+++ b/src/GraphQL.Tests/Shared/JsonStringExtensions.cs
@@ -10,12 +10,14 @@ namespace GraphQL
         /// </summary>
         /// <param name="json">A json representation of the <see cref="ExecutionResult.Data"/> to be set.</param>
         /// <param name="errors">Any errors.</param>
+        /// <param name="executed">Indicates if the operation included execution.</param>
         /// <returns>ExecutionResult.</returns>
-        public static ExecutionResult ToExecutionResult(this string json, ExecutionErrors errors = null)
+        public static ExecutionResult ToExecutionResult(this string json, ExecutionErrors errors = null, bool executed = true)
             => new ExecutionResult
             {
                 Data = string.IsNullOrWhiteSpace(json) ? null : json.ToDictionary(),
-                Errors = errors
+                Errors = errors,
+                Executed = executed
             };
     }
 }

--- a/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
@@ -99,7 +99,7 @@ namespace GraphQL.Tests.StarWars
             error.AddLocation(4, 25);
             errors.Add(error);
 
-            AssertQuery(query, CreateQueryResult(null, errors), null, null);
+            AssertQuery(query, CreateQueryResult(null, errors, executed: false), null, null);
         }
     }
 }

--- a/src/GraphQL/Execution/ExecutionErrors.cs
+++ b/src/GraphQL/Execution/ExecutionErrors.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GraphQL
 {
@@ -9,14 +10,26 @@ namespace GraphQL
     /// </summary>
     public class ExecutionErrors : IEnumerable<ExecutionError>
     {
-        internal readonly List<ExecutionError> Errors = new List<ExecutionError>();
+        internal List<ExecutionError> List;
+
+        internal ExecutionErrors(int capacity)
+        {
+            List = new List<ExecutionError>(capacity);
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="ExecutionErrors"/>.
+        /// </summary>
+        public ExecutionErrors()
+        {
+        }
 
         /// <summary>
         /// Adds an execution error to the list.
         /// </summary>
         public virtual void Add(ExecutionError error)
         {
-            Errors.Add(error ?? throw new ArgumentNullException(nameof(error)));
+            (List ??= new List<ExecutionError>()).Add(error ?? throw new ArgumentNullException(nameof(error)));
         }
 
         /// <summary>
@@ -31,15 +44,15 @@ namespace GraphQL
         /// <summary>
         /// Returns the number of execution errors in the list.
         /// </summary>
-        public int Count => Errors.Count;
+        public int Count => List?.Count ?? 0;
 
         /// <summary>
         /// Returns the execution error at the specified index.
         /// </summary>
-        public ExecutionError this[int index] => Errors[index];
+        public ExecutionError this[int index] => List != null ? List[index] : throw new IndexOutOfRangeException();
 
         /// <inheritdoc/>
-        public IEnumerator<ExecutionError> GetEnumerator() => Errors.GetEnumerator();
+        public IEnumerator<ExecutionError> GetEnumerator() => (List ?? Enumerable.Empty<ExecutionError>()).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/src/GraphQL/Execution/ExecutionErrors.cs
+++ b/src/GraphQL/Execution/ExecutionErrors.cs
@@ -9,14 +9,14 @@ namespace GraphQL
     /// </summary>
     public class ExecutionErrors : IEnumerable<ExecutionError>
     {
-        private readonly List<ExecutionError> _errors = new List<ExecutionError>();
+        internal readonly List<ExecutionError> Errors = new List<ExecutionError>();
 
         /// <summary>
         /// Adds an execution error to the list.
         /// </summary>
         public virtual void Add(ExecutionError error)
         {
-            _errors.Add(error ?? throw new ArgumentNullException(nameof(error)));
+            Errors.Add(error ?? throw new ArgumentNullException(nameof(error)));
         }
 
         /// <summary>
@@ -31,15 +31,15 @@ namespace GraphQL
         /// <summary>
         /// Returns the number of execution errors in the list.
         /// </summary>
-        public int Count => _errors.Count;
+        public int Count => Errors.Count;
 
         /// <summary>
         /// Returns the execution error at the specified index.
         /// </summary>
-        public ExecutionError this[int index] => _errors[index];
+        public ExecutionError this[int index] => Errors[index];
 
         /// <inheritdoc/>
-        public IEnumerator<ExecutionError> GetEnumerator() => _errors.GetEnumerator();
+        public IEnumerator<ExecutionError> GetEnumerator() => Errors.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -96,8 +96,10 @@ namespace GraphQL
         {
             if (errors?.Count > 0)
             {
-                foreach (var error in errors)
-                    AddError(error);
+                if (Errors == null)
+                    Errors = new ExecutionErrors(errors.Count);
+                foreach (var error in errors.List)
+                    Errors.Add(error);
             }
 
             return this;

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -12,6 +12,13 @@ namespace GraphQL
     public class ExecutionResult
     {
         /// <summary>
+        /// Indicates if the operation included execution. If an error was encountered BEFORE execution begins,
+        /// the data entry SHOULD NOT be present in the result. If an error was encountered DURING the execution
+        /// that prevented a valid response, the data entry in the response SHOULD BE null.
+        /// </summary>
+        public bool Executed { get; set; }
+
+        /// <summary>
         /// Returns the data from the graph resolvers. This property is serialized as part of the GraphQL json response.
         /// </summary>
         public object Data { get; set; }
@@ -68,6 +75,32 @@ namespace GraphQL
             Document = result.Document;
             Perf = result.Perf;
             Extensions = result.Extensions;
+        }
+
+        /// <summary>
+        /// Adds the specified error to <see cref="Errors"/>.
+        /// </summary>
+        /// <returns>Reference to this.</returns>
+        public ExecutionResult AddError(ExecutionError error)
+        {
+            (Errors ??= new ExecutionErrors()).Add(error);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds errors from the specified <see cref="ExecutionErrors"/> to <see cref="Errors"/>.
+        /// </summary>
+        /// <param name="errors">List of execution errors.</param>
+        /// <returns>Reference to this.</returns>
+        public ExecutionResult AddErrors(ExecutionErrors errors)
+        {
+            if (errors?.Count > 0)
+            {
+                foreach (var error in errors)
+                    AddError(error);
+            }
+
+            return this;
         }
     }
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -33,6 +33,7 @@ namespace GraphQL.Execution
 
             return new ExecutionResult
             {
+                Executed = true,
                 Data = data,
                 Query = context.Document.OriginalQuery,
                 Document = context.Document,

--- a/src/GraphQL/Resolvers/FuncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/FuncFieldResolver.cs
@@ -50,7 +50,7 @@ namespace GraphQL.Resolvers
                 return (context) => resolver(context.As<TSourceType>());
             }
 
-            if (typeof(IDataLoaderResult).IsAssignableFrom(typeof(TReturnType)))     
+            if (typeof(IDataLoaderResult).IsAssignableFrom(typeof(TReturnType)))
             {
                 // Data loaders cannot use pooled contexts
                 return (context) => resolver(context.As<TSourceType>());

--- a/src/GraphQL/Validation/ValidationResult.cs
+++ b/src/GraphQL/Validation/ValidationResult.cs
@@ -8,8 +8,17 @@ namespace GraphQL.Validation
         /// <summary>
         /// Initializes a new instance with the specified set of validation errors.
         /// </summary>
-        /// <param name="errors"></param>
+        /// <param name="errors">Set of validation errors.</param>
         public ValidationResult(IEnumerable<ValidationError> errors)
+        {
+            Errors.AddRange(errors);
+        }
+
+        /// <summary>
+        /// Initializes a new instance with the specified set of validation errors.
+        /// </summary>
+        /// <param name="errors">Set of validation errors.</param>
+        public ValidationResult(params ValidationError[] errors)
         {
             Errors.AddRange(errors);
         }


### PR DESCRIPTION
See https://spec.graphql.org/June2018/#sec-Data
> If an error was encountered before execution begins, the data entry should not be present in the result.
> If an error was encountered during the execution that prevented a valid response, the data entry in the response should be null.