### PR TITLE
Cleanup ScalarGraphType

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -157,12 +157,11 @@ GraphQL.NET will not receive new dependencies, since all methods just read or wr
 
 ### New parsing methods for scalars
 
-4 new methods for `ScalarGraphType` have been added in v4:
+2 new methods for `ScalarGraphType` have been added in v4:
 
 - `public bool CanParseLiteral/CanParseValue`
-- `protected virtual bool CanParseLiteralCore/CanParseValueCore`
 
-These methods checks for input coercion possibility. The last two can be overridden for custom scalars
+These methods checks for input coercion possibility. They can be overridden for custom scalars
 to validate input values without directly getting those values, i.e. without boxing.
 
 ### Ability to get parent resolve context of any level

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1779,18 +1779,21 @@ namespace GraphQL.Types
     public class BigIntGraphType : GraphQL.Types.ScalarGraphType
     {
         public BigIntGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
     public class BooleanGraphType : GraphQL.Types.ScalarGraphType
     {
         public BooleanGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
     public class ByteGraphType : GraphQL.Types.ScalarGraphType
     {
         public ByteGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
@@ -1851,8 +1854,8 @@ namespace GraphQL.Types
     public class DecimalGraphType : GraphQL.Types.ScalarGraphType
     {
         public DecimalGraphType() { }
-        protected override bool CanParseLiteralCore(GraphQL.Language.AST.IValue value) { }
-        protected override bool CanParseValueCore(object value) { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override bool CanParseValue(object value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
@@ -1977,6 +1980,7 @@ namespace GraphQL.Types
     public class FloatGraphType : GraphQL.Types.ScalarGraphType
     {
         public FloatGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
@@ -1994,8 +1998,8 @@ namespace GraphQL.Types
     public class GuidGraphType : GraphQL.Types.ScalarGraphType
     {
         public GuidGraphType() { }
-        protected override bool CanParseLiteralCore(GraphQL.Language.AST.IValue value) { }
-        protected override bool CanParseValueCore(object value) { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override bool CanParseValue(object value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
@@ -2103,6 +2107,7 @@ namespace GraphQL.Types
     public class IdGraphType : GraphQL.Types.ScalarGraphType
     {
         public IdGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
         public override object Serialize(object value) { }
@@ -2123,6 +2128,7 @@ namespace GraphQL.Types
     public class IntGraphType : GraphQL.Types.ScalarGraphType
     {
         public IntGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
@@ -2169,6 +2175,7 @@ namespace GraphQL.Types
     public class LongGraphType : GraphQL.Types.ScalarGraphType
     {
         public LongGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
@@ -2247,16 +2254,15 @@ namespace GraphQL.Types
     public class SByteGraphType : GraphQL.Types.ScalarGraphType
     {
         public SByteGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
     public abstract class ScalarGraphType : GraphQL.Types.GraphType
     {
         protected ScalarGraphType() { }
-        public bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        protected virtual bool CanParseLiteralCore(GraphQL.Language.AST.IValue value) { }
-        public bool CanParseValue(object value) { }
-        protected virtual bool CanParseValueCore(object value) { }
+        public virtual bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public virtual bool CanParseValue(object value) { }
         public abstract object ParseLiteral(GraphQL.Language.AST.IValue value);
         public abstract object ParseValue(object value);
         public virtual object Serialize(object value) { }
@@ -2328,6 +2334,7 @@ namespace GraphQL.Types
     public class ShortGraphType : GraphQL.Types.ScalarGraphType
     {
         public ShortGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
@@ -2338,6 +2345,7 @@ namespace GraphQL.Types
     public class StringGraphType : GraphQL.Types.ScalarGraphType
     {
         public StringGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
@@ -2374,18 +2382,21 @@ namespace GraphQL.Types
     public class UIntGraphType : GraphQL.Types.ScalarGraphType
     {
         public UIntGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
     public class ULongGraphType : GraphQL.Types.ScalarGraphType
     {
         public ULongGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
     public class UShortGraphType : GraphQL.Types.ScalarGraphType
     {
         public UShortGraphType() { }
+        public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }

--- a/src/GraphQL/Types/Scalars/BigIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BigIntGraphType.cs
@@ -20,5 +20,14 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(BigInteger));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value switch
+        {
+            BigIntValue _ => true,
+            LongValue _ => true,
+            IntValue _ => true,
+            _ => false
+        };
     }
 }

--- a/src/GraphQL/Types/Scalars/BooleanGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BooleanGraphType.cs
@@ -13,5 +13,8 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(bool));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value is BooleanValue;
     }
 }

--- a/src/GraphQL/Types/Scalars/ByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ByteGraphType.cs
@@ -18,5 +18,13 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(byte));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value switch
+        {
+            ByteValue _ => true,
+            IntValue intValue => byte.MinValue <= intValue.Value && intValue.Value <= byte.MaxValue,
+            _ => false
+        };
     }
 }

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -11,36 +11,50 @@ namespace GraphQL.Types
     public class DecimalGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        protected override bool CanParseLiteralCore(IValue value)
+        public override bool CanParseLiteral(IValue value)
         {
-            return value switch
+            try
             {
-                DecimalValue _ => true,
-                IntValue _ => true,
-                LongValue _ => true,
-                StringValue s => decimal.TryParse(s.Value, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out _),
-                FloatValue f => Ret(checked((decimal)f.Value)),
-                BigIntValue b => Ret(checked((decimal)b.Value)),
-                _ => false
-            };
+                return value switch
+                {
+                    DecimalValue _ => true,
+                    IntValue _ => true,
+                    LongValue _ => true,
+                    StringValue s => decimal.TryParse(s.Value, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out _),
+                    FloatValue f => Ret(checked((decimal)f.Value)),
+                    BigIntValue b => Ret(checked((decimal)b.Value)),
+                    _ => false
+                };
+            }
+            catch
+            {
+                return false;
+            }
 
             static bool Ret(decimal _) => true;
         }
 
         /// <inheritdoc/>
-        protected override bool CanParseValueCore(object value)
+        public override bool CanParseValue(object value)
         {
-            return value switch
+            try
             {
-                decimal _ => true,
-                int _ => true,
-                long _ => true,
-                string s => decimal.TryParse(s, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out _),
-                float f => Ret(checked((decimal)f)),
-                BigInteger b => Ret(checked((decimal)b)),
-                double d => Ret(checked((decimal)d)),
-                _ => false
-            };
+                return value switch
+                {
+                    decimal _ => true,
+                    int _ => true,
+                    long _ => true,
+                    string s => decimal.TryParse(s, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out _),
+                    float f => Ret(checked((decimal)f)),
+                    BigInteger b => Ret(checked((decimal)b)),
+                    double d => Ret(checked((decimal)d)),
+                    _ => false
+                };
+            }
+            catch
+            {
+                return false;
+            }
 
             static bool Ret(decimal _) => true;
         }

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -12,8 +12,8 @@ namespace GraphQL.Types
         public override object ParseLiteral(IValue value) => value switch
         {
             FloatValue floatVal => floatVal.Value,
-            IntValue intVal => checked((double)intVal.Value),
-            LongValue longVal => checked((double)longVal.Value),
+            IntValue intVal => (double)intVal.Value,
+            LongValue longVal => (double)longVal.Value,
             DecimalValue decVal => checked((double)decVal.Value),
             BigIntValue bigIntVal => checked((double)bigIntVal.Value),
             _ => null
@@ -21,5 +21,28 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(double));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value)
+        {
+            try
+            {
+                return value switch
+                {
+                    FloatValue _ => true,
+                    IntValue _ => true,
+                    LongValue _ => true,
+                    DecimalValue decVal => Ret(checked((double)decVal.Value)),
+                    BigIntValue bigIntVal => Ret(checked((double)bigIntVal.Value)),
+                    _ => false
+                };
+            }
+            catch
+            {
+                return false;
+            }
+
+            static bool Ret(double _) => true;
+        }
     }
 }

--- a/src/GraphQL/Types/Scalars/GuidGraphType.cs
+++ b/src/GraphQL/Types/Scalars/GuidGraphType.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Types
     public class GuidGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        protected override bool CanParseLiteralCore(IValue value) => value switch
+        public override bool CanParseLiteral(IValue value) => value switch
         {
             GuidValue _ => true,
             StringValue s => Guid.TryParse(s.Value, out _),
@@ -17,7 +17,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        protected override bool CanParseValueCore(object value) => value switch
+        public override bool CanParseValue(object value) => value switch
         {
             Guid _ => true,
             string s => Guid.TryParse(s, out _),

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -37,5 +37,14 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => value?.ToString().Trim(' ', '"');
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value switch
+        {
+            StringValue _ => true,
+            IntValue _ => true,
+            LongValue _ => true,
+            _ => false
+        };
     }
 }

--- a/src/GraphQL/Types/Scalars/IntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IntGraphType.cs
@@ -21,5 +21,8 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(int));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value is IntValue;
     }
 }

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -18,5 +18,8 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(long));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value is IntValue || value is LongValue;
     }
 }

