### PR TITLE
Add RequestServices to ValidationContext

### DIFF
--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2827,6 +2827,7 @@ namespace GraphQL.Validation
         public GraphQL.Inputs Extensions { get; set; }
         public bool HasErrors { get; }
         public GraphQLParser.AST.GraphQLOperationDefinition Operation { get; set; }
+        public System.IServiceProvider? RequestServices { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
@@ -2844,12 +2845,12 @@ namespace GraphQL.Validation
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError
     {
-        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, GraphQLParser.AST.ASTNode node) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, params GraphQLParser.AST.ASTNode[] nodes) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, System.Exception? innerException, GraphQLParser.AST.ASTNode node) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, System.Exception? innerException, params GraphQLParser.AST.ASTNode[]? nodes) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, GraphQLParser.AST.ASTNode node) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, params GraphQLParser.AST.ASTNode[] nodes) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, System.Exception? innerException, GraphQLParser.AST.ASTNode node) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, System.Exception? innerException, params GraphQLParser.AST.ASTNode[]? nodes) { }
         public System.Collections.Generic.IEnumerable<GraphQLParser.AST.ASTNode> Nodes { get; }
-        public string Number { get; set; }
+        public string? Number { get; set; }
     }
     public readonly struct ValidationOptions
     {
@@ -2858,6 +2859,7 @@ namespace GraphQL.Validation
         public GraphQLParser.AST.GraphQLDocument Document { get; set; }
         public GraphQL.Inputs Extensions { get; set; }
         public GraphQLParser.AST.GraphQLOperationDefinition Operation { get; set; }
+        public System.IServiceProvider? RequestServices { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2845,10 +2845,12 @@ namespace GraphQL.Validation
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError
     {
-        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, GraphQLParser.AST.ASTNode node) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, params GraphQLParser.AST.ASTNode[] nodes) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, System.Exception? innerException, GraphQLParser.AST.ASTNode node) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, System.Exception? innerException, params GraphQLParser.AST.ASTNode[]? nodes) { }
+        public ValidationError(string message) { }
+        public ValidationError(string message, System.Exception? innerException) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, GraphQLParser.AST.ASTNode node) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, params GraphQLParser.AST.ASTNode[] nodes) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, System.Exception? innerException, GraphQLParser.AST.ASTNode node) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, System.Exception? innerException, params GraphQLParser.AST.ASTNode[]? nodes) { }
         public System.Collections.Generic.IEnumerable<GraphQLParser.AST.ASTNode> Nodes { get; }
         public string? Number { get; set; }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2831,10 +2831,12 @@ namespace GraphQL.Validation
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError
     {
-        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, GraphQLParser.AST.ASTNode node) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, params GraphQLParser.AST.ASTNode[] nodes) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, System.Exception? innerException, GraphQLParser.AST.ASTNode node) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, System.Exception? innerException, params GraphQLParser.AST.ASTNode[]? nodes) { }
+        public ValidationError(string message) { }
+        public ValidationError(string message, System.Exception? innerException) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, GraphQLParser.AST.ASTNode node) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, params GraphQLParser.AST.ASTNode[] nodes) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, System.Exception? innerException, GraphQLParser.AST.ASTNode node) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, System.Exception? innerException, params GraphQLParser.AST.ASTNode[]? nodes) { }
         public System.Collections.Generic.IEnumerable<GraphQLParser.AST.ASTNode> Nodes { get; }
         public string? Number { get; set; }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2813,6 +2813,7 @@ namespace GraphQL.Validation
         public GraphQL.Inputs Extensions { get; set; }
         public bool HasErrors { get; }
         public GraphQLParser.AST.GraphQLOperationDefinition Operation { get; set; }
+        public System.IServiceProvider? RequestServices { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
@@ -2830,12 +2831,12 @@ namespace GraphQL.Validation
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError
     {
-        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, GraphQLParser.AST.ASTNode node) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, params GraphQLParser.AST.ASTNode[] nodes) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, System.Exception? innerException, GraphQLParser.AST.ASTNode node) { }
-        public ValidationError(GraphQLParser.ROM originalQuery, string number, string message, System.Exception? innerException, params GraphQLParser.AST.ASTNode[]? nodes) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, GraphQLParser.AST.ASTNode node) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, params GraphQLParser.AST.ASTNode[] nodes) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, System.Exception? innerException, GraphQLParser.AST.ASTNode node) { }
+        public ValidationError(GraphQLParser.ROM originalQuery, string? number, string message, System.Exception? innerException, params GraphQLParser.AST.ASTNode[]? nodes) { }
         public System.Collections.Generic.IEnumerable<GraphQLParser.AST.ASTNode> Nodes { get; }
