### PR TITLE
Support naming policy in serializers

### DIFF
--- a/docs2/site/docs/migrations/migration4.md
+++ b/docs2/site/docs/migrations/migration4.md
@@ -214,6 +214,7 @@ Here are some of the situations that you may run into with version 4:
 - `EnumGraphType` is stricter, requiring internal values for serialization, and external values for deserialization
 - `IdGraphType` (which allows any basic type) does not coerce variable values to trimmed strings during deserialization
 - `IdGraphType` does not trim serialized values (but does convert them to strings)
+- `DateTimeGraphType` serializes values to strings instead of letting the JSON serializer do so
 
 If you have a schema-first schema, you may run into an issue with enumeration types, since the `SchemaBuilder` uses the name of each
 enumeration value as its value also. In other words, you must return a string corresponding to the enumeration value (e.g, `"Cat"` or

--- a/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
@@ -21,7 +21,7 @@ namespace GraphQL.NewtonsoftJson
     public class ExecutionResultJsonConverter : Newtonsoft.Json.JsonConverter
     {
         public ExecutionResultJsonConverter(GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
-        public ExecutionResultJsonConverter(GraphQL.Execution.IErrorInfoProvider errorInfoProvider, Newtonsoft.Json.Serialization.NamingStrategy? namingStrategy) { }
+        public ExecutionResultJsonConverter(GraphQL.Execution.IErrorInfoProvider errorInfoProvider, Newtonsoft.Json.Serialization.NamingStrategy namingStrategy) { }
         public override bool CanRead { get; }
         public override bool CanConvert(System.Type objectType) { }
         public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { }

--- a/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
@@ -21,6 +21,7 @@ namespace GraphQL.NewtonsoftJson
     public class ExecutionResultJsonConverter : Newtonsoft.Json.JsonConverter
     {
         public ExecutionResultJsonConverter(GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
+        public ExecutionResultJsonConverter(GraphQL.Execution.IErrorInfoProvider errorInfoProvider, Newtonsoft.Json.Serialization.NamingStrategy? namingStrategy) { }
         public override bool CanRead { get; }
         public override bool CanConvert(System.Type objectType) { }
         public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { }

--- a/src/GraphQL.ApiTests/GraphQL.SystemTextJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.SystemTextJson.approved.txt
@@ -1,5 +1,11 @@
 namespace GraphQL.SystemTextJson
 {
+    public class ApolloTraceJsonConverter : System.Text.Json.Serialization.JsonConverter<GraphQL.Instrumentation.ApolloTrace>
+    {
+        public ApolloTraceJsonConverter() { }
+        public override GraphQL.Instrumentation.ApolloTrace Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { }
+        public override void Write(System.Text.Json.Utf8JsonWriter writer, GraphQL.Instrumentation.ApolloTrace value, System.Text.Json.JsonSerializerOptions options) { }
+    }
     public class DocumentWriter : GraphQL.IDocumentWriter
     {
         public DocumentWriter() { }

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultContractResolver.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultContractResolver.cs
@@ -19,7 +19,7 @@ namespace GraphQL.NewtonsoftJson
         protected override JsonConverter ResolveContractConverter(Type objectType)
         {
             if (typeof(ExecutionResult).IsAssignableFrom(objectType))
-                return new ExecutionResultJsonConverter(_errorInfoProvider);
+                return new ExecutionResultJsonConverter(_errorInfoProvider, NamingStrategy);
 
             return base.ResolveContractConverter(objectType);
         }

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
@@ -18,14 +18,14 @@ namespace GraphQL.NewtonsoftJson
         /// Initializes a new instance with the specified <see cref="IErrorInfoProvider"/>.
         /// </summary>
         public ExecutionResultJsonConverter(IErrorInfoProvider errorInfoProvider)
-            : this(errorInfoProvider, new CamelCaseNamingStrategy())
+            : this(errorInfoProvider, null)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance with the specified <see cref="IErrorInfoProvider"/>.
+        /// Initializes a new instance with the specified <see cref="IErrorInfoProvider"/> and <see cref="NamingStrategy"/>.
         /// </summary>
-        public ExecutionResultJsonConverter(IErrorInfoProvider errorInfoProvider, NamingStrategy? namingStrategy)
+        public ExecutionResultJsonConverter(IErrorInfoProvider errorInfoProvider, NamingStrategy namingStrategy)
         {
             _errorInfoProvider = errorInfoProvider ?? throw new ArgumentNullException(nameof(errorInfoProvider));
             _namingStrategy = namingStrategy;

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using GraphQL.Execution;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace GraphQL.NewtonsoftJson
 {
@@ -11,13 +12,23 @@ namespace GraphQL.NewtonsoftJson
     public class ExecutionResultJsonConverter : JsonConverter
     {
         private readonly IErrorInfoProvider _errorInfoProvider;
+        private readonly NamingStrategy _namingStrategy;
 
         /// <summary>
         /// Initializes a new instance with the specified <see cref="IErrorInfoProvider"/>.
         /// </summary>
         public ExecutionResultJsonConverter(IErrorInfoProvider errorInfoProvider)
+            : this(errorInfoProvider, new CamelCaseNamingStrategy())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance with the specified <see cref="IErrorInfoProvider"/>.
+        /// </summary>
+        public ExecutionResultJsonConverter(IErrorInfoProvider errorInfoProvider, NamingStrategy? namingStrategy)
         {
             _errorInfoProvider = errorInfoProvider ?? throw new ArgumentNullException(nameof(errorInfoProvider));
+            _namingStrategy = namingStrategy;
         }
 
         /// <inheritdoc/>
@@ -67,7 +78,10 @@ namespace GraphQL.NewtonsoftJson
                     writer.WriteStartObject();
                     foreach (var childNode in objectExecutionNode.SubFields)
                     {
-                        writer.WritePropertyName(childNode.Name);
+                        var propName = childNode.Name;
+                        if (_namingStrategy != null)
+                            propName = _namingStrategy.GetPropertyName(propName, false);
+                        writer.WritePropertyName(propName);
                         WriteExecutionNode(writer, childNode, serializer);
                     }
                     writer.WriteEndObject();

--- a/src/GraphQL.SystemTextJson/ApolloTraceJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ApolloTraceJsonConverter.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GraphQL.Instrumentation;
+
+namespace GraphQL.SystemTextJson
+{
+    /// <summary>
+    /// Converts an instance of <see cref="ApolloTrace"/> to/from JSON.
+    /// </summary>
+    public class ApolloTraceJsonConverter : JsonConverter<ApolloTrace>
+    {
+        private readonly JsonSerializerOptions _optionsNoIndent = new()
+        {
+            WriteIndented = false,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        private readonly JsonSerializerOptions _optionsIndent = new()
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, ApolloTrace value, JsonSerializerOptions options)
+            => JsonSerializer.Serialize(writer, value, options.WriteIndented ? _optionsIndent : _optionsNoIndent);
+
+        /// <inheritdoc/>
+        public override ApolloTrace Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => JsonSerializer.Deserialize<ApolloTrace>(ref reader);
+    }
+}

--- a/src/GraphQL.SystemTextJson/DocumentWriter.cs
+++ b/src/GraphQL.SystemTextJson/DocumentWriter.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Execution;
+using GraphQL.Instrumentation;
 
 namespace GraphQL.SystemTextJson
 {
@@ -122,6 +123,11 @@ namespace GraphQL.SystemTextJson
             if (!_options.Converters.Any(c => c.CanConvert(typeof(ExecutionResult))))
             {
                 _options.Converters.Add(new ExecutionResultJsonConverter(errorInfoProvider ?? new ErrorInfoProvider()));
+            }
+
+            if (!_options.Converters.Any(c => c.CanConvert(typeof(ApolloTrace))))
+            {
+                _options.Converters.Add(new ApolloTraceJsonConverter());
             }
 
             if (!_options.Converters.Any(c => c.CanConvert(typeof(JsonConverterBigInteger))))

--- a/src/GraphQL.SystemTextJson/DocumentWriter.cs
+++ b/src/GraphQL.SystemTextJson/DocumentWriter.cs
@@ -131,7 +131,7 @@ namespace GraphQL.SystemTextJson
         }
 
         private static JsonSerializerOptions GetDefaultSerializerOptions(bool indent)
-            => new JsonSerializerOptions { WriteIndented = indent, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            => new JsonSerializerOptions { WriteIndented = indent };
 
         /// <inheritdoc/>
         public Task WriteAsync<T>(Stream stream, T value, CancellationToken cancellationToken = default)

--- a/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
@@ -107,6 +107,8 @@ namespace GraphQL.SystemTextJson
 
         private static void WriteProperty(Utf8JsonWriter writer, string propertyName, object propertyValue, JsonSerializerOptions options)
         {
+            if (options.PropertyNamingPolicy != null)
+                propertyName = options.PropertyNamingPolicy.ConvertName(propertyName);
             writer.WritePropertyName(propertyName);
             WriteValue(writer, propertyValue, options);
         }

--- a/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
@@ -69,7 +69,10 @@ namespace GraphQL.SystemTextJson
                     writer.WriteStartObject();
                     foreach (var childNode in objectExecutionNode.SubFields)
                     {
-                        writer.WritePropertyName(childNode.Name);
+                        var propertyName = childNode.Name;
+                        if (options.PropertyNamingPolicy != null)
+                            propertyName = options.PropertyNamingPolicy.ConvertName(propertyName);
+                        writer.WritePropertyName(propertyName);
                         WriteExecutionNode(writer, childNode, options);
                     }
                     writer.WriteEndObject();

--- a/src/GraphQL.Tests/Bugs/Bug2839NewtonsoftJson.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2839NewtonsoftJson.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using GraphQL.NewtonsoftJson;
+using GraphQL.Types;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class Bug2839NewtonsoftJson
+    {
+        [Fact]
+        public async Task Bug2839Test()
+        {
+            var schema = new Schema { Query = new TestQuery() };
+            schema.ReplaceScalar(new MyDateTimeGraphType());
+
+            var exec = new DocumentExecuter();
+
+            var result = exec.ExecuteAsync(options =>
+            {
+                options.Schema = schema;
+                options.Query = "{ test { thisIsAString, thisIsADateTime } }";
+            }
+            ).Result;
+
+            var writer = new DocumentWriter(options =>
+            {
+                options.Converters.Add(new IsoDateTimeConverter()
+                {
+                    DateTimeFormat = "yyyy-MMM-dd"
+                });
+
+                options.ContractResolver = new ExecutionResultContractResolver(new ErrorInfoProvider())
+                {
+                    NamingStrategy = new KebabCaseNamingStrategy(true, false, false)
+                };
+            });
+
+            var str = await writer.WriteToStringAsync(result);
+            str.ShouldBeCrossPlatJson("{\"data\":{\"test\":{\"this-is-a-string\":\"String Value\",\"this-is-a-date-time\":\"2022-Jan-04\"}}}");
+        }
+
+        public class TestQuery : ObjectGraphType
+        {
+            public TestQuery()
+            {
+                Name = "testQuery";
+                Description = "Test description";
+
+                Field<TestResponseType>(
+                    name: "test",
+                    resolve: context => new TestResponse());
+            }
+        }
+
+        public class TestResponseType : ObjectGraphType<TestResponse>
+        {
+            public TestResponseType()
+            {
+                Name = "TestReponse";
+                Field<StringGraphType>("ThisIsAString");
+                Field<DateTimeGraphType>("ThisIsADateTime");
+            }
+        }
+
+        public class TestResponse
+        {
+            public string ThisIsAString { get; set; }
+            public DateTime ThisIsADateTime { get; set; }
+            public TestResponse()
+            {
+                ThisIsAString = "String Value";
+                ThisIsADateTime = new DateTime(2022, 1, 4, 10, 20, 30);
+            }
+        }
+
+        public class MyDateTimeGraphType : DateTimeGraphType
+        {
+            public MyDateTimeGraphType()
+            {
+                Name = "DateTime";
+            }
+
+            public override object Serialize(object value) => value switch
+            {
+                DateTime _ => value,
+                DateTimeOffset _ => value,
+                null => null,
+                _ => ThrowSerializationError(value)
+            };
+        }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug2839NewtonsoftJson.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2839NewtonsoftJson.cs
@@ -30,7 +30,8 @@ namespace GraphQL.Tests.Bugs
             {
                 options.Converters.Add(new IsoDateTimeConverter()
                 {
-                    DateTimeFormat = "yyyy-MMM-dd"
+                    DateTimeFormat = "yyyy-MMM-dd",
+                    Culture = System.Globalization.CultureInfo.InvariantCulture,
                 });
 
                 options.ContractResolver = new ExecutionResultContractResolver(new ErrorInfoProvider())

--- a/src/GraphQL.Tests/Bugs/Bug2839SystemTextJson.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2839SystemTextJson.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class Bug2839SystemTextJson
+    {
+        [Fact]
+        public async Task Bug2839Test()
+        {
+            var schema = new Schema { Query = new TestQuery() };
+            schema.ReplaceScalar(new MyDateTimeGraphType());
+
+            var exec = new DocumentExecuter();
+
+            var result = exec.ExecuteAsync(options =>
+            {
+                options.Schema = schema;
+                options.Query = "{ test { thisIsAString, thisIsADateTime } }";
+            }
+            ).Result;
+
+            var writer = new DocumentWriter(options =>
+            {
+                options.PropertyNamingPolicy = new MyNamingPolicy();
+                options.Converters.Add(new MyDateTimeConverter());
+            });
+
+            var str = await writer.WriteToStringAsync(result);
+            str.ShouldBeCrossPlatJson("{\"data\":{\"TEST\":{\"THISISASTRING\":\"String Value\",\"THISISADATETIME\":\"2022-Jan-04\"}}}");
+        }
+
+        public class TestQuery : ObjectGraphType
+        {
+            public TestQuery()
+            {
+                Name = "testQuery";
+                Description = "Test description";
+
+                Field<TestResponseType>(
+                    name: "test",
+                    resolve: context => new TestResponse());
+            }
+        }
+
+        public class TestResponseType : ObjectGraphType<TestResponse>
+        {
+            public TestResponseType()
+            {
+                Name = "TestReponse";
+                Field<StringGraphType>("ThisIsAString");
+                Field<DateTimeGraphType>("ThisIsADateTime");
+            }
+        }
+
+        public class TestResponse
+        {
+            public string ThisIsAString { get; set; }
+            public DateTime ThisIsADateTime { get; set; }
+            public TestResponse()
+            {
+                ThisIsAString = "String Value";
+                ThisIsADateTime = new DateTime(2022, 1, 4, 10, 20, 30);
+            }
+        }
+
+        public class MyDateTimeGraphType : DateTimeGraphType
+        {
+            public MyDateTimeGraphType()
+            {
+                Name = "DateTime";
+            }
+
+            public override object Serialize(object value) => value switch
+            {
+                DateTime _ => value,
+                DateTimeOffset _ => value,
+                null => null,
+                _ => ThrowSerializationError(value)
+            };
+        }
+
+        public class MyDateTimeConverter : JsonConverter<DateTime>
+        {
+            public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                => throw new NotImplementedException();
+
+            public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.ToString("yyyy-MMM-dd"));
+            }
+        }
+
+        public class MyNamingPolicy : JsonNamingPolicy
+        {
+            public override string ConvertName(string name) => name.ToUpper();
+        }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug2839SystemTextJson.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2839SystemTextJson.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Buffers;
-using System.Buffers.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using GraphQL.Execution;
 using GraphQL.SystemTextJson;
 using GraphQL.Types;
 using Xunit;

--- a/src/GraphQL.Tests/Bugs/Bug2839SystemTextJson.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2839SystemTextJson.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -92,13 +93,13 @@ namespace GraphQL.Tests.Bugs
 
             public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
             {
-                writer.WriteStringValue(value.ToString("yyyy-MMM-dd"));
+                writer.WriteStringValue(value.ToString("yyyy-MMM-dd", CultureInfo.InvariantCulture));
             }
         }
 
         public class MyNamingPolicy : JsonNamingPolicy
         {
-            public override string ConvertName(string name) => name.ToUpper();
+            public override string ConvertName(string name) => name.ToUpper(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/GraphQL.Tests/DocumentWritersTestData.cs
+++ b/src/GraphQL.Tests/DocumentWritersTestData.cs
@@ -10,7 +10,6 @@ namespace GraphQL.Tests
             new SystemTextJson.DocumentWriter(new System.Text.Json.JsonSerializerOptions
             {
                 WriteIndented = true,
-                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
                 Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping // less strict about what is encoded into \uXXXX
             }),
             new NewtonsoftJson.DocumentWriter(indent: true)

--- a/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
@@ -66,8 +66,9 @@ query {
             new HashSet<List<object>>(paths).ShouldBe(expectedPaths);
         }
 
-        [Fact]
-        public async Task serialization_should_have_correct_case()
+        [Theory]
+        [ClassData(typeof(DocumentWritersTestData))]
+        public async Task serialization_should_have_correct_case(IDocumentWriter writer)
         {
             var trace = new ApolloTrace(new DateTime(2019, 12, 05, 15, 38, 00, DateTimeKind.Utc), 102.5);
             var expected = @"{
@@ -88,7 +89,7 @@ query {
   }
 }";
 
-            var result = await Writer.WriteToStringAsync(trace);
+            var result = await writer.WriteToStringAsync(trace);
 
             result.ShouldBeCrossPlat(expected);
         }


### PR DESCRIPTION
Fixes both the Newtonsoft.Json and System.Text.Json serializers to honor the naming policy set in the serializer's options.

Since the _effective_ property naming policy for both System.Text.Json and Newtonsoft.Json was `null` (unchanged) for `ExecutionResult` nodes, I changed the default naming policy to `null` for System.Text.Json to prevent this bugfix from being a breaking bug fix.

However, with the System.Text.Json serializer only, child nodes of `extensions` previously used camelCase property naming policy whereas now it will use 'none' property naming policy by default.  (Apollo tracing nodes will continue to use camelCase property name encoding.)  This was the intended behavior and matches that of the Newtonsoft.Json converter.