### PR TITLE
IGraphQLBuilder improvements

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.MicrosoftDI.approved.txt
@@ -51,7 +51,7 @@ namespace GraphQL.MicrosoftDI
         public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, System.Threading.Tasks.Task<TReturnType>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5> WithScope() { }
     }
-    public class GraphQLBuilder : GraphQL.DI.GraphQLBuilderBase
+    public class GraphQLBuilder : GraphQL.DI.GraphQLBuilderBase, Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Collections.Generic.ICollection<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IEnumerable<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IList<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.IEnumerable
     {
         public GraphQLBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
         public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }

--- a/src/GraphQL.ApiTests/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.MicrosoftDI.approved.txt
@@ -57,9 +57,9 @@ namespace GraphQL.MicrosoftDI
         public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
         public override GraphQL.DI.IGraphQLBuilder Configure<TOptions>(System.Action<TOptions, System.IServiceProvider>? action = null)
             where TOptions :  class, new () { }
-        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance) { }
-        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime) { }
-        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime) { }
+        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance, bool replace = false) { }
+        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false) { }
+        public override GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false) { }
         public override GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, object implementationInstance) { }
         public override GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime) { }
         public override GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime) { }

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -262,6 +262,7 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder Configure<TOptions>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, System.Action<TOptions>? action)
             where TOptions :  class, new () { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.ExecutionOptions> action) { }
+        public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureSchema(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Types.ISchema> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureSchema(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Types.ISchema, System.IServiceProvider> action) { }
         public static GraphQL.DI.IGraphQLBuilder Register<TService>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, GraphQL.DI.ServiceLifetime serviceLifetime)
@@ -742,7 +743,7 @@ namespace GraphQL.DI
     }
     public interface IConfigureExecution
     {
-        void Configure(GraphQL.ExecutionOptions executionOptions);
+        System.Threading.Tasks.Task ConfigureAsync(GraphQL.ExecutionOptions executionOptions);
     }
     public interface IConfigureSchema
     {

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -265,13 +265,13 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureSchema(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Types.ISchema> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureSchema(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Types.ISchema, System.IServiceProvider> action) { }
-        public static GraphQL.DI.IGraphQLBuilder Register<TService>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, GraphQL.DI.ServiceLifetime serviceLifetime)
+        public static GraphQL.DI.IGraphQLBuilder Register<TService>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false)
             where TService :  class { }
-        public static GraphQL.DI.IGraphQLBuilder Register<TService>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, TService implementationInstance)
+        public static GraphQL.DI.IGraphQLBuilder Register<TService>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, TService implementationInstance, bool replace = false)
             where TService :  class { }
-        public static GraphQL.DI.IGraphQLBuilder Register<TService>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, System.Func<System.IServiceProvider, TService> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime)
+        public static GraphQL.DI.IGraphQLBuilder Register<TService>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, System.Func<System.IServiceProvider, TService> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false)
             where TService :  class { }
-        public static GraphQL.DI.IGraphQLBuilder Register<TService, TImplementation>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, GraphQL.DI.ServiceLifetime serviceLifetime)
+        public static GraphQL.DI.IGraphQLBuilder Register<TService, TImplementation>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false)
             where TService :  class
             where TImplementation :  class, TService { }
         public static GraphQL.DI.IGraphQLBuilder TryRegister<TService>(this GraphQL.DI.IGraphQLBuilder graphQLBuilder, GraphQL.DI.ServiceLifetime serviceLifetime)
@@ -734,9 +734,9 @@ namespace GraphQL.DI
         public abstract GraphQL.DI.IGraphQLBuilder Configure<TOptions>(System.Action<TOptions, System.IServiceProvider>? action = null)
             where TOptions :  class, new ();
         protected virtual void Initialize() { }
