### PR TITLE
Fix NameValidator

### DIFF
--- a/src/GraphQL.Tests/Utilities/NameValidatorTests.cs
+++ b/src/GraphQL.Tests/Utilities/NameValidatorTests.cs
@@ -31,8 +31,19 @@ namespace GraphQL.Tests.Utilities
             Should.Throw<ArgumentOutOfRangeException>(() => NameValidator.ValidateName(" ", NamedElement.Field));
 
         [Fact]
-        public void ValidateName_whenNameStartsWithReservedCharacters_throwsArgumentOutOfRange() =>
+        public void ValidateName_whenNameStartsWithReservedCharacters_throwsArgumentOutOfRange()
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => NameValidator.ValidateName("__dede", NamedElement.Type));
+            Should.Throw<ArgumentOutOfRangeException>(() => NameValidator.ValidateName("__dede", NamedElement.Directive));
             Should.Throw<ArgumentOutOfRangeException>(() => NameValidator.ValidateName("__dede", NamedElement.Field));
+            Should.Throw<ArgumentOutOfRangeException>(() => NameValidator.ValidateName("__dede", NamedElement.Argument));
+        }
+
+        [Fact]
+        public void ValidateName_whenNameStartsWithReservedCharacters_validForCertainElements()
+        {
+            NameValidator.ValidateName("__dede", NamedElement.EnumValue);
+        }
 
         [Theory]
         [InlineData("śćłó")]

--- a/src/GraphQL.Tests/Utilities/NameValidatorTests.cs
+++ b/src/GraphQL.Tests/Utilities/NameValidatorTests.cs
@@ -40,7 +40,7 @@ namespace GraphQL.Tests.Utilities
         }
 
         [Fact]
-        public void ValidateName_whenNameStartsWithReservedCharacters_validForCertainElements()
+        public void ValidateName_whenNameStartsWithReservedCharacters_validForEnumValues()
         {
             NameValidator.ValidateName("__dede", NamedElement.EnumValue);
         }

--- a/src/GraphQL/Utilities/NameValidator.cs
+++ b/src/GraphQL/Utilities/NameValidator.cs
@@ -30,7 +30,7 @@ namespace GraphQL.Utilities
         {
             ValidateNameNotNull(name, type);
 
-            if (name.Length > 1 && name[0] == '_' && name[1] == '_')
+            if (name.Length > 1 && name[0] == '_' && name[1] == '_' && type != NamedElement.EnumValue)
             {
                 throw new ArgumentOutOfRangeException(nameof(name),
                     $"A {type.ToString().ToLower()} name: '{name}' must not begin with __, which is reserved by GraphQL introspection.");


### PR DESCRIPTION
> All **types and directives** defined within a schema must not have a name which begins with "__" (two underscores), as this is used exclusively by GraphQL’s introspection system.

See: https://spec.graphql.org/June2018/#sec-Schema

> All fields defined within an Object type must not have a name which begins with "__" (two underscores), as this is used exclusively by GraphQL’s introspection system.

See: https://spec.graphql.org/June2018/#sec-Objects

> All arguments defined within a field must not have a name which begins with "__" (two underscores), as this is used exclusively by GraphQL’s introspection system.

See: https://spec.graphql.org/June2018/#sec-Field-Arguments

> Types and fields required by the GraphQL introspection system that are used in the same context as user‐defined types and fields are prefixed with "__" two underscores. This in order to avoid naming collisions with user‐defined GraphQL types. Conversely, GraphQL type system authors must not define any types, fields, arguments, or any other type system artifact with two leading underscores.

See: https://spec.graphql.org/June2018/#sec-Reserved-Names

Please review @sungam3r .  There does not seem to be any reason why an enum cannot be named "__TEST".  It is not a "type system artifact" -- it's a value.  Would you agree??  Whatever you think.