### PR TITLE
Rework of FederatedSchemaPrinter fix

### DIFF
--- a/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
@@ -6,11 +6,13 @@ namespace GraphQL.Tests.Utilities.Federation
 {
     public class FederatedSchemaPrinterTests
     {
-        [Fact]
-        public void PrintObject_ReturnsEmptyString_GivenQueryTypeHasOnlyFederatedFields()
+        [Theory]
+        [InlineData(@"type X @key(fields: ""id"") { id: ID! }")]
+        [InlineData(@"schema { query: MyQuery } type MyQuery type X @key(fields: ""id"") { id: ID! }")]
+        public void PrintObject_ReturnsEmptyString_GivenQueryTypeHasOnlyFederatedFields(string definitions)
         {
             // Arrange
-            var schema = FederatedSchema.For(@"type X @key(fields: ""id"") { id: ID! }");
+            var schema = FederatedSchema.For(definitions);
             SchemaPrinterOptions options = default;
 
             schema.Initialize();

--- a/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
@@ -7,9 +7,9 @@ namespace GraphQL.Tests.Utilities.Federation
     public class FederatedSchemaPrinterTests
     {
         [Theory]
-        [InlineData(@"type X @key(fields: ""id"") { id: ID! }")]
-        [InlineData(@"schema { query: MyQuery } type MyQuery type X @key(fields: ""id"") { id: ID! }")]
-        public void PrintObject_ReturnsEmptyString_GivenQueryTypeHasOnlyFederatedFields(string definitions)
+        [InlineData(@"type X @key(fields: ""id"") { id: ID! }", "type Query")]
+        [InlineData(@"schema { query: MyQuery } type MyQuery type X @key(fields: ""id"") { id: ID! }", "type MyQuery")]
+        public void PrintObject_ReturnsEmptyString_GivenQueryTypeHasOnlyFederatedFields(string definitions, string expected)
         {
             // Arrange
             var schema = FederatedSchema.For(definitions);
@@ -24,7 +24,7 @@ namespace GraphQL.Tests.Utilities.Federation
             string result = federatedSchemaPrinter.PrintObject(query);
 
             // Assert
-            Assert.Equal(string.Empty, result);
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -52,10 +52,6 @@ namespace GraphQL.Utilities.Federation
 
         public override string PrintObject(IObjectGraphType type)
         {
-            // Do not return an empty query type: "Query { }" as it is not valid as part of the sdl.
-            if (type != null && string.Equals(type.Name, "Query", StringComparison.Ordinal) && !type.Fields.Any(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name)))
-                return string.Empty;
-
             var isExtension = type!.IsExtensionType();
 
             var interfaces = type!.ResolvedInterfaces.List.Select(x => x.Name).ToList();
@@ -68,7 +64,10 @@ namespace GraphQL.Utilities.Federation
 
             var extended = isExtension ? "extend " : "";
 
-            return FormatDescription(type.Description) + "{1}type {2}{3}{4} {{{0}{5}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, implementedInterfaces, federatedDirectives, PrintFields(type));
+            if (type.Fields.Any(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name)))
+                return FormatDescription(type.Description) + "{1}type {2}{3}{4} {{{0}{5}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, implementedInterfaces, federatedDirectives, PrintFields(type));
+            else
+                return FormatDescription(type.Description) + "{0}type {1}{2}{3}".ToFormat(extended, type.Name, implementedInterfaces, federatedDirectives);
         }
 
         public override string PrintInterface(IInterfaceGraphType type)

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -199,7 +199,10 @@ namespace GraphQL.Utilities
                 ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
                 : "";
 
-            return FormatDescription(type.Description) + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));
+            if (type.Fields.Count > 0)
+                return FormatDescription(type.Description) + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));
+            else
+                return FormatDescription(type.Description) + "type {0}{1}".ToFormat(type.Name, implementedInterfaces);
         }
 
         public virtual string PrintInterface(IInterfaceGraphType type)


### PR DESCRIPTION
See #2576. I think that it should be done in different way. First - type for queries may have any name, not only "Query".  Second - empty type definitions are allowed by the spec. See https://github.com/graphql-dotnet/parser/pull/117 fix. I changed both printers and test. 