### PR TITLE
Generate received files for all TFMs in one test run.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,7 @@ test:
   - src/GraphQL.Harness.Tests/**/*
   - src/GraphQL.MicrosoftDI.Tests/**/*
   - src/GraphQL.Tests/**/*
+  - src/GraphQL.ApiTests/**/*.cs
 
 CI:
   - .github/workflows/**/*

--- a/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
+++ b/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Tested locally.