### PR TITLE
Rewrite auth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GraphQL for .NET
 
+![License](https://img.shields.io/github/license/graphql-dotnet/graphql-dotnet)
+
 [![Join the chat at https://gitter.im/graphql-dotnet/graphql-dotnet](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/graphql-dotnet/graphql-dotnet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Test code](https://github.com/graphql-dotnet/graphql-dotnet/actions/workflows/test-code.yml/badge.svg)](https://github.com/graphql-dotnet/graphql-dotnet/actions/workflows/test-code.yml)


### PR DESCRIPTION
The example is outdated and I deleted it. I considered that it makes no sense to try to give here a manually written example. We have two full-fledged authorization projects and it is much easier to refer to them. It is unlikely that someone will use their own authorization. An old example could confuse the reader because he could have the impression that this example should be copied and used as is.