### PR TITLE
Nullable reference type annotations part 6

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -635,34 +635,34 @@ namespace GraphQL.Builders
     public static class FieldBuilder
     {
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>(GraphQL.Types.IGraphType type) { }
-        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>(System.Type type = null) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>(System.Type? type = null) { }
     }
     public class FieldBuilder<TSourceType, TReturnType>
     {
         public GraphQL.Types.EventStreamFieldType FieldType { get; }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument> configure = null)
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string description, System.Action<GraphQL.Types.QueryArgument> configure = null)
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string description, TArgumentType defaultValue = default, System.Action<GraphQL.Types.QueryArgument> configure = null)
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string? description, TArgumentType? defaultValue = default, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Configure(System.Action<GraphQL.Types.FieldType> configure) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType defaultValue = default) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DeprecationReason(string deprecationReason) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Description(string description) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType? defaultValue = default) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Description(string? description) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object argumentValue) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver resolver) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.IResolveFieldContext<TSourceType>, TReturnType> resolve) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType>> resolve) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolve) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Subscribe(System.Func<GraphQL.Subscription.IResolveEventStreamContext<TSourceType>, System.IObservable<TReturnType>> subscribe) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> SubscribeAsync(System.Func<GraphQL.Subscription.IResolveEventStreamContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType>>> subscribeAsync) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Subscribe(System.Func<GraphQL.Subscription.IResolveEventStreamContext<TSourceType>, System.IObservable<TReturnType?>> subscribe) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> SubscribeAsync(System.Func<GraphQL.Subscription.IResolveEventStreamContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType?>>> subscribeAsync) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
-        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(System.Type type = null, string name = "default") { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
     {
@@ -730,7 +730,7 @@ namespace GraphQL.DI
     public abstract class GraphQLBuilderBase : GraphQL.DI.IGraphQLBuilder
     {
         protected GraphQLBuilderBase() { }
-        public abstract GraphQL.DI.IGraphQLBuilder Configure<TOptions>(System.Action<TOptions, System.IServiceProvider> action = null)
+        public abstract GraphQL.DI.IGraphQLBuilder Configure<TOptions>(System.Action<TOptions, System.IServiceProvider>? action = null)
             where TOptions :  class, new ();
         protected virtual void Initialize() { }
         public abstract GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance);
@@ -750,7 +750,7 @@ namespace GraphQL.DI
     }
     public interface IGraphQLBuilder
     {
-        GraphQL.DI.IGraphQLBuilder Configure<TOptions>(System.Action<TOptions, System.IServiceProvider> action = null)
+        GraphQL.DI.IGraphQLBuilder Configure<TOptions>(System.Action<TOptions, System.IServiceProvider>? action = null)
             where TOptions :  class, new ();
         GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance);
         GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime);
@@ -1168,11 +1168,11 @@ namespace GraphQL.Introspection
     public class DefaultSchemaComparer : GraphQL.Introspection.ISchemaComparer
     {
         public DefaultSchemaComparer() { }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType> DirectiveComparer { get; }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.IGraphType> TypeComparer { get; }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument> ArgumentComparer(GraphQL.Types.IFieldType field) { }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition> EnumValueComparer(GraphQL.Types.EnumerationGraphType parent) { }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.IFieldType> FieldComparer(GraphQL.Types.IGraphType parent) { }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType>? DirectiveComparer { get; }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.IGraphType>? TypeComparer { get; }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument>? ArgumentComparer(GraphQL.Types.IFieldType field) { }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition>? EnumValueComparer(GraphQL.Types.EnumerationGraphType parent) { }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.IFieldType>? FieldComparer(GraphQL.Types.IGraphType parent) { }
     }
     public class DefaultSchemaFilter : GraphQL.Introspection.ISchemaFilter
     {
@@ -1193,11 +1193,11 @@ namespace GraphQL.Introspection
     }
     public interface ISchemaComparer
     {
-        System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType> DirectiveComparer { get; }
-        System.Collections.Generic.IComparer<GraphQL.Types.IGraphType> TypeComparer { get; }
-        System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument> ArgumentComparer(GraphQL.Types.IFieldType field);
-        System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition> EnumValueComparer(GraphQL.Types.EnumerationGraphType parent);
-        System.Collections.Generic.IComparer<GraphQL.Types.IFieldType> FieldComparer(GraphQL.Types.IGraphType parent);
+        System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType>? DirectiveComparer { get; }
+        System.Collections.Generic.IComparer<GraphQL.Types.IGraphType>? TypeComparer { get; }
+        System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument>? ArgumentComparer(GraphQL.Types.IFieldType field);
+        System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition>? EnumValueComparer(GraphQL.Types.EnumerationGraphType parent);
+        System.Collections.Generic.IComparer<GraphQL.Types.IFieldType>? FieldComparer(GraphQL.Types.IGraphType parent);
     }
     public interface ISchemaFilter
     {
@@ -1823,7 +1823,7 @@ namespace GraphQL.Types
         public AppliedDirectives() { }
         public int Count { get; }
         public void Add(GraphQL.Types.AppliedDirective directive) { }
-        public GraphQL.Types.AppliedDirective Find(string name) { }
+        public GraphQL.Types.AppliedDirective? Find(string name) { }
         public System.Collections.Generic.IEnumerator<GraphQL.Types.AppliedDirective> GetEnumerator() { }
         public int Remove(string name) { }
     }
@@ -2302,11 +2302,11 @@ namespace GraphQL.Types
     {
         public QueryArgument(GraphQL.Types.IGraphType type) { }
         public QueryArgument(System.Type type) { }
-        public object DefaultValue { get; set; }
-        public string Description { get; set; }
+        public object? DefaultValue { get; set; }
+        public string? Description { get; set; }
         public string Name { get; set; }
-        public GraphQL.Types.IGraphType ResolvedType { get; set; }
-        public System.Type Type { get; }
+        public GraphQL.Types.IGraphType? ResolvedType { get; set; }
+        public System.Type? Type { get; }
     }
     public class QueryArgument<TType> : GraphQL.Types.QueryArgument
         where TType : GraphQL.Types.IGraphType
@@ -2545,24 +2545,24 @@ namespace GraphQL.Types.Relay.DataObjects
         where TEdge : GraphQL.Types.Relay.DataObjects.Edge<TNode>
     {
         public Connection() { }
-        public System.Collections.Generic.List<TEdge> Edges { get; set; }
-        public System.Collections.Generic.List<TNode> Items { get; }
-        public GraphQL.Types.Relay.DataObjects.PageInfo PageInfo { get; set; }
+        public System.Collections.Generic.List<TEdge>? Edges { get; set; }
+        public System.Collections.Generic.List<TNode?>? Items { get; }
+        public GraphQL.Types.Relay.DataObjects.PageInfo? PageInfo { get; set; }
         public int? TotalCount { get; set; }
     }
     public class Edge<TNode>
     {
         public Edge() { }
-        public string Cursor { get; set; }
+        public string? Cursor { get; set; }
         public TNode Node { get; set; }
     }
     public class PageInfo
     {
         public PageInfo() { }
-        public string EndCursor { get; set; }
+        public string? EndCursor { get; set; }
         public bool HasNextPage { get; set; }
         public bool HasPreviousPage { get; set; }
-        public string StartCursor { get; set; }
+        public string? StartCursor { get; set; }
     }
 }
 namespace GraphQL.Utilities
@@ -2764,7 +2764,7 @@ namespace GraphQL.Utilities
     {
         public static int DamerauLevenshteinDistance(string source, string target, int threshold) { }
         public static string QuotedOrList(System.Collections.Generic.IEnumerable<string> items, int maxLength = 5) { }
-        public static string[] SuggestionList(string input, System.Collections.Generic.IEnumerable<string> options) { }
+        public static string[] SuggestionList(string input, System.Collections.Generic.IEnumerable<string>? options) { }
     }
     public class TypeConfig : GraphQL.Utilities.MetadataProvider
     {

--- a/src/GraphQL/AstExtensions.cs
+++ b/src/GraphQL/AstExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Language.AST;
 

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Builders;

--- a/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Utilities;
 
 namespace GraphQL

--- a/src/GraphQL/BoolBox.cs
+++ b/src/GraphQL/BoolBox.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary> Boolean values to avoid boxing. </summary>

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -7,8 +7,6 @@ using GraphQL.Types;
 using GraphQL.Types.Relay;
 using GraphQL.Types.Relay.DataObjects;
 
-#nullable enable
-
 namespace GraphQL.Builders
 {
     /// <summary>

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -6,8 +6,6 @@ using System.Threading.Tasks;
 using GraphQL.Types;
 using GraphQL.Types.Relay;
 
-#nullable enable
-
 namespace GraphQL.Builders
 {
     /// <summary>

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Builders
         /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
         /// <typeparam name="TReturnType">The type of the return value of the resolver.</typeparam>
         /// <param name="type">The graph type of the field.</param>
-        public static FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>(Type type = null)
+        public static FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>(Type? type = null)
             => FieldBuilder<TSourceType, TReturnType>.Create(type);
 
         /// <inheritdoc cref="Create{TSourceType, TReturnType}(Type)"/>
@@ -59,7 +59,7 @@ namespace GraphQL.Builders
         }
 
         /// <inheritdoc cref="Create(IGraphType, string)"/>
-        public static FieldBuilder<TSourceType, TReturnType> Create(Type type = null, string name = "default")
+        public static FieldBuilder<TSourceType, TReturnType> Create(Type? type = null, string name = "default")
         {
             var fieldType = new EventStreamFieldType
             {
@@ -92,7 +92,7 @@ namespace GraphQL.Builders
         /// <summary>
         /// Sets the description of the field.
         /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> Description(string description)
+        public virtual FieldBuilder<TSourceType, TReturnType> Description(string? description)
         {
             FieldType.Description = description;
             return this;
@@ -101,7 +101,7 @@ namespace GraphQL.Builders
         /// <summary>
         /// Sets the deprecation reason of the field.
         /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> DeprecationReason(string deprecationReason)
+        public virtual FieldBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason)
         {
             FieldType.DeprecationReason = deprecationReason;
             return this;
@@ -110,13 +110,13 @@ namespace GraphQL.Builders
         /// <summary>
         /// Sets the default value of fields on input object graph types.
         /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType defaultValue = default)
+        public virtual FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType? defaultValue = default)
         {
             FieldType.DefaultValue = defaultValue;
             return this;
         }
 
-        internal FieldBuilder<TSourceType, TReturnType> DefaultValue(object defaultValue)
+        internal FieldBuilder<TSourceType, TReturnType> DefaultValue(object? defaultValue)
         {
             FieldType.DefaultValue = defaultValue;
             return this;
@@ -125,7 +125,7 @@ namespace GraphQL.Builders
         /// <summary>
         /// Sets the resolver for the field.
         /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> Resolve(IFieldResolver resolver)
+        public virtual FieldBuilder<TSourceType, TReturnType> Resolve(IFieldResolver? resolver)
         {
             FieldType.Resolver = resolver;
             return this;
@@ -136,7 +136,7 @@ namespace GraphQL.Builders
             => Resolve(new FuncFieldResolver<TSourceType, TReturnType>(resolve));
 
         /// <inheritdoc cref="Resolve(IFieldResolver)"/>
-        public virtual FieldBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveFieldContext<TSourceType>, Task<TReturnType>> resolve)
+        public virtual FieldBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveFieldContext<TSourceType>, Task<TReturnType?>> resolve)
             => Resolve(new AsyncFieldResolver<TSourceType, TReturnType>(resolve));
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace GraphQL.Builders
         /// <param name="name">The name of the argument.</param>
         /// <param name="description">The description of the argument.</param>
         /// <param name="configure">A delegate to further configure the argument.</param>
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string description, Action<QueryArgument> configure = null)
+        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure = null)
             where TArgumentGraphType : IGraphType
             => Argument<TArgumentGraphType>(name, arg =>
             {
@@ -170,8 +170,8 @@ namespace GraphQL.Builders
         /// <param name="description">The description of the argument.</param>
         /// <param name="defaultValue">The default value of the argument.</param>
         /// <param name="configure">A delegate to further configure the argument.</param>
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string description,
-            TArgumentType defaultValue = default, Action<QueryArgument> configure = null)
+        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string? description,
+            TArgumentType? defaultValue = default, Action<QueryArgument>? configure = null)
             where TArgumentGraphType : IGraphType
             => Argument<TArgumentGraphType>(name, arg =>
             {
@@ -186,7 +186,7 @@ namespace GraphQL.Builders
         /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
         /// <param name="name">The name of the argument.</param>
         /// <param name="configure">A delegate to further configure the argument.</param>
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, Action<QueryArgument> configure = null)
+        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, Action<QueryArgument>? configure = null)
             where TArgumentGraphType : IGraphType
         {
             var arg = new QueryArgument(typeof(TArgumentGraphType))
@@ -194,6 +194,7 @@ namespace GraphQL.Builders
                 Name = name,
             };
             configure?.Invoke(arg);
+            FieldType.Arguments ??= new QueryArguments();
             FieldType.Arguments.Add(arg);
             return this;
         }
