### PR TITLE
Optimize connection builder

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.MicrosoftDI.approved.txt
@@ -3,8 +3,8 @@ namespace GraphQL.MicrosoftDI
     public class ConnectionResolverBuilder<TSourceType, TReturnType>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType> resolver) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType> resolver) { }
+        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1> WithService<T1>() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithServices<T1, T2>() { }
@@ -15,40 +15,40 @@ namespace GraphQL.MicrosoftDI
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, TReturnType> resolver) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, TReturnType> resolver) { }
+        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithService<T2>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, TReturnType> resolver) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, TReturnType> resolver) { }
+        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3> WithService<T3>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType> resolver) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType> resolver) { }
+        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4> WithService<T4>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType> resolver) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType> resolver) { }
+        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5> WithService<T5>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType> resolver) { }
-        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType> resolver) { }
+        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5> WithScope() { }
     }
     public class ResolverBuilder<TSourceType, TReturnType>
@@ -114,10 +114,10 @@ namespace GraphQL.MicrosoftDI
     {
         public static GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, object> Resolve<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder) { }
         public static GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType> Resolve<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder) { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType> resolver) { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType> resolver) { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolver) { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public static void ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType> resolver) { }
+        public static void ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType> resolver) { }
+        public static void ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public static void ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolver) { }
     }
     public static class ScopedFieldBuilderExtensions
     {

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -512,8 +512,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
-        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType> resolver) { }
-        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolver) { }
+        public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType> resolver) { }
+        public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType>(string name = "default")
             where TNodeType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.MicrosoftDI/ConnectionResolverBuilder.cs
+++ b/src/GraphQL.MicrosoftDI/ConnectionResolverBuilder.cs
@@ -59,12 +59,22 @@ namespace GraphQL.MicrosoftDI
         /// <summary>
         /// Specifies the delegate to execute when the field is being resolved.
         /// </summary>
-        public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
-            => _scoped ? _builder.ResolveScoped(resolver) : _builder.Resolve(resolver);
+        public void Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
+        {
+            if (_scoped)
+                _builder.ResolveScoped(resolver);
+            else
+                _builder.Resolve(resolver);
+        }
 
         /// <inheritdoc cref="Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
-            => _scoped ? _builder.ResolveScopedAsync(resolver) : _builder.ResolveAsync(resolver);
+        public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
+        {
+            if (_scoped)
+                _builder.ResolveScopedAsync(resolver);
+            else
+                _builder.ResolveAsync(resolver);
+        }
     }
 
     /// <summary>
@@ -94,25 +104,31 @@ namespace GraphQL.MicrosoftDI
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, TReturnType> resolver)
+        public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, TReturnType> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver2 =
                 context => resolver(
                     context,
                     context.RequestServices.GetRequiredService<T1>());
 
-            return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
+            if (_scoped)
+                _builder.ResolveScoped(resolver2);
+            else
+                _builder.Resolve(resolver2);
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, Task<TReturnType>> resolver)
+        public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, Task<TReturnType>> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver2 =
                 context => resolver(
                     context,
                     context.RequestServices.GetRequiredService<T1>());
 
-            return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
+            if (_scoped)
+                _builder.ResolveScopedAsync(resolver2);
+            else
+                _builder.ResolveAsync(resolver2);
         }
     }
 
@@ -143,7 +159,7 @@ namespace GraphQL.MicrosoftDI
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, TReturnType> resolver)
+        public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, TReturnType> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver2 =
                 context => resolver(
@@ -151,11 +167,14 @@ namespace GraphQL.MicrosoftDI
                     context.RequestServices.GetRequiredService<T1>(),
                     context.RequestServices.GetRequiredService<T2>());
 
-            return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
+            if (_scoped)
+                _builder.ResolveScoped(resolver2);
+            else
+                _builder.Resolve(resolver2);
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, Task<TReturnType>> resolver)
+        public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, Task<TReturnType>> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver2 =
                 context => resolver(
@@ -163,7 +182,10 @@ namespace GraphQL.MicrosoftDI
                     context.RequestServices.GetRequiredService<T1>(),
                     context.RequestServices.GetRequiredService<T2>());
 
-            return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
+            if (_scoped)
+                _builder.ResolveScopedAsync(resolver2);
+            else
+                _builder.ResolveAsync(resolver2);
         }
     }
 
@@ -194,7 +216,7 @@ namespace GraphQL.MicrosoftDI
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType> resolver)
+        public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver2 =
                 context => resolver(
@@ -203,11 +225,14 @@ namespace GraphQL.MicrosoftDI
                     context.RequestServices.GetRequiredService<T2>(),
                     context.RequestServices.GetRequiredService<T3>());
 
