### PR TITLE
FieldBuilder and ConnectionBuilder implement IProvideMetadata

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -454,7 +454,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class ConnectionBuilder<TSourceType>
+    public class ConnectionBuilder<TSourceType> : GraphQL.Types.IProvideMetadata
     {
         public GraphQL.Types.FieldType FieldType { get; set; }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, string description)
@@ -485,7 +485,7 @@ namespace GraphQL.Builders
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>(GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>(System.Type type = null) { }
     }
-    public class FieldBuilder<TSourceType, TReturnType>
+    public class FieldBuilder<TSourceType, TReturnType> : GraphQL.Types.IProvideMetadata
     {
         public GraphQL.Types.EventStreamFieldType FieldType { get; }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument> configure = null)

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Types;
 using GraphQL.Types.Relay;
@@ -50,7 +51,7 @@ namespace GraphQL.Builders
     /// <summary>
     /// Builds a connection field for graphs that have the specified source type.
     /// </summary>
-    public class ConnectionBuilder<TSourceType>
+    public class ConnectionBuilder<TSourceType> : IProvideMetadata
     {
         private bool _isUnidirectional;
 
@@ -272,5 +273,13 @@ namespace GraphQL.Builders
                 throw new ArgumentException("Cannot use `last` with unidirectional connections.");
             }
         }
+
+        Dictionary<string, object> IProvideMetadata.Metadata => FieldType.Metadata;
+
+        TType IProvideMetadata.GetMetadata<TType>(string key, TType defaultValue) => FieldType.GetMetadata(key, defaultValue);
+
+        TType IProvideMetadata.GetMetadata<TType>(string key, Func<TType> defaultValueFactory) => FieldType.GetMetadata(key, defaultValueFactory);
+
+        bool IProvideMetadata.HasMetadata(string key) => FieldType.HasMetadata(key);
     }
 }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Resolvers;
 using GraphQL.Subscription;
@@ -30,7 +31,7 @@ namespace GraphQL.Builders
     /// </summary>
     /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
     /// <typeparam name="TReturnType">The type of the return value of the resolver.</typeparam>
-    public class FieldBuilder<TSourceType, TReturnType>
+    public class FieldBuilder<TSourceType, TReturnType> : IProvideMetadata
     {
         /// <summary>
         /// Returns the generated field.
@@ -253,5 +254,13 @@ namespace GraphQL.Builders
             FieldType.ApplyDirective(name, configure);
             return this;
         }
+
+        Dictionary<string, object> IProvideMetadata.Metadata => FieldType.Metadata;
+
+        TType IProvideMetadata.GetMetadata<TType>(string key, TType defaultValue) => FieldType.GetMetadata(key, defaultValue);
+
+        TType IProvideMetadata.GetMetadata<TType>(string key, Func<TType> defaultValueFactory) => FieldType.GetMetadata(key, defaultValueFactory);
+
+        bool IProvideMetadata.HasMetadata(string key) => FieldType.HasMetadata(key);
     }
 }


### PR DESCRIPTION
This allows to call any extension method defined on `IProvideMetadata`.