-        public string Number { get; set; }
+        public string? Number { get; set; }
     }
     public readonly struct ValidationOptions
     {
@@ -2844,6 +2845,7 @@ namespace GraphQL.Validation
         public GraphQLParser.AST.GraphQLDocument Document { get; set; }
         public GraphQL.Inputs Extensions { get; set; }
         public GraphQLParser.AST.GraphQLOperationDefinition Operation { get; set; }
+        public System.IServiceProvider? RequestServices { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }

--- a/src/GraphQL.Tests/Validation/RequestServicesTests.cs
+++ b/src/GraphQL.Tests/Validation/RequestServicesTests.cs
@@ -1,0 +1,68 @@
+#nullable enable
+
+using GraphQL.MicrosoftDI;
+using GraphQL.Types;
+using GraphQL.Validation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Tests.Validation;
+
+public class RequestServicesTests
+{
+    [Fact]
+    public async Task ValidationRuleUsesServiceProviderFromDocumentExecuter()
+    {
+        // prepare service provider
+        var services = new ServiceCollection();
+        services.AddScoped<Class1>();
+        services.AddGraphQL(b => b
+            .AddAutoSchema<Query>()
+            .AddValidationRule<MyValidationRule>());
+        using var provider = services.BuildServiceProvider();
+
+        // test class1 with root service provider
+        var class1 = provider.GetRequiredService<Class1>();
+        class1.GetNum.ShouldBe(1);
+
+        // should be same instance as class1
+        var class1b = provider.GetRequiredService<Class1>();
+        class1b.GetNum.ShouldBe(2);
+
+        // execute a request within a service scope
+        var executer = provider.GetRequiredService<IDocumentExecuter<ISchema>>();
+        using var scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        var result = await executer.ExecuteAsync(new ExecutionOptions
+        {
+            Query = "{hero}",
+            RequestServices = scope.ServiceProvider,
+        });
+
+        // MyValidationRule should always add an error message
+        result.Executed.ShouldBeFalse();
+
+        // verify that class1.GetNum returned "1" because it is a scoped instance
+        result.Errors.ShouldHaveSingleItem().Message.ShouldBe("Num is 1");
+    }
+
+    private class MyValidationRule : IValidationRule
+    {
+        public ValueTask<INodeVisitor?> ValidateAsync(ValidationContext context)
+        {
+            var num = context.RequestServices.GetRequiredService<Class1>().GetNum;
+            context.ReportError(new ValidationError(context.Document.Source, null, $"Num is {num}"));
+            return default;
+        }
+    }
+
+    private class Query
+    {
+        public static string Hero => "hello";
+    }
+
+    private class Class1
+    {
+        private int _num;
+
+        public int GetNum => Interlocked.Increment(ref _num);
+    }
+}

--- a/src/GraphQL.Tests/Validation/RequestServicesTests.cs
+++ b/src/GraphQL.Tests/Validation/RequestServicesTests.cs
@@ -56,7 +56,7 @@ public class RequestServicesTests
         public ValueTask<INodeVisitor?> ValidateAsync(ValidationContext context)
         {
             var num = context.RequestServices.GetRequiredService<Class1>().GetNum;
-            context.ReportError(new ValidationError(context.Document.Source, null, $"Num is {num}"));
+            context.ReportError(new ValidationError($"Num is {num}"));
             return default;
         }
     }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -161,6 +161,7 @@ namespace GraphQL
                             Rules = validationRules,
                             Operation = operation,
                             UserContext = options.UserContext,
+                            RequestServices = options.RequestServices,
                             CancellationToken = options.CancellationToken,
                             Schema = options.Schema,
                             Variables = options.Variables ?? Inputs.Empty,

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -63,6 +63,7 @@ namespace GraphQL.Validation
             context.Variables = options.Variables;
             context.Extensions = options.Extensions;
             context.Operation = options.Operation;
+            context.RequestServices = options.RequestServices;
             context.CancellationToken = options.CancellationToken;
 
             return ValidateAsyncCoreAsync(context, options.Rules ?? CoreRules);

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -25,6 +25,7 @@ namespace GraphQL.Validation
             NonUserContext = null;
             Variables = null!;
             Extensions = null!;
+            RequestServices = null!;
         }
 
         /// <summary>

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -66,6 +66,9 @@ namespace GraphQL.Validation
         /// <inheritdoc cref="ExecutionOptions.Extensions"/>
         public Inputs Extensions { get; set; } = null!;
 
+        /// <inheritdoc cref="ExecutionOptions.RequestServices"/>
+        public IServiceProvider? RequestServices { get; set; }
+
         /// <summary>
         /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;
         /// defaults to <see cref="CancellationToken.None"/>

