### PR TITLE
Enable SchemaPrinter to sort output

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2744,6 +2744,7 @@ namespace GraphQL.Utilities
     public class SchemaPrinterOptions
     {
         public SchemaPrinterOptions() { }
+        public GraphQL.Introspection.ISchemaComparer? Comparer { get; set; }
         public bool IncludeDeprecationReasons { get; set; }
         public bool IncludeDescriptions { get; set; }
         public bool OldImplementsSyntax { get; set; }

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -1750,7 +1750,7 @@ enum Beta {
 }
 ");
             var printer = new SchemaPrinter(schema, new SchemaPrinterOptions { Comparer = new GraphQL.Introspection.AlphabeticalSchemaComparer() });
-            var ret = printer.Print();
+            var actual = printer.Print();
             var expected = @"directive @test1(
   arg2: Boolean!
   arg1: Boolean!
@@ -1787,9 +1787,8 @@ type Zebra {
   field3: String
 }
 ";
-            ret.ShouldBe(expected, StringCompareShould.IgnoreLineEndings);
+            actual.ShouldBe(expected, StringCompareShould.IgnoreLineEndings);
         }
-
 
         public class FooType : ObjectGraphType
         {

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -855,6 +855,42 @@ union SingleUnion = Foo
         }
 
         [Fact]
+        public void prints_input_type_with_default_as_dictionary()
+        {
+            var schema = Schema.For(@"
+input SomeInput {
+  age: Int!
+  name: String!
+  isDeveloper: Boolean!
+}
+
+type Query {
+  str(argOne: SomeInput! = { age: 42, name: ""Tom"", isDeveloper: true },
+      argTwo: [SomeInput] = [{ age: 12, name: ""Tom1"", isDeveloper: false }, { age: 22, name: ""Tom2"", isDeveloper: true }]): String!
+}
+");
+
+            var expected = new Dictionary<string, string>
+            {
+                {
+                    "SomeInput",
+@"input SomeInput {
+  age: Int!
+  name: String!
+  isDeveloper: Boolean!
+}"
+                },
+                                {
+                    "Query",
+@"type Query {
+  str(argOne: SomeInput! = { age: 42, name: ""Tom"", isDeveloper: true }, argTwo: [SomeInput] = [{ age: 12, name: ""Tom1"", isDeveloper: false }, { age: 22, name: ""Tom2"", isDeveloper: true }]): String!
+}"
+                },
+            };
+            AssertEqual(print(schema), expected);
+        }
+
+        [Fact]
         public void prints_custom_scalar()
         {
             var root = new ObjectGraphType { Name = "Query" };

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -862,6 +862,7 @@ input SomeInput {
   age: Int!
   name: String!
   isDeveloper: Boolean!
+  unused: Boolean
 }
 
 type Query {
@@ -878,12 +879,44 @@ type Query {
   age: Int!
   name: String!
   isDeveloper: Boolean!
+  unused: Boolean
 }"
                 },
                                 {
                     "Query",
 @"type Query {
   str(argOne: SomeInput! = { age: 42, name: ""Tom"", isDeveloper: true }, argTwo: [SomeInput] = [{ age: 12, name: ""Tom1"", isDeveloper: false }, { age: 22, name: ""Tom2"", isDeveloper: true }]): String!
+}"
+                },
+            };
+            AssertEqual(print(schema), expected);
+        }
+
+        [Fact]
+        public void prints_input_type_with_default_as_dictionary_null_values()
+        {
+            var schema = Schema.For(@"
+input SomeInput {
+  age: Int = 2
+}
+
+type Query {
+  str(arg: SomeInput = { age: null }): String!
+}
+");
+
+            var expected = new Dictionary<string, string>
+            {
+                {
+                    "SomeInput",
+@"input SomeInput {
+  age: Int = 2
+}"
+                },
+                                {
+                    "Query",
+@"type Query {
+  str(arg: SomeInput = { age: null }): String!
 }"
                 },
             };

