### PR TITLE
Fix formatting for AstPrinter value nodes

### DIFF
--- a/src/GraphQL.Tests/Language/ValueNodeTests.cs
+++ b/src/GraphQL.Tests/Language/ValueNodeTests.cs
@@ -11,25 +11,25 @@ namespace GraphQL.Tests.Language
     public class ValueNodeTests
     {
         [Fact]
-        public void double_cannot_contain_nan()
+        public void floatvalue_cannot_contain_nan()
         {
             Should.Throw<ArgumentOutOfRangeException>(() => new FloatValue(double.NaN));
         }
 
         [Fact]
-        public void double_cannot_contain_infinity()
+        public void floatvalue_cannot_contain_infinity()
         {
             Should.Throw<ArgumentOutOfRangeException>(() => new FloatValue(double.PositiveInfinity));
         }
 
         [Fact]
-        public void double_cannot_contain_negativeinfinity()
+        public void floatvalue_cannot_contain_negativeinfinity()
         {
             Should.Throw<ArgumentOutOfRangeException>(() => new FloatValue(double.NegativeInfinity));
         }
 
         [Fact]
-        public void string_cannot_be_null()
+        public void stringvalue_cannot_be_null()
         {
             Should.Throw<ArgumentNullException>(() => new StringValue(null));
         }

--- a/src/GraphQL.Tests/Language/ValueNodeTests.cs
+++ b/src/GraphQL.Tests/Language/ValueNodeTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using GraphQL.Language;
+using GraphQL.Language.AST;
+using GraphQLParser;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Language
+{
+    public class ValueNodeTests
+    {
+        [Fact]
+        public void double_cannot_contain_nan()
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => new FloatValue(double.NaN));
+        }
+
+        [Fact]
+        public void double_cannot_contain_infinity()
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => new FloatValue(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public void double_cannot_contain_negativeinfinity()
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => new FloatValue(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void string_cannot_be_null()
+        {
+            Should.Throw<ArgumentNullException>(() => new StringValue(null));
+        }
+    }
+}

--- a/src/GraphQL.Tests/Language/ValueNodeTests.cs
+++ b/src/GraphQL.Tests/Language/ValueNodeTests.cs
@@ -14,18 +14,6 @@ namespace GraphQL.Tests.Language
         }
 
         [Fact]
-        public void floatvalue_cannot_contain_infinity()
-        {
-            Should.Throw<ArgumentOutOfRangeException>(() => new FloatValue(double.PositiveInfinity));
-        }
-
-        [Fact]
-        public void floatvalue_cannot_contain_negativeinfinity()
-        {
-            Should.Throw<ArgumentOutOfRangeException>(() => new FloatValue(double.NegativeInfinity));
-        }
-
-        [Fact]
         public void stringvalue_cannot_be_null()
         {
             Should.Throw<ArgumentNullException>(() => new StringValue(null));

--- a/src/GraphQL.Tests/Language/ValueNodeTests.cs
+++ b/src/GraphQL.Tests/Language/ValueNodeTests.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Linq;
-using GraphQL.Language;
 using GraphQL.Language.AST;
-using GraphQLParser;
 using Shouldly;
 using Xunit;
 

--- a/src/GraphQL.Tests/Language/ValueNodeTests.cs
+++ b/src/GraphQL.Tests/Language/ValueNodeTests.cs
@@ -14,9 +14,35 @@ namespace GraphQL.Tests.Language
         }
 
         [Fact]
-        public void stringvalue_cannot_be_null()
+        public void stringvalue_cannot_contain_null()
         {
             Should.Throw<ArgumentNullException>(() => new StringValue(null));
+        }
+
+        [Fact]
+        public void namenode_cannot_contain_null()
+        {
+            Should.Throw<ArgumentNullException>(() => new NameNode(null));
+        }
+
+        [Fact]
+        public void namenode_can_contain_empty_location()
+        {
+            new NameNode("a").SourceLocation.ShouldBe(default(SourceLocation));
+            new NameNode("a", default(SourceLocation)).SourceLocation.ShouldBe(default(SourceLocation));
+        }
+
+        [Fact]
+        public void enumvalue_cannot_contain_null()
+        {
+            Should.Throw<ArgumentNullException>(() => new EnumValue(null));
+        }
+
+        [Fact]
+        public void enumvalue_cannot_contain_invalid_characters()
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => new EnumValue("kebab-enum"));
+            Should.Throw<ArgumentOutOfRangeException>(() => new EnumValue(new NameNode("kebab-enum")));
         }
     }
 }