-        public abstract GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance);
-        public abstract GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime);
-        public abstract GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime);
+        public abstract GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance, bool replace = false);
+        public abstract GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false);
+        public abstract GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false);
         public abstract GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, object implementationInstance);
         public abstract GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime);
         public abstract GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime);
@@ -753,9 +753,9 @@ namespace GraphQL.DI
     {
         GraphQL.DI.IGraphQLBuilder Configure<TOptions>(System.Action<TOptions, System.IServiceProvider>? action = null)
             where TOptions :  class, new ();
-        GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance);
-        GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime);
-        GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime);
+        GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, object implementationInstance, bool replace = false);
+        GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false);
+        GraphQL.DI.IGraphQLBuilder Register(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime, bool replace = false);
         GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, object implementationInstance);
         GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, System.Func<System.IServiceProvider, object> implementationFactory, GraphQL.DI.ServiceLifetime serviceLifetime);
         GraphQL.DI.IGraphQLBuilder TryRegister(System.Type serviceType, System.Type implementationType, GraphQL.DI.ServiceLifetime serviceLifetime);

--- a/src/GraphQL.DataLoader.Tests/GraphQLBuilderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/GraphQLBuilderTests.cs
@@ -21,7 +21,7 @@ namespace GraphQL.DataLoader.Tests
             var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
             mockServiceProvider.Setup(x => x.GetService(typeof(DataLoaderDocumentListener))).Returns(instance).Verifiable();
             mockBuilder.Setup(x => x.Register(typeof(IConfigureExecution), It.IsAny<object>(), false))
