### PR TITLE
Fix compiler errors

### DIFF
--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -512,6 +512,7 @@ namespace GraphQL.Tests.Types
 
         private struct NullSourceStructFailureTest
         {
+            public NullSourceStructFailureTest() { }
             public bool Example1 { get; set; } = true;
             public string Example2() => "test";
             public int Example3 = 3;
@@ -709,6 +710,7 @@ namespace GraphQL.Tests.Types
         [Name("Test")]
         public struct TestStructModel
         {
+            public TestStructModel() { }
             [Id]
             public int Id { get; set; } = 1;
             public static string Name = "Example";

--- a/src/GraphQL/Validation/ValidationOptions.cs
+++ b/src/GraphQL/Validation/ValidationOptions.cs
@@ -9,6 +9,13 @@ namespace GraphQL.Validation
     public readonly struct ValidationOptions
     {
         /// <summary>
+        /// Creates a default instance of <see cref="ValidationOptions"/>.
+        /// </summary>
+        public ValidationOptions()
+        {
+        }
+
+        /// <summary>
         /// Gets or sets the <see cref="ISchema"/> to validate the <see cref="GraphQLDocument"/> against.
         /// </summary>
         public ISchema Schema { get; init; } = null!;
@@ -22,7 +29,7 @@ namespace GraphQL.Validation
         /// Gets or sets a list of rules to use to validate the <see cref="GraphQLDocument"/>.
         /// If no rules are specified, <see cref="DocumentValidator.CoreRules"/> are used.
         /// </summary>
-        public IEnumerable<IValidationRule>? Rules { get; init; }
+        public IEnumerable<IValidationRule>? Rules { get; init; } = null;
 
         /// <summary>
         /// Gets or sets the user context, which can be used by validation rules
@@ -49,6 +56,6 @@ namespace GraphQL.Validation
         /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;
         /// defaults to <see cref="CancellationToken.None"/>
         /// </summary>
-        public CancellationToken CancellationToken { get; init; }
+        public CancellationToken CancellationToken { get; init; } = default;
     }
 }


### PR DESCRIPTION
Fixes a bit weird (new) compiler errors on 6.0.200 SDK:
> A 'struct' with field initializers must include an explicitly declared constructor

See https://github.com/dotnet/sdk/issues/23971

Core idea of new compiler "feature" - run field initializers from declared constructors **only**.