### PR TITLE
Add InputExtensions; rename Extensions and Inputs

### DIFF
--- a/docs2/site/docs/getting-started/dependency-injection.md
+++ b/docs2/site/docs/getting-started/dependency-injection.md
@@ -253,7 +253,7 @@ var result = await _executer.ExecuteAsync(options =>
 {
     options.Schema = schema;
     options.Query = request.Query;
-    options.Inputs = request.Variables.ToInputs();
+    options.Variables = request.Variables.ToInputs();
     options.RequestServices = context.RequestServices;
 });
 ```

--- a/docs2/site/docs/getting-started/variables.md
+++ b/docs2/site/docs/getting-started/variables.md
@@ -36,6 +36,6 @@ var inputs = variablesJson.ToInputs();
 await schema.ExecuteAsync(_ =>
 {
   _.Query = "...";
-  _.Inputs = inputs;
+  _.Variables = inputs;
 });
 ```

--- a/docs2/site/docs/migrations/migration3.md
+++ b/docs2/site/docs/migrations/migration3.md
@@ -122,7 +122,7 @@ private static async Task ExecuteAsync(HttpContext context, ISchema schema)
         options.Schema = schema;
         options.Query = request.Query;
         options.OperationName = request.OperationName;
-        options.Inputs = request.Variables.ToInputs();
+        options.Variables = request.Variables.ToInputs();
     });
 
     context.Response.ContentType = "application/json";
@@ -158,7 +158,7 @@ private static async Task ExecuteAsync(HttpContext context, ISchema schema)
         options.Schema = schema;
         options.Query = request.Query;
         options.OperationName = request.OperationName;
-        options.Inputs = request.Variables.ToInputs();
+        options.Variables = request.Variables.ToInputs();
     });
 
     context.Response.ContentType = "application/json";

--- a/docs2/site/docs/migrations/migration3.md
+++ b/docs2/site/docs/migrations/migration3.md
@@ -122,7 +122,7 @@ private static async Task ExecuteAsync(HttpContext context, ISchema schema)
         options.Schema = schema;
         options.Query = request.Query;
         options.OperationName = request.OperationName;
-        options.Variables = request.Variables.ToInputs();
+        options.Inputs = request.Variables.ToInputs();
     });
 
     context.Response.ContentType = "application/json";
@@ -158,7 +158,7 @@ private static async Task ExecuteAsync(HttpContext context, ISchema schema)
         options.Schema = schema;
         options.Query = request.Query;
         options.OperationName = request.OperationName;
-        options.Variables = request.Variables.ToInputs();
+        options.Inputs = request.Variables.ToInputs();
     });
 
     context.Response.ContentType = "application/json";

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -6,7 +6,11 @@ See [issues](https://github.com/graphql-dotnet/graphql-dotnet/issues?q=milestone
 
 ###
 
-###
+### Input Extensions support
+
+`Extensions` deserialized from GraphQL requests can now be set on the `ExecutionOptions.Extensions` property
+and passed through to field resolvers via `IResolveFieldContext.InputExtensions`. Note that standard .NET
+dictionaries (such as `Dictionary<TKey, TValue>`) are thread-safe for read-only operations.
 
 ## Breaking Changes
 
@@ -21,3 +25,14 @@ renamed to have `Async` suffix.
 
 1. Use async methods to get or set a cache.
 2. Cache items cannot be removed anymore.
+
+### `IResolveFieldContext.Extensions` property renamed to `OutputExtensions`
+
+To clarify and differ output extensions from input extensions, `IResolveFieldContext.Extensions`
+has now been renamed to `OutputExtensions`. There has not been any change to the `GetExtension` and
+`SetExtension` thread-safe extension methods.
+
+### `ExecutionOptions.Inputs` property renamed to `Variables`
+
+To better align the execution options with the specification, the `Inputs` property containing
+the execution variables has now been renamed to `Variables`.

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -26,13 +26,13 @@ renamed to have `Async` suffix.
 1. Use async methods to get or set a cache.
 2. Cache items cannot be removed anymore.
 
-### `IResolveFieldContext.Extensions` property renamed to `OutputExtensions`
+### `IResolveFieldContext.Extensions` property renamed to `OutputExtensions` and related changes
 
 To clarify and differ output extensions from input extensions, `IResolveFieldContext.Extensions`
-has now been renamed to `OutputExtensions`. There has not been any change to the `GetExtension` and
-`SetExtension` thread-safe extension methods.
+has now been renamed to `OutputExtensions`. The `GetExtension` and `SetExtension` thread-safe
+extension methods have also been renamed to `GetOutputExtension` and `SetOutputExtension` respectively.
 
-### `ExecutionOptions.Inputs` property renamed to `Variables`
+### `ExecutionOptions.Inputs` and `ValidationContext.Inputs` properties renamed to `Variables`
 
-To better align the execution options with the specification, the `Inputs` property containing
-the execution variables has now been renamed to `Variables`.
+To better align the execution options and variable context with the specification, the `Inputs`
+property containing the execution variables has now been renamed to `Variables`.

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -117,7 +117,7 @@ namespace GraphQL
         public GraphQL.Validation.Complexity.ComplexityConfiguration? ComplexityConfiguration { get; set; }
         public GraphQL.Language.AST.Document? Document { get; set; }
         public bool EnableMetrics { get; set; }
-        public GraphQL.Inputs? Inputs { get; set; }
+        public GraphQL.Inputs? Extensions { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
         public int? MaxParallelExecutionCount { get; set; }
         public string? OperationName { get; set; }
@@ -129,6 +129,7 @@ namespace GraphQL
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? ValidationRules { get; set; }
+        public GraphQL.Inputs? Variables { get; set; }
     }
     public class ExecutionResult
     {
@@ -338,11 +339,12 @@ namespace GraphQL
         System.Threading.CancellationToken CancellationToken { get; }
         GraphQL.Language.AST.Document Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
-        System.Collections.Generic.IDictionary<string, object?> Extensions { get; }
         GraphQL.Language.AST.Field FieldAst { get; }
         GraphQL.Types.FieldType FieldDefinition { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         GraphQL.Instrumentation.Metrics Metrics { get; }
         GraphQL.Language.AST.Operation Operation { get; }
+        System.Collections.Generic.IDictionary<string, object?> OutputExtensions { get; }
         GraphQL.IResolveFieldContext? Parent { get; }
         GraphQL.Types.IObjectGraphType ParentType { get; }
         System.Collections.Generic.IEnumerable<object> Path { get; }
@@ -412,11 +414,12 @@ namespace GraphQL
         public System.Threading.CancellationToken CancellationToken { get; }
         public GraphQL.Language.AST.Document Document { get; }
         public GraphQL.ExecutionErrors Errors { get; }
-        public System.Collections.Generic.IDictionary<string, object?> Extensions { get; }
         public GraphQL.Language.AST.Field FieldAst { get; }
         public GraphQL.Types.FieldType FieldDefinition { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         public GraphQL.Instrumentation.Metrics Metrics { get; }
         public GraphQL.Language.AST.Operation Operation { get; }
+        public System.Collections.Generic.IDictionary<string, object?> OutputExtensions { get; }
         public GraphQL.IResolveFieldContext? Parent { get; }
         public GraphQL.Types.IObjectGraphType ParentType { get; }
         public System.Collections.Generic.IEnumerable<object> Path { get; }
@@ -438,11 +441,12 @@ namespace GraphQL
         public System.Threading.CancellationToken CancellationToken { get; set; }
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
-        public System.Collections.Generic.IDictionary<string, object?> Extensions { get; set; }
         public GraphQL.Language.AST.Field FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
         public GraphQL.Instrumentation.Metrics Metrics { get; set; }
         public GraphQL.Language.AST.Operation Operation { get; set; }
+        public System.Collections.Generic.IDictionary<string, object?> OutputExtensions { get; set; }
         public GraphQL.IResolveFieldContext? Parent { get; set; }
         public GraphQL.Types.IObjectGraphType ParentType { get; set; }
         public System.Collections.Generic.IEnumerable<object> Path { get; set; }
@@ -855,11 +859,12 @@ namespace GraphQL.Execution
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
         public GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; set; }
-        public System.Collections.Generic.Dictionary<string, object?> Extensions { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; set; }
         public int? MaxParallelExecutionCount { get; set; }
         public GraphQL.Instrumentation.Metrics Metrics { get; set; }
         public GraphQL.Language.AST.Operation Operation { get; set; }
+        public System.Collections.Generic.Dictionary<string, object?> OutputExtensions { get; set; }
         public System.IServiceProvider? RequestServices { get; set; }
         public object? RootValue { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
@@ -951,11 +956,12 @@ namespace GraphQL.Execution
         GraphQL.Language.AST.Document Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
         GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; }
-        System.Collections.Generic.Dictionary<string, object?> Extensions { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
         int? MaxParallelExecutionCount { get; }
         GraphQL.Instrumentation.Metrics Metrics { get; }
         GraphQL.Language.AST.Operation Operation { get; }
+        System.Collections.Generic.Dictionary<string, object?> OutputExtensions { get; }
         System.IServiceProvider? RequestServices { get; }
         object? RootValue { get; }
         GraphQL.Types.ISchema Schema { get; }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -467,9 +467,9 @@ namespace GraphQL
         public static GraphQL.IResolveFieldContext<TSource> Copy<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
         public static object? GetArgument(this GraphQL.IResolveFieldContext context, System.Type argumentType, string name, object? defaultValue = null) { }
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
-        public static object? GetExtension(this GraphQL.IResolveFieldContext context, string path) { }
+        public static object? GetOutputExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
-        public static void SetExtension(this GraphQL.IResolveFieldContext context, string path, object? value) { }
+        public static void SetOutputExtension(this GraphQL.IResolveFieldContext context, string path, object? value) { }
     }
     public class ResolveFieldContext<TSource> : GraphQL.ResolveFieldContext, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<TSource>
     {
@@ -2915,14 +2915,14 @@ namespace GraphQL.Validation
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "validationResult",
                 "variables"})]
-        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? inputs = null, string? operationName = null) { }
+        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? variables = null, string? operationName = null) { }
     }
     public interface IDocumentValidator
     {
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "validationResult",
                 "variables"})]
