### PR TITLE
Allow ScopedAttribute to work with subscription fields

### DIFF
--- a/src/GraphQL.MicrosoftDI.Tests/ScopedAttributeTests.cs
+++ b/src/GraphQL.MicrosoftDI.Tests/ScopedAttributeTests.cs
@@ -1,3 +1,4 @@
+using GraphQL.Subscription;
 using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -39,6 +40,35 @@ namespace GraphQL.MicrosoftDI.Tests
             Class1.DisposedCount.ShouldBe(5);
         }
 
+        [Fact]
+        public async void ScopedSubscriptionWorks()
+        {
+            Class1.DisposedCount = 0;
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<Class1>();
+            serviceCollection.AddScoped<Class2>();
+            var rootServiceProvider = serviceCollection.BuildServiceProvider(false);
+            var graphType = new AutoRegisteringObjectGraphType<TestClass>();
+            var context = new ResolveEventStreamContext
+            {
+                Source = new TestClass(),
+                RequestServices = rootServiceProvider,
+            };
+            var unscopedSubscriptionResolver = ((EventStreamFieldType)graphType.Fields.Find(nameof(TestClass.UnscopedAsyncSubscription))!).AsyncSubscriber!;
+            var scopedAsyncSubscriptionResolver = ((EventStreamFieldType)graphType.Fields.Find(nameof(TestClass.ScopedAsyncSubscription))!).AsyncSubscriber!;
+            (await unscopedSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("0 1"));
+            (await unscopedSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("1 2"));
+            (await unscopedSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("2 3"));
+            Class1.DisposedCount.ShouldBe(0);
+            (await scopedAsyncSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("0 1"));
+            Class1.DisposedCount.ShouldBe(1);
+            (await scopedAsyncSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("0 1"));
+            Class1.DisposedCount.ShouldBe(2);
+            (await unscopedSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("3 4"));
+            rootServiceProvider.Dispose();
+            Class1.DisposedCount.ShouldBe(3);
+        }
+
         private class TestClass
         {
             public string UnscopedField([FromServices] Class1 arg1, [FromServices] Class2 arg2)
@@ -58,6 +88,39 @@ namespace GraphQL.MicrosoftDI.Tests
                 await Task.Yield();
                 return $"{arg1.Value++} {arg2.Value}";
             }
+
+            public async Task<IObservable<string>> UnscopedAsyncSubscription([FromServices] Class1 arg1, [FromServices] Class2 arg2)
+            {
+                await Task.Yield();
+                return new SampleObservable($"{arg1.Value++} {arg2.Value}");
+            }
+
+            [Scoped]
+            public async Task<IObservable<string>> ScopedAsyncSubscription([FromServices] Class1 arg1, [FromServices] Class2 arg2)
+            {
+                await Task.Yield();
+                return new SampleObservable($"{arg1.Value++} {arg2.Value}");
+            }
+        }
+
+        private class SampleObservable : IObservable<string>, IDisposable
+        {
+            private readonly string _data;
+
+            public SampleObservable(string data)
+            {
+                _data = data;
+            }
+
+            public IDisposable Subscribe(IObserver<string> observer)
+            {
+                //immediately push the predefined data
+                observer.OnNext(_data);
+                //return a dummy value
+                return this;
+            }
+
+            void IDisposable.Dispose() { }
         }
 
         private class Class1 : IDisposable
@@ -91,6 +154,24 @@ namespace GraphQL.MicrosoftDI.Tests
             }
 
             public int Value => _class1.Value;
+        }
+
+        private class SampleObserver : IObserver<object>
+        {
+            private string _expectedData;
+
+            public SampleObserver(string expectedData)
+            {
+                _expectedData = expectedData;
+            }
+
+            public void OnCompleted() => throw new NotImplementedException();
+            public void OnError(Exception error) => throw new NotImplementedException();
+            public void OnNext(object value)
+            {
+                value.ShouldBe(_expectedData);
+                _expectedData = null; //match only once
+            }
         }
     }
 }

--- a/src/GraphQL.MicrosoftDI/DynamicScopedEventStreamResolver.cs
+++ b/src/GraphQL.MicrosoftDI/DynamicScopedEventStreamResolver.cs
@@ -1,0 +1,34 @@
+using GraphQL.Resolvers;
+using GraphQL.Subscription;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.MicrosoftDI
+{
+    /// <summary>
+    /// When resolving a field, this implementation calls
+    /// <see cref="IResolveFieldContext.RequestServices"/>.<see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)">CreateScope</see>
+    /// to create a dependency injection scope. Then it calls the specified <see cref="IAsyncEventStreamResolver"/>, passing the scoped service provider
+    /// within <see cref="IResolveFieldContext.RequestServices"/>, and returns the result.
+    /// </summary>
+    internal class DynamicScopedEventStreamResolver : IAsyncEventStreamResolver
+    {
+        private readonly Func<IResolveEventStreamContext, Task<IObservable<object?>>> _resolverFunc;
+
+        /// <summary>
+        /// Initializes a new instance that creates a service scope and runs the specified delegate when resolving a field.
+        /// </summary>
+        public DynamicScopedEventStreamResolver(IAsyncEventStreamResolver resolver)
+        {
+            _resolverFunc = async context =>
+            {
+                using (var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope())
+                {
+                    return await resolver.SubscribeAsync(new ScopedResolveEventStreamContextAdapter(context, scope.ServiceProvider)).ConfigureAwait(false);
+                }
+            };
+        }
+
+        /// <inheritdoc/>
+        public Task<IObservable<object?>> SubscribeAsync(IResolveEventStreamContext context) => _resolverFunc(context);
+    }
+}

