### PR TITLE
Make type reference classes public

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -502,7 +502,7 @@ default continues to be `ResolverType.Resolver`.
 * `CoreToVanillaConverter.Convert` method now requires only one `GraphQLDocument` argument.
 * `GraphTypesLookup` has been renamed to `SchemaTypes` with a significant decrease in public APIs 
 * `TypeCollectionContext` class is now internal, also all methods with this parameter in `GraphTypesLookup` (now `SchemaTypes`) are private.
-* `GraphQLTypeReference` class is now internal, also `GraphTypesLookup.ApplyTypeReferences` is now private.
+* `GraphTypesLookup.ApplyTypeReferences` is now private.
 * `IHaveDefaultValue.Type` has been moved to `IProvideResolvedType.Type`
 * `ErrorLocation` struct became `readonly`.
 * `DebugNodeVisitor` class has been removed.

--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -436,6 +436,10 @@ schema.RegisterTypeMapping<int, MyIntGraphType>();
 schema.RegisterTypeMapping<string, MySpecialFormattedStringGraphType>();
 ```
 
+If you have dynamic code that relies on a call to `GraphTypeTypeRegistry.Get<T>` then you will need to instead utilize
+a graph type of `GraphQLClrOutputTypeReference<T>` or `GraphQLClrInputTypeReference<T>` where `T` is the CLR type.
+The type reference will be replaced with the proper graph type during schema initialization.
+
 ### Classes for automatic GraphType registration by default use all properties of the CLR type
 
 In v4 `AutoRegisteringObjectGraphType<TSourceType>` and `AutoRegisteringInputObjectGraphType<TSourceType>`

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1836,6 +1836,19 @@ namespace GraphQL.Types
         public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public override object ParseValue(object value) { }
     }
+    public sealed class GraphQLClrInputTypeReference<T> : GraphQL.Types.InputObjectGraphType { }
+    public sealed class GraphQLClrOutputTypeReference<T> : GraphQL.Types.InterfaceGraphType { }
+    public sealed class GraphQLTypeReference : GraphQL.Types.InterfaceGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
+    {
+        public GraphQLTypeReference(string typeName) { }
+        public GraphQL.Types.Interfaces Interfaces { get; }
+        public System.Func<object, bool> IsTypeOf { get; set; }
+        public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public string TypeName { get; }
+        public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
     public abstract class GraphType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         protected GraphType() { }

--- a/src/GraphQL/Types/GraphQLTypeReference.cs
+++ b/src/GraphQL/Types/GraphQLTypeReference.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Types
     /// reference to the actual GraphQL type before using the reference.
     /// </summary>
     [DebuggerDisplay("ref {TypeName,nq}")]
-    internal sealed class GraphQLTypeReference : InterfaceGraphType, IObjectGraphType
+    public sealed class GraphQLTypeReference : InterfaceGraphType, IObjectGraphType
     {
         public GraphQLTypeReference(string typeName)
         {
@@ -21,20 +21,25 @@ namespace GraphQL.Types
         /// </summary>
         public string TypeName { get; private set; }
 
+        /// <inheritdoc/>
         public Func<object, bool> IsTypeOf
         {
             get => throw Invalid();
             set => throw Invalid();
         }
-
+        
+        /// <inheritdoc/>
         public void AddResolvedInterface(IInterfaceGraphType graphType) => throw Invalid();
 
+        /// <inheritdoc/>
         public Interfaces Interfaces => throw Invalid();
 
+        /// <inheritdoc/>
         public ResolvedInterfaces ResolvedInterfaces => throw Invalid();
 
         private InvalidOperationException Invalid() => new InvalidOperationException($"This is just a reference to '{TypeName}'. Resolve the real type first.");
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is GraphQLTypeReference other
@@ -42,6 +47,7 @@ namespace GraphQL.Types
                 : base.Equals(obj);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode() => TypeName?.GetHashCode() ?? 0;
     }
 
@@ -49,7 +55,7 @@ namespace GraphQL.Types
     /// Represents a placeholder for another GraphQL Output type, referenced by CLR type. Must be replaced with a
     /// reference to the actual GraphQL type before using the reference.
     /// </summary>
-    internal sealed class GraphQLClrOutputTypeReference<T> : InterfaceGraphType
+    public sealed class GraphQLClrOutputTypeReference<T> : InterfaceGraphType
     {
         internal GraphQLClrOutputTypeReference()
         {
@@ -61,7 +67,7 @@ namespace GraphQL.Types
     /// Represents a placeholder for another GraphQL Input type, referenced by CLR type. Must be replaced with a
     /// reference to the actual GraphQL type before using the reference.
     /// </summary>
-    internal sealed class GraphQLClrInputTypeReference<T> : InputObjectGraphType
+    public sealed class GraphQLClrInputTypeReference<T> : InputObjectGraphType
     {
         internal GraphQLClrInputTypeReference()
         {


### PR DESCRIPTION
Fixes #2364 

These three classes seem necessary (or at the very least, useful) for people writing dynamic schema builder code.
- `GraphQLTypeReference`
- `GraphQLClrOutputTypeReference`
- `GraphQLClrInputTypeReference`

This PR makes them public.