### PR TITLE
Rename SubscribeAsync to ResolveAsync and similar

### DIFF
--- a/docs2/site/docs/getting-started/subscriptions.md
+++ b/docs2/site/docs/getting-started/subscriptions.md
@@ -36,7 +36,7 @@ public class ChatSubscriptions : ObjectGraphType
       Name = "messageAdded",
       Type = typeof(MessageType),
       Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-      StreamResolver = new SourceStreamResolver<Message>(StreamResolver)
+      StreamResolver = new SourceStreamResolver<Message>(ResolveStream)
     });
   }
 
@@ -45,7 +45,7 @@ public class ChatSubscriptions : ObjectGraphType
     return context.Source as Message;
   }
 
-  private IObservable<Message> StreamResolver(IResolveFieldContext context)
+  private IObservable<Message> ResolveStream(IResolveFieldContext context)
   {
     return _chat.Messages();
   }

--- a/docs2/site/docs/getting-started/subscriptions.md
+++ b/docs2/site/docs/getting-started/subscriptions.md
@@ -36,7 +36,7 @@ public class ChatSubscriptions : ObjectGraphType
       Name = "messageAdded",
       Type = typeof(MessageType),
       Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-      Subscriber = new SourceStreamResolver<Message>(Subscribe)
+      StreamResolver = new SourceStreamResolver<Message>(StreamResolver)
     });
   }
 
@@ -45,7 +45,7 @@ public class ChatSubscriptions : ObjectGraphType
     return context.Source as Message;
   }
 
-  private IObservable<Message> Subscribe(IResolveFieldContext context)
+  private IObservable<Message> StreamResolver(IResolveFieldContext context)
   {
     return _chat.Messages();
   }

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -1097,7 +1097,7 @@ See https://www.npgsql.org/doc/types/datetime.html
 Previously this rule, part of the GraphQL specification, was not enabled by default; in
 GraphQL.NET v5 it is enabled by default as part of the `DocumentValidator.CoreRules` list.
 
