### PR TITLE
DateTime value processing for DateTimeOffsetGraphType

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.5.0-preview</VersionPrefix>
+    <VersionPrefix>4.5.1-preview</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.5.1-preview</VersionPrefix>
+    <VersionPrefix>4.5.0-preview</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/GraphQL.Tests/Types/DateTimeOffsetGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DateTimeOffsetGraphTypeTests.cs
@@ -55,5 +55,26 @@ namespace GraphQL.Tests.Types
                     new DateTimeOffset(2015, 11, 21, 19, 59, 32, 987, TimeSpan.FromHours(2)));
             });
         }
+
+        public static object[][] DateTimeTypeTests()
+        {
+            var dateTimeNow = DateTime.Now;
+            var dateTimeUtcNow = DateTime.UtcNow;
+            var dateTimeUnspecified = new DateTime(2015, 11, 21, 17, 59, 32, DateTimeKind.Unspecified);
+
+            return new object[][]
+            {
+                new object[] { dateTimeNow, new DateTimeOffset(dateTimeNow) },
+                new object[] { dateTimeUtcNow, new DateTimeOffset(dateTimeUtcNow) },
+                new object[] { dateTimeUnspecified, new DateTimeOffset(dateTimeUnspecified, TimeSpan.Zero) }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(DateTimeTypeTests))]
+        public void coerces_dateTime_type_to_date(DateTime input, DateTimeOffset expected)
+        {
+            CultureTestHelper.UseCultures(() => _type.ParseValue(input).ShouldBe(expected));
+        }
     }
 }

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -34,7 +34,7 @@ namespace GraphQL.Types
         public override object? ParseValue(object? value) => value switch
         {
             DateTimeOffset _ => value,
-            DateTime d => d.Kind == DateTimeKind.Unspecified ? new DateTimeOffset(d, TimeSpan.Zero) : new DateTimeOffset(d),
+            DateTime d => d.Kind == DateTimeKind.Unspecified ? new DateTimeOffset(d, TimeSpan.Zero) : new DateTimeOffset(d), // handles Unspecified as UTC to preserve the same behavior as for System.Text.Json
             string s => ParseDate(s),
             null => null,
             _ => ThrowValueConversionError(value)

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -34,6 +34,7 @@ namespace GraphQL.Types
         public override object? ParseValue(object? value) => value switch
         {
             DateTimeOffset _ => value,
+            DateTime d => d.Kind == DateTimeKind.Unspecified ? new DateTimeOffset(d, TimeSpan.Zero) : new DateTimeOffset(d),
             string s => ParseDate(s),
             null => null,
             _ => ThrowValueConversionError(value)


### PR DESCRIPTION
I've noticed that it seems like impossible to send argument of `DateTimeOffset` type via variables to `GraphQL.Server` if `.AddNewtonsoftJson()` serializer with default settings is used. At this case I received the following response:

**Query:**
```
mutation test($arg: DateTimeOffset) {
  someOperation(arg1: $arg)
}
```

**Variables:**
```
{
  "arg": "2015-12-22T10:10:10+03:00"
}
```

**Response:**
```
{
  "errors": [
    {
      "message": "GraphQL.Validation.InvalidVariableError: Variable '$arg' is invalid. Unable to convert '12/22/2015 10:10:10' to 'DateTimeOffset'\r\n ---> System.InvalidOperationException: Unable to convert '12/22/2015 10:10:10' to the scalar type 'DateTimeOffset'\r\n   at GraphQL.Types.ScalarGraphType.ThrowValueConversionError(Object value) in /_/src/GraphQL/Types/Scalars/ScalarGraphType.cs:line 207\r\n   at GraphQL.Types.DateTimeOffsetGraphType.ParseValue(Object value) in /_/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs:line 39\r\n   at GraphQL.Validation.ValidationContext.<GetVariableValue>g__ParseValueScalar|39_1(ScalarGraphType scalarGraphType, VariableDefinition variableDef, VariableName variableName, Object value) in /_/src/GraphQL/Validation/ValidationContext.cs:line 324\r\n   --- End of inner exception stack trace ---\r\n   at GraphQL.Validation.ValidationContext.<GetVariableValue>g__ParseValueScalar|39_1(ScalarGraphType scalarGraphType, VariableDefinition variableDef, VariableName variableName, Object value) in /_/src/GraphQL/Validation/ValidationContext.cs:line 328\r\n   at GraphQL.Validation.ValidationContext.<GetVariableValue>g__ParseValue|39_0(IGraphType type, VariableDefinition variableDef, VariableName variableName, Object value, IVariableVisitor visitor) in /_/src/GraphQL/Validation/ValidationContext.cs:line 309\r\n   at GraphQL.Validation.ValidationContext.GetVariableValues(ISchema schema, VariableDefinitions variableDefinitions, Inputs inputs, IVariableVisitor visitor) in /_/src/GraphQL/Validation/ValidationContext.cs:line 231",
      "extensions": {
        "code": "INVALID_VALUE",
        "codes": [
          "INVALID_VALUE",
          "INVALID_OPERATION"
        ],
        "number": "5.8"
      }
    }
  ]
}
```

The reason is the serializer passes to [DateTimeOffsetGraphType.ParseValue](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs#L34) method value of `DateTime` type for which there is no corresponding clause.

The possible workaround is to configure options this way `.AddNewtonsoftJson(s => s.DateParseHandling = Newtonsoft.Json.DateParseHandling.None)`, but I think is is not an obvious solution for everyone.