### PR TITLE
Nulls passed to DataLoader LoadAsync pass through as default results

### DIFF
--- a/src/GraphQL.DataLoader/DataLoaderExtensions.cs
+++ b/src/GraphQL.DataLoader/DataLoaderExtensions.cs
@@ -28,7 +28,9 @@ namespace GraphQL.DataLoader
 
             foreach (var key in keys)
             {
-                results.Add(dataLoader.LoadAsync(key));
+                results.Add(key != null
+                    ? dataLoader.LoadAsync(key)
+                    : new DataLoaderResult<T>(Task.FromResult<T>(default)));
             }
 
             return new DataLoaderResultWhenAll<T>(results);


### PR DESCRIPTION
I have a usecase where chained dataloaders are used to check for a valid permission. A dataloader of type `IDataLoader<T, T?>` (input and output of same type), if permission is missing, the value is null.

I've tried several different ways to approach this and settled on returning null in the results, however, DataLoader's `LoadAsync` doesn't accept nulls.