### PR TITLE
Add InputType and OutputType attributes

### DIFF
--- a/docs2/site/docs/getting-started/custom-scalars.md
+++ b/docs2/site/docs/getting-started/custom-scalars.md
@@ -279,8 +279,8 @@ public class MySchema
 ```
 
 This is not necessary if you use the alternate `Field<T>` syntax which specifies the graph type
-to be used for the field, or if your scalar data type is marked with the `GraphQLMetadata`
-attribute setting the `InputType` and/or `OutputType` properties.
+to be used for the field, or if your scalar data type is marked with the
+`[InputType]` and/or `[OutputType]` attributes.
 
 In this example, you created a custom scalar. In summary:
 

--- a/docs2/site/docs/getting-started/schema-types.md
+++ b/docs2/site/docs/getting-started/schema-types.md
@@ -340,12 +340,13 @@ var schema = Schema.For(definitions, c =>
 ## Type Mapping
 
 When specifying a field using the shortcut syntax `Field(x => x.Parent)`, which does not specify
-a specific graph type, GraphQL.NET will first look at the data model to see if it has a `GraphQLMetadata`
-attribute specified on it indicating the graph type to use for the data model. For instance, you can
-specify the graph type for a `Widget` class in the following manner:
+a specific graph type, GraphQL.NET will first look at the data model to see if it has an `[InputType]`
+or `[OutputType]` attribute specified on it indicating the graph type to use for the data model. For
+instance, you can specify the graph type for a `Widget` class in the following manner:
 
 ```csharp