@@ -207,13 +208,13 @@ namespace GraphQL.Builders
             return this;
         }
 
-        public virtual FieldBuilder<TSourceType, TReturnType> Subscribe(Func<IResolveEventStreamContext<TSourceType>, IObservable<TReturnType>> subscribe)
+        public virtual FieldBuilder<TSourceType, TReturnType> Subscribe(Func<IResolveEventStreamContext<TSourceType>, IObservable<TReturnType?>> subscribe)
         {
             FieldType.Subscriber = new EventStreamResolver<TSourceType, TReturnType>(subscribe);
             return this;
         }
 
-        public virtual FieldBuilder<TSourceType, TReturnType> SubscribeAsync(Func<IResolveEventStreamContext<TSourceType>, Task<IObservable<TReturnType>>> subscribeAsync)
+        public virtual FieldBuilder<TSourceType, TReturnType> SubscribeAsync(Func<IResolveEventStreamContext<TSourceType>, Task<IObservable<TReturnType?>>> subscribeAsync)
         {
             FieldType.AsyncSubscriber = new AsyncEventStreamResolver<TSourceType, TReturnType>(subscribeAsync);
             return this;
@@ -237,7 +238,7 @@ namespace GraphQL.Builders
         /// <param name="name">Directive name.</param>
         /// <param name="argumentName">Argument name.</param>
         /// <param name="argumentValue">Argument value.</param>
-        public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object argumentValue)
+        public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue)
         {
             FieldType.ApplyDirective(name, argumentName, argumentValue);
             return this;

--- a/src/GraphQL/Caching/DefaultDocumentCache.cs
+++ b/src/GraphQL/Caching/DefaultDocumentCache.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 
 namespace GraphQL.Caching

--- a/src/GraphQL/Caching/IDocumentCache.cs
+++ b/src/GraphQL/Caching/IDocumentCache.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 
 namespace GraphQL.Caching

--- a/src/GraphQL/ConstrainedArray.cs
+++ b/src/GraphQL/ConstrainedArray.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Conversion/CamelCaseNameConverter.cs
+++ b/src/GraphQL/Conversion/CamelCaseNameConverter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Types;
 
 namespace GraphQL.Conversion

--- a/src/GraphQL/Conversion/DefaultNameConverter.cs
+++ b/src/GraphQL/Conversion/DefaultNameConverter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Types;
 
 namespace GraphQL.Conversion

--- a/src/GraphQL/Conversion/INameConverter.cs
+++ b/src/GraphQL/Conversion/INameConverter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Types;
 
 namespace GraphQL.Conversion

--- a/src/GraphQL/Conversion/PascalCaseNameConverter.cs
+++ b/src/GraphQL/Conversion/PascalCaseNameConverter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Types;
 
 namespace GraphQL.Conversion

--- a/src/GraphQL/Conversion/ValueConverter.cs
+++ b/src/GraphQL/Conversion/ValueConverter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/GraphQL/DI/DefaultServiceProvider.cs
+++ b/src/GraphQL/DI/DefaultServiceProvider.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL

--- a/src/GraphQL/DI/FuncServiceProvider.cs
+++ b/src/GraphQL/DI/FuncServiceProvider.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL

--- a/src/GraphQL/DI/GraphQLBuilderBase.cs
+++ b/src/GraphQL/DI/GraphQLBuilderBase.cs
@@ -70,7 +70,7 @@ namespace GraphQL.DI
         public abstract IGraphQLBuilder TryRegister(Type serviceType, object implementationInstance);
 
         /// <inheritdoc/>
-        public abstract IGraphQLBuilder Configure<TOptions>(Action<TOptions, IServiceProvider> action = null)
+        public abstract IGraphQLBuilder Configure<TOptions>(Action<TOptions, IServiceProvider>? action = null)
             where TOptions : class, new();
     }
 }

--- a/src/GraphQL/DI/IGraphQLBuilder.cs
+++ b/src/GraphQL/DI/IGraphQLBuilder.cs
@@ -35,7 +35,7 @@ namespace GraphQL.DI
         /// <br/><br/>
         /// Passing <see langword="null"/> as the delegate is allowed and will skip this registration.
         /// </summary>
-        IGraphQLBuilder Configure<TOptions>(Action<TOptions, IServiceProvider> action = null)
+        IGraphQLBuilder Configure<TOptions>(Action<TOptions, IServiceProvider>? action = null)
             where TOptions : class, new();
     }
 }

--- a/src/GraphQL/DataLoader/IDataLoaderResult.cs
+++ b/src/GraphQL/DataLoader/IDataLoaderResult.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/GraphQL/DirectivesExtensions.cs
+++ b/src/GraphQL/DirectivesExtensions.cs
@@ -2,8 +2,6 @@ using System;
 using GraphQL.Introspection;
 using GraphQL.Types;
 
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary>
@@ -184,7 +182,7 @@ namespace GraphQL
                        var result = context.ArrayPool.Rent<AppliedDirective>(appliedDirectives!.Count);
 
                        int index = 0;
-                       foreach (var applied in appliedDirectives.List)
+                       foreach (var applied in appliedDirectives.List!)
                        {
                            // return only registered directives allowed by filter
                            var schemaDirective = context.Schema.Directives.Find(applied.Name);

--- a/src/GraphQL/DoNotMapClrTypeAttribute.cs
+++ b/src/GraphQL/DoNotMapClrTypeAttribute.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL

--- a/src/GraphQL/DocumentWriterExtensions.cs
+++ b/src/GraphQL/DocumentWriterExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/GraphQL/Execution/ArgumentValue.cs
+++ b/src/GraphQL/Execution/ArgumentValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Execution
 {
     /// <summary>

--- a/src/GraphQL/Execution/DocumentError.cs
+++ b/src/GraphQL/Execution/DocumentError.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using GraphQL.Resolvers;

--- a/src/GraphQL/Execution/ErrorInfo.cs
+++ b/src/GraphQL/Execution/ErrorInfo.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/Execution/ErrorInfoProvider.cs
+++ b/src/GraphQL/Execution/ErrorInfoProvider.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
+++ b/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Validation;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Execution/ExecutionErrors.cs
+++ b/src/GraphQL/Execution/ExecutionErrors.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Language.AST;
@@ -28,7 +26,7 @@ namespace GraphQL.Execution
             foreach (var arg in definitionArguments.List!)
             {
                 var value = astArguments?.ValueFor(arg.Name);
-                var type = arg.ResolvedType;
+                var type = arg.ResolvedType!;
 
                 values[arg.Name] = CoerceValue(type, value, variables, arg.DefaultValue);
             }

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Execution;

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -134,7 +132,7 @@ namespace GraphQL.Execution
                     var arg = context.Schema.Directives.Skip.Arguments!.Find("if")!;
 
 #pragma warning disable CS8605 // Unboxing a possibly null value.
-                    if ((bool)ExecutionHelper.CoerceValue(arg.ResolvedType, directive.Arguments?.ValueFor(arg.Name), context.Variables, arg.DefaultValue).Value)
+                    if ((bool)ExecutionHelper.CoerceValue(arg.ResolvedType!, directive.Arguments?.ValueFor(arg.Name), context.Variables, arg.DefaultValue).Value)
 #pragma warning restore CS8605 // Unboxing a possibly null value.
                         return false;
                 }
@@ -145,7 +143,7 @@ namespace GraphQL.Execution
                     var arg = context.Schema.Directives.Include.Arguments!.Find("if")!;
 
 #pragma warning disable CS8605 // Unboxing a possibly null value.
-                    return (bool)ExecutionHelper.CoerceValue(arg.ResolvedType, directive.Arguments?.ValueFor(arg.Name), context.Variables, arg.DefaultValue).Value;
+                    return (bool)ExecutionHelper.CoerceValue(arg.ResolvedType!, directive.Arguments?.ValueFor(arg.Name), context.Variables, arg.DefaultValue).Value;
 #pragma warning restore CS8605 // Unboxing a possibly null value.
                 }
             }

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language;
 using GraphQL.Language.AST;
 using GraphQLParser;

--- a/src/GraphQL/Execution/IDocumentBuilder.cs
+++ b/src/GraphQL/Execution/IDocumentBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/Execution/IDocumentExecuter.cs
+++ b/src/GraphQL/Execution/IDocumentExecuter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 

