### PR TITLE
For 4.8, restrict parser to pre-8 versions

### DIFF
--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="7.2.0" />
+    <PackageReference Include="GraphQL-Parser" Version="[7.2.0,8.0.0)" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />


### PR DESCRIPTION
Parser 8.0.0 is not compatible with GraphQL.NET 4.8