### PR TITLE
Remove support for GraphQLMetadata attribute to set graph type name

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -228,3 +228,21 @@ calls are made to the underlying stream. Only `System.Text.Json` supports asynch
 
 - `InputsConverter` renamed to `InputsJsonConverter`
 - `ExecutionResultContractResolver` renamed to `GraphQLContractResolver`
+
+### 18. `GraphQLMetadataAttribute` cannot be applied to graph type classes
+
+The `[GraphQLMetadata]` attribute is designed to be used for schema-first configurations
+and has not changed in this regard. For code-first graph definitions, please set the
+GraphQL type name within the constructor.
+
+```csharp
+//[GraphQLMetadata("Person")] //previously supported
+public class HumanType : ObjectGraphType<Human>
+{
+    public HumanType()
+    {
+        Name = "Person"; //correct implementation
+        ...
+    }
+}
+```

--- a/src/GraphQL.Tests/Types/ObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ObjectGraphTypeTests.cs
@@ -9,8 +9,16 @@ namespace GraphQL.Tests.Types
     {
         private class TestInterface : InterfaceGraphType { }
 
-        [GraphQLMetadata(Name = ":::")]
-        private class TypeWithInvalidName : ObjectGraphType { }
+        private class TypeWithInvalidName : ObjectGraphType
+        {
+            public TypeWithInvalidName()
+            {
+                Name = ":::";
+            }
+        }
+
+        [GraphQLMetadata(Name = "testing")]
+        private class TypeWithAttribute : ObjectGraphType { }
 
         [Fact]
         public void can_implement_interfaces()
@@ -44,6 +52,13 @@ namespace GraphQL.Tests.Types
                 System.Threading.Thread.Sleep(100); // wait a bit and retry
                 Should.Throw<ArgumentOutOfRangeException>(() => new TypeWithInvalidName()).Message.ShouldBe(ex.Message);
             }
+        }
+
+        [Fact]
+        public void should_ignore_graphqlmetadata_attribute()
+        {
+            var type = new TypeWithAttribute();
+            type.Name.ShouldBe("TypeWithAttribute");
         }
     }
 }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
@@ -707,6 +707,40 @@ namespace GraphQL.Tests.Utilities
             type.Fields.Count.ShouldBe(2);
         }
 
+        [Fact]
+        public void builds_with_customized_clr_type()
+        {
+            var definitions = @"
+                type Query {
+                    test: MyTestType
+                }
+
+                type MyTestType {
+                    myTestField: ID
+                }
+            ";
+
+            var schema = Schema.For(definitions, b => b.Types.Include<TestType>());
+            schema.Initialize();
+
+            var graphType = schema.AllTypes["MyTestType"].ShouldNotBeNull().ShouldBeAssignableTo<ObjectGraphType>();
+            graphType.Description.ShouldBe("Test1");
+            graphType.DeprecationReason.ShouldBe("Test2");
+            var fieldType = graphType.Fields.Find("myTestField").ShouldNotBeNull();
+            fieldType.Description.ShouldBe("Test3");
+            fieldType.DeprecationReason.ShouldBe("Test4");
+            fieldType.ResolvedType.ShouldBeOfType<IdGraphType>();
+            var context = new ResolveFieldContext() { Source = new TestType() };
+            fieldType.Resolver.Resolve(context).ShouldBeOfType<string>().ShouldBe("value");
+        }
+
+        [GraphQLMetadata("MyTestType", Description = "Test1", DeprecationReason = "Test2")]
+        internal class TestType
+        {
+            [GraphQLMetadata("myTestField", Description = "Test3", DeprecationReason = "Test4")]
+            public string Example() => "value";
+        }
+
         internal class Movie
         {
             [GraphQLMetadata("movies", DeprecationReason = "my reason")]

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -33,13 +33,6 @@ namespace GraphQL.Types
         {
             var type = GetType();
 
-            var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
-
-            if (!string.IsNullOrEmpty(attr?.Name))
-            {
-                return attr!.Name!;
-            }
-
             string name = type.Name;
             if (GlobalSwitches.UseDeclaringTypeNames)
             {

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using GraphQL.Utilities;
 
 namespace GraphQL.Types


### PR DESCRIPTION
See #2876 

Suggest to remove support for this attribute on graph type classes in code-first scenarios since the attribute was designed for schema-first and is not fully supported for code-first in any case.  There is no good reason for this attribute, because if a user has derived from `ObjectGraphType` in order to add an attribute, then they certainly can add code to the constructor.

Only possibly way I could see someone wishing to use the attribute today would be as follows:

```cs
[GraphQLMetadata("Person")]
public class PersonType : AutoRegisteringObjectGraphType<Human> { }
```

Even if such a scenario was desired, it should have supported all relevant properties.  In any case, in a subsequent PR, I will be adding support for the attribute to be applied to the CLR type as in the following example:

```cs
//note that defining the class is now optional because the name can be applied to the CLR type
public class PersonType : AutoRegisteringObjectGraphType<Human> { }

[GraphQLMetadata("Person")]
public class Human { ... }
```

This will align the use case of the attribute with that of schema-first, which is that it is designed to be set on a CLR type.

In the cases where a user cannot set attributes on their data classes, they can still resort to setting the GraphQL type name within the constructor:

```cs
public class PersonType : AutoRegisteringObjectGraphType<Human>
{
    public PersonType()
    {
        Name = "Person";
    }
}
```
