### PR TITLE
DeprecationReason as computed property stored in Metadata (in applieddirectives), also changes " to ' in some error messages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.2.1-preview</VersionPrefix>
+    <VersionPrefix>4.3.0-preview</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -39,13 +39,15 @@ namespace GraphQL
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
         public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, System.Action<GraphQL.Types.AppliedDirective> configure)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
-        public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, string argumentName, object argumentValue)
+        public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, string argumentName, object? argumentValue)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
-        public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, string argument1Name, object argument1Value, string argument2Name, object argument2Value)
+        public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
-        public static GraphQL.Types.AppliedDirective FindAppliedDirective(this GraphQL.Types.IProvideMetadata provider, string name) { }
-        public static GraphQL.Types.AppliedDirectives GetAppliedDirectives(this GraphQL.Types.IProvideMetadata provider) { }
+        public static GraphQL.Types.AppliedDirective? FindAppliedDirective(this GraphQL.Types.IProvideMetadata provider, string name) { }
+        public static GraphQL.Types.AppliedDirectives? GetAppliedDirectives(this GraphQL.Types.IProvideMetadata provider) { }
         public static bool HasAppliedDirectives(this GraphQL.Types.IProvideMetadata provider) { }
+        public static TMetadataProvider RemoveAppliedDirective<TMetadataProvider>(this TMetadataProvider provider, string name)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
     }
     public class DocumentExecuter : GraphQL.IDocumentExecuter
     {
@@ -1654,6 +1656,7 @@ namespace GraphQL.Types
         public void Add(GraphQL.Types.AppliedDirective directive) { }
         public GraphQL.Types.AppliedDirective Find(string name) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Types.AppliedDirective> GetEnumerator() { }
+        public int Remove(string name) { }
     }
     public class AutoRegisteringInputObjectGraphType<TSourceType> : GraphQL.Types.InputObjectGraphType<TSourceType>
     {
@@ -1764,7 +1767,7 @@ namespace GraphQL.Types
     {
         public DirectiveArgument(string name) { }
         public string Name { get; set; }
-        public object Value { get; set; }
+        public object? Value { get; set; }
     }
     public class DirectiveGraphType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.INamedType, GraphQL.Types.IProvideDescription
     {
@@ -1866,7 +1869,7 @@ namespace GraphQL.Types
         public FieldType() { }
         public GraphQL.Types.QueryArguments Arguments { get; set; }
         public object DefaultValue { get; set; }
-        public string DeprecationReason { get; set; }
+        public string? DeprecationReason { get; set; }
         public string Description { get; set; }
         public string Name { get; set; }
         public GraphQL.Types.IGraphType ResolvedType { get; set; }
@@ -1896,7 +1899,7 @@ namespace GraphQL.Types
     public abstract class GraphType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         protected GraphType() { }
-        public string DeprecationReason { get; set; }
+        public string? DeprecationReason { get; set; }
         public string Description { get; set; }
         public string Name { get; set; }
         protected bool Equals(GraphQL.Types.IGraphType other) { }
@@ -2442,6 +2445,7 @@ namespace GraphQL.Utilities
         public virtual void VisitSchema(GraphQL.Types.ISchema schema) { }
         public virtual void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
     }
+    [System.Obsolete("This class is no longer required to set DeprecationReason property")]
     public class DeprecatedDirectiveVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
         public DeprecatedDirectiveVisitor() { }

--- a/src/GraphQL.Tests/Initialization/SchemaInitializationTestBase.cs
+++ b/src/GraphQL.Tests/Initialization/SchemaInitializationTestBase.cs
@@ -17,5 +17,11 @@ namespace GraphQL.Tests.Initialization
         public void ShouldThrow<TSchema, TException>(string errorMessage)
             where TSchema : Schema, new()
             where TException : Exception => ShouldThrow<TSchema, TException>(ex => ex.Message.ShouldBe(errorMessage));
+
+        public void ShouldNotThrow<TSchema>()
+            where TSchema : Schema, new()
+        {
+            new TSchema().Initialize();
+        }
     }
 }

