### PR TITLE
Remove ValidationOnSchemaInitialize

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -530,7 +530,7 @@ default continues to be `ResolverType.Resolver`.
 * `ObjectExecutionNode.SubFields` property type was changed from `Dictionary<string, ExecutionNode>` to `ExecutionNode[]`
 * `ExecutionNode.IsResultSet` has been removed
 * `ExecutionNode.Source` is read-only; additional derived classes have been added for subscriptions
-* `NameValidator.ValidateName` accept an enum instead of a string for their second argument
+* `NameValidator.ValidateName` accepts an enum instead of a string for its second argument
 * `NameValidator.ValidateNameOnSchemaInitialize` has been made internal and `ValidationOnSchemaInitialize` has been removed
 * `ExecutionNode.PropagateNull` must be called before `ExecutionNode.ToValue`; see reference implementation
 * `IDocumentValidator.ValidateAsync` does not take `originalQuery` parameter; use `Document.OriginalQuery` instead

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -129,10 +129,8 @@ It is not recommended to use this feature for interim calculations, as it is bet
 - `EnableReadDeprecationReasonFromAttributes` enables or disables setting default values for 'deprecationReason' from `ObsoleteAttribute`. Enabled by default.
 - `EnableReadDescriptionFromAttributes` enables or disables setting default values for 'description' from `DescriptionAttribute`. Enabled by default.
 - `EnableReadDescriptionFromXmlDocumentation` enables or disables setting default values for 'description' from XML documentation. Disabled by default.
-- `Validation` configures the validator used when setting the `Name` property on types, arguments, etc. Can be used to disable validation
+- `NameValidation` configures the validator used when setting the `Name` property on types, arguments, etc. Can be used to disable validation
   when the configured `INameConverter` fixes up invalid names. See `ISchema.NameConverter`.
-- `ValidationOnSchemaInitialize` configures the validator used to verify the schema after the `INameConverter` has processed all the names.
-  Disabling this validator is unlikely to be of any use, since the parser will not be able to parse a document that contains invalid characters in a name.
 
 It is recommended to configure these options once when your application starts, such as within your `void Main()` method, a static
 constructor of your schema, or a similar location.

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -530,7 +530,8 @@ default continues to be `ResolverType.Resolver`.
 * `ObjectExecutionNode.SubFields` property type was changed from `Dictionary<string, ExecutionNode>` to `ExecutionNode[]`
 * `ExecutionNode.IsResultSet` has been removed
 * `ExecutionNode.Source` is read-only; additional derived classes have been added for subscriptions
