### PR TITLE
ValidationContext.ParseValueScalar: Convert input scalar type into correct one.

### DIFF
--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -325,7 +325,14 @@ namespace GraphQL.Validation
                     //  example.: type is int. value is '10'. 
                     //     This value can be parsed from string into int and solution is very practical for wide usage.
                     // Maybe best practice should be add new global switch which enable/disable this option.
-                    value = Convert.ChangeType(value, scalarGraphType);
+                    if (SchemaTypes.BuiltInScalarMappings.Where(m => m.Value == scalarGraphType.GetType()).Any())
+                    {
+                        var type = SchemaTypes.BuiltInScalarMappings.Where(m => m.Value == scalarGraphType.GetType()).FirstOrDefault().Key;
+                        if (type != null)
+                        {
+                            value = Convert.ChangeType(value, type);
+                        }
+                    }
 
                     return scalarGraphType.ParseValue(value);
                 }

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -321,6 +321,12 @@ namespace GraphQL.Validation
             {
                 try
                 {
+                    //  Convert input scalar type into correct one.
+                    //  example.: type is int. value is '10'. 
+                    //     This value can be parsed from string into int and solution is very practical for wide usage.
+                    // Maybe best practice should be add new global switch which enable/disable this option.
+                    value = Convert.ChangeType(value, scalarGraphType);
+
                     return scalarGraphType.ParseValue(value);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Migration from 3.x on 4.x have some issiue in my case.
Version 3 was not respected scalar input types.  But i think that is this good in most cases.

Especially javascript  (which is most common client  for graphql) in not most cases  treatment value '10' (string) and 10  (numeric) as same value.