### PR TITLE
Configure serializers so they can be easily extended if need be

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
@@ -50,12 +50,14 @@ namespace GraphQL.NewtonsoftJson
     {
         public GraphQLSerializer() { }
         public GraphQLSerializer(GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
+        protected GraphQLSerializer(Newtonsoft.Json.JsonSerializer jsonSerializer) { }
         public GraphQLSerializer(Newtonsoft.Json.JsonSerializerSettings serializerSettings) { }
         public GraphQLSerializer(System.Action<Newtonsoft.Json.JsonSerializerSettings> configureSerializerSettings) { }
         public GraphQLSerializer(bool indent) { }
         public GraphQLSerializer(Newtonsoft.Json.JsonSerializerSettings serializerSettings, GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
         public GraphQLSerializer(System.Action<Newtonsoft.Json.JsonSerializerSettings> configureSerializerSettings, GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
         public GraphQLSerializer(bool indent, GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
+        protected Newtonsoft.Json.JsonSerializer Serializer { get; }
         public T Deserialize<T>(string json) { }
         public T Read<T>(System.IO.TextReader json) { }
         public System.Threading.Tasks.ValueTask<T> ReadAsync<T>(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/GraphQL.ApiTests/GraphQL.SystemTextJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.SystemTextJson.approved.txt
@@ -41,6 +41,7 @@ namespace GraphQL.SystemTextJson
         public GraphQLSerializer(System.Action<System.Text.Json.JsonSerializerOptions> configureSerializerOptions, GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
         public GraphQLSerializer(bool indent, GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
         public GraphQLSerializer(System.Text.Json.JsonSerializerOptions serializerOptions, GraphQL.Execution.IErrorInfoProvider errorInfoProvider) { }
+        protected System.Text.Json.JsonSerializerOptions SerializerOptions { get; }
         public T Deserialize<T>(string json) { }
         public System.Threading.Tasks.ValueTask<T> ReadAsync<T>(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default) { }
         public T ReadNode<T>(object value) { }

--- a/src/GraphQL.NewtonsoftJson/GraphQLSerializer.cs
+++ b/src/GraphQL.NewtonsoftJson/GraphQLSerializer.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Execution;
+using GraphQL.Instrumentation;
+using GraphQL.Transport;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -17,7 +19,7 @@ namespace GraphQL.NewtonsoftJson
     public class GraphQLSerializer : IGraphQLTextSerializer
     {
         private readonly JsonArrayPool _jsonArrayPool = new JsonArrayPool(ArrayPool<char>.Shared);
-        private readonly JsonSerializer _serializer;
+        protected JsonSerializer Serializer { get; }
         private static readonly Encoding _utf8Encoding = new UTF8Encoding(false);
 
         /// <summary>
@@ -104,9 +106,14 @@ namespace GraphQL.NewtonsoftJson
         {
         }
 
-        private GraphQLSerializer(JsonSerializer jsonSerializer)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GraphQLSerializer"/> class with the specified <see cref="JsonSerializer"/>.
+        /// The specified <see cref="JsonSerializer"/> should support serializing and/or deserializing <see cref="ExecutionResult"/>,
+        /// <see cref="GraphQLRequest"/>, <see cref="Inputs"/>, <see cref="OperationMessage"/> and <see cref="ApolloTrace"/>.
+        /// </summary>
+        protected GraphQLSerializer(JsonSerializer jsonSerializer)
         {
-            _serializer = jsonSerializer;
+            Serializer = jsonSerializer;
         }
 
         private static JsonSerializerSettings GetDefaultSerializerSettings(bool indent, IErrorInfoProvider errorInfoProvider)
@@ -150,7 +157,7 @@ namespace GraphQL.NewtonsoftJson
                 AutoCompleteOnClose = false
             };
 
-            _serializer.Serialize(jsonWriter, value);
+            Serializer.Serialize(jsonWriter, value);
             await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
@@ -163,7 +170,7 @@ namespace GraphQL.NewtonsoftJson
             {
                 CloseOutput = false
             };
-            _serializer.Serialize(stringWriter, value);
+            Serializer.Serialize(stringWriter, value);
         }
 
         /// <inheritdoc/>
@@ -179,7 +186,7 @@ namespace GraphQL.NewtonsoftJson
         {
             using var stringReader = new StreamReader(stream, Encoding.UTF8, true, 1024, true);
             using var jsonReader = new JsonTextReader(stringReader);
-            return new ValueTask<T>(_serializer.Deserialize<T>(jsonReader));
+            return new ValueTask<T>(Serializer.Deserialize<T>(jsonReader));
         }
 
         /// <summary>
@@ -191,7 +198,7 @@ namespace GraphQL.NewtonsoftJson
             {
                 CloseInput = false
             };
-            return _serializer.Deserialize<T>(jsonReader);
+            return Serializer.Deserialize<T>(jsonReader);
         }
 
         /// <inheritdoc/>
@@ -203,7 +210,7 @@ namespace GraphQL.NewtonsoftJson
         /// A <paramref name="jObject"/> of <see langword="null"/> returns <see langword="default"/>.
         /// </summary>
         private T ReadNode<T>(JObject jObject)
-            => jObject == null ? default : jObject.ToObject<T>(_serializer);
+            => jObject == null ? default : jObject.ToObject<T>(Serializer);
 
         /// <summary>
         /// Converts the <see cref="JObject"/> representing a single JSON value into a <typeparamref name="T"/>.

--- a/src/GraphQL.NewtonsoftJson/GraphQLSerializer.cs
+++ b/src/GraphQL.NewtonsoftJson/GraphQLSerializer.cs
@@ -19,8 +19,12 @@ namespace GraphQL.NewtonsoftJson
     public class GraphQLSerializer : IGraphQLTextSerializer
     {
         private readonly JsonArrayPool _jsonArrayPool = new JsonArrayPool(ArrayPool<char>.Shared);
-        protected JsonSerializer Serializer { get; }
         private static readonly Encoding _utf8Encoding = new UTF8Encoding(false);
+
+        /// <summary>
+        /// Returns the underlying serializer.
+        /// </summary>
+        protected JsonSerializer Serializer { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphQLSerializer"/> class with default settings:

--- a/src/GraphQL.SystemTextJson/GraphQLSerializer.cs
+++ b/src/GraphQL.SystemTextJson/GraphQLSerializer.cs
@@ -17,6 +17,9 @@ namespace GraphQL.SystemTextJson
     /// </summary>
     public class GraphQLSerializer : IGraphQLTextSerializer
     {
+        /// <summary>
+        /// Returns the set of options used by the underlying serializer.
+        /// </summary>
         protected JsonSerializerOptions SerializerOptions { get; }
 
         /// <summary>

--- a/src/GraphQL.SystemTextJson/GraphQLSerializer.cs
+++ b/src/GraphQL.SystemTextJson/GraphQLSerializer.cs
@@ -17,7 +17,7 @@ namespace GraphQL.SystemTextJson
     /// </summary>
     public class GraphQLSerializer : IGraphQLTextSerializer
     {
-        private readonly JsonSerializerOptions _options;
+        protected JsonSerializerOptions SerializerOptions { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphQLSerializer"/> class with default settings:
@@ -68,8 +68,8 @@ namespace GraphQL.SystemTextJson
             if (configureSerializerOptions == null)
                 throw new ArgumentNullException(nameof(configureSerializerOptions));
 
-            _options = GetDefaultSerializerOptions(indent: false);
-            configureSerializerOptions.Invoke(_options);
+            SerializerOptions = GetDefaultSerializerOptions(indent: false);
+            configureSerializerOptions.Invoke(SerializerOptions);
 
             ConfigureOptions(null);
         }
@@ -81,7 +81,7 @@ namespace GraphQL.SystemTextJson
         /// <param name="serializerOptions">Specifies the JSON serializer settings</param>
         public GraphQLSerializer(JsonSerializerOptions serializerOptions)
         {
-            _options = serializerOptions ?? throw new ArgumentNullException(nameof(serializerOptions));
+            SerializerOptions = serializerOptions ?? throw new ArgumentNullException(nameof(serializerOptions));
 
             // TODO: fix this: it modifies serializerOptions
             ConfigureOptions(null);
@@ -94,7 +94,7 @@ namespace GraphQL.SystemTextJson
         /// <param name="errorInfoProvider">Specifies the <see cref="IErrorInfoProvider"/> instance to use to serialize GraphQL errors</param>
         public GraphQLSerializer(JsonSerializerOptions serializerOptions, IErrorInfoProvider errorInfoProvider)
         {
-            _options = serializerOptions ?? throw new ArgumentNullException(nameof(serializerOptions));
+            SerializerOptions = serializerOptions ?? throw new ArgumentNullException(nameof(serializerOptions));
 
             // TODO: fix this: it modifies serializerOptions
             ConfigureOptions(errorInfoProvider ?? throw new ArgumentNullException(nameof(errorInfoProvider)));
@@ -114,47 +114,47 @@ namespace GraphQL.SystemTextJson
             if (errorInfoProvider == null)
                 throw new ArgumentNullException(nameof(errorInfoProvider));
 
-            _options = GetDefaultSerializerOptions(indent: false);
-            configureSerializerOptions.Invoke(_options);
+            SerializerOptions = GetDefaultSerializerOptions(indent: false);
+            configureSerializerOptions.Invoke(SerializerOptions);
 
             ConfigureOptions(errorInfoProvider);
         }
 
         private void ConfigureOptions(IErrorInfoProvider errorInfoProvider)
         {
-            if (!_options.Converters.Any(c => c.CanConvert(typeof(ExecutionResult))))
+            if (!SerializerOptions.Converters.Any(c => c.CanConvert(typeof(ExecutionResult))))
             {
-                _options.Converters.Add(new ExecutionResultJsonConverter(errorInfoProvider ?? new ErrorInfoProvider()));
+                SerializerOptions.Converters.Add(new ExecutionResultJsonConverter(errorInfoProvider ?? new ErrorInfoProvider()));
             }
 
-            if (!_options.Converters.Any(c => c.CanConvert(typeof(ApolloTrace))))
+            if (!SerializerOptions.Converters.Any(c => c.CanConvert(typeof(ApolloTrace))))
             {
-                _options.Converters.Add(new ApolloTraceJsonConverter());
+                SerializerOptions.Converters.Add(new ApolloTraceJsonConverter());
             }
 
-            if (!_options.Converters.Any(c => c.CanConvert(typeof(JsonConverterBigInteger))))
+            if (!SerializerOptions.Converters.Any(c => c.CanConvert(typeof(JsonConverterBigInteger))))
             {
-                _options.Converters.Add(new JsonConverterBigInteger());
+                SerializerOptions.Converters.Add(new JsonConverterBigInteger());
             }
 
-            if (!_options.Converters.Any(c => c.CanConvert(typeof(Inputs))))
+            if (!SerializerOptions.Converters.Any(c => c.CanConvert(typeof(Inputs))))
             {
-                _options.Converters.Add(new InputsJsonConverter());
+                SerializerOptions.Converters.Add(new InputsJsonConverter());
             }
 
-            if (!_options.Converters.Any(c => c.CanConvert(typeof(GraphQLRequest))))
+            if (!SerializerOptions.Converters.Any(c => c.CanConvert(typeof(GraphQLRequest))))
             {
-                _options.Converters.Add(new GraphQLRequestJsonConverter());
+                SerializerOptions.Converters.Add(new GraphQLRequestJsonConverter());
             }
 
-            if (!_options.Converters.Any(c => c.CanConvert(typeof(List<GraphQLRequest>))))
+            if (!SerializerOptions.Converters.Any(c => c.CanConvert(typeof(List<GraphQLRequest>))))
             {
-                _options.Converters.Add(new GraphQLRequestListJsonConverter());
+                SerializerOptions.Converters.Add(new GraphQLRequestListJsonConverter());
             }
 
-            if (!_options.Converters.Any(c => c.CanConvert(typeof(OperationMessage))))
+            if (!SerializerOptions.Converters.Any(c => c.CanConvert(typeof(OperationMessage))))
             {
-                _options.Converters.Add(new OperationMessageJsonConverter());
+                SerializerOptions.Converters.Add(new OperationMessageJsonConverter());
             }
         }
 
@@ -163,19 +163,19 @@ namespace GraphQL.SystemTextJson
 
         /// <inheritdoc/>
         public Task WriteAsync<T>(Stream stream, T value, CancellationToken cancellationToken = default)
-            => JsonSerializer.SerializeAsync(stream, value, _options, cancellationToken);
+            => JsonSerializer.SerializeAsync(stream, value, SerializerOptions, cancellationToken);
 
         /// <inheritdoc/>
         public ValueTask<T> ReadAsync<T>(Stream stream, CancellationToken cancellationToken = default)
-            => JsonSerializer.DeserializeAsync<T>(stream, _options, cancellationToken);
+            => JsonSerializer.DeserializeAsync<T>(stream, SerializerOptions, cancellationToken);
 
         /// <inheritdoc/>
         public string Serialize<T>(T value)
-            => JsonSerializer.Serialize(value, _options);
+            => JsonSerializer.Serialize(value, SerializerOptions);
 
         /// <inheritdoc/>
         public T Deserialize<T>(string json)
-            => json == null ? default : JsonSerializer.Deserialize<T>(json, _options);
+            => json == null ? default : JsonSerializer.Deserialize<T>(json, SerializerOptions);
 
         /*******
         /// <summary>
@@ -195,9 +195,9 @@ namespace GraphQL.SystemTextJson
         /// </summary>
         private T ReadNode<T>(JsonElement jsonElement)
 #if NET6_0_OR_GREATER
-            => JsonSerializer.Deserialize<T>(jsonElement, _options);
+            => JsonSerializer.Deserialize<T>(jsonElement, SerializerOptions);
 #else
-            => JsonSerializer.Deserialize<T>(jsonElement.GetRawText(), _options);
+            => JsonSerializer.Deserialize<T>(jsonElement.GetRawText(), SerializerOptions);
 #endif
 
         /// <summary>


### PR DESCRIPTION
For Newtonsoft.Json, the method that builds the serializer is static and can't be made virtual.  So I exposed the constructor with the serializer as protected, so derived classes can build their own serializer.

For System.Text.Json, derived classes can place additional configuration within the derived constructor of the class.