-[GraphQLMetadata(InputType = typeof(WidgetInputGraphType), OutputType = typeof(WidgetGraphType)]
+[InputType(typeof(WidgetInputGraphType))]
+[OutputType(typeof(WidgetGraphType))]
 public class Widget
 {
     ...

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -320,9 +320,11 @@ namespace GraphQL
         public GraphQLMetadataAttribute(string name) { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        [System.Obsolete("Please use the [InputType] attribute instead of this property.")]
         public System.Type? InputType { get; set; }
         public System.Type? IsTypeOf { get; set; }
         public string? Name { get; set; }
+        [System.Obsolete("Please use the [OutputType] attribute instead of this property.")]
         public System.Type? OutputType { get; set; }
         public GraphQL.ResolverType ResolverType { get; set; }
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
@@ -362,6 +364,12 @@ namespace GraphQL
     public interface IResolveFieldContext<out TSource> : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
     {
         TSource Source { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.All)]
+    public class InputTypeAttribute : System.Attribute
+    {
+        public InputTypeAttribute(System.Type graphType) { }
+        public System.Type InputType { get; set; }
     }
     public class Inputs : System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>
     {
@@ -408,6 +416,12 @@ namespace GraphQL
         public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType? mappedType = null) { }
         public static T ToObject<T>(this System.Collections.Generic.IDictionary<string, object?> source)
             where T :  class { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.All)]
+    public class OutputTypeAttribute : System.Attribute
+    {
+        public OutputTypeAttribute(System.Type graphType) { }
+        public System.Type OutputType { get; set; }
     }
     public class ReadonlyResolveFieldContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<object?>
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -320,9 +320,11 @@ namespace GraphQL
         public GraphQLMetadataAttribute(string name) { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        [System.Obsolete("Please use the [InputType] attribute instead of this property.")]
         public System.Type? InputType { get; set; }
         public System.Type? IsTypeOf { get; set; }
         public string? Name { get; set; }
+        [System.Obsolete("Please use the [OutputType] attribute instead of this property.")]
         public System.Type? OutputType { get; set; }
         public GraphQL.ResolverType ResolverType { get; set; }
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
@@ -362,6 +364,12 @@ namespace GraphQL
     public interface IResolveFieldContext<out TSource> : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
     {
         TSource Source { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.All)]
+    public class InputTypeAttribute : System.Attribute
+    {
+        public InputTypeAttribute(System.Type graphType) { }
+        public System.Type InputType { get; set; }
     }
     public class Inputs : System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>
     {
@@ -408,6 +416,12 @@ namespace GraphQL
         public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType? mappedType = null) { }
         public static T ToObject<T>(this System.Collections.Generic.IDictionary<string, object?> source)
             where T :  class { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.All)]
+    public class OutputTypeAttribute : System.Attribute
+    {
+        public OutputTypeAttribute(System.Type graphType) { }
+        public System.Type OutputType { get; set; }
     }
     public class ReadonlyResolveFieldContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext, GraphQL.IResolveFieldContext<object?>
     {

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -211,6 +211,30 @@ namespace GraphQL.Tests.Utilities
         [InlineData(typeof(Task), true, TypeMappingMode.OutputType, null)]
         [InlineData(typeof(Task<string>), true, TypeMappingMode.UseBuiltInScalarMappings, null)]
         [InlineData(typeof(Task<string>), true, TypeMappingMode.OutputType, null)]
+        [InlineData(typeof(AttributeTest1), true, TypeMappingMode.InputType, typeof(CustomInputGraphType))]
+        [InlineData(typeof(AttributeTest1), false, TypeMappingMode.InputType, typeof(NonNullGraphType<CustomInputGraphType>))]
+        [InlineData(typeof(AttributeTest2), true, TypeMappingMode.InputType, typeof(CustomInputGraphType))]
+        [InlineData(typeof(AttributeTest2), false, TypeMappingMode.InputType, typeof(NonNullGraphType<CustomInputGraphType>))]
+        [InlineData(typeof(AttributeTest3), true, TypeMappingMode.InputType, typeof(GraphQLClrInputTypeReference<AttributeTest3>))]
+        [InlineData(typeof(AttributeTest3), false, TypeMappingMode.InputType, typeof(NonNullGraphType<GraphQLClrInputTypeReference<AttributeTest3>>))]
+        [InlineData(typeof(AttributeTest1), true, TypeMappingMode.OutputType, typeof(CustomOutputGraphType))]
+        [InlineData(typeof(AttributeTest1), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<CustomOutputGraphType>))]
+        [InlineData(typeof(AttributeTest2), true, TypeMappingMode.OutputType, typeof(GraphQLClrOutputTypeReference<AttributeTest2>))]
+        [InlineData(typeof(AttributeTest2), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<GraphQLClrOutputTypeReference<AttributeTest2>>))]
+        [InlineData(typeof(AttributeTest3), true, TypeMappingMode.OutputType, typeof(CustomOutputGraphType))]
+        [InlineData(typeof(AttributeTest3), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<CustomOutputGraphType>))]
+        [InlineData(typeof(AttributeTest4), true, TypeMappingMode.InputType, typeof(CustomInputGraphType))]
+        [InlineData(typeof(AttributeTest4), false, TypeMappingMode.InputType, typeof(NonNullGraphType<CustomInputGraphType>))]
+        [InlineData(typeof(AttributeTest5), true, TypeMappingMode.InputType, typeof(CustomInputGraphType))]
+        [InlineData(typeof(AttributeTest5), false, TypeMappingMode.InputType, typeof(NonNullGraphType<CustomInputGraphType>))]
+        [InlineData(typeof(AttributeTest6), true, TypeMappingMode.InputType, typeof(GraphQLClrInputTypeReference<AttributeTest6>))]
+        [InlineData(typeof(AttributeTest6), false, TypeMappingMode.InputType, typeof(NonNullGraphType<GraphQLClrInputTypeReference<AttributeTest6>>))]
+        [InlineData(typeof(AttributeTest4), true, TypeMappingMode.OutputType, typeof(CustomOutputGraphType))]
+        [InlineData(typeof(AttributeTest4), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<CustomOutputGraphType>))]
+        [InlineData(typeof(AttributeTest5), true, TypeMappingMode.OutputType, typeof(GraphQLClrOutputTypeReference<AttributeTest5>))]
+        [InlineData(typeof(AttributeTest5), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<GraphQLClrOutputTypeReference<AttributeTest5>>))]
+        [InlineData(typeof(AttributeTest6), true, TypeMappingMode.OutputType, typeof(CustomOutputGraphType))]
+        [InlineData(typeof(AttributeTest6), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<CustomOutputGraphType>))]
         public void GetGraphTypeFromType_Matrix(Type type, bool nullable, TypeMappingMode typeMappingMode, Type expectedType)
         {
             if (expectedType == null)
@@ -395,5 +419,32 @@ namespace GraphQL.Tests.Utilities
         private class MappedEnumGraphType : EnumerationGraphType<MappedEnum>
         {
         }
+
+        private class CustomInputGraphType : InputObjectGraphType
+        {
+        }
+
+        private class CustomOutputGraphType : ObjectGraphType
+        {
+        }
+
+        [GraphQLMetadata(InputType = typeof(CustomInputGraphType), OutputType = typeof(CustomOutputGraphType))]
+        private class AttributeTest1 { }
+
+        [GraphQLMetadata(InputType = typeof(CustomInputGraphType))]
+        private class AttributeTest2 { }
+
+        [GraphQLMetadata(OutputType = typeof(CustomOutputGraphType))]
+        private class AttributeTest3 { }
+
+        [InputType(typeof(CustomInputGraphType))]
+        [OutputType(typeof(CustomOutputGraphType))]
+        private class AttributeTest4 { }
+
+        [InputType(typeof(CustomInputGraphType))]
+        private class AttributeTest5 { }
+
+        [OutputType(typeof(CustomOutputGraphType))]
+        private class AttributeTest6 { }
     }
 }