--- a/src/GraphQL.MicrosoftDI/DynamicScopedEventStreamResolver.cs
+++ b/src/GraphQL.MicrosoftDI/DynamicScopedEventStreamResolver.cs
@@ -21,10 +21,8 @@ namespace GraphQL.MicrosoftDI
         {
             _resolverFunc = async context =>
             {
-                using (var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope())
-                {
-                    return await resolver.SubscribeAsync(new ScopedResolveEventStreamContextAdapter(context, scope.ServiceProvider)).ConfigureAwait(false);
-                }
+                using var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope();
+                return await resolver.SubscribeAsync(new ScopedResolveEventStreamContextAdapter(context, scope.ServiceProvider)).ConfigureAwait(false);
             };
         }
 

--- a/src/GraphQL.MicrosoftDI/ScopedAttribute.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedAttribute.cs
@@ -12,10 +12,18 @@ namespace GraphQL
         /// <inheritdoc/>
         public override void Modify(FieldType fieldType, bool isInputType)
         {
-            if (isInputType || fieldType.Resolver == null)
+            if (isInputType)
                 return;
 
-            fieldType.Resolver = new DynamicScopedFieldResolver(fieldType.Resolver);
+            if (fieldType.Resolver != null)
+            {
+                fieldType.Resolver = new DynamicScopedFieldResolver(fieldType.Resolver);
+            }
+
+            if (fieldType is EventStreamFieldType eventStreamFieldType && eventStreamFieldType.AsyncSubscriber != null)
+            {
+                eventStreamFieldType.AsyncSubscriber = new DynamicScopedEventStreamResolver(eventStreamFieldType.AsyncSubscriber);
+            }
         }
     }
 }

--- a/src/GraphQL.MicrosoftDI/ScopedResolveEventStreamContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveEventStreamContextAdapter.cs
@@ -1,0 +1,66 @@
+using GraphQL.Execution;
+using GraphQL.Instrumentation;
+using GraphQL.Subscription;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQLParser.AST;
+
+namespace GraphQL.MicrosoftDI
+{
+    internal sealed class ScopedResolveEventStreamContextAdapter : IResolveEventStreamContext
+    {
+        private readonly IResolveEventStreamContext _baseContext;
+
+        public ScopedResolveEventStreamContextAdapter(IResolveEventStreamContext baseContext, IServiceProvider serviceProvider)
+        {
+            _baseContext = baseContext ?? throw new ArgumentNullException(nameof(baseContext));
+            RequestServices = serviceProvider;
+        }
+
+        public object? Source => _baseContext.Source;
+
+        public GraphQLField FieldAst => _baseContext.FieldAst;
+
+        public FieldType FieldDefinition => _baseContext.FieldDefinition;
+
+        public IObjectGraphType ParentType => _baseContext.ParentType;
+
+        public IResolveFieldContext? Parent => _baseContext.Parent;
+
+        public IDictionary<string, ArgumentValue>? Arguments => _baseContext.Arguments;
+
+        public IDictionary<string, DirectiveInfo>? Directives => _baseContext.Directives;
+
+        public object? RootValue => _baseContext.RootValue;
+
+        public ISchema Schema => _baseContext.Schema;
+
+        public GraphQLDocument Document => _baseContext.Document;
+
+        public GraphQLOperationDefinition Operation => _baseContext.Operation;
+
+        public Variables Variables => _baseContext.Variables;
+
+        public CancellationToken CancellationToken => _baseContext.CancellationToken;
+
+        public Metrics Metrics => _baseContext.Metrics;
+
+        public ExecutionErrors Errors => _baseContext.Errors;
+
+        public IEnumerable<object> Path => _baseContext.Path;
+
+        public IEnumerable<object> ResponsePath => _baseContext.ResponsePath;
+
+        public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields => _baseContext.SubFields;
+
+        public IServiceProvider RequestServices { get; }
+
+        public IDictionary<string, object?> UserContext => _baseContext.UserContext;
+
+        public IReadOnlyDictionary<string, object?> InputExtensions => _baseContext.InputExtensions;
+
+        public IDictionary<string, object?> OutputExtensions => _baseContext.OutputExtensions;
+
+        public IExecutionArrayPool ArrayPool => _baseContext.ArrayPool;
+    }
+}


### PR DESCRIPTION
Depends on
- #2974 

Note: although the field resolver is 'scoped', it is scoped only for the duration that it takes the resolver to return the `IObservable<T>`.  It does not maintain the scope until the client disconnects from the subscription.  Rather, the observable is expected to maintain its own lifetime and watch for a call to `IDisposable.Dispose` to detect a disconnection.  As such, this addition may have limited usefulness (e.g. database calls prior to returning the observable), but I think this should be the proper/expected behavior if someone were to tag a subscription method with the `[Scoped]` attribute.

I'm open to suggestions here, of course, and another option would be to create a separate attribute for a more lengthy service scope for subscription fields.