### PR TITLE
Add ISchema.AdditionalTypeInstances

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1922,6 +1922,7 @@ namespace GraphQL.Types
     }
     public interface ISchema : GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
+        System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AdditionalTypeInstances { get; }
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         GraphQL.Types.SchemaTypes AllTypes { get; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
@@ -2127,6 +2128,7 @@ namespace GraphQL.Types
     {
         public Schema() { }
         public Schema(System.IServiceProvider services) { }
+        public System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AdditionalTypeInstances { get; }
         public System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
         public GraphQL.Types.SchemaTypes AllTypes { get; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -77,12 +77,12 @@ namespace GraphQL.Types
         SchemaTypes AllTypes { get; }
 
         /// <summary>
-        /// A list of additional graph types manually added to the schema by RegisterType call.
+        /// A list of additional graph types manually added to the schema by a <see cref="RegisterType(Type)"/> call.
         /// </summary>
         IEnumerable<Type> AdditionalTypes { get; }
 
         /// <summary>
-        /// A list of additional graph type instances manually added to the schema by RegisterType call.
+        /// A list of additional graph type instances manually added to the schema by a <see cref="RegisterType(IGraphType)"/> call.
         /// </summary>
         IEnumerable<IGraphType> AdditionalTypeInstances { get; }
 

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -82,6 +82,11 @@ namespace GraphQL.Types
         IEnumerable<Type> AdditionalTypes { get; }
 
         /// <summary>
+        /// A list of additional graph type instances manually added to the schema by RegisterType call.
+        /// </summary>
+        IEnumerable<IGraphType> AdditionalTypeInstances { get; }
+
+        /// <summary>
         /// Adds the specified instance of an <see cref="ISchemaNodeVisitor"/> to the schema.
         /// When initializing a schema, all registered visitors will be executed on each
         /// schema element when it is traversed.

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -164,6 +164,9 @@ namespace GraphQL.Types
         public IEnumerable<Type> AdditionalTypes => _additionalTypes ?? Enumerable.Empty<Type>();
 
         /// <inheritdoc/>
+        public IEnumerable<IGraphType> AdditionalTypeInstances => _additionalInstances ?? Enumerable.Empty<IGraphType>();
+
+        /// <inheritdoc/>
         public FieldType SchemaMetaFieldType => AllTypes.SchemaMetaFieldType;
 
         /// <inheritdoc/>


### PR DESCRIPTION
Realized this property was missing when trying to enumerate the additionally registered graph type instances.