### PR TITLE
Updated the FederatedSchemaPrinter file to prevent adding an empty Query { } as part of the SDL.

### DIFF
--- a/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
@@ -1,4 +1,3 @@
-using System;
 using GraphQL.Types;
 using GraphQL.Utilities;
 using GraphQL.Utilities.Federation;
@@ -24,7 +23,7 @@ namespace GraphQL.Tests.Utilities.Federation
             string result = federatedSchemaPrinter.PrintObject(query);
 
             // Assert
-            Assert.Equal(String.Empty, result);
+            Assert.Equal(string.Empty, result);
         }
     }
 }

--- a/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
@@ -1,0 +1,30 @@
+using System;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using GraphQL.Utilities.Federation;
+using Xunit;
+
+namespace GraphQL.Tests.Utilities.Federation
+{
+    public class FederatedSchemaPrinterTests
+    {
+        [Fact]
+        public void PrintObject_ReturnsEmptyString_GivenQueryTypeHasOnlyFederatedFields()
+        {
+            // Arrange
+            ISchema schema = default;
+            SchemaPrinterOptions options = default;
+            var query = new ObjectGraphType { Name = "Query" };
+            query.Field("_entities", new NonNullGraphType(new ListGraphType(new NonNullGraphType(new GraphQLTypeReference("_Any")))));
+            query.Field("_service", new NonNullGraphType(new GraphQLTypeReference("_Service")));
+
+            var federatedSchemaPrinter = new FederatedSchemaPrinter(schema, options);
+
+            // Act
+            string result = federatedSchemaPrinter.PrintObject(query);
+
+            // Assert
+            Assert.Equal(String.Empty, result);
+        }
+    }
+}

--- a/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
@@ -1,4 +1,3 @@
-using GraphQL.Types;
 using GraphQL.Utilities;
 using GraphQL.Utilities.Federation;
 using Xunit;
@@ -11,12 +10,12 @@ namespace GraphQL.Tests.Utilities.Federation
         public void PrintObject_ReturnsEmptyString_GivenQueryTypeHasOnlyFederatedFields()
         {
             // Arrange
-            ISchema schema = default;
+            var schema = FederatedSchema.For(@"type X @key(fields: ""id"") { id: ID! }");
             SchemaPrinterOptions options = default;
-            var query = new ObjectGraphType { Name = "Query" };
-            query.Field("_entities", new NonNullGraphType(new ListGraphType(new NonNullGraphType(new GraphQLTypeReference("_Any")))));
-            query.Field("_service", new NonNullGraphType(new GraphQLTypeReference("_Service")));
 
+            schema.Initialize();
+
+            var query = schema.Query;
             var federatedSchemaPrinter = new FederatedSchemaPrinter(schema, options);
 
             // Act

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -61,8 +61,7 @@ namespace GraphQL
         {
             var isIntrospection = context.ParentType == null ? context.FieldDefinition.IsIntrospectionField() : context.ParentType.IsIntrospectionType();
             var argumentName = isIntrospection ? name : (context.Schema?.NameConverter.NameForArgument(name, context.ParentType, context.FieldDefinition) ?? name);
-            ArgumentValue value = default;
-            return (context.Arguments?.TryGetValue(argumentName, out value) ?? false) && value.Source != ArgumentSource.FieldDefault;
+            return context.Arguments != null && context.Arguments.TryGetValue(argumentName, out var value) && value.Source != ArgumentSource.FieldDefault;
         }
 
         /// <summary>

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -52,6 +52,10 @@ namespace GraphQL.Utilities.Federation
 
         public override string PrintObject(IObjectGraphType type)
         {
+            // Do not return an empty query type: "Query { }" as it is not valid as part of the sdl.
+            if (type != null && String.Equals(type.Name, "Query", StringComparison.Ordinal) && !type.Fields.Any(x => !IsFederatedType(x.ResolvedType.GetNamedType().Name)))
+               return String.Empty;
+
             var isExtension = type.IsExtensionType();
 
             var interfaces = type.ResolvedInterfaces.List.Select(x => x.Name).ToList();

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -53,8 +53,8 @@ namespace GraphQL.Utilities.Federation
         public override string PrintObject(IObjectGraphType type)
         {
             // Do not return an empty query type: "Query { }" as it is not valid as part of the sdl.
-            if (type != null && String.Equals(type.Name, "Query", StringComparison.Ordinal) && !type.Fields.Any(x => !IsFederatedType(x.ResolvedType.GetNamedType().Name)))
-                return String.Empty;
+            if (type != null && string.Equals(type.Name, "Query", StringComparison.Ordinal) && !type.Fields.Any(x => !IsFederatedType(x.ResolvedType.GetNamedType().Name)))
+                return string.Empty;
 
             var isExtension = type.IsExtensionType();
 

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -54,7 +54,7 @@ namespace GraphQL.Utilities.Federation
         {
             // Do not return an empty query type: "Query { }" as it is not valid as part of the sdl.
             if (type != null && String.Equals(type.Name, "Query", StringComparison.Ordinal) && !type.Fields.Any(x => !IsFederatedType(x.ResolvedType.GetNamedType().Name)))
-               return String.Empty;
+                return String.Empty;
 
             var isExtension = type.IsExtensionType();
 


### PR DESCRIPTION
Updated the FederatedSchemaPrinter file to prevent adding an empty Query { } as part of the SDL. This occurs if the query type only contains federated fields.

This does not prevent the Query type from being part of the SDL if the type includes non-federated fields.

Added an xUnit test case for this, and as there was no associated test class for FederatedSchemaPrinter a new test class was created.

See issue #2563.