### PR TITLE
Rename DirectiveGraphType into Directive

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -401,20 +401,22 @@ services.AddGraphQL(builder => builder
 
 ### 9. `ExecutionHelper.GetArgumentValues` was renamed to `GetArguments`
 
-### 10. `schema`, `variableDefinitions` and `variables` arguments were removed from `ValidationContext.GetVariableValues`
+### 10. `DirectiveGraphType` was renamed to `Directive`
+
+### 11. `schema`, `variableDefinitions` and `variables` arguments were removed from `ValidationContext.GetVariableValues`
 
 Use `ValidationContext.Schema`, `ValidationContext.Operation.Variables` and `ValidationContext.Variables` properties
 
-### 11. `ValidationContext.OperationName` was changed to `ValidationContext.Operation`
+### 12. `ValidationContext.OperationName` was changed to `ValidationContext.Operation`
 
-### 12. All arguments from `IDocumentValidator.ValidateAsync` were wrapped into `ValidationOptions` struct
+### 13. All arguments from `IDocumentValidator.ValidateAsync` were wrapped into `ValidationOptions` struct
 
-### 13. All methods from `IGraphQLBuilder` were moved into `IServiceRegister` interface
+### 14. All methods from `IGraphQLBuilder` were moved into `IServiceRegister` interface
 
 Use `IGraphQLBuilder.Services` property if you need to register services into DI container.
 If you use provided extension methods upon `IGraphQLBuilder` then your code does not require any changes.
 
-### 14. Changes caused by GraphQL-Parser v8
+### 15. Changes caused by GraphQL-Parser v8
 
 - The `GraphQL.Language.AST` namespace and all classes from it have been removed in favor of ones
   from `GraphQLParser.AST` namespace in GraphQL-Parser project. Examples of changed usages:
@@ -444,7 +446,7 @@ If you use provided extension methods upon `IGraphQLBuilder` then your code does
 - All scalars works with `GraphQLParser.AST.GraphQLValue` instead of `GraphQL.Language.AST.IValue`
 - `IInputObjectGraphType.ToAST` returns `GraphQLParser.AST.GraphQLObjectValue` instead of `GraphQL.Language.AST.IValue`
 
-### 15. Classes and members marked as obsolete have been removed
+### 16. Classes and members marked as obsolete have been removed
 
 The following classes and members that were marked with `[Obsolete]` in v4 have been removed:
 
@@ -467,13 +469,13 @@ read-only instead of read-write, such as `Field.Alias`.
 Various classes' constructors in the `GraphQL.Language.AST` namespace have been
 removed in favor of other constructors.
 
-### 16. `IDocumentWriter` has been renamed to `IGraphQLSerializer` and related changes.
+### 17. `IDocumentWriter` has been renamed to `IGraphQLSerializer` and related changes.
 
 As such, the `DocumentWriter` classes have been renamed to `GraphQLSerializer`, and the
 `AddDocumentWriter` extension method for `IGraphQLBuilder` has been renamed to `AddSerializer`.
 The `WriteAsync` method's functionality has not changed.
 
-### 17. Extension methods for parsing variables (e.g. `ToInputs`) have been removed.
+### 18. Extension methods for parsing variables (e.g. `ToInputs`) have been removed.
 
 Please use the `Read<Inputs>()` method of an `IGraphQLSerializer` implementation, or the
 `Deserialize<Inputs>()` method of an `IGraphQLTextSerializer` implementation. Note that
@@ -507,7 +509,7 @@ public static class StringExtensions
 The new `Read` and `Deserialize` methods of the `Newtonsoft.Json` implementation
 will default to reading dates as strings unless configured otherwise in the settings.
 
-### 18. The `WriteToStringAsync` extension methods have been removed.
+### 19. The `WriteToStringAsync` extension methods have been removed.
 
 Please use the `Serialize()` method of an `IGraphQLTextSerializer` implementation.
 The asynchronous text serialization methods have been removed as the underlying serialization
@@ -517,12 +519,12 @@ The `WriteAsync()` method can be used to asynchronously serialize to a stream. H
 the `Newtonsoft.Json` serializer does not support asynchronous serialization, so synchronous
 calls are made to the underlying stream. Only `System.Text.Json` supports asynchronous writing.
 
-### 19. Other changes to the serialization infrastructure
+### 20. Other changes to the serialization infrastructure
 
 - `InputsConverter` renamed to `InputsJsonConverter`
 - `ExecutionResultContractResolver` renamed to `GraphQLContractResolver`
 
-### 20. `GraphQLMetadataAttribute` cannot be applied to graph type classes
+### 21. `GraphQLMetadataAttribute` cannot be applied to graph type classes
 
 The `[GraphQLMetadata]` attribute is designed to be used for schema-first configurations
 and has not changed in this regard. For code-first graph definitions, please set the
@@ -540,7 +542,7 @@ public class HumanType : ObjectGraphType<Human>
 }
 ```
 
-### 21. `AstPrinter` class was removed
+### 22. `AstPrinter` class was removed
 
 `AstPrinter` class was removed in favor of `SDLPrinter` from GraphQL-Parser project.
 
@@ -565,13 +567,13 @@ string s = writer.ToString();
 into provided `TextWriter`. In the majority of cases it does not allocate memory in
 the managed heap at all.
 
-### 22. Possible breaking changes in `InputObjectGraphType<TSourceType>`
+### 23. Possible breaking changes in `InputObjectGraphType<TSourceType>`
 
 `InputObjectGraphType<TSourceType>.ToAST` and `InputObjectGraphType<TSourceType>.IsValidDefault`
 methods were changed in such a way that now you may be required to also override `ToAST` if you override
 `ParseDictionary`. Changes in those methods are made for earlier error detection and schema printing.
 
-### 23. `AutoRegisteringObjectGraphType` changes
+### 24. `AutoRegisteringObjectGraphType` changes
 
 The protected method `GetRegisteredProperties` has been renamed to `GetRegisteredMembers`
 and now supports properties, methods and fields, although fields are not included
@@ -595,19 +597,19 @@ Register this class within your DI engine like this:
 services.AddTransient(typeof(AutoRegisteringObjectGraphType<>), typeof(AutoRegisteringObjectGraphTypeWithoutMethods<>));
 ```
 
-### 24. `AutoRegisteringInputObjectGraphType` changes
+### 25. `AutoRegisteringInputObjectGraphType` changes
 
 The protected method `GetRegisteredProperties` has been renamed to `GetRegisteredMembers`
 and now supports returning both properties and fields, although fields are not included
 with the default implementation. Override the method in a derived class to include fields.
 
-### 25. `EnumerationGraphType` parses exact names
+### 26. `EnumerationGraphType` parses exact names
 
 Consider GraphQL `enum Color { RED GREEN BLUE }` and corresponding `EnumerationGraphType`.
 In v4 `ParseValue("rED")` yields internal value for `RED` name. In v5 this behavior was changed
 and `ParseValue("rED")` throws error `Unable to convert 'rED' to the scalar type 'Color'`.
 
-### 26. `EnumerationGraphType.AddValue` changes
+### 27. `EnumerationGraphType.AddValue` changes
 
 `description` argument from `EnumerationGraphType.AddValue` method was marked as optional
 and moved after `value` argument. If you use this method and set descriptions, you will need
@@ -615,7 +617,7 @@ to change the order of arguments. Since changing the order of arguments in some 
 invisible to the caller and lead to hardly detected bugs, the method name has been changed from
 `AddValue` to `Add`.
 
