### PR TITLE
Fix bug: schema instance was registered incorrectly by AddSchema

### DIFF
--- a/src/GraphQL.Tests/DI/GraphQLBuilderTests.cs
+++ b/src/GraphQL.Tests/DI/GraphQLBuilderTests.cs
@@ -272,18 +272,8 @@ namespace GraphQL.Tests.DI
         public void AddSchema_Instance()
         {
             var schema = new TestSchema();
-            _builderMock.Setup(b => b.Register(typeof(TestSchema), It.IsAny<Func<IServiceProvider, object>>(), ServiceLifetime.Singleton, false))
-                .Returns<Type, Func<IServiceProvider, object>, ServiceLifetime, bool>((_, factory, _, _) =>
-                {
-                    factory(null).ShouldBe(schema);
-                    return _builder;
-                }).Verifiable();
-            _builderMock.Setup(b => b.TryRegister(typeof(ISchema), It.IsAny<Func<IServiceProvider, object>>(), ServiceLifetime.Singleton))
-                .Returns<Type, Func<IServiceProvider, object>, ServiceLifetime>((_, factory, _) =>
-                {
-                    factory(null).ShouldBe(schema);
-                    return _builder;
-                }).Verifiable();
+            _builderMock.Setup(b => b.Register(typeof(TestSchema), schema, false)).Returns(_builder).Verifiable();
+            _builderMock.Setup(b => b.TryRegister(typeof(ISchema), schema)).Returns(_builder).Verifiable();
             _builder.AddSchema(schema);
             Verify();
         }

--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -174,7 +174,16 @@ namespace GraphQL
         /// </summary>
         public static IGraphQLBuilder AddSchema<TSchema>(this IGraphQLBuilder builder, TSchema schema)
             where TSchema : class, ISchema
-            => schema == null ? throw new ArgumentNullException(nameof(schema)) : AddSchema(builder, _ => schema, ServiceLifetime.Singleton);
+        {
+            if (schema == null)
+                throw new ArgumentNullException(nameof(schema));
+
+            // Register the service with the DI provider as TSchema, overwriting any existing registration
+            // Also register the service as ISchema if not already registered.
+            builder.TryRegisterAsBoth<ISchema, TSchema>(schema);
+
+            return builder;
+        }
 
         /// <inheritdoc cref="AddSchema{TSchema}(IGraphQLBuilder, ServiceLifetime)"/>
         public static IGraphQLBuilder AddSchema<TSchema>(this IGraphQLBuilder builder, Func<IServiceProvider, TSchema> schemaFactory, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)


### PR DESCRIPTION
It would be disposed when it should not have been because the wrong `Register` method was called