### PR TITLE
Test for duplicate type name for generic graph type

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug2279.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2279.cs
@@ -15,7 +15,10 @@ namespace GraphQL.Tests.Bugs
             var e = Should.Throw<InvalidOperationException>(() => s.Initialize());
             var t1 = typeof(Bug2279GraphType<int>).FullName;
             var t2 = typeof(Bug2279GraphType<string>).FullName;
-            e.Message.ShouldBe($"Unable to register GraphType '{t1}' with the name 'Bug2279GraphType_1';\r\nthe name 'Bug2279GraphType_1' is already registered to '{t2}'.");
+            //nl will be determined at compile time dictated by how git is configured to handle line endings, not what environment the code was ran in
+            var nl = @"
+";
+            e.Message.ShouldBe($"Unable to register GraphType '{t1}' with the name 'Bug2279GraphType_1';{nl}the name 'Bug2279GraphType_1' is already registered to '{t2}'.");
         }
     }
 

--- a/src/GraphQL.Tests/Bugs/Bug2279.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2279.cs
@@ -1,0 +1,55 @@
+using System;
+using GraphQL.Types;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/2279
+    public class Bug2279DuplicateType : QueryTestBase<Bug2279Schema>
+    {
+        [Fact]
+        public void NoDuplicateTypeNames()
+        {
+            var s = new Bug2279Schema();
+            var e = Should.Throw<InvalidOperationException>(() => s.Initialize());
+            e.Message.ShouldBe("Unable to register GraphType 'GraphQL.Tests.Bugs.Bug2279GraphType`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]' with the name 'Bug2279GraphType_1';" + Environment.NewLine + "the name 'Bug2279GraphType_1' is already registered to 'GraphQL.Tests.Bugs.Bug2279GraphType`1[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]'.");
+        }
+    }
+
+    public class Bug2279Schema : Schema
+    {
+        public Bug2279Schema()
+        {
+            Query = new Bug2279Query();
+        }
+    }
+
+    public class Bug2279Query : ObjectGraphType
+    {
+        public Bug2279Query()
+        {
+            Field<Bug2279GraphType<string>>(
+                "string",
+                resolve: ctx => "hello");
+            Field<Bug2279GraphType<int>>(
+                "int",
+                resolve: ctx => 3);
+        }
+    }
+
+    public class Bug2279GraphType<T> : ObjectGraphType<T>
+    {
+        public Bug2279GraphType()
+        {
+            if (typeof(T) == typeof(int))
+            {
+                Field<IntGraphType, T>().Name("value").Resolve(x => x.Source);
+            }
+            else
+            {
+                Field<StringGraphType, T>().Name("value").Resolve(x => x.Source);
+            }
+        }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug2279.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2279.cs
@@ -13,8 +13,9 @@ namespace GraphQL.Tests.Bugs
         {
             var s = new Bug2279Schema();
             var e = Should.Throw<InvalidOperationException>(() => s.Initialize());
-            e.Message.ShouldBe(@"Unable to register GraphType 'GraphQL.Tests.Bugs.Bug2279GraphType`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]' with the name 'Bug2279GraphType_1';
-the name 'Bug2279GraphType_1' is already registered to 'GraphQL.Tests.Bugs.Bug2279GraphType`1[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]'.");
+            var t1 = typeof(Bug2279GraphType<int>).FullName;
+            var t2 = typeof(Bug2279GraphType<string>).FullName;
+            e.Message.ShouldBe($"Unable to register GraphType '{t1}' with the name 'Bug2279GraphType_1';\r\nthe name 'Bug2279GraphType_1' is already registered to '{t2}'.");
         }
     }
 

--- a/src/GraphQL.Tests/Bugs/Bug2279.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2279.cs
@@ -13,7 +13,8 @@ namespace GraphQL.Tests.Bugs
         {
             var s = new Bug2279Schema();
             var e = Should.Throw<InvalidOperationException>(() => s.Initialize());
-            e.Message.ShouldBe("Unable to register GraphType 'GraphQL.Tests.Bugs.Bug2279GraphType`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]' with the name 'Bug2279GraphType_1';" + Environment.NewLine + "the name 'Bug2279GraphType_1' is already registered to 'GraphQL.Tests.Bugs.Bug2279GraphType`1[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]'.");
+            e.Message.ShouldBe(@"Unable to register GraphType 'GraphQL.Tests.Bugs.Bug2279GraphType`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]' with the name 'Bug2279GraphType_1';
+the name 'Bug2279GraphType_1' is already registered to 'GraphQL.Tests.Bugs.Bug2279GraphType`1[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]'.");
         }
     }
 


### PR DESCRIPTION
This passes both against `master` and `develop`... ???

See #2279 