-                .Returns<Type, IConfigureExecution>((_, action) =>
+                .Returns<Type, IConfigureExecution, bool>((_, action, _) =>
                 {
                     var options = new ExecutionOptions()
                     {

--- a/src/GraphQL.DataLoader.Tests/GraphQLBuilderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/GraphQLBuilderTests.cs
@@ -27,7 +27,7 @@ namespace GraphQL.DataLoader.Tests
                     {
                         RequestServices = mockServiceProvider.Object
                     };
-                    action.Configure(options);
+                    action.ConfigureAsync(options).Wait();
                     options.Listeners.ShouldContain(instance);
                     return builder;
                 }).Verifiable();

--- a/src/GraphQL.DataLoader.Tests/GraphQLBuilderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/GraphQLBuilderTests.cs
@@ -15,12 +15,12 @@ namespace GraphQL.DataLoader.Tests
             var instance = new DataLoaderDocumentListener(new DataLoaderContextAccessor());
             var mockBuilder = new Mock<IGraphQLBuilder>(MockBehavior.Strict);
             var builder = mockBuilder.Object;
-            mockBuilder.Setup(x => x.Register(typeof(IDataLoaderContextAccessor), typeof(DataLoaderContextAccessor), ServiceLifetime.Singleton)).Returns(builder).Verifiable();
-            mockBuilder.Setup(x => x.Register(typeof(IDocumentExecutionListener), typeof(DataLoaderDocumentListener), ServiceLifetime.Singleton)).Returns(builder).Verifiable();
-            mockBuilder.Setup(x => x.Register(typeof(DataLoaderDocumentListener), typeof(DataLoaderDocumentListener), ServiceLifetime.Singleton)).Returns(builder).Verifiable();
+            mockBuilder.Setup(x => x.Register(typeof(IDataLoaderContextAccessor), typeof(DataLoaderContextAccessor), ServiceLifetime.Singleton, false)).Returns(builder).Verifiable();
+            mockBuilder.Setup(x => x.Register(typeof(IDocumentExecutionListener), typeof(DataLoaderDocumentListener), ServiceLifetime.Singleton, false)).Returns(builder).Verifiable();
+            mockBuilder.Setup(x => x.Register(typeof(DataLoaderDocumentListener), typeof(DataLoaderDocumentListener), ServiceLifetime.Singleton, false)).Returns(builder).Verifiable();
             var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
             mockServiceProvider.Setup(x => x.GetService(typeof(DataLoaderDocumentListener))).Returns(instance).Verifiable();
-            mockBuilder.Setup(x => x.Register(typeof(IConfigureExecution), It.IsAny<object>()))
+            mockBuilder.Setup(x => x.Register(typeof(IConfigureExecution), It.IsAny<object>(), false))
                 .Returns<Type, IConfigureExecution>((_, action) =>
                 {
                     var options = new ExecutionOptions()

--- a/src/GraphQL.MicrosoftDI/GraphQLBuilder.cs
+++ b/src/GraphQL.MicrosoftDI/GraphQLBuilder.cs
@@ -58,38 +58,59 @@ namespace GraphQL.MicrosoftDI
         }
 
         /// <inheritdoc/>
-        public override IGraphQLBuilder Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime)
+        public override IGraphQLBuilder Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime, bool replace = false)
         {
             if (serviceType == null)
                 throw new ArgumentNullException(nameof(serviceType));
             if (implementationFactory == null)
                 throw new ArgumentNullException(nameof(implementationFactory));
 
-            Services.Add(new ServiceDescriptor(serviceType, implementationFactory, TranslateLifetime(serviceLifetime)));
+            if (replace)
+            {
+                Services.Replace(new ServiceDescriptor(serviceType, implementationFactory, TranslateLifetime(serviceLifetime)));
+            }
+            else
+            {
+                Services.Add(new ServiceDescriptor(serviceType, implementationFactory, TranslateLifetime(serviceLifetime)));
+            }
             return this;
         }
 
         /// <inheritdoc/>
-        public override IGraphQLBuilder Register(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime)
+        public override IGraphQLBuilder Register(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime, bool replace = false)
         {
             if (serviceType == null)
                 throw new ArgumentNullException(nameof(serviceType));
             if (implementationType == null)
                 throw new ArgumentNullException(nameof(implementationType));
 
-            Services.Add(new ServiceDescriptor(serviceType, implementationType, TranslateLifetime(serviceLifetime)));
+            if (replace)
+            {
+                Services.Replace(new ServiceDescriptor(serviceType, implementationType, TranslateLifetime(serviceLifetime)));
+            }
+            else
+            {
+                Services.Add(new ServiceDescriptor(serviceType, implementationType, TranslateLifetime(serviceLifetime)));
+            }
             return this;
         }
 
         /// <inheritdoc/>
-        public override IGraphQLBuilder Register(Type serviceType, object implementationInstance)
+        public override IGraphQLBuilder Register(Type serviceType, object implementationInstance, bool replace = false)
         {
             if (serviceType == null)
                 throw new ArgumentNullException(nameof(serviceType));
             if (implementationInstance == null)
                 throw new ArgumentNullException(nameof(implementationInstance));
 
-            Services.Add(new ServiceDescriptor(serviceType, implementationInstance));
+            if (replace)
+            {
+                Services.Replace(new ServiceDescriptor(serviceType, implementationInstance));
+            }
+            else
+            {
+                Services.Add(new ServiceDescriptor(serviceType, implementationInstance));
+            }
             return this;
         }
 

--- a/src/GraphQL.MicrosoftDI/GraphQLBuilder.cs
+++ b/src/GraphQL.MicrosoftDI/GraphQLBuilder.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using GraphQL.DI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -14,7 +16,7 @@ namespace GraphQL.MicrosoftDI
     /// An implementation of <see cref="IGraphQLBuilder"/> which uses the Microsoft dependency injection framework
     /// to register services and configure options.
     /// </summary>
-    public class GraphQLBuilder : GraphQLBuilderBase
+    public class GraphQLBuilder : GraphQLBuilderBase, IServiceCollection
     {
         /// <summary>
         /// Returns the underlying <see cref="IServiceCollection"/> of this builder.
@@ -126,5 +128,19 @@ namespace GraphQL.MicrosoftDI
             Services.TryAdd(new ServiceDescriptor(serviceType, implementationInstance));
             return this;
         }
+
+        int ICollection<ServiceDescriptor>.Count => Services.Count;
+        bool ICollection<ServiceDescriptor>.IsReadOnly => Services.IsReadOnly;
+        ServiceDescriptor IList<ServiceDescriptor>.this[int index] { get => Services[index]; set => Services[index] = value; }
+        int IList<ServiceDescriptor>.IndexOf(ServiceDescriptor item) => Services.IndexOf(item);
+        void IList<ServiceDescriptor>.Insert(int index, ServiceDescriptor item) => Services.Insert(index, item);
+        void IList<ServiceDescriptor>.RemoveAt(int index) => Services.RemoveAt(index);
+        void ICollection<ServiceDescriptor>.Add(ServiceDescriptor item) => Services.Add(item);
+        void ICollection<ServiceDescriptor>.Clear() => Services.Clear();
+        bool ICollection<ServiceDescriptor>.Contains(ServiceDescriptor item) => Services.Contains(item);
+        void ICollection<ServiceDescriptor>.CopyTo(ServiceDescriptor[] array, int arrayIndex) => Services.CopyTo(array, arrayIndex);
+        bool ICollection<ServiceDescriptor>.Remove(ServiceDescriptor item) => Services.Remove(item);
+        IEnumerator<ServiceDescriptor> IEnumerable<ServiceDescriptor>.GetEnumerator() => Services.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)Services).GetEnumerator();
     }
 }

