### PR TITLE
Add additional deserialization extensions to GraphQL

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
+++ b/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="GraphQL.SystemReactive.received.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>
 

--- a/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
+++ b/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="GraphQL.SystemReactive.received.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>
 

--- a/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
@@ -32,6 +32,7 @@ namespace GraphQL.NewtonsoftJson
     }
     public static class StringExtensions
     {
+        [System.Obsolete("This method will be removed in a future version of GraphQL.NET.")]
         public static object GetValue(this object value) { }
         public static System.Collections.Generic.Dictionary<string, object> ToDictionary(this string json) { }
         public static GraphQL.Inputs ToInputs(this Newtonsoft.Json.Linq.JObject obj) { }

--- a/src/GraphQL.ApiTests/GraphQL.SystemTextJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.SystemTextJson.approved.txt
@@ -38,7 +38,10 @@ namespace GraphQL.SystemTextJson
     }
     public static class StringExtensions
     {
+        public static T FromJson<T>(this string json) { }
+        public static System.Threading.Tasks.ValueTask<T> FromJsonAsync<T>(this System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.Dictionary<string, object> ToDictionary(this string json) { }
+        public static GraphQL.Inputs ToInputs(this System.Text.Json.JsonElement obj) { }
         public static GraphQL.Inputs ToInputs(this string json) { }
     }
 }

--- a/src/GraphQL.Harness/GraphQLMiddleware.cs
+++ b/src/GraphQL.Harness/GraphQLMiddleware.cs
@@ -1,12 +1,12 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Instrumentation;
-using GraphQL.Types;
 using GraphQL.SystemTextJson;
+using GraphQL.Types;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using System.Threading;
 
 namespace Example
 {

--- a/src/GraphQL.Harness/GraphQLMiddleware.cs
+++ b/src/GraphQL.Harness/GraphQLMiddleware.cs
@@ -1,11 +1,12 @@
 using System;
-using System.Text.Json;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
+using GraphQL.SystemTextJson;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using System.Threading;
 
 namespace Example
 {
@@ -50,11 +51,7 @@ namespace Example
         {
             var start = DateTime.UtcNow;
 
-            var request = await JsonSerializer.DeserializeAsync<GraphQLRequest>
-            (
-                context.Request.Body,
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-            );
+            var request = await context.Request.Body.FromJsonAsync<GraphQLRequest>(context.RequestAborted);
 
             var result = await _executer.ExecuteAsync(options =>
             {
@@ -65,6 +62,7 @@ namespace Example
                 options.UserContext = _settings.BuildUserContext?.Invoke(context);
                 options.EnableMetrics = _settings.EnableMetrics;
                 options.RequestServices = context.RequestServices;
+                options.CancellationToken = context.RequestAborted;
             });
 
             if (_settings.EnableMetrics)
@@ -72,15 +70,15 @@ namespace Example
                 result.EnrichWithApolloTracing(start);
             }
 
-            await WriteResponseAsync(context, result);
+            await WriteResponseAsync(context, result, context.RequestAborted);
         }
 
-        private async Task WriteResponseAsync(HttpContext context, ExecutionResult result)
+        private async Task WriteResponseAsync(HttpContext context, ExecutionResult result, CancellationToken cancellationToken)
         {
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = 200; // OK
 
-            await _writer.WriteAsync(context.Response.Body, result);
+            await _writer.WriteAsync(context.Response.Body, result, cancellationToken);
         }
     }
 }

--- a/src/GraphQL.Harness/GraphQLRequest.cs
+++ b/src/GraphQL.Harness/GraphQLRequest.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
-using GraphQL.SystemTextJson;
 
 namespace Example
 {
@@ -10,7 +8,6 @@ namespace Example
 
         public string Query { get; set; }
 
-        [JsonConverter(typeof(ObjectDictionaryConverter))]
         public Dictionary<string, object> Variables { get; set; }
     }
 }