-### 27. The settings class provided to `GraphQL.NewtonsoftJson.GraphQLSerializer` has changed.
+### 28. The settings class provided to `GraphQL.NewtonsoftJson.GraphQLSerializer` has changed.
 
 Previously the settings class used was `Newtonsoft.Json.JsonSerializerSettings`. Now the class
 is `GraphQL.NewtonsoftJson.JsonSerializerSettings`. The class inherits from the former class,

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -903,9 +903,9 @@ namespace GraphQL.Execution
     }
     public class DirectiveInfo
     {
-        public DirectiveInfo(GraphQL.Types.DirectiveGraphType directive, System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue> arguments) { }
+        public DirectiveInfo(GraphQL.Types.Directive directive, System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue> arguments) { }
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue> Arguments { get; }
-        public GraphQL.Types.DirectiveGraphType Directive { get; }
+        public GraphQL.Types.Directive Directive { get; }
         public object? GetArgument(System.Type argumentType, string name, object? defaultValue = null) { }
         public TType GetArgument<TType>(string name, TType defaultValue = default) { }
     }
@@ -1272,7 +1272,7 @@ namespace GraphQL.Introspection
     public class AlphabeticalSchemaComparer : GraphQL.Introspection.ISchemaComparer
     {
         public AlphabeticalSchemaComparer() { }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType> DirectiveComparer { get; }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.Directive> DirectiveComparer { get; }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.IGraphType> TypeComparer { get; }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument> ArgumentComparer(GraphQL.Types.IFieldType field) { }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition> EnumValueComparer(GraphQL.Types.EnumerationGraphType parent) { }
@@ -1281,7 +1281,7 @@ namespace GraphQL.Introspection
     public class DefaultSchemaComparer : GraphQL.Introspection.ISchemaComparer
     {
         public DefaultSchemaComparer() { }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType>? DirectiveComparer { get; }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.Directive>? DirectiveComparer { get; }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.IGraphType>? TypeComparer { get; }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument>? ArgumentComparer(GraphQL.Types.IFieldType field) { }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition>? EnumValueComparer(GraphQL.Types.EnumerationGraphType parent) { }
@@ -1293,7 +1293,7 @@ namespace GraphQL.Introspection
         protected static readonly System.Threading.Tasks.Task<bool> Forbidden;
         public DefaultSchemaFilter() { }
         public virtual System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.QueryArgument argument) { }
-        public virtual System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.DirectiveGraphType directive) { }
+        public virtual System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.Directive directive) { }
         public virtual System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue) { }
         public virtual System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field) { }
         public virtual System.Threading.Tasks.Task<bool> AllowType(GraphQL.Types.IGraphType type) { }
@@ -1306,7 +1306,7 @@ namespace GraphQL.Introspection
     }
     public interface ISchemaComparer
     {
-        System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType>? DirectiveComparer { get; }
+        System.Collections.Generic.IComparer<GraphQL.Types.Directive>? DirectiveComparer { get; }
         System.Collections.Generic.IComparer<GraphQL.Types.IGraphType>? TypeComparer { get; }
         System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument>? ArgumentComparer(GraphQL.Types.IFieldType field);
         System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition>? EnumValueComparer(GraphQL.Types.EnumerationGraphType parent);
@@ -1315,7 +1315,7 @@ namespace GraphQL.Introspection
     public interface ISchemaFilter
     {
         System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.QueryArgument argument);
-        System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.DirectiveGraphType directive);
+        System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.Directive directive);
         System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue);
         System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field);
         System.Threading.Tasks.Task<bool> AllowType(GraphQL.Types.IGraphType type);
@@ -1356,7 +1356,7 @@ namespace GraphQL.Introspection
     {
         public @__AppliedDirective() { }
     }
-    public class @__Directive : GraphQL.Types.ObjectGraphType<GraphQL.Types.DirectiveGraphType>
+    public class @__Directive : GraphQL.Types.ObjectGraphType<GraphQL.Types.Directive>
     {
         public @__Directive(bool allowAppliedDirectives = false, bool allowRepeatable = false) { }
     }
@@ -1713,21 +1713,15 @@ namespace GraphQL.Types
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
-    public class DeprecatedDirective : GraphQL.Types.DirectiveGraphType
+    public class DeprecatedDirective : GraphQL.Types.Directive
     {
         public DeprecatedDirective() { }
         public override bool? Introspectable { get; }
     }
-    public class DirectiveArgument
+    public class Directive : GraphQL.Utilities.MetadataProvider, GraphQL.Types.INamedType, GraphQL.Types.IProvideDescription
     {
-        public DirectiveArgument(string name) { }
-        public string Name { get; set; }
-        public object? Value { get; set; }
-    }
-    public class DirectiveGraphType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.INamedType, GraphQL.Types.IProvideDescription
-    {
-        public DirectiveGraphType(string name, params GraphQLParser.AST.DirectiveLocation[] locations) { }
-        public DirectiveGraphType(string name, System.Collections.Generic.IEnumerable<GraphQLParser.AST.DirectiveLocation> locations) { }
+        public Directive(string name, params GraphQLParser.AST.DirectiveLocation[] locations) { }
+        public Directive(string name, System.Collections.Generic.IEnumerable<GraphQLParser.AST.DirectiveLocation> locations) { }
         public GraphQL.Types.QueryArguments? Arguments { get; set; }
         public string? Description { get; set; }
         public virtual bool? Introspectable { get; }
@@ -1736,6 +1730,12 @@ namespace GraphQL.Types
         public bool Repeatable { get; set; }
         public override string ToString() { }
         public virtual void Validate(GraphQL.Types.AppliedDirective applied) { }
+    }
+    public class DirectiveArgument
+    {
+        public DirectiveArgument(string name) { }
+        public string Name { get; set; }
+        public object? Value { get; set; }
     }
     [System.AttributeUsage(System.AttributeTargets.Enum, AllowMultiple=false)]
     public abstract class EnumCaseAttribute : System.Attribute
@@ -1965,7 +1965,7 @@ namespace GraphQL.Types
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
     }
-    public class IncludeDirective : GraphQL.Types.DirectiveGraphType
+    public class IncludeDirective : GraphQL.Types.Directive
     {
         public IncludeDirective() { }
     }
@@ -2008,7 +2008,7 @@ namespace GraphQL.Types
         public bool Contains(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
     }
-    public class LengthDirective : GraphQL.Types.DirectiveGraphType
+    public class LengthDirective : GraphQL.Types.Directive
     {
         public LengthDirective() { }
         public override bool? Introspectable { get; }
@@ -2186,17 +2186,17 @@ namespace GraphQL.Types
         public static GraphQL.Types.Schema For<TSchemaBuilder>(string typeDefinitions, System.Action<TSchemaBuilder>? configure = null)
             where TSchemaBuilder : GraphQL.Utilities.SchemaBuilder, new () { }
     }
-    public class SchemaDirectives : System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType>, System.Collections.IEnumerable
+    public class SchemaDirectives : System.Collections.Generic.IEnumerable<GraphQL.Types.Directive>, System.Collections.IEnumerable
     {
         public SchemaDirectives() { }
         public int Count { get; }
         public virtual GraphQL.Types.DeprecatedDirective Deprecated { get; }
         public virtual GraphQL.Types.IncludeDirective Include { get; }
         public virtual GraphQL.Types.SkipDirective Skip { get; }
-        public GraphQL.Types.DirectiveGraphType? Find(GraphQLParser.ROM name) { }
-        public System.Collections.Generic.IEnumerator<GraphQL.Types.DirectiveGraphType> GetEnumerator() { }
-        public void Register(GraphQL.Types.DirectiveGraphType directive) { }
-        public void Register(params GraphQL.Types.DirectiveGraphType[] directives) { }
+        public GraphQL.Types.Directive? Find(GraphQLParser.ROM name) { }
+        public System.Collections.Generic.IEnumerator<GraphQL.Types.Directive> GetEnumerator() { }
+        public void Register(GraphQL.Types.Directive directive) { }
+        public void Register(params GraphQL.Types.Directive[] directives) { }
     }
     public class SchemaTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
     {
@@ -2224,7 +2224,7 @@ namespace GraphQL.Types
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
-    public class SkipDirective : GraphQL.Types.DirectiveGraphType
+    public class SkipDirective : GraphQL.Types.Directive
     {
         public SkipDirective() { }
     }
@@ -2390,8 +2390,8 @@ namespace GraphQL.Utilities
     public sealed class AppliedDirectivesValidationVisitor : GraphQL.Utilities.ISchemaNodeVisitor
     {
         public static readonly GraphQL.Utilities.AppliedDirectivesValidationVisitor Instance;
-        public void VisitDirective(GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
-        public void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
+        public void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
@@ -2416,8 +2416,8 @@ namespace GraphQL.Utilities
     public abstract class BaseSchemaNodeVisitor : GraphQL.Utilities.ISchemaNodeVisitor
     {
         protected BaseSchemaNodeVisitor() { }
-        public virtual void VisitDirective(GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
-        public virtual void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
+        public virtual void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public virtual void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public virtual void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public virtual void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public virtual void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
@@ -2448,8 +2448,8 @@ namespace GraphQL.Utilities
     }
     public interface ISchemaNodeVisitor
     {
-        void VisitDirective(GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema);
-        void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema);
+        void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema);
+        void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema);
         void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema);
         void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema);
         void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema);