--- a/src/GraphQL/Validation/ValidationError.cs
+++ b/src/GraphQL/Validation/ValidationError.cs
@@ -21,9 +21,8 @@ namespace GraphQL.Validation
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified error message. Sets the
-        /// <see cref="ExecutionError.Code">Code</see> property based on the inner exception.
-        /// Loads any exception data from the inner exception into this instance.
+        /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified error message and code.
+        /// Sets additional codes based on the inner exception(s). Loads any exception data from the inner exception into this instance.
         /// </summary>
         public ValidationError(string message, Exception? innerException) : base(message, innerException)
         {

--- a/src/GraphQL/Validation/ValidationError.cs
+++ b/src/GraphQL/Validation/ValidationError.cs
@@ -12,8 +12,26 @@ namespace GraphQL.Validation
     {
         private readonly List<ASTNode> _nodes = new();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified error message.
+        /// </summary>
+        public ValidationError(string message) : base(message)
+        {
+            Code = GetValidationErrorCode(GetType());
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified error message. Sets the
+        /// <see cref="ExecutionError.Code">Code</see> property based on the inner exception.
+        /// Loads any exception data from the inner exception into this instance.
+        /// </summary>
+        public ValidationError(string message, Exception? innerException) : base(message, innerException)
+        {
+            Code = GetValidationErrorCode(GetType());
+        }
+
         /// <inheritdoc cref="ValidationError(ROM, string, string, ASTNode[])"/>
-        public ValidationError(ROM originalQuery, string? number, string message, ASTNode node)
+        public ValidationError(ROM originalQuery, string number, string message, ASTNode node)
             : this(originalQuery, number, message, (Exception?)null, node)
         {
         }
@@ -22,7 +40,7 @@ namespace GraphQL.Validation
         /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified error message and code.
         /// Sets locations based on the original query and specified AST nodes that this error applies to.
         /// </summary>
-        public ValidationError(ROM originalQuery, string? number, string message, params ASTNode[] nodes)
+        public ValidationError(ROM originalQuery, string number, string message, params ASTNode[] nodes)
             : this(originalQuery, number, message, null, nodes)
         {
         }
@@ -30,7 +48,7 @@ namespace GraphQL.Validation
         /// <inheritdoc cref="ValidationError(ROM, string, string, Exception, ASTNode[])"/>
         public ValidationError(
             ROM originalQuery,
-            string? number,
+            string number,
             string message,
             Exception? innerException,
             ASTNode node)
@@ -53,7 +71,7 @@ namespace GraphQL.Validation
         /// </summary>
         public ValidationError(
             ROM originalQuery,
-            string? number,
+            string number,
             string message,
             Exception? innerException,
             params ASTNode[]? nodes)

--- a/src/GraphQL/Validation/ValidationError.cs
+++ b/src/GraphQL/Validation/ValidationError.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Validation
         private readonly List<ASTNode> _nodes = new();
 
         /// <inheritdoc cref="ValidationError(ROM, string, string, ASTNode[])"/>
-        public ValidationError(ROM originalQuery, string number, string message, ASTNode node)
+        public ValidationError(ROM originalQuery, string? number, string message, ASTNode node)
             : this(originalQuery, number, message, (Exception?)null, node)
         {
         }
@@ -22,7 +22,7 @@ namespace GraphQL.Validation
         /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified error message and code.
         /// Sets locations based on the original query and specified AST nodes that this error applies to.
         /// </summary>
-        public ValidationError(ROM originalQuery, string number, string message, params ASTNode[] nodes)
+        public ValidationError(ROM originalQuery, string? number, string message, params ASTNode[] nodes)
             : this(originalQuery, number, message, null, nodes)
         {
         }
@@ -30,7 +30,7 @@ namespace GraphQL.Validation
         /// <inheritdoc cref="ValidationError(ROM, string, string, Exception, ASTNode[])"/>
         public ValidationError(
             ROM originalQuery,
-            string number,
+            string? number,
             string message,
             Exception? innerException,
             ASTNode node)
@@ -53,7 +53,7 @@ namespace GraphQL.Validation
         /// </summary>
         public ValidationError(
             ROM originalQuery,
-            string number,
+            string? number,
             string message,
             Exception? innerException,
             params ASTNode[]? nodes)
@@ -88,6 +88,6 @@ namespace GraphQL.Validation
         /// <summary>
         /// Gets or sets the rule number of this validation error corresponding to the paragraph number from the official specification.
         /// </summary>
-        public string Number { get; set; }
+        public string? Number { get; set; }
     }
 }

--- a/src/GraphQL/Validation/ValidationOptions.cs
+++ b/src/GraphQL/Validation/ValidationOptions.cs
@@ -52,6 +52,9 @@ namespace GraphQL.Validation
         /// </summary>
         public GraphQLOperationDefinition Operation { get; init; } = null!;
 
+        /// <inheritdoc cref="ExecutionOptions.RequestServices"/>
+        public IServiceProvider? RequestServices { get; init; } = null;
+
         /// <summary>
         /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;
         /// defaults to <see cref="CancellationToken.None"/>


### PR DESCRIPTION
I tried to write a validation rule today and was quite surprised to find that I could not access the scoped service provider provided to the request.

Also, to add an error to the validation context, you have to add an instance of `ValidationError`, which currently requires that `Number` be provided.  This is merely a NRT error, as `Number` is not actually required.  Note that `Number` is defined as the following:

> Gets or sets the rule number of this validation error corresponding to the paragraph number from the official specification.

So obviously there is no "paragraph number from the official specification" for custom validation errors.  Hence `Number` should not be required for custom validation errors anyway.