-        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? inputs = null, string? operationName = null);
+        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? variables = null, string? operationName = null);
     }
     public interface INodeVisitor
     {
@@ -2994,16 +2994,16 @@ namespace GraphQL.Validation
         public GraphQL.Language.AST.Document Document { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.ValidationError> Errors { get; }
         public bool HasErrors { get; }
-        public GraphQL.Inputs? Inputs { get; set; }
         public string? OperationName { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
+        public GraphQL.Inputs? Variables { get; set; }
         public GraphQL.Language.AST.FragmentDefinition? GetFragment(string name) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentDefinition> GetRecursivelyReferencedFragments(GraphQL.Language.AST.Operation operation) { }
-        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Inputs inputs, GraphQL.Validation.IVariableVisitor? visitor = null) { }
+        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Inputs variables, GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetVariables(GraphQL.Language.AST.IHaveSelectionSet node) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -467,9 +467,9 @@ namespace GraphQL
         public static GraphQL.IResolveFieldContext<TSource> Copy<TSource>(this GraphQL.IResolveFieldContext<TSource> context) { }
         public static object? GetArgument(this GraphQL.IResolveFieldContext context, System.Type argumentType, string name, object? defaultValue = null) { }
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
-        public static object? GetExtension(this GraphQL.IResolveFieldContext context, string path) { }
+        public static object? GetOutputExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
-        public static void SetExtension(this GraphQL.IResolveFieldContext context, string path, object? value) { }
+        public static void SetOutputExtension(this GraphQL.IResolveFieldContext context, string path, object? value) { }
     }
     public class ResolveFieldContext<TSource> : GraphQL.ResolveFieldContext, GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<TSource>
     {
@@ -2901,14 +2901,14 @@ namespace GraphQL.Validation
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "validationResult",
                 "variables"})]
-        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? inputs = null, string? operationName = null) { }
+        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? variables = null, string? operationName = null) { }
     }
     public interface IDocumentValidator
     {
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "validationResult",
                 "variables"})]
