### PR TITLE
Update migration doc re serialization

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -65,6 +65,7 @@ Specific support is provided for serializing and deserializing to the following 
 | Class                   | Notes |
 |-------------------------|-------|
 | `ExecutionResult`       | Only serialization is supported |
+| `ExecutionError`        | Only serialization is supported |
 | `GraphQLRequest`        | |
 | `IList<GraphQLRequest>` | Other common collection variations, such as `IEnumerable<>` or `List<>`, are also supported |
 | `OperationMessage`      | `Payload` is an `object` and can be deserialized to `GraphQLRequest` via `ReadNode` |


### PR DESCRIPTION
Add `ExecutionError` as a supported serialization type