### PR TITLE
Add GraphQLRelayName extension

### DIFF
--- a/src/GraphQL.Tests/TypeExtensionsTests.cs
+++ b/src/GraphQL.Tests/TypeExtensionsTests.cs
@@ -32,6 +32,19 @@ namespace GraphQL.Tests
             TypeExtensions.IsNullable(type).ShouldBeTrue();
         }
 
+        [Theory]
+        [InlineData(typeof(TestEnum))]
+        [InlineData(typeof(FooType))]
+        [InlineData(typeof(FooTypes))]
+        [InlineData(typeof(Foo))]
+        public void allow_non_relay_types_to_have_type_in_name(Type type)
+        {
+            Assert.Equal(type.Name, TypeExtensions.GraphQLName(type));
+        }
+
         private enum TestEnum { }
+        private enum FooType { }
+        private enum FooTypes { }
+        private class Foo { }
     }
 }

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -75,6 +75,12 @@ namespace GraphQL
                 typeName = typeName.Substring(0, typeName.IndexOf('`'));
             }
 
+            return typeName;
+        }
+
+        public static string GraphQLRelayName(this Type type)
+        {
+            var typeName = GraphQLName(type);
             typeName = typeName.Replace(nameof(GraphType), nameof(Type));
 
             return typeName.EndsWith(nameof(Type), StringComparison.InvariantCulture)

--- a/src/GraphQL/Types/Relay/ConnectionType.cs
+++ b/src/GraphQL/Types/Relay/ConnectionType.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Types.Relay
         /// <inheritdoc/>
         public ConnectionType()
         {
-            string graphQLTypeName = typeof(TNodeType).GraphQLName();
+            string graphQLTypeName = typeof(TNodeType).GraphQLRelayName();
             Name = $"{graphQLTypeName}Connection";
             Description =
                 $"A connection from an object to a list of objects of type `{graphQLTypeName}`.";

--- a/src/GraphQL/Types/Relay/EdgeType.cs
+++ b/src/GraphQL/Types/Relay/EdgeType.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Types.Relay
         /// <inheritdoc/>
         public EdgeType()
         {
-            string graphQLTypeName = typeof(TNodeType).GraphQLName();
+            string graphQLTypeName = typeof(TNodeType).GraphQLRelayName();
             Name = $"{graphQLTypeName}Edge";
             Description =
                 $"An edge in a connection from an object to another object of type `{graphQLTypeName}`.";


### PR DESCRIPTION
We ran into an issue of conflicting type name when Including a class named `OrderOccasion` and an enum named `OrderOccasionType`. The `Type` extension `.GraphQLName()` was removing the trailing text `Type` causing the server to fail with `System.InvalidOperationException : Unable to serialize 'DELIVERY' to the scalar type 'OrderOccasionType'.` and registering `OrderOccasion` twice.

```
config.Types.Include<OrderOccasion>();
config.Types.Include<OrderOccasionType>();
```

The work around is to explicitly name the type with bypasses `Type.GraphQLName()` extension altogether.
```
config.Types.Include<OrderOccasionType>("OrderOccasionType");
```

We added an explicit `.GraphQLRelayName()` extension for specific Relay use case and updated code and tests appropriately.

Cheers! 🍻