### PR TITLE
Change generic type constraint of NonNullGraphType

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2186,7 +2186,7 @@ namespace GraphQL.Types
         public override string ToString() { }
     }
     public sealed class NonNullGraphType<T> : GraphQL.Types.NonNullGraphType
-        where T : GraphQL.Types.GraphType
+        where T : GraphQL.Types.IGraphType
     {
         public NonNullGraphType() { }
         public override System.Type Type { get; }

--- a/src/GraphQL/Types/Composite/NonNullGraphType.cs
+++ b/src/GraphQL/Types/Composite/NonNullGraphType.cs
@@ -53,7 +53,7 @@ namespace GraphQL.Types
 
     /// <inheritdoc cref="NonNullGraphType"/>
     public sealed class NonNullGraphType<T> : NonNullGraphType
-        where T : GraphType
+        where T : IGraphType
     {
         /// <summary>
         /// Initializes a new instance for the specified inner graph type.


### PR DESCRIPTION
Of note, `ResolvedType` is of type `IGraphType`, and `ListGraphType<>`'s constraint is already `IGraphType` 