### PR TITLE
Update Sample to use a scoped dependency for data, to reflect real world usage

### DIFF
--- a/src/GraphQL.Harness/Startup.cs
+++ b/src/GraphQL.Harness/Startup.cs
@@ -38,8 +38,10 @@ namespace GraphQL.Harness
                 return new ErrorInfoProvider(new ErrorInfoProviderOptions { ExposeExceptionStackTrace = settings.Value.ExposeExceptions });
             });
 
-            // add something like repository
-            // services.AddSingleton<StarWarsData>();
+            // register static data
+            services.AddSingleton<StarWarsData>();
+
+            // register repository
             services.AddScoped<IStarWarsDataRespository, StarWarsDataRespository>();
 
             // add graph types

--- a/src/GraphQL.Harness/Startup.cs
+++ b/src/GraphQL.Harness/Startup.cs
@@ -3,6 +3,7 @@ using Example;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.StarWars;
+using GraphQL.StarWars.DataRepository;
 using GraphQL.StarWars.Types;
 using GraphQL.SystemTextJson;
 using GraphQL.Types;
@@ -39,6 +40,7 @@ namespace GraphQL.Harness
 
             // add something like repository
             services.AddSingleton<StarWarsData>();
+            services.AddScoped<IStarWarsDataRespository, StarWarsDataRespository>();
 
             // add graph types
             services.AddSingleton<StarWarsQuery>();

--- a/src/GraphQL.Harness/Startup.cs
+++ b/src/GraphQL.Harness/Startup.cs
@@ -39,7 +39,7 @@ namespace GraphQL.Harness
             });
 
             // add something like repository
-            services.AddSingleton<StarWarsData>();
+            // services.AddSingleton<StarWarsData>();
             services.AddScoped<IStarWarsDataRespository, StarWarsDataRespository>();
 
             // add graph types

--- a/src/GraphQL.Harness/Startup.cs
+++ b/src/GraphQL.Harness/Startup.cs
@@ -4,9 +4,7 @@ using GraphQL.Instrumentation;
 using GraphQL.MicrosoftDI;
 using GraphQL.StarWars;
 using GraphQL.StarWars.DataRepository;
-using GraphQL.StarWars.Types;
 using GraphQL.SystemTextJson;
-using GraphQL.Types;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -56,31 +54,8 @@ namespace GraphQL.Harness
             // register static data
             services.AddSingleton<StarWarsData>();
 
-            // register repository
-            services.AddScoped<IStarWarsDataRespository, StarWarsDataRespository>();
-
-            // add graph types
-            services.AddSingleton<StarWarsQuery>();
-            services.AddSingleton<StarWarsMutation>();
-            services.AddSingleton<HumanType>();
-            services.AddSingleton<HumanInputType>();
-            services.AddSingleton<DroidType>();
-            services.AddSingleton<CharacterInterface>();
-            services.AddSingleton<EpisodeEnum>();
-
-            // add schema
-            services.AddSingleton<ISchema, StarWarsSchema>(services =>
-            {
-                var settings = services.GetRequiredService<IOptions<GraphQLSettings>>();
-                var schema = new StarWarsSchema(services);
-                if (settings.Value.EnableMetrics)
-                {
-                    var middlewares = services.GetRequiredService<IEnumerable<IFieldMiddleware>>();
-                    foreach (var middleware in middlewares)
-                        schema.FieldMiddleware.Use(middleware);
-                }
-                return schema;
-            });
+            //reister repository
+            services.AddSingleton<IStarWarsDataRespository, StarWarsDataRespository>();
 
             // add infrastructure stuff
             services.AddHttpContextAccessor();

--- a/src/GraphQL.Harness/Startup.cs
+++ b/src/GraphQL.Harness/Startup.cs
@@ -54,7 +54,7 @@ namespace GraphQL.Harness
             // register static data
             services.AddSingleton<StarWarsData>();
 
-            //reister repository
+            // register repository
             services.AddSingleton<IStarWarsDataRespository, StarWarsDataRespository>();
 
             // add infrastructure stuff