-### 45. `IEventStreamResolver` and `EventStreamResolver` renamed
+### 45. Subscription methods, classes and interfaces renamed
 
 - `IEventStreamResolver` is now `ISourceStreamResolver`
 - `EventStreamResolver` is now `SourceStreamResolver`

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -1101,3 +1101,6 @@ GraphQL.NET v5 it is enabled by default as part of the `DocumentValidator.CoreRu
 
 - `IEventStreamResolver` is now `ISourceStreamResolver`
 - `EventStreamResolver` is now `SourceStreamResolver`
+- `IAsyncEventStreamResolver` and `AsyncEventStreamResolver` have been removed
+- `IEventStreamResolver.Subscriber` is now `ISourceStreamResolver.ResolveAsync`
+- Field builder `Subscribe` and `SubscribeAsync` methods are now `ResolveStream` and `ResolveStreamAsync`

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -624,7 +624,7 @@ namespace GraphQL
     public enum ResolverType
     {
         Resolver = 0,
-        Subscriber = 1,
+        StreamResolver = 1,
     }
     public static class SchemaExtensions
     {
@@ -1528,7 +1528,7 @@ namespace GraphQL.Resolvers
     }
     public interface ISourceStreamResolver
     {
-        System.Threading.Tasks.ValueTask<System.IObservable<object?>> SubscribeAsync(GraphQL.IResolveFieldContext context);
+        System.Threading.Tasks.ValueTask<System.IObservable<object?>> ResolveAsync(GraphQL.IResolveFieldContext context);
     }
     public class MemberResolver : GraphQL.Resolvers.IFieldResolver
     {
@@ -1548,19 +1548,19 @@ namespace GraphQL.Resolvers
         public SourceStreamMethodResolver(System.Reflection.MethodInfo methodInfo, System.Linq.Expressions.LambdaExpression instanceExpression, System.Collections.Generic.IList<System.Linq.Expressions.LambdaExpression> methodArgumentExpressions) { }
         protected override System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<object?>>> BuildSourceStreamResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
-        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> SubscribeAsync(GraphQL.IResolveFieldContext context) { }
+        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> ResolveStreamAsync(GraphQL.IResolveFieldContext context) { }
     }
     public class SourceStreamResolver<TReturnType> : GraphQL.Resolvers.ISourceStreamResolver
     {
         public SourceStreamResolver(System.Func<GraphQL.IResolveFieldContext, System.IObservable<TReturnType?>> sourceStreamResolver) { }
         public SourceStreamResolver(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
-        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> SubscribeAsync(GraphQL.IResolveFieldContext context) { }
+        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
     public class SourceStreamResolver<TSourceType, TReturnType> : GraphQL.Resolvers.ISourceStreamResolver
     {
         public SourceStreamResolver(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.IObservable<TReturnType?>> sourceStreamResolver) { }
         public SourceStreamResolver(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.ValueTask<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
-        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> SubscribeAsync(GraphQL.IResolveFieldContext context) { }
+        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
 }
 namespace GraphQL.Transport
@@ -1863,7 +1863,7 @@ namespace GraphQL.Types
         public string Name { get; set; }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
         public GraphQL.Resolvers.IFieldResolver? Resolver { get; set; }
-        public GraphQL.Resolvers.ISourceStreamResolver? Subscriber { get; set; }
+        public GraphQL.Resolvers.ISourceStreamResolver? StreamResolver { get; set; }
         public System.Type? Type { get; set; }
     }
     public class FloatGraphType : GraphQL.Types.ScalarGraphType
@@ -2490,8 +2490,8 @@ namespace GraphQL.Utilities
         public string Name { get; }
         public GraphQL.Resolvers.IFieldResolver? Resolver { get; set; }
         public GraphQL.Reflection.IAccessor? ResolverAccessor { get; set; }
-        public GraphQL.Resolvers.ISourceStreamResolver? Subscriber { get; set; }
-        public GraphQL.Reflection.IAccessor? SubscriberAccessor { get; set; }
+        public GraphQL.Resolvers.ISourceStreamResolver? StreamResolver { get; set; }
+        public GraphQL.Reflection.IAccessor? StreamResolverAccessor { get; set; }
         public GraphQL.Utilities.ArgumentConfig ArgumentFor(string argumentName) { }
     }
     public interface ISchemaNodeVisitor

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -801,9 +801,9 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.IResolveFieldContext<TSourceType>, TReturnType?> resolve) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolve) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveStream(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.IObservable<TReturnType?>> sourceStreamResolver) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Subscribe(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.IObservable<TReturnType?>> sourceStreamResolver) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> SubscribeAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(System.Type? type = null, string name = "default") { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -624,7 +624,7 @@ namespace GraphQL
     public enum ResolverType
     {
         Resolver = 0,
-        Subscriber = 1,
+        StreamResolver = 1,
     }
     public static class SchemaExtensions
     {
@@ -1528,7 +1528,7 @@ namespace GraphQL.Resolvers
     }
     public interface ISourceStreamResolver
     {
-        System.Threading.Tasks.ValueTask<System.IObservable<object?>> SubscribeAsync(GraphQL.IResolveFieldContext context);
+        System.Threading.Tasks.ValueTask<System.IObservable<object?>> ResolveAsync(GraphQL.IResolveFieldContext context);
     }
     public class MemberResolver : GraphQL.Resolvers.IFieldResolver
     {
@@ -1548,19 +1548,19 @@ namespace GraphQL.Resolvers
         public SourceStreamMethodResolver(System.Reflection.MethodInfo methodInfo, System.Linq.Expressions.LambdaExpression instanceExpression, System.Collections.Generic.IList<System.Linq.Expressions.LambdaExpression> methodArgumentExpressions) { }
         protected override System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<object?>>> BuildSourceStreamResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
-        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> SubscribeAsync(GraphQL.IResolveFieldContext context) { }
+        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> ResolveStreamAsync(GraphQL.IResolveFieldContext context) { }
     }
     public class SourceStreamResolver<TReturnType> : GraphQL.Resolvers.ISourceStreamResolver
     {
         public SourceStreamResolver(System.Func<GraphQL.IResolveFieldContext, System.IObservable<TReturnType?>> sourceStreamResolver) { }
         public SourceStreamResolver(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
-        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> SubscribeAsync(GraphQL.IResolveFieldContext context) { }
+        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
     public class SourceStreamResolver<TSourceType, TReturnType> : GraphQL.Resolvers.ISourceStreamResolver
     {
         public SourceStreamResolver(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.IObservable<TReturnType?>> sourceStreamResolver) { }
         public SourceStreamResolver(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.ValueTask<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
-        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> SubscribeAsync(GraphQL.IResolveFieldContext context) { }
+        public System.Threading.Tasks.ValueTask<System.IObservable<object?>> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
 }
 namespace GraphQL.Transport
@@ -1856,7 +1856,7 @@ namespace GraphQL.Types
         public string Name { get; set; }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
         public GraphQL.Resolvers.IFieldResolver? Resolver { get; set; }
-        public GraphQL.Resolvers.ISourceStreamResolver? Subscriber { get; set; }
+        public GraphQL.Resolvers.ISourceStreamResolver? StreamResolver { get; set; }
         public System.Type? Type { get; set; }
     }
     public class FloatGraphType : GraphQL.Types.ScalarGraphType
@@ -2476,8 +2476,8 @@ namespace GraphQL.Utilities
         public string Name { get; }
         public GraphQL.Resolvers.IFieldResolver? Resolver { get; set; }
         public GraphQL.Reflection.IAccessor? ResolverAccessor { get; set; }
-        public GraphQL.Resolvers.ISourceStreamResolver? Subscriber { get; set; }
-        public GraphQL.Reflection.IAccessor? SubscriberAccessor { get; set; }
+        public GraphQL.Resolvers.ISourceStreamResolver? StreamResolver { get; set; }
+        public GraphQL.Reflection.IAccessor? StreamResolverAccessor { get; set; }
         public GraphQL.Utilities.ArgumentConfig ArgumentFor(string argumentName) { }
     }
     public interface ISchemaNodeVisitor

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -801,9 +801,9 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.IResolveFieldContext<TSourceType>, TReturnType?> resolve) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolve) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveStream(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.IObservable<TReturnType?>> sourceStreamResolver) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Subscribe(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.IObservable<TReturnType?>> sourceStreamResolver) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> SubscribeAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(System.Type? type = null, string name = "default") { }

--- a/src/GraphQL.DataLoader.Tests/Types/SubscriptionType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/SubscriptionType.cs
@@ -19,7 +19,7 @@ namespace GraphQL.DataLoader.Tests.Types
                 Name = "orderAdded",
                 Type = typeof(OrderType),
                 Resolver = new FuncFieldResolver<Order>(ResolveMessage),
-                StreamResolver = new SourceStreamResolver<Order>(StreamResolver)
+                StreamResolver = new SourceStreamResolver<Order>(ResolveStream)
             });
         }
 
@@ -28,7 +28,7 @@ namespace GraphQL.DataLoader.Tests.Types
             return context.Source as Order;
         }
 
-        private IObservable<Order> StreamResolver(IResolveFieldContext context)
+        private IObservable<Order> ResolveStream(IResolveFieldContext context)
         {
             return ordersStore.GetOrderObservable();
         }

--- a/src/GraphQL.DataLoader.Tests/Types/SubscriptionType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/SubscriptionType.cs
@@ -19,7 +19,7 @@ namespace GraphQL.DataLoader.Tests.Types
                 Name = "orderAdded",
                 Type = typeof(OrderType),
                 Resolver = new FuncFieldResolver<Order>(ResolveMessage),
-                Subscriber = new SourceStreamResolver<Order>(Subscribe)
+                StreamResolver = new SourceStreamResolver<Order>(StreamResolver)
             });
         }
 
@@ -28,7 +28,7 @@ namespace GraphQL.DataLoader.Tests.Types
             return context.Source as Order;
         }
 
-        private IObservable<Order> Subscribe(IResolveFieldContext context)
+        private IObservable<Order> StreamResolver(IResolveFieldContext context)
         {
             return ordersStore.GetOrderObservable();
         }

--- a/src/GraphQL.MicrosoftDI.Tests/ScopedAttributeTests.cs
+++ b/src/GraphQL.MicrosoftDI.Tests/ScopedAttributeTests.cs
@@ -53,17 +53,17 @@ namespace GraphQL.MicrosoftDI.Tests
                 Source = new TestClass(),
                 RequestServices = rootServiceProvider,
             };
-            var unscopedSubscriptionResolver = graphType.Fields.Find(nameof(TestClass.UnscopedAsyncSubscription))!.Subscriber!;
-            var scopedAsyncSubscriptionResolver = graphType.Fields.Find(nameof(TestClass.ScopedAsyncSubscription))!.Subscriber!;
-            (await unscopedSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("0 1"));
-            (await unscopedSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("1 2"));
-            (await unscopedSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("2 3"));
+            var unscopedSubscriptionResolver = graphType.Fields.Find(nameof(TestClass.UnscopedAsyncSubscription))!.StreamResolver!;
+            var scopedAsyncSubscriptionResolver = graphType.Fields.Find(nameof(TestClass.ScopedAsyncSubscription))!.StreamResolver!;
+            (await unscopedSubscriptionResolver.ResolveAsync(context)).Subscribe(new SampleObserver("0 1"));
+            (await unscopedSubscriptionResolver.ResolveAsync(context)).Subscribe(new SampleObserver("1 2"));
+            (await unscopedSubscriptionResolver.ResolveAsync(context)).Subscribe(new SampleObserver("2 3"));
             Class1.DisposedCount.ShouldBe(0);
-            (await scopedAsyncSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("0 1"));
+            (await scopedAsyncSubscriptionResolver.ResolveAsync(context)).Subscribe(new SampleObserver("0 1"));
             Class1.DisposedCount.ShouldBe(1);
-            (await scopedAsyncSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("0 1"));
+            (await scopedAsyncSubscriptionResolver.ResolveAsync(context)).Subscribe(new SampleObserver("0 1"));
             Class1.DisposedCount.ShouldBe(2);
-            (await unscopedSubscriptionResolver.SubscribeAsync(context)).Subscribe(new SampleObserver("3 4"));
+            (await unscopedSubscriptionResolver.ResolveAsync(context)).Subscribe(new SampleObserver("3 4"));
             rootServiceProvider.Dispose();
             Class1.DisposedCount.ShouldBe(3);
         }

--- a/src/GraphQL.MicrosoftDI/DynamicScopedSourceStreamResolver.cs
+++ b/src/GraphQL.MicrosoftDI/DynamicScopedSourceStreamResolver.cs
@@ -21,11 +21,11 @@ namespace GraphQL.MicrosoftDI
             _resolverFunc = async context =>
             {
                 using var scope = (context.RequestServices ?? throw new MissingRequestServicesException()).CreateScope();
-                return await resolver.SubscribeAsync(new ScopedResolveFieldContextAdapter<object>(context, scope.ServiceProvider)).ConfigureAwait(false);
+                return await resolver.ResolveAsync(new ScopedResolveFieldContextAdapter<object>(context, scope.ServiceProvider)).ConfigureAwait(false);
             };
         }
 
         /// <inheritdoc/>
-        public ValueTask<IObservable<object?>> SubscribeAsync(IResolveFieldContext context) => _resolverFunc(context);
+        public ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context) => _resolverFunc(context);
     }
 }

--- a/src/GraphQL.MicrosoftDI/ScopedAttribute.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedAttribute.cs
@@ -20,9 +20,9 @@ namespace GraphQL
                 fieldType.Resolver = new DynamicScopedFieldResolver(fieldType.Resolver);
             }
 
-            if (fieldType.Subscriber != null)
+            if (fieldType.StreamResolver != null)
             {
-                fieldType.Subscriber = new DynamicScopedSourceStreamResolver(fieldType.Subscriber);
+                fieldType.StreamResolver = new DynamicScopedSourceStreamResolver(fieldType.StreamResolver);
             }
         }
     }

--- a/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
@@ -61,7 +61,7 @@ public class SubscriptionExecutionStrategyTests
         var result = await ExecuteAsync("subscription { testWithInitialError(custom: false) }");
         result.ShouldNotBeSuccessful();
         result.Executed.ShouldBeTrue();
-        result.ShouldBeSimilarTo(@"{ ""errors"":[{ ""message"":""Could not subscribe to field \u0027testWithInitialError\u0027."",""locations"":[{ ""line"":1,""column"":16}],""path"":[""testWithInitialError""],""extensions"":{ ""code"":""APPLICATION"",""codes"":[""APPLICATION""]} }],""data"":null}");
+        result.ShouldBeSimilarTo(@"{ ""errors"":[{ ""message"":""Could not resolve source stream for field \u0027testWithInitialError\u0027."",""locations"":[{ ""line"":1,""column"":16}],""path"":[""testWithInitialError""],""extensions"":{ ""code"":""APPLICATION"",""codes"":[""APPLICATION""]} }],""data"":null}");
     }
 
     [Fact]
@@ -202,7 +202,7 @@ public class SubscriptionExecutionStrategyTests
     {
         var result = await ExecuteAsync("subscription { notSubscriptionField }");
         result.ShouldNotBeSuccessful();
-        result.ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: Subscriber not set for field \u0027notSubscriptionField\u0027."",""locations"":[{""line"":1,""column"":16}],""path"":[""notSubscriptionField""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}],""data"":null}");
+        result.ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: Stream resolver not set for field \u0027notSubscriptionField\u0027."",""locations"":[{""line"":1,""column"":16}],""path"":[""notSubscriptionField""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}],""data"":null}");
     }
 
     public int Counter = 0;

--- a/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
@@ -28,7 +28,7 @@ namespace GraphQL.Tests.Subscription
                 Name = "messageAdded",
                 Type = typeof(MessageType),
                 Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-                Subscriber = new SourceStreamResolver<Message>(Subscribe)
+                StreamResolver = new SourceStreamResolver<Message>(Subscribe)
             });
 
             AddField(new FieldType
@@ -39,7 +39,7 @@ namespace GraphQL.Tests.Subscription
                 ),
                 Type = typeof(MessageType),
                 Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-                Subscriber = new SourceStreamResolver<Message>(SubscribeById)
+                StreamResolver = new SourceStreamResolver<Message>(SubscribeById)
             });
 
             AddField(new FieldType
@@ -47,7 +47,7 @@ namespace GraphQL.Tests.Subscription
                 Name = "messageAddedAsync",
                 Type = typeof(MessageType),
                 Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-                Subscriber = new SourceStreamResolver<Message>(SubscribeAsync)
+                StreamResolver = new SourceStreamResolver<Message>(SubscribeAsync)
             });
 
             AddField(new FieldType
@@ -58,7 +58,7 @@ namespace GraphQL.Tests.Subscription
                 ),
                 Type = typeof(MessageType),
                 Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-                Subscriber = new SourceStreamResolver<Message>(SubscribeByIdAsync)
+                StreamResolver = new SourceStreamResolver<Message>(SubscribeByIdAsync)
             });
 
             AddField(new FieldType
@@ -66,7 +66,7 @@ namespace GraphQL.Tests.Subscription
                 Name = "messageGetAll",
                 Type = typeof(ListGraphType<MessageType>),
                 Resolver = new FuncFieldResolver<List<Message>>(context => context.Source as List<Message>),
-                Subscriber = new SourceStreamResolver<List<Message>>(context => _chat.MessagesGetAll())
+                StreamResolver = new SourceStreamResolver<List<Message>>(context => _chat.MessagesGetAll())
             });
 
             AddField(new FieldType
@@ -74,7 +74,7 @@ namespace GraphQL.Tests.Subscription
                 Name = "newMessageContent",
                 Type = typeof(StringGraphType),
                 Resolver = new FuncFieldResolver<string>(context => context.Source as string),
-                Subscriber = new SourceStreamResolver<string>(context => Subscribe(context).Select(message => message.Content))
+                StreamResolver = new SourceStreamResolver<string>(context => Subscribe(context).Select(message => message.Content))
             });
         }
 

--- a/src/GraphQL.Tests/Subscription/SubscriptionSchemaWithReflection.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionSchemaWithReflection.cs
@@ -41,7 +41,7 @@ namespace GraphQL.Tests.Subscription
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Conventions")]
     public class Subscription
     {
-        [GraphQLMetadata(Name = "messageAdded", ResolverType = ResolverType.Subscriber)]
+        [GraphQLMetadata(Name = "messageAdded", ResolverType = ResolverType.StreamResolver)]
         public IObservable<Message> SubscribeMessageAdded(IResolveFieldContext context)
         {
             return SubscriptionSchemaWithReflection.Chat.Messages();
@@ -53,7 +53,7 @@ namespace GraphQL.Tests.Subscription
             return context.Source as Message;
         }
 
-        [GraphQLMetadata(Name = "messageGetAll", ResolverType = ResolverType.Subscriber)]
+        [GraphQLMetadata(Name = "messageGetAll", ResolverType = ResolverType.StreamResolver)]
         public IObservable<List<Message>> SubscribeMessageGetAll(IResolveFieldContext context)
         {
             return SubscriptionSchemaWithReflection.Chat.MessagesGetAll();
@@ -65,7 +65,7 @@ namespace GraphQL.Tests.Subscription
             return context.Source as List<Message>;
         }
 
-        [GraphQLMetadata(Name = "messageAddedByUser", ResolverType = ResolverType.Subscriber)]
+        [GraphQLMetadata(Name = "messageAddedByUser", ResolverType = ResolverType.StreamResolver)]
         public IObservable<Message> SubscribeMessageAddedByUser(IResolveFieldContext context, string id)
         {
             var messages = SubscriptionSchemaWithReflection.Chat.Messages();
@@ -78,7 +78,7 @@ namespace GraphQL.Tests.Subscription
             return context.Source as Message;
         }
 
-        [GraphQLMetadata(Name = "messageAddedAsync", ResolverType = ResolverType.Subscriber)]
+        [GraphQLMetadata(Name = "messageAddedAsync", ResolverType = ResolverType.StreamResolver)]
         public Task<IObservable<Message>> SubscribeMessageAddedAsync(IResolveFieldContext context)
         {
             return SubscriptionSchemaWithReflection.Chat.MessagesAsync();
@@ -90,7 +90,7 @@ namespace GraphQL.Tests.Subscription
             return context.Source as Message;
         }
 
-        [GraphQLMetadata(Name = "messageAddedByUserAsync", ResolverType = ResolverType.Subscriber)]
+        [GraphQLMetadata(Name = "messageAddedByUserAsync", ResolverType = ResolverType.StreamResolver)]
         public async Task<IObservable<Message>> SubscribeMessageAddedByUserAsync(IResolveFieldContext context, string id)
         {
             var messages = await SubscriptionSchemaWithReflection.Chat.MessagesAsync();

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -210,7 +210,7 @@ namespace GraphQL.Builders
         /// </summary>
         public virtual FieldBuilder<TSourceType, TReturnType> Subscribe(Func<IResolveFieldContext<TSourceType>, IObservable<TReturnType?>> sourceStreamResolver)
         {
-            FieldType.Subscriber = new SourceStreamResolver<TSourceType, TReturnType>(sourceStreamResolver);
+            FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(sourceStreamResolver);
             return this;
         }
 
@@ -219,7 +219,7 @@ namespace GraphQL.Builders
         /// </summary>
         public virtual FieldBuilder<TSourceType, TReturnType> SubscribeAsync(Func<IResolveFieldContext<TSourceType>, Task<IObservable<TReturnType?>>> sourceStreamResolver)
         {
-            FieldType.Subscriber = new SourceStreamResolver<TSourceType, TReturnType>(context => new ValueTask<IObservable<TReturnType?>>(sourceStreamResolver(context)));
+            FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(context => new ValueTask<IObservable<TReturnType?>>(sourceStreamResolver(context)));
             return this;
         }
 

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -206,18 +206,18 @@ namespace GraphQL.Builders
         }
 
         /// <summary>
-        /// Sets an event resolver for the field.
+        /// Sets a source stream resolver for the field.
         /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> Subscribe(Func<IResolveFieldContext<TSourceType>, IObservable<TReturnType?>> sourceStreamResolver)
+        public virtual FieldBuilder<TSourceType, TReturnType> ResolveStream(Func<IResolveFieldContext<TSourceType>, IObservable<TReturnType?>> sourceStreamResolver)
         {
             FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(sourceStreamResolver);
             return this;
         }
 
         /// <summary>
-        /// Sets an event resolver for the field.
+        /// Sets a source stream resolver for the field.
         /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> SubscribeAsync(Func<IResolveFieldContext<TSourceType>, Task<IObservable<TReturnType?>>> sourceStreamResolver)
+        public virtual FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(Func<IResolveFieldContext<TSourceType>, Task<IObservable<TReturnType?>>> sourceStreamResolver)
         {
             FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(context => new ValueTask<IObservable<TReturnType?>>(sourceStreamResolver(context)));
             return this;

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -90,13 +90,13 @@ public class SubscriptionExecutionStrategy : ExecutionStrategy
 
         try
         {
-            if (node.FieldDefinition?.Subscriber == null)
+            if (node.FieldDefinition?.StreamResolver == null)
             {
                 // todo: this should be caught by schema validation
-                throw new InvalidOperationException($"Subscriber not set for field '{node.Field.Name}'.");
+                throw new InvalidOperationException($"Stream resolver not set for field '{node.Field.Name}'.");
             }
 
-            sourceStream = await node.FieldDefinition.Subscriber.SubscribeAsync(resolveContext).ConfigureAwait(false);
+            sourceStream = await node.FieldDefinition.StreamResolver.ResolveAsync(resolveContext).ConfigureAwait(false);
 
             if (sourceStream == null)
             {
@@ -117,7 +117,7 @@ public class SubscriptionExecutionStrategy : ExecutionStrategy
         catch (Exception exception)
         {
             context.Errors.Add(await HandleExceptionInternalAsync(context, node, exception,
-                $"Could not subscribe to field '{node.Field.Name}'.").ConfigureAwait(false));
+                $"Could not resolve source stream for field '{node.Field.Name}'.").ConfigureAwait(false));
             return null;
         }
 

--- a/src/GraphQL/GraphQLMetadataAttribute.cs
+++ b/src/GraphQL/GraphQLMetadataAttribute.cs
@@ -161,8 +161,8 @@ namespace GraphQL
         /// </summary>
         Resolver,
         /// <summary>
-        /// Indicates the specified method is an event stream resolver
+        /// Indicates the specified method is an source stream resolver
         /// </summary>
-        Subscriber
+        StreamResolver
     }
 }

--- a/src/GraphQL/Reflection/ReflectionHelper.cs
+++ b/src/GraphQL/Reflection/ReflectionHelper.cs
@@ -40,7 +40,7 @@ namespace GraphQL.Reflection
         /// </summary>
         /// <param name="type">The type to check.</param>
         /// <param name="field">The desired field.</param>
-        /// <param name="resolverType">Indicates if a resolver or subscriber method is requested.</param>
+        /// <param name="resolverType">Indicates if a resolver or stream resolver method is requested.</param>
         public static MethodInfo? MethodForField(this Type type, string field, ResolverType resolverType)
         {
             var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);

--- a/src/GraphQL/Resolvers/ISourceStreamResolver.cs
+++ b/src/GraphQL/Resolvers/ISourceStreamResolver.cs
@@ -9,6 +9,6 @@ namespace GraphQL.Resolvers
     public interface ISourceStreamResolver
     {
         /// <inheritdoc cref="ISourceStreamResolver"/>
-        ValueTask<IObservable<object?>> SubscribeAsync(IResolveFieldContext context);
+        ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context);
     }
 }

--- a/src/GraphQL/Resolvers/SourceStreamMethodResolver.cs
+++ b/src/GraphQL/Resolvers/SourceStreamMethodResolver.cs
@@ -104,7 +104,9 @@ namespace GraphQL.Resolvers
         private static async ValueTask<IObservable<object?>> CastFromTaskAsync<T>(Task<IObservable<T>> task) where T : class
             => await task.ConfigureAwait(false);
 
-        /// <inheritdoc/>
-        public ValueTask<IObservable<object?>> SubscribeAsync(IResolveFieldContext context) => _sourceStreamResolver(context);
+        /// <inheritdoc cref="ISourceStreamResolver.ResolveAsync(IResolveFieldContext)" />
+        public ValueTask<IObservable<object?>> ResolveStreamAsync(IResolveFieldContext context) => _sourceStreamResolver(context);
+
+        ValueTask<IObservable<object?>> ISourceStreamResolver.ResolveAsync(IResolveFieldContext context) => ResolveStreamAsync(context);
     }
 }

--- a/src/GraphQL/Resolvers/SourceStreamResolver.cs
+++ b/src/GraphQL/Resolvers/SourceStreamResolver.cs
@@ -34,7 +34,7 @@ namespace GraphQL.Resolvers
         }
 
         /// <inheritdoc/>
-        public ValueTask<IObservable<object?>> SubscribeAsync(IResolveFieldContext context)
+        public ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context)
             => _sourceStreamResolver(context);
     }
 
@@ -68,7 +68,7 @@ namespace GraphQL.Resolvers
         }
 
         /// <inheritdoc/>
-        public ValueTask<IObservable<object?>> SubscribeAsync(IResolveFieldContext context)
+        public ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context)
             => _sourceStreamResolver(context);
     }
 }

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -85,7 +85,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Configures query arguments and a field resolver for the specified <see cref="FieldType"/>, overwriting
         /// any existing configuration within <see cref="FieldType.Arguments"/>, <see cref="FieldType.Resolver"/>
-        /// and <see cref="FieldType.Subscriber"/>.
+        /// and <see cref="FieldType.StreamResolver"/>.
         /// <br/><br/>
         /// For fields and properties, no query arguments are added and the field resolver simply pulls the appropriate
         /// member from <see cref="IResolveFieldContext.Source"/>.
@@ -101,7 +101,7 @@ namespace GraphQL.Types
                 var resolver = new MemberResolver(propertyInfo, BuildMemberInstanceExpression(memberInfo));
                 fieldType.Arguments = null;
                 fieldType.Resolver = resolver;
-                fieldType.Subscriber = null;
+                fieldType.StreamResolver = null;
             }
             else if (memberInfo is MethodInfo methodInfo)
             {
@@ -128,13 +128,13 @@ namespace GraphQL.Types
                 {
                     var resolver = new SourceStreamMethodResolver(methodInfo, memberInstanceExpression, expressions);
                     fieldType.Resolver = resolver;
-                    fieldType.Subscriber = resolver;
+                    fieldType.StreamResolver = resolver;
                 }
                 else
                 {
                     var resolver = new MemberResolver(methodInfo, memberInstanceExpression, expressions);
                     fieldType.Resolver = resolver;
-                    fieldType.Subscriber = null;
+                    fieldType.StreamResolver = null;
                 }
                 fieldType.Arguments = queryArguments;
             }
@@ -143,7 +143,7 @@ namespace GraphQL.Types
                 var resolver = new MemberResolver(fieldInfo, BuildMemberInstanceExpression(memberInfo));
                 fieldType.Arguments = null;
                 fieldType.Resolver = resolver;
-                fieldType.Subscriber = null;
+                fieldType.StreamResolver = null;
             }
             else if (memberInfo == null)
             {

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -335,7 +335,7 @@ namespace GraphQL.Types
         /// <param name="description">The description of this field.</param>
         /// <param name="arguments">A list of arguments for the field.</param>
         /// <param name="resolve">A field resolver delegate. Data from an event stream is processed by this field resolver as the source before being passed to the field's children as the source. Typically this would be <c>context => context.Source</c>.</param>
-        /// <param name="subscribe">An even stream resolver delegate.</param>
+        /// <param name="subscribe">An source stream resolver delegate.</param>
         /// <param name="deprecationReason">The deprecation reason for the field.</param>
         /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
         public FieldType FieldSubscribe<TGraphType>(
@@ -357,7 +357,7 @@ namespace GraphQL.Types
                 Resolver = resolve != null
                     ? new FuncFieldResolver<TSourceType, object>(resolve)
                     : null,
-                Subscriber = subscribe != null
+                StreamResolver = subscribe != null
                     ? new SourceStreamResolver<object>(subscribe)
                     : null
             });
@@ -371,7 +371,7 @@ namespace GraphQL.Types
         /// <param name="description">The description of this field.</param>
         /// <param name="arguments">A list of arguments for the field.</param>
         /// <param name="resolve">A field resolver delegate. Data from an event stream is processed by this field resolver as the source before being passed to the field's children as the source. Typically this would be <c>context => context.Source</c>.</param>
-        /// <param name="subscribeAsync">An even stream resolver delegate.</param>
+        /// <param name="subscribeAsync">An source stream resolver delegate.</param>
         /// <param name="deprecationReason">The deprecation reason for the field.</param>
         /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
         public FieldType FieldSubscribeAsync<TGraphType>(
@@ -393,7 +393,7 @@ namespace GraphQL.Types
                 Resolver = resolve != null
                     ? new FuncFieldResolver<TSourceType, object>(resolve)
                     : null,
-                Subscriber = subscribeAsync != null
+                StreamResolver = subscribeAsync != null
                     ? new SourceStreamResolver<object>(context => new ValueTask<IObservable<object?>>(subscribeAsync(context)))
                     : null
             });

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -335,7 +335,7 @@ namespace GraphQL.Types
         /// <param name="description">The description of this field.</param>
         /// <param name="arguments">A list of arguments for the field.</param>
         /// <param name="resolve">A field resolver delegate. Data from an event stream is processed by this field resolver as the source before being passed to the field's children as the source. Typically this would be <c>context => context.Source</c>.</param>
-        /// <param name="subscribe">An source stream resolver delegate.</param>
+        /// <param name="subscribe">A source stream resolver delegate.</param>
         /// <param name="deprecationReason">The deprecation reason for the field.</param>
         /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
         public FieldType FieldSubscribe<TGraphType>(
@@ -371,7 +371,7 @@ namespace GraphQL.Types
         /// <param name="description">The description of this field.</param>
         /// <param name="arguments">A list of arguments for the field.</param>
         /// <param name="resolve">A field resolver delegate. Data from an event stream is processed by this field resolver as the source before being passed to the field's children as the source. Typically this would be <c>context => context.Source</c>.</param>
-        /// <param name="subscribeAsync">An source stream resolver delegate.</param>
+        /// <param name="subscribeAsync">A source stream resolver delegate.</param>
         /// <param name="deprecationReason">The deprecation reason for the field.</param>
         /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
         public FieldType FieldSubscribeAsync<TGraphType>(

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -79,6 +79,6 @@ namespace GraphQL.Types
         /// <summary>
         /// Gets or sets a subscription resolver for the field. Only applicable to subscription fields.
         /// </summary>
-        public ISourceStreamResolver? Subscriber { get; set; }
+        public ISourceStreamResolver? StreamResolver { get; set; }
     }
 }

--- a/src/GraphQL/Utilities/FieldConfig.cs
+++ b/src/GraphQL/Utilities/FieldConfig.cs
@@ -50,7 +50,7 @@ namespace GraphQL.Utilities
         /// <summary>
         /// Gets or sets the event stream resolver.
         /// </summary>
-        public ISourceStreamResolver? Subscriber { get; set; }
+        public ISourceStreamResolver? StreamResolver { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="IAccessor"/> representing the class member
@@ -62,7 +62,7 @@ namespace GraphQL.Utilities
         /// Gets or sets the <see cref="IAccessor"/> representing the class member
         /// to be executed for the subscription field's event stream resolver.
         /// </summary>
-        public IAccessor? SubscriberAccessor { get; set; }
+        public IAccessor? StreamResolverAccessor { get; set; }
 
         /// <summary>
         /// Gets configuration for specific field argument by argument name.

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -327,9 +327,9 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
         private void InitializeSubscriptionField(FieldConfig config, Type? parentType)
         {
             config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);
-            config.SubscriberAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Subscriber);
+            config.StreamResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.StreamResolver);
 
-            if (config.ResolverAccessor != null && config.SubscriberAccessor != null)
+            if (config.ResolverAccessor != null && config.StreamResolverAccessor != null)
             {
                 config.Resolver = AutoRegisteringHelper.BuildFieldResolver(
                     config.ResolverAccessor.MethodInfo,
@@ -344,8 +344,8 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
                         a.Modify(config);
                 }
 
-                config.Subscriber = AutoRegisteringHelper.BuildSourceStreamResolver(
-                    config.SubscriberAccessor.MethodInfo,
+                config.StreamResolver = AutoRegisteringHelper.BuildSourceStreamResolver(
+                    config.StreamResolverAccessor.MethodInfo,
                     null, // unknown source type
                     null, // unknown FieldType
                     AutoRegisteringHelper.BuildInstanceExpressionForSchemaBuilder(config.ResolverAccessor.DeclaringType, ServiceProvider));
@@ -404,7 +404,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
                 Description = fieldConfig.Description ?? fieldDef.Description?.Value.ToString() ?? fieldDef.MergeComments(),
                 ResolvedType = ToGraphType(fieldDef.Type!),
                 Resolver = fieldConfig.Resolver,
-                Subscriber = fieldConfig.Subscriber,
+                StreamResolver = fieldConfig.StreamResolver,
             };
 
             fieldConfig.CopyMetadataTo(field);


### PR DESCRIPTION
Last of #3022

- Rename SubscribeAsync to ResolveAsync
- Rename Subscriber to StreamResolver
- Rename field builder methods Subscribe and SubscribeAsync to ResolveStream and ResolveStreamAsync

Does not rename field builder method parameters containing delegates which are currently 'resolve' and 'subscribe'.