--- a/src/GraphQL/Execution/IErrorInfoProvider.cs
+++ b/src/GraphQL/Execution/IErrorInfoProvider.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Execution
 {
     /// <summary>

--- a/src/GraphQL/Execution/IExecutionArrayPool.cs
+++ b/src/GraphQL/Execution/IExecutionArrayPool.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Execution
 {
     /// <summary>

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/GraphQL/Execution/IExecutionStrategy.cs
+++ b/src/GraphQL/Execution/IExecutionStrategy.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Execution/IProvideUserContext.cs
+++ b/src/GraphQL/Execution/IProvideUserContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/Execution/Inputs.cs
+++ b/src/GraphQL/Execution/Inputs.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Execution/InputsExtensions.cs
+++ b/src/GraphQL/Execution/InputsExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace GraphQL

--- a/src/GraphQL/Execution/InvalidOperationError.cs
+++ b/src/GraphQL/Execution/InvalidOperationError.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/Execution/NoOperationError.cs
+++ b/src/GraphQL/Execution/NoOperationError.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Execution/Nodes/ExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.DataLoader;

--- a/src/GraphQL/Execution/Nodes/IParentExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/IParentExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Execution/Nodes/NullExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/NullExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 using GraphQL.Types;
 

--- a/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Execution/Nodes/RootExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/RootExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 using GraphQL.Types;
 

--- a/src/GraphQL/Execution/Nodes/SubscriptionArrayExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionArrayExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 using GraphQL.Types;
 

--- a/src/GraphQL/Execution/Nodes/SubscriptionObjectExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionObjectExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 using GraphQL.Types;
 

--- a/src/GraphQL/Execution/Nodes/SubscriptionValueExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionValueExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 using GraphQL.Types;
 

--- a/src/GraphQL/Execution/Nodes/ValueExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ValueExecutionNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 using GraphQL.Types;
 

--- a/src/GraphQL/Execution/ParallelExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ParallelExecutionStrategy.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.DataLoader;

--- a/src/GraphQL/Execution/SerialExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SerialExecutionStrategy.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.DataLoader;

--- a/src/GraphQL/Execution/SyntaxError.cs
+++ b/src/GraphQL/Execution/SyntaxError.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQLParser.Exceptions;
 

--- a/src/GraphQL/Execution/UnhandledError.cs
+++ b/src/GraphQL/Execution/UnhandledError.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/Execution/UnhandledExceptionContext.cs
+++ b/src/GraphQL/Execution/UnhandledExceptionContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Execution

--- a/src/GraphQL/ExperimentalFeatures.cs
+++ b/src/GraphQL/ExperimentalFeatures.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary>

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.ComponentModel;
 using GraphQL.Conversion;

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -6,6 +6,7 @@
     <Authors>Joe McBride</Authors>
     <Copyright>Copyright (c) 2015-2021 Joseph T. McBride, Ivan Maximov, Shane Krueger, et al. All rights reserved.</Copyright>
     <PackageTags>GraphQL;json;api</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using System.Reflection;

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.ComponentModel;

--- a/src/GraphQL/GraphQLMetadataAttribute.cs
+++ b/src/GraphQL/GraphQLMetadataAttribute.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Utilities;
 

--- a/src/GraphQL/IDocumentWriter.cs
+++ b/src/GraphQL/IDocumentWriter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/GraphQL/Instrumentation/ApolloTrace.cs
+++ b/src/GraphQL/Instrumentation/ApolloTrace.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using GraphQL.Resolvers;

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Types;
 

--- a/src/GraphQL/Instrumentation/FieldMiddlewareDelegate.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareDelegate.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 
 namespace GraphQL.Instrumentation

--- a/src/GraphQL/Instrumentation/IFieldMiddleware.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddleware.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 
 namespace GraphQL.Instrumentation

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Types;
 

--- a/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
+++ b/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/GraphQL/Instrumentation/Metrics.cs
+++ b/src/GraphQL/Instrumentation/Metrics.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Instrumentation/PerfRecord.cs
+++ b/src/GraphQL/Instrumentation/PerfRecord.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/src/GraphQL/Instrumentation/ValueStopwatch.cs
+++ b/src/GraphQL/Instrumentation/ValueStopwatch.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics;
 

--- a/src/GraphQL/Introspection/ISchemaComparer.cs
+++ b/src/GraphQL/Introspection/ISchemaComparer.cs
@@ -12,34 +12,34 @@ namespace GraphQL.Introspection
         /// Returns a comparer for GraphQL types.
         /// If this returns <see langword="null"/> then the original type ordering is preserved.
         /// </summary>
-        IComparer<IGraphType> TypeComparer { get; }
+        IComparer<IGraphType>? TypeComparer { get; }
 
         /// <summary>
         /// Returns a comparer for fields withing enclosing type.
         /// If this returns <see langword="null"/> then the original field ordering is preserved.
         /// </summary>
         /// <param name="parent"> Parent type to which the fields belong. </param>
-        IComparer<IFieldType> FieldComparer(IGraphType parent);
+        IComparer<IFieldType>? FieldComparer(IGraphType parent);
 
         /// <summary>
         /// Returns a comparer for field arguments.
         /// If this returns <see langword="null"/> then the original argument ordering is preserved.
         /// </summary>
         /// <param name="field"> The field to which the arguments belong. </param>
-        IComparer<QueryArgument> ArgumentComparer(IFieldType field);
+        IComparer<QueryArgument>? ArgumentComparer(IFieldType field);
 
         /// <summary>
         /// Returns a comparer for enum values.
         /// If this returns <see langword="null"/> then the original enum value ordering is preserved.
         /// </summary>
         /// <param name="parent"> The enumeration to which the enum values belong. </param>
-        IComparer<EnumValueDefinition> EnumValueComparer(EnumerationGraphType parent);
+        IComparer<EnumValueDefinition>? EnumValueComparer(EnumerationGraphType parent);
 
         /// <summary>
         /// Returns a comparer for GraphQL directives.
         /// If this returns <see langword="null"/> then the original directive ordering is preserved.
         /// </summary>
-        IComparer<DirectiveGraphType> DirectiveComparer { get; }
+        IComparer<DirectiveGraphType>? DirectiveComparer { get; }
     }
 
     /// <summary>
@@ -48,19 +48,19 @@ namespace GraphQL.Introspection
     public class DefaultSchemaComparer : ISchemaComparer
     {
         /// <inheritdoc/>
-        public virtual IComparer<IGraphType> TypeComparer => null;
+        public virtual IComparer<IGraphType>? TypeComparer => null;
 
         /// <inheritdoc/>
-        public virtual IComparer<DirectiveGraphType> DirectiveComparer => null;
+        public virtual IComparer<DirectiveGraphType>? DirectiveComparer => null;
 
         /// <inheritdoc/>
-        public virtual IComparer<QueryArgument> ArgumentComparer(IFieldType field) => null;
+        public virtual IComparer<QueryArgument>? ArgumentComparer(IFieldType field) => null;
 
         /// <inheritdoc/>
-        public virtual IComparer<EnumValueDefinition> EnumValueComparer(EnumerationGraphType parent) => null;
+        public virtual IComparer<EnumValueDefinition>? EnumValueComparer(EnumerationGraphType parent) => null;
 
         /// <inheritdoc/>
-        public virtual IComparer<IFieldType> FieldComparer(IGraphType parent) => null;
+        public virtual IComparer<IFieldType>? FieldComparer(IGraphType parent) => null;
     }
 
     /// <summary>

--- a/src/GraphQL/Introspection/TypeMetaFieldType.cs
+++ b/src/GraphQL/Introspection/TypeMetaFieldType.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Introspection
             Type = typeof(__Type);
             Description = "Request the type information of a single type.";
             Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "name" });
-            Resolver = new FuncFieldResolver<object>(context => context.Schema.AllTypes[context.GetArgument<string>("name")]);
+            Resolver = new FuncFieldResolver<object>(context => context.Schema.AllTypes[context.GetArgument<string>("name")!]);
         }
     }
 }

--- a/src/GraphQL/Introspection/__AppliedDirective.cs
+++ b/src/GraphQL/Introspection/__AppliedDirective.cs
@@ -19,12 +19,12 @@ namespace GraphQL.Introspection
             Field<NonNullGraphType<StringGraphType>>(
                 "name",
                 "Directive name",
-                resolve: context => context.Source.Name);
+                resolve: context => context.Source!.Name);
 
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<__DirectiveArgument>>>>(
                 "args",
                 "Values of explicitly specified directive arguments",
-                resolve: context => context.Source.List ?? Enumerable.Empty<DirectiveArgument>());
+                resolve: context => context.Source!.List ?? Enumerable.Empty<DirectiveArgument>());
         }
     }
 }

--- a/src/GraphQL/Introspection/__Directive.cs
+++ b/src/GraphQL/Introspection/__Directive.cs
@@ -28,33 +28,33 @@ namespace GraphQL.Introspection
                 "conditionally including or skipping a field. Directives provide this by " +
                 "describing additional information to the executor.";
 
-            Field<NonNullGraphType<StringGraphType>>("name", resolve: context => context.Source.Name);
+            Field<NonNullGraphType<StringGraphType>>("name", resolve: context => context.Source!.Name);
 
-            Field<StringGraphType>("description", resolve: context => context.Source.Description);
+            Field<StringGraphType>("description", resolve: context => context.Source!.Description);
 
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<__DirectiveLocation>>>>("locations");
 
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<__InputValue>>>>("args",
-                resolve: context => context.Source.Arguments?.List ?? Enumerable.Empty<QueryArgument>()
+                resolve: context => context.Source!.Arguments?.List ?? Enumerable.Empty<QueryArgument>()
             );
 
             if (allowRepeatable)
-                Field<NonNullGraphType<BooleanGraphType>>("isRepeatable", resolve: context => context.Source.Repeatable);
+                Field<NonNullGraphType<BooleanGraphType>>("isRepeatable", resolve: context => context.Source!.Repeatable);
 
             Field<NonNullGraphType<BooleanGraphType>>("onOperation", deprecationReason: "Use 'locations'.",
-                resolve: context => context.Source.Locations.Any(l =>
+                resolve: context => context.Source!.Locations.Any(l =>
                         l == DirectiveLocation.Query ||
                         l == DirectiveLocation.Mutation ||
                         l == DirectiveLocation.Subscription));
 
             Field<NonNullGraphType<BooleanGraphType>>("onFragment", deprecationReason: "Use 'locations'.",
-                resolve: context => context.Source.Locations.Any(l =>
+                resolve: context => context.Source!.Locations.Any(l =>
                         l == DirectiveLocation.FragmentSpread ||
                         l == DirectiveLocation.InlineFragment ||
                         l == DirectiveLocation.FragmentDefinition));
 
             Field<NonNullGraphType<BooleanGraphType>>("onField", deprecationReason: "Use 'locations'.",
-                resolve: context => context.Source.Locations.Any(l => l == DirectiveLocation.Field));
+                resolve: context => context.Source!.Locations.Any(l => l == DirectiveLocation.Field));
 
             if (allowAppliedDirectives)
                 this.AddAppliedDirectivesField("directive");

--- a/src/GraphQL/Introspection/__DirectiveArgument.cs
+++ b/src/GraphQL/Introspection/__DirectiveArgument.cs
@@ -26,24 +26,24 @@ namespace GraphQL.Introspection
             Field<NonNullGraphType<StringGraphType>>(
                 "name",
                 "Argument name",
-                resolve: context => context.Source.Name);
+                resolve: context => context.Source!.Name);
 
             Field<NonNullGraphType<StringGraphType>>(
                 "value",
                 "A GraphQL-formatted string representing the value for argument.",
                 resolve: context =>
                 {
-                    var argument = context.Source;
+                    var argument = context.Source!;
                     if (argument.Value == null)
                         return "null";
 
-                    var grandParent = context.Parent.Parent;
+                    var grandParent = context.Parent!.Parent!;
                     int index = (int)grandParent.Path.Last();
-                    var appliedDirective = ((IList<AppliedDirective>)grandParent.Source)[index];
+                    var appliedDirective = ((IList<AppliedDirective>)grandParent.Source!)[index];
                     var directiveDefinition = context.Schema.Directives.Find(appliedDirective.Name);
-                    var argumentDefinition = directiveDefinition.Arguments.Find(argument.Name);
+                    var argumentDefinition = directiveDefinition!.Arguments!.Find(argument.Name);
 
-                    var ast = argumentDefinition.ResolvedType.ToAST(argument.Value);
+                    var ast = argumentDefinition!.ResolvedType!.ToAST(argument.Value);
                     string result = AstPrinter.Print(ast);
                     return string.IsNullOrWhiteSpace(result) ? null : result;
                 });

