### PR TITLE
Update nullability attribute of typed Source fields

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -404,7 +404,7 @@ namespace GraphQL
         public static T ToObject<T>(this System.Collections.Generic.IDictionary<string, object?> source)
             where T :  class { }
     }
-    public class ReadonlyResolveFieldContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<object>
+    public class ReadonlyResolveFieldContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<object?>
     {
         public ReadonlyResolveFieldContext(GraphQL.Execution.ExecutionNode node, GraphQL.Execution.ExecutionContext context) { }
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue>? Arguments { get; }
@@ -429,7 +429,7 @@ namespace GraphQL
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; }
         public GraphQL.Language.AST.Variables Variables { get; }
     }
-    public class ResolveFieldContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<object>
+    public class ResolveFieldContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<object?>
     {
         public ResolveFieldContext() { }
         public ResolveFieldContext(GraphQL.IResolveFieldContext context) { }
@@ -1787,7 +1787,7 @@ namespace GraphQL.Subscription
 {
     public interface IResolveEventStreamContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext { }
     public interface IResolveEventStreamContext<out TSource> : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<TSource>, GraphQL.Subscription.IResolveEventStreamContext { }
-    public class ResolveEventStreamContext : GraphQL.Subscription.ResolveEventStreamContext<object>, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.Subscription.IResolveEventStreamContext
+    public class ResolveEventStreamContext : GraphQL.Subscription.ResolveEventStreamContext<object?>, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.Subscription.IResolveEventStreamContext
     {
         public ResolveEventStreamContext() { }
     }
@@ -2272,7 +2272,7 @@ namespace GraphQL.Types
         public NonNullGraphType() { }
         public override System.Type Type { get; }
     }
-    public class ObjectGraphType : GraphQL.Types.ObjectGraphType<object>
+    public class ObjectGraphType : GraphQL.Types.ObjectGraphType<object?>
     {
         public ObjectGraphType() { }
     }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -101,6 +101,6 @@ namespace GraphQL
     public interface IResolveFieldContext<out TSource> : IResolveFieldContext
     {
         /// <inheritdoc cref="IResolveFieldContext.Source"/>
-        new TSource? Source { get; }
+        new TSource Source { get; }
     }
 }

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -11,7 +11,7 @@ namespace GraphQL
     /// <summary>
     /// A readonly implementation of <see cref="IResolveFieldContext"/>.
     /// </summary>
-    public class ReadonlyResolveFieldContext : IResolveFieldContext<object>
+    public class ReadonlyResolveFieldContext : IResolveFieldContext<object?>
     {
         // WARNING: if you add a new field here, then don't forget to clear it in Reset method!
         private ExecutionNode _executionNode;

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -12,7 +12,7 @@ namespace GraphQL
     /// <summary>
     /// A mutable implementation of <see cref="IResolveFieldContext"/>
     /// </summary>
-    public class ResolveFieldContext : IResolveFieldContext<object>
+    public class ResolveFieldContext : IResolveFieldContext<object?>
     {
         /// <inheritdoc/>
         public Field FieldAst { get; set; }
@@ -132,9 +132,9 @@ namespace GraphQL
         }
 
         /// <inheritdoc cref="ResolveFieldContext.Source"/>
-        public new TSource? Source
+        public new TSource Source
         {
-            get => (TSource?)base.Source;
+            get => (TSource)base.Source!;
             set => base.Source = value;
         }
     }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -27,7 +27,7 @@ namespace GraphQL
         internal void Reset()
         {
             _baseContext = null!;
-            Source = default;
+            Source = default!;
         }
 
         internal ResolveFieldContextAdapter<T> Set(IResolveFieldContext baseContext)
@@ -42,7 +42,7 @@ namespace GraphQL
             {
                 try
                 {
-                    Source = (T?)baseContext.Source;
+                    Source = (T)baseContext.Source!;
                 }
                 catch (InvalidCastException)
                 {
@@ -53,7 +53,7 @@ namespace GraphQL
             return this;
         }
 
-        public T? Source { get; private set; }
+        public T Source { get; private set; }
 
         public Field FieldAst => _baseContext.FieldAst;
 

--- a/src/GraphQL/Subscription/ResolveEventStreamContext.cs
+++ b/src/GraphQL/Subscription/ResolveEventStreamContext.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Subscription
         public ResolveEventStreamContext(IResolveEventStreamContext context) : base(context) { }
     }
 
