### PR TITLE
Update package reference to GraphQL-Parser

### DIFF
--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="5.3.3" />
+    <PackageReference Include="GraphQL-Parser" Version="[5.3.3,6)" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <!--<PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />-->


### PR DESCRIPTION
Fixes #2399 for version 3.3.x (if we decide to release another revision)

https://docs.microsoft.com/en-us/nuget/concepts/package-versioning

Package version is now defined as:
- `[5.3.3,6)`
- Compatible with >= 5.3.3 and < 6
- Prefer smallest compatible version (5.3.3)

Alternate choice:
- `[5.*,6)`
- Compatible with >= 5 and < 6
- Prefer highest compatible version (currently 5.3.3)