--- a/src/GraphQL/Introspection/__EnumValue.cs
+++ b/src/GraphQL/Introspection/__EnumValue.cs
@@ -19,11 +19,11 @@ namespace GraphQL.Introspection
                 "a placeholder for a string or numeric value. However an Enum value is " +
                 "returned in a JSON response as a string.";
 
-            Field<NonNullGraphType<StringGraphType>>("name", resolve: context => context.Source.Name);
-            Field<StringGraphType>("description", resolve: context => context.Source.Description);
+            Field<NonNullGraphType<StringGraphType>>("name", resolve: context => context.Source!.Name);
+            Field<StringGraphType>("description", resolve: context => context.Source!.Description);
 
             Field<NonNullGraphType<BooleanGraphType>>("isDeprecated", resolve: context => (!string.IsNullOrWhiteSpace(context.Source?.DeprecationReason)).Boxed());
-            Field<StringGraphType>("deprecationReason", resolve: context => context.Source.DeprecationReason);
+            Field<StringGraphType>("deprecationReason", resolve: context => context.Source!.DeprecationReason);
 
             if (allowAppliedDirectives)
                 this.AddAppliedDirectivesField("enum value");

--- a/src/GraphQL/Introspection/__Field.cs
+++ b/src/GraphQL/Introspection/__Field.cs
@@ -59,7 +59,7 @@ namespace GraphQL.Introspection
                         var arguments = context.ArrayPool.Rent<QueryArgument>(source.Arguments.Count);
 
                         int index = 0;
-                        foreach (var argument in source.Arguments.List)
+                        foreach (var argument in source.Arguments.List!)
                         {
                             if (await context.Schema.Filter.AllowArgument(source, argument).ConfigureAwait(false))
                                 arguments[index++] = argument;

--- a/src/GraphQL/Introspection/__InputValue.cs
+++ b/src/GraphQL/Introspection/__InputValue.cs
@@ -25,7 +25,7 @@ namespace GraphQL.Introspection
 
             Field<StringGraphType>("description");
 
-            Field<NonNullGraphType<__Type>>("type", resolve: context => ((IProvideResolvedType)context.Source).ResolvedType);
+            Field<NonNullGraphType<__Type>>("type", resolve: context => ((IProvideResolvedType)context.Source!).ResolvedType);
 
             Field<StringGraphType>(
                 "defaultValue",
@@ -36,7 +36,7 @@ namespace GraphQL.Introspection
                     if (hasDefault?.DefaultValue == null)
                         return null;
 
-                    var ast = hasDefault.ResolvedType.ToAST(hasDefault.DefaultValue);
+                    var ast = hasDefault.ResolvedType!.ToAST(hasDefault.DefaultValue);
                     string result = AstPrinter.Print(ast);
                     return string.IsNullOrWhiteSpace(result) ? null : result;
                 });

--- a/src/GraphQL/Introspection/__Schema.cs
+++ b/src/GraphQL/Introspection/__Schema.cs
@@ -57,7 +57,7 @@ namespace GraphQL.Introspection
                 "If this server supports mutation, the type that mutation operations will be rooted at.",
                 resolve: async context =>
                 {
-                    return await context.Schema.Filter.AllowType(context.Schema.Mutation).ConfigureAwait(false)
+                    return context.Schema.Mutation != null && await context.Schema.Filter.AllowType(context.Schema.Mutation).ConfigureAwait(false)
                         ? context.Schema.Mutation
                         : null;
                 });
@@ -67,7 +67,7 @@ namespace GraphQL.Introspection
                 "If this server supports subscription, the type that subscription operations will be rooted at.",
                 resolve: async context =>
                 {
-                    return await context.Schema.Filter.AllowType(context.Schema.Subscription).ConfigureAwait(false)
+                    return context.Schema.Subscription != null && await context.Schema.Filter.AllowType(context.Schema.Subscription).ConfigureAwait(false)
                         ? context.Schema.Subscription
                         : null;
                 });

--- a/src/GraphQL/Introspection/__Type.cs
+++ b/src/GraphQL/Introspection/__Type.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Introspection
                     : throw new InvalidOperationException($"Unknown kind of type: {context.Source}");
             });
 
-            Field<StringGraphType>("name", resolve: context => context.Source.Name);
+            Field<StringGraphType>("name", resolve: context => context.Source!.Name);
 
             Field<StringGraphType>("description");
 

--- a/src/GraphQL/Introspection/__TypeKind.cs
+++ b/src/GraphQL/Introspection/__TypeKind.cs
@@ -1,7 +1,5 @@
 using GraphQL.Types;
 
-#nullable enable
-
 namespace GraphQL.Introspection
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/AbstractNode.cs
+++ b/src/GraphQL/Language/AST/AbstractNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/Argument.cs
+++ b/src/GraphQL/Language/AST/Argument.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/Arguments.cs
+++ b/src/GraphQL/Language/AST/Arguments.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Language/AST/CommentNode.cs
+++ b/src/GraphQL/Language/AST/CommentNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/Directive.cs
+++ b/src/GraphQL/Language/AST/Directive.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/Directives.cs
+++ b/src/GraphQL/Language/AST/Directives.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Language/AST/Document.cs
+++ b/src/GraphQL/Language/AST/Document.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/Field.cs
+++ b/src/GraphQL/Language/AST/Field.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/FragmentDefinition.cs
+++ b/src/GraphQL/Language/AST/FragmentDefinition.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/FragmentSpread.cs
+++ b/src/GraphQL/Language/AST/FragmentSpread.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/Fragments.cs
+++ b/src/GraphQL/Language/AST/Fragments.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Language/AST/IDefinition.cs
+++ b/src/GraphQL/Language/AST/IDefinition.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/IFragment.cs
+++ b/src/GraphQL/Language/AST/IFragment.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/IHaveDirectives.cs
+++ b/src/GraphQL/Language/AST/IHaveDirectives.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/IHaveName.cs
+++ b/src/GraphQL/Language/AST/IHaveName.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/IHaveSelectionSet.cs
+++ b/src/GraphQL/Language/AST/IHaveSelectionSet.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Language.AST

--- a/src/GraphQL/Language/AST/IHaveValue.cs
+++ b/src/GraphQL/Language/AST/IHaveValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/INode.cs
+++ b/src/GraphQL/Language/AST/INode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/ISelection.cs
+++ b/src/GraphQL/Language/AST/ISelection.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/IType.cs
+++ b/src/GraphQL/Language/AST/IType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/IValue.cs
+++ b/src/GraphQL/Language/AST/IValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/InlineFragment.cs
+++ b/src/GraphQL/Language/AST/InlineFragment.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/ListType.cs
+++ b/src/GraphQL/Language/AST/ListType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/NameNode.cs
+++ b/src/GraphQL/Language/AST/NameNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/NamedType.cs
+++ b/src/GraphQL/Language/AST/NamedType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/NonNullType.cs
+++ b/src/GraphQL/Language/AST/NonNullType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/NullValue.cs
+++ b/src/GraphQL/Language/AST/NullValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/Operation.cs
+++ b/src/GraphQL/Language/AST/Operation.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/OperationType.cs
+++ b/src/GraphQL/Language/AST/OperationType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/Operations.cs
+++ b/src/GraphQL/Language/AST/Operations.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Language/AST/SelectionSet.cs
+++ b/src/GraphQL/Language/AST/SelectionSet.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Language/AST/SourceLocation.cs
+++ b/src/GraphQL/Language/AST/SourceLocation.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics;
 

--- a/src/GraphQL/Language/AST/ValueNodes/BigIntValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/BigIntValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Numerics;
 
 namespace GraphQL.Language.AST

--- a/src/GraphQL/Language/AST/ValueNodes/BooleanValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/BooleanValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/ValueNodes/DecimalValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/DecimalValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/ValueNodes/EnumValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/EnumValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Utilities;
 
 namespace GraphQL.Language.AST

--- a/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/FloatValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Language.AST

--- a/src/GraphQL/Language/AST/ValueNodes/IntValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/IntValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/ValueNodes/ListValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ListValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Language/AST/ValueNodes/LongValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/LongValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectField.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/ValueNodes/ObjectValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ObjectValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Language/AST/ValueNodes/StringValue.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/StringValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Language.AST

--- a/src/GraphQL/Language/AST/ValueNodes/ValueNode.cs
+++ b/src/GraphQL/Language/AST/ValueNodes/ValueNode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Language.AST

--- a/src/GraphQL/Language/AST/Variable.cs
+++ b/src/GraphQL/Language/AST/Variable.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Language.AST