--- a/src/GraphQL.StarWars/DataRepository/IStarWarsDataRespository.cs
+++ b/src/GraphQL.StarWars/DataRepository/IStarWarsDataRespository.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL.StarWars.Types;
+
+namespace GraphQL.StarWars.DataRepository
+{
+    public interface IStarWarsDataRespository
+    {
+        IEnumerable<StarWarsCharacter> GetFriends(StarWarsCharacter character);
+
+        StarWarsCharacter AddCharacter(StarWarsCharacter character);
+
+        Task<Human> GetHumanByIdAsync(string id);
+
+        Task<Droid> GetDroidByIdAsync(string id);
+
+        Task<List<StarWarsCharacter>> GetCharactersAsync(List<string> guids);
+    }
+}

--- a/src/GraphQL.StarWars/DataRepository/IStarWarsDataRespository.cs
+++ b/src/GraphQL.StarWars/DataRepository/IStarWarsDataRespository.cs
@@ -15,5 +15,7 @@ namespace GraphQL.StarWars.DataRepository
         Task<Droid> GetDroidByIdAsync(string id);
 
         Task<List<StarWarsCharacter>> GetCharactersAsync(List<string> guids);
+
+        Task<List<StarWarsCharacter>> GetAllCharactersAsync();
     }
 }

--- a/src/GraphQL.StarWars/DataRepository/StarWarsDataRespository.cs
+++ b/src/GraphQL.StarWars/DataRepository/StarWarsDataRespository.cs
@@ -92,5 +92,12 @@ namespace GraphQL.StarWars.DataRepository
 
             return Task.FromResult(results);
         }
+
+        public async Task<List<StarWarsCharacter>> GetAllCharactersAsync()
+        {
+            var results = await Task.FromResult(_characters.ToList());
+
+            return results;
+        }
     }
 }

--- a/src/GraphQL.StarWars/DataRepository/StarWarsDataRespository.cs
+++ b/src/GraphQL.StarWars/DataRepository/StarWarsDataRespository.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.StarWars.Types;
 
-namespace GraphQL.StarWars
+namespace GraphQL.StarWars.DataRepository
 {
-    public class StarWarsData
+    public class StarWarsDataRespository : IStarWarsDataRespository
     {
-        private readonly List<StarWarsCharacter> _characters = new List<StarWarsCharacter>();
-
-        public StarWarsData()
+        private static readonly List<StarWarsCharacter> _characters = new()
         {
-            _characters.Add(new Human
+            new Human
             {
                 Id = "1",
                 Name = "Luke",
@@ -19,18 +17,16 @@ namespace GraphQL.StarWars
                 AppearsIn = new[] { 4, 5, 6 },
                 HomePlanet = "Tatooine",
                 Cursor = "MQ=="
-            });
-
-            _characters.Add(new Human
+            },
+            new Human
             {
                 Id = "2",
                 Name = "Vader",
                 AppearsIn = new[] { 4, 5, 6 },
                 HomePlanet = "Tatooine",
                 Cursor = "Mg=="
-            });
-
-            _characters.Add(new Droid
+            },
+            new Droid
             {
                 Id = "3",
                 Name = "R2-D2",
@@ -38,17 +34,16 @@ namespace GraphQL.StarWars
                 AppearsIn = new[] { 4, 5, 6 },
                 PrimaryFunction = "Astromech",
                 Cursor = "Mw=="
-            });
-
-            _characters.Add(new Droid
+            },
+            new Droid
             {
                 Id = "4",
                 Name = "C-3PO",
                 AppearsIn = new[] { 4, 5, 6 },
                 PrimaryFunction = "Protocol",
                 Cursor = "NA=="
-            });
-        }
+            }
+        };
 
         public IEnumerable<StarWarsCharacter> GetFriends(StarWarsCharacter character)
         {
@@ -57,13 +52,13 @@ namespace GraphQL.StarWars
                 return null;
             }
 
-            var friends = new List<StarWarsCharacter>();
             var lookup = character.Friends;
-            if (lookup != null)
+            if (lookup == null)
             {
-                foreach (var c in _characters.Where(h => lookup.Contains(h.Id)))
-                    friends.Add(c);
+                return Enumerable.Empty<StarWarsCharacter>();
             }
