### PR TITLE
Make IsExternalInit internal

### DIFF
--- a/src/GraphQL.Tests/IsExternalInit.cs
+++ b/src/GraphQL.Tests/IsExternalInit.cs
@@ -9,7 +9,7 @@ namespace System.Runtime.CompilerServices
     /// This class should not be used by developers in source code.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static class IsExternalInit
+    internal static class IsExternalInit
     {
     }
 }


### PR DESCRIPTION
Not a big deal for a test project, but I believe that IsExternalInit should always be marked internal when defined in a library.