--- a/src/GraphQL/Language/AST/VariableDefinition.cs
+++ b/src/GraphQL/Language/AST/VariableDefinition.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Language/AST/VariableDefinitions.cs
+++ b/src/GraphQL/Language/AST/VariableDefinitions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Language/AST/VariableReference.cs
+++ b/src/GraphQL/Language/AST/VariableReference.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Language.AST
 {
     /// <summary>

--- a/src/GraphQL/Language/AST/Variables.cs
+++ b/src/GraphQL/Language/AST/Variables.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Language/CoreToVanillaConverter.cs
+++ b/src/GraphQL/Language/CoreToVanillaConverter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/GraphQL/LightweightCache.cs
+++ b/src/GraphQL/LightweightCache.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/MemoryExtensions.cs
+++ b/src/GraphQL/MemoryExtensions.cs
@@ -3,8 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary>

--- a/src/GraphQL/ObjectExtensions.cs
+++ b/src/GraphQL/ObjectExtensions.cs
@@ -7,8 +7,6 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using GraphQL.Types;
 
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary>

--- a/src/GraphQL/Reflection/AccessorFieldResolver.cs
+++ b/src/GraphQL/Reflection/AccessorFieldResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Resolvers;
 

--- a/src/GraphQL/Reflection/IAccessor.cs
+++ b/src/GraphQL/Reflection/IAccessor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/GraphQL/Reflection/ReflectionHelper.cs
+++ b/src/GraphQL/Reflection/ReflectionHelper.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using System.Reflection;

--- a/src/GraphQL/Reflection/SingleMethodAccessor.cs
+++ b/src/GraphQL/Reflection/SingleMethodAccessor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/GraphQL/Reflection/SinglePropertyAccessor.cs
+++ b/src/GraphQL/Reflection/SinglePropertyAccessor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/GraphQL/ResolveFieldContext/IResolveConnectionContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveConnectionContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Resolvers;
 
 namespace GraphQL.Builders

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Execution;

--- a/src/GraphQL/ResolveFieldContext/ResolveConnectionContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveConnectionContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Builders

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Execution;

--- a/src/GraphQL/Resolvers/AsyncEventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/AsyncEventStreamResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using GraphQL.Reflection;

--- a/src/GraphQL/Resolvers/AsyncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/AsyncFieldResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 

--- a/src/GraphQL/Resolvers/DelegateFieldModelBinderResolver.cs
+++ b/src/GraphQL/Resolvers/DelegateFieldModelBinderResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Reflection;
 using System.Runtime.ExceptionServices;

--- a/src/GraphQL/Resolvers/EventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/EventStreamResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Reflection;
 using GraphQL.Subscription;

--- a/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
+++ b/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq.Expressions;
 

--- a/src/GraphQL/Resolvers/FieldResolverExtensions.cs
+++ b/src/GraphQL/Resolvers/FieldResolverExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 

--- a/src/GraphQL/Resolvers/FuncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/FuncFieldResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using GraphQL.DataLoader;

--- a/src/GraphQL/Resolvers/IEventStreamResolver.cs
+++ b/src/GraphQL/Resolvers/IEventStreamResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using GraphQL.Subscription;

--- a/src/GraphQL/Resolvers/IFieldResolver.cs
+++ b/src/GraphQL/Resolvers/IFieldResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Types;
 

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Linq.Expressions;

--- a/src/GraphQL/SchemaExtensions.cs
+++ b/src/GraphQL/SchemaExtensions.cs
@@ -5,8 +5,6 @@ using GraphQL.Introspection;
 using GraphQL.Types;
 using GraphQL.Utilities;
 
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary>

--- a/src/GraphQL/Shim/DecimalData.cs
+++ b/src/GraphQL/Shim/DecimalData.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL
 {
     // * DESCRIPTION TAKEN FROM MS REFERENCE SOURCE *

--- a/src/GraphQL/Shim/Numbers.cs
+++ b/src/GraphQL/Shim/Numbers.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Globalization;
 

--- a/src/GraphQL/StringExtensions.cs
+++ b/src/GraphQL/StringExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary>

--- a/src/GraphQL/Subscription/IResolveEventStreamContext.cs
+++ b/src/GraphQL/Subscription/IResolveEventStreamContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Subscription
 {
     public interface IResolveEventStreamContext : IResolveFieldContext

--- a/src/GraphQL/Subscription/ResolveEventStreamContext.cs
+++ b/src/GraphQL/Subscription/ResolveEventStreamContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Subscription
 {
     public class ResolveEventStreamContext<T> : ResolveFieldContext<T>, IResolveEventStreamContext<T>

--- a/src/GraphQL/Subscription/SubscriptionExecutionResult.cs
+++ b/src/GraphQL/Subscription/SubscriptionExecutionResult.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/TaskExtensions.cs
+++ b/src/GraphQL/TaskExtensions.cs
@@ -1,8 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.CSharp.RuntimeBinder;
 
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary>

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -9,8 +9,6 @@ using GraphQL.DataLoader;
 using GraphQL.Types;
 using GraphQL.Utilities;
 
-#nullable enable
-
 namespace GraphQL
 {
     /// <summary>

--- a/src/GraphQL/Types/Collections/AppliedDirectives.cs
+++ b/src/GraphQL/Types/Collections/AppliedDirectives.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Types
     /// </summary>
     public class AppliedDirectives : IEnumerable<AppliedDirective>
     {
-        internal List<AppliedDirective> List { get; private set; }
+        internal List<AppliedDirective>? List { get; private set; }
 
         /// <summary>
         /// Gets the count of applied directives.
@@ -36,7 +36,7 @@ namespace GraphQL.Types
         /// Finds a directive by its name from the list. If the list contains several
         /// directives with the given name, then the first one is returned.
         /// </summary>
-        public AppliedDirective Find(string name)
+        public AppliedDirective? Find(string name)
         {
             // DO NOT USE LINQ ON HOT PATH
             if (List != null)

--- a/src/GraphQL/Types/Collections/Interfaces.cs
+++ b/src/GraphQL/Types/Collections/Interfaces.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Types/Collections/PossibleTypes.cs
+++ b/src/GraphQL/Types/Collections/PossibleTypes.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Types/Collections/QueryArguments.cs
+++ b/src/GraphQL/Types/Collections/QueryArguments.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Types/Collections/ResolvedInterfaces.cs
+++ b/src/GraphQL/Types/Collections/ResolvedInterfaces.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Types/Collections/SchemaDirectives.cs
+++ b/src/GraphQL/Types/Collections/SchemaDirectives.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -631,7 +629,7 @@ Make sure that your ServiceProvider is configured correctly.");
                     {
                         foreach (var arg in field.Arguments.List!)
                         {
-                            arg.ResolvedType = ConvertTypeReference(type, arg.ResolvedType);
+                            arg.ResolvedType = ConvertTypeReference(type, arg.ResolvedType!);
                         }
                     }
                 }

--- a/src/GraphQL/Types/Collections/TypeFields.cs
+++ b/src/GraphQL/Types/Collections/TypeFields.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq.Expressions;
 using System.Threading.Tasks;

--- a/src/GraphQL/Types/Composite/IAbstractGraphType.cs
+++ b/src/GraphQL/Types/Composite/IAbstractGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Types

--- a/src/GraphQL/Types/Composite/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/InputObjectGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using GraphQL.Language.AST;
 

--- a/src/GraphQL/Types/Composite/InterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/InterfaceGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Types

--- a/src/GraphQL/Types/Composite/ListGraphType.cs
+++ b/src/GraphQL/Types/Composite/ListGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Types

--- a/src/GraphQL/Types/Composite/NonNullGraphType.cs
+++ b/src/GraphQL/Types/Composite/NonNullGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Types

--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Types

--- a/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using GraphQL.Resolvers;

--- a/src/GraphQL/Types/Composite/UnionGraphType.cs
+++ b/src/GraphQL/Types/Composite/UnionGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Types/Directives/AppliedDirective.cs
+++ b/src/GraphQL/Types/Directives/AppliedDirective.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Types/Directives/Built-in/DeprecatedDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/DeprecatedDirective.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Directives/Built-in/IncludeDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/IncludeDirective.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Directives/Built-in/SkipDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/SkipDirective.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Directives/DirectiveArgument.cs
+++ b/src/GraphQL/Types/Directives/DirectiveArgument.cs
@@ -1,7 +1,5 @@
 using GraphQL.Utilities;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Directives/DirectiveGraphType.cs
+++ b/src/GraphQL/Types/Directives/DirectiveGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Utilities;

--- a/src/GraphQL/Types/Directives/DirectiveLocation.cs
+++ b/src/GraphQL/Types/Directives/DirectiveLocation.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.ComponentModel;
 
 namespace GraphQL.Types

--- a/src/GraphQL/Types/Directives/LengthDirective.cs
+++ b/src/GraphQL/Types/Directives/LengthDirective.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Validation.Rules;
 

--- a/src/GraphQL/Types/Fields/EventStreamFieldType.cs
+++ b/src/GraphQL/Types/Fields/EventStreamFieldType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Resolvers;
 
 namespace GraphQL.Types

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics;
 using GraphQL.Resolvers;

--- a/src/GraphQL/Types/Fields/IFieldType.cs
+++ b/src/GraphQL/Types/Fields/IFieldType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/GraphQLTypeReference.cs
+++ b/src/GraphQL/Types/GraphQLTypeReference.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics;
 

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Reflection;
 using GraphQL.Utilities;

--- a/src/GraphQL/Types/IGraphType.cs
+++ b/src/GraphQL/Types/IGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/IHaveDefaultValue.cs
+++ b/src/GraphQL/Types/IHaveDefaultValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/IImplementInterfaces.cs
+++ b/src/GraphQL/Types/IImplementInterfaces.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/IProvideMetadata.cs
+++ b/src/GraphQL/Types/IProvideMetadata.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Types/IProvideResolvedType.cs
+++ b/src/GraphQL/Types/IProvideResolvedType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Conversion;

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -26,8 +26,8 @@ namespace GraphQL.Types
     [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
     public class QueryArgument : MetadataProvider, IHaveDefaultValue, IProvideDescription
     {
-        private Type _type;
-        private IGraphType _resolvedType;
+        private Type? _type;
+        private IGraphType? _resolvedType;
 
         /// <summary>
         /// Initializes a new instance of the argument.
@@ -52,13 +52,13 @@ namespace GraphQL.Types
             Type = type;
         }
 
-        private string _name;
+        private string? _name;
         /// <summary>
         /// Gets or sets the name of the argument.
         /// </summary>
         public string Name
         {
-            get => _name;
+            get => _name!;
             set
             {
                 if (_name != value)
@@ -72,30 +72,30 @@ namespace GraphQL.Types
         /// <summary>
         /// Gets or sets the description of the argument.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the default value of the argument.
         /// </summary>
-        public object DefaultValue { get; set; }
+        public object? DefaultValue { get; set; }
 
         /// <summary>
         /// Returns the graph type of this argument.
         /// </summary>
-        public IGraphType ResolvedType
+        public IGraphType? ResolvedType
         {
             get => _resolvedType;
             set => _resolvedType = CheckResolvedType(value);
         }
 
         /// <inheritdoc/>
-        public Type Type
+        public Type? Type
         {
             get => _type;
             internal set => _type = CheckType(value);
         }
 
-        private Type CheckType(Type type)
+        private Type? CheckType(Type? type)
         {
             if (type?.IsInputType() == false)
                 throw Create(nameof(Type), type);
@@ -103,7 +103,7 @@ namespace GraphQL.Types
             return type;
         }
 
-        private IGraphType CheckResolvedType(IGraphType type)
+        private IGraphType? CheckResolvedType(IGraphType? type)
         {
             if (type != null && !type.IsGraphQLTypeReference() && type.IsInputType() == false)
                 throw Create(nameof(ResolvedType), type.GetType());

--- a/src/GraphQL/Types/Relay/DataObjects/Connection.cs
+++ b/src/GraphQL/Types/Relay/DataObjects/Connection.cs
@@ -19,17 +19,17 @@ namespace GraphQL.Types.Relay.DataObjects
         /// <summary>
         /// Additional pagination information for this result data set.
         /// </summary>
-        public PageInfo PageInfo { get; set; }
+        public PageInfo? PageInfo { get; set; }
 
         /// <summary>
         /// The result data set, stored as a list of edges containing a node (the data) and a cursor (a unique identifier for the data).
         /// </summary>
-        public List<TEdge> Edges { get; set; }
+        public List<TEdge>? Edges { get; set; }
 
         /// <summary>
         /// The result data set.
         /// </summary>
-        public List<TNode> Items => Edges?.Select(edge => edge.Node).ToList();
+        public List<TNode?>? Items => Edges?.Select(edge => edge.Node).ToList();
     }
 
     /// <summary>

--- a/src/GraphQL/Types/Relay/DataObjects/Edge.cs
+++ b/src/GraphQL/Types/Relay/DataObjects/Edge.cs
@@ -9,11 +9,11 @@ namespace GraphQL.Types.Relay.DataObjects
         /// <summary>
         /// The cursor of this edge's node. A cursor is a string representation of a unique identifier of this node.
         /// </summary>
-        public string Cursor { get; set; }
+        public string? Cursor { get; set; }
 
         /// <summary>
         /// The node. A node is a single row of data within the result data set.
         /// </summary>
-        public TNode Node { get; set; }
+        public TNode? Node { get; set; }
     }
 }

--- a/src/GraphQL/Types/Relay/DataObjects/PageInfo.cs
+++ b/src/GraphQL/Types/Relay/DataObjects/PageInfo.cs
@@ -18,11 +18,11 @@ namespace GraphQL.Types.Relay.DataObjects
         /// <summary>
         /// The cursor of the first node in the result data set.
         /// </summary>
-        public string StartCursor { get; set; }
+        public string? StartCursor { get; set; }
 
         /// <summary>
         /// The cursor of the last node in the result data set.
         /// </summary>
-        public string EndCursor { get; set; }
+        public string? EndCursor { get; set; }
     }
 }

--- a/src/GraphQL/Types/Scalars/BigIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BigIntGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/BooleanGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BooleanGraphType.cs
@@ -1,7 +1,5 @@
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/ByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ByteGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/DateGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateGraphType.cs
@@ -2,8 +2,6 @@ using System;
 using System.Globalization;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
@@ -2,8 +2,6 @@ using System;
 using System.Globalization;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -2,8 +2,6 @@ using System;
 using System.Globalization;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/EnumerationGraphType.cs
@@ -8,8 +8,6 @@ using System.Reflection;
 using GraphQL.Language.AST;
 using GraphQL.Utilities;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/GuidGraphType.cs
+++ b/src/GraphQL/Types/Scalars/GuidGraphType.cs
@@ -2,8 +2,6 @@ using System;
 using System.Globalization;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -2,8 +2,6 @@ using System;
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/IntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IntGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/SByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/SByteGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/ScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ScalarGraphType.cs
@@ -2,8 +2,6 @@ using System;
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/ShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ShortGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -1,7 +1,5 @@
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanMillisecondsGraphType.cs
@@ -2,8 +2,6 @@ using System;
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
@@ -2,8 +2,6 @@ using System;
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/UIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UIntGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/ULongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ULongGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/UShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UShortGraphType.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -1,8 +1,6 @@
 using System;
 using GraphQL.Language.AST;
 
-#nullable enable
-
 namespace GraphQL.Types
 {
     /// <summary>

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Types/TypeCollectionContext.cs
+++ b/src/GraphQL/Types/TypeCollectionContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Types/TypeExtensions.cs
+++ b/src/GraphQL/Types/TypeExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Language.AST;
 

--- a/src/GraphQL/Utilities/ArgumentConfig.cs
+++ b/src/GraphQL/Utilities/ArgumentConfig.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Utilities
 {
     /// <summary>

--- a/src/GraphQL/Utilities/AstPrinter.cs
+++ b/src/GraphQL/Utilities/AstPrinter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Utilities/Federation/AnyScalarGraphType.cs
+++ b/src/GraphQL/Utilities/Federation/AnyScalarGraphType.cs
@@ -1,8 +1,6 @@
 using GraphQL.Language.AST;
 using GraphQL.Types;
 
-#nullable enable
-
 namespace GraphQL.Utilities.Federation
 {
     /// <summary>

--- a/src/GraphQL/Utilities/Federation/AnyValue.cs
+++ b/src/GraphQL/Utilities/Federation/AnyValue.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 
 namespace GraphQL.Utilities.Federation

--- a/src/GraphQL/Utilities/Federation/FederatedResolveContext.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedResolveContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace GraphQL.Utilities.Federation

--- a/src/GraphQL/Utilities/Federation/FederatedSchema.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchema.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Types;
 

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Utilities/Federation/FuncFederatedResolver.cs
+++ b/src/GraphQL/Utilities/Federation/FuncFederatedResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 

--- a/src/GraphQL/Utilities/Federation/IFederatedResolver.cs
+++ b/src/GraphQL/Utilities/Federation/IFederatedResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 
 namespace GraphQL.Utilities.Federation

--- a/src/GraphQL/Utilities/Federation/ServiceGraphType.cs
+++ b/src/GraphQL/Utilities/Federation/ServiceGraphType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Types;
 
 namespace GraphQL.Utilities.Federation

--- a/src/GraphQL/Utilities/Federation/TypeConfigExtensions.cs
+++ b/src/GraphQL/Utilities/Federation/TypeConfigExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 

--- a/src/GraphQL/Utilities/FieldConfig.cs
+++ b/src/GraphQL/Utilities/FieldConfig.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Reflection;
 using GraphQL.Resolvers;
 

--- a/src/GraphQL/Utilities/MetadataProvider.cs
+++ b/src/GraphQL/Utilities/MetadataProvider.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Types;

--- a/src/GraphQL/Utilities/NameValidator.cs
+++ b/src/GraphQL/Utilities/NameValidator.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Utilities

--- a/src/GraphQL/Utilities/NamedElement.cs
+++ b/src/GraphQL/Utilities/NamedElement.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Utilities
 {
     /// <summary>

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
+++ b/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Types;

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -263,7 +261,7 @@ namespace GraphQL.Utilities
 
         public string PrintInputValue(QueryArgument argument)
         {
-            var argumentType = argument.ResolvedType;
+            var argumentType = argument.ResolvedType!;
             var desc = "{0}: {1}".ToFormat(argument.Name, argumentType);
 
             if (argument.DefaultValue != null)

--- a/src/GraphQL/Utilities/SchemaPrinterOptions.cs
+++ b/src/GraphQL/Utilities/SchemaPrinterOptions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Utilities
 {
     /// <summary>

--- a/src/GraphQL/Utilities/ServiceProviderExtensions.cs
+++ b/src/GraphQL/Utilities/ServiceProviderExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace GraphQL.Utilities

--- a/src/GraphQL/Utilities/StringUtils.cs
+++ b/src/GraphQL/Utilities/StringUtils.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,7 +29,7 @@ namespace GraphQL.Utilities
         /// Given an invalid input string and a list of valid options, returns a filtered
         /// list of valid options sorted based on their similarity with the input.
         /// </summary>
-        public static string[] SuggestionList(string input, IEnumerable<string> options)
+        public static string[] SuggestionList(string input, IEnumerable<string>? options)
         {
             if (options == null)
             {

--- a/src/GraphQL/Utilities/TypeConfig.cs
+++ b/src/GraphQL/Utilities/TypeConfig.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Reflection;
 using GraphQL.Types;

--- a/src/GraphQL/Utilities/TypeSettings.cs
+++ b/src/GraphQL/Utilities/TypeSettings.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/GraphQL/Utilities/Visitors/AppliedDirectivesValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/AppliedDirectivesValidationVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using GraphQL.Types;

--- a/src/GraphQL/Utilities/Visitors/BaseSchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/BaseSchemaNodeVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Types;
 
 namespace GraphQL.Utilities

--- a/src/GraphQL/Utilities/Visitors/DeprecatedDirectiveVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/DeprecatedDirectiveVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Types;
 

--- a/src/GraphQL/Utilities/Visitors/ISchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/ISchemaNodeVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Types;
 
 namespace GraphQL.Utilities

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using GraphQL.Types;
@@ -285,9 +283,9 @@ namespace GraphQL.Utilities
         {
             if (argument.DefaultValue is GraphQLValue value)
             {
-                argument.DefaultValue = Execution.ExecutionHelper.CoerceValue(argument.ResolvedType, Language.CoreToVanillaConverter.Value(value)).Value;
+                argument.DefaultValue = Execution.ExecutionHelper.CoerceValue(argument.ResolvedType!, Language.CoreToVanillaConverter.Value(value)).Value;
             }
-            else if (argument.DefaultValue != null && !argument.ResolvedType.IsValidDefault(argument.DefaultValue))
+            else if (argument.DefaultValue != null && !argument.ResolvedType!.IsValidDefault(argument.DefaultValue))
             {
                 throw new InvalidOperationException($"The default value of argument '{argument.Name}' of field '{type.Name}.{field.Name}' is invalid.");
             }

--- a/src/GraphQL/Utilities/XmlDocumentationExtensions.cs
+++ b/src/GraphQL/Utilities/XmlDocumentationExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.IO;

--- a/src/GraphQL/Validation/BaseVariableVisitor.cs
+++ b/src/GraphQL/Validation/BaseVariableVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using GraphQL.Language.AST;
 using GraphQL.Types;

--- a/src/GraphQL/Validation/BasicVisitor.cs
+++ b/src/GraphQL/Validation/BasicVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/CompositeVariableVisitor.cs
+++ b/src/GraphQL/Validation/CompositeVariableVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using GraphQL.Language.AST;
 using GraphQL.Types;

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/GraphQL/Validation/Errors.Custom/InputFieldsAndArgumentsOfCorrectLengthError.cs
+++ b/src/GraphQL/Validation/Errors.Custom/InputFieldsAndArgumentsOfCorrectLengthError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public InputFieldsAndArgumentsOfCorrectLengthError(ValidationContext context, INode node, int? length, int? min, int? max)
-            : base(context.Document.OriginalQuery, NUMBER, BadValueMessage(node, length, min, max), node)
+            : base(context.Document.OriginalQuery!, NUMBER, BadValueMessage(node, length, min, max), node)
         {
         }
 
@@ -21,7 +21,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public InputFieldsAndArgumentsOfCorrectLengthError(ValidationContext context, VariableDefinition node, VariableName variableName, int? length, int? min, int? max)
-            : base(context.Document.OriginalQuery, NUMBER, BadValueMessage(variableName, length, min, max), node)
+            : base(context.Document.OriginalQuery!, NUMBER, BadValueMessage(variableName, length, min, max), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors.Custom/InvalidVariableError.cs
+++ b/src/GraphQL/Validation/Errors.Custom/InvalidVariableError.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Validation
         /// Initializes a new instance of the <see cref="InvalidVariableError"/> class for a specified variable and error message.
         /// </summary>
         public InvalidVariableError(ValidationContext context, VariableDefinition node, VariableName variableName, string message) :
-            base(context.Document.OriginalQuery, NUMBER, $"Variable '${variableName}' is invalid. {message}", node)
+            base(context.Document.OriginalQuery!, NUMBER, $"Variable '${variableName}' is invalid. {message}", node)
         {
             Code = "INVALID_VALUE";
         }
@@ -26,7 +26,7 @@ namespace GraphQL.Validation
         /// and error message. Loads any exception data from the inner exception into this instance.
         /// </summary>
         public InvalidVariableError(ValidationContext context, VariableDefinition node, VariableName variableName, string message, Exception innerException) :
-            base(context.Document.OriginalQuery, NUMBER, $"Variable '${variableName}' is invalid. {message}", innerException, node)
+            base(context.Document.OriginalQuery!, NUMBER, $"Variable '${variableName}' is invalid. {message}", innerException, node)
         {
             Code = "INVALID_VALUE";
         }

--- a/src/GraphQL/Validation/Errors/ArgumentsOfCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/ArgumentsOfCorrectTypeError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ArgumentsOfCorrectTypeError(ValidationContext context, Argument node, string verboseErrors)
-            : base(context.Document.OriginalQuery, NUMBER, BadValueMessage(node.Name, verboseErrors), node)
+            : base(context.Document.OriginalQuery!, NUMBER, BadValueMessage(node.Name, verboseErrors), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/DefaultValuesOfCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/DefaultValuesOfCorrectTypeError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public DefaultValuesOfCorrectTypeError(ValidationContext context, VariableDefinition varDefAst, IGraphType inputType, string verboseErrors)
-            : base(context.Document.OriginalQuery, NUMBER, BadValueForDefaultArgMessage(varDefAst.Name, inputType.ToString(), varDefAst.DefaultValue.StringFrom(context.Document), verboseErrors), varDefAst.DefaultValue)
+            : base(context.Document.OriginalQuery!, NUMBER, BadValueForDefaultArgMessage(varDefAst.Name, inputType.ToString(), varDefAst.DefaultValue!.StringFrom(context.Document), verboseErrors), varDefAst.DefaultValue!)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/DirectivesInAllowedLocationsError.cs
+++ b/src/GraphQL/Validation/Errors/DirectivesInAllowedLocationsError.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public DirectivesInAllowedLocationsError(ValidationContext context, Directive node, DirectiveLocation candidateLocation)
-            : base(context.Document.OriginalQuery, "5.7.2", $"Directive '{node.Name}' may not be used on {candidateLocation}.", node)
+            : base(context.Document.OriginalQuery!, "5.7.2", $"Directive '{node.Name}' may not be used on {candidateLocation}.", node)
         {
         }
     }

--- a/src/GraphQL/Validation/Errors/FieldsOnCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/FieldsOnCorrectTypeError.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public FieldsOnCorrectTypeError(ValidationContext context, Field node, IGraphType type, IEnumerable<string> suggestedTypeNames, IEnumerable<string> suggestedFieldNames)
-            : base(context.Document.OriginalQuery, NUMBER, UndefinedFieldMessage(node.Name, type.Name, suggestedTypeNames, suggestedFieldNames), node)
+            : base(context.Document.OriginalQuery!, NUMBER, UndefinedFieldMessage(node.Name, type.Name, suggestedTypeNames, suggestedFieldNames), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/FragmentsOnCompositeTypesError.cs
+++ b/src/GraphQL/Validation/Errors/FragmentsOnCompositeTypesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public FragmentsOnCompositeTypesError(ValidationContext context, InlineFragment node)
-            : base(context.Document.OriginalQuery, NUMBER, InlineFragmentOnNonCompositeErrorMessage(node.Type.StringFrom(context.Document)), node.Type)
+            : base(context.Document.OriginalQuery!, NUMBER, InlineFragmentOnNonCompositeErrorMessage(node.Type!.StringFrom(context.Document)), node.Type!)
         {
         }
 
@@ -21,7 +21,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public FragmentsOnCompositeTypesError(ValidationContext context, FragmentDefinition node)
-            : base(context.Document.OriginalQuery, NUMBER, FragmentOnNonCompositeErrorMessage(node.Name, node.Type.StringFrom(context.Document)), node.Type)
+            : base(context.Document.OriginalQuery!, NUMBER, FragmentOnNonCompositeErrorMessage(node.Name, node.Type.StringFrom(context.Document)), node.Type)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public KnownArgumentNamesError(ValidationContext context, Argument node, FieldType fieldDef, IGraphType parentType)
-            : base(context.Document.OriginalQuery, NUMBER,
+            : base(context.Document.OriginalQuery!, NUMBER,
                 UnknownArgMessage(
                     node.Name,
                     fieldDef.Name,
@@ -30,7 +30,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public KnownArgumentNamesError(ValidationContext context, Argument node, DirectiveGraphType directive)
-            : base(context.Document.OriginalQuery, NUMBER,
+            : base(context.Document.OriginalQuery!, NUMBER,
                 UnknownDirectiveArgMessage(
                     node.Name,
                     directive.Name,

--- a/src/GraphQL/Validation/Errors/KnownDirectivesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownDirectivesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public KnownDirectivesError(ValidationContext context, Directive node)
-            : base(context.Document.OriginalQuery, NUMBER, $"Unknown directive '{node.Name}'.", node)
+            : base(context.Document.OriginalQuery!, NUMBER, $"Unknown directive '{node.Name}'.", node)
         {
         }
     }

--- a/src/GraphQL/Validation/Errors/KnownFragmentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownFragmentNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public KnownFragmentNamesError(ValidationContext context, FragmentSpread node, string fragmentName)
-            : base(context.Document.OriginalQuery, NUMBER, UnknownFragmentMessage(fragmentName), node)
+            : base(context.Document.OriginalQuery!, NUMBER, UnknownFragmentMessage(fragmentName), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/KnownTypeNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownTypeNamesError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public KnownTypeNamesError(ValidationContext context, NamedType node, string[] suggestedTypes)
-            : base(context.Document.OriginalQuery, NUMBER, UnknownTypeMessage(node.Name, suggestedTypes), node)
+            : base(context.Document.OriginalQuery!, NUMBER, UnknownTypeMessage(node.Name, suggestedTypes), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/LoneAnonymousOperationError.cs
+++ b/src/GraphQL/Validation/Errors/LoneAnonymousOperationError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public LoneAnonymousOperationError(ValidationContext context, Operation node)
-            : base(context.Document.OriginalQuery, NUMBER, AnonOperationNotAloneMessage(), node)
+            : base(context.Document.OriginalQuery!, NUMBER, AnonOperationNotAloneMessage(), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/NoFragmentCyclesError.cs
+++ b/src/GraphQL/Validation/Errors/NoFragmentCyclesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public NoFragmentCyclesError(ValidationContext context, string fragName, string[] spreadNames, params INode[] nodes)
-            : base(context.Document.OriginalQuery, NUMBER, CycleErrorMessage(fragName, spreadNames), nodes)
+            : base(context.Document.OriginalQuery!, NUMBER, CycleErrorMessage(fragName, spreadNames), nodes)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/NoUndefinedVariablesError.cs
+++ b/src/GraphQL/Validation/Errors/NoUndefinedVariablesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public NoUndefinedVariablesError(ValidationContext context, Operation node, VariableReference variableReference)
-            : base(context.Document.OriginalQuery, NUMBER, UndefinedVarMessage(variableReference.Name, node.Name), variableReference, node)
+            : base(context.Document.OriginalQuery!, NUMBER, UndefinedVarMessage(variableReference.Name, node.Name), variableReference, node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/NoUnusedFragmentsError.cs
+++ b/src/GraphQL/Validation/Errors/NoUnusedFragmentsError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public NoUnusedFragmentsError(ValidationContext context, FragmentDefinition node)
-            : base(context.Document.OriginalQuery, NUMBER, UnusedFragMessage(node.Name), node)
+            : base(context.Document.OriginalQuery!, NUMBER, UnusedFragMessage(node.Name), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/NoUnusedVariablesError.cs
+++ b/src/GraphQL/Validation/Errors/NoUnusedVariablesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public NoUnusedVariablesError(ValidationContext context, VariableDefinition node, Operation op)
-            : base(context.Document.OriginalQuery, NUMBER, UnusedVariableMessage(node.Name, op.Name), node)
+            : base(context.Document.OriginalQuery!, NUMBER, UnusedVariableMessage(node.Name, op.Name), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/OverlappingFieldsCanBeMergedError.cs
+++ b/src/GraphQL/Validation/Errors/OverlappingFieldsCanBeMergedError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public OverlappingFieldsCanBeMergedError(ValidationContext context, Conflict conflict)
-            : base(context.Document.OriginalQuery, NUMBER, FieldsConflictMessage(conflict.Reason.Name, conflict.Reason),
+            : base(context.Document.OriginalQuery!, NUMBER, FieldsConflictMessage(conflict.Reason.Name, conflict.Reason),
                   conflict.FieldsLeft.Concat(conflict.FieldsRight).ToArray())
         {
         }
@@ -34,7 +34,7 @@ namespace GraphQL.Validation.Errors
             }
             else
             {
-                return reasonMessage.Msg;
+                return reasonMessage.Msg!;
             }
         }
     }

--- a/src/GraphQL/Validation/Errors/PossibleFragmentSpreadsError.cs
+++ b/src/GraphQL/Validation/Errors/PossibleFragmentSpreadsError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public PossibleFragmentSpreadsError(ValidationContext context, InlineFragment node, IGraphType parentType, IGraphType fragType)
-            : base(context.Document.OriginalQuery, NUMBER, TypeIncompatibleAnonSpreadMessage(parentType.ToString(), fragType.ToString()), node)
+            : base(context.Document.OriginalQuery!, NUMBER, TypeIncompatibleAnonSpreadMessage(parentType.ToString(), fragType.ToString()), node)
         {
         }
 
@@ -22,7 +22,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public PossibleFragmentSpreadsError(ValidationContext context, FragmentSpread node, IGraphType parentType, IGraphType fragType)
-            : base(context.Document.OriginalQuery, NUMBER, TypeIncompatibleSpreadMessage(node.Name, parentType.ToString(), fragType.ToString()), node)
+            : base(context.Document.OriginalQuery!, NUMBER, TypeIncompatibleSpreadMessage(node.Name, parentType.ToString(), fragType.ToString()), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/ProvidedNonNullArgumentsError.cs
+++ b/src/GraphQL/Validation/Errors/ProvidedNonNullArgumentsError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ProvidedNonNullArgumentsError(ValidationContext context, Field node, QueryArgument arg)
-            : base(context.Document.OriginalQuery, NUMBER, MissingFieldArgMessage(node.Name, arg.Name, arg.ResolvedType.ToString()), node)
+            : base(context.Document.OriginalQuery!, NUMBER, MissingFieldArgMessage(node.Name, arg.Name, arg.ResolvedType!.ToString()), node)
         {
         }
 
@@ -22,7 +22,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ProvidedNonNullArgumentsError(ValidationContext context, Directive node, QueryArgument arg)
-            : base(context.Document.OriginalQuery, NUMBER, MissingDirectiveArgMessage(node.Name, arg.Name, arg.ResolvedType.ToString()), node)
+            : base(context.Document.OriginalQuery!, NUMBER, MissingDirectiveArgMessage(node.Name, arg.Name, arg.ResolvedType!.ToString()), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/ScalarLeafsError.cs
+++ b/src/GraphQL/Validation/Errors/ScalarLeafsError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ScalarLeafsError(ValidationContext context, SelectionSet node, Field field, IGraphType type)
-            : base(context.Document.OriginalQuery, NUMBER, NoSubselectionAllowedMessage(field.Name, type.ToString()), node)
+            : base(context.Document.OriginalQuery!, NUMBER, NoSubselectionAllowedMessage(field.Name, type.ToString()), node)
         {
         }
 
@@ -22,7 +22,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ScalarLeafsError(ValidationContext context, Field node, IGraphType type)
-            : base(context.Document.OriginalQuery, NUMBER, RequiredSubselectionMessage(node.Name, type.ToString()), node)
+            : base(context.Document.OriginalQuery!, NUMBER, RequiredSubselectionMessage(node.Name, type.ToString()), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/SingleRootFieldSubscriptionsError.cs
+++ b/src/GraphQL/Validation/Errors/SingleRootFieldSubscriptionsError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public SingleRootFieldSubscriptionsError(ValidationContext context, Operation operation, params ISelection[] nodes)
-            : base(context.Document.OriginalQuery, NUMBER, InvalidNumberOfRootFieldMessage(operation.Name), nodes)
+            : base(context.Document.OriginalQuery!, NUMBER, InvalidNumberOfRootFieldMessage(operation.Name), nodes)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueArgumentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueArgumentNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueArgumentNamesError(ValidationContext context, Argument node, Argument otherNode)
-            : base(context.Document.OriginalQuery, NUMBER, DuplicateArgMessage(node.Name), node, otherNode)
+            : base(context.Document.OriginalQuery!, NUMBER, DuplicateArgMessage(node.Name), node, otherNode)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueDirectivesPerLocationError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueDirectivesPerLocationError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueDirectivesPerLocationError(ValidationContext context, Directive node)
-            : base(context.Document.OriginalQuery, NUMBER, $"The directive '{node.Name}' can only be used once at this location.", node)
+            : base(context.Document.OriginalQuery!, NUMBER, $"The directive '{node.Name}' can only be used once at this location.", node)
         {
         }
     }

--- a/src/GraphQL/Validation/Errors/UniqueFragmentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueFragmentNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueFragmentNamesError(ValidationContext context, FragmentDefinition node, FragmentDefinition altNode)
-            : base(context.Document.OriginalQuery, NUMBER, DuplicateFragmentNameMessage(node.Name), node, altNode)
+            : base(context.Document.OriginalQuery!, NUMBER, DuplicateFragmentNameMessage(node.Name), node, altNode)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueInputFieldNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueInputFieldNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueInputFieldNamesError(ValidationContext context, IValue node, ObjectField altNode)
-            : base(context.Document.OriginalQuery, NUMBER, DuplicateInputField(altNode.Name), node, altNode.Value)
+            : base(context.Document.OriginalQuery!, NUMBER, DuplicateInputField(altNode.Name), node, altNode.Value)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueOperationNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueOperationNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueOperationNamesError(ValidationContext context, Operation node)
-            : base(context.Document.OriginalQuery, NUMBER, DuplicateOperationNameMessage(node.Name), node)
+            : base(context.Document.OriginalQuery!, NUMBER, DuplicateOperationNameMessage(node.Name), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/UniqueVariableNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueVariableNamesError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public UniqueVariableNamesError(ValidationContext context, VariableDefinition node, VariableDefinition altNode)
-            : base(context.Document.OriginalQuery, NUMBER, DuplicateVariableMessage(node.Name), node, altNode)
+            : base(context.Document.OriginalQuery!, NUMBER, DuplicateVariableMessage(node.Name), node, altNode)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/VariablesAreInputTypesError.cs
+++ b/src/GraphQL/Validation/Errors/VariablesAreInputTypesError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public VariablesAreInputTypesError(ValidationContext context, VariableDefinition node, IGraphType type)
-            : base(context.Document.OriginalQuery, NUMBER, UndefinedVarMessage(node.Name, type?.ToString() ?? node.Type.Name()), node)
+            : base(context.Document.OriginalQuery!, NUMBER, UndefinedVarMessage(node.Name, type?.ToString() ?? node.Type.Name()), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/VariablesInAllowedPositionError.cs
+++ b/src/GraphQL/Validation/Errors/VariablesInAllowedPositionError.cs
@@ -15,10 +15,10 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public VariablesInAllowedPositionError(ValidationContext context, VariableDefinition varDef, IGraphType varType, VariableUsage usage)
-            : base(context.Document.OriginalQuery, NUMBER, BadVarPosMessage(usage.Node.Name, varType.ToString(), usage.Type.ToString()))
+            : base(context.Document.OriginalQuery!, NUMBER, BadVarPosMessage(usage.Node.Name, varType.ToString(), usage.Type.ToString()))
         {
-            var varDefPos = new Location(context.Document.OriginalQuery, varDef.SourceLocation.Start);
-            var usagePos = new Location(context.Document.OriginalQuery, usage.Node.SourceLocation.Start);
+            var varDefPos = new Location(context.Document.OriginalQuery!, varDef.SourceLocation.Start);
+            var usagePos = new Location(context.Document.OriginalQuery!, usage.Node.SourceLocation.Start);
 
             AddLocation(varDefPos.Line, varDefPos.Column);
             AddLocation(usagePos.Line, usagePos.Column);

--- a/src/GraphQL/Validation/INodeVisitor.cs
+++ b/src/GraphQL/Validation/INodeVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 
 namespace GraphQL.Validation

--- a/src/GraphQL/Validation/IValidationResult.cs
+++ b/src/GraphQL/Validation/IValidationResult.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Validation
 {
     /// <summary>

--- a/src/GraphQL/Validation/IValidationRule.cs
+++ b/src/GraphQL/Validation/IValidationRule.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 
 namespace GraphQL.Validation

--- a/src/GraphQL/Validation/IVariableVisitor.cs
+++ b/src/GraphQL/Validation/IVariableVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using GraphQL.Language.AST;
 using GraphQL.Types;

--- a/src/GraphQL/Validation/IVariableVisitorProvider.cs
+++ b/src/GraphQL/Validation/IVariableVisitorProvider.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL.Validation
 {
     /// <summary>

--- a/src/GraphQL/Validation/MatchingNodeVisitor.cs
+++ b/src/GraphQL/Validation/MatchingNodeVisitor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Language.AST;
 

--- a/src/GraphQL/Validation/NodeVisitors.cs
+++ b/src/GraphQL/Validation/NodeVisitors.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using GraphQL.Language.AST;
 

--- a/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
+++ b/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Types;

--- a/src/GraphQL/Validation/Rules/5.7 - Directives/1+2. KnownDirectivesInAllowedLocations.cs
+++ b/src/GraphQL/Validation/Rules/5.7 - Directives/1+2. KnownDirectivesInAllowedLocations.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/5.7 - Directives/3. UniqueDirectivesPerLocation.cs
+++ b/src/GraphQL/Validation/Rules/5.7 - Directives/3. UniqueDirectivesPerLocation.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/1. UniqueVariableNames.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/1. UniqueVariableNames.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/2. VariablesAreInputTypes.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/2. VariablesAreInputTypes.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Types;
@@ -30,7 +28,7 @@ namespace GraphQL.Validation.Rules
 
             if (type == null || !type.IsInputType())
             {
-                context.ReportError(new VariablesAreInputTypesError(context, varDef, varDef.Type.GraphTypeFromType(context.Schema)));
+                context.ReportError(new VariablesAreInputTypesError(context, varDef, varDef.Type.GraphTypeFromType(context.Schema)!));
             }
         }).ToTask();
     }

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/3. NoUndefinedVariables.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/3. NoUndefinedVariables.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/4. NoUnusedVariables.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/4. NoUnusedVariables.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/5. VariablesInAllowedPosition.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/5. VariablesInAllowedPosition.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/GraphQL/Validation/Rules/ArgumentsOfCorrectType.cs
+++ b/src/GraphQL/Validation/Rules/ArgumentsOfCorrectType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;
@@ -29,7 +27,7 @@ namespace GraphQL.Validation.Rules
             if (argDef == null)
                 return;
 
-            var type = argDef.ResolvedType;
+            var type = argDef.ResolvedType!;
             var errors = context.IsValidLiteralValue(type, argAst.Value);
             if (errors != null)
             {

--- a/src/GraphQL/Validation/Rules/DefaultValuesOfCorrectType.cs
+++ b/src/GraphQL/Validation/Rules/DefaultValuesOfCorrectType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;

--- a/src/GraphQL/Validation/Rules/FieldsOnCorrectType.cs
+++ b/src/GraphQL/Validation/Rules/FieldsOnCorrectType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/GraphQL/Validation/Rules/FragmentsOnCompositeTypes.cs
+++ b/src/GraphQL/Validation/Rules/FragmentsOnCompositeTypes.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;

--- a/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/KnownFragmentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownFragmentNames.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;

--- a/src/GraphQL/Validation/Rules/KnownTypeNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownTypeNames.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/LoneAnonymousOperation.cs
+++ b/src/GraphQL/Validation/Rules/LoneAnonymousOperation.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Validation.Errors;

--- a/src/GraphQL/Validation/Rules/NoFragmentCycles.cs
+++ b/src/GraphQL/Validation/Rules/NoFragmentCycles.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/GraphQL/Validation/Rules/NoUnusedFragments.cs
+++ b/src/GraphQL/Validation/Rules/NoUnusedFragments.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/GraphQL/Validation/Rules/OverlappingFieldsCanBeMerged.cs
+++ b/src/GraphQL/Validation/Rules/OverlappingFieldsCanBeMerged.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/GraphQL/Validation/Rules/PossibleFragmentSpreads.cs
+++ b/src/GraphQL/Validation/Rules/PossibleFragmentSpreads.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Types;

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Types;

--- a/src/GraphQL/Validation/Rules/ScalarLeafs.cs
+++ b/src/GraphQL/Validation/Rules/ScalarLeafs.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 using GraphQL.Language.AST;
 using GraphQL.Types;

--- a/src/GraphQL/Validation/Rules/SingleRootFieldSubscriptions.cs
+++ b/src/GraphQL/Validation/Rules/SingleRootFieldSubscriptions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/UniqueArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueArgumentNames.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/UniqueFragmentNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueFragmentNames.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/UniqueInputFieldNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueInputFieldNames.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/Rules/UniqueOperationNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueOperationNames.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/TaskHelper.cs
+++ b/src/GraphQL/Validation/TaskHelper.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Threading.Tasks;
 
 namespace GraphQL.Validation

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Language.AST;

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/GraphQL/Validation/ValidationError.cs
+++ b/src/GraphQL/Validation/ValidationError.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using GraphQL.Execution;

--- a/src/GraphQL/Validation/ValidationResult.cs
+++ b/src/GraphQL/Validation/ValidationResult.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace GraphQL.Validation

--- a/src/GraphQL/Validation/VariableUsage.cs
+++ b/src/GraphQL/Validation/VariableUsage.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using GraphQL.Language.AST;
 using GraphQL.Types;
 

--- a/src/GraphQL/VariableName.cs
+++ b/src/GraphQL/VariableName.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace GraphQL
 {
     public struct VariableName


### PR DESCRIPTION
This concludes the first pass of NRT annotations for GraphQL.NET.  Many changes should be made, but would be breaking.  Most specifically, things like ResolvedType and Source which are typically non-null, yet can be at other times.  (e.g. ResolvedType before schema is initialized, and Source when it equals the root object).  There's also lots of data objects which start off null even though null is invalid, such as the name of a type.  Most of those I set as non-null.  There is very little code that I changed, rather I just added `!` where necessary to skip NRT checks.  So almost every reference to ResolvedType has now changed to `ResolvedType!`.  Another property of that nature is `Parent` -- almost always non-null, but not always.  So that's nullable.

I'm sure there will be some incorrect NRT annotations, but this is a start.  Again, the code should perform the same since it was not changed (except in a few rare circumstances).  So we can just pull requests to fix any incorrect NRT annotations.  Maybe for the next version we can use `init` properties so these NRT situations are less likely to occur.