### PR TITLE
Add forgotten ConfigureAwait(false) for v4

### DIFF
--- a/src/GraphQL.DataLoader/BatchDataLoader.cs
+++ b/src/GraphQL.DataLoader/BatchDataLoader.cs
@@ -53,7 +53,7 @@ namespace GraphQL.DataLoader
 
             _loader = async (keys, cancellationToken) =>
             {
-                var ret = await fetchDelegate(keys, cancellationToken);
+                var ret = await fetchDelegate(keys, cancellationToken).ConfigureAwait(false);
                 return ret.ToDictionary(keySelector, keyComparer);
             };
             _defaultValue = defaultValue;
@@ -63,7 +63,7 @@ namespace GraphQL.DataLoader
         protected override async Task FetchAsync(IEnumerable<DataLoaderPair<TKey, T>> list, CancellationToken cancellationToken)
         {
             var keys = list.Select(x => x.Key);
-            var dictionary = await _loader(keys, cancellationToken);
+            var dictionary = await _loader(keys, cancellationToken).ConfigureAwait(false);
             foreach (var item in list)
             {
                 if (!dictionary.TryGetValue(item.Key, out var value))

--- a/src/GraphQL.DataLoader/CollectionBatchDataLoader.cs
+++ b/src/GraphQL.DataLoader/CollectionBatchDataLoader.cs
@@ -47,7 +47,7 @@ namespace GraphQL.DataLoader
 
             _loader = async (keys, cancellationToken) =>
             {
-                var ret = await fetchDelegate(keys, cancellationToken);
+                var ret = await fetchDelegate(keys, cancellationToken).ConfigureAwait(false);
                 return ret.ToLookup(keySelector, keyComparer);
             };
         }
@@ -56,7 +56,7 @@ namespace GraphQL.DataLoader
         protected override async Task FetchAsync(IEnumerable<DataLoaderPair<TKey, IEnumerable<T>>> list, CancellationToken cancellationToken)
         {
             var keys = list.Select(x => x.Key);
-            var lookup = await _loader(keys, cancellationToken);
+            var lookup = await _loader(keys, cancellationToken).ConfigureAwait(false);
             foreach (var item in list)
             {
                 item.SetResult(lookup[item.Key]);

--- a/src/GraphQL.MicrosoftDI/ScopedAsyncFieldResolver.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedAsyncFieldResolver.cs
@@ -25,7 +25,7 @@ namespace GraphQL.MicrosoftDI
             {
                 using (var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope())
                 {
-                    return await resolver(new ScopedResolveFieldContextAdapter<object>(context, scope.ServiceProvider));
+                    return await resolver(new ScopedResolveFieldContextAdapter<object>(context, scope.ServiceProvider)).ConfigureAwait(false);
                 }
             };
         }
@@ -45,7 +45,7 @@ namespace GraphQL.MicrosoftDI
             {
                 using (var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope())
                 {
-                    return await resolver(new ScopedResolveFieldContextAdapter<TSourceType>(context, scope.ServiceProvider));
+                    return await resolver(new ScopedResolveFieldContextAdapter<TSourceType>(context, scope.ServiceProvider)).ConfigureAwait(false);
                 }
             };
         }

--- a/src/GraphQL.MicrosoftDI/ScopedConnectionBuilderExtensions.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedConnectionBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace GraphQL.MicrosoftDI
             {
                 using (var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope())
                 {
-                    return await resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider));
+                    return await resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider)).ConfigureAwait(false);
                 }
             });
         }
@@ -74,7 +74,7 @@ namespace GraphQL.MicrosoftDI
             {
                 using (var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope())
                 {
-                    return await resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider));
+                    return await resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider)).ConfigureAwait(false);
                 }
             });
         }

--- a/src/GraphQL/DirectivesExtensions.cs
+++ b/src/GraphQL/DirectivesExtensions.cs
@@ -186,7 +186,7 @@ namespace GraphQL
                        {
                            // return only registered directives allowed by filter
                            var schemaDirective = context.Schema.Directives.Find(applied.Name);
-                           if (schemaDirective != null && await context.Schema.Filter.AllowDirective(schemaDirective))
+                           if (schemaDirective != null && await context.Schema.Filter.AllowDirective(schemaDirective).ConfigureAwait(false))
                            {
                                result[index++] = applied;
                            }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -78,7 +78,7 @@ namespace GraphQL
                 foreach (var configuration in _configurations)
                 {
                     // allocation free when the configuration delegate is not asynchronous
-                    await configuration.ConfigureAsync(options);
+                    await configuration.ConfigureAsync(options).ConfigureAwait(false);
                 }
             }
 

--- a/src/GraphQL/Execution/ParallelExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ParallelExecutionStrategy.cs
@@ -124,7 +124,7 @@ namespace GraphQL.Execution
                     }
                     try
                     {
-                        await Task.WhenAll(currentTasks);
+                        await Task.WhenAll(currentTasks).ConfigureAwait(false);
                     }
                     catch
                     {

--- a/src/GraphQL/Introspection/__Type.cs
+++ b/src/GraphQL/Introspection/__Type.cs
@@ -105,7 +105,7 @@ namespace GraphQL.Introspection
                     int index = 0;
                     foreach (var possible in type.PossibleTypes.List)
                     {
-                        if (await context.Schema.Filter.AllowType(possible))
+                        if (await context.Schema.Filter.AllowType(possible).ConfigureAwait(false))
                             possibleTypes[index++] = possible;
                     }
 

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -117,7 +117,7 @@ namespace GraphQL.Validation
                             }
                             return rule.ValidateAsync(context);
                         }).Where(x => x != null);
-                        visitors = (await Task.WhenAll(awaitedVisitors)).ToList();
+                        visitors = (await Task.WhenAll(awaitedVisitors).ConfigureAwait(false)).ToList();
                     }
 
                     visitors.Insert(0, context.TypeInfo);


### PR DESCRIPTION
Note: Need to check `DocumentExecuter` (call to `IDocumentCache.GetAsync`) and `DocumentValidator` for v5