### PR TITLE
Fix deserialization bug for batches containing null

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.NewtonsoftJson.approved.txt
@@ -42,7 +42,7 @@ namespace GraphQL.NewtonsoftJson
         public override bool CanRead { get; }
         public override bool CanWrite { get; }
         public override bool CanConvert(System.Type objectType) { }
-        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer) { }
+        public override object? ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer) { }
         public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer) { }
     }
     public class GraphQLRequestListJsonConverter : Newtonsoft.Json.JsonConverter

--- a/src/GraphQL.NewtonsoftJson/GraphQLRequestJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/GraphQLRequestJsonConverter.cs
@@ -67,8 +67,11 @@ namespace GraphQL.NewtonsoftJson
         }
 
         /// <inheritdoc/>
-        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
             if (reader.TokenType != JsonToken.StartObject)
                 throw new JsonException();
 

--- a/src/GraphQL.NewtonsoftJson/GraphQLRequestListJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/GraphQLRequestListJsonConverter.cs
@@ -9,7 +9,7 @@ namespace GraphQL.NewtonsoftJson
     /// <br/><br/>
     /// To determine if a single request is a batch request or not, deserialize to the type
     /// <see cref="IList{T}">IList</see>&lt;<see cref="GraphQLRequest"/>&gt; and examine the type
-    /// of the returned object to see if it <see cref="GraphQLRequest"/>[].
+    /// of the returned object to see if it is <see cref="GraphQLRequest"/>[].
     /// If the returned object is an array, then it is not a batch request.
     /// </summary>
     public class GraphQLRequestListJsonConverter : JsonConverter

--- a/src/GraphQL.NewtonsoftJson/GraphQLRequestListJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/GraphQLRequestListJsonConverter.cs
@@ -6,6 +6,11 @@ namespace GraphQL.NewtonsoftJson
     /// <summary>
     /// A custom JsonConverter for reading a list of <see cref="GraphQLRequest"/> objects.
     /// Will deserialize a single request into a list containing one request. Doesn't support writing.
+    /// <br/><br/>
+    /// To determine if a single request is a batch request or not, deserialize to the type
+    /// <see cref="IList{T}">IList</see>&lt;<see cref="GraphQLRequest"/>&gt; and examine the type
+    /// of the returned object to see if it <see cref="GraphQLRequest"/>[].
+    /// If the returned object is an array, then it is not a batch request.
     /// </summary>
     public class GraphQLRequestListJsonConverter : JsonConverter
     {
@@ -41,6 +46,7 @@ namespace GraphQL.NewtonsoftJson
             if (reader.TokenType == JsonToken.StartObject)
             {
                 var request = serializer.Deserialize<GraphQLRequest>(reader)!;
+                // do not change behavior here; see class notes
                 return objectType == typeof(List<GraphQLRequest>)
                     ? new List<GraphQLRequest>(1) { request }
                     : new GraphQLRequest[] { request };
@@ -60,9 +66,8 @@ namespace GraphQL.NewtonsoftJson
                         : list;
                 }
 
-                var request = serializer.Deserialize<GraphQLRequest>(reader);
-                if (request != null)
-                    list.Add(request);
+                var request = serializer.Deserialize<GraphQLRequest>(reader)!;
+                list.Add(request);
             }
 
             //unexpected end of data

--- a/src/GraphQL.SystemTextJson/GraphQLRequestListJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/GraphQLRequestListJsonConverter.cs
@@ -10,7 +10,7 @@ namespace GraphQL.SystemTextJson
     /// <br/><br/>
     /// To determine if a single request is a batch request or not, deserialize to the type
     /// <see cref="IList{T}">IList</see>&lt;<see cref="GraphQLRequest"/>&gt; and examine the type
-    /// of the returned object to see if it <see cref="GraphQLRequest"/>[].
+    /// of the returned object to see if it is <see cref="GraphQLRequest"/>[].
     /// If the returned object is an array, then it is not a batch request.
     /// </summary>
     public class GraphQLRequestListJsonConverter : JsonConverter<IEnumerable<GraphQLRequest>>

--- a/src/GraphQL.Tests/Serialization/GraphQLRequestTests.cs
+++ b/src/GraphQL.Tests/Serialization/GraphQLRequestTests.cs
@@ -173,6 +173,37 @@ namespace GraphQL.Tests.Serialization
 
         [Theory]
         [ClassData(typeof(GraphQLSerializersTestData))]
+        public void Reads_Null_GraphQLRequest_In_List(IGraphQLTextSerializer serializer)
+        {
+            var actual = serializer.Deserialize<GraphQLRequest[]>("[null]");
+            actual.Length.ShouldBe(1);
+            actual.First().ShouldBeNull();
+        }
+
+        [Theory]
+        [ClassData(typeof(GraphQLSerializersTestData))]
+        public void BatchRequestAsIListIsNotArrayForListOfSingle(IGraphQLTextSerializer serializer)
+        {
+            // verifies that when deserializing to IList<GraphQLRequest>, and when a single item is in the list, the result is not a GraphQLRequest[]
+            // note: the server counts on this behavior to determine whether or not a request is a batch request
+            var actual = serializer.Deserialize<IList<GraphQLRequest>>("[{}]");
+            actual.ShouldNotBeOfType<GraphQLRequest[]>();
+            actual.Count.ShouldBe(1);
+        }
+
+        [Theory]
+        [ClassData(typeof(GraphQLSerializersTestData))]
+        public void BatchRequestAsIListIsArrayForSingle(IGraphQLTextSerializer serializer)
+        {
+            // verifies that when deserializing to IList<GraphQLRequest>, and when it is not a batch request, the result is a GraphQLRequest[1]
+            // note: the server counts on this behavior to determine whether or not a request is a batch request
+            var actual = serializer.Deserialize<IList<GraphQLRequest>>("{}");
+            actual.ShouldBeOfType<GraphQLRequest[]>();
+            actual.Count.ShouldBe(1);
+        }
+
+        [Theory]
+        [ClassData(typeof(GraphQLSerializersTestData))]
         public void Reads_GraphQLRequest_List_NotCaseSensitive(IGraphQLTextSerializer serializer)
         {
             var test = @"{""VARIABLES"":{""date"":""2015-12-22T10:10:10+03:00""},""query"":""test""}";


### PR DESCRIPTION
Fixes a bug where if a batch request as follows was processed by the server:

```json
[null]
```

Then the server would only receive an empty array and respond like this:

```json
[]
```

Rather than the correct response which should be something of this nature:

```json
[
  {
    "errors": [{"message":"GraphQL request cannot be null."}]
  }
]
```