### PR TITLE
[Discussion] Demonstrate failure of .NET 6 nrt code

### DIFF
--- a/src/GraphQL.Tests/NRTTests.cs
+++ b/src/GraphQL.Tests/NRTTests.cs
@@ -1,0 +1,46 @@
+#nullable enable
+#if NET6_0_OR_GREATER
+using System;
+using System.Reflection;
+using Shouldly;
+using Xunit;
+
+namespace GraphQL.Tests
+{
+    public class NRTTests
+    {
+        [Fact]
+        public void TestNRTField2()
+        {
+            var type = typeof(NullableClass18);
+            var field = type.GetMethod("Field2").ShouldNotBeNull();
+            var returnParameter = field.ReturnParameter;
+            var context = new NullabilityInfoContext();
+            var info = context.Create(returnParameter);
+
+            info.Type.ShouldBe(typeof(Tuple<Tuple<string, string>, string>));
+            info.ReadState.ShouldBe(NullabilityState.NotNull);
+            info.GenericTypeArguments.Length.ShouldBe(2);
+
+            info.GenericTypeArguments[0].Type.ShouldBe(typeof(Tuple<string, string>));
+            info.GenericTypeArguments[0].ReadState.ShouldBe(NullabilityState.NotNull);
+            info.GenericTypeArguments[0].GenericTypeArguments.Length.ShouldBe(2);
+
+            info.GenericTypeArguments[0].GenericTypeArguments[0].Type.ShouldBe(typeof(string));
+            info.GenericTypeArguments[0].GenericTypeArguments[0].ReadState.ShouldBe(NullabilityState.Nullable);
+
+            info.GenericTypeArguments[0].GenericTypeArguments[1].Type.ShouldBe(typeof(string));
+            info.GenericTypeArguments[0].GenericTypeArguments[1].ReadState.ShouldBe(NullabilityState.Nullable);
+
+            info.GenericTypeArguments[1].Type.ShouldBe(typeof(string));
+            info.GenericTypeArguments[1].ReadState.ShouldBe(NullabilityState.NotNull); //incorrectly reports nullable
+        }
+
+        public class NullableClass18
+        {
+            //check ordering of nested types
+            public static Tuple<Tuple<string?, string?>, string> Field2() => null!;
+        }
+    }
+}
+#endif

--- a/src/GraphQL.Tests/NRTTests.cs
+++ b/src/GraphQL.Tests/NRTTests.cs
@@ -18,20 +18,25 @@ namespace GraphQL.Tests
             var context = new NullabilityInfoContext();
             var info = context.Create(returnParameter);
 
+            //test 1
             info.Type.ShouldBe(typeof(Tuple<Tuple<string, string>, string>));
             info.ReadState.ShouldBe(NullabilityState.NotNull);
             info.GenericTypeArguments.Length.ShouldBe(2);
 
+            //test 2
             info.GenericTypeArguments[0].Type.ShouldBe(typeof(Tuple<string, string>));
             info.GenericTypeArguments[0].ReadState.ShouldBe(NullabilityState.NotNull);
             info.GenericTypeArguments[0].GenericTypeArguments.Length.ShouldBe(2);
 
+            //test 3
             info.GenericTypeArguments[0].GenericTypeArguments[0].Type.ShouldBe(typeof(string));
             info.GenericTypeArguments[0].GenericTypeArguments[0].ReadState.ShouldBe(NullabilityState.Nullable);
 
+            //test 4
             info.GenericTypeArguments[0].GenericTypeArguments[1].Type.ShouldBe(typeof(string));
             info.GenericTypeArguments[0].GenericTypeArguments[1].ReadState.ShouldBe(NullabilityState.Nullable);
 
+            //test 5
             info.GenericTypeArguments[1].Type.ShouldBe(typeof(string));
             info.GenericTypeArguments[1].ReadState.ShouldBe(NullabilityState.NotNull); //incorrectly reports nullable
         }
@@ -40,6 +45,23 @@ namespace GraphQL.Tests
         {
             //check ordering of nested types
             public static Tuple<Tuple<string?, string?>, string> Field2() => null!;
+            /*             1      2      3        4         5
+             *
+             * 1: Tuple<Tuple<string, string>, string>
+             *    non-null
+             *
+             * 2: Tuple<string, string>
+             *    non-null
+             *
+             * 3: string
+             *    nullable
+             *
+             * 4: string
+             *    nullable
+             *
+             * 5: string
+             *    non-null
+             */
         }
     }
 }

--- a/src/GraphQL.Tests/NRTTests.cs
+++ b/src/GraphQL.Tests/NRTTests.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Tests
         [Fact]
         public void TestNRTField2()
         {
-            var type = typeof(NullableClass18);
+            var type = typeof(NullableTestClass);
             var field = type.GetMethod("Field2").ShouldNotBeNull();
             var returnParameter = field.ReturnParameter;
             var context = new NullabilityInfoContext();
@@ -41,9 +41,8 @@ namespace GraphQL.Tests
             info.GenericTypeArguments[1].ReadState.ShouldBe(NullabilityState.NotNull); //incorrectly reports nullable
         }
 
-        public class NullableClass18
+        public class NullableTestClass
         {
-            //check ordering of nested types
             public static Tuple<Tuple<string?, string?>, string> Field2() => null!;
             /*             1      2      3        4         5
              *


### PR DESCRIPTION
Demonstrates that the `NullabilityInfoContext` class of .NET 6 does not correctly report NRT annotations.  (My code in PR #2840 does.)

Note: this is not a compiler failure.  It is a failure of the interpretation code.  And it does not even deal with many of the complexities that can occur with NRT annotations -- it's simply a couple nested generic types.