### PR TITLE
Correctly serialize Uris.

### DIFF
--- a/src/GraphQL.Tests/Types/UriGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/UriGraphTypeTests.cs
@@ -36,5 +36,17 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void Serialize_stringAsInvalidUri_ThrowsFormatException() =>
             Should.Throw<UriFormatException>(() => uriGraphType.Serialize("www.wp.pl"));
+
+        [Fact]
+        public void Serialize_uriWithSpecialCharacters_ReturnValidUriGraphType() =>
+            uriGraphType.Serialize(new Uri("https://example.com/foo%20bar")).ShouldBe("https://example.com/foo%20bar");
+
+        [Fact]
+        public void Serialize_relativeUriWithSpecialCharacters_ReturnValidUriGraphType() =>
+            uriGraphType.Serialize(new Uri("/foo%20bar", UriKind.Relative)).ShouldBe("/foo%20bar");
+
+        [Fact]
+        public void Serialize_uriIsNormalized_ReturnValidUriGraphType() =>
+            uriGraphType.Serialize(new Uri("HTTPS://example.com")).ShouldBe("https://example.com/");
     }
 }

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -29,6 +29,12 @@ namespace GraphQL.Types
         };
 
         /// <inheritdoc/>
-        public override object? Serialize(object? value) => ParseValue(value)?.ToString();
+        public override object? Serialize(object? value) => ParseValue(value) switch
+        {
+            Uri { IsAbsoluteUri: true } uri => uri.AbsoluteUri,
+            Uri { IsAbsoluteUri: false } uri => uri.OriginalString,
+            null => null,
+            _ => ThrowSerializationError(value)
+        };
     }
 }


### PR DESCRIPTION
`Uri.ToString()` may return a corrupt URI. See https://faithlife.codes/blog/2010/08/uritostring_must_die/.