### PR TITLE
Add SchemaTypes.Initialize

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2427,7 +2427,7 @@ namespace GraphQL.Types
         protected virtual System.Type? GetGraphTypeFromClrType(System.Type clrType, bool isInputType, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "ClrType",
                 "GraphType"})] System.Collections.Generic.List<System.ValueTuple<System.Type, System.Type>> typeMappings) { }
-        protected virtual void Initialize(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
+        protected void Initialize(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
     }
     public class ShortGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2427,6 +2427,7 @@ namespace GraphQL.Types
         protected virtual System.Type? GetGraphTypeFromClrType(System.Type clrType, bool isInputType, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "ClrType",
                 "GraphType"})] System.Collections.Generic.List<System.ValueTuple<System.Type, System.Type>> typeMappings) { }
+        protected virtual void Initialize(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
     }
     public class ShortGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
@@ -4,7 +4,9 @@ using GraphQL.DI;
 using GraphQL.StarWars;
 using GraphQL.StarWars.IoC;
 using GraphQL.StarWars.Types;
+using GraphQL.Types;
 using Moq;
+using Shouldly;
 using Xunit;
 
 namespace GraphQL.Tests.Types.Collections
@@ -36,6 +38,27 @@ namespace GraphQL.Tests.Types.Collections
             mock.Verify(x => x.GetService(typeof(EpisodeEnum)), Times.Once);
             mock.Verify(x => x.GetService(typeof(IEnumerable<IConfigureSchema>)), Times.Once);
             mock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void cannot_call_initialize_more_than_once()
+        {
+            _ = new SchemaTypes_Test_Cannot_Initialize_More_Than_Once();
+        }
+
+        private class SchemaTypes_Test_Cannot_Initialize_More_Than_Once : SchemaTypes
+        {
+            public SchemaTypes_Test_Cannot_Initialize_More_Than_Once()
+            {
+                var serviceProvider = new DefaultServiceProvider();
+                var schema = new Schema(serviceProvider)
+                {
+                    Query = new ObjectGraphType()
+                };
+                schema.Query.AddField(new FieldType { Name = "field1", Type = typeof(IntGraphType) });
+                Initialize(schema, serviceProvider);
+                Should.Throw<InvalidOperationException>(() => Initialize(schema, serviceProvider));
+            }
         }
     }
 }

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -104,18 +104,22 @@ namespace GraphQL.Types
             Initialize(schema, serviceProvider);
         }
 
+        private bool _initialized = false;
         /// <summary>
         /// Initializes the instance for the specified schema, and with the specified type resolver.
         /// </summary>
         /// <param name="schema">A schema for which this instance is created.</param>
         /// <param name="serviceProvider">A service provider used to resolve graph types.</param>
         /// </summary>
-        protected virtual void Initialize(ISchema schema, IServiceProvider serviceProvider)
+        protected void Initialize(ISchema schema, IServiceProvider serviceProvider)
         {
             if (schema == null)
                 throw new ArgumentNullException(nameof(schema));
             if (serviceProvider == null)
                 throw new ArgumentNullException(nameof(serviceProvider));
+            if (_initialized)
+                throw new InvalidOperationException("SchemaTypes has already been initialized.");
+            _initialized = true;
 
             var types = GetSchemaTypes(schema, serviceProvider);
             var typeMappingsEnumerable = schema.TypeMappings ?? throw new ArgumentNullException(nameof(schema) + "." + nameof(ISchema.TypeMappings));

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -45,7 +45,7 @@ namespace GraphQL.Types
         };
 
         // Introspection types http://spec.graphql.org/June2018/#sec-Schema-Introspection
-        private readonly Dictionary<Type, IGraphType> _introspectionTypes;
+        private Dictionary<Type, IGraphType> _introspectionTypes;
 
         // Standard scalars https://graphql.github.io/graphql-spec/June2018/#sec-Scalars
         private readonly Dictionary<Type, IGraphType> _builtInScalars = new IGraphType[]
@@ -80,8 +80,8 @@ namespace GraphQL.Types
         }
         .ToDictionary(t => t.GetType());
 
-        private readonly TypeCollectionContext _context;
-        private readonly INameConverter _nameConverter;
+        private TypeCollectionContext _context;
+        private INameConverter _nameConverter;
 
         /// <summary>
         /// Initializes a new instance with no types registered.
@@ -97,7 +97,20 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="schema">A schema for which this instance is created.</param>
         /// <param name="serviceProvider">A service provider used to resolve graph types.</param>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public SchemaTypes(ISchema schema, IServiceProvider serviceProvider)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+            Initialize(schema, serviceProvider);
+        }
+
+        /// <summary>
+        /// Initializes the instance for the specified schema, and with the specified type resolver.
+        /// </summary>
+        /// <param name="schema">A schema for which this instance is created.</param>
+        /// <param name="serviceProvider">A service provider used to resolve graph types.</param>
+        /// </summary>
+        protected virtual void Initialize(ISchema schema, IServiceProvider serviceProvider)
         {
             if (schema == null)
                 throw new ArgumentNullException(nameof(schema));
@@ -234,7 +247,7 @@ namespace GraphQL.Types
         /// Returns a dictionary that relates type names to graph types.
         /// </summary>
         protected internal virtual Dictionary<string, IGraphType> Dictionary { get; } = new Dictionary<string, IGraphType>();
-        private readonly Dictionary<Type, IGraphType> _typeDictionary;
+        private Dictionary<Type, IGraphType> _typeDictionary;
 
         /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
         public IEnumerator<IGraphType> GetEnumerator() => Dictionary.Values.GetEnumerator();


### PR DESCRIPTION
The current design of `SchemaTypes` is such that no properties can be set on derived classes before initialization occurs.  For example, this code doesn't work:

```cs
private class MySchemaTypes : SchemaTypes
{
    private readonly Dictionary<Type, Type> _mapping;

    public MySchemaTypes(ISchema schema, IServiceProvider serviceProvider, Dictionary<Type, Type> customMapping)
        : base(schema, serviceProvider)
    {
        _mapping = customMapping;
    }

    protected override Type? GetGraphTypeFromClrType(Type clrType, bool isInputType, List<(Type ClrType, Type GraphType)> typeMappings)
    {
        var ret = base.GetGraphTypeFromClrType(clrType, isInputType, typeMappings);
        if (ret != null) return ret;

        //custom logic here, which requires values passed into the constructor
        if (!isInputType)
            return _mapping[clrType]; //throws null reference exception!!!

        return null;
    }
}
```

This PR fixes that by adding a protected `Initialize(schema, serviceProvider)` method, which can be called by the default constructor like so:

```cs
private class MySchemaTypes : SchemaTypes
{
    private readonly Dictionary<Type, Type> _mapping;

    public MySchemaTypes(ISchema schema, IServiceProvider serviceProvider, Dictionary<Type, Type> customMapping)
    {
        _mapping = customMapping;
        Initialize(schema, serviceProvider);
    }

    protected override Type? GetGraphTypeFromClrType(Type clrType, bool isInputType, List<(Type ClrType, Type GraphType)> typeMappings)
    {
        var ret = base.GetGraphTypeFromClrType(clrType, isInputType, typeMappings);
        if (ret != null) return ret;

        //custom logic here, which requires values passed into the constructor
        if (!isInputType)
            return _mapping[clrType]; //works now

        return null;
    }
}
```
