### PR TITLE
C#10: Natural type of a lambda expression

### DIFF
--- a/src/GraphQL.Tests/Bugs/Issue2932_DemoDIGraphType.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2932_DemoDIGraphType.cs
@@ -176,7 +176,7 @@ public class Issue2932_DemoDIGraphType : QueryTestBase<Issue2932_DemoDIGraphType
 
         // each field resolver will build a new instance of DIObject
         protected override LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo)
-            => (Expression<Func<IResolveFieldContext, DIObject>>)(context => MemberInstanceFunc(context));
+            => (IResolveFieldContext context) => MemberInstanceFunc(context);
 
         private DIObject MemberInstanceFunc(IResolveFieldContext context)
         {

--- a/src/GraphQL.Tests/Types/ArgumentInformationTests.cs
+++ b/src/GraphQL.Tests/Types/ArgumentInformationTests.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using System.Linq.Expressions;
 using System.Reflection;
 using GraphQL.Types;
 

--- a/src/GraphQL.Tests/Types/ArgumentInformationTests.cs
+++ b/src/GraphQL.Tests/Types/ArgumentInformationTests.cs
@@ -23,7 +23,7 @@ public class ArgumentInformationTests
     {
         var info = new ArgumentInformation(_testParameterInfo, typeof(object), new FieldType(), new TypeInformation(_testParameterInfo))
         {
-            Expression = (Expression<Func<IResolveFieldContext, int>>)(context => 23)
+            Expression = (IResolveFieldContext context) => 23
         };
         info.Expression.Compile().DynamicInvoke(new object?[] { null }).ShouldBeOfType<int>().ShouldBe(23);
     }
@@ -33,7 +33,7 @@ public class ArgumentInformationTests
     {
         var info = new ArgumentInformation(_testParameterInfo, typeof(object), new FieldType(), new TypeInformation(_testParameterInfo))
         {
-            Expression = (Expression<Func<IResolveFieldContext, object>>)(context => 23)
+            Expression = (IResolveFieldContext context) => 23
         };
         info.Expression.Compile().DynamicInvoke(new object?[] { null }).ShouldBeOfType<int>().ShouldBe(23);
     }
@@ -42,7 +42,7 @@ public class ArgumentInformationTests
     public void Expression_Throws_For_Invalid_ObjectType()
     {
         var info = new ArgumentInformation(_testParameterInfo, typeof(object), new FieldType(), new TypeInformation(_testParameterInfo));
-        var error = Should.Throw<ArgumentException>(() => info.Expression = (Expression<Func<IResolveFieldContext, object>>)(context => "hello"));
+        var error = Should.Throw<ArgumentException>(() => info.Expression = (IResolveFieldContext context) => "hello");
         error.Message.ShouldBe("Value must be a lambda expression delegate of type Func<IResolveFieldContext, Int32>.");
     }
 
@@ -50,7 +50,7 @@ public class ArgumentInformationTests
     public void Expression_Throws_For_Invalid_Type()
     {
         var info = new ArgumentInformation(_testParameterInfo, typeof(object), new FieldType(), new TypeInformation(_testParameterInfo));
-        var error = Should.Throw<ArgumentException>(() => info.Expression = (Expression<Func<IResolveFieldContext, string>>)(context => "hello"));
+        var error = Should.Throw<ArgumentException>(() => info.Expression = (IResolveFieldContext context) => "hello");
         error.Message.ShouldBe("Value must be a lambda expression delegate of type Func<IResolveFieldContext, Int32>.");
     }
 

--- a/src/GraphQL/Types/ArgumentInformation.cs
+++ b/src/GraphQL/Types/ArgumentInformation.cs
@@ -38,13 +38,11 @@ namespace GraphQL.Types
         {
             if (parameterInfo.ParameterType == typeof(IResolveFieldContext))
             {
-                Expression<Func<IResolveFieldContext, IResolveFieldContext>> expr = x => x;
-                Expression = expr;
+                Expression = (IResolveFieldContext x) => x;
             }
             else if (parameterInfo.ParameterType == typeof(CancellationToken))
             {
-                Expression<Func<IResolveFieldContext, CancellationToken>> expr = x => x.CancellationToken;
-                Expression = expr;
+                Expression = (IResolveFieldContext x) => x.CancellationToken;
             }
         }
 
@@ -131,7 +129,7 @@ namespace GraphQL.Types
             if (typeof(TParameterType) != ParameterInfo.ParameterType)
                 throw new ArgumentException($"Delegate must be of type Func<IResolveFieldContext, {ParameterInfo.ParameterType.Name}>.", nameof(argumentDelegate));
 
-            Expression = (Expression<Func<IResolveFieldContext, TParameterType?>>)(context => argumentDelegate(context));
+            Expression = (IResolveFieldContext context) => argumentDelegate(context);
         }
 
         /// <summary>


### PR DESCRIPTION
New feature of C#10 https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/lambda-expressions#natural-type-of-a-lambda-expression - compiler now may infer type of lambda used for methods and expressions.

Rel: https://github.com/github/codeql/issues/8627 
