### PR TITLE
fix 'DateTimeOffset's Offset loss

### DIFF
--- a/src/GraphQL.Tests/Types/DateTimeOffsetGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DateTimeOffsetGraphTypeTests.cs
@@ -51,8 +51,10 @@ namespace GraphQL.Tests.Types
         {
             CultureTestHelper.UseCultures(() =>
             {
-                _type.ParseValue("2015-11-21T19:59:32.987+0200").ShouldBe(
-                    new DateTimeOffset(2015, 11, 21, 19, 59, 32, 987, TimeSpan.FromHours(2)));
+                var dateTimeOffset = (DateTimeOffset)_type.ParseValue("2015-11-21T19:59:32.987+0200");
+                dateTimeOffset.Date.ShouldBe(new DateTime(2015, 11, 21));
+                dateTimeOffset.TimeOfDay.ShouldBe(new TimeSpan(0, 19, 59, 32, 987));
+                dateTimeOffset.Offset.ShouldBe(TimeSpan.FromHours(2));
             });
         }
 

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -43,7 +43,7 @@ namespace GraphQL.Types
             // ISO-8601 format
             // Note that the "O" format is similar but always prints the fractional parts
             // of the second, which is not required by ISO-8601.
-            if (DateTimeOffset.TryParseExact(stringValue, "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var date))
+            if (DateTimeOffset.TryParseExact(stringValue, "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out var date))
             {
                 return date;
             }


### PR DESCRIPTION
`DateTimeOffsetGraphType.ParseDate` drops the offset and there is no way to get the original client's offset. I've removed flag ` DateTimeStyles.AdjustToUniversal` and changed test: later it checked using `DateTimeOffset.Equals` that compares UTC time. Now it checks properties separately to avoid data loss.