### PR TITLE
Initialize schema for all public methods in printers

### DIFF
--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2728,6 +2728,7 @@ namespace GraphQL.Utilities
     {
         public SchemaPrinter(GraphQL.Types.ISchema schema, GraphQL.Utilities.SchemaPrinterOptions? options = null) { }
         protected GraphQL.Utilities.SchemaPrinterOptions Options { get; }
+        protected GraphQL.Types.ISchema Schema { get; set; }
         public string[] BreakLine(string line, int len) { }
         public string FormatDefaultValue(object? value, GraphQL.Types.IGraphType graphType) { }
         protected string FormatDescription(string? description, string indentation = "") { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2714,6 +2714,7 @@ namespace GraphQL.Utilities
     {
         public SchemaPrinter(GraphQL.Types.ISchema schema, GraphQL.Utilities.SchemaPrinterOptions? options = null) { }
         protected GraphQL.Utilities.SchemaPrinterOptions Options { get; }
+        protected GraphQL.Types.ISchema Schema { get; set; }
         public string[] BreakLine(string line, int len) { }
         public string FormatDefaultValue(object? value, GraphQL.Types.IGraphType graphType) { }
         protected string FormatDescription(string? description, string indentation = "") { }

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -32,14 +32,14 @@ namespace GraphQL.Utilities.Federation
 
         public string PrintFederatedDirectives(IGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             return type.IsInputObjectType() ? "" : PrintFederatedDirectivesFromAst(type);
         }
 
         public string PrintFederatedDirectivesFromAst(IProvideMetadata type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var astDirectives = type.GetAstType<IHasDirectivesNode>()?.Directives ?? type.GetExtensionDirectives<GraphQLDirective>();
             if (astDirectives == null)
@@ -57,14 +57,14 @@ namespace GraphQL.Utilities.Federation
 
         public string PrintAstDirective(GraphQLDirective directive)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             return AstPrinter.Print(CoreToVanillaConverter.Directive(directive));
         }
 
         public override string PrintObject(IObjectGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             // Do not return an empty query type: "Query { }" as it is not valid as part of the sdl.
             if (type != null && string.Equals(type.Name, "Query", StringComparison.Ordinal) && !type.Fields.Any(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name)))
@@ -87,7 +87,7 @@ namespace GraphQL.Utilities.Federation
 
         public override string PrintInterface(IInterfaceGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var isExtension = type.IsExtensionType();
             var extended = isExtension ? "extend " : "";
@@ -97,7 +97,7 @@ namespace GraphQL.Utilities.Federation
 
         public override string PrintFields(IComplexGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var fields = type?.Fields
                 .Where(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name))
@@ -118,7 +118,7 @@ namespace GraphQL.Utilities.Federation
 
         public string PrintFederatedSchema()
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             return PrintFilteredSchema(
                 directiveName => !IsBuiltInDirective(directiveName) && !IsFederatedDirective(directiveName),

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -30,10 +30,17 @@ namespace GraphQL.Utilities.Federation
         {
         }
 
-        public string PrintFederatedDirectives(IGraphType type) => type.IsInputObjectType() ? "" : PrintFederatedDirectivesFromAst(type);
+        public string PrintFederatedDirectives(IGraphType type)
+        {
+            Schema.Initialize();
+
+            return type.IsInputObjectType() ? "" : PrintFederatedDirectivesFromAst(type);
+        }
 
         public string PrintFederatedDirectivesFromAst(IProvideMetadata type)
         {
+            Schema.Initialize();
+
             var astDirectives = type.GetAstType<IHasDirectivesNode>()?.Directives ?? type.GetExtensionDirectives<GraphQLDirective>();
             if (astDirectives == null)
                 return "";
@@ -48,10 +55,17 @@ namespace GraphQL.Utilities.Federation
             return string.IsNullOrWhiteSpace(dirs) ? "" : $" {dirs}";
         }
 
-        public string PrintAstDirective(GraphQLDirective directive) => AstPrinter.Print(CoreToVanillaConverter.Directive(directive));
+        public string PrintAstDirective(GraphQLDirective directive)
+        {
+            Schema.Initialize();
+
+            return AstPrinter.Print(CoreToVanillaConverter.Directive(directive));
+        }
 
         public override string PrintObject(IObjectGraphType type)
         {
+            Schema.Initialize();
+
             // Do not return an empty query type: "Query { }" as it is not valid as part of the sdl.
             if (type != null && string.Equals(type.Name, "Query", StringComparison.Ordinal) && !type.Fields.Any(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name)))
                 return string.Empty;
@@ -73,6 +87,8 @@ namespace GraphQL.Utilities.Federation
 
         public override string PrintInterface(IInterfaceGraphType type)
         {
+            Schema.Initialize();
+
             var isExtension = type.IsExtensionType();
             var extended = isExtension ? "extend " : "";
 
@@ -81,6 +97,8 @@ namespace GraphQL.Utilities.Federation
 
         public override string PrintFields(IComplexGraphType type)
         {
+            Schema.Initialize();
+
             var fields = type?.Fields
                 .Where(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name))
                 .Select(x =>
@@ -100,6 +118,8 @@ namespace GraphQL.Utilities.Federation
 
         public string PrintFederatedSchema()
         {
+            Schema.Initialize();
+
             return PrintFilteredSchema(
                 directiveName => !IsBuiltInDirective(directiveName) && !IsFederatedDirective(directiveName),
                 typeName => !IsFederatedType(typeName) && IsDefinedType(typeName));

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -82,7 +82,7 @@ namespace GraphQL.Utilities
         /// <returns>SDL document.</returns>
         public string PrintFilteredSchema(Func<string, bool> directiveFilter, Func<string, bool> typeFilter)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var directives = Schema.Directives.Where(d => directiveFilter(d.Name)).OrderBy(d => d.Name, StringComparer.Ordinal).ToList();
             var types = Schema.AllTypes
@@ -118,7 +118,7 @@ namespace GraphQL.Utilities
 
         public string? PrintSchemaDefinition(ISchema schema)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             if (IsSchemaOfCommonNames(Schema))
                 return null;
@@ -158,7 +158,7 @@ namespace GraphQL.Utilities
          */
         public bool IsSchemaOfCommonNames(ISchema schema)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             if (schema.Query != null && schema.Query.Name != "Query")
             {
@@ -180,7 +180,7 @@ namespace GraphQL.Utilities
 
         public string PrintType(IGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             return type switch
             {
@@ -197,14 +197,14 @@ namespace GraphQL.Utilities
 
         public string PrintScalar(ScalarGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             return $"{FormatDescription(type.Description)}scalar {type.Name}";
         }
 
         public virtual string PrintObject(IObjectGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var interfaces = type.ResolvedInterfaces.List.Select(x => x.Name).ToList();
             var delimiter = Options.OldImplementsSyntax ? ", " : " & ";
@@ -217,14 +217,14 @@ namespace GraphQL.Utilities
 
         public virtual string PrintInterface(IInterfaceGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             return FormatDescription(type.Description) + "interface {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, PrintFields(type));
         }
 
         public string PrintUnion(UnionGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var possibleTypes = string.Join(" | ", type.PossibleTypes.Select(x => x.Name));
             return FormatDescription(type.Description) + "union {0} = {1}".ToFormat(type.Name, possibleTypes);
@@ -232,7 +232,7 @@ namespace GraphQL.Utilities
 
         public string PrintEnum(EnumerationGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var values = string.Join(Environment.NewLine, type.Values.OrderBy(Options.Comparer?.EnumValueComparer(type)).Select(x => FormatDescription(x.Description, "  ") + "  " + x.Name + (Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : "")));
             return FormatDescription(type.Description) + "enum {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, values);
@@ -240,7 +240,7 @@ namespace GraphQL.Utilities
 
         public string PrintInputObject(IInputObjectGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var fields = type.Fields.OrderBy<FieldType>(Options.Comparer?.FieldComparer(type)).Select(x => PrintInputValue(x));
             return FormatDescription(type.Description) + "input {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, string.Join(Environment.NewLine, fields));
@@ -248,7 +248,7 @@ namespace GraphQL.Utilities
 
         public virtual string PrintFields(IComplexGraphType type)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var fields = type?.Fields
                 .OrderBy<FieldType>(Options.Comparer?.FieldComparer(type))
@@ -268,7 +268,7 @@ namespace GraphQL.Utilities
 
         public string PrintArgs(FieldType field)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             if (field.Arguments == null || field.Arguments.Count == 0)
             {
@@ -280,7 +280,7 @@ namespace GraphQL.Utilities
 
         public string PrintInputValue(FieldType field)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var argumentType = field.ResolvedType!;
             var description = $"{FormatDescription(field.Description, "  ")}  {field.Name}: {argumentType}";
@@ -295,7 +295,7 @@ namespace GraphQL.Utilities
 
         public string PrintInputValue(QueryArgument argument)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var argumentType = argument.ResolvedType!;
             var desc = "{0}: {1}".ToFormat(argument.Name, argumentType);
@@ -310,7 +310,7 @@ namespace GraphQL.Utilities
 
         public string PrintDirective(DirectiveGraphType directive)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             var builder = new StringBuilder();
             builder.Append(FormatDescription(directive.Description));
@@ -362,7 +362,7 @@ namespace GraphQL.Utilities
 
         public string FormatDefaultValue(object? value, IGraphType graphType)
         {
-            Schema.Initialize();
+            Schema?.Initialize();
 
             if (value == null)
                 return "null";

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -56,7 +56,7 @@ namespace GraphQL.Utilities
 
         protected static bool IsBuiltInDirective(string directiveName) => _builtInDirectives.Contains(directiveName);
 
-        private ISchema Schema { get; set; }
+        protected ISchema Schema { get; set; }
 
         protected SchemaPrinterOptions Options { get; }
 
@@ -118,6 +118,8 @@ namespace GraphQL.Utilities
 
         public string? PrintSchemaDefinition(ISchema schema)
         {
+            Schema.Initialize();
+
             if (IsSchemaOfCommonNames(Schema))
                 return null;
 
@@ -156,6 +158,8 @@ namespace GraphQL.Utilities
          */
         public bool IsSchemaOfCommonNames(ISchema schema)
         {
+            Schema.Initialize();
+
             if (schema.Query != null && schema.Query.Name != "Query")
             {
                 return false;
@@ -176,6 +180,8 @@ namespace GraphQL.Utilities
 
         public string PrintType(IGraphType type)
         {
+            Schema.Initialize();
+
             return type switch
             {
                 EnumerationGraphType graphType => PrintEnum(graphType),
@@ -189,10 +195,17 @@ namespace GraphQL.Utilities
             };
         }
 
-        public string PrintScalar(ScalarGraphType type) => $"{FormatDescription(type.Description)}scalar {type.Name}";
+        public string PrintScalar(ScalarGraphType type)
+        {
+            Schema.Initialize();
+
+            return $"{FormatDescription(type.Description)}scalar {type.Name}";
+        }
 
         public virtual string PrintObject(IObjectGraphType type)
         {
+            Schema.Initialize();
+
             var interfaces = type.ResolvedInterfaces.List.Select(x => x.Name).ToList();
             var delimiter = Options.OldImplementsSyntax ? ", " : " & ";
             var implementedInterfaces = interfaces.Count > 0
@@ -204,29 +217,39 @@ namespace GraphQL.Utilities
 
         public virtual string PrintInterface(IInterfaceGraphType type)
         {
+            Schema.Initialize();
+
             return FormatDescription(type.Description) + "interface {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, PrintFields(type));
         }
 
         public string PrintUnion(UnionGraphType type)
         {
+            Schema.Initialize();
+
             var possibleTypes = string.Join(" | ", type.PossibleTypes.Select(x => x.Name));
             return FormatDescription(type.Description) + "union {0} = {1}".ToFormat(type.Name, possibleTypes);
         }
 
         public string PrintEnum(EnumerationGraphType type)
         {
+            Schema.Initialize();
+
             var values = string.Join(Environment.NewLine, type.Values.OrderBy(Options.Comparer?.EnumValueComparer(type)).Select(x => FormatDescription(x.Description, "  ") + "  " + x.Name + (Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : "")));
             return FormatDescription(type.Description) + "enum {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, values);
         }
 
         public string PrintInputObject(IInputObjectGraphType type)
         {
+            Schema.Initialize();
+
             var fields = type.Fields.OrderBy<FieldType>(Options.Comparer?.FieldComparer(type)).Select(x => PrintInputValue(x));
             return FormatDescription(type.Description) + "input {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, string.Join(Environment.NewLine, fields));
         }
 
         public virtual string PrintFields(IComplexGraphType type)
         {
+            Schema.Initialize();
+
             var fields = type?.Fields
                 .OrderBy<FieldType>(Options.Comparer?.FieldComparer(type))
                 .Select(x =>
@@ -245,6 +268,8 @@ namespace GraphQL.Utilities
 
         public string PrintArgs(FieldType field)
         {
+            Schema.Initialize();
+
             if (field.Arguments == null || field.Arguments.Count == 0)
             {
                 return string.Empty;
@@ -255,6 +280,8 @@ namespace GraphQL.Utilities
 
         public string PrintInputValue(FieldType field)
         {
+            Schema.Initialize();
+
             var argumentType = field.ResolvedType!;
             var description = $"{FormatDescription(field.Description, "  ")}  {field.Name}: {argumentType}";
 
@@ -268,6 +295,8 @@ namespace GraphQL.Utilities
 
         public string PrintInputValue(QueryArgument argument)
         {
+            Schema.Initialize();
+
             var argumentType = argument.ResolvedType!;
             var desc = "{0}: {1}".ToFormat(argument.Name, argumentType);
 
@@ -281,6 +310,8 @@ namespace GraphQL.Utilities
 
         public string PrintDirective(DirectiveGraphType directive)
         {
+            Schema.Initialize();
+
             var builder = new StringBuilder();
             builder.Append(FormatDescription(directive.Description));
             builder.Append($"directive @{directive.Name}");
@@ -331,6 +362,8 @@ namespace GraphQL.Utilities
 
         public string FormatDefaultValue(object? value, IGraphType graphType)
         {
+            Schema.Initialize();
+
             if (value == null)
                 return "null";
 


### PR DESCRIPTION
Fixes #2577 - Rough and straightforward. Just a reminder - I said that we can get rid of most printer code if use the SDL visitor from the parser project.