@@ -2500,7 +2500,7 @@ namespace GraphQL.Utilities
         protected virtual GraphQL.Types.IGraphType? GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }
         protected virtual GraphQL.Types.QueryArgument ToArgument(GraphQL.Utilities.ArgumentConfig argumentConfig, GraphQLParser.AST.GraphQLInputValueDefinition inputDef) { }
-        protected virtual GraphQL.Types.DirectiveGraphType ToDirective(GraphQLParser.AST.GraphQLDirectiveDefinition directiveDef) { }
+        protected virtual GraphQL.Types.Directive ToDirective(GraphQLParser.AST.GraphQLDirectiveDefinition directiveDef) { }
         protected virtual GraphQL.Types.EnumerationGraphType ToEnumerationType(GraphQLParser.AST.GraphQLEnumTypeDefinition enumDef) { }
         protected virtual GraphQL.Types.FieldType ToFieldType(string parentTypeName, GraphQLParser.AST.GraphQLFieldDefinition fieldDef) { }
         protected virtual GraphQL.Types.FieldType ToFieldType(string parentTypeName, GraphQLParser.AST.GraphQLInputValueDefinition inputDef) { }
@@ -2527,7 +2527,7 @@ namespace GraphQL.Utilities
         public virtual string PrintComment(string? comment, string indentation = "", bool firstInBlock = true) { }
         public string PrintDeprecation(string? reason) { }
         public string PrintDescription(string? description, string indentation = "", bool firstInBlock = true) { }
-        public string PrintDirective(GraphQL.Types.DirectiveGraphType directive) { }
+        public string PrintDirective(GraphQL.Types.Directive directive) { }
         public string PrintEnum(GraphQL.Types.EnumerationGraphType type) { }
         public virtual string PrintFields(GraphQL.Types.IComplexGraphType type) { }
         public string PrintFilteredSchema(System.Func<string, bool> directiveFilter, System.Func<string, bool> typeFilter) { }
@@ -2557,8 +2557,8 @@ namespace GraphQL.Utilities
     public sealed class SchemaValidationVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
         public static readonly GraphQL.Utilities.SchemaValidationVisitor Instance;
-        public override void VisitDirective(GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
-        public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public override void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public override void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
         public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
@@ -2761,7 +2761,7 @@ namespace GraphQL.Validation
         public void Enter(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
         public GraphQLParser.AST.ASTNode? GetAncestor(int index) { }
         public GraphQL.Types.QueryArgument? GetArgument() { }
-        public GraphQL.Types.DirectiveGraphType? GetDirective() { }
+        public GraphQL.Types.Directive? GetDirective() { }
         public GraphQL.Types.FieldType? GetFieldDef(int index = 0) { }
         public GraphQL.Types.IGraphType? GetInputType(int index = 0) { }
         public GraphQL.Types.IGraphType? GetLastType(int index = 0) { }
@@ -2909,7 +2909,7 @@ namespace GraphQL.Validation.Errors
     [System.Serializable]
     public class KnownArgumentNamesError : GraphQL.Validation.ValidationError
     {
-        public KnownArgumentNamesError(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument node, GraphQL.Types.DirectiveGraphType directive) { }
+        public KnownArgumentNamesError(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument node, GraphQL.Types.Directive directive) { }
         public KnownArgumentNamesError(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument node, GraphQL.Types.FieldType fieldDef, GraphQL.Types.IGraphType parentType) { }
     }
     [System.Serializable]

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -903,9 +903,9 @@ namespace GraphQL.Execution
     }
     public class DirectiveInfo
     {
-        public DirectiveInfo(GraphQL.Types.DirectiveGraphType directive, System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue> arguments) { }
+        public DirectiveInfo(GraphQL.Types.Directive directive, System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue> arguments) { }
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue> Arguments { get; }
-        public GraphQL.Types.DirectiveGraphType Directive { get; }
+        public GraphQL.Types.Directive Directive { get; }
         public object? GetArgument(System.Type argumentType, string name, object? defaultValue = null) { }
         public TType GetArgument<TType>(string name, TType defaultValue = default) { }
     }
@@ -1272,7 +1272,7 @@ namespace GraphQL.Introspection
     public class AlphabeticalSchemaComparer : GraphQL.Introspection.ISchemaComparer
     {
         public AlphabeticalSchemaComparer() { }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType> DirectiveComparer { get; }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.Directive> DirectiveComparer { get; }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.IGraphType> TypeComparer { get; }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument> ArgumentComparer(GraphQL.Types.IFieldType field) { }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition> EnumValueComparer(GraphQL.Types.EnumerationGraphType parent) { }
@@ -1281,7 +1281,7 @@ namespace GraphQL.Introspection
     public class DefaultSchemaComparer : GraphQL.Introspection.ISchemaComparer
     {
         public DefaultSchemaComparer() { }
-        public virtual System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType>? DirectiveComparer { get; }
+        public virtual System.Collections.Generic.IComparer<GraphQL.Types.Directive>? DirectiveComparer { get; }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.IGraphType>? TypeComparer { get; }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument>? ArgumentComparer(GraphQL.Types.IFieldType field) { }
         public virtual System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition>? EnumValueComparer(GraphQL.Types.EnumerationGraphType parent) { }
@@ -1293,7 +1293,7 @@ namespace GraphQL.Introspection
         protected static readonly System.Threading.Tasks.Task<bool> Forbidden;
         public DefaultSchemaFilter() { }
         public virtual System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.QueryArgument argument) { }
-        public virtual System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.DirectiveGraphType directive) { }
+        public virtual System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.Directive directive) { }
         public virtual System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue) { }
         public virtual System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field) { }
         public virtual System.Threading.Tasks.Task<bool> AllowType(GraphQL.Types.IGraphType type) { }