--- a/src/GraphQL.NewtonsoftJson/StringExtensions.cs
+++ b/src/GraphQL.NewtonsoftJson/StringExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -29,7 +30,7 @@ namespace GraphQL.NewtonsoftJson
         /// </remarks>
         public static Inputs ToInputs(this JObject obj)
         {
-            var variables = obj?.GetValue() as Dictionary<string, object>;
+            var variables = obj?.GetValueInternal() as Dictionary<string, object>;
             return variables.ToInputs();
         }
 
@@ -46,7 +47,7 @@ namespace GraphQL.NewtonsoftJson
                     DateFormatHandling = DateFormatHandling.IsoDateFormat,
                     DateParseHandling = DateParseHandling.None
                 });
-            return GetValue(values) as Dictionary<string, object>;
+            return GetValueInternal(values) as Dictionary<string, object>;
         }
 
         /// <summary>
@@ -54,14 +55,18 @@ namespace GraphQL.NewtonsoftJson
         /// </summary>
         /// <param name="value">The object containing the value to extract.</param>
         /// <remarks>If the value is a recognized type, it is returned unaltered.</remarks>
+        [Obsolete("This method will be removed in a future version of GraphQL.NET.")]
         public static object GetValue(this object value)
+            => GetValueInternal(value);
+
+        private static object GetValueInternal(this object value)
         {
             if (value is JObject objectValue)
             {
                 var output = new Dictionary<string, object>();
                 foreach (var kvp in objectValue)
                 {
-                    output.Add(kvp.Key, GetValue(kvp.Value));
+                    output.Add(kvp.Key, GetValueInternal(kvp.Value));
                 }
                 return output;
             }
@@ -70,7 +75,7 @@ namespace GraphQL.NewtonsoftJson
             {
                 return new Dictionary<string, object>
                 {
-                    { propertyValue.Name, GetValue(propertyValue.Value) }
+                    { propertyValue.Name, GetValueInternal(propertyValue.Value) }
                 };
             }
 
@@ -78,7 +83,7 @@ namespace GraphQL.NewtonsoftJson
             {
                 return arrayValue.Children().Aggregate(new List<object>(), (list, token) =>
                 {
-                    list.Add(GetValue(token));
+                    list.Add(GetValueInternal(token));
                     return list;
                 });
             }

--- a/src/GraphQL.SystemTextJson/StringExtensions.cs
+++ b/src/GraphQL.SystemTextJson/StringExtensions.cs
@@ -63,7 +63,7 @@ namespace GraphQL.SystemTextJson
         public static Inputs ToInputs(this JsonElement obj)
         {
             if (obj.ValueKind == JsonValueKind.Null)
-                return null;
+                return Inputs.Empty;
 
             if (obj.ValueKind != JsonValueKind.Object)
                 throw new InvalidOperationException("This element is not an object element");

--- a/src/GraphQL.SystemTextJson/StringExtensions.cs
+++ b/src/GraphQL.SystemTextJson/StringExtensions.cs
@@ -1,5 +1,9 @@
+using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GraphQL.SystemTextJson
 {
@@ -36,5 +40,81 @@ namespace GraphQL.SystemTextJson
         /// <returns>Dictionary.</returns>
         public static Dictionary<string, object> ToDictionary(this string json)
             => JsonSerializer.Deserialize<Dictionary<string, object>>(json, _jsonOptions);
+
+        /// <summary>
+        /// Deserializes a JSON-formatted string of data into the specified type.
+        /// Any <see cref="Dictionary{TKey, TValue}">Dictionary&lt;string, object&gt;</see> objects will be deserialized
+        /// into the proper format for passing to <see cref="InputsExtensions.ToInputs(Dictionary{string, object})"/>.
+        /// </summary>
+        public static T FromJson<T>(this string json)
+            => JsonSerializer.Deserialize<T>(json, _jsonOptions);
+
+        /// <summary>
+        /// Deserializes a JSON-formatted stream of data into the specified type.
+        /// Any <see cref="Dictionary{TKey, TValue}">Dictionary&lt;string, object&gt;</see> objects will be deserialized
+        /// into the proper format for passing to <see cref="InputsExtensions.ToInputs(Dictionary{string, object})"/>.
+        /// </summary>
+        public static ValueTask<T> FromJsonAsync<T>(this System.IO.Stream stream, CancellationToken cancellationToken = default)
+            => JsonSerializer.DeserializeAsync<T>(stream, _jsonOptions, cancellationToken);
+
+        /// <summary>
+        /// Converts a JSON element into an <see cref="Inputs"/> object.
+        /// </summary>
+        public static Inputs ToInputs(this JsonElement obj)
+        {
+            if (obj.ValueKind == JsonValueKind.Null)
+                return null;
+
+            if (obj.ValueKind != JsonValueKind.Object)
+                throw new InvalidOperationException("This element is not an object element");
+
+            var dic = (Dictionary<string, object>)GetValue(obj);
+            return dic.ToInputs();
+
+            object GetValue(JsonElement node)
+            {
+                switch (node.ValueKind)
+                {
+                    case JsonValueKind.Null:
+                        return null;
+                    case JsonValueKind.True:
+                        return BoolBox.True;
+                    case JsonValueKind.False:
+                        return BoolBox.False;
+                    case JsonValueKind.String:
+                        return node.GetString();
+                    case JsonValueKind.Number:
+                        if (node.TryGetInt32(out var val))
+                            return val;
+                        if (node.TryGetInt64(out var val2))
+                            return val2;
+                        if (node.TryGetUInt64(out var val3))
+                            return val3;
+                        if (BigInteger.TryParse(node.GetRawText(), out var val4))
+                            return val4;
+                        if (node.TryGetDouble(out var val5))
+                            return val5;
+                        if (node.TryGetDecimal(out var val6))
+                            return val6;
+                        throw new NotImplementedException($"Unexpected Number value. Raw text was: {node.GetRawText()}");
+                    case JsonValueKind.Object:
+                        var dic = new Dictionary<string, object>();
+                        foreach (var prop in node.EnumerateObject())
+                        {
+                            dic.Add(prop.Name, GetValue(prop.Value));
+                        }
+                        return dic;
+                    case JsonValueKind.Array:
+                        var array = new List<object>();
+                        foreach (var prop in node.EnumerateArray())
+                        {
+                            array.Add(GetValue(prop));
+                        }
+                        return array;
+                    default:
+                        throw new NotImplementedException($"Unexpected element type '{node.ValueKind}'.");
+                }
+            }
+        }
     }
 }

--- a/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
@@ -114,7 +114,7 @@ namespace GraphQL.Tests.Serialization
             actual["itemString"].ShouldBeOfType<string>().ShouldBe("test");
             actual["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
             actual["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.4);
-            actual["itemBigInt"].ShouldBeOfType<BigInteger>().ShouldBe((BigInteger)((dynamic)_example).itemBigInt);
+            actual["itemBigInt"].ShouldBeOfType<BigInteger>().ShouldBe(_example.itemBigInt);
         }
     }
 }