--- a/src/GraphQL/Types/Scalars/SByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/SByteGraphType.cs
@@ -18,5 +18,13 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(sbyte));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value switch
+        {
+            SByteValue _ => true,
+            IntValue intValue => sbyte.MinValue <= intValue.Value && intValue.Value <= sbyte.MaxValue,
+            _ => false
+        };
     }
 }

--- a/src/GraphQL/Types/Scalars/ScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ScalarGraphType.cs
@@ -55,45 +55,15 @@ namespace GraphQL.Types
         /// definition or query and checks if it can be converted into an appropriate internal value. In other words
         /// it checks if a scalar can be converted from its client-side representation as an argument to its
         /// server-side representation.
-        /// </summary>
-        /// <param name="value"> AST value node. </param>
-        public bool CanParseLiteral(IValue value)
-        {
-            try
-            {
-                return CanParseLiteralCore(value);
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Checks for literal input coercion possibility. It takes an abstract syntax tree (AST) element from a schema
-        /// definition or query and checks if it can be converted into an appropriate internal value. In other words
-        /// it checks if a scalar can be converted from its client-side representation as an argument to its
-        /// server-side representation.
-        /// <br/>
+        /// <br/><br/>
         /// This method can be overridden to validate input values without directly getting those values, i.e. without boxing.
         /// </summary>
         /// <param name="value"> AST value node. </param>
-        protected virtual bool CanParseLiteralCore(IValue value) => ParseLiteral(value) != null;
-
-        /// <summary>
-        /// Checks for value input coercion possibility. Argument values can not only provided via GraphQL syntax inside a
-        /// query, but also via variable. It checks if a scalar can be converted from its client-side representation
-        /// as a variable to its server-side representation.
-        /// <br/><br/>
-        /// Parsing for arguments and variables are handled separately because while arguments must
-        /// always be expressed in GraphQL query syntax, variable format is transport-specific (usually JSON).
-        /// </summary>
-        /// <param name="value"> Runtime object from variables. </param>
-        public bool CanParseValue(object value)
+        public virtual bool CanParseLiteral(IValue value)
         {
             try
             {
-                return CanParseValueCore(value);
+                return ParseLiteral(value) != null;
             }
             catch
             {
@@ -108,10 +78,20 @@ namespace GraphQL.Types
         /// <br/><br/>
         /// Parsing for arguments and variables are handled separately because while arguments must
         /// always be expressed in GraphQL query syntax, variable format is transport-specific (usually JSON).
-        /// <br/>
+        /// <br/><br/>
         /// This method can be overridden to validate input values without directly getting those values, i.e. without boxing.
         /// </summary>
         /// <param name="value"> Runtime object from variables. </param>
-        protected virtual bool CanParseValueCore(object value) => ParseValue(value) != null;
+        public virtual bool CanParseValue(object value)
+        {
+            try
+            {
+                return ParseValue(value) != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/GraphQL/Types/Scalars/ShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ShortGraphType.cs
@@ -18,5 +18,13 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(short));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value switch
+        {
+            ShortValue _ => true,
+            IntValue intValue => short.MinValue <= intValue.Value && intValue.Value <= short.MaxValue,
+            _ => false
+        };
     }
 }

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -13,5 +13,8 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => value?.ToString();
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value is StringValue;
     }
 }

--- a/src/GraphQL/Types/Scalars/UIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UIntGraphType.cs
@@ -19,5 +19,14 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(uint));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value switch
+        {
+            UIntValue _ => true,
+            IntValue intValue => intValue.Value >= 0,
+            LongValue longValue => uint.MinValue <= longValue.Value && longValue.Value <= uint.MaxValue,
+            _ => false
+        };
     }
 }

