### PR TITLE
Add default implementation of ParseLiteral

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2116,7 +2116,7 @@ namespace GraphQL.Types
         public virtual bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
         public virtual bool CanParseValue(object value) { }
         public virtual bool IsValidDefault(object value) { }
-        public abstract object ParseLiteral(GraphQL.Language.AST.IValue value);
+        public virtual object ParseLiteral(GraphQL.Language.AST.IValue value) { }
         public abstract object ParseValue(object value);
         public virtual object Serialize(object value) { }
         protected GraphQL.Language.AST.IValue ThrowASTConversionError(object value) { }

--- a/src/GraphQL/Types/Scalars/ScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ScalarGraphType.cs
@@ -44,7 +44,7 @@ namespace GraphQL.Types
         /// <returns>Internal scalar representation. Returning <see langword="null"/> is valid.</returns>
         public virtual object ParseLiteral(IValue value) => value switch
         {
-            BooleanValue b => ParseValue(b.Value),
+            BooleanValue b => ParseValue(b.Value.Boxed()),
             IntValue i => ParseValue(i.Value),
             LongValue l => ParseValue(l.Value),
             BigIntValue bi => ParseValue(bi.Value),

--- a/src/GraphQL/Types/Scalars/ScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ScalarGraphType.cs
@@ -42,7 +42,18 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="value">AST value node. Must not be <see langword="null"/>, but may be <see cref="NullValue"/>.</param>
         /// <returns>Internal scalar representation. Returning <see langword="null"/> is valid.</returns>
-        public abstract object ParseLiteral(IValue value);
+        public virtual object ParseLiteral(IValue value) => value switch
+        {
+            BooleanValue b => ParseValue(b.Value),
+            IntValue i => ParseValue(i.Value),
+            LongValue l => ParseValue(l.Value),
+            BigIntValue bi => ParseValue(bi.Value),
+            FloatValue f => ParseValue(f.Value),
+            DecimalValue d => ParseValue(d.Value),
+            StringValue s => ParseValue(s.Value),
+            NullValue _ => ParseValue(null),
+            _ => ThrowLiteralConversionError(value)
+        };
 
         /// <summary>
         /// Value input coercion. Argument values can not only provided via GraphQL syntax inside a


### PR DESCRIPTION
Does not affect built-in types, since specific implementations reduce boxing.

For custom scalars, now a person can simply implement `ParseValue` and all other methods have default implementations.