### PR TITLE
Add typed IDocumentExecuter

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -556,7 +556,8 @@ when implementing the newer `graphql-transport-ws` WebSockets protocol.
 To better support user classes based on a specific schema, the `IDocumentExecuter<>` interface
 and default implementation has been added which allows for executing a request without specifying
 the schema in the `ExecutionOptions`. The execution will pull the schema from dependency injection
-at run-time, supporting both singleton and scoped schemas.
+at run-time, supporting both singleton and scoped schemas. `RequestServices` is required to be
+provided.
 
 ```csharp
 // sample that executes a request against MySchema

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -551,6 +551,24 @@ be properly serialized. Now you may serialize a `ExecutionError` instance direct
 be handled by the specified `IErrorInfoProvider` and serialized correctly. This can be useful
 when implementing the newer `graphql-transport-ws` WebSockets protocol.
 
+### 18. `IDocumentExecuter<>` interface added to better support multiple schema registrations.
+
+To better support user classes based on a specific schema, the `IDocumentExecuter<>` interface
+and default implementation has been added which allows for executing a request without specifying
+the schema in the `ExecutionOptions`. The execution will pull the schema from dependency injection
+at run-time, supporting both singleton and scoped schemas.
+
+```csharp
+// sample that executes a request against MySchema
+var executer = serviceProvider.GetRequiredService<IDocumentExecuter<MySchema>>();
+var options = new ExecutionOptions
+{
+    Query = "{hero}",
+    RequestServices = serviceProvider,
+};
+var result = await executer.ExecuteAsync(options);
+```
+
 ## Breaking Changes
 
 ### 1. UnhandledExceptionDelegate

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -376,6 +376,8 @@ namespace GraphQL
     {
         System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options);
     }
+    public interface IDocumentExecuter<TSchema> : GraphQL.IDocumentExecuter
+        where TSchema : GraphQL.Types.ISchema { }
     public interface IGraphQLSerializer
     {
         System.Threading.Tasks.ValueTask<T?> ReadAsync<T>(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default);

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -376,6 +376,8 @@ namespace GraphQL
     {
         System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options);
     }
+    public interface IDocumentExecuter<TSchema> : GraphQL.IDocumentExecuter
+        where TSchema : GraphQL.Types.ISchema { }
     public interface IGraphQLSerializer
     {
         System.Threading.Tasks.ValueTask<T?> ReadAsync<T>(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default);

--- a/src/GraphQL.Tests/DI/GraphQLBuilderBaseTests.cs
+++ b/src/GraphQL.Tests/DI/GraphQLBuilderBaseTests.cs
@@ -29,6 +29,7 @@ namespace GraphQL.Tests.DI
                     return builder.ServiceRegister;
                 }).Verifiable();
             mock.Setup(b => b.TryRegister(typeof(IDocumentExecuter), typeof(DocumentExecuter), ServiceLifetime.Singleton, RegistrationCompareMode.ServiceType)).Returns(builder.ServiceRegister).Verifiable();
+            mock.Setup(b => b.TryRegister(typeof(IDocumentExecuter<>), typeof(DocumentExecuter<>), ServiceLifetime.Singleton, RegistrationCompareMode.ServiceType)).Returns(builder.ServiceRegister).Verifiable();
             mock.Setup(b => b.TryRegister(typeof(IDocumentBuilder), typeof(GraphQLDocumentBuilder), ServiceLifetime.Singleton, RegistrationCompareMode.ServiceType)).Returns(builder.ServiceRegister).Verifiable();
             mock.Setup(b => b.TryRegister(typeof(IDocumentValidator), typeof(DocumentValidator), ServiceLifetime.Singleton, RegistrationCompareMode.ServiceType)).Returns(builder.ServiceRegister).Verifiable();
             mock.Setup(b => b.TryRegister(typeof(IComplexityAnalyzer), typeof(ComplexityAnalyzer), ServiceLifetime.Singleton, RegistrationCompareMode.ServiceType)).Returns(builder.ServiceRegister).Verifiable();

--- a/src/GraphQL.Tests/Execution/DocumentExecuterTests.cs
+++ b/src/GraphQL.Tests/Execution/DocumentExecuterTests.cs
@@ -61,15 +61,15 @@ namespace GraphQL.Tests.Execution
                 .AddSchema<Schema1>()
                 .AddSchema<Schema2>()
                 .AddSystemTextJson());
-            services.AddSingleton(typeof(MyExecuter<>));
+            services.AddSingleton(typeof(StringExecuter<>));
             var provider = services.BuildServiceProvider();
 
             // verify executing with Schema1 works with custom class
-            var executer1 = provider.GetRequiredService<MyExecuter<Schema1>>();
+            var executer1 = provider.GetRequiredService<StringExecuter<Schema1>>();
             var result1 = await executer1.ExecuteAsync("{hero}");
             result1.ShouldBe("{\"data\":{\"hero\":\"hello\"}}");
 
-            // verify executing with Schema2 works with IDocumentExecuter<>
+            // verify executing with Schema2 works with IDocumentExecuter<> directly
             var executer2 = provider.GetRequiredService<IDocumentExecuter<Schema2>>();
             var result2 = await executer2.ExecuteAsync(new ExecutionOptions { Query = "{hero}", RequestServices = provider });
             var serializer = provider.GetRequiredService<IGraphQLTextSerializer>();
@@ -79,13 +79,13 @@ namespace GraphQL.Tests.Execution
             await Should.ThrowAsync<InvalidOperationException>(async () => await executer2.ExecuteAsync(new ExecutionOptions { Schema = new Schema1(provider), Query = "{hero}", RequestServices = provider }));
         }
 
-        private class MyExecuter<TSchema> where TSchema : ISchema
+        private class StringExecuter<TSchema> where TSchema : ISchema
         {
             private readonly IDocumentExecuter<TSchema> _executer;
             private readonly IGraphQLTextSerializer _serializer;
             private readonly IServiceScopeFactory _scopeFactory;
 
-            public MyExecuter(IDocumentExecuter<TSchema> executer, IGraphQLTextSerializer serializer, IServiceScopeFactory scopeFactory)
+            public StringExecuter(IDocumentExecuter<TSchema> executer, IGraphQLTextSerializer serializer, IServiceScopeFactory scopeFactory)
             {
                 _executer = executer;
                 _serializer = serializer;

--- a/src/GraphQL.Tests/Execution/DocumentExecuterTests.cs
+++ b/src/GraphQL.Tests/Execution/DocumentExecuterTests.cs
@@ -76,7 +76,8 @@ namespace GraphQL.Tests.Execution
             serializer.Serialize(result2).ShouldBe("{\"data\":{\"hero\":\"hello2\"}}");
 
             // verify that you cannot specify Schema with this implementation
-            await Should.ThrowAsync<InvalidOperationException>(async () => await executer2.ExecuteAsync(new ExecutionOptions { Schema = new Schema1(provider), Query = "{hero}", RequestServices = provider }));
+            var err = await Should.ThrowAsync<InvalidOperationException>(async () => await executer2.ExecuteAsync(new ExecutionOptions { Schema = new Schema1(provider), Query = "{hero}", RequestServices = provider }));
+            err.Message.ShouldBe("ExecutionOptions.Schema must be null when calling this typed IDocumentExecuter<> implementation; it will be pulled from the dependency injection provider.");
         }
 
         private class StringExecuter<TSchema> where TSchema : ISchema

--- a/src/GraphQL.Tests/Execution/DocumentExecuterTests.cs
+++ b/src/GraphQL.Tests/Execution/DocumentExecuterTests.cs
@@ -1,9 +1,12 @@
 using GraphQL.Caching;
 using GraphQL.DI;
 using GraphQL.Execution;
+using GraphQL.MicrosoftDI;
+using GraphQL.SystemTextJson;
 using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQL.Validation.Complexity;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.Tests.Execution
 {
@@ -48,6 +51,77 @@ namespace GraphQL.Tests.Execution
             });
             ret.Errors.ShouldBeNull();
             mutationStrategy.Executed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task TypedInterfaceMapping()
+        {
+            var services = new ServiceCollection();
+            services.AddGraphQL(b => b
+                .AddSchema<Schema1>()
+                .AddSchema<Schema2>()
+                .AddSystemTextJson());
+            services.AddSingleton(typeof(MyExecuter<>));
+            var provider = services.BuildServiceProvider();
+
+            // verify executing with Schema1 works with custom class
+            var executer1 = provider.GetRequiredService<MyExecuter<Schema1>>();
+            var result1 = await executer1.ExecuteAsync("{hero}");
+            result1.ShouldBe("{\"data\":{\"hero\":\"hello\"}}");
+
+            // verify executing with Schema2 works with IDocumentExecuter<>
+            var executer2 = provider.GetRequiredService<IDocumentExecuter<Schema2>>();
+            var result2 = await executer2.ExecuteAsync(new ExecutionOptions { Query = "{hero}", RequestServices = provider });
+            var serializer = provider.GetRequiredService<IGraphQLTextSerializer>();
+            serializer.Serialize(result2).ShouldBe("{\"data\":{\"hero\":\"hello2\"}}");
+
+            // verify that you cannot specify Schema with this implementation
+            await Should.ThrowAsync<InvalidOperationException>(async () => await executer2.ExecuteAsync(new ExecutionOptions { Schema = new Schema1(provider), Query = "{hero}", RequestServices = provider }));
+        }
+
+        private class MyExecuter<TSchema> where TSchema : ISchema
+        {
+            private readonly IDocumentExecuter<TSchema> _executer;
+            private readonly IGraphQLTextSerializer _serializer;
+            private readonly IServiceScopeFactory _scopeFactory;
+
+            public MyExecuter(IDocumentExecuter<TSchema> executer, IGraphQLTextSerializer serializer, IServiceScopeFactory scopeFactory)
+            {
+                _executer = executer;
+                _serializer = serializer;
+                _scopeFactory = scopeFactory;
+            }
+
+            public async Task<string> ExecuteAsync(string query)
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var result = await _executer.ExecuteAsync(new ExecutionOptions
+                {
+                    Query = query,
+                    RequestServices = scope.ServiceProvider,
+                });
+                return _serializer.Serialize(result);
+            }
+        }
+
+        private class Schema1 : Schema
+        {
+            public Schema1(IServiceProvider provider) : base(provider)
+            {
+                var graph = new ObjectGraphType { Name = "Query" };
+                graph.Field<StringGraphType>("hero", resolve: context => "hello");
+                Query = graph;
+            }
+        }
+
+        private class Schema2 : Schema
+        {
+            public Schema2(IServiceProvider provider) : base(provider)
+            {
+                var graph = new ObjectGraphType { Name = "Query" };
+                graph.Field<StringGraphType>("hero", resolve: context => "hello2");
+                Query = graph;
+            }
         }
 
         private class SampleGraph

--- a/src/GraphQL/DI/GraphQLBuilderBase.cs
+++ b/src/GraphQL/DI/GraphQLBuilderBase.cs
@@ -43,6 +43,7 @@ namespace GraphQL.DI
 
             // configure service implementations to use the configured default services when not overridden by a user
             Services.TryRegister<IDocumentExecuter, DocumentExecuter>(ServiceLifetime.Singleton);
+            Services.TryRegister(typeof(IDocumentExecuter<>), typeof(DocumentExecuter<>), ServiceLifetime.Singleton);
             Services.TryRegister<IDocumentBuilder, GraphQLDocumentBuilder>(ServiceLifetime.Singleton);
             Services.TryRegister<IDocumentValidator, DocumentValidator>(ServiceLifetime.Singleton);
             Services.TryRegister<IComplexityAnalyzer, ComplexityAnalyzer>(ServiceLifetime.Singleton);

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -341,7 +341,7 @@ namespace GraphQL
         public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)
         {
             if (options.Schema != null)
-                throw new InvalidOperationException("Schema must be null when calling this typed IDocumentExecuter<> implementation; it will be pulled from the dependency injection provider.");
+                throw new InvalidOperationException("ExecutionOptions.Schema must be null when calling this typed IDocumentExecuter<> implementation; it will be pulled from the dependency injection provider.");
 
             var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
             var schema = requestServices.GetRequiredService<TSchema>();

--- a/src/GraphQL/Execution/IDocumentExecuter.cs
+++ b/src/GraphQL/Execution/IDocumentExecuter.cs
@@ -1,3 +1,5 @@
+using GraphQL.Types;
+
 namespace GraphQL
 {
     /// <summary>
@@ -18,6 +20,15 @@ namespace GraphQL
         /// </summary>
         /// <param name="options">The options of the execution</param>
         Task<ExecutionResult> ExecuteAsync(ExecutionOptions options);
+    }
+
+    /// <summary>
+    /// Process an entire GraphQL request against a specific schema, given an input GraphQL request string.
+    /// This is intended to be called by user code to process a query.
+    /// </summary>
+    public interface IDocumentExecuter<TSchema> : IDocumentExecuter
+        where TSchema : ISchema
+    {
     }
 
     /// <summary>


### PR DESCRIPTION
I would like to add this to better support multiple schemas.  It adds a single interface to the public API.  An example of its use is provided in the tests - see `StringExecuter` sample class.