### PR TITLE
Better error handling for AppliedDirectivesValidationVisitor and SchemaValidationVisitor

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.3.1-preview</VersionPrefix>
+    <VersionPrefix>4.3.2-preview</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.3.2-preview</VersionPrefix>
+    <VersionPrefix>4.4.0-preview</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -344,6 +344,7 @@ namespace GraphQL.Types
         {
             //TODO: add different validations, also see SchemaBuilder.Validate
             //TODO: checks for parsed SDL may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653
+            // Do not change the order of these validations.
             SchemaValidationVisitor.Instance.Run(this);
             AppliedDirectivesValidationVisitor.Instance.Run(this);
         }

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using GraphQL.Introspection;
+using GraphQL.Language.AST;
 using GraphQL.Types;
 
 namespace GraphQL.Utilities
@@ -391,7 +392,7 @@ namespace GraphQL.Utilities
             {
                 return string.Empty;
             }
-            return $" @deprecated(reason: \"{reason.Replace("\"", "\\\"")}\")";
+            return $" @deprecated(reason: {AstPrinter.Print(new StringValue(reason))})";
         }
 
         public string[] BreakLine(string line, int len)

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -197,6 +197,9 @@ namespace GraphQL.Utilities
             {
                 throw new InvalidOperationException($"The default value of Input Object type field '{type.Name}.{field.Name}' is invalid.");
             }
+
+            if (field.Arguments?.Count > 0)
+                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have any arguments specified.");
         }
 
         #endregion


### PR DESCRIPTION
Also fixes (potential) bug with escaping when printing deprecation reason in `SchemaPrinter`.