--- a/src/GraphQL.Tests/Utilities/StringUtilsTests.cs
+++ b/src/GraphQL.Tests/Utilities/StringUtilsTests.cs
@@ -9,19 +9,19 @@ namespace GraphQL.Tests.Utilities
         [Fact]
         public void quoted_or_list_one()
         {
-            StringUtils.QuotedOrList(new[] { "A" }).ShouldBe("\"A\"");
+            StringUtils.QuotedOrList(new[] { "A" }).ShouldBe("'A'");
         }
 
         [Fact]
         public void quoted_or_list_two()
         {
-            StringUtils.QuotedOrList(new[] { "A", "B" }).ShouldBe("\"A\" or \"B\"");
+            StringUtils.QuotedOrList(new[] { "A", "B" }).ShouldBe("'A' or 'B'");
         }
 
         [Fact]
         public void quoted_or_list_three()
         {
-            StringUtils.QuotedOrList(new[] { "A", "B", "C" }).ShouldBe("\"A\", \"B\", or \"C\"");
+            StringUtils.QuotedOrList(new[] { "A", "B", "C" }).ShouldBe("'A', 'B', or 'C'");
         }
     }
 }

--- a/src/GraphQL/Types/Collections/AppliedDirectives.cs
+++ b/src/GraphQL/Types/Collections/AppliedDirectives.cs
@@ -49,8 +49,14 @@ namespace GraphQL.Types
             }
 
             return null;
-
         }
+
+        /// <summary>
+        /// Removes a directive by its name from the list. If the list contains several
+        /// directives with the given name, then all such directives will be removed.
+        /// </summary>
+        public int Remove(string name) => List?.RemoveAll(d => d.Name == name) ?? 0;
+
         /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
         public IEnumerator<AppliedDirective> GetEnumerator() => (List ?? System.Linq.Enumerable.Empty<AppliedDirective>()).GetEnumerator();
 

--- a/src/GraphQL/Types/Directives/DirectiveArgument.cs
+++ b/src/GraphQL/Types/Directives/DirectiveArgument.cs
@@ -1,5 +1,7 @@
 using GraphQL.Utilities;
 
+#nullable enable
+
 namespace GraphQL.Types
 {
     /// <summary>
@@ -34,6 +36,6 @@ namespace GraphQL.Types
         /// <summary>
         /// Argument value.
         /// </summary>
-        public object Value { get; set; }
+        public object? Value { get; set; }
     }
 }

--- a/src/GraphQL/Types/Directives/DirectiveArgument.cs
+++ b/src/GraphQL/Types/Directives/DirectiveArgument.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Types
             Name = name;
         }
 
-        private string _name;
+        private string _name = null!;
 
         /// <summary>
         /// Argument name.

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -36,7 +36,11 @@ namespace GraphQL.Types
         public string Description { get; set; }
 
         /// <inheritdoc/>
-        public string DeprecationReason { get; set; }
+        public string? DeprecationReason
+        {
+            get => this.GetDeprecationReason();
+            set => this.SetDeprecationReason(value);
+        }
 
         /// <summary>
         /// Gets or sets the default value of the field. Only applies to fields of input object graph types.

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -83,7 +83,11 @@ namespace GraphQL.Types
         public string Description { get; set; }
 
         /// <inheritdoc/>
-        public string DeprecationReason { get; set; }
+        public string? DeprecationReason
+        {
+            get => this.GetDeprecationReason();
+            set => this.SetDeprecationReason(value);
+        }
 
         /// <inheritdoc />
         public override string ToString() => Name;

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -259,7 +259,11 @@ namespace GraphQL.Types
         /// <summary>
         /// The reason this enumeration member has been deprecated; <see langword="null"/> if this member has not been deprecated.
         /// </summary>
-        public string? DeprecationReason { get; set; }
+        public string? DeprecationReason
+        {
+            get => this.GetDeprecationReason();
+            set => this.SetDeprecationReason(value);
+        }
 
         private object? _value;
         /// <summary>

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -41,7 +41,6 @@ namespace GraphQL.Types
 
             Directives = new SchemaDirectives();
             Directives.Register(Directives.Include, Directives.Skip, Directives.Deprecated);