--- a/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using GraphQL.NewtonsoftJson;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Serialization
+{
+    public class NewtonsoftJsonTests
+    {
+        private readonly object _example = new
+        {
+            array = new object[]
+                {
+                    null,
+                    "test",
+                    123,
+                    1.2
+                },
+            obj = new
+            {
+                itemNull = (string)null,
+                itemString = "test",
+                itemNum = 123,
+                itemFloat = 12.3,
+            },
+            itemNull = (string)null,
+            itemString = "test",
+            itemNum = 123,
+            itemFloat = 12.3,
+            itemBigInt = BigInteger.Parse("1234567890123456789012345678901234567890"),
+        };
+        private readonly string _exampleJson = "{\"array\":[null,\"test\",123,1.2],\"obj\":{\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.3},\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.3,\"itemBigInt\":1234567890123456789012345678901234567890}";
+
+        [Fact]
+        public async Task SerializeWithDocumentWriter()
+        {
+            var dw = new DocumentWriter();
+            var actual = await dw.WriteToStringAsync(_example);
+            actual.ShouldBe(_exampleJson);
+        }
+
+        [Fact]
+        public void StringToDictionary()
+        {
+            var actual = _exampleJson.ToDictionary();
+            Verify(actual);
+        }
+
+        [Fact]
+        public void StringToInputs()
+        {
+            var actual = _exampleJson.ToInputs();
+            Verify(actual);
+        }
+
+        [Fact]
+        public void ElementToInputs()
+        {
+            var test = $"{{\"query\":\"hello\",\"variables\":{_exampleJson}}}";
+            var actual = Newtonsoft.Json.JsonConvert.DeserializeObject<TestClass2>(test);
+            actual.query.ShouldBe("hello");
+            var variables = actual.variables.ToInputs();
+            Verify(variables);
+        }
+
+        private class TestClass1
+        {
+            public string query { get; set; }
+            public Dictionary<string, object> variables { get; set; }
+        }
+
+        private class TestClass2
+        {
+            public string query { get; set; }
+            public JObject variables { get; set; }
+        }
+
+        private void Verify(IReadOnlyDictionary<string, object> actual)
+        {
+            var array = actual["array"].ShouldBeOfType<List<object>>();
+            array[0].ShouldBeNull();
+            array[1].ShouldBeOfType<string>().ShouldBe("test");
+            array[2].ShouldBeOfType<int>().ShouldBe(123);
+            array[3].ShouldBeOfType<double>().ShouldBe(1.2);
+            var obj = actual["obj"].ShouldBeOfType<Dictionary<string, object>>();
+            obj["itemNull"].ShouldBeNull();
+            obj["itemString"].ShouldBeOfType<string>().ShouldBe("test");
+            obj["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
+            obj["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.3);
+            actual["itemNull"].ShouldBeNull();
+            actual["itemString"].ShouldBeOfType<string>().ShouldBe("test");
+            actual["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
+            actual["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.3);
+            actual["itemBigInt"].ShouldBeOfType<BigInteger>().ShouldBe((BigInteger)((dynamic)_example).itemBigInt);
+        }
+    }
+}

--- a/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Tests.Serialization
 {
     public class NewtonsoftJsonTests
     {
-        private readonly object _example = new
+        private readonly TestData _example = new TestData
         {
             array = new object[]
                 {
@@ -20,14 +20,14 @@ namespace GraphQL.Tests.Serialization
                     123,
                     1.2
                 },
-            obj = new
+            obj = new TestChildData
             {
-                itemNull = (string)null,
+                itemNull = null,
                 itemString = "test",
                 itemNum = 123,
                 itemFloat = 12.4,
             },
-            itemNull = (string)null,
+            itemNull = null,
             itemString = "test",
             itemNum = 123,
             itemFloat = 12.4,
@@ -77,6 +77,25 @@ namespace GraphQL.Tests.Serialization
         {
             public string query { get; set; }
             public JObject variables { get; set; }
+        }
+
+        public class TestData
+        {
+            public object[] array { get; set; }
+            public TestChildData obj { get; set; }
+            public string itemNull { get; set; }
+            public string itemString { get; set; }
+            public int itemNum { get; set; }
+            public double itemFloat { get; set; }
+            public BigInteger itemBigInt { get; set; }
+        }
+
+        public class TestChildData
+        {
+            public string itemNull { get; set; }
+            public string itemString { get; set; }
+            public int itemNum { get; set; }
+            public double itemFloat { get; set; }
         }
 
         private void Verify(IReadOnlyDictionary<string, object> actual)

--- a/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
@@ -25,15 +25,15 @@ namespace GraphQL.Tests.Serialization
                 itemNull = (string)null,
                 itemString = "test",
                 itemNum = 123,
-                itemFloat = 12.3,
+                itemFloat = 12.4,
             },
             itemNull = (string)null,
             itemString = "test",
             itemNum = 123,
-            itemFloat = 12.3,
+            itemFloat = 12.4,
             itemBigInt = BigInteger.Parse("1234567890123456789012345678901234567890"),
         };
-        private readonly string _exampleJson = "{\"array\":[null,\"test\",123,1.2],\"obj\":{\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.3},\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.3,\"itemBigInt\":1234567890123456789012345678901234567890}";
+        private readonly string _exampleJson = "{\"array\":[null,\"test\",123,1.2],\"obj\":{\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.4},\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.4,\"itemBigInt\":1234567890123456789012345678901234567890}";
 
         [Fact]
         public async Task SerializeWithDocumentWriter()
@@ -90,11 +90,11 @@ namespace GraphQL.Tests.Serialization
             obj["itemNull"].ShouldBeNull();
             obj["itemString"].ShouldBeOfType<string>().ShouldBe("test");
             obj["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
-            obj["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.3);
+            obj["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.4);
             actual["itemNull"].ShouldBeNull();
             actual["itemString"].ShouldBeOfType<string>().ShouldBe("test");
             actual["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
-            actual["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.3);
+            actual["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.4);
             actual["itemBigInt"].ShouldBeOfType<BigInteger>().ShouldBe((BigInteger)((dynamic)_example).itemBigInt);
         }
     }

--- a/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
@@ -81,7 +81,7 @@ namespace GraphQL.Tests.Serialization
         [Fact]
         public void ToInputsReturnsEmptyForNull()
         {
-            ((string)null).ToInputs().ShouldBeNull();
+            ((string)null).ToInputs().ShouldNotBeNull().Count.ShouldBe(0);
         }
 
         private class TestClass1

--- a/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/NewtonsoftJsonTests.cs
@@ -67,6 +67,23 @@ namespace GraphQL.Tests.Serialization
             Verify(variables);
         }
 
+        [Fact]
+        public void ElementToInputs_ReturnsEmptyForNull()
+        {
+            var test = $"{{\"query\":\"hello\",\"variables\":null}}";
+            var actual = Newtonsoft.Json.JsonConvert.DeserializeObject<TestClass2>(test);
+            actual.query.ShouldBe("hello");
+            var variables = actual.variables.ToInputs();
+            variables.ShouldNotBeNull();
+            variables.Count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void ToInputsReturnsEmptyForNull()
+        {
+            ((string)null).ToInputs().ShouldBeNull();
+        }
+
         private class TestClass1
         {
             public string query { get; set; }

--- a/src/GraphQL.Tests/Serialization/ObjectDictionaryConverterFacts.cs
+++ b/src/GraphQL.Tests/Serialization/ObjectDictionaryConverterFacts.cs
@@ -5,7 +5,7 @@ using GraphQL.SystemTextJson;
 using Shouldly;
 using Xunit;
 
-namespace GraphQL.Tests
+namespace GraphQL.Tests.Serialization
 {
     public class ObjectDictionaryConverterFacts
     {

--- a/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
@@ -90,6 +90,23 @@ namespace GraphQL.Tests.Serialization
             Verify(variables);
         }
 
+        [Fact]
+        public void ElementToInputs_ReturnsEmptyForNull()
+        {
+            var test = $"{{\"query\":\"hello\",\"variables\":null}}";
+            var actual = test.FromJson<TestClass2>();
+            actual.query.ShouldBe("hello");
+            var variables = actual.variables.ToInputs();
+            variables.ShouldNotBeNull();
+            variables.Count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void ToInputsReturnsEmptyForNull()
+        {
+            ((string)null).ToInputs().ShouldBeNull();
+        }
+
         private class TestClass1
         {
             public string query { get; set; }

--- a/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GraphQL.SystemTextJson;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Serialization
+{
+    public class SystemTextJsonTests
+    {
+        private readonly object _example = new
+        {
+            array = new object[]
+                {
+                    null,
+                    "test",
+                    123,
+                    1.2
+                },
+            obj = new
+            {
+                itemNull = (string)null,
+                itemString = "test",
+                itemNum = 123,
+                itemFloat = 12.3,
+            },
+            itemNull = (string)null,
+            itemString = "test",
+            itemNum = 123,
+            itemFloat = 12.3,
+            itemBigInt = BigInteger.Parse("1234567890123456789012345678901234567890"),
+        };
+        private readonly string _exampleJson = "{\"array\":[null,\"test\",123,1.2],\"obj\":{\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.3},\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.3,\"itemBigInt\":1234567890123456789012345678901234567890}";
+
+        [Fact]
+        public async Task SerializeWithDocumentWriter()
+        {
+            var dw = new DocumentWriter();
+            var actual = await dw.WriteToStringAsync(_example);
+            actual.ShouldBe(_exampleJson);
+        }
+
+        [Fact]
+        public void StringToDictionary()
+        {
+            var actual = _exampleJson.ToDictionary();
+            Verify(actual);
+        }
+
+        [Fact]
+        public void StringToInputs()
+        {
+            var actual = _exampleJson.ToInputs();
+            Verify(actual);
+        }
+
+        [Fact]
+        public void FromJson()
+        {
+            var test = $"{{\"query\":\"hello\",\"variables\":{_exampleJson}}}";
+            var actual = test.FromJson<TestClass1>();
+            actual.query.ShouldBe("hello");
+            Verify(actual.variables);
+        }
+
+        [Fact]
+        public async Task FromJsonAsync()
+        {
+            var test = $"{{\"query\":\"hello\",\"variables\":{_exampleJson}}}";
+            var testData = new MemoryStream(Encoding.UTF8.GetBytes(test));
+            var actual = await testData.FromJsonAsync<TestClass1>();
+            actual.query.ShouldBe("hello");
+            Verify(actual.variables);
+        }
+
+        [Fact]
+        public void ElementToInputs()
+        {
+            var test = $"{{\"query\":\"hello\",\"variables\":{_exampleJson}}}";
+            var actual = test.FromJson<TestClass2>();
+            actual.query.ShouldBe("hello");
+            var variables = actual.variables.ToInputs();
+            Verify(variables);
+        }
+
+        private class TestClass1
+        {
+            public string query { get; set; }
+            public Dictionary<string, object> variables { get; set; }
+        }
+
+        private class TestClass2
+        {
+            public string query { get; set; }
+            public JsonElement variables { get; set; }
+        }
+
+        private void Verify(IReadOnlyDictionary<string, object> actual)
+        {
+            var array = actual["array"].ShouldBeOfType<List<object>>();
+            array[0].ShouldBeNull();
+            array[1].ShouldBeOfType<string>().ShouldBe("test");
+            array[2].ShouldBeOfType<int>().ShouldBe(123);
+            array[3].ShouldBeOfType<double>().ShouldBe(1.2);
+            var obj = actual["obj"].ShouldBeOfType<Dictionary<string, object>>();
+            obj["itemNull"].ShouldBeNull();
+            obj["itemString"].ShouldBeOfType<string>().ShouldBe("test");
+            obj["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
+            obj["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.3);
+            actual["itemNull"].ShouldBeNull();
+            actual["itemString"].ShouldBeOfType<string>().ShouldBe("test");
+            actual["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
+            actual["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.3);
+            actual["itemBigInt"].ShouldBeOfType<BigInteger>().ShouldBe((BigInteger)((dynamic)_example).itemBigInt);
+        }
+    }
+}

--- a/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
@@ -104,7 +104,7 @@ namespace GraphQL.Tests.Serialization
         [Fact]
         public void ToInputsReturnsEmptyForNull()
         {
-            ((string)null).ToInputs().ShouldBeNull();
+            ((string)null).ToInputs().ShouldNotBeNull().Count.ShouldBe(0);
         }
 
         private class TestClass1

--- a/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
@@ -24,7 +24,7 @@ namespace GraphQL.Tests.Serialization
                 },
             obj = new TestChildData
             {
-                itemNull = (string)null,
+                itemNull = null,
                 itemString = "test",
                 itemNum = 123,
                 itemFloat = 12.4,

--- a/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJsonTests.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Tests.Serialization
 {
     public class SystemTextJsonTests
     {
-        private readonly object _example = new
+        private readonly TestData _example = new TestData
         {
             array = new object[]
                 {
@@ -22,25 +22,27 @@ namespace GraphQL.Tests.Serialization
                     123,
                     1.2
                 },
-            obj = new
+            obj = new TestChildData
             {
                 itemNull = (string)null,
                 itemString = "test",
                 itemNum = 123,
-                itemFloat = 12.3,
+                itemFloat = 12.4,
             },
-            itemNull = (string)null,
+            itemNull = null,
             itemString = "test",
             itemNum = 123,
-            itemFloat = 12.3,
+            itemFloat = 12.4,
             itemBigInt = BigInteger.Parse("1234567890123456789012345678901234567890"),
         };
-        private readonly string _exampleJson = "{\"array\":[null,\"test\",123,1.2],\"obj\":{\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.3},\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.3,\"itemBigInt\":1234567890123456789012345678901234567890}";
+        private readonly string _exampleJson = "{\"array\":[null,\"test\",123,1.2],\"obj\":{\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.4},\"itemNull\":null,\"itemString\":\"test\",\"itemNum\":123,\"itemFloat\":12.4,\"itemBigInt\":1234567890123456789012345678901234567890}";
 
         [Fact]
         public async Task SerializeWithDocumentWriter()
         {
             var dw = new DocumentWriter();
+            // note: WriteToStringAsync<object>(...) always returns "{}" on .Net Core 2.1 / 3.1, but works fine on 5.0
+            // so we need to use a strongly typed object here
             var actual = await dw.WriteToStringAsync(_example);
             actual.ShouldBe(_exampleJson);
         }
@@ -100,6 +102,25 @@ namespace GraphQL.Tests.Serialization
             public JsonElement variables { get; set; }
         }
 
+        public class TestData
+        {
+            public object[] array { get; set; }
+            public TestChildData obj { get; set; }
+            public string itemNull { get; set; }
+            public string itemString { get; set; }
+            public int itemNum { get; set; }
+            public double itemFloat { get; set; }
+            public BigInteger itemBigInt { get; set; }
+        }
+
+        public class TestChildData
+        {
+            public string itemNull { get; set; }
+            public string itemString { get; set; }
+            public int itemNum { get; set; }
+            public double itemFloat { get; set; }
+        }
+
         private void Verify(IReadOnlyDictionary<string, object> actual)
         {
             var array = actual["array"].ShouldBeOfType<List<object>>();
@@ -111,12 +132,12 @@ namespace GraphQL.Tests.Serialization
             obj["itemNull"].ShouldBeNull();
             obj["itemString"].ShouldBeOfType<string>().ShouldBe("test");
             obj["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
-            obj["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.3);
+            obj["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.4);
             actual["itemNull"].ShouldBeNull();
             actual["itemString"].ShouldBeOfType<string>().ShouldBe("test");
             actual["itemNum"].ShouldBeOfType<int>().ShouldBe(123);
-            actual["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.3);
-            actual["itemBigInt"].ShouldBeOfType<BigInteger>().ShouldBe((BigInteger)((dynamic)_example).itemBigInt);
+            actual["itemFloat"].ShouldBeOfType<double>().ShouldBe(12.4);
+            actual["itemBigInt"].ShouldBeOfType<BigInteger>().ShouldBe(_example.itemBigInt);
         }
     }
 }

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -88,7 +88,7 @@ namespace GraphQL.Validation
 
                 if (!rules.Any())
                 {
-                    variables = context.GetVariableValues(schema, variableDefinitions, inputs); // can report errors even without rules enabled
+                    variables = context.GetVariableValues(schema, variableDefinitions, inputs ?? Inputs.Empty); // can report errors even without rules enabled
                 }
                 else
                 {


### PR DESCRIPTION
See #2510 

- `FromJson` and `FromJsonAsync` are new methods for `GraphQL.SystemTextJson`.  They cannot be implemented for Newtonsoft due to its nature.  Or least, I'm not sure how at the moment.
- `ToInputs(this JsonElement element)` is a new method in `GraphQL.SystemTextJson`.  This mimics a similar method within `GraphQL.NewtonsoftJson` that already exists there (as `ToInputs(this JObject obj)`).  It uses a local `GetValue` function.  There exists a similar `GetValue` function in the `GraphQL.NewtonsoftJson` library for the same purpose which is public.  I do not see why this needs to be public, so it remains private in `GraphQL.SystemTextJson`.