--- a/src/GraphQL/Introspection/ISchemaComparer.cs
+++ b/src/GraphQL/Introspection/ISchemaComparer.cs
@@ -4,7 +4,7 @@ using GraphQL.Types;
 namespace GraphQL.Introspection
 {
     /// <summary>
-    /// Provides the ability to order the schema elements upon introspection.
+    /// Provides the ability to order the schema elements upon introspection or printing.
     /// </summary>
     public interface ISchemaComparer
     {

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -356,7 +356,8 @@ namespace GraphQL.Utilities
                 if (value is IDictionary<string, object?> dic)
                 {
                     // note: per spec, unspecified properties may not exist within the dictionary
-                    if (!dic.TryGetValue(propertyName, out propertyValue)) continue;
+                    if (!dic.TryGetValue(propertyName, out propertyValue))
+                        continue;
                 }
                 // if 'value' is stored as an object -- e.g. new MyObject { Value = "Test" } -- then pull from the property directly
                 else

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -10,6 +10,12 @@ using GraphQL.Types;
 
 namespace GraphQL.Utilities
 {
+    internal static class SchemaPrinterExtensions
+    {
+        public static IEnumerable<T> OrderBy<T>(this IEnumerable<T> list, IComparer<T>? comparer)
+            => comparer == null ? list : list.OrderBy(x => x, comparer);
+    }
+
     /// <summary>
     /// Enables printing schema as SDL (Schema Definition Language) document.
     /// <br/>
@@ -90,8 +96,8 @@ namespace GraphQL.Utilities
             {
                 PrintSchemaDefinition(Schema),
             }
-            .Concat(directives.Select(PrintDirective))
-            .Concat(types.Select(PrintType))
+            .Concat(directives.OrderBy(Options.Comparer?.DirectiveComparer).Select(PrintDirective))
+            .Concat(types.OrderBy(Options.Comparer?.TypeComparer).Select(PrintType))
             .Where(x => x != null)
             .ToList();
 
@@ -209,19 +215,20 @@ namespace GraphQL.Utilities
 
         public string PrintEnum(EnumerationGraphType type)
         {
-            var values = string.Join(Environment.NewLine, type.Values.Select(x => FormatDescription(x.Description, "  ") + "  " + x.Name + (Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : "")));
+            var values = string.Join(Environment.NewLine, type.Values.OrderBy(Options.Comparer?.EnumValueComparer(type)).Select(x => FormatDescription(x.Description, "  ") + "  " + x.Name + (Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : "")));
             return FormatDescription(type.Description) + "enum {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, values);
         }
 
         public string PrintInputObject(IInputObjectGraphType type)
         {
-            var fields = type.Fields.Select(x => PrintInputValue(x));
+            var fields = type.Fields.OrderBy<FieldType>(Options.Comparer?.FieldComparer(type)).Select(x => PrintInputValue(x));
             return FormatDescription(type.Description) + "input {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, string.Join(Environment.NewLine, fields));
         }
 
         public virtual string PrintFields(IComplexGraphType type)
         {
             var fields = type?.Fields
+                .OrderBy<FieldType>(Options.Comparer?.FieldComparer(type))
                 .Select(x =>
                 new
                 {
@@ -243,7 +250,7 @@ namespace GraphQL.Utilities
                 return string.Empty;
             }
 
-            return "({0})".ToFormat(string.Join(", ", field.Arguments.Select(PrintInputValue))); //TODO: iterator allocation
+            return "({0})".ToFormat(string.Join(", ", field.Arguments.OrderBy(Options.Comparer?.ArgumentComparer(field)).Select(PrintInputValue))); //TODO: iterator allocation
         }
 
         public string PrintInputValue(FieldType field)
@@ -296,11 +303,13 @@ namespace GraphQL.Utilities
         {
             if (arguments == null || arguments.Count == 0)
                 return null;
+            //v5 todo: sort directive arguments list via Options.Comparer -- needs ArgumentComparer(DirectiveGraphType directive)
             return string.Join(Environment.NewLine, arguments.Select(arg => $"  {PrintInputValue(arg)}"));
         }
 
         private string FormatDirectiveLocationList(IEnumerable<DirectiveLocation> locations)
         {
+            //v5 todo: sort DirectiveLocation list via Options.Comparer -- needs DirectiveLocationComparer(DirectiveGraphType directive)
             return string.Join(" | ", locations.Select(x => __DirectiveLocation.Instance.Serialize(x))); //TODO: remove allocations
         }
 
@@ -338,21 +347,25 @@ namespace GraphQL.Utilities
             var sb = new StringBuilder();
             sb.Append("{ ");
 
-            foreach (var field in input.Fields)
+            foreach (var field in input.Fields.OrderBy(Options.Comparer?.FieldComparer(input)))
             {
                 string propertyName = field.GetMetadata<string>(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME) ?? field.Name;
-                PropertyInfo propertyInfo;
 
-                try
+                if (!(value is IDictionary<string, object?> dic && dic.TryGetValue(propertyName, out var propertyValue)))
                 {
-                    propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-                }
-                catch (AmbiguousMatchException)
-                {
-                    propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                    PropertyInfo propertyInfo;
+                    try
+                    {
+                        propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                    }
+                    catch (AmbiguousMatchException)
+                    {
+                        propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                    }
+
+                    propertyValue = propertyInfo.GetValue(value);
                 }
 
-                object propertyValue = propertyInfo.GetValue(value);
                 if (propertyValue != null)
                 {
                     sb.Append(field.Name)

--- a/src/GraphQL/Utilities/SchemaPrinterOptions.cs
+++ b/src/GraphQL/Utilities/SchemaPrinterOptions.cs
@@ -1,3 +1,5 @@
+using GraphQL.Introspection;
+
 namespace GraphQL.Utilities
 {
     /// <summary>
@@ -24,5 +26,11 @@ namespace GraphQL.Utilities
         /// Indicates whether to print descriptions as comments for compatibility with the 2016 GraphQL specification.
         /// </summary>
         public bool PrintDescriptionsAsComments { get; set; } = true;
+
+        /// <summary>
+        /// Provides the ability to order the schema elements upon printing.
+        /// By default all elements are returned as-is; no sorting is applied.
+        /// </summary>
+        public ISchemaComparer? Comparer { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #2685 

Note: due to the limitations of `ISchemaComparer`, there is no way to sort directive locations or directive arguments.  Changing an interface signature is a breaking change and will need to be done in v5; an issue will be created to address this.  I think this is still worthwhile to include the other changes in v4.

Another temporary solution would be to evaluate `Options.Comparer is AlphabeticalSchemaComparer`, and if so, sort the members alphabetically.  I did not do so.