### PR TITLE
Cleanup build warnings

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,6 +17,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <IsPackable>true</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -8,7 +8,6 @@
 
   <PropertyGroup Condition="'$(IsPackable)' == 'true'">
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -8,9 +8,12 @@
 
   <PropertyGroup Condition="'$(IsPackable)' == 'true'">
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>CS8604</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);1591</NoWarn>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsPackable)' != 'true'">
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/src/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
+++ b/src/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net6;net5;netcoreapp3.1</TargetFrameworks>
     <OutputType>exe</OutputType>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Harness/CountFieldMiddleware.cs
+++ b/src/GraphQL.Harness/CountFieldMiddleware.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Diagnostics;
 using GraphQL;
 using GraphQL.Instrumentation;

--- a/src/GraphQL.Harness/GraphQL.Harness.csproj
+++ b/src/GraphQL.Harness/GraphQL.Harness.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6;net5;netcoreapp3.1</TargetFrameworks>
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/GraphQL.StarWars/GraphQL.StarWars.csproj
+++ b/src/GraphQL.StarWars/GraphQL.StarWars.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
@@ -56,7 +56,7 @@ namespace GraphQL.SystemTextJson
                     writer.WriteStartObject();
                     foreach (var childNode in objectExecutionNode.SubFields)
                     {
-                        var propertyName = childNode.Name;
+                        var propertyName = childNode.Name!;
                         if (options.PropertyNamingPolicy != null)
                             propertyName = options.PropertyNamingPolicy.ConvertName(propertyName);
                         writer.WritePropertyName(propertyName);

--- a/src/GraphQL.SystemTextJson/InputsJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/InputsJsonConverter.cs
@@ -61,12 +61,12 @@ namespace GraphQL.SystemTextJson
                 _ => throw new InvalidOperationException($"Unexpected token type: {reader.TokenType}")
             };
 
