### PR TITLE
Apply NRT annotations to scalars

### DIFF
--- a/.github/workflows/wipcheck.yml
+++ b/.github/workflows/wipcheck.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Fail build if pull request title contains [WIP]
         env:
           TITLE: ${{ github.event.pull_request.title }}
-        if: ${{ contains(github.event.pull_request.title, '[WIP]') }} # This function is not case sensitive.
+        if: ${{ contains(github.event.pull_request.title, '[WIP]') }} # This function is case insensitive.
         run: |
           echo Warning! PR title "$TITLE" contains [WIP]. Remove [WIP] from the title when PR is ready.
           exit 1

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -1620,24 +1620,24 @@ namespace GraphQL.Types
     {
         public BigIntGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class BooleanGraphType : GraphQL.Types.ScalarGraphType
     {
         public BooleanGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override bool CanParseValue(object value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override GraphQL.Language.AST.IValue ToAST(object value) { }
+        public override bool CanParseValue(object? value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override GraphQL.Language.AST.IValue? ToAST(object? value) { }
     }
     public class ByteGraphType : GraphQL.Types.ScalarGraphType
     {
         public ByteGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public abstract class ComplexGraphType<TSourceType> : GraphQL.Types.GraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
@@ -1677,30 +1677,30 @@ namespace GraphQL.Types
     public class DateGraphType : GraphQL.Types.ScalarGraphType
     {
         public DateGraphType() { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
     }
     public class DateTimeGraphType : GraphQL.Types.ScalarGraphType
     {
         public DateTimeGraphType() { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
     }
     public class DateTimeOffsetGraphType : GraphQL.Types.ScalarGraphType
     {
         public DateTimeOffsetGraphType() { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
     }
     public class DecimalGraphType : GraphQL.Types.ScalarGraphType
     {
         public DecimalGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class DeprecatedDirective : GraphQL.Types.DirectiveGraphType
     {
@@ -1768,19 +1768,19 @@ namespace GraphQL.Types
     public class EnumValueDefinition : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription
     {
         public EnumValueDefinition() { }
-        public string DeprecationReason { get; set; }
-        public string Description { get; set; }
+        public string? DeprecationReason { get; set; }
+        public string? Description { get; set; }
         public string Name { get; set; }
-        public object Value { get; set; }
+        public object? Value { get; set; }
     }
     public class EnumValues : System.Collections.Generic.IEnumerable<GraphQL.Types.EnumValueDefinition>, System.Collections.IEnumerable
     {
         public EnumValues() { }
         public int Count { get; }
-        public GraphQL.Types.EnumValueDefinition this[string name] { get; }
+        public GraphQL.Types.EnumValueDefinition? this[string name] { get; }
         public void Add(GraphQL.Types.EnumValueDefinition value) { }
-        public GraphQL.Types.EnumValueDefinition FindByName(string name, System.StringComparison comparison = 5) { }
-        public GraphQL.Types.EnumValueDefinition FindByValue(object value) { }
+        public GraphQL.Types.EnumValueDefinition? FindByName(string name, System.StringComparison comparison = 5) { }
+        public GraphQL.Types.EnumValueDefinition? FindByValue(object? value) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Types.EnumValueDefinition> GetEnumerator() { }
     }
     public class EnumerationGraphType : GraphQL.Types.ScalarGraphType
@@ -1788,13 +1788,13 @@ namespace GraphQL.Types
         public EnumerationGraphType() { }
         public GraphQL.Types.EnumValues Values { get; }
         public void AddValue(GraphQL.Types.EnumValueDefinition value) { }
-        public void AddValue(string name, string description, object value, string deprecationReason = null) { }
+        public void AddValue(string name, string? description, object? value, string? deprecationReason = null) { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override bool CanParseValue(object value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
-        public override GraphQL.Language.AST.IValue ToAST(object value) { }
+        public override bool CanParseValue(object? value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
+        public override GraphQL.Language.AST.IValue? ToAST(object? value) { }
     }
     public class EnumerationGraphType<TEnum> : GraphQL.Types.EnumerationGraphType
         where TEnum : System.Enum
@@ -1824,8 +1824,8 @@ namespace GraphQL.Types
     {
         public FloatGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public sealed class GraphQLClrInputTypeReference<T> : GraphQL.Types.InputObjectGraphType { }
     public sealed class GraphQLClrOutputTypeReference<T> : GraphQL.Types.InterfaceGraphType { }
@@ -1855,10 +1855,10 @@ namespace GraphQL.Types
     {
         public GuidGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override bool CanParseValue(object value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
+        public override bool CanParseValue(object? value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
     }
     public interface IAbstractGraphType : GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
@@ -1906,11 +1906,11 @@ namespace GraphQL.Types
     }
     public interface IProvideDeprecationReason
     {
-        string DeprecationReason { get; set; }
+        string? DeprecationReason { get; set; }
     }
     public interface IProvideDescription
     {
-        string Description { get; set; }
+        string? Description { get; set; }
     }
     public interface IProvideMetadata
     {
@@ -1960,9 +1960,9 @@ namespace GraphQL.Types
     {
         public IdGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
     }
     public class IncludeDirective : GraphQL.Types.DirectiveGraphType
     {
@@ -1983,8 +1983,8 @@ namespace GraphQL.Types
     {
         public IntGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class InterfaceGraphType : GraphQL.Types.InterfaceGraphType<object>
     {
@@ -2030,8 +2030,8 @@ namespace GraphQL.Types
     {
         public LongGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class NonNullGraphType : GraphQL.Types.GraphType, GraphQL.Types.IProvideResolvedType
     {
@@ -2109,23 +2109,23 @@ namespace GraphQL.Types
     {
         public SByteGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public abstract class ScalarGraphType : GraphQL.Types.GraphType
     {
         protected ScalarGraphType() { }
         public virtual bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public virtual bool CanParseValue(object value) { }
+        public virtual bool CanParseValue(object? value) { }
         public virtual bool IsValidDefault(object value) { }
-        public virtual object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public abstract object ParseValue(object value);
-        public virtual object Serialize(object value) { }
-        protected GraphQL.Language.AST.IValue ThrowASTConversionError(object value) { }
+        public virtual object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public abstract object? ParseValue(object? value);
+        public virtual object? Serialize(object? value) { }
+        protected GraphQL.Language.AST.IValue ThrowASTConversionError(object? value) { }
         protected object ThrowLiteralConversionError(GraphQL.Language.AST.IValue input) { }
-        protected object ThrowSerializationError(object value) { }
-        protected object ThrowValueConversionError(object value) { }
-        public virtual GraphQL.Language.AST.IValue ToAST(object value) { }
+        protected object ThrowSerializationError(object? value) { }
+        protected object ThrowValueConversionError(object? value) { }
+        public virtual GraphQL.Language.AST.IValue? ToAST(object? value) { }
     }
     public class Schema : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.ISchema, System.IDisposable, System.IServiceProvider
     {
@@ -2200,8 +2200,8 @@ namespace GraphQL.Types
     {
         public ShortGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class SkipDirective : GraphQL.Types.DirectiveGraphType
     {
@@ -2211,23 +2211,23 @@ namespace GraphQL.Types
     {
         public StringGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override bool CanParseValue(object value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override bool CanParseValue(object? value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class TimeSpanMillisecondsGraphType : GraphQL.Types.ScalarGraphType
     {
         public TimeSpanMillisecondsGraphType() { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
     }
     public class TimeSpanSecondsGraphType : GraphQL.Types.ScalarGraphType
     {
         public TimeSpanSecondsGraphType() { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
     }
     public static class TypeExtensions
     {
@@ -2249,22 +2249,22 @@ namespace GraphQL.Types
     {
         public UIntGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class ULongGraphType : GraphQL.Types.ScalarGraphType
     {
         public ULongGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class UShortGraphType : GraphQL.Types.ScalarGraphType
     {
         public UShortGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
     }
     public class UnionGraphType : GraphQL.Types.GraphType, GraphQL.Types.IAbstractGraphType, GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
@@ -2280,9 +2280,9 @@ namespace GraphQL.Types
     public class UriGraphType : GraphQL.Types.ScalarGraphType
     {
         public UriGraphType() { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override object Serialize(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override object? Serialize(object? value) { }
     }
 }
 namespace GraphQL.Types.Relay
@@ -2569,11 +2569,11 @@ namespace GraphQL.Utilities.Federation
     {
         public AnyScalarGraphType() { }
         public override bool CanParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override bool CanParseValue(object value) { }
+        public override bool CanParseValue(object? value) { }
         public override bool IsValidDefault(object value) { }
-        public override object ParseLiteral(GraphQL.Language.AST.IValue value) { }
-        public override object ParseValue(object value) { }
-        public override GraphQL.Language.AST.IValue ToAST(object value) { }
+        public override object? ParseLiteral(GraphQL.Language.AST.IValue value) { }
+        public override object? ParseValue(object? value) { }
+        public override GraphQL.Language.AST.IValue? ToAST(object? value) { }
     }
     public class AnyValue : GraphQL.Language.AST.ValueNode<object>
     {

--- a/src/GraphQL.Tests/Types/AllScalarGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AllScalarGraphTypeTests.cs
@@ -23,6 +23,8 @@ namespace GraphQL.Tests.Types
          *    BooleanGraphType
          *    FloatGraphType
          *    StringGraphType
+         *
+         *  Does not test:
          *    IdGraphType
          *    DecimalGraphType
          *    UriGraphType

--- a/src/GraphQL.Tests/Types/AllScalarGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AllScalarGraphTypeTests.cs
@@ -19,20 +19,18 @@ namespace GraphQL.Tests.Types
          *    UIntGraphType
          *    LongGraphType
          *    ULongGraphType
-         *    
+         *
          *    BooleanGraphType
          *    FloatGraphType
          *    StringGraphType
-         *    
-         *  Does not test:
          *    IdGraphType
          *    DecimalGraphType
          *    UriGraphType
          *    date/time graph types
          *    enumeration graph types
-         *    
+         *
          *  Does test ALL scalars' handling of null
-         *  
+         *
          */
 
         [Theory]

--- a/src/GraphQL/Introspection/__DirectiveLocation.cs
+++ b/src/GraphQL/Introspection/__DirectiveLocation.cs
@@ -1,5 +1,7 @@
 using GraphQL.Types;
 
+#nullable enable
+
 namespace GraphQL.Introspection
 {
     /// <summary>

--- a/src/GraphQL/Introspection/__TypeKind.cs
+++ b/src/GraphQL/Introspection/__TypeKind.cs
@@ -1,5 +1,7 @@
 using GraphQL.Types;
 
+#nullable enable
+
 namespace GraphQL.Introspection
 {
     /// <summary>

--- a/src/GraphQL/Types/IGraphType.cs
+++ b/src/GraphQL/Types/IGraphType.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Gets or sets the element description.
         /// </summary>
-        string Description { get; set; }
+        string? Description { get; set; }
     }
 
     /// <summary>
@@ -35,7 +37,7 @@ namespace GraphQL.Types
         /// Gets or sets the reason this element has been deprecated;
         /// <see langword="null"/> if this element has not been deprecated.
         /// </summary>
-        string DeprecationReason { get; set; }
+        string? DeprecationReason { get; set; }
     }
 
     /// <summary>

--- a/src/GraphQL/Types/Scalars/BigIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BigIntGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class BigIntGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => new BigInteger(intValue.Value),
             LongValue longValue => new BigInteger(longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             BigInteger _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/BooleanGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BooleanGraphType.cs
@@ -1,5 +1,7 @@
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -9,7 +11,7 @@ namespace GraphQL.Types
     public class BooleanGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             BooleanValue b => b.Value.Boxed(),
             NullValue _ => null,
@@ -20,7 +22,7 @@ namespace GraphQL.Types
         public override bool CanParseLiteral(IValue value) => value is BooleanValue || value is NullValue;
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             bool _ => value,
             null => null,
@@ -28,10 +30,10 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override bool CanParseValue(object value) => value is bool || value == null;
+        public override bool CanParseValue(object? value) => value is bool || value == null;
 
         /// <inheritdoc/>
-        public override IValue ToAST(object value) => value switch
+        public override IValue? ToAST(object? value) => value switch
         {
             bool b => new BooleanValue(b),
             null => new NullValue(),

--- a/src/GraphQL/Types/Scalars/ByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ByteGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class ByteGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => checked((byte)intValue.Value),
             LongValue longValue => checked((byte)longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             byte _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/DateGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateGraphType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Globalization;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             NullValue _ => null,
             StringValue stringValue => ParseDate(stringValue.Value),
@@ -27,7 +29,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             DateTime d => ValidateDate(d, value), // no boxing
             string stringValue => ParseDate(stringValue),
@@ -36,7 +38,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object Serialize(object value) => value switch
+        public override object? Serialize(object? value) => value switch
         {
             DateTime d => ValidateDate(d).ToString("yyyy-MM-dd", DateTimeFormatInfo.InvariantInfo),
             null => null,

--- a/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Globalization;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             StringValue stringValue => ParseDate(stringValue.Value),
             NullValue _ => null,
@@ -29,7 +31,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             DateTime _ => value,
             string s => ParseDate(s),
@@ -51,7 +53,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object Serialize(object value) => value switch
+        public override object? Serialize(object? value) => value switch
         {
             // ISO-8601 format
             // Note that the "O" format is similar but always prints the fractional parts

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Globalization;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             StringValue stringValue => ParseDate(stringValue.Value),
             NullValue _ => null,
@@ -29,7 +31,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             DateTimeOffset _ => value,
             string s => ParseDate(s),
@@ -51,7 +53,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object Serialize(object value) => value switch
+        public override object? Serialize(object? value) => value switch
         {
             // ISO-8601 format
             // Note that the "O" format is similar but always prints the fractional parts

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class DecimalGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intVal => (decimal)intVal.Value,
             LongValue longVal => (decimal)longVal.Value,
@@ -46,7 +48,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             decimal _ => value,
             int i => checked((decimal)i),

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 using GraphQL.Language.AST;
 using GraphQL.Utilities;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -33,7 +35,7 @@ namespace GraphQL.Types
         /// <param name="description">A description of the enumeration member.</param>
         /// <param name="value">The value of the enumeration member, as referenced by the code (e.g. <see cref="ConsoleColor.Red"/>).</param>
         /// <param name="deprecationReason">The reason this enumeration member has been deprecated; <see langword="null"/> if this member has not been deprecated.</param>
-        public void AddValue(string name, string description, object value, string deprecationReason = null)
+        public void AddValue(string name, string? description, object? value, string? deprecationReason = null)
         {
             AddValue(new EnumValueDefinition
             {
@@ -62,7 +64,7 @@ namespace GraphQL.Types
         public EnumValues Values { get; }
 
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             EnumValue enumValue => Values.FindByName(enumValue.Name)?.Value ?? ThrowLiteralConversionError(value),
             NullValue _ => null,
@@ -78,7 +80,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             string s => Values.FindByName(s)?.Value ?? ThrowValueConversionError(value),
             null => null,
@@ -86,7 +88,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override bool CanParseValue(object value) => value switch
+        public override bool CanParseValue(object? value) => value switch
         {
             string s => Values.FindByName(s) != null,
             null => true,
@@ -94,9 +96,9 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object Serialize(object value)
+        public override object? Serialize(object? value)
         {
-            if (value == null)
+            if (value == null) // TODO: why? null as internal value may be mapped to some external enumeration name
                 return null;
 
             var foundByValue = Values.FindByValue(value);
@@ -106,9 +108,9 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override IValue ToAST(object value)
+        public override IValue? ToAST(object? value)
         {
-            if (value == null)
+            if (value == null) // TODO: why? null as internal value may be mapped to some external enumeration name
                 return new NullValue();
 
             var foundByValue = Values.FindByValue(value);
@@ -167,9 +169,9 @@ namespace GraphQL.Types
         internal List<EnumValueDefinition> List { get; } = new List<EnumValueDefinition>();
 
         /// <summary>
-        /// Returns an enumeration definition for the specified name.
+        /// Returns an enumeration definition for the specified name and <see langword="null"/> if not found.
         /// </summary>
-        public EnumValueDefinition this[string name] => FindByName(name);
+        public EnumValueDefinition? this[string name] => FindByName(name);
 
         /// <summary>
         /// Gets the count of enumeration definitions.
@@ -185,7 +187,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Returns an enumeration definition for the specified name.
         /// </summary>
-        public EnumValueDefinition FindByName(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        public EnumValueDefinition? FindByName(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
             // DO NOT USE LINQ ON HOT PATH
             foreach (var def in List)
@@ -200,7 +202,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Returns an enumeration definition for the specified name.
         /// </summary>
-        internal EnumValueDefinition FindByName(ReadOnlySpan<char> name)
+        internal EnumValueDefinition? FindByName(ReadOnlySpan<char> name)
         {
             // DO NOT USE LINQ ON HOT PATH
             foreach (var def in List)
@@ -215,7 +217,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Returns an enumeration definition for the specified value.
         /// </summary>
-        public EnumValueDefinition FindByValue(object value)
+        public EnumValueDefinition? FindByValue(object? value)
         {
             if (value is Enum)
             {
@@ -225,7 +227,7 @@ namespace GraphQL.Types
             // DO NOT USE LINQ ON HOT PATH
             foreach (var def in List)
             {
-                if (def.UnderlyingValue.Equals(value))
+                if (Equals(def.UnderlyingValue, value))
                     return def;
             }
 
@@ -247,23 +249,23 @@ namespace GraphQL.Types
         /// <summary>
         /// The name of the enumeration member, as exposed through the GraphQL endpoint (e.g. "RED").
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         /// <summary>
         /// A description of the enumeration member.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// The reason this enumeration member has been deprecated; <see langword="null"/> if this member has not been deprecated.
         /// </summary>
-        public string DeprecationReason { get; set; }
+        public string? DeprecationReason { get; set; }
 
-        private object _value;
+        private object? _value;
         /// <summary>
         /// The value of the enumeration member, as referenced by the code (e.g. <see cref="ConsoleColor.Red"/>).
         /// </summary>
-        public object Value
+        public object? Value
         {
             get => _value;
             set
@@ -278,6 +280,6 @@ namespace GraphQL.Types
         /// <summary>
         /// When mapped to a member of an <see cref="Enum"/>, contains the underlying enumeration value; otherwise contains <see cref="Value" />.
         /// </summary>
-        internal object UnderlyingValue { get; set; }
+        internal object? UnderlyingValue { get; set; }
     }
 }

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class FloatGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             FloatValue floatVal => floatVal.Value,
             IntValue intVal => (double)intVal.Value,
@@ -46,7 +48,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             double _ => value,
             int i => checked((double)i),

--- a/src/GraphQL/Types/Scalars/GuidGraphType.cs
+++ b/src/GraphQL/Types/Scalars/GuidGraphType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Globalization;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class GuidGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             StringValue s => Guid.Parse(s.Value),
             NullValue _ => null,
@@ -26,7 +28,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             Guid _ => value, // no boxing
             string s => Guid.Parse(s),
@@ -35,7 +37,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override bool CanParseValue(object value) => value switch
+        public override bool CanParseValue(object? value) => value switch
         {
             Guid _ => true,
             string s => Guid.TryParse(s, out _),
@@ -44,7 +46,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object Serialize(object value) => value switch
+        public override object? Serialize(object? value) => value switch
         {
             Guid g => g.ToString("D", CultureInfo.InvariantCulture),
             null => null,

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -25,7 +27,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             StringValue str => str.Value,
             IntValue num => num.Value,
@@ -47,7 +49,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             string _ => value,
             int _ => value,
@@ -65,6 +67,6 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object Serialize(object value) => ParseValue(value)?.ToString();
+        public override object? Serialize(object? value) => ParseValue(value)?.ToString();
     }
 }

--- a/src/GraphQL/Types/Scalars/IntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IntGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class IntGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => intValue.Value,
             LongValue longValue => checked((int)longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             int _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class LongGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => checked((long)intValue.Value),
             LongValue longValue => checked((long)longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             long _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/SByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/SByteGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class SByteGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => checked((sbyte)intValue.Value),
             LongValue longValue => checked((sbyte)longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             sbyte _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/ScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ScalarGraphType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         /// the serialization layer. For complex types like a Date or Money scalar this involves
         /// formatting the value. Returning <see langword="null"/> is valid.
         /// </returns>
-        public virtual object Serialize(object value) => ParseValue(value);
+        public virtual object? Serialize(object? value) => ParseValue(value);
 
         /// <summary>
         /// Literal input coercion. It takes an abstract syntax tree (AST) element from a schema
@@ -43,7 +45,7 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="value">AST value node. Must not be <see langword="null"/>, but may be <see cref="NullValue"/>.</param>
         /// <returns>Internal scalar representation. Returning <see langword="null"/> is valid.</returns>
-        public virtual object ParseLiteral(IValue value) => value switch
+        public virtual object? ParseLiteral(IValue value) => value switch
         {
             BooleanValue b => ParseValue(b.Value.Boxed()),
             IntValue i => ParseValue(i.Value),
@@ -68,7 +70,7 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="value">Runtime object from variables. May be <see langword="null"/>.</param>
         /// <returns>Internal scalar representation. Returning <see langword="null"/> is valid.</returns>
-        public abstract object ParseValue(object value);
+        public abstract object? ParseValue(object? value);
 
         /// <summary>
         /// Checks for literal input coercion possibility. It takes an abstract syntax tree (AST) element from a schema
@@ -106,8 +108,8 @@ namespace GraphQL.Types
         /// <br/><br/>
         /// This method must return <see langword="true"/> when passed a <see langword="null"/> value.
         /// </summary>
-        /// <param name="value">Runtime object from variables. Must not be <see langword="null"/>.</param>
-        public virtual bool CanParseValue(object value)
+        /// <param name="value">Runtime object from variables. May be <see langword="null"/>.</param>
+        public virtual bool CanParseValue(object? value)
         {
             try
             {
@@ -148,7 +150,7 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="value">The value to convert. May be <see langword="null"/>.</param>
         /// <returns>AST representation of the specified value. Returning <see langword="null"/> indicates a failed conversion. Returning <see cref="NullValue"/> is valid.</returns>
-        public virtual IValue ToAST(object value)
+        public virtual IValue? ToAST(object? value)
         {
             var serialized = Serialize(value);
             return serialized switch
@@ -176,9 +178,9 @@ namespace GraphQL.Types
         /// Throws an exception indicating that a value cannot be converted to its AST representation. Typically called by
         /// <see cref="ToAST(object)"/> if the provided object (an internal representation) is not valid for this scalar type.
         /// </summary>
-        protected internal IValue ThrowASTConversionError(object value)
+        protected internal IValue ThrowASTConversionError(object? value)
         {
-            throw new InvalidOperationException($"Unable to convert '{value}' to its AST representation for the scalar type '{Name}'.");
+            throw new InvalidOperationException($"Unable to convert '{value ?? "(null)"}' to its AST representation for the scalar type '{Name}'.");
         }
 
         /// <summary>
@@ -200,9 +202,9 @@ namespace GraphQL.Types
         /// This also may be called for serialization errors during <see cref="ToAST(object)"/>, since <see cref="ToAST(object)"/> calls <see cref="Serialize(object)"/>
         /// by default, which by default calls <see cref="ParseValue(object)"/>.
         /// </remarks>
-        protected object ThrowValueConversionError(object value)
+        protected object ThrowValueConversionError(object? value)
         {
-            throw new InvalidOperationException($"Unable to convert '{value}' to the scalar type '{Name}'");
+            throw new InvalidOperationException($"Unable to convert '{value ?? "(null)"}' to the scalar type '{Name}'");
         }
 
         /// <summary>
@@ -215,9 +217,9 @@ namespace GraphQL.Types
         /// of <see cref="ToAST(object)"/> calls <see cref="Serialize(object)"/> to serialize the value before converting the
         /// result to an AST node.
         /// </remarks>
-        protected object ThrowSerializationError(object value)
+        protected object ThrowSerializationError(object? value)
         {
-            throw new InvalidOperationException($"Unable to serialize '{value}' to the scalar type '{Name}'.");
+            throw new InvalidOperationException($"Unable to serialize '{value ?? "(null)"}' to the scalar type '{Name}'.");
         }
     }
 }

--- a/src/GraphQL/Types/Scalars/ShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ShortGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class ShortGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => checked((short)intValue.Value),
             LongValue longValue => checked((short)longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             short _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -1,5 +1,7 @@
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -9,7 +11,7 @@ namespace GraphQL.Types
     public class StringGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             StringValue s => s.Value,
             NullValue _ => null,
@@ -20,7 +22,7 @@ namespace GraphQL.Types
         public override bool CanParseLiteral(IValue value) => value is StringValue || value is NullValue;
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             string _ => value,
             null => null,
@@ -28,6 +30,6 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override bool CanParseValue(object value) => value is string || value == null;
+        public override bool CanParseValue(object? value) => value is string || value == null;
     }
 }

--- a/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => TimeSpan.FromMilliseconds(intValue.Value),
             LongValue longValue => TimeSpan.FromMilliseconds(longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             TimeSpan _ => value, // no boxing
             int i => TimeSpan.FromMilliseconds(i),
@@ -47,7 +49,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object Serialize(object value) => value switch
+        public override object? Serialize(object? value) => value switch
         {
             TimeSpan timeSpan => (long)timeSpan.TotalMilliseconds,
             int i => (long)i,

--- a/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => TimeSpan.FromSeconds(intValue.Value),
             LongValue longValue => TimeSpan.FromSeconds(longValue.Value),
@@ -31,7 +33,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             TimeSpan _ => value, // no boxing
             int i => TimeSpan.FromSeconds(i),
@@ -48,7 +50,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object Serialize(object value) => value switch
+        public override object? Serialize(object? value) => value switch
         {
             TimeSpan timeSpan => (long)timeSpan.TotalSeconds,
             int i => (long)i,

--- a/src/GraphQL/Types/Scalars/UIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UIntGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class UIntGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => checked((uint)intValue.Value),
             LongValue longValue => checked((uint)longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             uint _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/ULongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ULongGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class ULongGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => checked((ulong)intValue.Value),
             LongValue longValue => checked((ulong)longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             ulong _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/UShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UShortGraphType.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class UShortGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             IntValue intValue => checked((ushort)intValue.Value),
             LongValue longValue => checked((ushort)longValue.Value),
@@ -30,7 +32,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             ushort _ => value,
             null => null,

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -1,6 +1,8 @@
 using System;
 using GraphQL.Language.AST;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -10,7 +12,7 @@ namespace GraphQL.Types
     public class UriGraphType : ScalarGraphType
     {
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value switch
+        public override object? ParseLiteral(IValue value) => value switch
         {
             StringValue s => new Uri(s.Value),
             NullValue _ => null,
@@ -18,7 +20,7 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value switch
+        public override object? ParseValue(object? value) => value switch
         {
             string s => new Uri(s),
             Uri _ => value,
@@ -27,6 +29,6 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object Serialize(object value) => ParseValue(value)?.ToString();
+        public override object? Serialize(object? value) => ParseValue(value)?.ToString();
     }
 }

--- a/src/GraphQL/Utilities/Federation/AnyScalarGraphType.cs
+++ b/src/GraphQL/Utilities/Federation/AnyScalarGraphType.cs
@@ -1,6 +1,8 @@
 using GraphQL.Language.AST;
 using GraphQL.Types;
 
+#nullable enable
+
 namespace GraphQL.Utilities.Federation
 {
     /// <summary>
@@ -17,21 +19,21 @@ namespace GraphQL.Utilities.Federation
         }
 
         /// <inheritdoc/>
-        public override object ParseLiteral(IValue value) => value.Value;
+        public override object? ParseLiteral(IValue value) => value.Value;
 
         /// <inheritdoc/>
-        public override object ParseValue(object value) => value;
+        public override object? ParseValue(object? value) => value;
 
         /// <inheritdoc/>
         public override bool CanParseLiteral(IValue value) => true;
 
         /// <inheritdoc/>
-        public override bool CanParseValue(object value) => true;
+        public override bool CanParseValue(object? value) => true;
 
         /// <inheritdoc/>
         public override bool IsValidDefault(object value) => true;
 
         /// <inheritdoc/>
-        public override IValue ToAST(object value) => new AnyValue(value);
+        public override IValue? ToAST(object? value) => new AnyValue(value);
     }
 }


### PR DESCRIPTION
I suggest gradually add `#nullable enable` by individual PRs. It will be easier. When we add nullable annotations throughout the code, then we can add `<Nullable>enable</Nullable>` to Directory.build.props and delete all `#nullable enable` from files.