-        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? inputs = null, string? operationName = null);
+        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? variables = null, string? operationName = null);
     }
     public interface INodeVisitor
     {
@@ -2980,16 +2980,16 @@ namespace GraphQL.Validation
         public GraphQL.Language.AST.Document Document { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.ValidationError> Errors { get; }
         public bool HasErrors { get; }
-        public GraphQL.Inputs? Inputs { get; set; }
         public string? OperationName { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
+        public GraphQL.Inputs? Variables { get; set; }
         public GraphQL.Language.AST.FragmentDefinition? GetFragment(string name) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentDefinition> GetRecursivelyReferencedFragments(GraphQL.Language.AST.Operation operation) { }
-        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Inputs inputs, GraphQL.Validation.IVariableVisitor? visitor = null) { }
+        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Inputs variables, GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetVariables(GraphQL.Language.AST.IHaveSelectionSet node) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -117,7 +117,7 @@ namespace GraphQL
         public GraphQL.Validation.Complexity.ComplexityConfiguration? ComplexityConfiguration { get; set; }
         public GraphQL.Language.AST.Document? Document { get; set; }
         public bool EnableMetrics { get; set; }
-        public GraphQL.Inputs? Inputs { get; set; }
+        public GraphQL.Inputs? Extensions { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
         public int? MaxParallelExecutionCount { get; set; }
         public string? OperationName { get; set; }
@@ -129,6 +129,7 @@ namespace GraphQL
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? ValidationRules { get; set; }
+        public GraphQL.Inputs? Variables { get; set; }
     }
     public class ExecutionResult
     {
@@ -338,11 +339,12 @@ namespace GraphQL
         System.Threading.CancellationToken CancellationToken { get; }
         GraphQL.Language.AST.Document Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
-        System.Collections.Generic.IDictionary<string, object?> Extensions { get; }
         GraphQL.Language.AST.Field FieldAst { get; }
         GraphQL.Types.FieldType FieldDefinition { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         GraphQL.Instrumentation.Metrics Metrics { get; }
         GraphQL.Language.AST.Operation Operation { get; }
+        System.Collections.Generic.IDictionary<string, object?> OutputExtensions { get; }
         GraphQL.IResolveFieldContext? Parent { get; }
         GraphQL.Types.IObjectGraphType ParentType { get; }
         System.Collections.Generic.IEnumerable<object> Path { get; }
@@ -412,11 +414,12 @@ namespace GraphQL
         public System.Threading.CancellationToken CancellationToken { get; }
         public GraphQL.Language.AST.Document Document { get; }
         public GraphQL.ExecutionErrors Errors { get; }
-        public System.Collections.Generic.IDictionary<string, object?> Extensions { get; }
         public GraphQL.Language.AST.Field FieldAst { get; }
         public GraphQL.Types.FieldType FieldDefinition { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         public GraphQL.Instrumentation.Metrics Metrics { get; }
         public GraphQL.Language.AST.Operation Operation { get; }
+        public System.Collections.Generic.IDictionary<string, object?> OutputExtensions { get; }
         public GraphQL.IResolveFieldContext? Parent { get; }
         public GraphQL.Types.IObjectGraphType ParentType { get; }
         public System.Collections.Generic.IEnumerable<object> Path { get; }
@@ -438,11 +441,12 @@ namespace GraphQL
         public System.Threading.CancellationToken CancellationToken { get; set; }
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
-        public System.Collections.Generic.IDictionary<string, object?> Extensions { get; set; }
         public GraphQL.Language.AST.Field FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
         public GraphQL.Instrumentation.Metrics Metrics { get; set; }
         public GraphQL.Language.AST.Operation Operation { get; set; }
+        public System.Collections.Generic.IDictionary<string, object?> OutputExtensions { get; set; }
         public GraphQL.IResolveFieldContext? Parent { get; set; }
         public GraphQL.Types.IObjectGraphType ParentType { get; set; }
         public System.Collections.Generic.IEnumerable<object> Path { get; set; }
@@ -855,11 +859,12 @@ namespace GraphQL.Execution
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
         public GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; set; }
-        public System.Collections.Generic.Dictionary<string, object?> Extensions { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; set; }
         public int? MaxParallelExecutionCount { get; set; }
         public GraphQL.Instrumentation.Metrics Metrics { get; set; }
         public GraphQL.Language.AST.Operation Operation { get; set; }
+        public System.Collections.Generic.Dictionary<string, object?> OutputExtensions { get; set; }
         public System.IServiceProvider? RequestServices { get; set; }
         public object? RootValue { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
@@ -951,11 +956,12 @@ namespace GraphQL.Execution
         GraphQL.Language.AST.Document Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
         GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; }
-        System.Collections.Generic.Dictionary<string, object?> Extensions { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
         int? MaxParallelExecutionCount { get; }
         GraphQL.Instrumentation.Metrics Metrics { get; }
         GraphQL.Language.AST.Operation Operation { get; }
+        System.Collections.Generic.Dictionary<string, object?> OutputExtensions { get; }
         System.IServiceProvider? RequestServices { get; }
         object? RootValue { get; }
         GraphQL.Types.ISchema Schema { get; }

--- a/src/GraphQL.Benchmarks/Benchmarks/DetailedBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/DetailedBenchmark.cs
@@ -131,7 +131,7 @@ namespace GraphQL.Benchmarks
                     {
                         o.Schema = benchmarkInfo.Schema;
                         o.Query = benchmarkInfo.Query;
-                        o.Inputs = benchmarkInfo.InputsString?.ToInputs();
+                        o.Variables = benchmarkInfo.InputsString?.ToInputs();
                     }).GetAwaiter().GetResult();
                     break;
                 case StageEnum.Parse:
@@ -261,7 +261,8 @@ namespace GraphQL.Benchmarks
                     Operation = Operation,
                     Variables = Variables,
                     Errors = new ExecutionErrors(),
-                    Extensions = new Dictionary<string, object>(),
+                    InputExtensions = Inputs.Empty,
+                    OutputExtensions = new Dictionary<string, object>(),
                     CancellationToken = default,
 
                     Metrics = Instrumentation.Metrics.None,

--- a/src/GraphQL.Benchmarks/Benchmarks/VariableBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/VariableBenchmark.cs
@@ -83,7 +83,7 @@ namespace GraphQL.Benchmarks
                 _.Schema = schema;
                 _.Query = query;
                 _.Document = document;
-                _.Inputs = inputs;
+                _.Variables = inputs;
                 _.ValidationRules = EnableValidation ? null : Array.Empty<IValidationRule>();
                 _.ThrowOnUnhandledException = true;
             }).GetAwaiter().GetResult();

--- a/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
+++ b/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
@@ -58,13 +58,13 @@ namespace GraphQL.DataLoader.Tests
         public ExecutionResult AssertQuerySuccess<TSchema>(
             string query,
             string expected,
-            Inputs inputs = null,
+            Inputs variables = null,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default)
             where TSchema : ISchema
         {
             var queryResult = CreateQueryResult(expected);
-            return AssertQuery<TSchema>(query, queryResult, inputs, userContext, cancellationToken);
+            return AssertQuery<TSchema>(query, queryResult, variables, userContext, cancellationToken);
         }
 
         public ExecutionResult AssertQuerySuccess<TSchema>(Action<ExecutionOptions> options, string expected)
@@ -123,7 +123,7 @@ namespace GraphQL.DataLoader.Tests
         public ExecutionResult AssertQuery<TSchema>(
             string query,
             ExecutionResult expectedExecutionResult,
-            Inputs inputs = null,
+            Inputs variables = null,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default)
             where TSchema : ISchema
@@ -132,7 +132,7 @@ namespace GraphQL.DataLoader.Tests
                 opts =>
                 {
                     opts.Query = query;
-                    opts.Variables = inputs;
+                    opts.Variables = variables;
                     opts.UserContext = userContext;
                     opts.CancellationToken = cancellationToken;
 

--- a/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
+++ b/src/GraphQL.DataLoader.Tests/QueryTestBase.cs
@@ -132,7 +132,7 @@ namespace GraphQL.DataLoader.Tests
                 opts =>
                 {
                     opts.Query = query;
-                    opts.Inputs = inputs;
+                    opts.Variables = inputs;
                     opts.UserContext = userContext;
                     opts.CancellationToken = cancellationToken;
 

--- a/src/GraphQL.Harness/GraphQLMiddleware.cs
+++ b/src/GraphQL.Harness/GraphQLMiddleware.cs
@@ -58,7 +58,7 @@ namespace Example
                 options.Schema = schema;
                 options.Query = request.Query;
                 options.OperationName = request.OperationName;
-                options.Inputs = request.Variables;
+                options.Variables = request.Variables;
                 options.UserContext = _settings.BuildUserContext?.Invoke(context);
                 options.EnableMetrics = _settings.EnableMetrics;
                 options.RequestServices = context.RequestServices;

--- a/src/GraphQL.MicrosoftDI.Tests/AdapterTests.cs
+++ b/src/GraphQL.MicrosoftDI.Tests/AdapterTests.cs
@@ -57,7 +57,8 @@ namespace GraphQL.MicrosoftDI.Tests
                 CancellationToken = default,
                 Document = new Document(),
                 Errors = new ExecutionErrors(),
-                Extensions = new Dictionary<string, object>() { { "1", new object() } },
+                InputExtensions = new Dictionary<string, object>() { { "7", new object() } },
+                OutputExtensions = new Dictionary<string, object>() { { "1", new object() } },
                 FieldAst = new Field(default, new NameNode("test")),
                 FieldDefinition = new FieldType(),
                 Metrics = new Instrumentation.Metrics(),
@@ -80,7 +81,8 @@ namespace GraphQL.MicrosoftDI.Tests
             mocked.CancellationToken.ShouldBe(rfc.CancellationToken);
             mocked.Document.ShouldBe(rfc.Document);
             mocked.Errors.ShouldBe(rfc.Errors);
-            mocked.Extensions.ShouldBe(rfc.Extensions);
+            mocked.InputExtensions.ShouldBe(rfc.InputExtensions);
+            mocked.OutputExtensions.ShouldBe(rfc.OutputExtensions);
             mocked.FieldAst.ShouldBe(rfc.FieldAst);
             mocked.FieldDefinition.ShouldBe(rfc.FieldDefinition);
             mocked.Metrics.ShouldBe(rfc.Metrics);

--- a/src/GraphQL.MicrosoftDI.Tests/ConnectionAdapterTests.cs
+++ b/src/GraphQL.MicrosoftDI.Tests/ConnectionAdapterTests.cs
@@ -35,7 +35,8 @@ namespace GraphQL.MicrosoftDI.Tests
             rccMock.SetupGet(x => x.CancellationToken).Returns((CancellationToken)default);
             rccMock.SetupGet(x => x.Document).Returns(new Document());
             rccMock.SetupGet(x => x.Errors).Returns(new ExecutionErrors());
-            rccMock.SetupGet(x => x.Extensions).Returns(new Dictionary<string, object>() { { "1", new object() } });
+            rccMock.SetupGet(x => x.InputExtensions).Returns(new Dictionary<string, object>() { { "7", new object() } });
+            rccMock.SetupGet(x => x.OutputExtensions).Returns(new Dictionary<string, object>() { { "1", new object() } });
             rccMock.SetupGet(x => x.FieldAst).Returns(new Field(default, new NameNode("test")));
             rccMock.SetupGet(x => x.FieldDefinition).Returns(new FieldType());
             rccMock.SetupGet(x => x.Metrics).Returns(new Instrumentation.Metrics());
@@ -66,7 +67,8 @@ namespace GraphQL.MicrosoftDI.Tests
             mocked.CancellationToken.ShouldBe(rcc.CancellationToken);
             mocked.Document.ShouldBe(rcc.Document);
             mocked.Errors.ShouldBe(rcc.Errors);
-            mocked.Extensions.ShouldBe(rcc.Extensions);
+            mocked.InputExtensions.ShouldBe(rcc.InputExtensions);
+            mocked.OutputExtensions.ShouldBe(rcc.OutputExtensions);
             mocked.FieldAst.ShouldBe(rcc.FieldAst);
             mocked.FieldDefinition.ShouldBe(rcc.FieldDefinition);
             mocked.Metrics.ShouldBe(rcc.Metrics);

--- a/src/GraphQL.MicrosoftDI/ScopedResolveConnectionContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveConnectionContextAdapter.cs
@@ -57,7 +57,9 @@ namespace GraphQL.MicrosoftDI
 
         public IDictionary<string, object> UserContext => _baseContext.UserContext;
 
-        public IDictionary<string, object> Extensions => _baseContext.Extensions;
+        public IReadOnlyDictionary<string, object> InputExtensions => _baseContext.InputExtensions;
+
+        public IDictionary<string, object> OutputExtensions => _baseContext.OutputExtensions;
 
         object IResolveFieldContext.Source => _baseContext.Source;
 

--- a/src/GraphQL.MicrosoftDI/ScopedResolveFieldContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveFieldContextAdapter.cs
@@ -73,7 +73,9 @@ namespace GraphQL.MicrosoftDI
 
         public IDictionary<string, object> UserContext => _baseContext.UserContext;
 
-        public IDictionary<string, object> Extensions => _baseContext.Extensions;
+        public IReadOnlyDictionary<string, object> InputExtensions => _baseContext.InputExtensions;
+
+        public IDictionary<string, object> OutputExtensions => _baseContext.OutputExtensions;
 
         object IResolveFieldContext.Source => _baseContext.Source;
 

--- a/src/GraphQL.SystemReactive/ExecutionResultExtensions.cs
+++ b/src/GraphQL.SystemReactive/ExecutionResultExtensions.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Execution
             result.Query = context.Document.OriginalQuery;
             result.Document = context.Document;
             result.Operation = context.Operation;
-            result.Extensions = context.Extensions;
+            result.Extensions = context.OutputExtensions;
 
             return result;
         }

--- a/src/GraphQL.Tests/BasicQueryTestBase.cs
+++ b/src/GraphQL.Tests/BasicQueryTestBase.cs
@@ -19,14 +19,14 @@ namespace GraphQL.Tests
             ISchema schema,
             string query,
             string expected,
-            Inputs inputs = null,
+            Inputs variables = null,
             object root = null,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
             IEnumerable<IValidationRule> rules = null)
         {
             var queryResult = CreateQueryResult(expected);
-            return AssertQuery(schema, query, queryResult, inputs, root, userContext, cancellationToken, rules);
+            return AssertQuery(schema, query, queryResult, variables, root, userContext, cancellationToken, rules);
         }
 
         public ExecutionResult AssertQuerySuccess(Action<ExecutionOptions> options, string expected)
@@ -64,7 +64,7 @@ namespace GraphQL.Tests
             ISchema schema,
             string query,
             ExecutionResult expectedExecutionResult,
-            Inputs inputs,
+            Inputs variables,
             object root,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
@@ -75,7 +75,7 @@ namespace GraphQL.Tests
                 _.Schema = schema;
                 _.Query = query;
                 _.Root = root;
-                _.Variables = inputs;
+                _.Variables = variables;
                 _.UserContext = userContext;
                 _.CancellationToken = cancellationToken;
                 _.ValidationRules = rules;

--- a/src/GraphQL.Tests/BasicQueryTestBase.cs
+++ b/src/GraphQL.Tests/BasicQueryTestBase.cs
@@ -75,7 +75,7 @@ namespace GraphQL.Tests
                 _.Schema = schema;
                 _.Query = query;
                 _.Root = root;
-                _.Inputs = inputs;
+                _.Variables = inputs;
                 _.UserContext = userContext;
                 _.CancellationToken = cancellationToken;
                 _.ValidationRules = rules;

--- a/src/GraphQL.Tests/Bugs/Bug1831.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1831.cs
@@ -42,7 +42,7 @@ namespace GraphQL.Tests.Bugs
             };
             error3.AddLocation(1, 7);
             var expected = CreateQueryResult(null, new ExecutionErrors { error1, error2, error3 }, executed: false);
-            AssertQueryIgnoreErrors("query($arg: abcdefg) { test1 (arg: $arg) }", expected, inputs: $"{{ \"arg\": {param} }}".ToInputs(), expectedErrorCount: 3, renderErrors: true);
+            AssertQueryIgnoreErrors("query($arg: abcdefg) { test1 (arg: $arg) }", expected, variables: $"{{ \"arg\": {param} }}".ToInputs(), expectedErrorCount: 3, renderErrors: true);
         }
     }
 