-            RegisterVisitor(DeprecatedDirectiveVisitor.Instance);
         }
 
         /// <summary>

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -223,6 +223,12 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
                 throw new InvalidOperationException($"Unknown field '{typeConfig.Name}.{fieldConfig.Name}' has no resolver. Verify that you have configured SchemaBuilder correctly.");
         }
 
+        private void OverrideDeprecationReason(IProvideDeprecationReason element, string reason)
+        {
+            if (reason != null)
+                element.DeprecationReason = reason;
+        }
+
         protected virtual IObjectGraphType ToObjectGraphType(GraphQLObjectTypeDefinition astType, bool isExtensionType = false)
         {
             var name = (string)astType.Name.Value;
@@ -243,7 +249,6 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             if (!isExtensionType)
             {
                 type.Description = typeConfig.Description ?? astType.Comment?.Text.ToString();
-                type.DeprecationReason = typeConfig.DeprecationReason;
                 type.IsTypeOf = typeConfig.IsTypeOfFunc;
             }
 
@@ -278,6 +283,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             else
             {
                 type.SetAstType(astType);
+                OverrideDeprecationReason(type, typeConfig.DeprecationReason);
             }
 
             return type;
@@ -340,7 +346,6 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             {
                 Name = fieldConfig.Name,
                 Description = fieldConfig.Description ?? fieldDef.Comment?.Text.ToString(),
-                DeprecationReason = fieldConfig.DeprecationReason,
                 ResolvedType = ToGraphType(fieldDef.Type),
                 Resolver = fieldConfig.Resolver
             };
@@ -350,6 +355,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             field.Arguments = ToQueryArguments(fieldConfig, fieldDef.Arguments);
 
             field.SetAstType(fieldDef);
+            OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
 
             return field;
         }
@@ -369,7 +375,6 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             {
                 Name = fieldConfig.Name,
                 Description = fieldConfig.Description ?? fieldDef.Comment?.Text.ToString(),
-                DeprecationReason = fieldConfig.DeprecationReason,
                 ResolvedType = ToGraphType(fieldDef.Type),
                 Resolver = fieldConfig.Resolver,
                 Subscriber = fieldConfig.Subscriber,
@@ -381,6 +386,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             field.Arguments = ToQueryArguments(fieldConfig, fieldDef.Arguments);
 
             field.SetAstType(fieldDef);
+            OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
 
             return field;
         }
@@ -400,10 +406,11 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             {
                 Name = fieldConfig.Name,
                 Description = fieldConfig.Description ?? inputDef.Comment?.Text.ToString(),
-                DeprecationReason = fieldConfig.DeprecationReason,
                 ResolvedType = ToGraphType(inputDef.Type),
                 DefaultValue = fieldConfig.DefaultValue ?? inputDef.DefaultValue
             }.SetAstType(inputDef);
+
+            OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
 
             return field;
         }
@@ -419,9 +426,10 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             {
                 Name = name,
                 Description = typeConfig.Description ?? interfaceDef.Comment?.Text.ToString(),
-                DeprecationReason = typeConfig.DeprecationReason,
                 ResolveType = typeConfig.ResolveType,
             }.SetAstType(interfaceDef);
+
+            OverrideDeprecationReason(type, typeConfig.DeprecationReason);
 
             typeConfig.CopyMetadataTo(type);
 
@@ -445,9 +453,10 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             {
                 Name = name,
                 Description = typeConfig.Description ?? unionDef.Comment?.Text.ToString(),
-                DeprecationReason = typeConfig.DeprecationReason,
                 ResolveType = typeConfig.ResolveType,
             }.SetAstType(unionDef);
+
+            OverrideDeprecationReason(type, typeConfig.DeprecationReason);
 
             typeConfig.CopyMetadataTo(type);
 
@@ -474,8 +483,9 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             {
                 Name = name,
                 Description = typeConfig.Description ?? inputDef.Comment?.Text.ToString(),
-                DeprecationReason = typeConfig.DeprecationReason,
             }.SetAstType(inputDef);
+
+            OverrideDeprecationReason(type, typeConfig.DeprecationReason);
 
             typeConfig.CopyMetadataTo(type);
 