--- a/src/GraphQL.Tests/DI/GraphQLBuilderBaseTests.cs
+++ b/src/GraphQL.Tests/DI/GraphQLBuilderBaseTests.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Tests.DI
                 var schema = Mock.Of<ISchema>(MockBehavior.Strict);
 
                 //verify no action if schema is set
-                action.Configure(new ExecutionOptions { Schema = schema, RequestServices = Mock.Of<IServiceProvider>(MockBehavior.Strict) });
+                action.ConfigureAsync(new ExecutionOptions { Schema = schema, RequestServices = Mock.Of<IServiceProvider>(MockBehavior.Strict) }).Wait();
 
                 //verify schema is pulled from service provider if schema is not set
                 var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
@@ -46,7 +46,7 @@ namespace GraphQL.Tests.DI
                 {
                     RequestServices = mockServiceProvider.Object,
                 };
-                action.Configure(opts);
+                action.ConfigureAsync(opts).Wait();
                 opts.Schema.ShouldBe(schema);
                 mockServiceProvider.Verify();
 

--- a/src/GraphQL.Tests/DI/GraphQLBuilderBaseTests.cs
+++ b/src/GraphQL.Tests/DI/GraphQLBuilderBaseTests.cs
@@ -32,7 +32,7 @@ namespace GraphQL.Tests.DI
             mock.Setup(b => b.TryRegister(typeof(IDocumentCache), DefaultDocumentCache.Instance)).Returns(builder).Verifiable();
             mock.Setup(b => b.TryRegister(typeof(IErrorInfoProvider), typeof(ErrorInfoProvider), ServiceLifetime.Singleton)).Returns(builder).Verifiable();
             mock.Setup(b => b.Configure((Action<ErrorInfoProviderOptions, IServiceProvider>)null)).Returns(builder).Verifiable();
