### PR TITLE
Fix rounding of decimal numbers for STJ

### DIFF
--- a/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
+++ b/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\GraphQL\Shim\DecimalData.cs" Link="DecimalData.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>

--- a/src/GraphQL.Tests/Bugs/Bug2958DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2958DecimalPrecisionTests.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using GraphQL.Transport;
+
+namespace GraphQL.Tests.Bugs
+{
+    public class Bug2958DecimalPrecisionTests : QueryTestBase<DecimalSchema>
+    {
+        public class Bug2958DecimalPrecisionTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] { new SystemTextJson.GraphQLSerializer() };
+                yield return new object[] { new NewtonsoftJson.GraphQLSerializer(settings => settings.FloatParseHandling = Newtonsoft.Json.FloatParseHandling.Decimal) };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        [Theory]
+        [ClassData(typeof(Bug2958DecimalPrecisionTestData))]
+        public void double_to_decimal_does_not_lose_precision(IGraphQLTextSerializer serializer)
+        {
+            string request = @"{
+""operationName"": ""TestMutation"",
+""variables"": {
+  ""input"": {
+    ""discount"": 12345678901234.56
+    }
+},
+""query"": ""mutation TestMutation($input: MutationType!)""
+}";
+
+            var inputs = serializer.Deserialize<GraphQLRequest>(request);
+            inputs.Variables.ShouldNotBeNull();
+            inputs.Variables.Count.ShouldBe(1);
+            var inner = inputs.Variables["input"].ShouldBeOfType<Dictionary<string, object>>();
+            inner.Count.ShouldBe(1);
+            var value = inner["discount"];
+            value.ShouldBeOfType<decimal>().ShouldBe(12345678901234.56m);
+        }
+    }
+}

--- a/src/GraphQL/GraphQLExtensions.cs
+++ b/src/GraphQL/GraphQLExtensions.cs
@@ -605,7 +605,7 @@ namespace GraphQL
             {
                 // Cast the decimal to our struct to avoid the decimal.GetBits allocations.
                 var decBits = System.Runtime.CompilerServices.Unsafe.As<decimal, DecimalData>(ref dec);
-                decimal temp = new decimal(dbl);
+                decimal temp = new(dbl);
                 var dblAsDecBits = System.Runtime.CompilerServices.Unsafe.As<decimal, DecimalData>(ref temp);
                 if (!decBits.Equals(dblAsDecBits))
                     return dec;


### PR DESCRIPTION
Fixes #2958 

@[dulcisclade](https://github.com/dulcisclade) note that for NSJ you may set `settings.FloatParseHandling = Newtonsoft.Json.FloatParseHandling.Decimal`