### PR TITLE
Add SchemaBuilder.CreateSchema

### DIFF
--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2550,6 +2550,7 @@ namespace GraphQL.Utilities
         public System.IServiceProvider ServiceProvider { get; set; }
         public GraphQL.Utilities.TypeSettings Types { get; }
         public virtual GraphQL.Types.Schema Build(string typeDefinitions) { }
+        protected virtual GraphQL.Types.Schema CreateSchema() { }
         protected virtual GraphQL.Types.IGraphType? GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }
         protected virtual GraphQL.Types.QueryArgument ToArgument(GraphQL.Utilities.ArgumentConfig argumentConfig, GraphQLParser.AST.GraphQLInputValueDefinition inputDef) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2536,6 +2536,7 @@ namespace GraphQL.Utilities
         public System.IServiceProvider ServiceProvider { get; set; }
         public GraphQL.Utilities.TypeSettings Types { get; }
         public virtual GraphQL.Types.Schema Build(string typeDefinitions) { }
+        protected virtual GraphQL.Types.Schema CreateSchema() { }
         protected virtual GraphQL.Types.IGraphType? GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }
         protected virtual GraphQL.Types.QueryArgument ToArgument(GraphQL.Utilities.ArgumentConfig argumentConfig, GraphQLParser.AST.GraphQLInputValueDefinition inputDef) { }

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -94,9 +94,11 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             // Also see Schema.Validate
         }
 
+        protected virtual Schema CreateSchema() => new(ServiceProvider, runConfigurations: RunConfigurations);
+
         private Schema BuildSchemaFrom(GraphQLDocument document)
         {
-            var schema = new Schema(ServiceProvider, runConfigurations: RunConfigurations);
+            var schema = CreateSchema();
 
             PreConfigure(schema);
 


### PR DESCRIPTION
Rel: #2959 . I continue to fight deadlocks in my tests. Now I want to be able to override `Schema.Validate` using schema built from `SchemaBuilder` so I need new protected method to return my subsclass with overridden method.