### PR TITLE
Fix argument type mapping regression

### DIFF
--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -300,6 +300,45 @@ namespace GraphQL.Tests.Utilities
         [InlineData(typeof(GraphQLClrInputTypeReference<MyEnum>), typeof(EnumerationGraphType<MyEnum>))]
         [InlineData(typeof(GraphQLClrInputTypeReference<MappedEnum>), typeof(MappedEnumGraphType))]
         [InlineData(typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<MyClass>>>>>), typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<MyClassInputType>>>>))]
+        public void InputTypeIsDereferenced_DirectiveArgument(Type referenceType, Type mappedType)
+        {
+            var query = new ObjectGraphType();
+            query.Field(typeof(StringGraphType), "test");
+            var schema = new Schema
+            {
+                Query = query
+            };
+            var directive = new DirectiveGraphType("MyDirective")
+            {
+                Arguments = new QueryArguments
+                {
+                    new QueryArgument(referenceType) { Name = "arg" }
+                }
+            };
+            directive.Locations.Add(DirectiveLocation.Field);
+            schema.Directives.Register(directive);
+            schema.RegisterTypeMapping(typeof(MyClass), typeof(MyClassObjectType));
+            schema.RegisterTypeMapping(typeof(MyClass), typeof(MyClassInputType));
+            schema.RegisterTypeMapping(typeof(MappedEnum), typeof(MappedEnumGraphType));
+            schema.Initialize();
+            schema.Directives.Find("MyDirective").Arguments.Find("arg").Type.ShouldBe(mappedType);
+        }
+
+        [Theory]
+        [InlineData(typeof(IntGraphType), typeof(IntGraphType))]
+        [InlineData(typeof(StringGraphType), typeof(StringGraphType))]
+        [InlineData(typeof(ListGraphType<StringGraphType>), typeof(ListGraphType<StringGraphType>))]
+        [InlineData(typeof(NonNullGraphType<StringGraphType>), typeof(NonNullGraphType<StringGraphType>))]
+        [InlineData(typeof(MyClassInputType), typeof(MyClassInputType))]
+        [InlineData(typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<MyClassInputType>>>>), typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<MyClassInputType>>>>))]
+        [InlineData(typeof(GraphQLClrInputTypeReference<int>), typeof(IntGraphType))]
+        [InlineData(typeof(GraphQLClrInputTypeReference<string>), typeof(StringGraphType))]
+        [InlineData(typeof(ListGraphType<GraphQLClrInputTypeReference<string>>), typeof(ListGraphType<StringGraphType>))]
+        [InlineData(typeof(NonNullGraphType<GraphQLClrInputTypeReference<string>>), typeof(NonNullGraphType<StringGraphType>))]
+        [InlineData(typeof(GraphQLClrInputTypeReference<MyClass>), typeof(MyClassInputType))]
+        [InlineData(typeof(GraphQLClrInputTypeReference<MyEnum>), typeof(EnumerationGraphType<MyEnum>))]
+        [InlineData(typeof(GraphQLClrInputTypeReference<MappedEnum>), typeof(MappedEnumGraphType))]
+        [InlineData(typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<MyClass>>>>>), typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<MyClassInputType>>>>))]
         public void InputTypeIsDereferenced_InputField(Type referenceType, Type mappedType)
         {
             var inputType = new InputObjectGraphType();
@@ -321,14 +360,6 @@ namespace GraphQL.Tests.Utilities
             var inputTypeActual = schema.Query.Fields.Find("test").Arguments.Find("arg").ResolvedType.ShouldBeOfType<InputObjectGraphType>();
             inputTypeActual.ShouldBe(inputType);
             inputTypeActual.Fields.Find("field").Type.ShouldBe(mappedType);
-        }
-
-        private class MyPairObjectType : ObjectGraphType<KeyValuePair<int, string>>
-        {
-            public MyPairObjectType()
-            {
-                Field<IntGraphType>("field");
-            }
         }
 
         private class MyClassObjectType : ObjectGraphType<MyClass>

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -274,7 +274,7 @@ namespace GraphQL.Tests.Utilities
                 {
                     new QueryArgument(referenceType) { Name = "arg" }
                 });
-            var schema = new Schema()
+            var schema = new Schema
             {
                 Query = query
             };

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -310,7 +310,7 @@ namespace GraphQL.Tests.Utilities
                 {
                     new QueryArgument(inputType) { Name = "arg" }
                 });
-            var schema = new Schema()
+            var schema = new Schema
             {
                 Query = query
             };

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -264,6 +264,7 @@ namespace GraphQL.Tests.Utilities
         [InlineData(typeof(NonNullGraphType<GraphQLClrInputTypeReference<string>>), typeof(NonNullGraphType<StringGraphType>))]
         [InlineData(typeof(GraphQLClrInputTypeReference<MyClass>), typeof(MyClassInputType))]
         [InlineData(typeof(GraphQLClrInputTypeReference<MyEnum>), typeof(EnumerationGraphType<MyEnum>))]
+        [InlineData(typeof(GraphQLClrInputTypeReference<MappedEnum>), typeof(MappedEnumGraphType))]
         [InlineData(typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<MyClass>>>>>), typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<MyClassInputType>>>>))]
         public void InputTypeIsDereferenced_Argument(Type referenceType, Type mappedType)
         {
@@ -279,6 +280,7 @@ namespace GraphQL.Tests.Utilities
             };
             schema.RegisterTypeMapping(typeof(MyClass), typeof(MyClassObjectType));
             schema.RegisterTypeMapping(typeof(MyClass), typeof(MyClassInputType));
