### PR TITLE
Enforce formatting in Visual Studio rather than by dotnet-format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -256,4 +256,6 @@ dotnet_naming_rule.async_methods_end_in_async.severity = warning
 
 # Remove unnecessary import https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005
 dotnet_diagnostic.IDE0005.severity = error
+
+# Enforce formatting
 dotnet_diagnostic.IDE0055.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -255,4 +255,5 @@ dotnet_naming_style.end_in_async_style.required_suffix = Async
 dotnet_naming_rule.async_methods_end_in_async.severity = warning
 
 # Remove unnecessary import https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005
-dotnet_diagnostic.IDE0005.severity = warning
+dotnet_diagnostic.IDE0005.severity = error
+dotnet_diagnostic.IDE0055.severity = error

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -47,14 +47,6 @@ jobs:
       - name: Install dependencies
         working-directory: src
         run: dotnet restore
-      - name: Check formatting
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        working-directory: src
-        run: |
-          dotnet tool install -g dotnet-format --version 6.0.243104 --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
-          dotnet format --no-restore --verify-no-changes --severity warn whitespace || (echo "Run 'dotnet format' to fix whitespace issues" && exit 1)
-          dotnet format --no-restore --verify-no-changes --severity warn analyzers || (echo "Run 'dotnet format' to fix analyzers issues" && exit 1)
-          dotnet format --no-restore --verify-no-changes --severity warn style || (echo "Run 'dotnet format' to fix style issues" && exit 1)
       - name: Build solution [Release]
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         working-directory: src


### PR DESCRIPTION
This should work much better.  No need to push bad code just to have CI tests flunk it.