-            return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
+            if (_scoped)
+                _builder.ResolveScoped(resolver2);
+            else
+                _builder.Resolve(resolver2);
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, Task<TReturnType>> resolver)
+        public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, Task<TReturnType>> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver2 =
                 context => resolver(
@@ -216,7 +241,10 @@ namespace GraphQL.MicrosoftDI
                     context.RequestServices.GetRequiredService<T2>(),
                     context.RequestServices.GetRequiredService<T3>());
 
-            return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
+            if (_scoped)
+                _builder.ResolveScopedAsync(resolver2);
+            else
+                _builder.ResolveAsync(resolver2);
         }
     }
 
@@ -247,7 +275,7 @@ namespace GraphQL.MicrosoftDI
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType> resolver)
+        public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver2 =
                 context => resolver(
@@ -257,11 +285,14 @@ namespace GraphQL.MicrosoftDI
                     context.RequestServices.GetRequiredService<T3>(),
                     context.RequestServices.GetRequiredService<T4>());
 
-            return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
+            if (_scoped)
+                _builder.ResolveScoped(resolver2);
+            else
+                _builder.Resolve(resolver2);
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, Task<TReturnType>> resolver)
+        public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, Task<TReturnType>> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver2 =
                 context => resolver(
@@ -271,7 +302,10 @@ namespace GraphQL.MicrosoftDI
                     context.RequestServices.GetRequiredService<T3>(),
                     context.RequestServices.GetRequiredService<T4>());
 
-            return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
+            if (_scoped)
+                _builder.ResolveScopedAsync(resolver2);
+            else
+                _builder.ResolveAsync(resolver2);
         }
     }
 
@@ -298,7 +332,7 @@ namespace GraphQL.MicrosoftDI
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType> resolver)
+        public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver2 =
                 context => resolver(
@@ -309,11 +343,14 @@ namespace GraphQL.MicrosoftDI
                     context.RequestServices.GetRequiredService<T4>(),
                     context.RequestServices.GetRequiredService<T5>());
 
-            return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
+            if (_scoped)
+                _builder.ResolveScoped(resolver2);
+            else
+                _builder.Resolve(resolver2);
         }
 
         /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-        public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, Task<TReturnType>> resolver)
+        public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, Task<TReturnType>> resolver)
         {
             Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver2 =
                 context => resolver(
@@ -324,7 +361,10 @@ namespace GraphQL.MicrosoftDI
                     context.RequestServices.GetRequiredService<T4>(),
                     context.RequestServices.GetRequiredService<T5>());
 
-            return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
+            if (_scoped)
+                _builder.ResolveScopedAsync(resolver2);
+            else
+                _builder.ResolveAsync(resolver2);
         }
     }
 }

--- a/src/GraphQL.MicrosoftDI/ScopedConnectionBuilderExtensions.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedConnectionBuilderExtensions.cs
@@ -12,9 +12,10 @@ namespace GraphQL.MicrosoftDI
     {
         /// <summary>
         /// Sets the resolver for the connection field. A dependency injection scope is created for the duration of the resolver's execution
-        /// and the scoped service provider is passed within <see cref="IResolveFieldContext.RequestServices"/>.
+        /// and the scoped service provider is passed within <see cref="IResolveFieldContext.RequestServices"/>. This method must be called after
+        /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
         /// </summary>
-        public static ConnectionBuilder<TSourceType> ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
+        public static void ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
         {
             if (resolver == null)
                 throw new ArgumentNullException(nameof(resolver));
@@ -25,11 +26,10 @@ namespace GraphQL.MicrosoftDI
                     return resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider));
                 }
             });
-            return builder;
         }
 
         /// <inheritdoc cref="ResolveScoped{TSourceType, TReturnType}(ConnectionBuilder{TSourceType}, Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-        public static ConnectionBuilder<TSourceType> ResolveScopedAsync<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
+        public static void ResolveScopedAsync<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
         {
             if (resolver == null)
                 throw new ArgumentNullException(nameof(resolver));
@@ -40,21 +40,21 @@ namespace GraphQL.MicrosoftDI
                     return await resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider));
                 }
             });
-            return builder;
         }
 
         /// <summary>
-        /// Creates a resolve builder for the connection field.
+        /// Creates a resolve builder for the connection field. This method must be called after
+        /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
         /// </summary>
         public static ConnectionResolverBuilder<TSourceType, object> Resolve<TSourceType>(this ConnectionBuilder<TSourceType> builder)
             => new ConnectionResolverBuilder<TSourceType, object>(builder.Returns<object>(), false);
 
         /// <inheritdoc cref="ResolveScoped{TSourceType, TReturnType}(ConnectionBuilder{TSourceType}, Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-        public static ConnectionBuilder<TSourceType, TReturnType> ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType, TReturnType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