--- a/src/GraphQL.Tests/NameFieldResolverTests.cs
+++ b/src/GraphQL.Tests/NameFieldResolverTests.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Tests
                 Name = "Anyone"
             };
 
-            Func<object> result = () => NameFieldResolver.Instance.Resolve(new ResolveFieldContext { Source = person, FieldAst = new Field(default, new NameNode(name) { }) });
+            Func<object> result = () => NameFieldResolver.Instance.Resolve(new ResolveFieldContext { Source = person, FieldAst = new Field(default, name == null ? default : new NameNode(name)) });
 
             if (throws)
                 Should.Throw<InvalidOperationException>(() => result());

--- a/src/GraphQL.Tests/Utilities/AstPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/AstPrinterTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Globalization;
 using GraphQL.Execution;
 using GraphQL.Language.AST;
 using GraphQL.Utilities;
+using GraphQL.Utilities.Federation;
 using Shouldly;
 using Xunit;
 
@@ -78,7 +80,7 @@ namespace GraphQL.Tests.Utilities
             int value = 3;
             var val = new IntValue(value);
             var result = _printer.Visit(val);
-            result.ShouldBe(value);
+            result.ShouldBe("3");
         }
 
         [Fact]
@@ -87,7 +89,7 @@ namespace GraphQL.Tests.Utilities
             long value = 3;
             var val = new LongValue(value);
             var result = _printer.Visit(val);
-            result.ShouldBe(value);
+            result.ShouldBe("3");
         }
 
         [Fact]
@@ -112,5 +114,69 @@ namespace GraphQL.Tests.Utilities
                 .Replace("\r\n", "\n")
                 .Replace("\r", "\n");
         }
+
+        [Fact]
+        public void anynode_throws()
+        {
+            Should.Throw<InvalidOperationException>(() => AstPrinter.Print(new AnyValue("")));
+        }
+
+        [Fact]
+        public void invalid_floatvalue_throws()
+        {
+            Should.Throw<InvalidOperationException>(() => AstPrinter.Print(new FloatValue(double.PositiveInfinity)));
+            Should.Throw<InvalidOperationException>(() => AstPrinter.Print(new FloatValue(double.NegativeInfinity)));
+            Should.Throw<InvalidOperationException>(() => AstPrinter.Print(new FloatValue(double.NaN)));
+        }
+
+        [Fact]
+        public void null_stringvalue_throws()
+        {
+            Should.Throw<InvalidOperationException>(() => AstPrinter.Print(new StringValue(null)));
+        }
+
+        [Theory]
+        [MemberData(nameof(NodeTests))]
+        public void prints_node(INode node, string expected)
+        {
+            AstPrinter.Print(node).ShouldBe(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(NodeTests))]
+        public void prints_node_cultures(INode node, string expected)
+        {
+            CultureTestHelper.UseCultures(() => prints_node(node, expected));
+        }
+
+        public static object[][] NodeTests = new object[][]
+        {
+            new object[] { new StringValue("test"), "\"test\"" },
+            new object[] { new StringValue("ab\"cd"), "\"ab\\\"cd\"" },
+            new object[] { new StringValue("ab\u0019cd"), "\"ab\\u0019cd\"" },
+            new object[] { new StringValue("\"abcd\""), "\"\\\"abcd\\\"\"" },
+            new object[] { new IntValue(int.MinValue), "-2147483648" },
+            new object[] { new IntValue(0), "0" },
+            new object[] { new IntValue(int.MaxValue), "2147483647" },
+            new object[] { new LongValue(long.MinValue), "-9223372036854775808" },
+            new object[] { new LongValue(0), "0" },
+            new object[] { new LongValue(long.MaxValue), "9223372036854775807" },
+            new object[] { new BigIntValue(new System.Numerics.BigInteger(decimal.MaxValue) * 1000 + 2), "79228162514264337593543950335002" },
+            new object[] { new FloatValue(double.MinValue), "-1.79769313486232E+308" },
+            new object[] { new FloatValue(double.Epsilon), "4.94065645841247E-324" },
+            new object[] { new FloatValue(double.MaxValue), "1.79769313486232E+308" },
+            new object[] { new FloatValue(0.00000001256), "1.256E-08" },
+            new object[] { new FloatValue(12.56), "12.56" },
+            new object[] { new FloatValue(3.33), "3.33" },
+            new object[] { new FloatValue(1.0), "1" },
+            new object[] { new FloatValue(34), "34" },
+            new object[] { new DecimalValue(1.0000m), "1"},
+            new object[] { new DecimalValue(decimal.MinValue), "-79228162514264337593543950335"},
+            new object[] { new DecimalValue(decimal.MaxValue), "79228162514264337593543950335"},
+            new object[] { new DecimalValue(0.00000000000000001m), "1E-17"},
+            new object[] { new BooleanValue(false), "false"},
+            new object[] { new BooleanValue(true), "true"},
+            new object[] { new EnumValue("TEST"), "TEST"},
+        };
     }
 }