@@ -499,8 +509,9 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             {
                 Name = name,
                 Description = typeConfig.Description ?? enumDef.Comment?.Text.ToString(),
-                DeprecationReason = typeConfig.DeprecationReason,
             }.SetAstType(enumDef);
+
+            OverrideDeprecationReason(type, typeConfig.DeprecationReason);
 
             if (enumDef.Values?.Count > 0) // just in case
             {
@@ -542,6 +553,8 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
                 Value = enumType == null ? name : Enum.Parse(enumType, name, true),
                 Name = name,
                 Description = valDef.Comment?.Text.ToString()
+                // TODO: SchemaFirst configuration (TypeConfig/FieldConfig) does not allow to specify DeprecationReason for enum values
+                //DeprecationReason = ???
             }.SetAstType(valDef);
         }
 

--- a/src/GraphQL/Utilities/StringUtils.cs
+++ b/src/GraphQL/Utilities/StringUtils.cs
@@ -10,14 +10,14 @@ namespace GraphQL.Utilities
     public static class StringUtils
     {
         /// <summary>
-        /// Given [ A, B, C ] return '"A", "B", or "C"'.
+        /// Given array of strings [ "A", "B", "C" ] return one string "'A', 'B' or 'C'".
         /// </summary>
-        public static string QuotedOrList(IEnumerable<string> items, int maxLength = 5)
+        public static string QuotedOrList(IEnumerable<string> items, int maxLength = 5) //TODO: make internal in v5 and change items type
         {
             string[] itemsArray = items.Take(maxLength).ToArray();
             int index = 0;
             return itemsArray
-                .Select(x => $"\"{x}\"")
+                .Select(x => $"'{x}'")
                 .Aggregate((list, quoted) =>
                     list +
                     (itemsArray.Length > 2 ? ", " : " ") +

--- a/src/GraphQL/Utilities/Visitors/AppliedDirectivesValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/AppliedDirectivesValidationVisitor.cs
@@ -83,7 +83,12 @@ namespace GraphQL.Utilities
                         throw new InvalidOperationException($"Unknown directive '{appliedDirective.Name}'.");
 
                     if (location != null && !schemaDirective.Locations.Contains(location.Value))
-                        throw new InvalidOperationException($"Directive '{schemaDirective.Name}' is applied in the wrong location '{location.Value}'. Allowed locations: {string.Join(", ", schemaDirective.Locations)}");
+                    {
+                        // TODO: think about strict check; needs to rewrite some tests (5)
+                        // This is a temporary solution for @deprecated directive that we actually allow to more schema elements.
+                        if (schemaDirective.Name != "deprecated")
+                            throw new InvalidOperationException($"Directive '{schemaDirective.Name}' is applied in the wrong location '{location.Value}'. Allowed locations: {string.Join(", ", schemaDirective.Locations)}");
+                    }
 
                     if (schemaDirective.Arguments?.Count > 0)
                     {

--- a/src/GraphQL/Utilities/Visitors/DeprecatedDirectiveVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/DeprecatedDirectiveVisitor.cs
@@ -1,3 +1,4 @@
+using System;
 using GraphQL.Types;
 
 namespace GraphQL.Utilities
@@ -5,7 +6,8 @@ namespace GraphQL.Utilities
     /// <summary>
     /// Visitor that sets <see cref="IProvideDeprecationReason.DeprecationReason"/> property to the corresponding schema elements.
     /// </summary>
-    public class DeprecatedDirectiveVisitor : BaseSchemaNodeVisitor
+    [Obsolete("This class is no longer required to set DeprecationReason property")]
+    public class DeprecatedDirectiveVisitor : BaseSchemaNodeVisitor // TODO: remove in v5
     {
         /// <summary>
         /// Returns a static instance of the <see cref="DeprecatedDirectiveVisitor"/>.


### PR DESCRIPTION
This PR addresses a problem with duplication of `@deprecated` directive set as `DeprecationReason` property and as applied directive in schema element metadata. Now it is stored in metadata. `DeprecationReason` became computed property. This also saves a bit of memory for each field, type and enum value if they don't have `DeprecationReason` which is expected in the most cases (wasn't a goal, but 😄).  No breaking changes.