### PR TITLE
Auto approve API

### DIFF
--- a/src/GraphQL.MemoryCache/MemoryDocumentCache.cs
+++ b/src/GraphQL.MemoryCache/MemoryDocumentCache.cs
@@ -68,11 +68,6 @@ namespace GraphQL.Caching
             set => _memoryCache.Set(query ?? throw new ArgumentNullException(nameof(query)), value, GetMemoryCacheEntryOptions(query));
         }
 
-        /// <summary>
-        /// Do somme.
-        /// </summary>
-        public static void DoSomething() { }
-
         /// <inheritdoc/>
         public virtual void Dispose()
         {

--- a/src/GraphQL.MemoryCache/MemoryDocumentCache.cs
+++ b/src/GraphQL.MemoryCache/MemoryDocumentCache.cs
@@ -68,6 +68,11 @@ namespace GraphQL.Caching
             set => _memoryCache.Set(query ?? throw new ArgumentNullException(nameof(query)), value, GetMemoryCacheEntryOptions(query));
         }
 
+        /// <summary>
+        /// Do somme.
+        /// </summary>
+        public static void DoSomething() { }
+
         /// <inheritdoc/>
         public virtual void Dispose()
         {


### PR DESCRIPTION
@Shane32 I think you like it.

The idea is pretty simple. We have long we use this test not as a test, but as a tool for controlling changes in API. We manually rename _approval_ files. Now this happens automatically, but only locally to accidentally not miss the changes.