-        private static List<object> ReadArray(ref Utf8JsonReader reader)
+        private static List<object?> ReadArray(ref Utf8JsonReader reader)
         {
             if (reader.TokenType != JsonTokenType.StartArray)
                 throw new JsonException();
 
-            var result = new List<object>();
+            var result = new List<object?>();
 
             while (reader.Read())
             {

--- a/src/GraphQL.Tests/QueryTestBase.cs
+++ b/src/GraphQL.Tests/QueryTestBase.cs
@@ -24,6 +24,7 @@ namespace GraphQL.Tests
             Executer = new DocumentExecuter(new TDocumentBuilder(), new DocumentValidator(), new ComplexityAnalyzer());
         }
 
+#pragma warning disable xUnit1013 // public method should be marked as test
         // WARNING: it is not static only for discoverability
         // WARNING: do not set any instance data inside
         // WARNING: method works on temporaly created instance
@@ -31,6 +32,7 @@ namespace GraphQL.Tests
         {
             register.TryRegister(typeof(TSchema), typeof(TSchema), ServiceLifetime.Singleton);
         }
+#pragma warning restore xUnit1013 // public method should be marked as test
 
         private IServiceProvider _serviceProvider;
 

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
@@ -158,7 +158,7 @@ namespace GraphQL.Utilities.Federation
             {
                 if (x is Dictionary<string, object> dict && dict.TryGetValue("__typename", out object? typeName))
                 {
-                    return new GraphQLTypeReference(typeName!.ToString());
+                    return new GraphQLTypeReference(typeName!.ToString()!);
                 }
 
                 // TODO: Provide another way to give graph type name, such as an attribute

--- a/src/GraphQL/Validation/Errors/DefaultValuesOfCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/DefaultValuesOfCorrectTypeError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public DefaultValuesOfCorrectTypeError(ValidationContext context, GraphQLVariableDefinition varDefAst, IGraphType inputType, string verboseErrors)
-            : base(context.Document.Source, NUMBER, BadValueForDefaultArgMessage(varDefAst.Variable.Name.StringValue, inputType.ToString(), varDefAst.DefaultValue!.Print(), verboseErrors), varDefAst.DefaultValue!)
+            : base(context.Document.Source, NUMBER, BadValueForDefaultArgMessage(varDefAst.Variable.Name.StringValue, inputType.ToString()!, varDefAst.DefaultValue!.Print(), verboseErrors), varDefAst.DefaultValue!)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Validation.Errors
                 UnknownArgMessage(
                     node.Name.StringValue,
                     fieldDef.Name,
-                    parentType.ToString(),
+                    parentType.ToString()!,
                     StringUtils.SuggestionList(node.Name.StringValue, fieldDef.Arguments?.List?.Select(q => q.Name))), //ISSUE:allocation
                 node)
         {

--- a/src/GraphQL/Validation/Errors/PossibleFragmentSpreadsError.cs
+++ b/src/GraphQL/Validation/Errors/PossibleFragmentSpreadsError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public PossibleFragmentSpreadsError(ValidationContext context, GraphQLInlineFragment node, IGraphType parentType, IGraphType fragType)
-            : base(context.Document.Source, NUMBER, TypeIncompatibleAnonSpreadMessage(parentType.ToString(), fragType.ToString()), node)
+            : base(context.Document.Source, NUMBER, TypeIncompatibleAnonSpreadMessage(parentType.ToString()!, fragType.ToString()!), node)
         {
         }
 
@@ -21,7 +21,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public PossibleFragmentSpreadsError(ValidationContext context, GraphQLFragmentSpread node, IGraphType parentType, IGraphType fragType)
-            : base(context.Document.Source, NUMBER, TypeIncompatibleSpreadMessage(node.FragmentName.Name.StringValue, parentType.ToString(), fragType.ToString()), node)
+            : base(context.Document.Source, NUMBER, TypeIncompatibleSpreadMessage(node.FragmentName.Name.StringValue, parentType.ToString()!, fragType.ToString()!), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/ProvidedNonNullArgumentsError.cs
+++ b/src/GraphQL/Validation/Errors/ProvidedNonNullArgumentsError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ProvidedNonNullArgumentsError(ValidationContext context, GraphQLField node, QueryArgument arg)
-            : base(context.Document.Source, NUMBER, MissingFieldArgMessage(node.Name.StringValue, arg.Name, arg.ResolvedType!.ToString()), node)
+            : base(context.Document.Source, NUMBER, MissingFieldArgMessage(node.Name.StringValue, arg.Name, arg.ResolvedType!.ToString()!), node)
         {
         }
 
@@ -21,7 +21,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ProvidedNonNullArgumentsError(ValidationContext context, GraphQLDirective node, QueryArgument arg)
-            : base(context.Document.Source, NUMBER, MissingDirectiveArgMessage(node.Name.StringValue, arg.Name, arg.ResolvedType!.ToString()), node)
+            : base(context.Document.Source, NUMBER, MissingDirectiveArgMessage(node.Name.StringValue, arg.Name, arg.ResolvedType!.ToString()!), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/ScalarLeafsError.cs
+++ b/src/GraphQL/Validation/Errors/ScalarLeafsError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ScalarLeafsError(ValidationContext context, GraphQLSelectionSet node, GraphQLField field, IGraphType type)
-            : base(context.Document.Source, NUMBER, NoSubselectionAllowedMessage(field.Name.StringValue, type.ToString()), node)
+            : base(context.Document.Source, NUMBER, NoSubselectionAllowedMessage(field.Name.StringValue, type.ToString()!), node)
         {
         }
 
@@ -21,7 +21,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public ScalarLeafsError(ValidationContext context, GraphQLField node, IGraphType type)
-            : base(context.Document.Source, NUMBER, RequiredSubselectionMessage(node.Name.StringValue, type.ToString()), node)
+            : base(context.Document.Source, NUMBER, RequiredSubselectionMessage(node.Name.StringValue, type.ToString()!), node)
         {
         }
 

--- a/src/GraphQL/Validation/Errors/VariablesInAllowedPositionError.cs
+++ b/src/GraphQL/Validation/Errors/VariablesInAllowedPositionError.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Validation.Errors
         /// Initializes a new instance with the specified properties.
         /// </summary>
         public VariablesInAllowedPositionError(ValidationContext context, GraphQLVariableDefinition varDef, IGraphType varType, VariableUsage usage)
-            : base(context.Document.Source, NUMBER, BadVarPosMessage(usage.Node.Name.StringValue, varType.ToString(), usage.Type.ToString()))
+            : base(context.Document.Source, NUMBER, BadVarPosMessage(usage.Node.Name.StringValue, varType.ToString()!, usage.Type.ToString()!))
         {
             var varDefLoc = Location.FromLinearPosition(context.Document.Source, varDef.Location.Start);
             var usageLoc = Location.FromLinearPosition(context.Document.Source, usage.Node.Location.Start);

--- a/src/Tests.props
+++ b/src/Tests.props
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)Tests.local.props" Condition="Exists('$(MSBuildThisFileDirectory)Tests.local.props')" />
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn);1591;IDE1006;CS0618</NoWarn>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
     <SingleTestPlatform Condition="'$(SingleTestPlatform)' == ''">false</SingleTestPlatform>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Tests.props
+++ b/src/Tests.props
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)Tests.local.props" Condition="Exists('$(MSBuildThisFileDirectory)Tests.local.props')" />
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <NoWarn>$(NoWarn);IDE1006;CS0618</NoWarn>
     <SingleTestPlatform Condition="'$(SingleTestPlatform)' == ''">false</SingleTestPlatform>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Changes:
- `ToString()` is marked as nullable, it seems (not in the IDE, but to the compiler) -- added `!` where necessary -- then removed NoWarn for that issue
- Fixed two or three other minor issues causing build warnings
- Enabled warnings-as-errors for the entire solution
- Disabled xml comments warning for all projects that do not pack solution-wide (was so already individually per project)
