### PR TITLE
Change AstPrinter guts to internal

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -535,6 +535,7 @@ default continues to be `ResolverType.Resolver`.
 * `ValidationContext.Print(INode node)` and `ValidationContext.Print(IGraphType type)` methods have been removed
 * `Directives.HasDuplicates` property has been removed
 * `KnownDirectives` validation rule has been renamed to `KnownDirectivesInAllowedLocations` and now also generates `5.7.2` validation error number
+* `AstPrinter` supporting classes have been removed; the static method `AstPrinter.Print(INode node)` is the only exposed member.
 
 ### Other Breaking Changes (including but not limited to)
 

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2354,35 +2354,6 @@ namespace GraphQL.Utilities
         public void VisitSchema(GraphQL.Types.ISchema schema) { }
         public void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
     }
-    public class AstPrintConfig
-    {
-        public AstPrintConfig() { }
-        public System.Collections.Generic.IEnumerable<GraphQL.Utilities.AstPrintFieldDefinition> Fields { get; }
-        public System.Func<GraphQL.Language.AST.INode, bool> Matches { get; set; }
-        public System.Func<System.Collections.Generic.IDictionary<string, object>, object> PrintAst { get; set; }
-        public void Field(GraphQL.Utilities.AstPrintFieldDefinition field) { }
-    }
-    public class AstPrintConfig<T> : GraphQL.Utilities.AstPrintConfig
-        where T : GraphQL.Language.AST.INode
-    {
-        public AstPrintConfig() { }
-        public void Field<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> resolve) { }
-        public void Print(System.Func<GraphQL.Utilities.PrintFormat<T>, object> configure) { }
-    }
-    public class AstPrintFieldDefinition
-    {
-        public AstPrintFieldDefinition() { }
-        public string Name { get; set; }
-        public GraphQL.Utilities.IValueResolver Resolver { get; set; }
-    }
-    public class AstPrintVisitor
-    {
-        public AstPrintVisitor() { }
-        public object ApplyConfig(GraphQL.Language.AST.INode node) { }
-        public void Config<T>(System.Action<GraphQL.Utilities.AstPrintConfig<T>> configure)
-            where T : GraphQL.Language.AST.INode { }
-        public object Visit(GraphQL.Language.AST.INode node) { }
-    }
     public static class AstPrinter
     {
         public static string Print(GraphQL.Language.AST.INode node) { }
@@ -2415,11 +2386,6 @@ namespace GraphQL.Utilities
         public override void VisitInterfaceFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
         public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
     }
-    public class ExpressionValueResolver<TObject, TProperty> : GraphQL.Utilities.IValueResolver, GraphQL.Utilities.IValueResolver<TProperty>
-    {
-        public ExpressionValueResolver(System.Linq.Expressions.Expression<System.Func<TObject, TProperty>> property) { }
-        public TProperty Resolve(in GraphQL.Utilities.ResolveValueContext context) { }
-    }
     public class FieldConfig : GraphQL.Utilities.MetadataProvider
     {
         public FieldConfig(string name) { }
@@ -2451,14 +2417,6 @@ namespace GraphQL.Utilities
         void VisitSchema(GraphQL.Types.ISchema schema);
         void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema);
     }
-    public interface IValueResolver
-    {
-        object Resolve(in GraphQL.Utilities.ResolveValueContext context);
-    }
-    public interface IValueResolver<T> : GraphQL.Utilities.IValueResolver
-    {
-        T Resolve(in GraphQL.Utilities.ResolveValueContext context);
-    }
     public class MetadataProvider : GraphQL.Types.IProvideMetadata
     {
         public MetadataProvider() { }
@@ -2480,20 +2438,6 @@ namespace GraphQL.Utilities
         Argument = 2,
         EnumValue = 3,
         Directive = 4,
-    }
-    public class PrintFormat<T>
-    {
-        public PrintFormat(System.Collections.Generic.IDictionary<string, object> args) { }
-        public object Arg(string key) { }
-        public object Arg<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> argument) { }
-        public TVal Arg<TVal>(string key) { }
-        public System.Collections.Generic.IEnumerable<object> ArgArray<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> argument) { }
-    }
-    public readonly struct ResolveValueContext
-    {
-        public ResolveValueContext(object source) { }
-        public object Source { get; }
-        public TType SourceAs<TType>() { }
     }
     public class SchemaBuilder
     {

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Utilities
         }
     }
 
-    public class AstPrintConfig
+    internal class AstPrintConfig
     {
         internal List<AstPrintFieldDefinition> FieldsList { get; } = new List<AstPrintFieldDefinition>();
         public IEnumerable<AstPrintFieldDefinition> Fields => FieldsList;
@@ -44,7 +44,7 @@ namespace GraphQL.Utilities
         }
     }
 
-    public class PrintFormat<T>
+    internal class PrintFormat<T>
     {
         private readonly IDictionary<string, object> _args;
 
@@ -77,7 +77,7 @@ namespace GraphQL.Utilities
         }
     }
 
-    public class AstPrintConfig<T> : AstPrintConfig
+    internal class AstPrintConfig<T> : AstPrintConfig
         where T : INode
     {
         public void Field<TProperty>(Expression<Func<T, TProperty>> resolve)
@@ -102,13 +102,13 @@ namespace GraphQL.Utilities
         }
     }
 
-    public class AstPrintFieldDefinition
+    internal class AstPrintFieldDefinition
     {
         public string Name { get; set; }
         public IValueResolver Resolver { get; set; }
     }
 
-    public readonly struct ResolveValueContext
+    internal readonly struct ResolveValueContext
     {
         public ResolveValueContext(object source)
         {
@@ -128,17 +128,17 @@ namespace GraphQL.Utilities
         }
     }
 
-    public interface IValueResolver
+    internal interface IValueResolver
     {
         object Resolve(in ResolveValueContext context);
     }
 
-    public interface IValueResolver<T> : IValueResolver
+    internal interface IValueResolver<T> : IValueResolver
     {
         new T Resolve(in ResolveValueContext context);
     }
 
-    public class ExpressionValueResolver<TObject, TProperty> : IValueResolver<TProperty>
+    internal class ExpressionValueResolver<TObject, TProperty> : IValueResolver<TProperty>
     {
         private readonly Func<TObject, TProperty> _property;
 
@@ -158,7 +158,7 @@ namespace GraphQL.Utilities
         }
     }
 
-    public class AstPrintVisitor
+    internal class AstPrintVisitor
     {
         private readonly List<AstPrintConfig> _configs = new List<AstPrintConfig>();
 


### PR DESCRIPTION
If someone needs access to the `AstPrinter` internals, we can make it public again.  Or refactor and then make it public again.  Seems that the only thing needed might be a hook in case someone adds another `ValueNode<T>` implementation, but with the new scalar types design, it should not be necessary.  All scalar nodes should be one of the predefined types.