+        public static void ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType, TReturnType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
         {
             if (resolver == null)
                 throw new ArgumentNullException(nameof(resolver));
-            return builder.Resolve(context =>
+            builder.Resolve(context =>
             {
                 using (var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope())
                 {
@@ -64,11 +64,11 @@ namespace GraphQL.MicrosoftDI
         }
 
         /// <inheritdoc cref="ResolveScopedAsync{TSourceType, TReturnType}(ConnectionBuilder{TSourceType}, Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-        public static ConnectionBuilder<TSourceType, TReturnType> ResolveScopedAsync<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType, TReturnType> builder, Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
+        public static void ResolveScopedAsync<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType, TReturnType> builder, Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
         {
             if (resolver == null)
                 throw new ArgumentNullException(nameof(resolver));
-            return builder.ResolveAsync(async context =>
+            builder.ResolveAsync(async context =>
             {
                 using (var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope())
                 {

--- a/src/GraphQL.MicrosoftDI/ScopedConnectionBuilderExtensions.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedConnectionBuilderExtensions.cs
@@ -13,7 +13,8 @@ namespace GraphQL.MicrosoftDI
         /// <summary>
         /// Sets the resolver for the connection field. A dependency injection scope is created for the duration of the resolver's execution
         /// and the scoped service provider is passed within <see cref="IResolveFieldContext.RequestServices"/>. This method must be called after
-        /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
+        /// <see cref="ConnectionBuilder{TSourceType, TReturnType}.PageSize(int?)">PageSize</see> and/or
+        /// <see cref="ConnectionBuilder{TSourceType, TReturnType}.Bidirectional">Bidirectional</see> have been called.
         /// </summary>
         public static void ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
         {
@@ -44,7 +45,8 @@ namespace GraphQL.MicrosoftDI
 
         /// <summary>
         /// Creates a resolve builder for the connection field. This method must be called after
-        /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
+        /// <see cref="ConnectionBuilder{TSourceType, TReturnType}.PageSize(int?)">PageSize</see> and/or
+        /// <see cref="ConnectionBuilder{TSourceType, TReturnType}.Bidirectional">Bidirectional</see> have been called.
         /// </summary>
         public static ConnectionResolverBuilder<TSourceType, object> Resolve<TSourceType>(this ConnectionBuilder<TSourceType> builder)
             => new ConnectionResolverBuilder<TSourceType, object>(builder.Returns<object>(), false);

--- a/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
@@ -401,12 +401,8 @@ namespace GraphQL.Tests.Builders
             graph.Connection<ChildType>()
                 .Name("connection")
                 .PageSize(10)
-                .Resolve(context =>
-                {
-                    context.First.ShouldBe(10);
-                    return null;
-                });
-            graph.Fields.Find("connection").Resolver.Resolve(new ResolveFieldContext());
+                .Resolve(context => context.First);
+            graph.Fields.Find("connection").Resolver.Resolve(new ResolveFieldContext()).ShouldBe(10);
         }
 
         [Fact]
@@ -416,12 +412,8 @@ namespace GraphQL.Tests.Builders
             graph.Connection<ChildType>()
                 .Name("connection")
                 .PageSize(10)
-                .ResolveAsync(context =>
-                {
-                    context.First.ShouldBe(10);
-                    return Task.FromResult<object>(null);
-                });
-            graph.Fields.Find("connection").Resolver.Resolve(new ResolveFieldContext());
+                .ResolveAsync(context => Task.FromResult<object>(context.First));
+            graph.Fields.Find("connection").Resolver.Resolve(new ResolveFieldContext()).ShouldBeOfType<Task<object>>().Result.ShouldBe(10);
         }
 
         public class ParentChildrenConnection : Connection<Child, ParentChildrenEdge>

--- a/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
@@ -394,6 +394,36 @@ namespace GraphQL.Tests.Builders
             graph.Fields.Find("connection").Arguments.Count(x => x.Name == "last").ShouldBe(1);
         }
 
+        [Fact]
+        public void should_use_pagesize()
+        {
+            var graph = new ObjectGraphType();
+            graph.Connection<ChildType>()
+                .Name("connection")
+                .PageSize(10)
+                .Resolve(context =>
+                {
+                    context.First.ShouldBe(10);
+                    return null;
+                });
+            graph.Fields.Find("connection").Resolver.Resolve(new ResolveFieldContext());
+        }
+
+        [Fact]
+        public void should_use_pagesize_async()
+        {
+            var graph = new ObjectGraphType();
+            graph.Connection<ChildType>()
+                .Name("connection")
+                .PageSize(10)
+                .ResolveAsync(context =>
+                {
+                    context.First.ShouldBe(10);
+                    return Task.FromResult<object>(null);
+                });
+            graph.Fields.Find("connection").Resolver.Resolve(new ResolveFieldContext());
+        }
+
         public class ParentChildrenConnection : Connection<Child, ParentChildrenEdge>
         {
             public int? HighestField2 => Edges?.Max(e => e.Node?.Field2);

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -348,9 +348,11 @@ namespace GraphQL.Builders
         /// </summary>
         public virtual void Resolve(Func<IResolveConnectionContext<TSourceType>, object> resolver)
         {
+            var isUnidirectional = !IsBidirectional;
+            var pageSize = PageSizeFromMetadata;
             FieldType.Resolver = new Resolvers.FuncFieldResolver<object>(context =>
             {
-                var connectionContext = new ResolveConnectionContext<TSourceType>(context, !IsBidirectional, PageSizeFromMetadata);
+                var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
                 CheckForErrors(connectionContext);
                 return resolver(connectionContext);
             });
@@ -361,9 +363,11 @@ namespace GraphQL.Builders
         /// </summary>
         public virtual void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<object>> resolver)
         {
+            var isUnidirectional = !IsBidirectional;
+            var pageSize = PageSizeFromMetadata;
             FieldType.Resolver = new Resolvers.AsyncFieldResolver<object>(context =>
             {
-                var connectionContext = new ResolveConnectionContext<TSourceType>(context, !IsBidirectional, PageSizeFromMetadata);
+                var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
                 CheckForErrors(connectionContext);
                 return resolver(connectionContext);
             });

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Builders
     {
         private bool IsBidirectional => FieldType.Arguments.Find("before")?.Type == typeof(StringGraphType) && FieldType.Arguments.Find("last")?.Type == typeof(IntGraphType);
 
-        private int? PageSizeFromMeatadata
+        private int? PageSizeFromMetadata
         {
             get => FieldType.GetMetadata<int?>(ConnectionBuilder<TSourceType>.PAGE_SIZE_METADATA_KEY);
             set => FieldType.WithMetadata(ConnectionBuilder<TSourceType>.PAGE_SIZE_METADATA_KEY, value);
@@ -127,7 +127,7 @@ namespace GraphQL.Builders
         /// </summary>
         public virtual ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize)
         {
-            PageSizeFromMeatadata = pageSize;
+            PageSizeFromMetadata = pageSize;
             return this;
         }
 
@@ -244,9 +244,11 @@ namespace GraphQL.Builders
         /// </summary>
         public virtual ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
         {
+            var isUnidirectional = !IsBidirectional;
+            var pageSize = PageSizeFromMetadata;
             FieldType.Resolver = new Resolvers.FuncFieldResolver<TReturnType>(context =>
             {
-                var connectionContext = new ResolveConnectionContext<TSourceType>(context, !IsBidirectional, PageSizeFromMeatadata);
+                var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
                 CheckForErrors(connectionContext);
                 return resolver(connectionContext);
             });
@@ -258,9 +260,11 @@ namespace GraphQL.Builders
         /// </summary>
         public virtual ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
         {
+            var isUnidirectional = !IsBidirectional;
+            var pageSize = PageSizeFromMetadata;
             FieldType.Resolver = new Resolvers.AsyncFieldResolver<TReturnType>(context =>
             {
-                var connectionContext = new ResolveConnectionContext<TSourceType>(context, !IsBidirectional, PageSizeFromMeatadata);
+                var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
                 CheckForErrors(connectionContext);
                 return resolver(connectionContext);
             });

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -240,9 +240,10 @@ namespace GraphQL.Builders
         }
 
         /// <summary>
-        /// Sets the resolver method for the connection field.
+        /// Sets the resolver method for the connection field. This method must be called after
+        /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
         /// </summary>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
+        public virtual void Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType> resolver)
         {
             var isUnidirectional = !IsBidirectional;
             var pageSize = PageSizeFromMetadata;
@@ -252,13 +253,13 @@ namespace GraphQL.Builders
                 CheckForErrors(connectionContext);
                 return resolver(connectionContext);
             });
-            return this;
         }
 
         /// <summary>
-        /// Sets the resolver method for the connection field.
+        /// Sets the resolver method for the connection field. This method must be called after
+        /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
         /// </summary>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
+        public virtual void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType>> resolver)
         {
             var isUnidirectional = !IsBidirectional;
             var pageSize = PageSizeFromMetadata;
@@ -268,7 +269,6 @@ namespace GraphQL.Builders
                 CheckForErrors(connectionContext);
                 return resolver(connectionContext);
             });
-            return this;
         }
 
         private void CheckForErrors(IResolveConnectionContext<TSourceType> context)


### PR DESCRIPTION
Captures IsBidirectional and PageSize properties when creating the connection resolver, preventing a metadata dictionary lookup and enumeration of field arguments each time that the connection is resolved.  This issue did not exist prior to 4.3 so this is a performance regression fix caused by #2458 .

Added test to verify that the PageSize value is utilized.  (There was no test for this previously.)

Also see #2518.