### PR TITLE
Make tests that modify static variables run without parallelism

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug2194.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2194.cs
@@ -3,6 +3,7 @@ using GraphQL.Utilities;
 
 namespace GraphQL.Tests.Bugs
 {
+    [Collection("StaticTests")]
     public class Bug2194
     {
         [Fact]

--- a/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
+++ b/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
@@ -2,6 +2,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Tests.Bugs
 {
+    [Collection("StaticTests")]
     public class Bug_nested_type_names_dont_conflict :
         QueryTestBase<Bug_nested_type_names_dont_conflict.MutationSchema>
     {

--- a/src/GraphQL.Tests/CultureTestHelper.cs
+++ b/src/GraphQL.Tests/CultureTestHelper.cs
@@ -17,6 +17,7 @@ namespace GraphQL.Tests
         /// <summary>
         /// Executes the specified delegate with a variety of cultures.
         /// Be sure to mark the test class with <c>[Collection("StaticTests")]</c>
+        /// to avoid the interference of static variables.
         /// </summary>
         public static void UseCultures(Action scope)
         {

--- a/src/GraphQL.Tests/CultureTestHelper.cs
+++ b/src/GraphQL.Tests/CultureTestHelper.cs
@@ -18,7 +18,6 @@ namespace GraphQL.Tests
         /// Executes the specified delegate with a variety of cultures.
         /// Be sure to mark the test class with <c>[Collection("StaticTests")]</c>
         /// </summary>
-        /// <param name="scope"></param>
         public static void UseCultures(Action scope)
         {
             foreach (var culture in Cultures)

--- a/src/GraphQL.Tests/CultureTestHelper.cs
+++ b/src/GraphQL.Tests/CultureTestHelper.cs
@@ -4,7 +4,7 @@ namespace GraphQL.Tests
 {
     public static class CultureTestHelper
     {
-        public static IEnumerable<CultureInfo> Cultures => new[]
+        private static IEnumerable<CultureInfo> Cultures => new[]
         {
             new CultureInfo("ru-RU"),
             new CultureInfo("fi-FI"),
@@ -14,6 +14,11 @@ namespace GraphQL.Tests
             new CultureInfo(CultureInfo.CurrentCulture.Name)
         };
 
+        /// <summary>
+        /// Executes the specified delegate with a variety of cultures.
+        /// Be sure to mark the test class with <c>[Collection("StaticTests")]</c>
+        /// </summary>
+        /// <param name="scope"></param>
         public static void UseCultures(Action scope)
         {
             foreach (var culture in Cultures)
@@ -22,7 +27,7 @@ namespace GraphQL.Tests
             }
         }
 
-        public static void UseCulture(CultureInfo culture, Action scope)
+        private static void UseCulture(CultureInfo culture, Action scope)
         {
             var before = CultureInfo.CurrentCulture;
             var beforeUi = CultureInfo.CurrentUICulture;

--- a/src/GraphQL.Tests/Extensions/PrintTests.cs
+++ b/src/GraphQL.Tests/Extensions/PrintTests.cs
@@ -3,6 +3,7 @@ using GraphQLParser.AST;
 
 namespace GraphQL.Tests.Extensions
 {
+    [Collection("StaticTests")]
     public class PrintTests
     {
         [Fact]

--- a/src/GraphQL.Tests/ObjectExtensionsTest.cs
+++ b/src/GraphQL.Tests/ObjectExtensionsTest.cs
@@ -1,5 +1,6 @@
 namespace GraphQL.Tests
 {
+    [Collection("StaticTests")]
     public class ObjectExtensionsTests
     {
         [Fact]

--- a/src/GraphQL.Tests/StaticTestsCollection.cs
+++ b/src/GraphQL.Tests/StaticTestsCollection.cs
@@ -1,0 +1,11 @@
+namespace GraphQL.Tests;
+
+// decorate any test classes containing tests that modify global variables with
+//   [Collection("StaticTests")]
+// these tests will run sequentially after all other tests are complete
+// be sure to restore the global variables to their initial state with a finally block
+
+[CollectionDefinition("StaticTests", DisableParallelization = true)]
+public class StaticTestsCollection
+{
+}

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -77,74 +77,86 @@ namespace GraphQL.Tests.Types
         [Fact]
         public void auto_register_object_graph_type()
         {
-            var schema = new Schema();
-            var type = new AutoRegisteringObjectGraphType<TestObject>(o => o.valuePair, o => o.someEnumerable);
-            schema.Query = type;
-            schema.Initialize();
+            try
+            {
+                GlobalSwitches.EnableReadDescriptionFromXmlDocumentation = true;
+                var schema = new Schema();
+                var type = new AutoRegisteringObjectGraphType<TestObject>(o => o.valuePair, o => o.someEnumerable);
+                schema.Query = type;
+                schema.Initialize();
 
-            type.Name.ShouldBe(nameof(TestObject));
-            type.Description.ShouldBe("Object for test");
-            type.DeprecationReason.ShouldBe("Obsolete for test");
-            type.Fields.Count.ShouldBe(18);
-            type.Fields.First(f => f.Name == nameof(TestObject.someString)).Description.ShouldBe("Super secret");
-            type.Fields.First(f => f.Name == nameof(TestObject.someString)).Type.ShouldBe(typeof(StringGraphType));
-            type.Fields.First(f => f.Name == nameof(TestObject.someRequiredString)).Type.ShouldBe(typeof(NonNullGraphType<StringGraphType>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someInt)).Type.ShouldBe(typeof(IntGraphType));
-            type.Fields.First(f => f.Name == nameof(TestObject.someNotNullInt)).Type.ShouldBe(typeof(NonNullGraphType<IntGraphType>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someBoolean)).DeprecationReason.ShouldBe("Use someInt");
-            // disabled to make tests stable without touch GlobalSwitches
-            //type.Fields.First(f => f.Name == nameof(TestObject.someShort)).Description.ShouldBe("Description from XML comment");
-            type.Fields.First(f => f.Name == nameof(TestObject.someEnumerableOfString)).Type.ShouldBe(typeof(ListGraphType<StringGraphType>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someEnum)).Type.ShouldBe(typeof(NonNullGraphType<EnumerationGraphType<Direction>>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someNullableEnum)).Type.ShouldBe(typeof(EnumerationGraphType<Direction>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someList)).Type.ShouldBe(typeof(ListGraphType<NonNullGraphType<IntGraphType>>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someListWithNullable)).Type.ShouldBe(typeof(ListGraphType<IntGraphType>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someRequiredList)).Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someRequiredListWithNullable)).Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<IntGraphType>>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someMoney)).Type.ShouldBe(typeof(AutoRegisteringObjectGraphType<Money>));
+                type.Name.ShouldBe(nameof(TestObject));
+                type.Description.ShouldBe("Object for test");
+                type.DeprecationReason.ShouldBe("Obsolete for test");
+                type.Fields.Count.ShouldBe(18);
+                type.Fields.First(f => f.Name == nameof(TestObject.someString)).Description.ShouldBe("Super secret");
+                type.Fields.First(f => f.Name == nameof(TestObject.someString)).Type.ShouldBe(typeof(StringGraphType));
+                type.Fields.First(f => f.Name == nameof(TestObject.someRequiredString)).Type.ShouldBe(typeof(NonNullGraphType<StringGraphType>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someInt)).Type.ShouldBe(typeof(IntGraphType));
+                type.Fields.First(f => f.Name == nameof(TestObject.someNotNullInt)).Type.ShouldBe(typeof(NonNullGraphType<IntGraphType>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someBoolean)).DeprecationReason.ShouldBe("Use someInt");
+                type.Fields.First(f => f.Name == nameof(TestObject.someShort)).Description.ShouldBe("Description from XML comment");
+                type.Fields.First(f => f.Name == nameof(TestObject.someEnumerableOfString)).Type.ShouldBe(typeof(ListGraphType<StringGraphType>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someEnum)).Type.ShouldBe(typeof(NonNullGraphType<EnumerationGraphType<Direction>>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someNullableEnum)).Type.ShouldBe(typeof(EnumerationGraphType<Direction>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someList)).Type.ShouldBe(typeof(ListGraphType<NonNullGraphType<IntGraphType>>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someListWithNullable)).Type.ShouldBe(typeof(ListGraphType<IntGraphType>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someRequiredList)).Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someRequiredListWithNullable)).Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<IntGraphType>>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someMoney)).Type.ShouldBe(typeof(AutoRegisteringObjectGraphType<Money>));
 
-            var enumType = new EnumerationGraphType<Direction>();
-            // disabled to make tests stable without touch GlobalSwitches
-            //enumType.Values["DESC"].Description.ShouldBe("Descending Order");
-            enumType.Values["RANDOM"].DeprecationReason.ShouldBe("Do not use Random. This makes no sense!");
+                var enumType = new EnumerationGraphType<Direction>();
+                enumType.Values["DESC"].Description.ShouldBe("Descending Order");
+                enumType.Values["RANDOM"].DeprecationReason.ShouldBe("Do not use Random. This makes no sense!");
+            }
+            finally
+            {
+                GlobalSwitches.EnableReadDescriptionFromXmlDocumentation = false;
+            }
         }
 
         [Fact]
         public void auto_register_input_object_graph_type()
         {
-            var schema = new Schema();
-            var type = new AutoRegisteringInputObjectGraphType<TestObject>(o => o.valuePair, o => o.someEnumerable);
-            var query = new ObjectGraphType();
-            query.Field<StringGraphType>("test", arguments: new QueryArguments(new QueryArgument(type) { Name = "input" }));
-            schema.Query = query;
-            schema.Initialize();
+            try
+            {
+                GlobalSwitches.EnableReadDescriptionFromXmlDocumentation = true;
+                var schema = new Schema();
+                var type = new AutoRegisteringInputObjectGraphType<TestObject>(o => o.valuePair, o => o.someEnumerable);
+                var query = new ObjectGraphType();
+                query.Field<StringGraphType>("test", arguments: new QueryArguments(new QueryArgument(type) { Name = "input" }));
+                schema.Query = query;
+                schema.Initialize();
 
-            type.Name.ShouldBe(nameof(TestObject));
-            type.Description.ShouldBe("Object for test");
-            type.DeprecationReason.ShouldBe("Obsolete for test");
-            type.Fields.Count.ShouldBe(18);
-            type.Fields.First(f => f.Name == nameof(TestObject.someString)).Description.ShouldBe("Super secret");
-            type.Fields.First(f => f.Name == nameof(TestObject.someString)).Type.ShouldBe(typeof(StringGraphType));
-            type.Fields.First(f => f.Name == nameof(TestObject.someRequiredString)).Type.ShouldBe(typeof(NonNullGraphType<StringGraphType>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someInt)).Type.ShouldBe(typeof(IntGraphType));
-            type.Fields.First(f => f.Name == nameof(TestObject.someNotNullInt)).Type.ShouldBe(typeof(NonNullGraphType<IntGraphType>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someBoolean)).DeprecationReason.ShouldBe("Use someInt");
-            type.Fields.First(f => f.Name == nameof(TestObject.someDate)).DefaultValue.ShouldBe(new DateTime(2019, 3, 14));
-            // disabled to make tests stable without touch GlobalSwitches
-            //type.Fields.First(f => f.Name == nameof(TestObject.someShort)).Description.ShouldBe("Description from XML comment");
-            type.Fields.First(f => f.Name == nameof(TestObject.someEnumerableOfString)).Type.ShouldBe(typeof(ListGraphType<StringGraphType>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someEnum)).Type.ShouldBe(typeof(NonNullGraphType<EnumerationGraphType<Direction>>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someNullableEnum)).Type.ShouldBe(typeof(EnumerationGraphType<Direction>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someList)).Type.ShouldBe(typeof(ListGraphType<NonNullGraphType<IntGraphType>>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someListWithNullable)).Type.ShouldBe(typeof(ListGraphType<IntGraphType>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someRequiredList)).Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someRequiredListWithNullable)).Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<IntGraphType>>));
-            type.Fields.First(f => f.Name == nameof(TestObject.someMoney)).Type.ShouldBe(typeof(AutoRegisteringInputObjectGraphType<Money>));
+                type.Name.ShouldBe(nameof(TestObject));
+                type.Description.ShouldBe("Object for test");
+                type.DeprecationReason.ShouldBe("Obsolete for test");
+                type.Fields.Count.ShouldBe(18);
+                type.Fields.First(f => f.Name == nameof(TestObject.someString)).Description.ShouldBe("Super secret");
+                type.Fields.First(f => f.Name == nameof(TestObject.someString)).Type.ShouldBe(typeof(StringGraphType));
+                type.Fields.First(f => f.Name == nameof(TestObject.someRequiredString)).Type.ShouldBe(typeof(NonNullGraphType<StringGraphType>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someInt)).Type.ShouldBe(typeof(IntGraphType));
+                type.Fields.First(f => f.Name == nameof(TestObject.someNotNullInt)).Type.ShouldBe(typeof(NonNullGraphType<IntGraphType>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someBoolean)).DeprecationReason.ShouldBe("Use someInt");
+                type.Fields.First(f => f.Name == nameof(TestObject.someDate)).DefaultValue.ShouldBe(new DateTime(2019, 3, 14));
+                type.Fields.First(f => f.Name == nameof(TestObject.someShort)).Description.ShouldBe("Description from XML comment");
+                type.Fields.First(f => f.Name == nameof(TestObject.someEnumerableOfString)).Type.ShouldBe(typeof(ListGraphType<StringGraphType>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someEnum)).Type.ShouldBe(typeof(NonNullGraphType<EnumerationGraphType<Direction>>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someNullableEnum)).Type.ShouldBe(typeof(EnumerationGraphType<Direction>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someList)).Type.ShouldBe(typeof(ListGraphType<NonNullGraphType<IntGraphType>>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someListWithNullable)).Type.ShouldBe(typeof(ListGraphType<IntGraphType>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someRequiredList)).Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someRequiredListWithNullable)).Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<IntGraphType>>));
+                type.Fields.First(f => f.Name == nameof(TestObject.someMoney)).Type.ShouldBe(typeof(AutoRegisteringInputObjectGraphType<Money>));
 