+
+            var friends = _characters.Where(h => lookup.Contains(h.Id));
             return friends;
         }
 
@@ -71,22 +66,31 @@ namespace GraphQL.StarWars
         {
             character.Id = _characters.Count.ToString();
             _characters.Add(character);
+
             return character;
         }
 
         public Task<Human> GetHumanByIdAsync(string id)
         {
-            return Task.FromResult(_characters.FirstOrDefault(h => h.Id == id && h is Human) as Human);
+            var match = _characters.FirstOrDefault(h => h.Id == id);
+            var human = match is Human asHuman ? asHuman : null;
+
+            return Task.FromResult(human);
         }
 
         public Task<Droid> GetDroidByIdAsync(string id)
         {
-            return Task.FromResult(_characters.FirstOrDefault(h => h.Id == id && h is Droid) as Droid);
+            var match = _characters.FirstOrDefault(h => h.Id == id);
+            var droid = match is Droid asHuman ? asHuman : null;
+
+            return Task.FromResult(droid);
         }
 
         public Task<List<StarWarsCharacter>> GetCharactersAsync(List<string> guids)
         {
-            return Task.FromResult(_characters.Where(c => guids.Contains(c.Id)).ToList());
+            var results = _characters.Where(c => guids.Contains(c.Id)).ToList();
+
+            return Task.FromResult(results);
         }
     }
 }

--- a/src/GraphQL.StarWars/DataRepository/StarWarsDataRespository.cs
+++ b/src/GraphQL.StarWars/DataRepository/StarWarsDataRespository.cs
@@ -70,20 +70,20 @@ namespace GraphQL.StarWars.DataRepository
             return character;
         }
 
-        public Task<Human> GetHumanByIdAsync(string id)
+        public async Task<Human> GetHumanByIdAsync(string id)
         {
             var match = _characters.FirstOrDefault(h => h.Id == id);
             var human = match is Human asHuman ? asHuman : null;
 
-            return Task.FromResult(human);
+            return await Task.FromResult(human);
         }
 
-        public Task<Droid> GetDroidByIdAsync(string id)
+        public async Task<Droid> GetDroidByIdAsync(string id)
         {
             var match = _characters.FirstOrDefault(h => h.Id == id);
             var droid = match is Droid asHuman ? asHuman : null;
 
-            return Task.FromResult(droid);
+            return await Task.FromResult(droid);
         }
 
         public Task<List<StarWarsCharacter>> GetCharactersAsync(List<string> guids)

--- a/src/GraphQL.StarWars/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL.StarWars/Extensions/ResolveFieldContextExtensions.cs
@@ -9,13 +9,15 @@ namespace GraphQL.StarWars.Extensions
 {
     public static class ResolveFieldContextExtensions
     {
-        public static Connection<U> GetPagedResults<T, U>(this IResolveConnectionContext<T> context, StarWarsData data, List<string> ids) where U : StarWarsCharacter
+        public static Connection<U> GetPagedResults<T, U>(this IResolveConnectionContext<T> context,
+            IEnumerable<StarWarsCharacter> starWarsCharacters,
+            List<string> ids) where U : StarWarsCharacter
         {
             List<string> idList;
             List<U> list;
             string cursor;
             string endCursor;
-            var pageSize = context.PageSize ?? 20;
+            int pageSize = context.PageSize ?? 20;
 
             if (context.IsUnidirectional || context.After != null || context.Before == null)
             {
@@ -46,7 +48,8 @@ namespace GraphQL.StarWars.Extensions
                 }
             }
 
-            list = data.GetCharactersAsync(idList).Result as List<U> ?? throw new InvalidOperationException($"GetCharactersAsync method should return list of '{typeof(U).Name}' items.");
+            list = starWarsCharacters.Where(x => idList.Contains(x.Id)).ToList() as List<U>
+                ?? throw new InvalidOperationException($"GetCharactersAsync method should return list of '{typeof(U).Name}' items.");
             cursor = list.Count > 0 ? list.Last().Cursor : null;
             endCursor = ids.Count > 0 ? Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(ids.Last())) : null;
 

--- a/src/GraphQL.StarWars/GraphQL.StarWars.csproj
+++ b/src/GraphQL.StarWars/GraphQL.StarWars.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\GraphQL.MicrosoftDI\GraphQL.MicrosoftDI.csproj" />
     <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
   </ItemGroup>

--- a/src/GraphQL.StarWars/StarWarsMutation.cs
+++ b/src/GraphQL.StarWars/StarWarsMutation.cs
@@ -31,17 +31,6 @@ namespace GraphQL.StarWars
                 .WithScope()
                 .WithService<IStarWarsDataRespository>()
                 .Resolve((context, starWarsDataRespository) => starWarsDataRespository.AddCharacter(context.GetArgument<Human>("human")));
-
-            //Field<HumanType>(
-            //    "createHuman",
-            //    arguments: new QueryArguments(
-            //        new QueryArgument<NonNullGraphType<HumanInputType>> { Name = "human" }
-            //    ),
-            //    resolve: context =>
-            //    {
-            //        var human = context.GetArgument<Human>("human");
-            //        return data.AddCharacter(human);
-            //    });
         }
     }
 }