--- a/src/GraphQL/Types/Scalars/ULongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ULongGraphType.cs
@@ -20,5 +20,14 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(ulong));
+
+        public override bool CanParseLiteral(IValue value) => value switch
+        {
+            ULongValue _ => true,
+            IntValue intValue => intValue.Value >= 0,
+            LongValue longValue => longValue.Value >= 0,
+            BigIntValue bigIntValue => bigIntValue.Value >= 0 && bigIntValue.Value <= ulong.MaxValue,
+            _ => false
+        };
     }
 }

--- a/src/GraphQL/Types/Scalars/UShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UShortGraphType.cs
@@ -18,5 +18,13 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public override object ParseValue(object value) => ValueConverter.ConvertTo(value, typeof(ushort));
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(IValue value) => value switch
+        {
+            UShortValue _ => true,
+            IntValue intValue => ushort.MinValue <= intValue.Value && intValue.Value <= ushort.MaxValue,
+            _ => false
+        };
     }
 }


### PR DESCRIPTION
This cleans up the API and eliminates boxing for many types of scalar graph types when accessed by `CanParseLiteral`.

I did not add code for `CanParseValue` because in almost all instances, `ValueConverter` is called, and so it cannot be determined which types can be supported.  Besides, that code path is not used by GraphQL.Net.

A `try..catch` block was only needed by a couple scalars.