### PR TITLE
Patch for issue 1927 - adding a field where Type = ListGraphType

### DIFF
--- a/src/GraphQL.Tests/Bugs/Issue1927ResolvedTypeWithType.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1927ResolvedTypeWithType.cs
@@ -1,4 +1,6 @@
+using System;
 using GraphQL.Types;
+using Shouldly;
 using Xunit;
 
 namespace GraphQL.Tests.Bugs
@@ -42,6 +44,12 @@ namespace GraphQL.Tests.Bugs
                 Query = obj
             };
             schema.Initialize();
+        }
+
+        [Fact]
+        public void test_nonnull_constructor()
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => new NonNullGraphType<NonNullGraphType<StringGraphType>>());
         }
     }
 }

--- a/src/GraphQL.Tests/Bugs/Issue1927ResolvedTypeWithType.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1927ResolvedTypeWithType.cs
@@ -51,5 +51,11 @@ namespace GraphQL.Tests.Bugs
         {
             Should.Throw<ArgumentOutOfRangeException>(() => new NonNullGraphType<NonNullGraphType<StringGraphType>>());
         }
+
+        [Fact]
+        public void test_fieldtype_type()
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => new FieldType { Type = typeof(string) });
+        }
     }
 }

--- a/src/GraphQL.Tests/Bugs/Issue1927ResolvedTypeWithType.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1927ResolvedTypeWithType.cs
@@ -1,0 +1,47 @@
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class Issue1927ResolvedTypeWithType
+    {
+        [Fact]
+        public void test_outputs()
+        {
+            var innerObject = new ObjectGraphType();
+            innerObject.AddField(new FieldType { Name = "test", ResolvedType = new StringGraphType(), Type = typeof(StringGraphType) });
+            var list = new ListGraphType(innerObject);
+            var obj = new ObjectGraphType();
+            obj.AddField(new FieldType { Name = "list", ResolvedType = list, Type = list.GetType() });
+            var schema = new Schema
+            {
+                Query = obj
+            };
+            schema.Initialize();
+        }
+
+        [Fact]
+        public void test_inputs()
+        {
+            var innerObject = new InputObjectGraphType();
+            innerObject.AddField(new FieldType { Name = "test", ResolvedType = new StringGraphType(), Type = typeof(StringGraphType) });
+            var list = new ListGraphType(innerObject);
+            var inputObj = new InputObjectGraphType();
+            inputObj.AddField(new FieldType { Name = "list", ResolvedType = list, Type = list.GetType() });
+            var obj = new ObjectGraphType();
+            var field = new FieldType
+            {
+                Name = "hello",
+                ResolvedType = new StringGraphType(),
+                Type = typeof(StringGraphType),
+                Arguments = new QueryArguments { new QueryArgument(inputObj) { Name = "input" } }
+            };
+            obj.AddField(field);
+            var schema = new Schema
+            {
+                Query = obj
+            };
+            schema.Initialize();
+        }
+    }
+}

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -56,7 +56,7 @@ namespace GraphQL
         ///   <c>true</c> if the indicated type implements IGraphType; otherwise, <c>false</c>.
         /// </returns>
         public static bool IsGraphType(this Type type)
-            => type.GetInterfaces().Contains(typeof(IGraphType));
+            => typeof(IGraphType).IsAssignableFrom(type);
 
         /// <summary>
         /// Gets the GraphQL name of the type. This is derived from the type name and can be overridden by the GraphQLMetadata Attribute.

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -97,13 +97,13 @@ namespace GraphQL.Types
             {
                 if (this is IInputObjectGraphType)
                 {
-                    if (fieldType.ResolvedType?.IsInputType() == false || fieldType.Type?.IsInputType() == false)
+                    if (fieldType.ResolvedType != null ? fieldType.ResolvedType.IsInputType() == false : fieldType.Type?.IsInputType() == false)
                         throw new ArgumentOutOfRangeException(nameof(fieldType),
                             $"Input type '{Name ?? GetType().GetFriendlyName()}' can have fields only of input types: ScalarGraphType, EnumerationGraphType or IInputObjectGraphType. Field '{fieldType.Name}' has an output type.");
                 }
                 else
                 {
-                    if (fieldType.ResolvedType?.IsOutputType() == false || fieldType.Type?.IsOutputType() == false)
+                    if (fieldType.ResolvedType != null ? fieldType.ResolvedType.IsOutputType() == false : fieldType.Type?.IsOutputType() == false)
                         throw new ArgumentOutOfRangeException(nameof(fieldType),
                             $"Output type '{Name ?? GetType().GetFriendlyName()}' can have fields only of output types: ScalarGraphType, ObjectGraphType, InterfaceGraphType, UnionGraphType or EnumerationGraphType. Field '{fieldType.Name}' has an input type.");
                 }

--- a/src/GraphQL/Types/Composite/ListGraphType.cs
+++ b/src/GraphQL/Types/Composite/ListGraphType.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Types
             ResolvedType = type;
         }
 