--- a/src/GraphQL.StarWars/StarWarsMutation.cs
+++ b/src/GraphQL.StarWars/StarWarsMutation.cs
@@ -1,8 +1,11 @@
+using GraphQL.MicrosoftDI;
+using GraphQL.StarWars.DataRepository;
 using GraphQL.StarWars.Types;
 using GraphQL.Types;
 
 namespace GraphQL.StarWars
 {
+    /// <summary>
     /// <example>
     /// This is an example JSON request for a mutation
     /// {
@@ -14,22 +17,31 @@ namespace GraphQL.StarWars
     ///   }
     /// }
     /// </example>
+    /// </summary>
     public class StarWarsMutation : ObjectGraphType<object>
     {
-        public StarWarsMutation(StarWarsData data)
+        public StarWarsMutation()
         {
             Name = "Mutation";
 
-            Field<HumanType>(
-                "createHuman",
-                arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<HumanInputType>> { Name = "human" }
-                ),
-                resolve: context =>
-                {
-                    var human = context.GetArgument<Human>("human");
-                    return data.AddCharacter(human);
-                });
+            Field<HumanType>()
+                .Name("createHuman")
+                .Argument<NonNullGraphType<HumanInputType>>("human")
+                .Resolve()
+                .WithScope()
+                .WithService<IStarWarsDataRespository>()
+                .Resolve((context, starWarsDataRespository) => starWarsDataRespository.AddCharacter(context.GetArgument<Human>("human")));
+
+            //Field<HumanType>(
+            //    "createHuman",
+            //    arguments: new QueryArguments(
+            //        new QueryArgument<NonNullGraphType<HumanInputType>> { Name = "human" }
+            //    ),
+            //    resolve: context =>
+            //    {
+            //        var human = context.GetArgument<Human>("human");
+            //        return data.AddCharacter(human);
+            //    });
         }
     }
 }

