### PR TITLE
Add Ignore attribute

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -152,7 +152,7 @@ type instead.
 
 #### Graphs and fields recognize attributes to control initialization behavior
 
-Any attribute that derives from `GraphQLAttribute`, such as `GraphQLAuthorizeAttribute`, is can be set on a
+Any attribute that derives from `GraphQLAttribute`, such as `GraphQLAuthorizeAttribute`, can be set on a
 CLR class or one if its properties and is configured for the graph or field type. New attributes have been
 updated or added for convenience as follows:
 
@@ -163,6 +163,7 @@ updated or added for convenience as follows:
 | `[OutputName]`       | Specifies a GraphQL name for an output CLR class or property |
 | `[InputType]`        | Specifies a graph type for a field on an input model |
 | `[OutputType]`       | Specifies a graph type for a field on an output model |
+| `[Ignore]`           | Indicates that a CLR property should not be mapped to a field |
 | `[Metadata]`         | Specifies custom metadata to be added to the graph type or field |
 | `[GraphQLAuthorize]` | Specifies an authorization policy for the graph type for field |
 | `[GraphQLMetadata]`  | Specifies name, description, deprecation reason, or other properties for the graph type or field |

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -375,6 +375,11 @@ namespace GraphQL
     {
         TSource Source { get; }
     }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.All, AllowMultiple=false)]
+    public class IgnoreAttribute : System.Attribute
+    {
+        public IgnoreAttribute() { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Property | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
     public class InputNameAttribute : GraphQL.GraphQLAttribute
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -375,6 +375,11 @@ namespace GraphQL
     {
         TSource Source { get; }
     }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.All, AllowMultiple=false)]
+    public class IgnoreAttribute : System.Attribute
+    {
+        public IgnoreAttribute() { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Property | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
     public class InputNameAttribute : GraphQL.GraphQLAttribute
     {

--- a/src/GraphQL.Tests/Types/AutoRegisteringInputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInputObjectGraphTypeTests.cs
@@ -158,6 +158,13 @@ namespace GraphQL.Tests.Types
         }
 
         [Fact]
+        public void Field_RecognizesIgnoreAttribute()
+        {
+            var graphType = new AutoRegisteringObjectGraphType<FieldTests>();
+            graphType.Fields.Find("Field11").ShouldBeNull();
+        }
+
+        [Fact]
         public void DefaultServiceProvider_Should_Create_AutoRegisteringGraphTypes()
         {
             var provider = new DefaultServiceProvider();
@@ -223,6 +230,8 @@ namespace GraphQL.Tests.Types
             public string? Field9 { get; set; }
             [OutputName("OutputField10")]
             public string? Field10 { get; set; }
+            [Ignore]
+            public string? Field11 { get; set; }
         }
 
         private class TestChangingFieldList<T> : AutoRegisteringInputObjectGraphType<T>

--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -158,6 +158,13 @@ namespace GraphQL.Tests.Types
         }
 
         [Fact]
+        public void Field_RecognizesIgnoreAttribute()
+        {
+            var graphType = new AutoRegisteringObjectGraphType<FieldTests>();
+            graphType.Fields.Find("Field11").ShouldBeNull();
+        }
+
+        [Fact]
         public void DefaultServiceProvider_Should_Create_AutoRegisteringGraphTypes()
         {
             var provider = new DefaultServiceProvider();
@@ -223,6 +230,8 @@ namespace GraphQL.Tests.Types
             public string? Field9 { get; set; }
             [OutputName("OutputField10")]
             public string? Field10 { get; set; }
+            [Ignore]
+            public string? Field11 { get; set; }
         }
 
         private class TestChangingFieldList<T> : AutoRegisteringObjectGraphType<T>

--- a/src/GraphQL/IgnoreAttribute.cs
+++ b/src/GraphQL/IgnoreAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace GraphQL
+{
+    /// <summary>
+    /// Does not add the marked property to the auto-registered GraphQL type as a field.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class IgnoreAttribute : Attribute
+    {
+    }
+}

--- a/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
@@ -54,6 +54,8 @@ namespace GraphQL.Types
         {
             foreach (var propertyInfo in GetRegisteredProperties())
             {
+                if (propertyInfo.IsDefined(typeof(IgnoreAttribute)))
+                    continue;
                 var fieldType = CreateField(propertyInfo);
                 if (fieldType != null)
                     yield return fieldType;

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -53,6 +53,8 @@ namespace GraphQL.Types
         {
             foreach (var propertyInfo in GetRegisteredProperties())
             {
+                if (propertyInfo.IsDefined(typeof(IgnoreAttribute)))
+                    continue;
                 var fieldType = CreateField(propertyInfo);
                 if (fieldType != null)
                     yield return fieldType;


### PR DESCRIPTION
Adds `[Ignore]` attribute so properties on data models can be easily skipped when auto-registering graph types:

```cs
public class ShoppingCartItem
{
    [OutputType(typeof(NonNullGraphType<IdGraphType>))]
    public int Id { get; set; }

    public int Quantity { get; set; }

    public string Description { get; set; }

    public decimal Price { get; set; }

    [Ignore]
    public decimal Total => Quantity * Price;
}
```

This new attribute does not inherit from `GraphQLAttribute`.  We could add another protected method to the `GraphQLAttribute` class -- something like `bool Ignore(PropertyInfo property, bool isInputType)` -- and then rewrite `IgnoreAttribute` to inherit `GraphQLAttribute`, but so far I don't see a good reason to do so.