### PR TITLE
Update GetArgument nullability definitions

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -462,7 +462,7 @@ namespace GraphQL
         public static GraphQL.IResolveFieldContext Copy(this GraphQL.IResolveFieldContext context) { }
         public static GraphQL.IResolveFieldContext<TSource> Copy<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
         public static object? GetArgument(this GraphQL.IResolveFieldContext context, System.Type argumentType, string name, object? defaultValue = null) { }
-        public static TType? GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType? defaultValue = default) { }
+        public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
         public static object? GetExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
         public static void SetExtension(this GraphQL.IResolveFieldContext context, string path, object? value) { }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -15,11 +15,11 @@ namespace GraphQL
         /// Returns the value of the specified field argument, or <paramref name="defaultValue"/> when unspecified or when specified as <see langword="null"/>.
         /// Field and variable default values take precedence over the <paramref name="defaultValue"/> parameter.
         /// </summary>
-        public static TType? GetArgument<TType>(this IResolveFieldContext context, string name, TType? defaultValue = default)
+        public static TType GetArgument<TType>(this IResolveFieldContext context, string name, TType defaultValue = default)
         {
             bool exists = context.TryGetArgument(typeof(TType), name, out object? result);
             return exists
-                ? result == null ? defaultValue : (TType?)result
+                ? result == null ? defaultValue : (TType)result
                 : defaultValue;
         }
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -15,7 +15,7 @@ namespace GraphQL
         /// Returns the value of the specified field argument, or <paramref name="defaultValue"/> when unspecified or when specified as <see langword="null"/>.
         /// Field and variable default values take precedence over the <paramref name="defaultValue"/> parameter.
         /// </summary>
-        public static TType GetArgument<TType>(this IResolveFieldContext context, string name, TType defaultValue = default)
+        public static TType GetArgument<TType>(this IResolveFieldContext context, string name, TType defaultValue = default!)
         {
             bool exists = context.TryGetArgument(typeof(TType), name, out object? result);
             return exists


### PR DESCRIPTION
See:
- #2705 

This is a non-breaking change.  I think it's the right answer.  If a user anticipates a null response, they can indicate it as such when they call `GetArgument` - for example `GetArgument<string?>`.