--- a/src/GraphQL.StarWars/StarWarsQuery.cs
+++ b/src/GraphQL.StarWars/StarWarsQuery.cs
@@ -9,31 +9,6 @@ namespace GraphQL.StarWars
 {
     public class StarWarsQuery : ObjectGraphType<object>
     {
-        //public StarWarsQuery(StarWarsData data)
-        //{
-        //    Name = "Query";
-
-        //    Field<CharacterInterface>("hero", resolve: context => data.GetDroidByIdAsync("3"));
-
-        //    Field<HumanType>(
-        //        "human",
-        //        arguments: new QueryArguments(
-        //            new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the human" }
-        //        ),
-        //        resolve: (context) => data.GetHumanByIdAsync(context.GetArgument<string>("id"))
-        //    );
-
-        //    Func<IResolveFieldContext, string, object> func = (context, id) => data.GetDroidByIdAsync(id);
-
-        //    FieldDelegate<DroidType>(
-        //        "droid",
-        //        arguments: new QueryArguments(
-        //            new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the droid" }
-        //        ),
-        //        resolve: func
-        //    );
-        //}
-
         public StarWarsQuery()
         {
             Name = "Query";

--- a/src/GraphQL.StarWars/StarWarsQuery.cs
+++ b/src/GraphQL.StarWars/StarWarsQuery.cs
@@ -1,8 +1,8 @@
 using System;
-using GraphQL.StarWars.Types;
-using GraphQL.Types;
 using GraphQL.MicrosoftDI;
 using GraphQL.StarWars.DataRepository;
+using GraphQL.StarWars.Types;
+using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.StarWars

--- a/src/GraphQL.StarWars/StarWarsQuery.cs
+++ b/src/GraphQL.StarWars/StarWarsQuery.cs
@@ -1,22 +1,55 @@
 using System;
 using GraphQL.StarWars.Types;
 using GraphQL.Types;
+using GraphQL.MicrosoftDI;
+using GraphQL.StarWars.DataRepository;
 
 namespace GraphQL.StarWars
 {
     public class StarWarsQuery : ObjectGraphType<object>
     {
+        //public StarWarsQuery(StarWarsData data)
+        //{
+        //    Name = "Query";
+
+        //    Field<CharacterInterface>("hero", resolve: context => data.GetDroidByIdAsync("3"));
+
+        //    Field<HumanType>(
+        //        "human",
+        //        arguments: new QueryArguments(
+        //            new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the human" }
+        //        ),
+        //        resolve: (context) => data.GetHumanByIdAsync(context.GetArgument<string>("id"))
+        //    );
+
+        //    Func<IResolveFieldContext, string, object> func = (context, id) => data.GetDroidByIdAsync(id);
+
+        //    FieldDelegate<DroidType>(
+        //        "droid",
+        //        arguments: new QueryArguments(
+        //            new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the droid" }
+        //        ),
+        //        resolve: func
+        //    );
+        //}
+
         public StarWarsQuery(StarWarsData data)
         {
             Name = "Query";
 
-            Field<CharacterInterface>("hero", resolve: context => data.GetDroidByIdAsync("3"));
+            Field<CharacterInterface>()
+                .Name("hero")
+                .Resolve()
+                .WithScope()
+                .WithService<IStarWarsDataRespository>()
+                .ResolveAsync((context, starWarsDataRespository) => starWarsDataRespository.GetDroidByIdAsync("3"));
+
             Field<HumanType>(
                 "human",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id", Description = "id of the human" }
                 ),
-                resolve: context => data.GetHumanByIdAsync(context.GetArgument<string>("id"))
+                resolve: (context) => data.GetHumanByIdAsync(context.GetArgument<string>("id"))
             );
 
             Func<IResolveFieldContext, string, object> func = (context, id) => data.GetDroidByIdAsync(id);

--- a/src/GraphQL.StarWars/Types/CharacterInterface.cs
+++ b/src/GraphQL.StarWars/Types/CharacterInterface.cs
@@ -11,7 +11,6 @@ namespace GraphQL.StarWars.Types
 
             Field<NonNullGraphType<StringGraphType>>("id", "The id of the character.", resolve: context => context.Source.Id);
             Field<StringGraphType>("name", "The name of the character.", resolve: context => context.Source.Name);
-
             Field<ListGraphType<CharacterInterface>>("friends");
             Field<ConnectionType<CharacterInterface, EdgeType<CharacterInterface>>>("friendsConnection");
             Field<ListGraphType<EpisodeEnum>>("appearsIn", "Which movie they appear in.");

--- a/src/GraphQL.StarWars/Types/DroidType.cs
+++ b/src/GraphQL.StarWars/Types/DroidType.cs
@@ -1,30 +1,51 @@
+using System.Threading.Tasks;
+using GraphQL.Builders;
+using GraphQL.MicrosoftDI;
+using GraphQL.StarWars.DataRepository;
 using GraphQL.StarWars.Extensions;
 using GraphQL.Types;
+using GraphQL.Types.Relay.DataObjects;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.StarWars.Types
 {
     public class DroidType : ObjectGraphType<Droid>
     {
-        public DroidType(StarWarsData data)
+        public DroidType()
         {
             Name = "Droid";
             Description = "A mechanical creature in the Star Wars universe.";
 
             Field<NonNullGraphType<StringGraphType>>("id", "The id of the droid.", resolve: context => context.Source.Id);
+
             Field<StringGraphType>("name", "The name of the droid.", resolve: context => context.Source.Name);
 
-            Field<ListGraphType<CharacterInterface>>("friends", resolve: context => data.GetFriends(context.Source));
+            Field<ListGraphType<CharacterInterface>>()
+                .Name("friends")
+                .Resolve()
+                .WithScope()
+                .WithService<IStarWarsDataRespository>()
+                .Resolve((context, starWarsDataRespository) => starWarsDataRespository.GetFriends(context.Source));
 
             Connection<CharacterInterface>()
                 .Name("friendsConnection")
                 .Description("A list of a character's friends.")
                 .Bidirectional()
-                .Resolve(context => context.GetPagedResults<Droid, StarWarsCharacter>(data, context.Source.Friends));
+                .Resolve(ResolveCharactersAsync);
 
             Field<ListGraphType<EpisodeEnum>>("appearsIn", "Which movie they appear in.");
+
             Field<StringGraphType>("primaryFunction", "The primary function of the droid.", resolve: context => context.Source.PrimaryFunction);
 
             Interface<CharacterInterface>();
+        }
+
+        private async Task<Connection<StarWarsCharacter>> ResolveCharactersAsync(IResolveConnectionContext<Droid> context)
+        {
+            var characters = await context.RequestServices.GetRequiredService<IStarWarsDataRespository>().GetAllCharactersAsync();
+            var pagedResults = context.GetPagedResults<Droid, StarWarsCharacter>(characters, context.Source.Friends);
+
+            return pagedResults;
         }
     }
 }

--- a/src/GraphQL.StarWars/Types/HumanType.cs
+++ b/src/GraphQL.StarWars/Types/HumanType.cs
@@ -1,30 +1,50 @@
+using System.Threading.Tasks;
+using GraphQL.Builders;
+using GraphQL.MicrosoftDI;
+using GraphQL.StarWars.DataRepository;
 using GraphQL.StarWars.Extensions;
 using GraphQL.Types;
+using GraphQL.Types.Relay.DataObjects;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.StarWars.Types
 {
     public class HumanType : ObjectGraphType<Human>
     {
-        public HumanType(StarWarsData data)
+        public HumanType()
         {
             Name = "Human";
 
             Field<NonNullGraphType<StringGraphType>>("id", "The id of the human.", resolve: context => context.Source.Id);
+
             Field<StringGraphType>("name", "The name of the human.", resolve: context => context.Source.Name);
 
-            Field<ListGraphType<CharacterInterface>>("friends", resolve: context => data.GetFriends(context.Source));
+            Field<ListGraphType<CharacterInterface>>()
+                .Name("friends")
+                .Resolve()
+                .WithScope()
+                .WithService<IStarWarsDataRespository>()
+                .Resolve((context, starWarsDataRespository) => starWarsDataRespository.GetFriends(context.Source));
 
             Connection<CharacterInterface>()
                 .Name("friendsConnection")
                 .Description("A list of a character's friends.")
                 .Bidirectional()
-                .Resolve(context => context.GetPagedResults<Human, StarWarsCharacter>(data, context.Source.Friends));
+                .Resolve(ResolveCharactersAsync);
 
             Field<ListGraphType<EpisodeEnum>>("appearsIn", "Which movie they appear in.");
 
             Field<StringGraphType>("homePlanet", "The home planet of the human.", resolve: context => context.Source.HomePlanet);
 
             Interface<CharacterInterface>();
+        }
+
+        private async Task<Connection<StarWarsCharacter>> ResolveCharactersAsync(IResolveConnectionContext<Human> context)
+        {
+            var characters = await context.RequestServices.GetRequiredService<IStarWarsDataRespository>().GetAllCharactersAsync();
+            var pagedResults = context.GetPagedResults<Human, StarWarsCharacter>(characters, context.Source.Friends);
+
+            return pagedResults;
         }
     }
 }


### PR DESCRIPTION
I have updated the `StarWarsData` sample to use a more real world sample of how things are usually set up in applications. This can serve as a sample reference implementation.

I noticed that we were using static `StarWarsData` class as a provider of data. 

I've converted the same into an `IStarWarsDataRespository` which mimics a layer responsible for actual business layer for apps. 