### PR TITLE
Allow GetArgument with default value to operate on reference types

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug2557.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2557.cs
@@ -1,0 +1,81 @@
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/2557
+    public class Bug2557 : QueryTestBase<Bug2557.MySchema>
+    {
+        [Fact]
+        public void NoDefault_NoArg() => AssertQuerySuccess("{ noDefault }", @"{ ""noDefault"": ""getArgumentDefault"" }");
+
+        [Fact]
+        public void NoDefault_LiteralArg() => AssertQuerySuccess(@"{ noDefault (arg: ""test"") }", @"{ ""noDefault"": ""test"" }");
+
+        [Fact]
+        public void NoDefault_LiteralNullArg() => AssertQuerySuccess("{ noDefault (arg: null) }", @"{ ""noDefault"": ""getArgumentDefault"" }");
+
+        [Fact]
+        public void NoDefault_VariableDefaultUnspecifiedArg() => AssertQuerySuccess(@"query($arg: String) { noDefault (arg: $arg) }", @"{ ""noDefault"": ""getArgumentDefault"" }");
+
+        [Fact]
+        public void NoDefault_VariableDefaultNullArg() => AssertQuerySuccess(@"query($arg: String = null) { noDefault (arg: $arg) }", @"{ ""noDefault"": ""getArgumentDefault"" }");
+
+        [Fact]
+        public void NoDefault_VariableDefaultArg() => AssertQuerySuccess(@"query($arg: String = ""test"") { noDefault (arg: $arg) }", @"{ ""noDefault"": ""test"" }");
+
+        [Fact]
+        public void NoDefault_VariableArg() => AssertQuerySuccess(@"query($arg: String) { noDefault (arg: $arg) }", @"{ ""noDefault"": ""test"" }", @"{ ""arg"": ""test"" }".ToInputs());
+
+        [Fact]
+        public void NoDefault_VariableNullArg() => AssertQuerySuccess(@"query($arg: String) { noDefault (arg: $arg) }", @"{ ""noDefault"": ""getArgumentDefault"" }", @"{ ""arg"": null }".ToInputs());
+
+        [Fact]
+        public void WithDefault_NoArg() => AssertQuerySuccess("{ withDefault }", @"{ ""withDefault"": ""fieldDefault"" }");
+
+        [Fact]
+        public void WithDefault_LiteralArg() => AssertQuerySuccess(@"{ withDefault (arg: ""test"") }", @"{ ""withDefault"": ""test"" }");
+
+        [Fact]
+        public void WithDefault_LiteralNullArg() => AssertQuerySuccess("{ withDefault (arg: null) }", @"{ ""withDefault"": ""getArgumentDefault"" }");
+
+        [Fact]
+        public void WithDefault_VariableDefaultUnspecifiedArg() => AssertQuerySuccess(@"query($arg: String) { withDefault (arg: $arg) }", @"{ ""withDefault"": ""fieldDefault"" }");
+
+        [Fact]
+        public void WithDefault_VariableDefaultNullArg() => AssertQuerySuccess(@"query($arg: String = null) { withDefault (arg: $arg) }", @"{ ""withDefault"": ""getArgumentDefault"" }");
+
+        [Fact]
+        public void WithDefault_VariableDefaultArg() => AssertQuerySuccess(@"query($arg: String = ""test"") { withDefault (arg: $arg) }", @"{ ""withDefault"": ""test"" }");
+
+        [Fact]
+        public void WithDefault_VariableArg() => AssertQuerySuccess(@"query($arg: String) { withDefault (arg: $arg) }", @"{ ""withDefault"": ""test"" }", @"{ ""arg"": ""test"" }".ToInputs());
+
+        [Fact]
+        public void WithDefault_VariableNullArg() => AssertQuerySuccess(@"query($arg: String) { withDefault (arg: $arg) }", @"{ ""withDefault"": ""getArgumentDefault"" }", @"{ ""arg"": null }".ToInputs());
+
+        public class MySchema : Schema
+        {
+            public MySchema()
+            {
+                Query = new MyQuery();
+            }
+        }
+
+        public class MyQuery : ObjectGraphType
+        {
+            public MyQuery()
+            {
+                Field<StringGraphType>(
+                    "noDefault",
+                    resolve: ctx => ctx.GetArgument<string>("arg", "getArgumentDefault"),
+                    arguments: new QueryArguments { new QueryArgument(typeof(StringGraphType)) { Name = "arg" } });
+                Field<StringGraphType>(
+                    "withDefault",
+                    resolve: ctx => ctx.GetArgument<string>("arg", "getArgumentDefault"),
+                    arguments: new QueryArguments { new QueryArgument(typeof(StringGraphType)) { Name = "arg", DefaultValue = "fieldDefault" } });
+            }
+        }
+    }
+}

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -11,21 +11,24 @@ namespace GraphQL
     /// </summary>
     public static class ResolveFieldContextExtensions
     {
-        /// <summary>Returns the value of the specified field argument, or defaultValue if none found</summary>
+        /// <summary>
+        /// Returns the value of the specified field argument, or <paramref name="defaultValue"/> when unspecified or when specified as <see langword="null"/>.
+        /// Field and variable default values take precedence over the <paramref name="defaultValue"/> parameter.
+        /// </summary>
         public static TType GetArgument<TType>(this IResolveFieldContext context, string name, TType defaultValue = default)
         {
             bool exists = context.TryGetArgument(typeof(TType), name, out object result);
             return exists
-                ? result == null && typeof(TType).IsValueType ? defaultValue : (TType)result
+                ? result == null ? defaultValue : (TType)result
                 : defaultValue;
         }
 
-        /// <summary>Returns the value of the specified field argument, or defaultValue if none found</summary>
+        /// <inheritdoc cref="GetArgument{TType}(IResolveFieldContext, string, TType)"/>
         public static object GetArgument(this IResolveFieldContext context, Type argumentType, string name, object defaultValue = null)
         {
             bool exists = context.TryGetArgument(argumentType, name, out object result);
             return exists
-                ? result == null && argumentType.IsValueType ? defaultValue : result
+                ? result ?? defaultValue
                 : defaultValue;
         }
 


### PR DESCRIPTION
Fixes #2557 

The bug is a regression against v3.2.0 and prior, but exists in 3.3.0 and newer.  The bug was introduced in ~#1456~ #2160.