@@ -1306,7 +1306,7 @@ namespace GraphQL.Introspection
     }
     public interface ISchemaComparer
     {
-        System.Collections.Generic.IComparer<GraphQL.Types.DirectiveGraphType>? DirectiveComparer { get; }
+        System.Collections.Generic.IComparer<GraphQL.Types.Directive>? DirectiveComparer { get; }
         System.Collections.Generic.IComparer<GraphQL.Types.IGraphType>? TypeComparer { get; }
         System.Collections.Generic.IComparer<GraphQL.Types.QueryArgument>? ArgumentComparer(GraphQL.Types.IFieldType field);
         System.Collections.Generic.IComparer<GraphQL.Types.EnumValueDefinition>? EnumValueComparer(GraphQL.Types.EnumerationGraphType parent);
@@ -1315,7 +1315,7 @@ namespace GraphQL.Introspection
     public interface ISchemaFilter
     {
         System.Threading.Tasks.Task<bool> AllowArgument(GraphQL.Types.IFieldType field, GraphQL.Types.QueryArgument argument);
-        System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.DirectiveGraphType directive);
+        System.Threading.Tasks.Task<bool> AllowDirective(GraphQL.Types.Directive directive);
         System.Threading.Tasks.Task<bool> AllowEnumValue(GraphQL.Types.EnumerationGraphType parent, GraphQL.Types.EnumValueDefinition enumValue);
         System.Threading.Tasks.Task<bool> AllowField(GraphQL.Types.IGraphType parent, GraphQL.Types.IFieldType field);
         System.Threading.Tasks.Task<bool> AllowType(GraphQL.Types.IGraphType type);
@@ -1356,7 +1356,7 @@ namespace GraphQL.Introspection
     {
         public @__AppliedDirective() { }
     }
-    public class @__Directive : GraphQL.Types.ObjectGraphType<GraphQL.Types.DirectiveGraphType>
+    public class @__Directive : GraphQL.Types.ObjectGraphType<GraphQL.Types.Directive>
     {
         public @__Directive(bool allowAppliedDirectives = false, bool allowRepeatable = false) { }
     }
@@ -1706,21 +1706,15 @@ namespace GraphQL.Types
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
-    public class DeprecatedDirective : GraphQL.Types.DirectiveGraphType
+    public class DeprecatedDirective : GraphQL.Types.Directive
     {
         public DeprecatedDirective() { }
         public override bool? Introspectable { get; }
     }
-    public class DirectiveArgument
+    public class Directive : GraphQL.Utilities.MetadataProvider, GraphQL.Types.INamedType, GraphQL.Types.IProvideDescription
     {
-        public DirectiveArgument(string name) { }
-        public string Name { get; set; }
-        public object? Value { get; set; }
-    }
-    public class DirectiveGraphType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.INamedType, GraphQL.Types.IProvideDescription
-    {
-        public DirectiveGraphType(string name, params GraphQLParser.AST.DirectiveLocation[] locations) { }
-        public DirectiveGraphType(string name, System.Collections.Generic.IEnumerable<GraphQLParser.AST.DirectiveLocation> locations) { }
+        public Directive(string name, params GraphQLParser.AST.DirectiveLocation[] locations) { }
+        public Directive(string name, System.Collections.Generic.IEnumerable<GraphQLParser.AST.DirectiveLocation> locations) { }
         public GraphQL.Types.QueryArguments? Arguments { get; set; }
         public string? Description { get; set; }
         public virtual bool? Introspectable { get; }
@@ -1729,6 +1723,12 @@ namespace GraphQL.Types
         public bool Repeatable { get; set; }
         public override string ToString() { }
         public virtual void Validate(GraphQL.Types.AppliedDirective applied) { }
+    }
+    public class DirectiveArgument
+    {
+        public DirectiveArgument(string name) { }
+        public string Name { get; set; }
+        public object? Value { get; set; }
     }
     [System.AttributeUsage(System.AttributeTargets.Enum, AllowMultiple=false)]
     public abstract class EnumCaseAttribute : System.Attribute
@@ -1958,7 +1958,7 @@ namespace GraphQL.Types
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
     }
-    public class IncludeDirective : GraphQL.Types.DirectiveGraphType
+    public class IncludeDirective : GraphQL.Types.Directive
     {
         public IncludeDirective() { }
     }
@@ -2001,7 +2001,7 @@ namespace GraphQL.Types
         public bool Contains(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
     }
-    public class LengthDirective : GraphQL.Types.DirectiveGraphType
+    public class LengthDirective : GraphQL.Types.Directive
     {
         public LengthDirective() { }
         public override bool? Introspectable { get; }
@@ -2179,17 +2179,17 @@ namespace GraphQL.Types
         public static GraphQL.Types.Schema For<TSchemaBuilder>(string typeDefinitions, System.Action<TSchemaBuilder>? configure = null)
             where TSchemaBuilder : GraphQL.Utilities.SchemaBuilder, new () { }
     }
-    public class SchemaDirectives : System.Collections.Generic.IEnumerable<GraphQL.Types.DirectiveGraphType>, System.Collections.IEnumerable
+    public class SchemaDirectives : System.Collections.Generic.IEnumerable<GraphQL.Types.Directive>, System.Collections.IEnumerable
     {
         public SchemaDirectives() { }
         public int Count { get; }
         public virtual GraphQL.Types.DeprecatedDirective Deprecated { get; }
         public virtual GraphQL.Types.IncludeDirective Include { get; }
         public virtual GraphQL.Types.SkipDirective Skip { get; }
-        public GraphQL.Types.DirectiveGraphType? Find(GraphQLParser.ROM name) { }
-        public System.Collections.Generic.IEnumerator<GraphQL.Types.DirectiveGraphType> GetEnumerator() { }
-        public void Register(GraphQL.Types.DirectiveGraphType directive) { }
-        public void Register(params GraphQL.Types.DirectiveGraphType[] directives) { }
+        public GraphQL.Types.Directive? Find(GraphQLParser.ROM name) { }
+        public System.Collections.Generic.IEnumerator<GraphQL.Types.Directive> GetEnumerator() { }
+        public void Register(GraphQL.Types.Directive directive) { }
+        public void Register(params GraphQL.Types.Directive[] directives) { }
     }
     public class SchemaTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
     {
@@ -2217,7 +2217,7 @@ namespace GraphQL.Types
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
-    public class SkipDirective : GraphQL.Types.DirectiveGraphType
+    public class SkipDirective : GraphQL.Types.Directive
     {
         public SkipDirective() { }
     }
@@ -2376,8 +2376,8 @@ namespace GraphQL.Utilities
     public sealed class AppliedDirectivesValidationVisitor : GraphQL.Utilities.ISchemaNodeVisitor
     {
         public static readonly GraphQL.Utilities.AppliedDirectivesValidationVisitor Instance;
-        public void VisitDirective(GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
-        public void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
+        public void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
@@ -2402,8 +2402,8 @@ namespace GraphQL.Utilities
     public abstract class BaseSchemaNodeVisitor : GraphQL.Utilities.ISchemaNodeVisitor
     {
         protected BaseSchemaNodeVisitor() { }
-        public virtual void VisitDirective(GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
-        public virtual void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
+        public virtual void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public virtual void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public virtual void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public virtual void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public virtual void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
@@ -2434,8 +2434,8 @@ namespace GraphQL.Utilities
     }
     public interface ISchemaNodeVisitor
     {
-        void VisitDirective(GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema);
-        void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema);
+        void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema);
+        void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema);
         void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema);
         void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema);
         void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema);
@@ -2486,7 +2486,7 @@ namespace GraphQL.Utilities
         protected virtual GraphQL.Types.IGraphType? GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }
         protected virtual GraphQL.Types.QueryArgument ToArgument(GraphQL.Utilities.ArgumentConfig argumentConfig, GraphQLParser.AST.GraphQLInputValueDefinition inputDef) { }
-        protected virtual GraphQL.Types.DirectiveGraphType ToDirective(GraphQLParser.AST.GraphQLDirectiveDefinition directiveDef) { }
+        protected virtual GraphQL.Types.Directive ToDirective(GraphQLParser.AST.GraphQLDirectiveDefinition directiveDef) { }
         protected virtual GraphQL.Types.EnumerationGraphType ToEnumerationType(GraphQLParser.AST.GraphQLEnumTypeDefinition enumDef) { }
         protected virtual GraphQL.Types.FieldType ToFieldType(string parentTypeName, GraphQLParser.AST.GraphQLFieldDefinition fieldDef) { }
         protected virtual GraphQL.Types.FieldType ToFieldType(string parentTypeName, GraphQLParser.AST.GraphQLInputValueDefinition inputDef) { }
@@ -2513,7 +2513,7 @@ namespace GraphQL.Utilities
         public virtual string PrintComment(string? comment, string indentation = "", bool firstInBlock = true) { }
         public string PrintDeprecation(string? reason) { }
         public string PrintDescription(string? description, string indentation = "", bool firstInBlock = true) { }
-        public string PrintDirective(GraphQL.Types.DirectiveGraphType directive) { }
+        public string PrintDirective(GraphQL.Types.Directive directive) { }
         public string PrintEnum(GraphQL.Types.EnumerationGraphType type) { }
         public virtual string PrintFields(GraphQL.Types.IComplexGraphType type) { }
         public string PrintFilteredSchema(System.Func<string, bool> directiveFilter, System.Func<string, bool> typeFilter) { }