-            var enumType = new EnumerationGraphType<Direction>();
-            // disabled to make tests stable without touch GlobalSwitches
-            //enumType.Values["DESC"].Description.ShouldBe("Descending Order");
-            enumType.Values["RANDOM"].DeprecationReason.ShouldBe("Do not use Random. This makes no sense!");
+                var enumType = new EnumerationGraphType<Direction>();
+                enumType.Values["DESC"].Description.ShouldBe("Descending Order");
+                enumType.Values["RANDOM"].DeprecationReason.ShouldBe("Do not use Random. This makes no sense!");
+            }
+            finally
+            {
+                GlobalSwitches.EnableReadDescriptionFromXmlDocumentation = false;
+            }
         }
 
         [Fact]

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -8,6 +8,7 @@ using GraphQL.Utilities;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class ComplexGraphTypeTests
     {
         internal class ComplexType<T> : ObjectGraphType<T>

--- a/src/GraphQL.Tests/Types/DateGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DateGraphTypeTests.cs
@@ -3,6 +3,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class DateGraphTypeTests
     {
         private readonly DateGraphType _type = new DateGraphType();

--- a/src/GraphQL.Tests/Types/DateOnlyGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DateOnlyGraphTypeTests.cs
@@ -5,6 +5,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class DateOnlyGraphTypeTests
     {
         private readonly DateOnlyGraphType _type = new();

--- a/src/GraphQL.Tests/Types/DateTimeGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DateTimeGraphTypeTests.cs
@@ -3,6 +3,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class DateTimeGraphTypeTests
     {
         private readonly DateTimeGraphType _type = new DateTimeGraphType();

--- a/src/GraphQL.Tests/Types/DateTimeOffsetGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DateTimeOffsetGraphTypeTests.cs
@@ -3,6 +3,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class DateTimeOffsetGraphTypeTests
     {
         private readonly DateTimeOffsetGraphType _type = new DateTimeOffsetGraphType();

--- a/src/GraphQL.Tests/Types/DecimalGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/DecimalGraphTypeTests.cs
@@ -3,6 +3,7 @@ using GraphQLParser.AST;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class DecimalGraphTypeTests
     {
         private readonly DecimalGraphType _type = new DecimalGraphType();

--- a/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/FloatGraphTypeTests.cs
@@ -4,6 +4,7 @@ using GraphQLParser.AST;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class FloatGraphTypeTests
     {
         private readonly FloatGraphType type = new FloatGraphType();

--- a/src/GraphQL.Tests/Types/TimeOnlyGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/TimeOnlyGraphTypeTests.cs
@@ -5,6 +5,7 @@ using GraphQL.Types;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class TimeOnlyGraphTypeTests
     {
         private readonly TimeOnlyGraphType _type = new();

--- a/src/GraphQL.Tests/Types/TimeSpanMillisecondsGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/TimeSpanMillisecondsGraphTypeTests.cs
@@ -5,6 +5,7 @@ using GraphQLParser.AST;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class TimeSpanMillisecondsGraphTypeTests
     {
         public class TimeSpanMillisecondsGraphTypeTestsData : IEnumerable<object[]>

--- a/src/GraphQL.Tests/Types/TimeSpanSecondsGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/TimeSpanSecondsGraphTypeTests.cs
@@ -5,6 +5,7 @@ using GraphQLParser.AST;
 
 namespace GraphQL.Tests.Types
 {
+    [Collection("StaticTests")]
     public class TimeSpanSecondsGraphTypeTests
     {
         public class TimeSpanSecondsGraphTypeTestsData : IEnumerable<object[]>

--- a/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
+++ b/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
@@ -3,6 +3,7 @@ using GraphQL.Validation.Rules;
 
 namespace GraphQL.Tests.Validation
 {
+    [Collection("StaticTests")]
     public class ArgumentsOfCorrectTypeTests : ValidationTestBase<ArgumentsOfCorrectType, ValidationSchema>
     {
         [Fact]

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -4,6 +4,11 @@ using GraphQL.Utilities;
 
 namespace GraphQL
 {
+    // decorate any test classes which contain tests that modify these global switches with
+    //   [Collection("StaticTests")]
+    // these tests will run sequentially after all other tests are complete
+    // be sure to restore the global switch to its initial state with a finally block
+
     /// <summary>
     /// Global options for configuring GraphQL execution.
     /// </summary>


### PR DESCRIPTION
Fixes remainder of #2982 issues (hopefully).

See:
- https://xunit.net/docs/shared-context
- https://xunit.net/docs/running-tests-in-parallel

> By default, each test class is a unique test collection. Tests within the same test class will not run in parallel against each other.

> If we need to indicate that multiple test classes should not be run in parallel against one another, then we place them into the same test collection. This is simply a matter of decorating each test class with an attribute that places them into the same uniquely named test collection:

> Parallel-capable test collections will be run first (in parallel), followed by parallel-disabled test collections (run sequentially).

So with these changes,
  1. All tests that modify static variables are now placed in the same "test collection" called "StaticTests", so that all those tests "will not run in parallel against each other.
  2. The new test collection (called "StaticTests") has parallelism disabled, which means it will run sequentially after all other tests complete

So basically all tests within a class marked with `[Collection("StaticTests")]` are guaranteed to not run in parallel with any other tests.

All tests that use the `CultureTestHelper` or modify `GlobalSwitches` have had their test classes marked with `[Collection("StaticTests")]`