--- a/src/GraphQL.Tests/Utilities/AstPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/AstPrinterTests.cs
@@ -127,6 +127,8 @@ namespace GraphQL.Tests.Utilities
         {
             var sample = new string(Enumerable.Range(0, 256).Select(x => (char)x).ToArray());
             var ret = AstPrinter.Print(new StringValue(sample));
+            foreach (var c in ret)
+                c.ShouldBeGreaterThanOrEqualTo(' ');
             var deserialized = System.Text.Json.JsonSerializer.Deserialize<string>(ret);
             deserialized.ShouldBe(sample);
         }

--- a/src/GraphQL.Tests/Utilities/AstPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/AstPrinterTests.cs
@@ -165,7 +165,7 @@ namespace GraphQL.Tests.Utilities
         public static object[][] NodeTests = new object[][]
         {
             new object[] { new StringValue("test"), @"""test""" },
-            new object[] { new StringValue("ab/cd"), @"""ab\/cd""" },
+            new object[] { new StringValue("ab/cd"), @"""ab/cd""" },
             new object[] { new StringValue("ab\bcd"), @"""ab\bcd""" },
             new object[] { new StringValue("ab\fcd"), @"""ab\fcd""" },
             new object[] { new StringValue("ab\rcd"), @"""ab\rcd""" },

--- a/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
+++ b/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
@@ -151,7 +151,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "stringArg", "String", "1.0", 3, 32);
+                Rule.badValue(_, "stringArg", "String", "1", 3, 32);
             });
         }
 
@@ -247,7 +247,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "intArg", "Int", "3.0", 3, 29);
+                Rule.badValue(_, "intArg", "Int", "3", 3, 29);
             });
         }
 
@@ -343,7 +343,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "booleanArg", "Boolean", "1.0", 3, 33);
+                Rule.badValue(_, "booleanArg", "Boolean", "1", 3, 33);
             });
         }
 
@@ -391,7 +391,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "idArg", "ID", "1.0", 3, 28);
+                Rule.badValue(_, "idArg", "ID", "1", 3, 28);
             });
         }
 
@@ -461,7 +461,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "dogCommand", "DogCommand", "1.0", 3, 33);
+                Rule.badValue(_, "dogCommand", "DogCommand", "1", 3, 33);
             });
         }
 

--- a/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
+++ b/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
@@ -151,7 +151,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "stringArg", "String", "1", 3, 32);
+                Rule.badValue(_, "stringArg", "String", "1.0", 3, 32);
             });
         }
 
@@ -247,7 +247,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "intArg", "Int", "3", 3, 29);
+                Rule.badValue(_, "intArg", "Int", "3.0", 3, 29);
             });
         }
 
@@ -343,7 +343,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "booleanArg", "Boolean", "1", 3, 33);
+                Rule.badValue(_, "booleanArg", "Boolean", "1.0", 3, 33);
             });
         }
 
@@ -391,7 +391,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "idArg", "ID", "1", 3, 28);
+                Rule.badValue(_, "idArg", "ID", "1.0", 3, 28);
             });
         }
 
@@ -461,7 +461,7 @@ namespace GraphQL.Tests.Validation
             ShouldFailRule(_ =>
             {
                 _.Query = query;
-                Rule.badValue(_, "dogCommand", "DogCommand", "1", 3, 33);
+                Rule.badValue(_, "dogCommand", "DogCommand", "1.0", 3, 33);
             });
         }
 

--- a/src/GraphQL/Language/AST/NameNode.cs
+++ b/src/GraphQL/Language/AST/NameNode.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Language.AST
         /// </summary>
         public NameNode(string name, SourceLocation location)
         {
-            Name = name;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
             SourceLocation = location;
         }
 