-* `NameValidator.ValidateName` and `NameValidator.ValidateNameOnSchemaInitialize` accept an enum instead of a string for their second argument
+* `NameValidator.ValidateName` accept an enum instead of a string for their second argument
+* `NameValidator.ValidateNameOnSchemaInitialize` has been made internal and `ValidationOnSchemaInitialize` has been removed
 * `ExecutionNode.PropagateNull` must be called before `ExecutionNode.ToValue`; see reference implementation
 * `IDocumentValidator.ValidateAsync` does not take `originalQuery` parameter; use `Document.OriginalQuery` instead
 * `IDocumentValidator.ValidateAsync` now returns `(IValidationResult validationResult, Variables variables)` tuple instead of single `IValidationResult` before

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -150,8 +150,7 @@ namespace GraphQL
     }
     public static class GlobalSwitches
     {
-        public static System.Action<string, GraphQL.Utilities.NamedElement> Validation;
-        public static System.Action<string, GraphQL.Utilities.NamedElement> ValidationOnSchemaInitialize;
+        public static System.Action<string, GraphQL.Utilities.NamedElement> NameValidation;
         public static bool EnableReadDefaultValueFromAttributes { get; set; }
         public static bool EnableReadDeprecationReasonFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromAttributes { get; set; }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2584,7 +2584,6 @@ namespace GraphQL.Utilities
     {
         public static void ValidateDefault(string name, GraphQL.Utilities.NamedElement type) { }
         public static void ValidateName(string name, GraphQL.Utilities.NamedElement type) { }
-        public static void ValidateNameOnSchemaInitialize(string name, GraphQL.Utilities.NamedElement type) { }
     }
     public enum NamedElement
     {

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -359,7 +359,7 @@ namespace GraphQL.Tests.Types
         [InlineData("id$")]
         public void does_not_throw_with_filtering_nameconverter(string fieldName)
         {
-            GlobalSwitches.Validation = (n, t) => { }; // disable "before" checks
+            GlobalSwitches.NameValidation = (n, t) => { }; // disable "before" checks
 
             try
             {
@@ -374,7 +374,7 @@ namespace GraphQL.Tests.Types
             }
             finally
             {
-                GlobalSwitches.Validation = NameValidator.ValidateDefault; // restore defaults
+                GlobalSwitches.NameValidation = NameValidator.ValidateDefault; // restore defaults
             }
         }
 

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -42,19 +42,13 @@ namespace GraphQL
         /// Setting this delegate allows you to use names not conforming to the specification, for example
         /// 'enum-member'. Only change it when absolutely necessary. This is typically only overridden
         /// when implementing a custom <see cref="INameConverter"/> that fixes names, making them spec-compliant.
-        /// </summary>
-        public static Action<string, NamedElement> Validation = NameValidator.ValidateDefault;
-
-        /// <summary>
-        /// Gets or sets current validation delegate during schema initialization. By default this delegate
-        /// validates all names according to the GraphQL <see href="http://spec.graphql.org/June2018/#sec-Names">specification</see>.
         /// <br/><br/>
-        /// Setting this delegate allows you to use names not conforming to the specification, for example
-        /// 'enum-member'. Only change it when absolutely necessary. Keep in mind that the parser cannot
-        /// parse incoming queries with invalid characters in the names, so it is likely that the resulting
-        /// member will be unusable.
+        /// Keep in mind that regardless of this setting, names are validated upon schema initialization,
+        /// after being processed by the <see cref="INameConverter"/>. This is due to the fact that the
+        /// parser cannot parse incoming queries with invalid characters in the names, so the resulting
+        /// member would become unusable.
         /// </summary>
-        public static Action<string, NamedElement> ValidationOnSchemaInitialize = NameValidator.ValidateDefault;
+        public static Action<string, NamedElement> NameValidation = NameValidator.ValidateDefault;
 
         /// <summary>
         /// This setting by default improves performance if your schema uses only scalar types or types marked with

--- a/src/GraphQL/Utilities/NameValidator.cs
+++ b/src/GraphQL/Utilities/NameValidator.cs
@@ -12,14 +12,14 @@ namespace GraphQL.Utilities
         /// </summary>
         /// <param name="name">GraphQL name.</param>
         /// <param name="type">Type of element: field, type, argument, enum.</param>
-        public static void ValidateName(string name, NamedElement type) => GlobalSwitches.Validation(name, type);
+        public static void ValidateName(string name, NamedElement type) => GlobalSwitches.NameValidation(name, type);
 
         /// <summary>
         /// Validates a specified name during schema initialization.
         /// </summary>
         /// <param name="name">GraphQL name.</param>
         /// <param name="type">Type of element: field, type, argument, enum.</param>
-        public static void ValidateNameOnSchemaInitialize(string name, NamedElement type) => GlobalSwitches.ValidationOnSchemaInitialize(name, type);
+        public static void ValidateNameOnSchemaInitialize(string name, NamedElement type) => ValidateDefault(name, type);
 
         /// <summary>
         /// Validates a specified name according to the GraphQL <see href="http://spec.graphql.org/June2018/#sec-Names">specification</see>.

--- a/src/GraphQL/Utilities/NameValidator.cs
+++ b/src/GraphQL/Utilities/NameValidator.cs
@@ -19,7 +19,7 @@ namespace GraphQL.Utilities
         /// </summary>
         /// <param name="name">GraphQL name.</param>
         /// <param name="type">Type of element: field, type, argument, enum.</param>
-        public static void ValidateNameOnSchemaInitialize(string name, NamedElement type) => ValidateDefault(name, type);
+        internal static void ValidateNameOnSchemaInitialize(string name, NamedElement type) => ValidateDefault(name, type);
 
         /// <summary>
         /// Validates a specified name according to the GraphQL <see href="http://spec.graphql.org/June2018/#sec-Names">specification</see>.


### PR DESCRIPTION
Fixes #2204 

Also renamed `GlobalSwitches.Validation` to `GlobalSwitches.NameValidation` to better indicate what this delegate is validating.