### PR TITLE
Nested input types with the same not supported

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
+++ b/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
@@ -36,10 +36,26 @@ mutation M($input_0: MyInput!) {
                     "run",
                     arguments: new QueryArguments(new QueryArgument<MyInputClass.MyInput> {Name = "input"}),
                     resolve: ctx => ctx.GetArgument<MyInputClass>("input").Id);
+                Field<StringGraphType>(
+                    "run2",
+                    arguments: new QueryArguments(new QueryArgument<MyInputClass2.MyInput> { Name = "input" }),
+                    resolve: ctx => ctx.GetArgument<MyInputClass2>("input").Id);
             }
         }
 
         public class MyInputClass
+        {
+            public string Id { get; set; }
+
+            public class MyInput : InputObjectGraphType
+            {
+                public MyInput()
+                {
+                    Field<NonNullGraphType<StringGraphType>>("id");
+                }
+            }
+        }
+        public class MyInputClass2
         {
             public string Id { get; set; }
 

--- a/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
+++ b/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
@@ -34,7 +34,7 @@ mutation M($input_0: MyInput!) {
             {
                 Field<StringGraphType>(
                     "run",
-                    arguments: new QueryArguments(new QueryArgument<MyInput> {Name = "input"}),
+                    arguments: new QueryArguments(new QueryArgument<MyInputClass.MyInput> {Name = "input"}),
                     resolve: ctx => ctx.GetArgument<MyInputClass>("input").Id);
             }
         }
@@ -42,14 +42,13 @@ mutation M($input_0: MyInput!) {
         public class MyInputClass
         {
             public string Id { get; set; }
-        }
 
-        public class MyInput : InputObjectGraphType
-        {
-            public MyInput()
+            public class MyInput : InputObjectGraphType
             {
-                Name = "MyInput"; // changed from "MyInput "
-                Field<NonNullGraphType<StringGraphType>>("id");
+                public MyInput()
+                {
+                    Field<NonNullGraphType<StringGraphType>>("id");
+                }
             }
         }
     }

--- a/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
+++ b/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Tests.Bugs
         [Fact]
         public void nested_type_names_dont_conflict()
         {
-            var inputs = @"{ ""input_0"": { ""id"": ""123"", ""foo"": null, ""bar"": null } }".ToInputs();
+            var inputs = @"{ ""input_0"": { ""id"": ""123""} }".ToInputs();
             var query = @"
 mutation M($input_0: MyInput!) {
   run(input: $input_0)
@@ -42,8 +42,6 @@ mutation M($input_0: MyInput!) {
         public class MyInputClass
         {
             public string Id { get; set; }
-            public string Foo { get; set; }
-            public string Bar { get; set; }
         }
 
         public class MyInput : InputObjectGraphType
@@ -52,8 +50,6 @@ mutation M($input_0: MyInput!) {
             {
                 Name = "MyInput"; // changed from "MyInput "
                 Field<NonNullGraphType<StringGraphType>>("id");
-                Field<StringGraphType>("foo");
-                Field<StringGraphType>("bar");
             }
         }
     }

--- a/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
+++ b/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
@@ -1,0 +1,60 @@
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class Bug_nested_type_names_dont_conflict :
+        QueryTestBase<Bug_nested_type_names_dont_conflict.MutationSchema>
+    {
+        [Fact]
+        public void nested_type_names_dont_conflict()
+        {
+            var inputs = @"{ ""input_0"": { ""id"": ""123"", ""foo"": null, ""bar"": null } }".ToInputs();
+            var query = @"
+mutation M($input_0: MyInput!) {
+  run(input: $input_0)
+}
+";
+            var expected = @"{ ""run"": ""123"" }";
+            AssertQuerySuccess(query, expected, inputs);
+        }
+
+        public class MutationSchema : Schema
+        {
+            public MutationSchema()
+            {
+                Mutation = new MyMutation();
+            }
+        }
+
+        public class MyMutation : ObjectGraphType
+        {
+            public MyMutation()
+            {
+                Field<StringGraphType>(
+                    "run",
+                    arguments: new QueryArguments(new QueryArgument<MyInput> {Name = "input"}),
+                    resolve: ctx => ctx.GetArgument<MyInputClass>("input").Id);
+            }
+        }
+
+        public class MyInputClass
+        {
+            public string Id { get; set; }
+            public string Foo { get; set; }
+            public string Bar { get; set; }
+        }
+
+        public class MyInput : InputObjectGraphType
+        {
+            public MyInput()
+            {
+                Name = "MyInput"; // changed from "MyInput "
+                Field<NonNullGraphType<StringGraphType>>("id");
+                Field<StringGraphType>("foo");
+                Field<StringGraphType>("bar");
+            }
+        }
+    }
+}


### PR DESCRIPTION
seems input types are keyed off the name, which is not unique. I assume the same would happen for input types in different namespaces