@@ -22,7 +22,7 @@ namespace GraphQL.Language.AST
         /// </summary>
         public NameNode(string name)
         {
-            Name = name;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
             SourceLocation = default;
         }
 

--- a/src/GraphQL/Language/AST/ValueNodes/EnumValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/EnumValue.cs
@@ -1,3 +1,5 @@
+using GraphQL.Utilities;
+
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Language.AST
         /// </summary>
         public EnumValue(NameNode name)
         {
-            Name = name.Name;
+            NameValidator.ValidateDefault(name.Name, NamedElement.EnumValue);
             NameNode = name;
         }
 
@@ -18,8 +20,8 @@ namespace GraphQL.Language.AST
         /// Initializes a new instance with a specified string representation of the enumeration value.
         /// </summary>
         public EnumValue(string name)
+            : this(new NameNode(name))
         {
-            Name = name;
         }
 
         object IValue.Value => Name;
@@ -27,7 +29,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the string representation of the enumeration value.
         /// </summary>
-        public string Name { get; }
+        public string Name => NameNode.Name;
 
         /// <summary>
         /// Returns a <see cref="NameNode"/> containing the string representation of the enumeration value.

--- a/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
@@ -12,8 +12,8 @@ namespace GraphQL.Language.AST
         /// </summary>
         public FloatValue(double value)
         {
-            if (double.IsNaN(value) || double.IsInfinity(value))
-                throw new ArgumentOutOfRangeException(nameof(value), @"Value cannot be {value}.");
+            if (double.IsNaN(value))
+                throw new ArgumentOutOfRangeException(nameof(value), "Value cannot be NaN.");
 
             Value = value;
         }

--- a/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
@@ -12,8 +12,10 @@ namespace GraphQL.Language.AST
         /// </summary>
         public FloatValue(double value)
         {
+            // TODO: see https://github.com/graphql-dotnet/graphql-dotnet/pull/2379#issuecomment-800828568 and https://github.com/graphql-dotnet/graphql-dotnet/pull/2379#issuecomment-800906086
+            // if (double.IsNaN(value) || double.IsInfinity(value))
             if (double.IsNaN(value))
-                throw new ArgumentOutOfRangeException(nameof(value), "Value cannot be NaN.");
+                throw new ArgumentOutOfRangeException(nameof(value), "Value cannot be NaN."); // Value cannot be NaN or Infinity.
 
             Value = value;
         }

--- a/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -10,6 +12,9 @@ namespace GraphQL.Language.AST
         /// </summary>
         public FloatValue(double value)
         {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                throw new ArgumentOutOfRangeException(nameof(value), @"Value cannot be {value}.");
+
             Value = value;
         }
     }

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
@@ -12,24 +12,23 @@ namespace GraphQL.Language.AST
         /// Initializes a new instance for the specified field name and value.
         /// </summary>
         public ObjectField(NameNode name, IValue value)
-            : this(name.Name, value)
         {
             NameNode = name;
+            Value = value;
         }
 
         /// <summary>
         /// Initializes a new instance for the specified field name and value.
         /// </summary>
         public ObjectField(string name, IValue value)
+            : this(new NameNode(name), value)
         {
-            Name = name;
-            Value = value;
         }
 
         /// <summary>
         /// Returns the name of the field.
         /// </summary>
-        public string Name { get; }
+        public string Name => NameNode.Name;
 
         /// <summary>
         /// Returns the <see cref="NameNode"/> containing the name of the field, if initialized with the <see cref="ObjectField.ObjectField(NameNode, IValue)"/> constructor.

--- a/src/GraphQL/Language/AST/ValueNodes/StringValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/StringValue.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace GraphQL.Language.AST
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Language.AST
         /// </summary>
         public StringValue(string value)
         {
-            Value = value;
+            Value = value ?? throw new ArgumentNullException(nameof(value));
         }
     }
 }

--- a/src/GraphQL/Language/AST/VariableReference.cs
+++ b/src/GraphQL/Language/AST/VariableReference.cs
@@ -10,7 +10,6 @@ namespace GraphQL.Language.AST
         /// </summary>
         public VariableReference(NameNode name)
         {
-            Name = name.Name;
             NameNode = name;
         }
 
