### PR TITLE
Serialize Error Extensions in System.Text.Json with provided options

### DIFF
--- a/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
@@ -271,7 +271,7 @@ namespace GraphQL.SystemTextJson
                 if (info.Extensions?.Count > 0)
                 {
                     writer.WritePropertyName("extensions");
-                    JsonSerializer.Serialize(writer, info.Extensions);
+                    JsonSerializer.Serialize(writer, info.Extensions, options);
                 }
 
                 writer.WriteEndObject();

--- a/src/GraphQL.Tests/Bugs/Bug2553.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2553.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using GraphQL.SystemTextJson;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class Bug2553
+    {
+        [Fact]
+        public async Task ShouldSerializeErrorExtensionsAccordingToOptions()
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+            options.Converters.Add(new ExecutionResultJsonConverter(new TestErrorInfoProvider()));
+
+            var executionResult = new ExecutionResult();
+            executionResult.AddError(new ExecutionError("An error occurred."));
+
+            var writer = new DocumentWriter(options);
+            string json = await writer.WriteToStringAsync(executionResult);
+
+            json.ShouldBeCrossPlatJson(@"{
+                ""errors"": [{
+                    ""message"":""An error occurred."",
+                    ""extensions"": {
+                        ""violations"": {
+                            ""message"":""An error occurred on field Email."",
+                            ""field"":""Email""
+                        }
+                    }
+                }]
+            }");
+        }
+    }
+
+    internal class TestErrorInfoProvider : ErrorInfoProvider
+    {
+        public override ErrorInfo GetInfo(ExecutionError executionError)
+        {
+            var info = base.GetInfo(executionError);
+
+            info.Extensions = new Dictionary<string, object>
+            {
+                {"violations", new TestExecutionError("An error occurred on field Email.", "Email")}
+            };
+            return info;
+        }
+    }
+
+    internal class TestExecutionError
+    {
+        public string Message { get; }
+        public string Field { get; }
+
+        public TestExecutionError(string message, string field)
+        {
+            Message = message;
+            Field = field;
+        }
+    }
+}


### PR DESCRIPTION
Extensions in errors should be serialized along with other values in the ExecutionResultJsonConverter

Addresses issue: https://github.com/graphql-dotnet/graphql-dotnet/issues/2552