-        /// <inheritdoc cref="ListGraphType.ListGraphType(IGraphType)"/>
+        /// <inheritdoc cref="ListGraphType(IGraphType)"/>
         protected ListGraphType(Type type)
         {
             Type = type;

--- a/src/GraphQL/Types/Composite/NonNullGraphType.cs
+++ b/src/GraphQL/Types/Composite/NonNullGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types
     public class NonNullGraphType<T> : NonNullGraphType
         where T : GraphType
     {
-        /// <inheritdoc cref="NonNullGraphType.NonNullGraphType(Type)"/>
+        /// <inheritdoc cref="NonNullGraphType(Type)"/>
         public NonNullGraphType()
             : base(typeof(T))
         {
@@ -27,18 +27,18 @@ namespace GraphQL.Types
             if (type is NonNullGraphType)
             {
                 // http://spec.graphql.org/draft/#sec-Type-System.Non-Null.Type-Validation
-                throw new ArgumentException("Cannot nest NonNull inside NonNull.", nameof(type));
+                throw new ArgumentOutOfRangeException(nameof(type), "Cannot nest NonNull inside NonNull.");
             }
 
             ResolvedType = type;
         }
 
-        /// <inheritdoc cref="NonNullGraphType.NonNullGraphType(IGraphType)"/>
+        /// <inheritdoc cref="NonNullGraphType(IGraphType)"/>
         protected NonNullGraphType(Type type)
         {
-            if (type == typeof(NonNullGraphType))
+            if (typeof(NonNullGraphType).IsAssignableFrom(type))
             {
-                throw new ArgumentException("Cannot nest NonNull inside NonNull.", nameof(type));
+                throw new ArgumentOutOfRangeException(nameof(type), "Cannot nest NonNull inside NonNull.");
             }
 
             Type = type;

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -68,12 +68,11 @@ namespace GraphQL.Types
             set
             {
                 if (value != null && !value.IsGraphType())
-                    ThrowInvalidType(value);
+                    throw new ArgumentOutOfRangeException("value", $"Type '{value}' is not a graph type");
                 _type = value;
             }
         }
 
-        private void ThrowInvalidType(Type type) => throw new ArgumentOutOfRangeException("value", $"Type '{type}' is not a graph type");
 
         /// <summary>
         /// Gets or sets the graph type of this field.

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -58,10 +58,22 @@ namespace GraphQL.Types
             }
         }
 
+        private Type _type;
         /// <summary>
         /// Gets or sets the graph type of this field.
         /// </summary>
-        public Type Type { get; set; }
+        public Type Type
+        {
+            get => _type;
+            set
+            {
+                if (value != null && !value.IsGraphType())
+                    throw Create(value);
+                _type = value;
+            }
+        }
+
+        private ArgumentOutOfRangeException Create(Type type) => new ArgumentOutOfRangeException("value", $"Type '{type}' is not a graph type");
 
         /// <summary>
         /// Gets or sets the graph type of this field.

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -68,12 +68,12 @@ namespace GraphQL.Types
             set
             {
                 if (value != null && !value.IsGraphType())
-                    throw Create(value);
+                    ThrowInvalidType(value);
                 _type = value;
             }
         }
 
-        private ArgumentOutOfRangeException Create(Type type) => new ArgumentOutOfRangeException("value", $"Type '{type}' is not a graph type");
+        private void ThrowInvalidType(Type type) => throw new ArgumentOutOfRangeException("value", $"Type '{type}' is not a graph type");
 
         /// <summary>
         /// Gets or sets the graph type of this field.


### PR DESCRIPTION
See issue #1927 

This does not fix the underlying issue, that `IsInputType` sometimes cannot accurately identify if the supplied type is an input or output type, but rather this code does not call `IsInputType` on `Type` if `ResolvedType` is set.

Note: both tests failed before and both pass now.  Also, the original code sample within #1927 was tested and now works.

Note: these are almost the only uses of `IsInputType(Type type)` and `IsOutputType(Type type)`.  The one other use does not suffer the same issue.

Also added check to `FieldType.Type` setter.