### PR TITLE
OperationName for ValidationContext

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.approved.txt
@@ -2887,17 +2887,17 @@ namespace GraphQL.Validation
     {
         public static readonly System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule> CoreRules;
         public DocumentValidator() { }
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "validationResult",
                 "variables"})]
-        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? inputs = null) { }
+        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? inputs = null, string? operationName = null) { }
     }
     public interface IDocumentValidator
     {
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "validationResult",
                 "variables"})]
-        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? inputs = null);
+        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? inputs = null, string? operationName = null);
     }
     public interface INodeVisitor
     {

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -142,7 +142,8 @@ namespace GraphQL
                         operation.Variables,
                         validationRules,
                         options.UserContext,
-                        options.Inputs);
+                        options.Inputs,
+                        options.OperationName);
                 }
 
                 if (options.ComplexityConfiguration != null && validationResult.IsValid && analyzeComplexity)

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -19,7 +19,8 @@ namespace GraphQL.Validation
             VariableDefinitions? variableDefinitions,
             IEnumerable<IValidationRule>? rules = null,
             IDictionary<string, object?> userContext = null!,
-            Inputs? inputs = null);
+            Inputs? inputs = null,
+            string? operationName = null);
     }
 
     /// <inheritdoc/>
@@ -67,7 +68,8 @@ namespace GraphQL.Validation
             VariableDefinitions? variableDefinitions,
             IEnumerable<IValidationRule>? rules = null,
             IDictionary<string, object?> userContext = null!,
-            Inputs? inputs = null)
+            Inputs? inputs = null,
+            string? operationName = null)
         {
             schema.Initialize();
 
@@ -77,6 +79,7 @@ namespace GraphQL.Validation
             context.TypeInfo = new TypeInfo(schema);
             context.UserContext = userContext;
             context.Inputs = inputs;
+            context.OperationName = operationName;
 
             try
             {


### PR DESCRIPTION
Hello. I guess `OperationName` property of `ValidationContext` has been always empty.