### PR TITLE
Fix to serialize ExecutionResult from subscriptions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.0.0-preview</VersionPrefix>
+    <VersionPrefix>4.0.1-preview</VersionPrefix>
     <LangVersion>8.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL.SystemReactive/SubscriptionExecutionStrategy.cs
@@ -134,6 +134,7 @@ namespace GraphQL.Execution
                         // Return the result
                         return new ExecutionResult
                         {
+                            Executed = true,
                             Data = new RootExecutionNode(null, null)
                             {
                                 SubFields = new ExecutionNode[]


### PR DESCRIPTION
Fixes `Subscribe_and_mutate_messages` test for https://github.com/graphql-dotnet/server/pull/518 . The error is that the data from the subscription comes with empty body. 
![изображение](https://user-images.githubusercontent.com/21261007/111549996-4bb21580-878e-11eb-9afa-d14a01a5e7d5.png)
