### PR TITLE
Update AutoRegisteringObjectGraphType nullable types

### DIFF
--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -25,7 +25,7 @@ namespace GraphQL.Types
         /// Creates a GraphQL type from <typeparamref name="TSourceType"/> by specifying fields to exclude from registration.
         /// </summary>
         /// <param name="excludedProperties"> Expressions for excluding fields, for example 'o => o.Age'. </param>
-        public AutoRegisteringObjectGraphType(params Expression<Func<TSourceType, object>>[]? excludedProperties)
+        public AutoRegisteringObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
         {
             AutoRegisteringHelper.SetFields(this, GetRegisteredProperties(), excludedProperties);
         }
@@ -54,7 +54,7 @@ namespace GraphQL.Types
         /// Creates a GraphQL type from <typeparamref name="TSourceType"/> by specifying fields to exclude from registration.
         /// </summary>
         /// <param name="excludedProperties"> Expressions for excluding fields, for example 'o => o.Age'. </param>
-        public AutoRegisteringInputObjectGraphType(params Expression<Func<TSourceType, object>>[]? excludedProperties)
+        public AutoRegisteringInputObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
         {
             AutoRegisteringHelper.SetFields(this, GetRegisteredProperties(), excludedProperties);
         }
@@ -67,7 +67,7 @@ namespace GraphQL.Types
 
     internal static class AutoRegisteringHelper
     {
-        internal static void SetFields<TSourceType>(ComplexGraphType<TSourceType> type, IEnumerable<PropertyInfo> properties, params Expression<Func<TSourceType, object>>[]? excludedProperties)
+        internal static void SetFields<TSourceType>(ComplexGraphType<TSourceType> type, IEnumerable<PropertyInfo> properties, params Expression<Func<TSourceType, object?>>[]? excludedProperties)
         {
             type.Name = typeof(TSourceType).GraphQLName();
 
@@ -96,7 +96,7 @@ namespace GraphQL.Types
             return propertyInfo.PropertyType.IsGenericType && propertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
 
-        private static string GetPropertyName<TSourceType>(Expression<Func<TSourceType, object>> expression)
+        private static string GetPropertyName<TSourceType>(Expression<Func<TSourceType, object?>> expression)
         {
             if (expression.Body is MemberExpression m1)
                 return m1.Member.Name;


### PR DESCRIPTION
Updated AutoRegisteringObjectGraphType and AutoRegisteringInputObjectGraphType constructors to allow nullable properties to be ignored