@@ -19,7 +18,7 @@ namespace GraphQL.Language.AST
         /// <summary>
         /// Returns the name of the variable being referenced.
         /// </summary>
-        public string Name { get; }
+        public string Name => NameNode.Name;
 
         /// <summary>
         /// Returns a <see cref="NameNode"/> containing the name of the variable being referenced.

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -311,8 +311,6 @@ namespace GraphQL.Utilities
                 c.Print(f =>
                 {
                     var val = (double)f.Arg(x => x.Value);
-                    if (double.IsNaN(val) || double.IsInfinity(val))
-                        throw new InvalidOperationException($"Cannot print value: {val}");
                     // print most compact form of value with up to 15 digits of precision (C# default)
                     // note: G17 format (17 digits of precision) is necessary to prevent losing any
                     // information during roundtrip to string. However, "3.33" prints something like
@@ -337,8 +335,6 @@ namespace GraphQL.Utilities
                 c.Print(f =>
                 {
                     var val = (string)f.Arg(x => x.Value);
-                    if (val == null)
-                        throw new InvalidOperationException("StringValue cannot contain null");
                     var sb = new System.Text.StringBuilder(val.Length + 2);
                     sb.Append('"');
                     foreach (var ch in val)

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -340,7 +340,7 @@ namespace GraphQL.Utilities
                     if (val == null)
                         throw new InvalidOperationException("StringValue cannot contain null");
                     var sb = new System.Text.StringBuilder(val.Length + 2);
-                    sb.Append('\"');
+                    sb.Append('"');
                     foreach (var ch in val)
                     {
                         if (ch < ' ')

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -350,7 +350,7 @@ namespace GraphQL.Utilities
                             else if (ch == '\r')
                                 sb.Append("\\\r");
                             else if (ch == '\t')
-                                sb.Append("\\\t");
+                                sb.Append("\\t");
                             else
                                 sb.Append("\\u" + ((int)ch).ToString("X4"));
                         }

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -358,8 +358,6 @@ namespace GraphQL.Utilities
                             else
                                 sb.Append("\\u" + ((int)ch).ToString("X4"));
                         }
-                        else if (ch == '/')
-                            sb.Append("\\/");
                         else if (ch == '\\')
                             sb.Append("\\\\");
                         else if (ch == '"')

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -4,7 +4,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Numerics;
 using GraphQL.Language.AST;
+using GraphQL.Utilities.Federation;
 
 namespace GraphQL.Utilities
 {
@@ -286,7 +288,7 @@ namespace GraphQL.Utilities
             Config<IntValue>(c =>
             {
                 c.Field(x => x.Value);
-                c.Print(f => f.Arg(x => x.Value));
+                c.Print(f => ((int)f.Arg(x => x.Value)).ToString(CultureInfo.InvariantCulture));
             });
 
             Config<NullValue>(c => c.Print(f => "null"));
@@ -294,13 +296,13 @@ namespace GraphQL.Utilities
             Config<LongValue>(c =>
             {
                 c.Field(x => x.Value);
-                c.Print(f => f.Arg(x => x.Value));
+                c.Print(f => ((long)f.Arg(x => x.Value)).ToString(CultureInfo.InvariantCulture));
             });
 
             Config<BigIntValue>(c =>
             {
                 c.Field(x => x.Value);
-                c.Print(f => f.Arg(x => x.Value));
+                c.Print(f => ((BigInteger)f.Arg(x => x.Value)).ToString(CultureInfo.InvariantCulture));
             });
 
             Config<FloatValue>(c =>
@@ -309,7 +311,11 @@ namespace GraphQL.Utilities
                 c.Print(f =>
                 {
                     var val = (double)f.Arg(x => x.Value);
-                    return val.ToString("0.0##############", CultureInfo.InvariantCulture);
+                    if (double.IsNaN(val) || double.IsInfinity(val))
+                        throw new InvalidOperationException($"Cannot print value: {val}");
+                    //print most compact form of value with up to 15 digits of precision (C# default)
+                    //note: G17 format (17 digits of precision) is necessary to prevent losing any information during roundtrip to string
+                    return val.ToString("G15", CultureInfo.InvariantCulture);
                 });
             });
 
@@ -319,7 +325,7 @@ namespace GraphQL.Utilities
                 c.Print(f =>
                 {
                     var val = (decimal)f.Arg(x => x.Value);
-                    return val.ToString("0.0##############", CultureInfo.InvariantCulture);
+                    return val.ToString("G29", CultureInfo.InvariantCulture); //prints most compact form of value without losing any precision
                 });
             });
 
@@ -328,25 +334,54 @@ namespace GraphQL.Utilities
                 c.Field(x => x.Value);
                 c.Print(f =>
                 {
-                    var val = f.Arg(x => x.Value);
-                    if (!string.IsNullOrWhiteSpace(val?.ToString()) && !val.ToString().StartsWith("\"", StringComparison.InvariantCulture))
+                    var val = (string)f.Arg(x => x.Value);
+                    if (val == null)
+                        throw new InvalidOperationException("StringValue cannot contain null");
+                    var sb = new System.Text.StringBuilder(val.Length + 2);
+                    sb.Append('\"');
+                    foreach (var ch in val)
                     {
-                        val = $"\"{val}\"";
+                        if (ch < ' ')
+                        {
+                            if (ch == '\n')
+                                sb.Append("\\\n");
+                            else if (ch == '\r')
+                                sb.Append("\\\r");
+                            else if (ch == '\t')
+                                sb.Append("\\\t");
+                            else
+                                sb.Append("\\u" + ((int)ch).ToString("X4"));
+                        }
+                        else if (ch == '\\')
+                            sb.Append("\\\\");
+                        else if (ch == '\"')
+                            sb.Append("\\\"");
+                        else
+                            sb.Append(ch);
                     }
-                    return val;
+                    sb.Append('\"');
+                    return sb;
                 });
+
             });
 
             Config<BooleanValue>(c =>
             {
                 c.Field(x => x.Value);
-                c.Print(f => f.Arg(x => x.Value)?.ToString().ToLower(CultureInfo.InvariantCulture));
+                c.Print(f => (bool)f.Arg(x => x.Value) ? "true" : "false");
             });
 
             Config<EnumValue>(c =>
             {
                 c.Field(x => x.Name);
-                c.Print(p => p.Arg(x => x.Name));
+                c.Print(p =>
+                {
+                    var name = (string)p.Arg(x => x.Name);
+                    if (name == null)
+                        throw new InvalidOperationException("EnumValue name cannot be null");
+                    NameValidator.ValidateDefault(name, NamedElement.EnumValue);
+                    return name;
+                });
             });
 
             Config<ListValue>(c =>
@@ -367,6 +402,8 @@ namespace GraphQL.Utilities
                 c.Field(x => x.Value);
                 c.Print(p => $"{p.Arg(x => x.Name)}: {p.Arg(x => x.Value)}");
             });
