### PR TITLE
Remove deprecated functionaliaty from the new SystemTextJson.FromJson methods

### DIFF
--- a/src/GraphQL.SystemTextJson/StringExtensions.cs
+++ b/src/GraphQL.SystemTextJson/StringExtensions.cs
@@ -41,7 +41,7 @@ namespace GraphQL.SystemTextJson
         /// <param name="json">A JSON formatted string.</param>
         /// <returns>Inputs.</returns>
         public static Inputs ToInputs(this string json)
-            => json != null ? JsonSerializer.Deserialize<Inputs>(json, _jsonOptions) : Inputs.Empty;
+            => json != null ? JsonSerializer.Deserialize<Inputs>(json, _jsonOptions2) : Inputs.Empty;
 
         /// <summary>
         /// Converts a JSON-formatted string into a dictionary of objects of their actual type.

--- a/src/GraphQL.SystemTextJson/StringExtensions.cs
+++ b/src/GraphQL.SystemTextJson/StringExtensions.cs
@@ -25,6 +25,16 @@ namespace GraphQL.SystemTextJson
             }
         };
 
+        private static readonly JsonSerializerOptions _jsonOptions2 = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new InputsConverter(),
+                new JsonConverterBigInteger(),
+            }
+        };
+
         /// <summary>
         /// Converts a JSON-formatted string into a dictionary.
         /// </summary>
@@ -50,7 +60,7 @@ namespace GraphQL.SystemTextJson
         /// Property names are converted to camel case and matched based on a case sensitive comparison (the default for System.Text.Json).
         /// </summary>
         public static T FromJson<T>(this string json)
-            => JsonSerializer.Deserialize<T>(json, _jsonOptions);
+            => JsonSerializer.Deserialize<T>(json, _jsonOptions2);
 
         /// <summary>
         /// Deserializes a JSON-formatted stream of data into the specified type.
@@ -60,7 +70,7 @@ namespace GraphQL.SystemTextJson
         /// Property names are converted to camel case and matched based on a case sensitive comparison (the default for System.Text.Json).
         /// </summary>
         public static ValueTask<T> FromJsonAsync<T>(this System.IO.Stream stream, CancellationToken cancellationToken = default)
-            => JsonSerializer.DeserializeAsync<T>(stream, _jsonOptions, cancellationToken);
+            => JsonSerializer.DeserializeAsync<T>(stream, _jsonOptions2, cancellationToken);
 
         /// <summary>
         /// Converts a JSON element into an <see cref="Inputs"/> object.

--- a/src/GraphQL.Tests/Serialization/SystemTextJson/StringExtensionTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJson/StringExtensionTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/GraphQL.Tests/Serialization/SystemTextJson/StringExtensionTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJson/StringExtensionTests.cs
@@ -63,44 +63,21 @@ namespace GraphQL.Tests.Serialization.SystemTextJson
         }
 
         [Fact]
-        public void FromJson()
-        {
-            var test = $"{{\"query\":\"hello\",\"variables\":{_exampleJson}}}";
-            var actual = test.FromJson<TestClass1>();
-            actual.query.ShouldBe("hello");
-            Verify(actual.variables);
-        }
-
-        [Fact]
         public void FromJson_Null()
         {
             var test = $"{{\"query\":\"hello\",\"variables\":null}}";
-            var actual = test.FromJson<TestClass1>();
-            actual.query.ShouldBe("hello");
-            actual.variables.ShouldBeNull();
+            var actual = test.FromJson<TestClass3>();
+            actual.Query.ShouldBe("hello");
+            actual.Variables.ShouldBeNull();
         }
 
         [Fact]
         public void FromJson_Missing()
         {
             var test = $"{{\"query\":\"hello\"}}";
-            var actual = test.FromJson<TestClass1>();
-            actual.query.ShouldBe("hello");
-            actual.variables.ShouldBeNull();
-        }
-
-        [Fact]
-        public async Task FromJsonAsync()
-        {
-            var test = $"{{\"query\":\"hello\",\"variables\":{_exampleJson}}}";
-            var testData = new MemoryStream(Encoding.UTF8.GetBytes(test));
-            var actual = await testData.FromJsonAsync<TestClass1>();
-            actual.query.ShouldBe("hello");
-            Verify(actual.variables);
-            // verify that the stream has not been disposed
-            testData.ReadByte().ShouldBe(-1);
-            testData.Dispose();
-            Should.Throw<ObjectDisposedException>(() => testData.ReadByte());
+            var actual = test.FromJson<TestClass3>();
+            actual.Query.ShouldBe("hello");
+            actual.Variables.ShouldBeNull();
         }
 
         [Fact]
@@ -196,12 +173,6 @@ namespace GraphQL.Tests.Serialization.SystemTextJson
         public void ToInputsReturnsEmptyForNull()
         {
             ((string)null).ToInputs().ShouldNotBeNull().Count.ShouldBe(0);
-        }
-
-        private class TestClass1
-        {
-            public string query { get; set; }
-            public Dictionary<string, object> variables { get; set; }
         }
 
         private class TestClass2


### PR DESCRIPTION
History:
- In PR #2521 we added `FromJson` extension methods to `SystemTextJson`, which deserializes `Dictionary<string, object>` .  They were not added to `NewtonsoftJson`.
- These methods were released with v4.4.0 on Apr 21.
- Then in #2522 we added `FromJson` extension methods to `NewtonsoftJson` along with `Inputs` parsing for both serialization engines.  The `Newtonsoft.FromJson` method does not deserialize `Dictionary<string, object>` types.
- Finally in #2526 we deprecated deserialization of `Dictionary<string, object>` types.

I suggest we remove the deprecated functionality from `SystemTextJson.FromJson`, unifying the method with the functionality with `NewtonsoftJson.FromJson`.  This functionality is a breaking change, but has only been available for the last 7 days within 4.4.0.  I think we should then release 4.5.0

Deserialization of `Dictionary<string, object>` types will still be available via `ToDictionary` extension methods and `ObjectDictionaryConverter` during the lifetime of v4.  This PR is only a breaking change from 4.4.0, which was released 7 days ago.

The new release (v4.5.0) will contain all of the changes to the serialization engines made over the last couple weeks:
- `ToDictionary` added for `SystemTextJson` (matching existing `ToDictionary` for `NewtonsoftJson`)
- `InputsConverter` added for both `SystemTextJson` and `NewtonsoftJson`
- `FromJson` added for both `SystemTextJson` and `NewtonsoftJson` which interprets `Inputs` values correctly
- `ObjectDictionaryConverter` deprecated for `SystemTextJson`
- `ToDictionary` deprecated for both `SystemTextJson` and `NewtonsoftJson`

Then I will work on adding documentation (which of course does not require a release).