@@ -2543,8 +2543,8 @@ namespace GraphQL.Utilities
     public sealed class SchemaValidationVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
         public static readonly GraphQL.Utilities.SchemaValidationVisitor Instance;
-        public override void VisitDirective(GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
-        public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.DirectiveGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public override void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
         public override void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
         public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
@@ -2747,7 +2747,7 @@ namespace GraphQL.Validation
         public void Enter(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
         public GraphQLParser.AST.ASTNode? GetAncestor(int index) { }
         public GraphQL.Types.QueryArgument? GetArgument() { }
-        public GraphQL.Types.DirectiveGraphType? GetDirective() { }
+        public GraphQL.Types.Directive? GetDirective() { }
         public GraphQL.Types.FieldType? GetFieldDef(int index = 0) { }
         public GraphQL.Types.IGraphType? GetInputType(int index = 0) { }
         public GraphQL.Types.IGraphType? GetLastType(int index = 0) { }
@@ -2895,7 +2895,7 @@ namespace GraphQL.Validation.Errors
     [System.Serializable]
     public class KnownArgumentNamesError : GraphQL.Validation.ValidationError
     {
-        public KnownArgumentNamesError(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument node, GraphQL.Types.DirectiveGraphType directive) { }
+        public KnownArgumentNamesError(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument node, GraphQL.Types.Directive directive) { }
         public KnownArgumentNamesError(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument node, GraphQL.Types.FieldType fieldDef, GraphQL.Types.IGraphType parentType) { }
     }
     [System.Serializable]

--- a/src/GraphQL.Tests/Bugs/BugWithCustomScalarsInDirective.cs
+++ b/src/GraphQL.Tests/Bugs/BugWithCustomScalarsInDirective.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Tests.Bugs
         }
     }
 
-    public class LinkDirective : DirectiveGraphType
+    public class LinkDirective : Directive
     {
         public LinkDirective() : base("link", DirectiveLocation.FieldDefinition, DirectiveLocation.Object, DirectiveLocation.Interface)
         {
@@ -45,7 +45,7 @@ namespace GraphQL.Tests.Bugs
         }
     }
 
