### PR TITLE
Use consistent version of System.Runtime.CompilerServices.Unsafe for netstandard2.0

### DIFF
--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The `netstandard2.0` build of `GraphQL` currently depends on two different versions of `System.Runtime.CompilerServices.Unsafe`:

|Version|From|
|-|-|
|4.5.3|System.Memory 4.5.4|
|4.7.1|GraphQL.csproj|

This forces consumers to either use binding redirects, or GAC multiple versions of the assembly. Since there's only one case where the assembly is used, and that functionality is supported in `4.5.3` it seems like we should just align to that version.