### PR TITLE
Add check for `ArgumentValue` source

### DIFF
--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -52,6 +52,12 @@ namespace GraphQL
                 return true;
             }
 
+            if (arg.Source == ArgumentSource.FieldDefault || arg.Source == ArgumentSource.VariableDefault)
+            {
+                result = null;
+                return false;
+            }
+
             result = arg.Value.GetPropertyValue(argumentType, context.FieldDefinition?.Arguments?.Find(argumentName)?.ResolvedType);
             return true;
         }


### PR DESCRIPTION
#2557 
If we always have an  `ArgumentValue` we'll never hit the default value (for valuetypes).