+            schema.RegisterTypeMapping(typeof(MappedEnum), typeof(MappedEnumGraphType));
             schema.Initialize();
             schema.Query.Fields.Find("test").Arguments.Find("arg").Type.ShouldBe(mappedType);
         }
@@ -296,13 +298,11 @@ namespace GraphQL.Tests.Utilities
         [InlineData(typeof(NonNullGraphType<GraphQLClrInputTypeReference<string>>), typeof(NonNullGraphType<StringGraphType>))]
         [InlineData(typeof(GraphQLClrInputTypeReference<MyClass>), typeof(MyClassInputType))]
         [InlineData(typeof(GraphQLClrInputTypeReference<MyEnum>), typeof(EnumerationGraphType<MyEnum>))]
+        [InlineData(typeof(GraphQLClrInputTypeReference<MappedEnum>), typeof(MappedEnumGraphType))]
         [InlineData(typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<MyClass>>>>>), typeof(NonNullGraphType<ListGraphType<ListGraphType<NonNullGraphType<MyClassInputType>>>>))]
         public void InputTypeIsDereferenced_InputField(Type referenceType, Type mappedType)
         {
-            var inputType = new InputObjectGraphType
-            {
-                Name = "TestType"
-            };
+            var inputType = new InputObjectGraphType();
             inputType.Field(referenceType, "field");
             var query = new ObjectGraphType();
             query.Field(typeof(IntGraphType), "test",
@@ -316,6 +316,7 @@ namespace GraphQL.Tests.Utilities
             };
             schema.RegisterTypeMapping(typeof(MyClass), typeof(MyClassObjectType));
             schema.RegisterTypeMapping(typeof(MyClass), typeof(MyClassInputType));
+            schema.RegisterTypeMapping(typeof(MappedEnum), typeof(MappedEnumGraphType));
             schema.Initialize();
             var inputTypeActual = schema.Query.Fields.Find("test").Arguments.Find("arg").ResolvedType.ShouldBeOfType<InputObjectGraphType>();
             inputTypeActual.ShouldBe(inputType);
@@ -353,6 +354,15 @@ namespace GraphQL.Tests.Utilities
         private enum MyEnum
         {
             Value1
+        }
+
+        private enum MappedEnum
+        {
+            Value1
+        }
+
+        private class MappedEnumGraphType : EnumerationGraphType<MappedEnum>
+        {
         }
     }
 }

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -241,7 +241,7 @@ namespace GraphQL.Tests.Utilities
         {
             var query = new ObjectGraphType();
             query.Field(referenceType, "test");
-            var schema = new Schema()
+            var schema = new Schema
             {
                 Query = query
             };

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -161,22 +161,7 @@ namespace GraphQL.Types
 
             foreach (var directive in directives)
             {
-                if (directive.Arguments?.Count > 0)
-                {
-                    foreach (var arg in directive.Arguments.List)
-                    {
-                        if (arg.ResolvedType != null)
-                        {
-                            AddTypeIfNotRegistered(arg.ResolvedType, ctx);
-                            arg.ResolvedType = ConvertTypeReference(directive, arg.ResolvedType);
-                        }
-                        else
-                        {
-                            AddTypeIfNotRegistered(arg.Type, ctx);
-                            arg.ResolvedType = BuildNamedType(arg.Type, ctx.ResolveType);
-                        }
-                    }
-                }
+                HandleDirective(directive, ctx);
             }
 
             ApplyTypeReferences();
@@ -477,6 +462,34 @@ namespace GraphQL.Types
                     else
                     {
                         AddTypeIfNotRegistered(arg.ResolvedType, context);
+                    }
+                }
+            }
+        }
+
+        private void HandleDirective(DirectiveGraphType directive, TypeCollectionContext context)
+        {
+            if (directive.Arguments?.Count > 0)
+            {
+                foreach (var arg in directive.Arguments.List)
+                {
+                    if (arg.ResolvedType == null)
+                    {
+                        if (arg.Type == null)
+                            throw new InvalidOperationException($"Both ResolvedType and Type properties on argument '{directive.Name}.{arg.Name}' are null.");
+
+                        object typeOrError = RebuildType(arg.Type, true, context.TypeMappings);
+                        if (typeOrError is string error)
+                            throw new InvalidOperationException($"The GraphQL type for argument '{directive.Name}.{arg.Name}' could not be derived implicitly. " + error);
+                        arg.Type = (Type)typeOrError;
+
+                        AddTypeIfNotRegistered(arg.Type, context);
+                        arg.ResolvedType = BuildNamedType(arg.Type, context.ResolveType);
+                    }
+                    else
+                    {
+                        AddTypeIfNotRegistered(arg.ResolvedType, context);
+                        arg.ResolvedType = ConvertTypeReference(directive, arg.ResolvedType);
                     }
                 }
             }

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -92,7 +92,7 @@ namespace GraphQL.Types
         public Type Type
         {
             get => _type;
-            private set => _type = CheckType(value);
+            internal set => _type = CheckType(value);
         }
 
         private Type CheckType(Type type)


### PR DESCRIPTION
Arguments' types are not mapped via the CLR type mappings.  Critical bug for anyone using who was using the `GraphTypeTypeRegistry` in v3 for argument types.