### PR TITLE
Introduce ValidationOptions

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -75,18 +75,20 @@ services.AddGraphQL(builder => builder
 
 ### 8. `GraphQLBuilderBase.Initialize` was renamed to `RegisterDefaultServices`
 
-### `schema` and `variables` arguments were removed from `ValidationContext.GetVariableValues`
+### 9. `schema`, `variableDefinitions` and `variables` arguments were removed from `ValidationContext.GetVariableValues`
 
-Use `ValidationContext.Schema` and `ValidationContext.Variables` properties
+Use `ValidationContext.Schema`, `ValidationContext.Operation.Variables` and `ValidationContext.Variables` properties
 
-### 9. All arguments from `IDocumentValidator.ValidateAsync` were wrapped into `ValidationOptions` class
+### 10. `ValidationContext.OperationName` was changed to `ValidationContext.Operation`
 
-### 10. All methods from `IGraphQLBuilder` were moved into `IServiceRegister` interface
+### 11. All arguments from `IDocumentValidator.ValidateAsync` were wrapped into `ValidationOptions` class
+
+### 12. All methods from `IGraphQLBuilder` were moved into `IServiceRegister` interface
 
 Use `IGraphQLBuilder.Services` property if you need to register services into DI container.
 If you use provided extension methods upon `IGraphQLBuilder` then your code does not require any changes.
 
-### 11. Classes and members marked as obsolete have been removed
+### 13. Classes and members marked as obsolete have been removed
 
 The following classes and members that were marked with `[Obsolete]` in v4 have been removed:
 

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -4,7 +4,7 @@ See [issues](https://github.com/graphql-dotnet/graphql-dotnet/issues?q=milestone
 
 ## New Features
 
-### DoNotMapClrType attribute can now be placed on the graph type or the CLR type
+### 1. DoNotMapClrType attribute can now be placed on the graph type or the CLR type
 
 When using the `.AddClrTypeMappings()` builder extension method, GraphQL.NET scans the
 specified assembly for graph types that inherit from `ObjectGraphType<T>` and adds a
@@ -13,42 +13,43 @@ It skips adding a mapping for any graph type marked with the `[DoNotMapClrType]`
 In v5, it will also skip adding the mapping if the CLR type is marked with the
 `[DoNotMapClrType]` attribute.
 
-### Input Extensions support
+### 2. Input Extensions support
 
 `Extensions` deserialized from GraphQL requests can now be set on the `ExecutionOptions.Extensions` property
 and passed through to field resolvers via `IResolveFieldContext.InputExtensions`. Note that standard .NET
-dictionaries (such as `Dictionary<TKey, TValue>`) are thread-safe for read-only operations.
+dictionaries (such as `Dictionary<TKey, TValue>`) are thread-safe for read-only operations. Also you can
+access these extensions from validation rules via `ValidationContext.Extensions`.
 
 ## Breaking Changes
 
-### UnhandledExceptionDelegate
+### 1. UnhandledExceptionDelegate
 
 `ExecutionOptions.UnhandledExceptionDelegate` and `IExecutionContext.UnhandledExceptionDelegate`
 properties type was changed from `Action<UnhandledExceptionContext>` to `Func<UnhandledExceptionContext, Task>`
 so now you may use async/await for exception handling. In this regard, some methods in `ExecutionStrategy` were
 renamed to have `Async` suffix.
 
-### `IDocumentCache` now has asynchronous methods instead of synchronous methods.
+### 2. `IDocumentCache` now has asynchronous methods instead of synchronous methods.
 
 The default get/set property of the interface has been replaced with `GetAsync` and `SetAsync` methods.
 Keys cannot be removed by setting a null value as they could before.
 
-### `IResolveFieldContext.Extensions` property renamed to `OutputExtensions` and related changes
+### 3. `IResolveFieldContext.Extensions` property renamed to `OutputExtensions` and related changes
 
 To clarify and differ output extensions from input extensions, `IResolveFieldContext.Extensions`
 has now been renamed to `OutputExtensions`. The `GetExtension` and `SetExtension` thread-safe
 extension methods have also been renamed to `GetOutputExtension` and `SetOutputExtension` respectively.
 
-### `ExecutionOptions.Inputs` and `ValidationContext.Inputs` properties renamed to `Variables`
+### 4. `ExecutionOptions.Inputs` and `ValidationContext.Inputs` properties renamed to `Variables`
 
 To better align the execution options and variable context with the specification, the `Inputs`
 property containing the execution variables has now been renamed to `Variables`.
 
-### `ConfigureExecution` GraphQL builder method renamed to `ConfigureExecutionOptions`
+### 5. `ConfigureExecution` GraphQL builder method renamed to `ConfigureExecutionOptions`
 
 Also, `IConfigureExecution` renamed to `IConfigureExecutionOptions`.
 
-### `AddGraphQL` now accepts a configuration delegate instead of returning `IGraphQLBuilder`
+### 6. `AddGraphQL` now accepts a configuration delegate instead of returning `IGraphQLBuilder`
 
 In order to prevent default implementations from ever being registered in the DI engine,
 the `AddGraphQL` method now accepts a configuration delegate where you can configure the
@@ -70,16 +71,22 @@ services.AddGraphQL(builder => builder
     .AddSchema<StarWarsSchema>());
 ```
 
-### `GraphQLExtensions.BuildNamedType` renamed and moved to `SchemaTypes.BuildGraphQLType`
+### 7. `GraphQLExtensions.BuildNamedType` was renamed and moved to `SchemaTypes.BuildGraphQLType`
 
-### `GraphQLBuilderBase.Initialize` renamed to `RegisterDefaultServices`
+### 8. `GraphQLBuilderBase.Initialize` was renamed to `RegisterDefaultServices`
 
-### All methods from `IGraphQLBuilder` were moved into `IServiceRegister` interface
+### `schema` and `variables` arguments were removed from `ValidationContext.GetVariableValues`
+
+Use `ValidationContext.Schema` and `ValidationContext.Variables` properties
+
+### 9. All arguments from `IDocumentValidator.ValidateAsync` were wrapped into `ValidationOptions` class
+
+### 10. All methods from `IGraphQLBuilder` were moved into `IServiceRegister` interface
 
 Use `IGraphQLBuilder.Services` property if you need to register services into DI container.
 If you use provided extension methods upon `IGraphQLBuilder` then your code does not require any changes.
 
-### Classes and members marked as obsolete have been removed
+### 11. Classes and members marked as obsolete have been removed
 
 The following classes and members that were marked with `[Obsolete]` in v4 have been removed:
 

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2970,12 +2970,13 @@ namespace GraphQL.Validation
         public ValidationContext() { }
         public GraphQL.Language.AST.Document Document { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.ValidationError> Errors { get; }
+        public GraphQL.Inputs Extensions { get; set; }
         public bool HasErrors { get; }
         public string? OperationName { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
-        public GraphQL.Inputs? Variables { get; set; }
+        public GraphQL.Inputs Variables { get; set; }
         public GraphQL.Language.AST.FragmentDefinition? GetFragment(string name) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
@@ -2999,12 +3000,13 @@ namespace GraphQL.Validation
     {
         public ValidationOptions() { }
         public GraphQL.Language.AST.Document Document { get; set; }
+        public GraphQL.Inputs Extensions { get; set; }
         public string? OperationName { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Language.AST.VariableDefinitions? VariableDefinitions { get; set; }
-        public GraphQL.Inputs? Variables { get; set; }
+        public GraphQL.Inputs Variables { get; set; }
     }
     public class ValidationResult : GraphQL.Validation.IValidationResult
     {

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2889,17 +2889,17 @@ namespace GraphQL.Validation
     {
         public static readonly System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule> CoreRules;
         public DocumentValidator() { }
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "validationResult",
                 "variables"})]
-        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? variables = null, string? operationName = null) { }
+        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Validation.ValidationOptions options) { }
     }
     public interface IDocumentValidator
     {
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "validationResult",
                 "variables"})]
-        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? variables = null, string? operationName = null);
+        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Validation.ValidationOptions options);
     }
     public interface INodeVisitor
     {
@@ -2980,7 +2980,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentDefinition> GetRecursivelyReferencedFragments(GraphQL.Language.AST.Operation operation) { }
-        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Inputs variables, GraphQL.Validation.IVariableVisitor? visitor = null) { }
+        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetVariables(GraphQL.Language.AST.IHaveSelectionSet node) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
@@ -2994,6 +2994,17 @@ namespace GraphQL.Validation
         public ValidationError(string originalQuery, string number, string message, System.Exception? innerException, params GraphQL.Language.AST.INode[]? nodes) { }
         public System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Nodes { get; }
         public string Number { get; set; }
+    }
+    public class ValidationOptions
+    {
+        public ValidationOptions() { }
+        public GraphQL.Language.AST.Document Document { get; set; }
+        public string? OperationName { get; set; }
+        public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
+        public GraphQL.Types.ISchema Schema { get; set; }
+        public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
+        public GraphQL.Language.AST.VariableDefinitions? VariableDefinitions { get; set; }
+        public GraphQL.Inputs? Variables { get; set; }
     }
     public class ValidationResult : GraphQL.Validation.IValidationResult
     {

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2972,7 +2972,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.ValidationError> Errors { get; }
         public GraphQL.Inputs Extensions { get; set; }
         public bool HasErrors { get; }
-        public string? OperationName { get; set; }
+        public GraphQL.Language.AST.Operation Operation { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
@@ -2981,7 +2981,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentDefinition> GetRecursivelyReferencedFragments(GraphQL.Language.AST.Operation operation) { }
-        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Validation.IVariableVisitor? visitor = null) { }
+        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetVariables(GraphQL.Language.AST.IHaveSelectionSet node) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
@@ -3001,11 +3001,10 @@ namespace GraphQL.Validation
         public ValidationOptions() { }
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.Inputs Extensions { get; set; }
-        public string? OperationName { get; set; }
+        public GraphQL.Language.AST.Operation Operation { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
-        public GraphQL.Language.AST.VariableDefinitions? VariableDefinitions { get; set; }
         public GraphQL.Inputs Variables { get; set; }
     }
     public class ValidationResult : GraphQL.Validation.IValidationResult

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2875,17 +2875,17 @@ namespace GraphQL.Validation
     {
         public static readonly System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule> CoreRules;
         public DocumentValidator() { }
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "validationResult",
                 "variables"})]
-        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? variables = null, string? operationName = null) { }
+        public System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Validation.ValidationOptions options) { }
     }
     public interface IDocumentValidator
     {
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "validationResult",
                 "variables"})]
-        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Types.ISchema schema, GraphQL.Language.AST.Document document, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? rules = null, System.Collections.Generic.IDictionary<string, object?> userContext = null, GraphQL.Inputs? variables = null, string? operationName = null);
+        System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Validation.IValidationResult, GraphQL.Language.AST.Variables>> ValidateAsync(GraphQL.Validation.ValidationOptions options);
     }
     public interface INodeVisitor
     {
@@ -2966,7 +2966,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentDefinition> GetRecursivelyReferencedFragments(GraphQL.Language.AST.Operation operation) { }
-        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Types.ISchema schema, GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Inputs variables, GraphQL.Validation.IVariableVisitor? visitor = null) { }
+        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetVariables(GraphQL.Language.AST.IHaveSelectionSet node) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
@@ -2980,6 +2980,17 @@ namespace GraphQL.Validation
         public ValidationError(string originalQuery, string number, string message, System.Exception? innerException, params GraphQL.Language.AST.INode[]? nodes) { }
         public System.Collections.Generic.IEnumerable<GraphQL.Language.AST.INode> Nodes { get; }
         public string Number { get; set; }
+    }
+    public class ValidationOptions
+    {
+        public ValidationOptions() { }
+        public GraphQL.Language.AST.Document Document { get; set; }
+        public string? OperationName { get; set; }
+        public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
+        public GraphQL.Types.ISchema Schema { get; set; }
+        public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
+        public GraphQL.Language.AST.VariableDefinitions? VariableDefinitions { get; set; }
+        public GraphQL.Inputs? Variables { get; set; }
     }
     public class ValidationResult : GraphQL.Validation.IValidationResult
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2958,7 +2958,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.ValidationError> Errors { get; }
         public GraphQL.Inputs Extensions { get; set; }
         public bool HasErrors { get; }
-        public string? OperationName { get; set; }
+        public GraphQL.Language.AST.Operation Operation { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
@@ -2967,7 +2967,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentDefinition> GetRecursivelyReferencedFragments(GraphQL.Language.AST.Operation operation) { }
-        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Language.AST.VariableDefinitions? variableDefinitions, GraphQL.Validation.IVariableVisitor? visitor = null) { }
+        public GraphQL.Language.AST.Variables GetVariableValues(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetVariables(GraphQL.Language.AST.IHaveSelectionSet node) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQL.Language.AST.IValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
@@ -2987,11 +2987,10 @@ namespace GraphQL.Validation
         public ValidationOptions() { }
         public GraphQL.Language.AST.Document Document { get; set; }
         public GraphQL.Inputs Extensions { get; set; }
-        public string? OperationName { get; set; }
+        public GraphQL.Language.AST.Operation Operation { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
-        public GraphQL.Language.AST.VariableDefinitions? VariableDefinitions { get; set; }
         public GraphQL.Inputs Variables { get; set; }
     }
     public class ValidationResult : GraphQL.Validation.IValidationResult

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2956,12 +2956,13 @@ namespace GraphQL.Validation
         public ValidationContext() { }
         public GraphQL.Language.AST.Document Document { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.ValidationError> Errors { get; }
+        public GraphQL.Inputs Extensions { get; set; }
         public bool HasErrors { get; }
         public string? OperationName { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
-        public GraphQL.Inputs? Variables { get; set; }
+        public GraphQL.Inputs Variables { get; set; }
         public GraphQL.Language.AST.FragmentDefinition? GetFragment(string name) { }
         public System.Collections.Generic.List<GraphQL.Language.AST.FragmentSpread> GetFragmentSpreads(GraphQL.Language.AST.SelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage> GetRecursiveVariables(GraphQL.Language.AST.Operation operation) { }
@@ -2985,12 +2986,13 @@ namespace GraphQL.Validation
     {
         public ValidationOptions() { }
         public GraphQL.Language.AST.Document Document { get; set; }
+        public GraphQL.Inputs Extensions { get; set; }
         public string? OperationName { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Language.AST.VariableDefinitions? VariableDefinitions { get; set; }
-        public GraphQL.Inputs? Variables { get; set; }
+        public GraphQL.Inputs Variables { get; set; }
     }
     public class ValidationResult : GraphQL.Validation.IValidationResult
     {

--- a/src/GraphQL.Benchmarks/Benchmarks/DetailedBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/DetailedBenchmark.cs
@@ -234,18 +234,22 @@ namespace GraphQL.Benchmarks
 
             public Language.AST.Variables ParseVariables()
             {
-                return Inputs == null ? null : new ValidationContext().GetVariableValues(Schema, Operation.Variables, Inputs);
+                return Inputs == null ? null : new ValidationContext
+                {
+                    Schema = Schema,
+                    Variables = Inputs,
+                }.GetVariableValues(Operation.Variables);
             }
 
             private static readonly DocumentValidator _documentValidator = new DocumentValidator();
             public IValidationResult Validate()
             {
-                return _documentValidator.ValidateAsync(
-                    Schema,
-                    Document,
-                    null,
-                    null,
-                    Inputs).Result.validationResult;
+                return _documentValidator.ValidateAsync(new ValidationOptions
+                {
+                    Schema = Schema,
+                    Document = Document,
+                    Variables = Inputs
+                }).Result.validationResult;
             }
 
             private static readonly ParallelExecutionStrategy _parallelExecutionStrategy = new ParallelExecutionStrategy();

--- a/src/GraphQL.Benchmarks/Benchmarks/DetailedBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/DetailedBenchmark.cs
@@ -238,7 +238,8 @@ namespace GraphQL.Benchmarks
                 {
                     Schema = Schema,
                     Variables = Inputs,
-                }.GetVariableValues(Operation.Variables);
+                    Operation = Operation,
+                }.GetVariableValues();
             }
 
             private static readonly DocumentValidator _documentValidator = new DocumentValidator();

--- a/src/GraphQL.Benchmarks/Benchmarks/ValidationBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/ValidationBenchmark.cs
@@ -69,7 +69,7 @@ namespace GraphQL.Benchmarks
             {
                 Schema = _schema,
                 Document = document,
-                VariableDefinitions = document.Operations.First().Variables
+                Operation = document.Operations.First()
             }).GetAwaiter().GetResult().validationResult;
 
         void IBenchmark.RunProfiler() => Introspection();

--- a/src/GraphQL.Benchmarks/Benchmarks/ValidationBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/ValidationBenchmark.cs
@@ -64,7 +64,13 @@ namespace GraphQL.Benchmarks
             _ = Validate(_heroDocument);
         }
 
-        private IValidationResult Validate(Document document) => _validator.ValidateAsync(_schema, document, document.Operations.First().Variables).GetAwaiter().GetResult().validationResult;
+        private IValidationResult Validate(Document document) => _validator.ValidateAsync(
+            new ValidationOptions
+            {
+                Schema = _schema,
+                Document = document,
+                VariableDefinitions = document.Operations.First().Variables
+            }).GetAwaiter().GetResult().validationResult;
 
         void IBenchmark.RunProfiler() => Introspection();
     }

--- a/src/GraphQL.Tests/Validation/ValidationTestBase.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestBase.cs
@@ -96,7 +96,14 @@ namespace GraphQL.Tests.Validation
             var documentBuilder = new GraphQLDocumentBuilder();
             var document = documentBuilder.Build(query);
             var validator = new DocumentValidator();
-            return validator.ValidateAsync(schema, document, document.Operations.FirstOrDefault()?.Variables, rules, variables: variables).Result.validationResult;
+            return validator.ValidateAsync(new ValidationOptions
+            {
+                Schema = schema,
+                Document = document,
+                Rules = rules,
+                VariableDefinitions = document.Operations.FirstOrDefault()?.Variables,
+                Variables = variables
+            }).Result.validationResult;
         }
     }
 }

--- a/src/GraphQL.Tests/Validation/ValidationTestBase.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestBase.cs
@@ -101,7 +101,7 @@ namespace GraphQL.Tests.Validation
                 Schema = schema,
                 Document = document,
                 Rules = rules,
-                VariableDefinitions = document.Operations.FirstOrDefault()?.Variables,
+                Operation = document.Operations.FirstOrDefault(),
                 Variables = variables
             }).Result.validationResult;
         }

--- a/src/GraphQL.Tests/Validation/ValidationTestConfig.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestConfig.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Tests.Validation
 
         public string Query { get; set; }
 
-        public Inputs Inputs { get; set; }
+        public Inputs Inputs { get; set; } = Inputs.Empty;
 
         public IList<IValidationRule> Rules => _rules;
 

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -143,13 +143,16 @@ namespace GraphQL
                 using (metrics.Subject("document", "Validating document"))
                 {
                     (validationResult, variables) = await _documentValidator.ValidateAsync(
-                        options.Schema,
-                        document,
-                        operation.Variables,
-                        validationRules,
-                        options.UserContext,
-                        options.Variables,
-                        options.OperationName).ConfigureAwait(false);
+                        new ValidationOptions
+                        {
+                            Document = document,
+                            Rules = validationRules,
+                            OperationName = options.OperationName,
+                            UserContext = options.UserContext,
+                            Schema = options.Schema,
+                            VariableDefinitions = operation.Variables,
+                            Variables = options.Variables,
+                        }).ConfigureAwait(false);
                 }
 
                 if (options.ComplexityConfiguration != null && validationResult.IsValid && analyzeComplexity)

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -147,10 +147,9 @@ namespace GraphQL
                         {
                             Document = document,
                             Rules = validationRules,
-                            OperationName = options.OperationName,
+                            Operation = operation,
                             UserContext = options.UserContext,
                             Schema = options.Schema,
-                            VariableDefinitions = operation.Variables,
                             Variables = options.Variables ?? Inputs.Empty,
                             Extensions = options.Extensions ?? Inputs.Empty,
                         }).ConfigureAwait(false);

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -151,7 +151,8 @@ namespace GraphQL
                             UserContext = options.UserContext,
                             Schema = options.Schema,
                             VariableDefinitions = operation.Variables,
-                            Variables = options.Variables,
+                            Variables = options.Variables ?? Inputs.Empty,
+                            Extensions = options.Extensions ?? Inputs.Empty,
                         }).ConfigureAwait(false);
                 }
 

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -65,6 +65,7 @@ namespace GraphQL.Validation
             context.TypeInfo = new TypeInfo(options.Schema);
             context.UserContext = options.UserContext;
             context.Variables = options.Variables;
+            context.Extensions = options.Extensions;
             context.OperationName = options.OperationName;
 
             var rules = options.Rules ?? CoreRules;

--- a/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
+++ b/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
@@ -81,7 +81,7 @@ namespace GraphQL.Validation.Rules
             {
                 CheckStringLength(strLiteral.Value);
             }
-            else if (node.Value is VariableReference vRef && context.Variables != null)
+            else if (node.Value is VariableReference vRef)
             {
                 if (context.Variables.TryGetValue(vRef.Name, out var value))
                 {

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Validation
             _errors = null;
             _fragments.Clear();
             _variables.Clear();
-            OperationName = null;
+            Operation = null!;
             Schema = null!;
             Document = null!;
             TypeInfo = null!;
@@ -36,9 +36,9 @@ namespace GraphQL.Validation
         }
 
         /// <summary>
-        /// Returns the operation name requested to be executed.
+        /// Returns the operation requested to be executed.
         /// </summary>
-        public string? OperationName { get; set; }
+        public Operation Operation { get; set; } = null!;
 
         /// <inheritdoc cref="ExecutionContext.Schema"/>
         public ISchema Schema { get; set; } = null!;
@@ -195,8 +195,10 @@ namespace GraphQL.Validation
         /// <summary>
         /// Returns all of the variable values defined for the operation from the attached <see cref="Variables"/> object.
         /// </summary>
-        public Variables GetVariableValues(VariableDefinitions? variableDefinitions, IVariableVisitor? visitor = null)
+        public Variables GetVariableValues(IVariableVisitor? visitor = null)
         {
+            var variableDefinitions = Operation?.Variables;
+
             if ((variableDefinitions?.List?.Count ?? 0) == 0)
             {
                 return Language.AST.Variables.None;

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -31,7 +31,8 @@ namespace GraphQL.Validation
             Document = null!;
             TypeInfo = null!;
             UserContext = null!;
-            Variables = null;
+            Variables = null!;
+            Extensions = null!;
         }
 
         /// <summary>
@@ -62,7 +63,10 @@ namespace GraphQL.Validation
         public bool HasErrors => _errors?.Count > 0;
 
         /// <inheritdoc cref="ExecutionOptions.Variables"/>
-        public Inputs? Variables { get; set; }
+        public Inputs Variables { get; set; } = null!;
+
+        /// <inheritdoc cref="ExecutionOptions.Extensions"/>
+        public Inputs Extensions { get; set; } = null!;
 
         /// <summary>
         /// Adds a validation error to the list of validation errors.
@@ -217,7 +221,7 @@ namespace GraphQL.Validation
                     var variable = new Variable(variableDef.Name);
 
                     // attempt to retrieve the variable value from the inputs
-                    if (Variables?.TryGetValue(variableDef.Name, out var variableValue) == true)
+                    if (Variables.TryGetValue(variableDef.Name, out var variableValue))
                     {
                         // parse the variable via ParseValue (for scalars) and ParseDictionary (for objects) as applicable
                         try

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -191,7 +191,7 @@ namespace GraphQL.Validation
         /// <summary>
         /// Returns all of the variable values defined for the operation from the attached <see cref="Variables"/> object.
         /// </summary>
-        public Variables GetVariableValues(ISchema schema, VariableDefinitions? variableDefinitions, Inputs variables, IVariableVisitor? visitor = null)
+        public Variables GetVariableValues(VariableDefinitions? variableDefinitions, IVariableVisitor? visitor = null)
         {
             if ((variableDefinitions?.List?.Count ?? 0) == 0)
             {
@@ -205,7 +205,7 @@ namespace GraphQL.Validation
                 foreach (var variableDef in variableDefinitions.List)
                 {
                     // find the IGraphType instance for the variable type
-                    var graphType = variableDef.Type.GraphTypeFromType(schema);
+                    var graphType = variableDef.Type.GraphTypeFromType(Schema);
 
                     if (graphType == null)
                     {
@@ -217,7 +217,7 @@ namespace GraphQL.Validation
                     var variable = new Variable(variableDef.Name);
 
                     // attempt to retrieve the variable value from the inputs
-                    if (variables.TryGetValue(variableDef.Name, out var variableValue))
+                    if (Variables?.TryGetValue(variableDef.Name, out var variableValue) == true)
                     {
                         // parse the variable via ParseValue (for scalars) and ParseDictionary (for objects) as applicable
                         try

--- a/src/GraphQL/Validation/ValidationOptions.cs
+++ b/src/GraphQL/Validation/ValidationOptions.cs
@@ -21,8 +21,9 @@ namespace GraphQL.Validation
 
         public Inputs Extensions { get; set; } = null!;
 
-        public VariableDefinitions? VariableDefinitions { get; set; }
-
-        public string? OperationName { get; set; }
+        /// <summary>
+        /// Executed operation.
+        /// </summary>
+        public Operation Operation { get; set; } = null!;
     }
 }

--- a/src/GraphQL/Validation/ValidationOptions.cs
+++ b/src/GraphQL/Validation/ValidationOptions.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+
+namespace GraphQL.Validation
+{
+    /// <summary>
+    /// Options used by <see cref="IDocumentValidator.ValidateAsync(ValidationOptions)"/>.
+    /// </summary>
+    public class ValidationOptions
+    {
+        public ISchema Schema { get; set; } = null!;
+
+        public Document Document { get; set; } = null!;
+
+        public IEnumerable<IValidationRule>? Rules { get; set; }
+
+        public IDictionary<string, object?> UserContext { get; set; } = null!;
+
+        public Inputs? Variables { get; set; }
+
+        public VariableDefinitions? VariableDefinitions { get; set; }
+
+        public string? OperationName { get; set; }
+    }
+}

--- a/src/GraphQL/Validation/ValidationOptions.cs
+++ b/src/GraphQL/Validation/ValidationOptions.cs
@@ -17,7 +17,9 @@ namespace GraphQL.Validation
 
         public IDictionary<string, object?> UserContext { get; set; } = null!;
 
-        public Inputs? Variables { get; set; }
+        public Inputs Variables { get; set; } = null!;
+
+        public Inputs Extensions { get; set; } = null!;
 
         public VariableDefinitions? VariableDefinitions { get; set; }
 


### PR DESCRIPTION
First commit - refactoring of `DocumentValidator.ValidateAsync` to wrap all arguments into one new for backward compatibility reasons in future.
Second commit - add extensions into `ValidationOptions`.
Third commit - migration notes.