+
+            Config<AnyValue>(c => c.Print(x => throw new InvalidOperationException("Cannot print AnyValue representations.")));
 
             // Directive
             Config<Directive>(c =>

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -313,8 +313,10 @@ namespace GraphQL.Utilities
                     var val = (double)f.Arg(x => x.Value);
                     if (double.IsNaN(val) || double.IsInfinity(val))
                         throw new InvalidOperationException($"Cannot print value: {val}");
-                    //print most compact form of value with up to 15 digits of precision (C# default)
-                    //note: G17 format (17 digits of precision) is necessary to prevent losing any information during roundtrip to string
+                    // print most compact form of value with up to 15 digits of precision (C# default)
+                    // note: G17 format (17 digits of precision) is necessary to prevent losing any
+                    // information during roundtrip to string. However, "3.33" prints something like
+                    // "3.330000000000001" which probably is not desirable.
                     return val.ToString("G15", CultureInfo.InvariantCulture);
                 });
             });

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -311,7 +311,7 @@ namespace GraphQL.Utilities
                 c.Print(f =>
                 {
                     var val = (double)f.Arg(x => x.Value);
-                    if (double.IsNaN(val) || double.IsInfinity(val))
+                    if (double.IsInfinity(val))
                         throw new InvalidOperationException($"Cannot print value: {val}");
                     // print most compact form of value with up to 15 digits of precision (C# default)
                     // note: G17 format (17 digits of precision) is necessary to prevent losing any
@@ -374,14 +374,7 @@ namespace GraphQL.Utilities
             Config<EnumValue>(c =>
             {
                 c.Field(x => x.Name);
-                c.Print(p =>
-                {
-                    var name = (string)p.Arg(x => x.Name);
-                    if (name == null)
-                        throw new InvalidOperationException("EnumValue name cannot be null");
-                    NameValidator.ValidateDefault(name, NamedElement.EnumValue);
-                    return name;
-                });
+                c.Print(p => p.Arg(x => x.Name));
             });
 
             Config<ListValue>(c =>

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -348,7 +348,7 @@ namespace GraphQL.Utilities
                             if (ch == '\n')
                                 sb.Append("\\\n");
                             else if (ch == '\r')
-                                sb.Append("\\\r");
+                                sb.Append("\\r");
                             else if (ch == '\t')
                                 sb.Append("\\t");
                             else

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -405,7 +405,7 @@ namespace GraphQL.Utilities
                 c.Print(p => $"{p.Arg(x => x.Name)}: {p.Arg(x => x.Value)}");
             });
 
-            Config<AnyValue>(c => c.Print(x => throw new InvalidOperationException("Cannot print AnyValue representations.")));
+            Config<AnyValue>(c => c.Print(x => throw new InvalidOperationException("Cannot print AnyValue representation.")));
 
             // Directive
             Config<Directive>(c =>

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -361,7 +361,7 @@ namespace GraphQL.Utilities
                         else
                             sb.Append(ch);
                     }
-                    sb.Append('\"');
+                    sb.Append('"');
                     return sb;
                 });
 

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -356,7 +356,7 @@ namespace GraphQL.Utilities
                         }
                         else if (ch == '\\')
                             sb.Append("\\\\");
