### PR TITLE
Allow nulls in data loaders to pass through

### DIFF
--- a/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
@@ -393,5 +393,19 @@ namespace GraphQL.DataLoader.Tests
             mock.Verify(x => x.GetUsersByIdAsync(new[] { 1 }, default), Times.Once,
                 "The keys passed to the fetch delegate should be de-duplicated");
         }
+
+        [Fact]
+        public async Task Returns_Null_For_Null_Reference_Types()
+        {
+            var loader = new BatchDataLoader<object, string>((_, _) => throw new Exception());
+            (await loader.LoadAsync(null).GetResultAsync()).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task Returns_Null_For_Null_Value_Types()
+        {
+            var loader = new BatchDataLoader<int?, string>((_, _) => throw new Exception());
+            (await loader.LoadAsync(null).GetResultAsync()).ShouldBeNull();
+        }
     }
 }

--- a/src/GraphQL.DataLoader.Tests/CollectionBatchLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/CollectionBatchLoaderTests.cs
@@ -152,5 +152,19 @@ namespace GraphQL.DataLoader.Tests
             mock.Verify(x => x.GetOrdersByUserIdAsync(new[] { 1 }, default), Times.Once,
                 "The keys passed to the fetch delegate should be de-duplicated");
         }
+
+        [Fact]
+        public async Task Returns_Null_For_Null_Reference_Types()
+        {
+            var loader = new CollectionBatchDataLoader<object, string>((_, _) => throw new Exception());
+            (await loader.LoadAsync(null).GetResultAsync()).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task Returns_Null_For_Null_Value_Types()
+        {
+            var loader = new CollectionBatchDataLoader<int?, string>((_, _) => throw new Exception());
+            (await loader.LoadAsync(null).GetResultAsync()).ShouldBeNull();
+        }
     }
 }

--- a/src/GraphQL.DataLoader/DataLoaderBase.cs
+++ b/src/GraphQL.DataLoader/DataLoaderBase.cs
@@ -79,6 +79,8 @@ namespace GraphQL.DataLoader
 
         /// <summary>
         /// Asynchronously load data for the provided given key.
+        /// If the key is <see langword="null"/> then a <see cref="DataLoaderResult{T}"/> containing
+        /// <see langword="null"/> will be immediately be returned.
         /// </summary>
         /// <param name="key">Key to use for loading data</param>
         /// <returns>
@@ -86,6 +88,11 @@ namespace GraphQL.DataLoader
         /// </returns>
         public virtual IDataLoaderResult<T> LoadAsync(TKey key)
         {
+            // dictionaries do not support keys with null values (null reference values or null value types),
+            // so in this case bypass the data loader and return null
+            if (key == null)
+                return DataLoaderResult<T>.DefaultValue;
+
             lock (_sync)
             {
                 //once it enters the lock, it is guaranteed to exit the lock, as it does not depend on external code
@@ -115,6 +122,7 @@ namespace GraphQL.DataLoader
 
         /// <summary>
         /// An abstract asynchronous function to load the values for a given list of keys.
+        /// None of the keys will be <see langword="null"/>.
         /// </summary>
         /// <remarks>
         /// This may be called on multiple threads if IDataLoader.LoadAsync is called on multiple threads.

--- a/src/GraphQL.DataLoader/DataLoaderBase.cs
+++ b/src/GraphQL.DataLoader/DataLoaderBase.cs
@@ -80,7 +80,7 @@ namespace GraphQL.DataLoader
         /// <summary>
         /// Asynchronously load data for the provided given key.
         /// If the key is <see langword="null"/> then a <see cref="DataLoaderResult{T}"/> containing
-        /// <see langword="null"/> will be immediately be returned.
+        /// <see langword="null"/> will be immediately returned.
         /// </summary>
         /// <param name="key">Key to use for loading data</param>
         /// <returns>

--- a/src/GraphQL.DataLoader/DataLoaderResult.cs
+++ b/src/GraphQL.DataLoader/DataLoaderResult.cs
@@ -13,6 +13,11 @@ namespace GraphQL.DataLoader
         private readonly Task<T> _result;
 
         /// <summary>
+        /// Returns an instance which always returns the default value.
+        /// </summary>
+        internal static readonly DataLoaderResult<T> DefaultValue = new(default(T));
+
+        /// <summary>
         /// Initializes a DataLoaderResult with the given asynchronous task
         /// </summary>
         public DataLoaderResult(Task<T> result)


### PR DESCRIPTION
Replaces:
- #2702

Not a breaking change because before an ArgumentNullException would have been thrown by the underlying dictionary.  So null values (reference or value types) were not supported previously.