-            mock.Setup(b => b.Register(typeof(IConfigureExecution), It.IsAny<IConfigureExecution>())).Returns<Type, IConfigureExecution>((_, action) =>
+            mock.Setup(b => b.Register(typeof(IConfigureExecution), It.IsAny<IConfigureExecution>(), false)).Returns<Type, IConfigureExecution, bool>((_, action, _) =>
             {
                 var schema = Mock.Of<ISchema>(MockBehavior.Strict);
 
@@ -77,14 +77,14 @@ namespace GraphQL.Tests.DI
             public override IGraphQLBuilder Configure<TOptions>(Action<TOptions, IServiceProvider> action = null)
                 => MockBuilder.Object.Configure(action);
 
-            public override IGraphQLBuilder Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime)
-                => MockBuilder.Object.Register(serviceType, implementationFactory, serviceLifetime);
+            public override IGraphQLBuilder Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime, bool replace = false)
+                => MockBuilder.Object.Register(serviceType, implementationFactory, serviceLifetime, replace);
 
-            public override IGraphQLBuilder Register(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime)
-                => MockBuilder.Object.Register(serviceType, implementationType, serviceLifetime);
+            public override IGraphQLBuilder Register(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime, bool replace = false)
+                => MockBuilder.Object.Register(serviceType, implementationType, serviceLifetime, replace);
 
-            public override IGraphQLBuilder Register(Type serviceType, object implementationInstance)
-                => MockBuilder.Object.Register(serviceType, implementationInstance);
+            public override IGraphQLBuilder Register(Type serviceType, object implementationInstance, bool replace = false)
+                => MockBuilder.Object.Register(serviceType, implementationInstance, replace);
 
             public override IGraphQLBuilder TryRegister(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime)
                 => MockBuilder.Object.TryRegister(serviceType, implementationFactory, serviceLifetime);

--- a/src/GraphQL.Tests/DI/GraphQLBuilderTests.cs
+++ b/src/GraphQL.Tests/DI/GraphQLBuilderTests.cs
@@ -86,7 +86,7 @@ namespace GraphQL.Tests.DI
                     actions = opts =>
                     {
                         actions2(opts);
-                        action.Configure(opts);
+                        action.ConfigureAsync(opts).Wait();
                     };
                     return _builder;
                 }).Verifiable();
@@ -344,7 +344,7 @@ namespace GraphQL.Tests.DI
                     //test with no complexity configuration
                     ran = false;
                     opts = new ExecutionOptions();
-                    action.Configure(opts);
+                    action.ConfigureAsync(opts).Wait();
                     ran.ShouldBeTrue();
 
                     //test with existing complexity configuration
@@ -354,7 +354,7 @@ namespace GraphQL.Tests.DI
                     {
                         ComplexityConfiguration = cc2,
                     };
-                    action.Configure(opts);
+                    action.ConfigureAsync(opts).Wait();
                     ran.ShouldBeTrue();
                     opts.ComplexityConfiguration.ShouldBe(cc2);
 
@@ -384,7 +384,7 @@ namespace GraphQL.Tests.DI
                     {
                         RequestServices = new Mock<IServiceProvider>(MockBehavior.Strict).Object,
                     };
-                    action.Configure(opts);
+                    action.ConfigureAsync(opts).Wait();
                     ran.ShouldBeTrue();
 
                     //test with existing complexity configuration
@@ -395,7 +395,7 @@ namespace GraphQL.Tests.DI
                         RequestServices = new Mock<IServiceProvider>(MockBehavior.Strict).Object,
                         ComplexityConfiguration = cc2,
                     };
-                    action.Configure(opts);
+                    action.ConfigureAsync(opts).Wait();
                     ran.ShouldBeTrue();
                     opts.ComplexityConfiguration.ShouldBe(cc2);
 
@@ -414,7 +414,7 @@ namespace GraphQL.Tests.DI
                     //test with no complexity configuration
                     opts = new ExecutionOptions();
                     opts.ComplexityConfiguration.ShouldBeNull();
-                    action.Configure(opts);
+                    action.ConfigureAsync(opts).Wait();
                     opts.ComplexityConfiguration.ShouldNotBeNull();
 
                     //test with existing complexity configuration
@@ -423,7 +423,7 @@ namespace GraphQL.Tests.DI
                     {
                         ComplexityConfiguration = cc2,
                     };
-                    action.Configure(opts);
+                    action.ConfigureAsync(opts).Wait();
                     opts.ComplexityConfiguration.ShouldBe(cc2);
 
                     return _builder;