-                        else if (ch == '\"')
+                        else if (ch == '"')
                             sb.Append("\\\"");
                         else
                             sb.Append(ch);

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -311,6 +311,8 @@ namespace GraphQL.Utilities
                 c.Print(f =>
                 {
                     var val = (double)f.Arg(x => x.Value);
+                    if (double.IsNaN(val) || double.IsInfinity(val))
+                        throw new InvalidOperationException($"Cannot print value: {val}");
                     // print most compact form of value with up to 15 digits of precision (C# default)
                     // note: G17 format (17 digits of precision) is necessary to prevent losing any
                     // information during roundtrip to string. However, "3.33" prints something like

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -336,14 +336,20 @@ namespace GraphQL.Utilities
                 c.Field(x => x.Value);
                 c.Print(f =>
                 {
+                    // http://spec.graphql.org/June2018/#sec-String-Value
+                    // TODO: can be changed to stackalloc / string.Create()
                     var val = (string)f.Arg(x => x.Value);
                     var sb = new System.Text.StringBuilder(val.Length + 2);
                     sb.Append('"');
-                    foreach (var ch in val)
+                    foreach (char ch in val)
                     {
                         if (ch < ' ')
                         {
-                            if (ch == '\n')
+                            if (ch == '\b')
+                                sb.Append("\\b");
+                            else if (ch == '\f')
+                                sb.Append("\\f");
+                            else if (ch == '\n')
                                 sb.Append("\\n");
                             else if (ch == '\r')
                                 sb.Append("\\r");
@@ -352,6 +358,8 @@ namespace GraphQL.Utilities
                             else
                                 sb.Append("\\u" + ((int)ch).ToString("X4"));
                         }
+                        else if (ch == '/')
+                            sb.Append("\\/");
                         else if (ch == '\\')
                             sb.Append("\\\\");
                         else if (ch == '"')

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -346,7 +346,7 @@ namespace GraphQL.Utilities
                         if (ch < ' ')
                         {
                             if (ch == '\n')
-                                sb.Append("\\\n");
+                                sb.Append("\\n");
                             else if (ch == '\r')
                                 sb.Append("\\r");
                             else if (ch == '\t')


### PR DESCRIPTION
Fixed bugs:
- Strings are not escaped
- Negative integers are not printed with the invariant culture, so the negative symbol can be incorrect
- Floating-point `double` values are not printed in the shortest form possible, either using an integer if possible or a "1.0E+44" syntax when necessary to represent very small or very large numbers.  Note that it is explicitly allowed that integer values can represent floating point input fields/arguments.
- Floating-point `double` values would not print very small values (e.g. less than 0.000000000001) at all.  Per the spec it should hold any value that can be represented by IEEE 754.
- Floating-point `decimal` values are not printed with the proper amount of precision, or in the shortest form possible
- Floating-point NaN/infinity values are printed instead of throwing an error
- AnyValue nodes are ignored, rather than throwing an exception
- EnumValue nodes with invalid characters in their names are printed instead of throwing an error