### PR TITLE
Expose Services within GraphQLBuilder

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.MicrosoftDI.approved.txt
@@ -51,6 +51,19 @@ namespace GraphQL.MicrosoftDI
         public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5> WithScope() { }
     }
+    public class GraphQLBuilder : GraphQL.DI.GraphQLBuilderBase
+    {
+        public GraphQLBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+        public override GraphQL.DI.IGraphQLBuilder Configure<TOptions>(System.Action<TOptions, System.IServiceProvider>? action = null)
+            where TOptions :  class, new () { }
+        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance) { }
+        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime) { }
+        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime) { }
+        public override GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, object implementationInstance) { }
+        public override GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime) { }
+        public override GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime) { }
+    }
     public static class GraphQLBuilderExtensions
     {
         public static GraphQL.DI.IGraphQLBuilder AddGraphQL(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }

--- a/src/GraphQL.MicrosoftDI/GraphQLBuilder.cs
+++ b/src/GraphQL.MicrosoftDI/GraphQLBuilder.cs
@@ -14,9 +14,13 @@ namespace GraphQL.MicrosoftDI
     /// An implementation of <see cref="IGraphQLBuilder"/> which uses the Microsoft dependency injection framework
     /// to register services and configure options.
     /// </summary>
-    internal class GraphQLBuilder : GraphQLBuilderBase
+    public class GraphQLBuilder : GraphQLBuilderBase
     {
-        private readonly IServiceCollection _services;
+        /// <summary>
+        /// Returns the underlying <see cref="IServiceCollection"/> of this builder.
+        /// </summary>
+        public IServiceCollection Services { get; }
+
         /// <summary>
         /// Initializes a new instance for the specified service collection.
         /// </summary>
@@ -25,7 +29,7 @@ namespace GraphQL.MicrosoftDI
         /// </remarks>
         public GraphQLBuilder(IServiceCollection services)
         {
-            _services = services ?? throw new ArgumentNullException(nameof(services));
+            Services = services ?? throw new ArgumentNullException(nameof(services));
             services.AddOptions();
             Initialize();
         }
@@ -59,7 +63,7 @@ namespace GraphQL.MicrosoftDI
             if (implementationFactory == null)
                 throw new ArgumentNullException(nameof(implementationFactory));
 
-            _services.Add(new ServiceDescriptor(serviceType, implementationFactory, TranslateLifetime(serviceLifetime)));
+            Services.Add(new ServiceDescriptor(serviceType, implementationFactory, TranslateLifetime(serviceLifetime)));
             return this;
         }
 
@@ -71,7 +75,7 @@ namespace GraphQL.MicrosoftDI
             if (implementationType == null)
                 throw new ArgumentNullException(nameof(implementationType));
 
-            _services.Add(new ServiceDescriptor(serviceType, implementationType, TranslateLifetime(serviceLifetime)));
+            Services.Add(new ServiceDescriptor(serviceType, implementationType, TranslateLifetime(serviceLifetime)));
             return this;
         }
 
@@ -83,7 +87,7 @@ namespace GraphQL.MicrosoftDI
             if (implementationInstance == null)
                 throw new ArgumentNullException(nameof(implementationInstance));
 
-            _services.Add(new ServiceDescriptor(serviceType, implementationInstance));
+            Services.Add(new ServiceDescriptor(serviceType, implementationInstance));
             return this;
         }
 
@@ -95,7 +99,7 @@ namespace GraphQL.MicrosoftDI
             if (implementationFactory == null)
                 throw new ArgumentNullException(nameof(implementationFactory));
 
-            _services.TryAdd(new ServiceDescriptor(serviceType, implementationFactory, TranslateLifetime(serviceLifetime)));
+            Services.TryAdd(new ServiceDescriptor(serviceType, implementationFactory, TranslateLifetime(serviceLifetime)));
             return this;
         }
 
@@ -107,7 +111,7 @@ namespace GraphQL.MicrosoftDI
             if (implementationType == null)
                 throw new ArgumentNullException(nameof(implementationType));
 
-            _services.TryAdd(new ServiceDescriptor(serviceType, implementationType, TranslateLifetime(serviceLifetime)));
+            Services.TryAdd(new ServiceDescriptor(serviceType, implementationType, TranslateLifetime(serviceLifetime)));
             return this;
         }
 
@@ -119,7 +123,7 @@ namespace GraphQL.MicrosoftDI
             if (implementationInstance == null)
                 throw new ArgumentNullException(nameof(implementationInstance));
 
-            _services.TryAdd(new ServiceDescriptor(serviceType, implementationInstance));
+            Services.TryAdd(new ServiceDescriptor(serviceType, implementationInstance));
             return this;
         }
     }


### PR DESCRIPTION
Allows extension methods to cast `IGraphQLBuilder` to `GraphQLBuilder` and retrieve the `IServiceCollection` via `Services`.  Works for only Microsoft-based DI of course, but this is needed for authorization extension methods that integrate with ASP.Net within the server project.