### PR TITLE
Fix github-script@v5 usage

### DIFF
--- a/.github/workflows/publish-code.yml
+++ b/.github/workflows/publish-code.yml
@@ -86,7 +86,7 @@ jobs:
             for (let file of await fs.readdir('src/out')) {
               console.log('uploading', file);
 
-              await github.repos.uploadReleaseAsset({
+              await github.rest.repos.uploadReleaseAsset({
                 owner,
                 repo,
                 release_id: ${{ github.event.release.id }},


### PR DESCRIPTION
Already tested here https://github.com/graphql-dotnet/server/blob/master/.github/workflows/publish.yml#L61