### PR TITLE
Fix NRE and interface duplication in multithreading scenario

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug2639.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2639.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/2639
+    public class Bug2639
+    {
+        [Fact]
+        public void Serial()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<Bug2639QueryType>();
+            services.AddSingleton<Bug2639InterfaceType>();
+            services.AddTransient<Bug2639Schema>();
+            using var provider = services.BuildServiceProvider();
+
+            for (int i=0; i<10; ++i)
+            {
+                using var schema = provider.GetRequiredService<Bug2639Schema>();
+                schema.Initialize();
+            }
+
+            var query = provider.GetRequiredService<Bug2639QueryType>();
+            query.ResolvedInterfaces.Count.ShouldBe(1);
+
+            var iface = provider.GetRequiredService<Bug2639InterfaceType>();
+            iface.PossibleTypes.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void Parallel()
+        {
+            for (int i = 0; i < 1000; ++i)
+            {
+                var services = new ServiceCollection();
+                services.AddSingleton<Bug2639QueryType>();
+                services.AddSingleton<Bug2639InterfaceType>();
+                services.AddTransient<Bug2639Schema>();
+                using var provider = services.BuildServiceProvider();
+
+                const int COUNT = 5;
+                var barrier = new Barrier(COUNT);
+
+                List<Bug2639Schema> schemas = new();
+                for (int c = 0; c < COUNT; ++c)
+                    schemas.Add(provider.GetRequiredService<Bug2639Schema>());
+
+                List<Task> tasks = new();
+                for (int c = 0; c < COUNT; ++c)
+                {
+                    var copy = c;
+                    tasks.Add(Task.Run(() =>
+                    {
+                        barrier.SignalAndWait();
+                        schemas[copy].Initialize();
+                    }));
+                }
+
+                Task.WaitAll(tasks.ToArray());
+
+                var query = provider.GetRequiredService<Bug2639QueryType>();
+                var iface = provider.GetRequiredService<Bug2639InterfaceType>();
+
+                query.ResolvedInterfaces.Count.ShouldBe(1, $"On iteration {i}");
+                iface.PossibleTypes.Count.ShouldBe(1, $"On iteration {i}");
+
+                schemas.ForEach(s => s.Dispose());
+            }
+        }
+    }
+
+    public sealed class Bug2639QueryType : ObjectGraphType
+    {
+        public Bug2639QueryType()
+        {
+            Field<StringGraphType>().Name("field");
+            Interface<Bug2639InterfaceType>();
+        }
+    }
+
+    public class Bug2639InterfaceType : InterfaceGraphType
+    {
+        public Bug2639InterfaceType()
+        {
+            Field<StringGraphType>().Name("field");
+            ResolveType = _ => null;
+        }
+    }
+
+    public class Bug2639Schema : Schema
+    {
+        public Bug2639Schema(IServiceProvider provider, Bug2639QueryType query)
+            : base(provider)
+        {
+            Query = query;
+        }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug2639.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2639.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Tests.Bugs
             services.AddTransient<Bug2639Schema>();
             using var provider = services.BuildServiceProvider();
 
-            for (int i=0; i<10; ++i)
+            for (int i = 0; i < 10; ++i)
             {
                 using var schema = provider.GetRequiredService<Bug2639Schema>();
                 schema.Initialize();

--- a/src/GraphQL/Types/Collections/PossibleTypes.cs
+++ b/src/GraphQL/Types/Collections/PossibleTypes.cs
@@ -22,7 +22,14 @@ namespace GraphQL.Types
                 throw new ArgumentNullException(nameof(type));
 
             if (!List.Contains(type))
-                List.Add(type);
+            {
+                // https://github.com/graphql-dotnet/graphql-dotnet/issues/2639
+                lock (List)
+                {
+                    if (!List.Contains(type))
+                        List.Add(type);
+                }
+            }
         }
 
         /// <summary>

--- a/src/GraphQL/Types/Collections/ResolvedInterfaces.cs
+++ b/src/GraphQL/Types/Collections/ResolvedInterfaces.cs
@@ -22,7 +22,14 @@ namespace GraphQL.Types
                 throw new ArgumentNullException(nameof(type));
 
             if (!List.Contains(type))
-                List.Add(type);
+            {
+                // https://github.com/graphql-dotnet/graphql-dotnet/issues/2639
+                lock (List)
+                {
+                    if (!List.Contains(type))
+                        List.Add(type);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #2639 

@Shane32 @diouxis I was able to reproduce bug and write a test.

@Shane32 That's exactly how you said. I agree that in general the bug may occur anywhere, because GraphQL.NET (at least for GraphType initialization) is not intended for multi-threaded scenarios. Nevertheless, fix is quite simple and test confirms that it works. Without fix I consistently got an error on each test run - from 0 to 300 iterations. I think it is worth merging this change, the code will not be worse from it and the loss of performance is ridiculous.