--- a/src/GraphQL/DI/GraphQLBuilderBase.cs
+++ b/src/GraphQL/DI/GraphQLBuilderBase.cs
@@ -67,13 +67,13 @@ namespace GraphQL.DI
         }
 
         /// <inheritdoc/>
-        public abstract IGraphQLBuilder Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime);
+        public abstract IGraphQLBuilder Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime, bool replace = false);
 
         /// <inheritdoc/>
-        public abstract IGraphQLBuilder Register(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime);
+        public abstract IGraphQLBuilder Register(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime, bool replace = false);
 
         /// <inheritdoc/>
-        public abstract IGraphQLBuilder Register(Type serviceType, object implementationInstance);
+        public abstract IGraphQLBuilder Register(Type serviceType, object implementationInstance, bool replace = false);
 
         /// <inheritdoc/>
         public abstract IGraphQLBuilder TryRegister(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime);

--- a/src/GraphQL/DI/IConfigureExecution.cs
+++ b/src/GraphQL/DI/IConfigureExecution.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace GraphQL.DI
 {
@@ -13,7 +14,7 @@ namespace GraphQL.DI
         /// <remarks>
         /// <see cref="ExecutionOptions.RequestServices"/> can be used to resolve other services from the dependency injection framework.
         /// </remarks>
-        void Configure(ExecutionOptions executionOptions);
+        Task ConfigureAsync(ExecutionOptions executionOptions);
     }
 
     internal class ConfigureExecution : IConfigureExecution
@@ -25,9 +26,25 @@ namespace GraphQL.DI
             _action = action ?? throw new ArgumentNullException(nameof(action));
         }
 
-        public void Configure(ExecutionOptions executionOptions)
+        public Task ConfigureAsync(ExecutionOptions executionOptions)
         {
             _action(executionOptions);
+            return Task.CompletedTask;
+        }
+    }
+
+    internal class ConfigureExecutionAsync : IConfigureExecution
+    {
+        private readonly Func<ExecutionOptions, Task> _action;
+
+        public ConfigureExecutionAsync(Func<ExecutionOptions, Task> action)
+        {
+            _action = action ?? throw new ArgumentNullException(nameof(action));
+        }
+
+        public Task ConfigureAsync(ExecutionOptions executionOptions)
+        {
+            return _action(executionOptions);
         }
     }
 }

--- a/src/GraphQL/DI/IGraphQLBuilder.cs
+++ b/src/GraphQL/DI/IGraphQLBuilder.cs
@@ -9,14 +9,15 @@ namespace GraphQL.DI
     {
         /// <summary>
         /// Registers the service of type <paramref name="serviceType"/> with the dependency injection provider.
+        /// Optionally removes any existing implementation of the same service type.
         /// </summary>
-        IGraphQLBuilder Register(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime);
+        IGraphQLBuilder Register(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime, bool replace = false);
 
-        /// <inheritdoc cref="Register(Type, Type, ServiceLifetime)"/>
-        IGraphQLBuilder Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime);
+        /// <inheritdoc cref="Register(Type, Type, ServiceLifetime, bool)"/>
+        IGraphQLBuilder Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime, bool replace = false);
 
-        /// <inheritdoc cref="Register(Type, Type, ServiceLifetime)"/>
-        IGraphQLBuilder Register(Type serviceType, object implementationInstance);
+        /// <inheritdoc cref="Register(Type, Type, ServiceLifetime, bool)"/>
+        IGraphQLBuilder Register(Type serviceType, object implementationInstance, bool replace = false);
 
         /// <summary>
         /// Registers the service of type <paramref name="serviceType"/> with the dependency injection provider if a service

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -79,7 +79,8 @@ namespace GraphQL
             {
                 foreach (var configuration in _configurations)
                 {
-                    configuration.Configure(options);
+                    // allocation free when the configuration delegate is not asynchronous
+                    await configuration.ConfigureAsync(options);
                 }
             }
 