-    public class SomeDirective : DirectiveGraphType
+    public class SomeDirective : Directive
     {
         public SomeDirective() : base("some", DirectiveLocation.Scalar)
         {

--- a/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
+++ b/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
@@ -99,7 +99,7 @@ namespace GraphQL.Tests.Initialization
             Directives.Register(new MyDirective());
         }
 
-        public class MyDirective : DirectiveGraphType
+        public class MyDirective : Directive
         {
             public MyDirective()
                 : base("my", DirectiveLocation.Field)
@@ -183,7 +183,7 @@ namespace GraphQL.Tests.Initialization
 
     public class SchemaWithNullDirectiveArgumentWhenShouldBeNonNull : Schema
     {
-        public class TestDirective : DirectiveGraphType
+        public class TestDirective : Directive
         {
             public TestDirective()
                 : base("test", DirectiveLocation.Schema, DirectiveLocation.FieldDefinition)

--- a/src/GraphQL.Tests/Introspection/AppliedDirectivesTests.cs
+++ b/src/GraphQL.Tests/Introspection/AppliedDirectivesTests.cs
@@ -45,7 +45,7 @@ namespace GraphQL.Tests.Introspection
             }
         }
 
-        private class TraitsDirective : DirectiveGraphType
+        private class TraitsDirective : Directive
         {
             public override bool? Introspectable => true;
 

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -328,7 +328,7 @@ namespace GraphQL.Tests.Utilities
             {
                 Query = query
             };
-            var directive = new DirectiveGraphType("MyDirective")
+            var directive = new Directive("MyDirective")
             {
                 Arguments = new QueryArguments
                 {

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
@@ -135,10 +135,10 @@ namespace GraphQL.Tests.Utilities
             ";
 
             var schema = Schema.For(definitions);
-            schema.Directives.Register(new DirectiveGraphType("public", DirectiveLocation.Schema));
-            schema.Directives.Register(new DirectiveGraphType("requireAuth", DirectiveLocation.Object) { Arguments = new QueryArguments(new QueryArgument<StringGraphType> { Name = "role" }) });
-            schema.Directives.Register(new DirectiveGraphType("traits", DirectiveLocation.FieldDefinition) { Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>> { Name = "volatile" }, new QueryArgument<BooleanGraphType> { Name = "documented" }, new QueryArgument<EnumerationGraphType<TestEnum>> { Name = "enumerated" }) });
-            schema.Directives.Register(new DirectiveGraphType("some", DirectiveLocation.FieldDefinition) { Repeatable = true });
+            schema.Directives.Register(new Directive("public", DirectiveLocation.Schema));
+            schema.Directives.Register(new Directive("requireAuth", DirectiveLocation.Object) { Arguments = new QueryArguments(new QueryArgument<StringGraphType> { Name = "role" }) });
+            schema.Directives.Register(new Directive("traits", DirectiveLocation.FieldDefinition) { Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>> { Name = "volatile" }, new QueryArgument<BooleanGraphType> { Name = "documented" }, new QueryArgument<EnumerationGraphType<TestEnum>> { Name = "enumerated" }) });
+            schema.Directives.Register(new Directive("some", DirectiveLocation.FieldDefinition) { Repeatable = true });
             schema.Initialized.ShouldBe(false);
             schema.Initialize();
 

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -112,7 +112,7 @@ directive @skip(
         [Fact]
         public void prints_directive_without_arguments()
         {
-            var d = new DirectiveGraphType("my", DirectiveLocation.Field, DirectiveLocation.Query);
+            var d = new Directive("my", DirectiveLocation.Field, DirectiveLocation.Query);
             string result = new SchemaPrinter(null).PrintDirective(d);
             result.ShouldBe("directive @my on FIELD | QUERY");
         }
@@ -120,7 +120,7 @@ directive @skip(
         [Fact]
         public void prints_repeatable_directive_without_arguments()
         {
-            var d = new DirectiveGraphType("my", DirectiveLocation.Field, DirectiveLocation.Query) { Repeatable = true };
+            var d = new Directive("my", DirectiveLocation.Field, DirectiveLocation.Query) { Repeatable = true };
             string result = new SchemaPrinter(null).PrintDirective(d);
             result.ShouldBe("directive @my repeatable on FIELD | QUERY");
         }
@@ -128,7 +128,7 @@ directive @skip(
         [Fact]
         public void prints_repeatable_directive_with_arguments()
         {
-            var d = new DirectiveGraphType("my", DirectiveLocation.Field, DirectiveLocation.Query)
+            var d = new Directive("my", DirectiveLocation.Field, DirectiveLocation.Query)
             {
                 Repeatable = true,
                 Arguments = new QueryArguments(new QueryArgument(new IntGraphType()) { Name = "max" })

--- a/src/GraphQL.Tests/Utilities/SchemaVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaVisitorTests.cs
@@ -100,7 +100,7 @@ namespace GraphQL.Tests.Utilities
                       query: Query
                     }
             ");
-            schema.Directives.Register(new DirectiveGraphType("description",
+            schema.Directives.Register(new Directive("description",
                 DirectiveLocation.Schema, DirectiveLocation.Union, DirectiveLocation.Interface, DirectiveLocation.Object,
                 DirectiveLocation.InputObject, DirectiveLocation.FieldDefinition, DirectiveLocation.InputFieldDefinition,
                 DirectiveLocation.ArgumentDefinition, DirectiveLocation.Enum, DirectiveLocation.EnumValue)

--- a/src/GraphQL.Tests/Utilities/Visitors/DescriptionDirectiveVisitor.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/DescriptionDirectiveVisitor.cs
@@ -23,7 +23,7 @@ namespace GraphQL.Tests.Utilities.Visitors
 
         public override void VisitSchema(ISchema schema) => SetDescription(schema);
 
-        public override void VisitDirective(DirectiveGraphType type, ISchema schema) => SetDescription(type);
+        public override void VisitDirective(Directive directive, ISchema schema) => SetDescription(directive);
 
         public override void VisitScalar(ScalarGraphType type, ISchema schema) => SetDescription(type);
 
@@ -37,7 +37,7 @@ namespace GraphQL.Tests.Utilities.Visitors
 
         public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema) => SetDescription(argument);
 
-        public override void VisitDirectiveArgumentDefinition(QueryArgument argument, DirectiveGraphType type, ISchema schema) => SetDescription(argument);
+        public override void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema) => SetDescription(argument);
 
         public override void VisitInterface(IInterfaceGraphType type, ISchema schema) => SetDescription(type);
 

--- a/src/GraphQL.Tests/Utilities/Visitors/UppercaseDirectiveVisitor.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/UppercaseDirectiveVisitor.cs
@@ -5,7 +5,7 @@ using GraphQLParser.AST;
 
 namespace GraphQL.Tests.Utilities.Visitors
 {
-    public class UpperDirective : DirectiveGraphType
+    public class UpperDirective : Directive
     {
         public UpperDirective()
             : base("upper", DirectiveLocation.FieldDefinition)

--- a/src/GraphQL.Tests/Validation/ValidationSchema.cs
+++ b/src/GraphQL.Tests/Validation/ValidationSchema.cs
@@ -300,12 +300,12 @@ namespace GraphQL.Tests.Validation
             this.RegisterType<Alien>();
 
             Directives.Register(
-                new DirectiveGraphType("onQuery", DirectiveLocation.Query),
-                new DirectiveGraphType("onMutation", DirectiveLocation.Mutation),
-                new DirectiveGraphType("directiveA", DirectiveLocation.Field),
-                new DirectiveGraphType("directiveB", DirectiveLocation.Field),
-                new DirectiveGraphType("directive", DirectiveLocation.Field),
-                new DirectiveGraphType("rep", DirectiveLocation.Field) { Repeatable = true },
+                new Directive("onQuery", DirectiveLocation.Query),
+                new Directive("onMutation", DirectiveLocation.Mutation),
+                new Directive("directiveA", DirectiveLocation.Field),
+                new Directive("directiveB", DirectiveLocation.Field),
+                new Directive("directive", DirectiveLocation.Field),
+                new Directive("rep", DirectiveLocation.Field) { Repeatable = true },
 
                 new LengthDirective()
             );

--- a/src/GraphQL/Execution/DirectiveInfo.cs
+++ b/src/GraphQL/Execution/DirectiveInfo.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Execution
         /// Creates an instance of <see cref="DirectiveInfo"/> with the specified
         /// directive definition and directive arguments.
         /// </summary>
-        public DirectiveInfo(DirectiveGraphType directive, IDictionary<string, ArgumentValue> arguments)
+        public DirectiveInfo(Directive directive, IDictionary<string, ArgumentValue> arguments)
         {
             Directive = directive;
             Arguments = arguments;
@@ -20,7 +20,7 @@ namespace GraphQL.Execution
         /// <summary>
         /// Directive definition.
         /// </summary>
-        public DirectiveGraphType Directive { get; }
+        public Directive Directive { get; }
 
         /// <summary>
         /// Dictionary of directive arguments.

--- a/src/GraphQL/Introspection/ISchemaComparer.cs
+++ b/src/GraphQL/Introspection/ISchemaComparer.cs
@@ -38,7 +38,7 @@ namespace GraphQL.Introspection
         /// Returns a comparer for GraphQL directives.
         /// If this returns <see langword="null"/> then the original directive ordering is preserved.
         /// </summary>
-        IComparer<DirectiveGraphType>? DirectiveComparer { get; }
+        IComparer<Directive>? DirectiveComparer { get; }
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ namespace GraphQL.Introspection
         public virtual IComparer<IGraphType>? TypeComparer => null;
 
         /// <inheritdoc/>
-        public virtual IComparer<DirectiveGraphType>? DirectiveComparer => null;
+        public virtual IComparer<Directive>? DirectiveComparer => null;
 
         /// <inheritdoc/>
         public virtual IComparer<QueryArgument>? ArgumentComparer(IFieldType field) => null;
@@ -78,9 +78,9 @@ namespace GraphQL.Introspection
             public int Compare(IGraphType? x, IGraphType? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
         }
 
-        private sealed class DirectiveByNameComparer : IComparer<DirectiveGraphType>
+        private sealed class DirectiveByNameComparer : IComparer<Directive>
         {
-            public int Compare(DirectiveGraphType? x, DirectiveGraphType? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
+            public int Compare(Directive? x, Directive? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
         }
 
         private sealed class ArgumentByNameComparer : IComparer<QueryArgument>
@@ -102,7 +102,7 @@ namespace GraphQL.Introspection
         public virtual IComparer<IGraphType> TypeComparer => _instance1;
 
         /// <inheritdoc/>
-        public virtual IComparer<DirectiveGraphType> DirectiveComparer => _instance2;
+        public virtual IComparer<Directive> DirectiveComparer => _instance2;
 
         /// <inheritdoc/>
         public virtual IComparer<QueryArgument> ArgumentComparer(IFieldType field) => _instance3;

--- a/src/GraphQL/Introspection/ISchemaFilter.cs
+++ b/src/GraphQL/Introspection/ISchemaFilter.cs
@@ -40,7 +40,7 @@ namespace GraphQL.Introspection
         /// Returns a boolean indicating whether the specified directive should be returned within the introspection query.
         /// </summary>
         /// <param name="directive">The directive to consider.</param>
-        Task<bool> AllowDirective(DirectiveGraphType directive);
+        Task<bool> AllowDirective(Directive directive);
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ namespace GraphQL.Introspection
         public virtual Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue) => Allowed;
 
         /// <inheritdoc/>
-        public virtual Task<bool> AllowDirective(DirectiveGraphType directive)
+        public virtual Task<bool> AllowDirective(Directive directive)
         {
             if (directive.Introspectable.HasValue)
                 return directive.Introspectable.Value ? Allowed : Forbidden;

--- a/src/GraphQL/Introspection/__Directive.cs
+++ b/src/GraphQL/Introspection/__Directive.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Introspection
     /// <summary>
     /// The <c>__Directive</c> introspection type represents a directive that a server supports.
     /// </summary>
-    public class __Directive : ObjectGraphType<DirectiveGraphType>
+    public class __Directive : ObjectGraphType<Directive>
     {
         /// <summary>
         /// Initializes a new instance of the <c>__Directive</c> introspection type.

--- a/src/GraphQL/Introspection/__Schema.cs
+++ b/src/GraphQL/Introspection/__Schema.cs
@@ -76,7 +76,7 @@ namespace GraphQL.Introspection
                 "A list of all directives supported by this server.",
                 resolve: async context =>
                 {
-                    var directives = context.ArrayPool.Rent<DirectiveGraphType>(context.Schema.Directives.Count);
+                    var directives = context.ArrayPool.Rent<Directive>(context.Schema.Directives.Count);
 
                     int index = 0;
                     foreach (var directive in context.Schema.Directives.List)

--- a/src/GraphQL/SchemaExtensions.cs
+++ b/src/GraphQL/SchemaExtensions.cs
@@ -319,7 +319,7 @@ namespace GraphQL
                 }
             }
 
-            public override void VisitDirectiveArgumentDefinition(QueryArgument argument, DirectiveGraphType type, ISchema schema) => Replace(argument);
+            public override void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema) => Replace(argument);
 
             public override void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema) => Replace(field);
 

--- a/src/GraphQL/Types/Collections/SchemaDirectives.cs
+++ b/src/GraphQL/Types/Collections/SchemaDirectives.cs
@@ -6,9 +6,9 @@ namespace GraphQL.Types
     /// <summary>
     /// A class that represents a list of directives supported by the schema.
     /// </summary>
-    public class SchemaDirectives : IEnumerable<DirectiveGraphType>
+    public class SchemaDirectives : IEnumerable<Directive>
     {
-        internal List<DirectiveGraphType> List { get; } = new List<DirectiveGraphType>();
+        internal List<Directive> List { get; } = new List<Directive>();
 
         /// <summary>
         /// Returns an instance of the predefined 'include' directive.
@@ -36,7 +36,7 @@ namespace GraphQL.Types
         /// Directives are used by the GraphQL runtime as a way of modifying execution
         /// behavior. Type system creators do not usually create them directly.
         /// </summary>
-        public void Register(DirectiveGraphType directive)
+        public void Register(Directive directive)
         {
             if (directive == null)
                 throw new ArgumentNullException(nameof(directive));
@@ -51,7 +51,7 @@ namespace GraphQL.Types
         /// Directives are used by the GraphQL runtime as a way of modifying execution
         /// behavior. Type system creators do not usually create them directly.
         /// </summary>
-        public void Register(params DirectiveGraphType[] directives)
+        public void Register(params Directive[] directives)
         {
             foreach (var directive in directives)
                 Register(directive);
@@ -61,7 +61,7 @@ namespace GraphQL.Types
         /// Searches the directive by its name and returns it.
         /// </summary>
         /// <param name="name">Directive name.</param>
-        public DirectiveGraphType? Find(ROM name)
+        public Directive? Find(ROM name)
         {
             foreach (var directive in List)
             {
@@ -73,7 +73,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<DirectiveGraphType> GetEnumerator() => List.GetEnumerator();
+        public IEnumerator<Directive> GetEnumerator() => List.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -530,7 +530,7 @@ namespace GraphQL.Types
             }
         }
 
-        private void HandleDirective(DirectiveGraphType directive, TypeCollectionContext context)
+        private void HandleDirective(Directive directive, TypeCollectionContext context)
         {
             if (directive.Arguments?.Count > 0)
             {

--- a/src/GraphQL/Types/Directives/Built-in/DeprecatedDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/DeprecatedDirective.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types
     /// <summary>
     /// Used to declare element of a GraphQL schema as deprecated.
     /// </summary>
-    public class DeprecatedDirective : DirectiveGraphType
+    public class DeprecatedDirective : Directive
     {
         /// <inheritdoc/>
         public override bool? Introspectable => true;

--- a/src/GraphQL/Types/Directives/Built-in/IncludeDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/IncludeDirective.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types
     /// <summary>
     /// Used to conditionally include fields or fragments.
     /// </summary>
-    public class IncludeDirective : DirectiveGraphType
+    public class IncludeDirective : Directive
     {
         /// <summary>
         /// Initializes a new instance of the 'include' directive.

--- a/src/GraphQL/Types/Directives/Built-in/SkipDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/SkipDirective.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types
     /// <summary>
     /// Used to conditionally skip (exclude) fields or fragments.
     /// </summary>
-    public class SkipDirective : DirectiveGraphType
+    public class SkipDirective : Directive
     {
         /// <summary>
         /// Initializes a new instance of the 'skip' directive.

--- a/src/GraphQL/Types/Directives/Custom/LengthDirective.cs
+++ b/src/GraphQL/Types/Directives/Custom/LengthDirective.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Types
     /// feature is enabled on schema. Use <see cref="InputFieldsAndArgumentsOfCorrectLength"/> validation
     /// rule if you want to enable checking for the length of arguments and input fields.
     /// </summary>
-    public class LengthDirective : DirectiveGraphType
+    public class LengthDirective : Directive
     {
         /// <inheritdoc/>
         public override bool? Introspectable => true;

--- a/src/GraphQL/Types/Directives/Directive.cs
+++ b/src/GraphQL/Types/Directives/Directive.cs
@@ -7,13 +7,13 @@ namespace GraphQL.Types
     /// Directives are used by the GraphQL runtime as a way of modifying execution
     /// behavior. Type system creators will usually not create these directly.
     /// </summary>
-    public class DirectiveGraphType : MetadataProvider, INamedType, IProvideDescription
+    public class Directive : MetadataProvider, INamedType, IProvideDescription
     {
         /// <summary>
         /// Initializes a new instance with the specified name.
         /// </summary>
         /// <param name="name">The directive name within the GraphQL schema.</param>
-        internal DirectiveGraphType(string name)
+        internal Directive(string name)
         {
             Name = name;
         }
@@ -23,7 +23,7 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="name">The directive name within the GraphQL schema.</param>
         /// <param name="locations">A list of locations where the directive can be applied.</param>
-        public DirectiveGraphType(string name, IEnumerable<DirectiveLocation> locations)
+        public Directive(string name, IEnumerable<DirectiveLocation> locations)
         {
             if (locations == null)
                 throw new ArgumentNullException(nameof(locations));
@@ -40,7 +40,7 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="name">The directive name within the GraphQL schema.</param>
         /// <param name="locations">A list of locations where the directive can be applied.</param>
-        public DirectiveGraphType(string name, params DirectiveLocation[] locations)
+        public Directive(string name, params DirectiveLocation[] locations)
         {
             if (locations == null)
                 throw new ArgumentNullException(nameof(locations));

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -93,7 +93,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
 
             PreConfigure(schema);
 
-            var directives = new List<DirectiveGraphType>();
+            var directives = new List<Directive>();
 
             foreach (var def in document.Definitions)
             {
@@ -511,9 +511,9 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             return type;
         }
 
-        protected virtual DirectiveGraphType ToDirective(GraphQLDirectiveDefinition directiveDef)
+        protected virtual Directive ToDirective(GraphQLDirectiveDefinition directiveDef)
         {
-            var result = new DirectiveGraphType(directiveDef.Name.StringValue) //ISSUE:allocation
+            var result = new Directive(directiveDef.Name.StringValue) //ISSUE:allocation
             {
                 Description = directiveDef.Description?.Value.ToString() ?? directiveDef.MergeComments(),
                 Repeatable = directiveDef.Repeatable,

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -191,7 +191,7 @@ namespace GraphQL.Utilities
                 IObjectGraphType objectGraphType => PrintObject(objectGraphType),
                 IInterfaceGraphType interfaceGraphType => PrintInterface(interfaceGraphType),
                 UnionGraphType unionGraphType => PrintUnion(unionGraphType),
-                DirectiveGraphType directiveGraphType => PrintDirective(directiveGraphType),  //TODO: DirectiveGraphType does not inherit IGraphType
+                Directive directiveGraphType => PrintDirective(directiveGraphType),  //TODO: DirectiveGraphType does not inherit IGraphType
                 IInputObjectGraphType input => PrintInputObject(input),
                 _ => throw new InvalidOperationException($"Unknown GraphType '{type.GetType().Name}' with name '{type.Name}'")
             };
@@ -315,7 +315,7 @@ namespace GraphQL.Utilities
             return desc;
         }
 
-        public string PrintDirective(DirectiveGraphType directive)
+        public string PrintDirective(Directive directive)
         {
             Schema?.Initialize();
 

--- a/src/GraphQL/Utilities/Visitors/AppliedDirectivesValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/AppliedDirectivesValidationVisitor.cs
@@ -24,13 +24,13 @@ namespace GraphQL.Utilities
         public void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema) => ValidateAppliedDirectives(argument, field, type, schema, DirectiveLocation.ArgumentDefinition);
 
         /// <inheritdoc/>
-        public void VisitDirectiveArgumentDefinition(QueryArgument argument, DirectiveGraphType type, ISchema schema) => ValidateAppliedDirectives(argument, type, null, schema, DirectiveLocation.ArgumentDefinition);
+        public void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema) => ValidateAppliedDirectives(argument, directive, null, schema, DirectiveLocation.ArgumentDefinition);
 
         /// <inheritdoc/>
         public void VisitEnum(EnumerationGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Enum);
 
         /// <inheritdoc/>
-        public void VisitDirective(DirectiveGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, null); // no location for directives (yet), see https://github.com/graphql/graphql-spec/issues/818
+        public void VisitDirective(Directive directive, ISchema schema) => ValidateAppliedDirectives(directive, null, null, schema, null); // no location for directives (yet), see https://github.com/graphql/graphql-spec/issues/818
 
         /// <inheritdoc/>
         public void VisitEnumValue(EnumValueDefinition value, EnumerationGraphType type, ISchema schema) => ValidateAppliedDirectives(value, type, null, schema, DirectiveLocation.EnumValue);
@@ -69,11 +69,11 @@ namespace GraphQL.Utilities
             string GetElementDescription() => (provider, parent1, parent2) switch
             {
                 (QueryArgument arg, FieldType field, INamedType type) => $"field argument '{type.Name}.{field.Name}:{arg.Name}'",
-                (QueryArgument arg, DirectiveGraphType dir, _) => $"directive argument '{dir.Name}:{arg.Name}'",
+                (QueryArgument arg, Directive dir, _) => $"directive argument '{dir.Name}:{arg.Name}'",
                 (EnumerationGraphType en, _, _) => $"enumeration '{en.Name}'",
                 (EnumValueDefinition enVal, EnumerationGraphType type, _) => $"enumeration value '{type.Name}.{enVal.Name}'",
                 (ScalarGraphType scalar, _, _) => $"scalar '{scalar.Name}'",
-                (DirectiveGraphType dir, _, _) => $"directive '{dir.Name}'",
+                (Directive dir, _, _) => $"directive '{dir.Name}'",
                 (FieldType field, INamedType type, _) => $"field '{type.Name}.{field.Name}'",
                 (IInputObjectGraphType input, _, _) => $"input '{input.Name}'",
                 (IInterfaceGraphType iface, _, _) => $"interface '{iface.Name}'",

--- a/src/GraphQL/Utilities/Visitors/BaseSchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/BaseSchemaNodeVisitor.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Utilities
         }
 
         /// <inheritdoc />
-        public virtual void VisitDirective(DirectiveGraphType type, ISchema schema)
+        public virtual void VisitDirective(Directive directive, ISchema schema)
         {
         }
 
@@ -59,7 +59,7 @@ namespace GraphQL.Utilities
         }
 
         /// <inheritdoc />
-        public virtual void VisitDirectiveArgumentDefinition(QueryArgument argument, DirectiveGraphType type, ISchema schema)
+        public virtual void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema)
         {
         }
 

--- a/src/GraphQL/Utilities/Visitors/ISchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/ISchemaNodeVisitor.cs
@@ -17,9 +17,9 @@ namespace GraphQL.Utilities
         void VisitSchema(ISchema schema);
 
         /// <summary>
-        /// Visits registered within the schema <see cref="DirectiveGraphType"/>.
+        /// Visits registered within the schema <see cref="Directive"/>.
         /// </summary>
-        void VisitDirective(DirectiveGraphType type, ISchema schema);
+        void VisitDirective(Directive directive, ISchema schema);
 
         /// <summary>
         /// Visits registered within the schema <see cref="ScalarGraphType"/>.
@@ -64,7 +64,7 @@ namespace GraphQL.Utilities
         /// <summary>
         /// Visits directive argument.
         /// </summary>
-        void VisitDirectiveArgumentDefinition(QueryArgument argument, DirectiveGraphType type, ISchema schema);
+        void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema);
 
         /// <summary>
         /// Visits registered within the schema <see cref="IInterfaceGraphType"/>.

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -230,10 +230,10 @@ namespace GraphQL.Utilities
         // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Type-System.Directives
         // Directive types have the potential to be invalid if incorrectly defined.
         /// <inheritdoc/>
-        public override void VisitDirective(DirectiveGraphType type, ISchema schema)
+        public override void VisitDirective(Directive directive, ISchema schema)
         {
-            if (type.Locations.Count == 0)
-                throw new InvalidOperationException($"Directive '{type.Name}' must have locations");
+            if (directive.Locations.Count == 0)
+                throw new InvalidOperationException($"Directive '{directive.Name}' must have locations");
 
             // 1. A directive definition must not contain the use of a directive which references itself directly.
             // TODO:
@@ -243,28 +243,28 @@ namespace GraphQL.Utilities
             // TODO:
 
             // 3
-            if (type.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The directive '{type.Name}' must not have a name which begins with the __ (two underscores).");
+            if (directive.Name.StartsWith("__"))
+                throw new InvalidOperationException($"The directive '{directive.Name}' must not have a name which begins with the __ (two underscores).");
 
-            ValidateDirectiveArgumentsUniqueness(type);
+            ValidateDirectiveArgumentsUniqueness(directive);
         }
 
         /// <inheritdoc/>
-        public override void VisitDirectiveArgumentDefinition(QueryArgument argument, DirectiveGraphType type, ISchema schema)
+        public override void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema)
         {
             // 4.1
             if (argument.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{type.Name}' must not have a name which begins with the __ (two underscores).");
+                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must not have a name which begins with the __ (two underscores).");
 
             if (!HasFullSpecifiedResolvedType(argument))
-                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{type.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
+                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
 
             if (argument.ResolvedType is GraphQLTypeReference)
-                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
+                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
 
             // 4.2
             if (!argument.ResolvedType!.IsInputType())
-                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{type.Name}' must be an input type.");
+                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must be an input type.");
 
             // validate default
             if (argument.DefaultValue is GraphQLValue value)
@@ -273,7 +273,7 @@ namespace GraphQL.Utilities
             }
             else if (argument.DefaultValue != null && !argument.ResolvedType!.IsValidDefault(argument.DefaultValue))
             {
-                throw new InvalidOperationException($"The default value of argument '{argument.Name}' of directive '{type.Name}' is invalid.");
+                throw new InvalidOperationException($"The default value of argument '{argument.Name}' of directive '{directive.Name}' is invalid.");
             }
         }
 
@@ -301,14 +301,14 @@ namespace GraphQL.Utilities
             }
         }
 
-        private void ValidateDirectiveArgumentsUniqueness(DirectiveGraphType type)
+        private void ValidateDirectiveArgumentsUniqueness(Directive directive)
         {
-            if (type.Arguments?.Count > 0)
+            if (directive.Arguments?.Count > 0)
             {
-                foreach (var item in type.Arguments.List!.ToLookup(f => f.Name))
+                foreach (var item in directive.Arguments.List!.ToLookup(f => f.Name))
                 {
                     if (item.Count() > 1)
-                        throw new InvalidOperationException($"The argument '{item.Key}' must have a unique name within directive '{type.Name}'; no two directive arguments may share the same name.");
+                        throw new InvalidOperationException($"The argument '{item.Key}' must have a unique name within directive '{directive.Name}'; no two directive arguments may share the same name.");
                 }
             }
         }

--- a/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
@@ -27,7 +27,7 @@ namespace GraphQL.Validation.Errors
         /// <summary>
         /// Initializes a new instance with the specified properties.
         /// </summary>
-        public KnownArgumentNamesError(ValidationContext context, GraphQLArgument node, DirectiveGraphType directive)
+        public KnownArgumentNamesError(ValidationContext context, GraphQLArgument node, Directive directive)
             : base(context.Document.Source, NUMBER,
                 UnknownDirectiveArgMessage(
                     node.Name.StringValue,

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Validation
         private readonly Stack<IGraphType> _parentTypeStack = new Stack<IGraphType>();
         private readonly Stack<FieldType?> _fieldDefStack = new Stack<FieldType?>();
         private readonly Stack<ASTNode> _ancestorStack = new Stack<ASTNode>();
-        private DirectiveGraphType? _directive;
+        private Directive? _directive;
         private QueryArgument? _argument;
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace GraphQL.Validation
         /// <summary>
         /// Returns the last directive specified, or <see langword="null"/> if none.
         /// </summary>
-        public DirectiveGraphType? GetDirective() => _directive;
+        public Directive? GetDirective() => _directive;
 
         /// <summary>
         /// Returns the last query argument matched, or <see langword="null"/> if none.


### PR DESCRIPTION
fixes #2329

I like that difference between graph types and directives is more explicit now.