--- a/src/GraphQL.Tests/Bugs/Issue2275.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2275.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Tests.Execution
                 _.Query = @"query($data:Input!) {
                                 request(data: $data)
                 }";
-                _.Inputs = @" {
+                _.Variables = @" {
                     ""data"": {
                         ""clientId"": 2,
                         ""filters"": [{

--- a/src/GraphQL.Tests/Bugs/Issue2387_OverrideBuiltInScalars.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2387_OverrideBuiltInScalars.cs
@@ -86,7 +86,7 @@ namespace GraphQL.Tests.Bugs
             var json = await schema.ExecuteAsync(_ =>
             {
                 _.Query = "query ($arg: Int!) { testInput(arg:$arg) }";
-                _.Inputs = "{\"arg\":123}".ToInputs();
+                _.Variables = "{\"arg\":123}".ToInputs();
             });
             json.ShouldBeCrossPlatJson("{\"data\":{\"testInput\": \"122\"}}");
         }
@@ -114,7 +114,7 @@ namespace GraphQL.Tests.Bugs
             var json = await schema.ExecuteAsync(_ =>
             {
                 _.Query = "query ($arg: String!) { testInputString(arg:$arg) }";
-                _.Inputs = "{\"arg\":\"hello\"}".ToInputs();
+                _.Variables = "{\"arg\":\"hello\"}".ToInputs();
             });
             json.ShouldBeCrossPlatJson("{\"data\":{\"testInputString\": \"input-hello\"}}");
         }

--- a/src/GraphQL.Tests/Bugs/Issue2392_OverrideBuiltInScalars_Alt.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2392_OverrideBuiltInScalars_Alt.cs
@@ -112,7 +112,7 @@ namespace GraphQL.Tests.Bugs
             var json = await schema.ExecuteAsync(_ =>
             {
                 _.Query = "query ($arg: Int!) { testInput(arg:$arg) }";
-                _.Inputs = "{\"arg\":123}".ToInputs();
+                _.Variables = "{\"arg\":123}".ToInputs();
             });
             json.ShouldBeCrossPlatJson("{\"data\":{\"testInput\": \"122\"}}");
         }