--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -20,33 +20,36 @@ namespace GraphQL
     public static class GraphQLBuilderExtensions
     {
         #region - Additional overloads for Register, TryRegister, ConfigureDefaults and Configure -
-        /// <inheritdoc cref="Register{TService}(IGraphQLBuilder, Func{IServiceProvider, TService}, ServiceLifetime)"/>
-        public static IGraphQLBuilder Register<TService>(this IGraphQLBuilder graphQLBuilder, ServiceLifetime serviceLifetime)
+        /// <inheritdoc cref="Register{TService}(IGraphQLBuilder, Func{IServiceProvider, TService}, ServiceLifetime, bool)"/>
+        public static IGraphQLBuilder Register<TService>(this IGraphQLBuilder graphQLBuilder, ServiceLifetime serviceLifetime, bool replace = false)
             where TService : class
-            => graphQLBuilder.Register(typeof(TService), typeof(TService), serviceLifetime);
+            => graphQLBuilder.Register(typeof(TService), typeof(TService), serviceLifetime, replace);
 
         /// <summary>
         /// Registers the service of type <typeparamref name="TService"/> with the dependency injection provider.
         /// An instance of <typeparamref name="TImplementation"/> will be created when an instance is needed.
+        /// Optionally removes any existing implementation of the same service type.
         /// </summary>
-        public static IGraphQLBuilder Register<TService, TImplementation>(this IGraphQLBuilder graphQLBuilder, ServiceLifetime serviceLifetime)
+        public static IGraphQLBuilder Register<TService, TImplementation>(this IGraphQLBuilder graphQLBuilder, ServiceLifetime serviceLifetime, bool replace = false)
             where TService : class
             where TImplementation : class, TService
-            => graphQLBuilder.Register(typeof(TService), typeof(TImplementation), serviceLifetime);
+            => graphQLBuilder.Register(typeof(TService), typeof(TImplementation), serviceLifetime, replace);
 
         /// <summary>
         /// Registers the service of type <typeparamref name="TService"/> with the dependency injection provider.
+        /// Optionally removes any existing implementation of the same service type.
         /// </summary>
-        public static IGraphQLBuilder Register<TService>(this IGraphQLBuilder graphQLBuilder, Func<IServiceProvider, TService> implementationFactory, ServiceLifetime serviceLifetime)
+        public static IGraphQLBuilder Register<TService>(this IGraphQLBuilder graphQLBuilder, Func<IServiceProvider, TService> implementationFactory, ServiceLifetime serviceLifetime, bool replace = false)
             where TService : class
-            => graphQLBuilder.Register(typeof(TService), implementationFactory ?? throw new ArgumentNullException(nameof(implementationFactory)), serviceLifetime);
+            => graphQLBuilder.Register(typeof(TService), implementationFactory ?? throw new ArgumentNullException(nameof(implementationFactory)), serviceLifetime, replace);
 
         /// <summary>
         /// Registers <paramref name="implementationInstance"/> as type <typeparamref name="TService"/> with the dependency injection provider.
+        /// Optionally removes any existing implementation of the same service type.
         /// </summary>
-        public static IGraphQLBuilder Register<TService>(this IGraphQLBuilder graphQLBuilder, TService implementationInstance)
+        public static IGraphQLBuilder Register<TService>(this IGraphQLBuilder graphQLBuilder, TService implementationInstance, bool replace = false)
             where TService : class
-            => graphQLBuilder.Register(typeof(TService), implementationInstance ?? throw new ArgumentNullException(nameof(implementationInstance)));
+            => graphQLBuilder.Register(typeof(TService), implementationInstance ?? throw new ArgumentNullException(nameof(implementationInstance)), replace);
 
         /// <inheritdoc cref="TryRegister{TService}(IGraphQLBuilder, Func{IServiceProvider, TService}, ServiceLifetime)"/>
         public static IGraphQLBuilder TryRegister<TService>(this IGraphQLBuilder graphQLBuilder, ServiceLifetime serviceLifetime)
@@ -634,7 +637,7 @@ namespace GraphQL
         /// </summary>
         public static IGraphQLBuilder AddDocumentWriter<TDocumentWriter>(this IGraphQLBuilder builder)
             where TDocumentWriter : class, IDocumentWriter
-            => builder.Register<IDocumentWriter, TDocumentWriter>(ServiceLifetime.Singleton);
+            => builder.Register<IDocumentWriter, TDocumentWriter>(ServiceLifetime.Singleton, true);
 
         /// <summary>
         /// Registers <paramref name="documentWriter"/> as a singleton of type <see cref="IDocumentWriter"/> within the
@@ -642,7 +645,7 @@ namespace GraphQL
         /// </summary>
         public static IGraphQLBuilder AddDocumentWriter<TDocumentWriter>(this IGraphQLBuilder builder, TDocumentWriter documentWriter)
             where TDocumentWriter : class, IDocumentWriter
-            => builder.Register<IDocumentWriter>(documentWriter ?? throw new ArgumentNullException(nameof(documentWriter)));
+            => builder.Register<IDocumentWriter>(documentWriter ?? throw new ArgumentNullException(nameof(documentWriter)), true);
 
         /// <summary>
         /// Registers <typeparamref name="TDocumentWriter"/> as a singleton of type <see cref="IDocumentWriter"/> within the
@@ -650,7 +653,7 @@ namespace GraphQL
         /// </summary>
         public static IGraphQLBuilder AddDocumentWriter<TDocumentWriter>(this IGraphQLBuilder builder, Func<IServiceProvider, TDocumentWriter> documentWriterFactory)
             where TDocumentWriter : class, IDocumentWriter
-            => builder.Register<IDocumentWriter>(documentWriterFactory ?? throw new ArgumentNullException(nameof(documentWriterFactory)), ServiceLifetime.Singleton);
+            => builder.Register<IDocumentWriter>(documentWriterFactory ?? throw new ArgumentNullException(nameof(documentWriterFactory)), ServiceLifetime.Singleton, true);
         #endregion
 
         #region - ConfigureSchema and ConfigureExecution -

--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using GraphQL.Caching;
 using GraphQL.DI;
 using GraphQL.Execution;
@@ -677,6 +678,18 @@ namespace GraphQL
         /// </remarks>
         public static IGraphQLBuilder ConfigureExecution(this IGraphQLBuilder builder, Action<ExecutionOptions> action)
             => builder.Register<IConfigureExecution>(new ConfigureExecution(action ?? throw new ArgumentNullException(nameof(action))));
+
+        /// <summary>
+        /// Configures an asynchronous action to run immediately prior to document execution.
+        /// Assumes that the document executer is <see cref="DocumentExecuter"/>, or that it derives from <see cref="DocumentExecuter"/> and calls
+        /// <see cref="DocumentExecuter(IDocumentBuilder, IDocumentValidator, IComplexityAnalyzer, IDocumentCache, System.Collections.Generic.IEnumerable{IConfigureExecution})"/>
+        /// within the constructor.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ExecutionOptions.RequestServices"/> can be used within the delegate to access the service provider for this execution.
+        /// </remarks>
+        public static IGraphQLBuilder ConfigureExecution(this IGraphQLBuilder builder, Func<ExecutionOptions, Task> action)
+            => builder.Register<IConfigureExecution>(new ConfigureExecutionAsync(action ?? throw new ArgumentNullException(nameof(action))));
         #endregion
 
         #region - AddValidationRule -


### PR DESCRIPTION
- Allow casting IGraphQLBuilder to IServiceCollection so that a reference to GraphQL.MicrosoftDI is not needed if it is necessary to access the underlying IServiceCollection
- Allow asynchronous execution configurations
- Allow service registrations that replace existing registrations