### PR TITLE
Allow SchemaTypes to be overridable

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2176,14 +2176,17 @@ namespace GraphQL.Types
     }
     public class SchemaTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
     {
+        protected SchemaTypes() { }
+        public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider graphTypeProvider) { }
         public int Count { get; }
+        protected virtual System.Collections.Generic.Dictionary<string, GraphQL.Types.IGraphType> Dictionary { get; }
         public GraphQL.Types.IGraphType this[string typeName] { get; }
+        protected virtual GraphQL.Types.FieldType SchemaMetaFieldType { get; }
+        protected virtual GraphQL.Types.FieldType TypeMetaFieldType { get; }
+        protected virtual GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
         public void ApplyMiddleware(GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
         public void ApplyMiddleware(System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Types.IGraphType> GetEnumerator() { }
-        public static GraphQL.Types.SchemaTypes Create(System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> types, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
-                "clrType",
-                "graphType"})] System.Collections.Generic.List<System.ValueTuple<System.Type, System.Type>> typeMappings, System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType> directives, System.Func<System.Type, GraphQL.Types.IGraphType> resolveType, GraphQL.Types.ISchema schema) { }
     }
     public class ShortGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -350,12 +350,7 @@ namespace GraphQL.Types
                 }
             }
 
-            _allTypes = SchemaTypes.Create(
-                GetTypes(),
-                _clrToGraphTypeMappings,
-                Directives,
-                type => (IGraphType)_services.GetRequiredService(type),
-                this);
+            _allTypes = new SchemaTypes(this, GetTypes(), _services);
 
             // At this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete.
             // However, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock.

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -307,34 +307,6 @@ namespace GraphQL.Types
 
         private void CreateSchemaTypes()
         {
-            IEnumerable<IGraphType> GetTypes()
-            {
-                if (_additionalInstances != null)
-                {
-                    foreach (var instance in _additionalInstances)
-                        yield return instance;
-                }
-
-                //TODO: According to the specification, Query is a required type. But if you uncomment these lines, then the mass of tests begin to fail, because they do not set Query.
-                // if (Query == null)
-                //    throw new InvalidOperationException("Query root type must be provided. See https://graphql.github.io/graphql-spec/June2018/#sec-Schema-Introspection");
-
-                if (Query != null)
-                    yield return Query;
-
-                if (Mutation != null)
-                    yield return Mutation;
-
-                if (Subscription != null)
-                    yield return Subscription;
-
-                if (_additionalTypes != null)
-                {
-                    foreach (var type in _additionalTypes)
-                        yield return (IGraphType)_services.GetRequiredService(type.GetNamedType());
-                }
-            }
-
             IEnumerable<ISchemaNodeVisitor> GetVisitors()
             {
                 if (_visitors != null)
@@ -350,7 +322,7 @@ namespace GraphQL.Types
                 }
             }
 
-            _allTypes = new SchemaTypes(this, GetTypes(), _services);
+            _allTypes = new SchemaTypes(this, _services);
 
             // At this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete.
             // However, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock.


### PR DESCRIPTION
Since `SchemaTypes` is not an interface (there is no `ISchemaTypes`), I would like to add the very minimum to the codebase to allow it to be replaced if desired.  I would like to experiment with doing so, but cannot as it is now because it is effectively a `sealed` class -- the constructor is private and even if it were not, the `Create` method is static.

In doing so, I took advantage of the fact that we are now passing `ISchema` to `Create`, and so there is no need to pass most of the rest of the arguments.  The code that executes is exactly the same; no changes were made.  It was simply reorganized a little.

The API changes to `SchemaTypes` are simple also:
- Add protected constructor that does nothing
- Make the `internal` members 'protected internal virtual' so they can be overridden:
  - Dictionary
  - SchemaMetaFieldType
  - TypeMetaFieldType
  - TypeNameMetaFieldType

The public members all access the dictionary, so I did not make them virtual at this time.  I would like to look at that, but it can be done after v4 has been released.  We also could/should make some members of `Schema` virtual.  However, it is an interface, so it can be replaced.

The only other change is that I did remove `CheckDisposed` because it was pointless.  There are no public members to allow adding types after initialization.  Retaining it would have required additional protected members.

This code requires PR #2365 in order to compile.

This PR is necessary by the fact that, unlike v3, `SchemaTypes` is referenced throughout the project.  There is no way with v4 to get around having to use `SchemaTypes`.  So this PR is designed to let `SchemaTypes` be replaced as needed.  Unfortunately since there are no protected methods yet, all of the code would need to be duplicated to the new class.  I hope to rectify that in a future non-breaking PR, but it will take time and I don't want to hold up v4.

@sungam3r If you feel that adding an interface is a better way to go, please let me know.