-    public class ResolveEventStreamContext : ResolveEventStreamContext<object>, IResolveEventStreamContext
+    public class ResolveEventStreamContext : ResolveEventStreamContext<object?>, IResolveEventStreamContext
     {
     }
 }

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -110,7 +110,6 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="schema">A schema for which this instance is created.</param>
         /// <param name="serviceProvider">A service provider used to resolve graph types.</param>
-        /// </summary>
         protected void Initialize(ISchema schema, IServiceProvider serviceProvider)
         {
             if (schema == null)

--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -66,7 +66,7 @@ namespace GraphQL.Types
     /// <summary>
     /// Represents a default base class for all object (that is, having their own properties) output graph types.
     /// </summary>
-    public class ObjectGraphType : ObjectGraphType<object>
+    public class ObjectGraphType : ObjectGraphType<object?>
     {
     }
 }

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -61,7 +61,7 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
 
             // 2.3
-            if (!field.ResolvedType.IsOutputType())
+            if (!field.ResolvedType!.IsOutputType())
                 throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must be an output type.");
 
             ValidateFieldArgumentsUniqueness(field, type);
@@ -81,7 +81,7 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
 
             // 2.4.2
-            if (!argument.ResolvedType.IsInputType())
+            if (!argument.ResolvedType!.IsInputType())
                 throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must be an input type.");
 
             // validate default value
@@ -123,7 +123,7 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
 
             // 2.3
-            if (!field.ResolvedType.IsOutputType())
+            if (!field.ResolvedType!.IsOutputType())
                 throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must be an output type.");
 
             ValidateFieldArgumentsUniqueness(field, type);
@@ -143,7 +143,7 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
 
             // 2.4.2
-            if (!argument.ResolvedType.IsInputType())
+            if (!argument.ResolvedType!.IsInputType())
                 throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must be an input type.");
 
             // validate default value
@@ -185,15 +185,15 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
 
             // 2.3
-            if (!field.ResolvedType.IsInputType())
+            if (!field.ResolvedType!.IsInputType())
                 throw new InvalidOperationException($"The input field '{field.Name}' of an Input Object '{type.Name}' must be an input type.");
 
             // validate default value
             if (field.DefaultValue is GraphQLValue value)
             {
-                field.DefaultValue = Execution.ExecutionHelper.CoerceValue(field.ResolvedType, Language.CoreToVanillaConverter.Value(value)).Value;
+                field.DefaultValue = Execution.ExecutionHelper.CoerceValue(field.ResolvedType!, Language.CoreToVanillaConverter.Value(value)).Value;
             }
-            else if (field.DefaultValue != null && !field.ResolvedType.IsValidDefault(field.DefaultValue))
+            else if (field.DefaultValue != null && !field.ResolvedType!.IsValidDefault(field.DefaultValue))
             {
                 throw new InvalidOperationException($"The default value of Input Object type field '{type.Name}.{field.Name}' is invalid.");
             }
@@ -265,15 +265,15 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
 
             // 4.2
-            if (!argument.ResolvedType.IsInputType())
+            if (!argument.ResolvedType!.IsInputType())
                 throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{type.Name}' must be an input type.");
 
             // validate default
             if (argument.DefaultValue is GraphQLValue value)
             {
-                argument.DefaultValue = Execution.ExecutionHelper.CoerceValue(argument.ResolvedType, Language.CoreToVanillaConverter.Value(value)).Value;
+                argument.DefaultValue = Execution.ExecutionHelper.CoerceValue(argument.ResolvedType!, Language.CoreToVanillaConverter.Value(value)).Value;
             }
-            else if (argument.DefaultValue != null && !argument.ResolvedType.IsValidDefault(argument.DefaultValue))
+            else if (argument.DefaultValue != null && !argument.ResolvedType!.IsValidDefault(argument.DefaultValue))
             {
                 throw new InvalidOperationException($"The default value of argument '{argument.Name}' of directive '{type.Name}' is invalid.");
             }


### PR DESCRIPTION
Fixes #2705

With this PR, `IResolveFieldContext<T>.Source` is not marked as nullable (unless `T` is a nullable type).  This is useful because in almost every use case, `Source` is not nullable -- only field resolvers within the root node (Query, Mutation, or Subscription) can have a null `Source` property.

`IResolveFieldContext.Source` is still typed as `object?`, and `ObjectGraphType` derives from `ObjectGraphType<object?>` so the `Source` property is still marked as nullable in these cases (since `ObjectGraphType` is most likely to be used for a root node).

Please note that this is a NON-breaking change, as nullability reference annotations do not change method signatures.  ~At least for reference types -- could this be a breaking change for generic types where the generic type is a value type?  I did not treat these changes as breaking changes previously.~