@@ -140,7 +140,7 @@ namespace GraphQL.Tests.Bugs
             var json = await schema.ExecuteAsync(_ =>
             {
                 _.Query = "query ($arg: String!) { testInputString(arg:$arg) }";
-                _.Inputs = "{\"arg\":\"hello\"}".ToInputs();
+                _.Variables = "{\"arg\":\"hello\"}".ToInputs();
             });
             json.ShouldBeCrossPlatJson("{\"data\":{\"testInputString\": \"input-hello\"}}");
         }

--- a/src/GraphQL.Tests/Bugs/NullableInputListTests.cs
+++ b/src/GraphQL.Tests/Bugs/NullableInputListTests.cs
@@ -32,7 +32,7 @@ namespace GraphQL.Tests.Bugs
                 {
                     ""example"": ""null""
                 }";
-            AssertQuerySuccess(query, expected, inputs: new Inputs(new Dictionary<string, object>
+            AssertQuerySuccess(query, expected, variables: new Inputs(new Dictionary<string, object>
             {
                 { "inputs", null }
             }));

--- a/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
+++ b/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
@@ -194,7 +194,7 @@ mutation {
         {
             var query = @"mutation AAA($val : Int!) { int(number: $val) }";
             var expected = @"{ ""int"": 100 }";
-            var result = AssertQueryWithErrors(query, expected, inputs: @"{ ""val"": ""100"" }".ToInputs(), expectedErrorCount: 1, executed: false);
+            var result = AssertQueryWithErrors(query, expected, variables: @"{ ""val"": ""100"" }".ToInputs(), expectedErrorCount: 1, executed: false);
             result.Errors[0].Message.ShouldBe(@"Variable '$val' is invalid. Unable to convert '100' to 'Int'");
         }
 
@@ -212,7 +212,7 @@ mutation {
         {
             var query = @"mutation AAA($val : Long!) { long(number: $val) }";
             var expected = @"{ ""long"": 100 }";
-            var result = AssertQueryWithErrors(query, expected, inputs: @"{ ""val"": ""100"" }".ToInputs(), expectedErrorCount: 1, executed: false);
+            var result = AssertQueryWithErrors(query, expected, variables: @"{ ""val"": ""100"" }".ToInputs(), expectedErrorCount: 1, executed: false);
             result.Errors[0].Message.ShouldBe(@"Variable '$val' is invalid. Unable to convert '100' to 'Long'");
         }
     }

--- a/src/GraphQL.Tests/Execution/DocumentExecuterExceptions.cs
+++ b/src/GraphQL.Tests/Execution/DocumentExecuterExceptions.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Tests.Execution
             {
                 Query = "query($arg: Byte!) { test(arg: $arg) }",
                 Schema = Schema,
-                Inputs = "{\"arg\":500}".ToInputs(),
+                Variables = "{\"arg\":500}".ToInputs(),
                 ThrowOnUnhandledException = true,
             });
             valid.ShouldNotBeNull();

--- a/src/GraphQL.Tests/Execution/FuncFieldResolverTests.cs
+++ b/src/GraphQL.Tests/Execution/FuncFieldResolverTests.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Tests.Execution
             {
                 Arguments = new Dictionary<string, ArgumentValue>(),
                 Errors = new ExecutionErrors(),
-                Extensions = new Dictionary<string, object>(),
+                OutputExtensions = new Dictionary<string, object>(),
             };
         }
 

--- a/src/GraphQL.Tests/Execution/Performance/ListPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/ListPerformanceTests.cs
@@ -112,7 +112,7 @@ namespace GraphQL.Tests.Execution.Performance
                 _.Schema = Schema;
                 _.Query = query;
                 _.Root = PeopleList;
-                _.Inputs = null;
+                _.Variables = null;
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;
@@ -147,7 +147,7 @@ namespace GraphQL.Tests.Execution.Performance
                 _.Schema = Schema;
                 _.Query = query;
                 _.Root = PeopleList;
-                _.Inputs = null;
+                _.Variables = null;
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;
@@ -194,7 +194,7 @@ namespace GraphQL.Tests.Execution.Performance
                 _.Schema = Schema;
                 _.Query = query;
                 _.Root = PeopleList;
-                _.Inputs = null;
+                _.Variables = null;
                 _.UserContext = null;
                 _.CancellationToken = default;
                 _.ValidationRules = null;

--- a/src/GraphQL.Tests/Execution/Performance/StarWarsPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/StarWarsPerformanceTests.cs
@@ -46,7 +46,7 @@ namespace GraphQL.Tests.Execution.Performance
                     _.Schema = Schema;
                     _.Query = query;
                     _.Root = null;
-                    _.Inputs = null;
+                    _.Variables = null;
                     _.UserContext = null;
                     _.CancellationToken = default;
                     _.ValidationRules = null;

--- a/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
+++ b/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
@@ -168,31 +168,31 @@ namespace GraphQL.Tests.Execution
         public void GetSetExtension_Should_Throw_On_Null()
         {
             IResolveFieldContext context = null;
-            Should.Throw<ArgumentNullException>(() => context.GetExtension("e"));
-            Should.Throw<ArgumentNullException>(() => context.SetExtension("e", 1));
+            Should.Throw<ArgumentNullException>(() => context.GetOutputExtension("e"));
+            Should.Throw<ArgumentNullException>(() => context.SetOutputExtension("e", 1));
 
             context = new ResolveFieldContext();
-            context.GetExtension("a").ShouldBe(null);
-            context.GetExtension("a.b.c.d").ShouldBe(null);
-            Should.Throw<ArgumentException>(() => context.SetExtension("e", 1));
+            context.GetOutputExtension("a").ShouldBe(null);
+            context.GetOutputExtension("a.b.c.d").ShouldBe(null);
+            Should.Throw<ArgumentException>(() => context.SetOutputExtension("e", 1));
         }
 
         [Fact]
         public void GetSetExtension_Should_Get_And_Set_Values()
         {
-            _context.GetExtension("a").ShouldBe(null);
-            _context.GetExtension("a.b.c.d").ShouldBe(null);
+            _context.GetOutputExtension("a").ShouldBe(null);
+            _context.GetOutputExtension("a.b.c.d").ShouldBe(null);
 
-            _context.SetExtension("a", 5);
-            _context.GetExtension("a").ShouldBe(5);
+            _context.SetOutputExtension("a", 5);
+            _context.GetOutputExtension("a").ShouldBe(5);
 
-            _context.SetExtension("a.b.c.d", "value");
-            _context.GetExtension("a.b.c.d").ShouldBe("value");
-            var d = _context.GetExtension("a.b").ShouldBeOfType<Dictionary<string, object>>();
+            _context.SetOutputExtension("a.b.c.d", "value");
+            _context.GetOutputExtension("a.b.c.d").ShouldBe("value");
+            var d = _context.GetOutputExtension("a.b").ShouldBeOfType<Dictionary<string, object>>();
             d.Count.ShouldBe(1);
 
-            _context.SetExtension("a.b.c", "override");
-            _context.GetExtension("a.b.c.d").ShouldBe(null);
+            _context.SetOutputExtension("a.b.c", "override");
+            _context.GetOutputExtension("a.b.c.d").ShouldBe(null);
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
+++ b/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Tests.Execution
             {
                 Arguments = new Dictionary<string, ArgumentValue>(),
                 Errors = new ExecutionErrors(),
-                Extensions = new Dictionary<string, object>(),
+                OutputExtensions = new Dictionary<string, object>(),
             };
         }
 

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -54,7 +54,7 @@ namespace GraphQL.Tests
         public ExecutionResult AssertQuerySuccess(
             string query,
             string expected,
-            Inputs inputs = null,
+            Inputs variables = null,
             object root = null,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
@@ -63,13 +63,13 @@ namespace GraphQL.Tests
             IDocumentWriter writer = null)
         {
             var queryResult = CreateQueryResult(expected);
-            return AssertQuery(query, queryResult, inputs, root, userContext, cancellationToken, rules, null, nameConverter, writer);
+            return AssertQuery(query, queryResult, variables, root, userContext, cancellationToken, rules, null, nameConverter, writer);
         }
 
         public ExecutionResult AssertQueryWithErrors(
             string query,
             string expected,
-            Inputs inputs = null,
+            Inputs variables = null,
             object root = null,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
@@ -83,7 +83,7 @@ namespace GraphQL.Tests
             return AssertQueryIgnoreErrors(
                 query,
                 queryResult,
-                inputs,
+                variables,
                 root,
                 userContext,
                 cancellationToken,
@@ -96,7 +96,7 @@ namespace GraphQL.Tests
         public ExecutionResult AssertQueryIgnoreErrors(
             string query,
             ExecutionResult expectedExecutionResult,
-            Inputs inputs = null,
+            Inputs variables = null,
             object root = null,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
@@ -110,7 +110,7 @@ namespace GraphQL.Tests
                 options.Schema = Schema;
                 options.Query = query;
                 options.Root = root;
-                options.Variables = inputs;
+                options.Variables = variables;
                 options.UserContext = userContext;
                 options.CancellationToken = cancellationToken;
                 options.ValidationRules = rules;
@@ -134,7 +134,7 @@ namespace GraphQL.Tests
         public ExecutionResult AssertQuery(
             string query,
             object expectedExecutionResultOrJson,
-            Inputs inputs,
+            Inputs variables,
             object root,
             IDictionary<string, object> userContext = null,
             CancellationToken cancellationToken = default,
@@ -150,7 +150,7 @@ namespace GraphQL.Tests
                 options.Schema = schema;
                 options.Query = query;
                 options.Root = root;
-                options.Variables = inputs;
+                options.Variables = variables;
                 options.UserContext = userContext;
                 options.CancellationToken = cancellationToken;
                 options.ValidationRules = rules;

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -110,7 +110,7 @@ namespace GraphQL.Tests
                 options.Schema = Schema;
                 options.Query = query;
                 options.Root = root;
-                options.Inputs = inputs;
+                options.Variables = inputs;
                 options.UserContext = userContext;
                 options.CancellationToken = cancellationToken;
                 options.ValidationRules = rules;
@@ -150,7 +150,7 @@ namespace GraphQL.Tests
                 options.Schema = schema;
                 options.Query = query;
                 options.Root = root;
-                options.Inputs = inputs;
+                options.Variables = inputs;
                 options.UserContext = userContext;
                 options.CancellationToken = cancellationToken;
                 options.ValidationRules = rules;

--- a/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
@@ -191,7 +191,7 @@ namespace GraphQL.Tests.Subscription
             {
                 Query = "subscription MessageAddedByUser($id:String!) { messageAddedByUser(id: $id) { from { id displayName } content sentAt } }",
                 Schema = schema,
-                Inputs = new Inputs(new Dictionary<string, object>
+                Variables = new Inputs(new Dictionary<string, object>
                 {
                     ["id"] = "1"
                 })
@@ -230,7 +230,7 @@ namespace GraphQL.Tests.Subscription
             {
                 Query = "subscription MessageAddedByUser($id:String!) { messageAddedByUserAsync(id: $id) { from { id displayName } content sentAt } }",
                 Schema = schema,
-                Inputs = new Inputs(new Dictionary<string, object>
+                Variables = new Inputs(new Dictionary<string, object>
                 {
                     ["id"] = "1"
                 })

--- a/src/GraphQL.Tests/Subscription/SubscriptionWithReflectionTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionWithReflectionTests.cs
@@ -126,7 +126,7 @@ namespace GraphQL.Tests.Subscription
             {
                 Query = "subscription MessageAddedByUser($id:String!) { messageAddedByUser(id: $id) { from { id displayName } content sentAt } }",
                 Schema = schema,
-                Inputs = new Inputs(new Dictionary<string, object>
+                Variables = new Inputs(new Dictionary<string, object>
                 {
                     ["id"] = "1"
                 })
@@ -166,7 +166,7 @@ namespace GraphQL.Tests.Subscription
             {
                 Query = "subscription MessageAddedByUser($id:String!) { messageAddedByUserAsync(id: $id) { from { id displayName } content sentAt } }",
                 Schema = schema,
-                Inputs = new Inputs(new Dictionary<string, object>
+                Variables = new Inputs(new Dictionary<string, object>
                 {
                     ["id"] = "1"
                 })

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTestBase.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTestBase.cs
@@ -36,7 +36,7 @@ namespace GraphQL.Tests.Utilities
                 {
                     _.Schema = schema;
                     _.Query = config.Query;
-                    _.Inputs = config.Variables.ToInputs();
+                    _.Variables = config.Variables.ToInputs();
                     _.Root = config.Root;
                     _.ThrowOnUnhandledException = config.ThrowOnUnhandledException;
                     _.Listeners.AddRange(config.Listeners);

--- a/src/GraphQL.Tests/Validation/ValidationTestBase.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestBase.cs
@@ -91,12 +91,12 @@ namespace GraphQL.Tests.Validation
             result.IsValid.ShouldBeTrue(message);
         }
 
-        private IValidationResult Validate(string query, ISchema schema, IEnumerable<IValidationRule> rules, Inputs inputs)
+        private IValidationResult Validate(string query, ISchema schema, IEnumerable<IValidationRule> rules, Inputs variables)
         {
             var documentBuilder = new GraphQLDocumentBuilder();
             var document = documentBuilder.Build(query);
             var validator = new DocumentValidator();
-            return validator.ValidateAsync(schema, document, document.Operations.FirstOrDefault()?.Variables, rules, inputs: inputs).Result.validationResult;
+            return validator.ValidateAsync(schema, document, document.Operations.FirstOrDefault()?.Variables, rules, variables: variables).Result.validationResult;
         }
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -142,7 +142,7 @@ namespace GraphQL
                         operation.Variables,
                         validationRules,
                         options.UserContext,
-                        options.Inputs,
+                        options.Variables,
                         options.OperationName);
                 }
 
@@ -274,7 +274,8 @@ namespace GraphQL
                 Operation = operation,
                 Variables = variables,
                 Errors = new ExecutionErrors(),
-                Extensions = new Dictionary<string, object?>(),
+                InputExtensions = options.Extensions ?? Inputs.Empty,
+                OutputExtensions = new Dictionary<string, object?>(),
                 CancellationToken = options.CancellationToken,
 
                 Metrics = metrics,

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -57,7 +57,10 @@ namespace GraphQL.Execution
         public int? MaxParallelExecutionCount { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, object?> Extensions { get; set; }
+        public IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
+
+        /// <inheritdoc/>
+        public Dictionary<string, object?> OutputExtensions { get; set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         /// <inheritdoc/>

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -33,7 +33,10 @@ namespace GraphQL
         public Document? Document { get; set; }
 
         /// <summary>Input variables to GraphQL request</summary>
-        public Inputs? Inputs { get; set; }
+        public Inputs? Variables { get; set; }
+
+        /// <summary>Input extensions to GraphQL request</summary>
+        public Inputs? Extensions { get; set; }
 
         /// <summary><see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel the request at any stage of its execution; defaults to <see cref="System.Threading.CancellationToken.None"/></summary>
         public CancellationToken CancellationToken { get; set; }

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -49,7 +49,7 @@ namespace GraphQL
         public PerfRecord[]? Perf { get; set; }
 
         /// <summary>
-        /// Returns additional user-defined data; see <see cref="IExecutionContext.Extensions"/> and <see cref="IResolveFieldContext.Extensions"/>. This property is serialized as part of the GraphQL json response.
+        /// Returns additional user-defined data; see <see cref="IExecutionContext.OutputExtensions"/> and <see cref="IResolveFieldContext.OutputExtensions"/>. This property is serialized as part of the GraphQL json response.
         /// </summary>
         public Dictionary<string, object?>? Extensions { get; set; }
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Execution
                 Query = context.Document.OriginalQuery,
                 Document = context.Document,
                 Operation = context.Operation,
-                Extensions = context.Extensions
+                Extensions = context.OutputExtensions
             };
         }
 

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -81,10 +81,17 @@ namespace GraphQL.Execution
         Variables Variables { get; }
 
         /// <summary>
+        /// A dictionary of extra information supplied with the GraphQL request.
+        /// This is reserved for implementors to extend the protocol however they see fit, and
+        /// hence there are no additional restrictions on its contents.
+        /// </summary>
+        IReadOnlyDictionary<string, object?> InputExtensions { get; }
+
+        /// <summary>
         /// The response map may also contain an entry with key extensions. This entry is reserved for implementors to extend the
         /// protocol however they see fit, and hence there are no additional restrictions on its contents.
         /// </summary>
-        Dictionary<string, object?> Extensions { get; }
+        Dictionary<string, object?> OutputExtensions { get; }
 
         /// <summary>
         /// The service provider for the executing request. Typically this is a scoped service provider

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -88,8 +88,8 @@ namespace GraphQL
         /// <summary>
         /// The response map may also contain an entry with key extensions. This entry is reserved for implementors to extend the
         /// protocol however they see fit, and hence there are no additional restrictions on its contents. This dictionary is shared
-        /// by all running resolvers and is not thread safe. Also you may use <see cref="ResolveFieldContextExtensions.GetExtension(IResolveFieldContext, string)">GetExtension</see>
-        /// and <see cref="ResolveFieldContextExtensions.SetExtension(IResolveFieldContext, string, object)">SetExtension</see>
+        /// by all running resolvers and is not thread safe. Also you may use <see cref="ResolveFieldContextExtensions.GetOutputExtension(IResolveFieldContext, string)">GetExtension</see>
+        /// and <see cref="ResolveFieldContextExtensions.SetOutputExtension(IResolveFieldContext, string, object)">SetExtension</see>
         /// methods.
         /// </summary>
         IDictionary<string, object?> OutputExtensions { get; }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -79,13 +79,20 @@ namespace GraphQL
         Dictionary<string, Field>? SubFields { get; }
 
         /// <summary>
+        /// A dictionary of extra information supplied with the GraphQL request.
+        /// This is reserved for implementors to extend the protocol however they see fit, and
+        /// hence there are no additional restrictions on its contents.
+        /// </summary>
+        IReadOnlyDictionary<string, object?> InputExtensions { get; }
+
+        /// <summary>
         /// The response map may also contain an entry with key extensions. This entry is reserved for implementors to extend the
         /// protocol however they see fit, and hence there are no additional restrictions on its contents. This dictionary is shared
         /// by all running resolvers and is not thread safe. Also you may use <see cref="ResolveFieldContextExtensions.GetExtension(IResolveFieldContext, string)">GetExtension</see>
         /// and <see cref="ResolveFieldContextExtensions.SetExtension(IResolveFieldContext, string, object)">SetExtension</see>
         /// methods.
         /// </summary>
-        IDictionary<string, object?> Extensions { get; }
+        IDictionary<string, object?> OutputExtensions { get; }
 
         /// <summary>The service provider for the executing request.</summary>
         IServiceProvider? RequestServices { get; }

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -116,7 +116,10 @@ namespace GraphQL
         object? IResolveFieldContext.Source => _executionNode.Source;
 
         /// <inheritdoc/>
-        public IDictionary<string, object?> Extensions => _executionContext.Extensions;
+        public IReadOnlyDictionary<string, object?> InputExtensions => _executionContext.InputExtensions;
+
+        /// <inheritdoc/>
+        public IDictionary<string, object?> OutputExtensions => _executionContext.OutputExtensions;
 
         /// <inheritdoc/>
         public IServiceProvider? RequestServices => _executionContext.RequestServices;

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -111,6 +111,7 @@ namespace GraphQL
             Path = context.Path;
             ResponsePath = context.ResponsePath;
             RequestServices = context.RequestServices;
+            InputExtensions = context.InputExtensions;
             OutputExtensions = context.OutputExtensions;
             ArrayPool = context.ArrayPool;
         }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -72,7 +72,10 @@ namespace GraphQL
         public IServiceProvider? RequestServices { get; set; }
 
         /// <inheritdoc/>
-        public IDictionary<string, object?> Extensions { get; set; }
+        public IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
+
+        /// <inheritdoc/>
+        public IDictionary<string, object?> OutputExtensions { get; set; }
 
         /// <inheritdoc/>
         public IExecutionArrayPool ArrayPool { get; set; }
@@ -108,7 +111,7 @@ namespace GraphQL
             Path = context.Path;
             ResponsePath = context.ResponsePath;
             RequestServices = context.RequestServices;
-            Extensions = context.Extensions;
+            OutputExtensions = context.OutputExtensions;
             ArrayPool = context.ArrayPool;
         }
     }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -89,7 +89,9 @@ namespace GraphQL
 
         public IDictionary<string, object?> UserContext => _baseContext.UserContext;
 
-        public IDictionary<string, object?> Extensions => _baseContext.Extensions;
+        public IReadOnlyDictionary<string, object?> InputExtensions => _baseContext.InputExtensions;
+
+        public IDictionary<string, object?> OutputExtensions => _baseContext.OutputExtensions;
 
         object? IResolveFieldContext.Source => Source;
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -95,12 +95,12 @@ namespace GraphQL
         private static readonly char[] _separators = { '.' };
 
         /// <summary>
-        /// Thread safe method to get value by path (key1.key2.keyN) from extensions dictionary.
+        /// Thread safe method to get value by path (key1.key2.keyN) from output extensions dictionary.
         /// </summary>
         /// <param name="context">Context with extensions response map.</param>
         /// <param name="path">Path to value in key1.key2.keyN format.</param>
         /// <returns>Value, if any exists on the specified path, otherwise <c>null</c>.</returns>
-        public static object? GetExtension(this IResolveFieldContext context, string path)
+        public static object? GetOutputExtension(this IResolveFieldContext context, string path)
         {
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
@@ -134,13 +134,13 @@ namespace GraphQL
         }
 
         /// <summary>
-        /// Thread safe method to set value by path (key1.key2.keyN) to extensions dictionary.
+        /// Thread safe method to set value by path (key1.key2.keyN) to output extensions dictionary.
         /// if the given path or its part contains values, then they will be overwritten.
         /// </summary>
         /// <param name="context">Context with extensions response map.</param>
         /// <param name="path">Path to value in key1.key2.keyN format.</param>
         /// <param name="value">Value to set.</param>
-        public static void SetExtension(this IResolveFieldContext context, string path, object? value)
+        public static void SetOutputExtension(this IResolveFieldContext context, string path, object? value)
         {
             if (context == null)
                 throw new ArgumentNullException(nameof(context));

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -105,12 +105,12 @@ namespace GraphQL
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            if (context.Extensions == null || context.Extensions.Count == 0)
+            if (context.OutputExtensions == null || context.OutputExtensions.Count == 0)
                 return null;
 
-            lock (context.Extensions)
+            lock (context.OutputExtensions)
             {
-                var values = context.Extensions;
+                var values = context.OutputExtensions;
 
                 if (path.IndexOf('.') != -1)
                 {
@@ -145,12 +145,12 @@ namespace GraphQL
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            if (context.Extensions == null)
+            if (context.OutputExtensions == null)
                 throw new ArgumentException("Extensions property is null", nameof(context));
 
-            lock (context.Extensions)
+            lock (context.OutputExtensions)
             {
-                var values = context.Extensions;
+                var values = context.OutputExtensions;
 
                 if (path.IndexOf('.') != -1)
                 {

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -19,7 +19,7 @@ namespace GraphQL.Validation
             VariableDefinitions? variableDefinitions,
             IEnumerable<IValidationRule>? rules = null,
             IDictionary<string, object?> userContext = null!,
-            Inputs? inputs = null,
+            Inputs? variables = null,
             string? operationName = null);
     }
 
@@ -69,7 +69,7 @@ namespace GraphQL.Validation
             VariableDefinitions? variableDefinitions,
             IEnumerable<IValidationRule>? rules = null,
             IDictionary<string, object?> userContext = null!,
-            Inputs? inputs = null,
+            Inputs? variables = null,
             string? operationName = null)
         {
             schema.Initialize();
@@ -79,18 +79,18 @@ namespace GraphQL.Validation
             context.Document = document;
             context.TypeInfo = new TypeInfo(schema);
             context.UserContext = userContext;
-            context.Inputs = inputs;
+            context.Variables = variables;
             context.OperationName = operationName;
 
             try
             {
-                Variables? variables = null;
+                Variables? variablesObj = null;
 
                 rules ??= CoreRules;
 
                 if (!rules.Any())
                 {
-                    variables = context.GetVariableValues(schema, variableDefinitions, inputs ?? Inputs.Empty); // can report errors even without rules enabled
+                    variablesObj = context.GetVariableValues(schema, variableDefinitions, variables ?? Inputs.Empty); // can report errors even without rules enabled
                 }
                 else
                 {
@@ -115,13 +115,13 @@ namespace GraphQL.Validation
 
                     new BasicVisitor(visitors).Visit(document, context);
 
-                    variables = context.GetVariableValues(schema, variableDefinitions, inputs ?? Inputs.Empty,
+                    variablesObj = context.GetVariableValues(schema, variableDefinitions, variables ?? Inputs.Empty,
                         variableVisitors == null ? null : variableVisitors.Count == 1 ? variableVisitors[0] : new CompositeVariableVisitor(variableVisitors));
                 }
 
                 return context.HasErrors
-                    ? (new ValidationResult(context.Errors), variables)
-                    : (SuccessfullyValidatedResult.Instance, variables);
+                    ? (new ValidationResult(context.Errors), variablesObj)
+                    : (SuccessfullyValidatedResult.Instance, variablesObj);
             }
             finally
             {

--- a/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
+++ b/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
@@ -81,9 +81,9 @@ namespace GraphQL.Validation.Rules
             {
                 CheckStringLength(strLiteral.Value);
             }
-            else if (node.Value is VariableReference vRef && context.Inputs != null)
+            else if (node.Value is VariableReference vRef && context.Variables != null)
             {
-                if (context.Inputs.TryGetValue(vRef.Name, out var value))
+                if (context.Variables.TryGetValue(vRef.Name, out var value))
                 {
                     if (value is string strVariable)
                         CheckStringLength(strVariable);

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -61,7 +61,7 @@ namespace GraphQL.Validation
         /// </summary>
         public bool HasErrors => _errors?.Count > 0;
 
-        /// <inheritdoc cref="ExecutionOptions.Inputs"/>
+        /// <inheritdoc cref="ExecutionOptions.Variables"/>
         public Inputs? Inputs { get; set; }
 
         /// <summary>

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -31,7 +31,7 @@ namespace GraphQL.Validation
             Document = null!;
             TypeInfo = null!;
             UserContext = null!;
-            Inputs = null;
+            Variables = null;
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace GraphQL.Validation
         public bool HasErrors => _errors?.Count > 0;
 
         /// <inheritdoc cref="ExecutionOptions.Variables"/>
-        public Inputs? Inputs { get; set; }
+        public Inputs? Variables { get; set; }
 
         /// <summary>
         /// Adds a validation error to the list of validation errors.
@@ -192,16 +192,16 @@ namespace GraphQL.Validation
         }
 
         /// <summary>
-        /// Returns all of the variable values defined for the operation from the attached <see cref="Inputs"/> object.
+        /// Returns all of the variable values defined for the operation from the attached <see cref="Variables"/> object.
         /// </summary>
-        public Variables GetVariableValues(ISchema schema, VariableDefinitions? variableDefinitions, Inputs inputs, IVariableVisitor? visitor = null)
+        public Variables GetVariableValues(ISchema schema, VariableDefinitions? variableDefinitions, Inputs variables, IVariableVisitor? visitor = null)
         {
             if ((variableDefinitions?.List?.Count ?? 0) == 0)
             {
-                return Variables.None;
+                return Language.AST.Variables.None;
             }
 
-            var variables = new Variables(variableDefinitions!.List!.Count);
+            var variablesObj = new Variables(variableDefinitions!.List!.Count);
 
             if (variableDefinitions != null)
             {
@@ -220,7 +220,7 @@ namespace GraphQL.Validation
                     var variable = new Variable(variableDef.Name);
 
                     // attempt to retrieve the variable value from the inputs
-                    if (inputs.TryGetValue(variableDef.Name, out var variableValue))
+                    if (variables.TryGetValue(variableDef.Name, out var variableValue))
                     {
                         // parse the variable via ParseValue (for scalars) and ParseDictionary (for objects) as applicable
                         try
@@ -240,7 +240,7 @@ namespace GraphQL.Validation
                         // parse the variable literal via ParseLiteral (for scalars) and ParseDictionary (for objects) as applicable
                         try
                         {
-                            variable.Value = ExecutionHelper.CoerceValue(graphType, variableDef.DefaultValue, variables, null).Value;
+                            variable.Value = ExecutionHelper.CoerceValue(graphType, variableDef.DefaultValue, variablesObj, null).Value;
                         }
                         catch (Exception ex)
                         {
@@ -258,16 +258,16 @@ namespace GraphQL.Validation
                     // if the variable was not specified and no default was specified, do not set variable.Value
 
                     // add the variable to the list of parsed variables defined for the operation
-                    variables.Add(variable);
+                    variablesObj.Add(variable);
                 }
             }
 
             // return the list of parsed variables defined for the operation
-            return variables;
+            return variablesObj;
         }
 
         /// <summary>
-        /// Return the specified variable's value for the document from the attached <see cref="Inputs"/> object.
+        /// Return the specified variable's value for the document from the attached <see cref="Variables"/> object.
         /// <br/><br/>
         /// Validates and parses the supplied input object according to the variable's type, and converts the object
         /// with <see cref="ScalarGraphType.ParseValue(object)"/> and


### PR DESCRIPTION
Replaces #2719 

Note:
- The `GetExtension` and `SetExtension` thread-safe extension methods have not been renamed.  Should they be?  `GetOutputExtension` and `SetOutputExtension` ?