--- a/src/GraphQL/GraphQLMetadataAttribute.cs
+++ b/src/GraphQL/GraphQLMetadataAttribute.cs
@@ -59,6 +59,7 @@ namespace GraphQL
         /// <summary>
         /// Indicates which GraphType input type this CLR type is mapped to (if used in input context).
         /// </summary>
+        [Obsolete("Please use the [InputType] attribute instead of this property.")]
         public Type? InputType
         {
             get => _mappedToInput;
@@ -74,6 +75,7 @@ namespace GraphQL
         /// <summary>
         /// Indicates which GraphType output type this CLR type is mapped to (if used in output context).
         /// </summary>
+        [Obsolete("Please use the [OutputType] attribute instead of this property.")]
         public Type? OutputType
         {
             get => _mappedToOutput;

--- a/src/GraphQL/InputTypeAttribute.cs
+++ b/src/GraphQL/InputTypeAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace GraphQL
+{
+    /// <summary>
+    /// Specifies an input graph type mapping for the CLR class marked with this attribute
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class InputTypeAttribute : Attribute
+    {
+        private Type _mappedToInput = null!;
+
+        /// <inheritdoc cref="InputTypeAttribute"/>
+        public InputTypeAttribute(Type graphType)
+        {
+            InputType = graphType;
+        }
+
+        /// <inheritdoc cref="InputTypeAttribute"/>
+        public Type InputType
+        {
+            get => _mappedToInput;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                if (!value.IsInputType())
+                    throw new ArgumentException(nameof(InputType), $"'{value}' should be an input type");
+
+                _mappedToInput = value;
+            }
+        }
+    }
+}

--- a/src/GraphQL/OutputTypeAttribute.cs
+++ b/src/GraphQL/OutputTypeAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace GraphQL
+{
+    /// <summary>
+    /// Specifies an output graph type mapping for the CLR class marked with this attribute
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class OutputTypeAttribute : Attribute
+    {
+        private Type _mappedToOutput = null!;
+
+        /// <inheritdoc cref="OutputTypeAttribute"/>
+        public OutputTypeAttribute(Type graphType)
+        {
+            OutputType = graphType;
+        }
+
+        /// <inheritdoc cref="OutputTypeAttribute"/>
+        public Type OutputType
+        {
+            get => _mappedToOutput;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                if (!value.IsOutputType())
+                    throw new ArgumentException(nameof(OutputType), $"'{value}' should be an output type");
+
+                _mappedToOutput = value;
+            }
+        }
+    }
+}

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -133,6 +133,7 @@ namespace GraphQL
             }
             else
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
                 if (attr != null)
                 {
@@ -142,6 +143,20 @@ namespace GraphQL
                         graphType = attr.OutputType;
                     else if (attr.InputType == attr.OutputType) // scalar
                         graphType = attr.InputType;
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                if (mode == TypeMappingMode.InputType)
+                {
+                    var inputAttr = type.GetCustomAttribute<InputTypeAttribute>();
+                    if (inputAttr != null)
+                        graphType = inputAttr.InputType;
+                }
+                else if (mode == TypeMappingMode.OutputType)
+                {
+                    var outputAttr = type.GetCustomAttribute<OutputTypeAttribute>();
+                    if (outputAttr != null)
+                        graphType = outputAttr.OutputType;
                 }
 
                 if (graphType == null)


### PR DESCRIPTION
Separates `InputType` and `OutputType` which are used for type mappings from the `GraphQLMetadata` attribute which is used for configuring an automatically-constructed graph type.

The old properties remain as obsolete members.