### PR TITLE
Add role support to authorization extensions

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -608,6 +608,19 @@ This allows for specifying roles rather than just policies that can be used to v
 As with `AuthorizeWithPolicy` (renamed from `AuthorizeWith`), it requires support by a third-party
 library to perform the validation.
 
+Similar to the ASP.Net Core `AuthorizeAttribute`, the new `AuthorizeWithRoles` method accepts
+a comma-separated list of role names that would allow access to the graph or field.
+
+```csharp
+graph.AuthorizeWithRoles("Administrators,Managers");
+```
+
+You may also supply a list of strings as in the following example:
+
+```csharp
+graph.AuthorizeWithRoles("Administrators", "Managers");
+```
+
 ## Breaking Changes
 
 ### 1. UnhandledExceptionDelegate

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -1118,4 +1118,4 @@ This was done for the purposes of the overall strategy for reducing memory consu
 
 ### 47. `AuthorizeWith` renamed to `AuthorizeWithPolicy`
 
-This change was made to clarify and differentiate between `AuthorizeWithRoles`
+This change was made to clarify and differentiate between `AuthorizeWithRoles`.

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -608,7 +608,7 @@ This allows for specifying roles rather than just policies that can be used to v
 As with `AuthorizeWithPolicy` (renamed from `AuthorizeWith`), it requires support by a third-party
 library to perform the validation.
 
-Similar to the ASP.Net Core `AuthorizeAttribute`, the new `AuthorizeWithRoles` method accepts
+Similar to the ASP.NET Core `AuthorizeAttribute`, the new `AuthorizeWithRoles` method accepts
 a comma-separated list of role names that would allow access to the graph or field.
 
 ```csharp

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -602,6 +602,12 @@ There are a number of other minor issues fixed; see these links for more details
 - https://github.com/graphql-dotnet/graphql-dotnet/issues/3002
 - https://github.com/graphql-dotnet/graphql-dotnet/pull/3004
 
+### 20. `AuthorizeWithRoles` added in GraphQL 5.1.0
+
+This allows for specifying roles rather than just policies that can be used to validate a request.
+As with `AuthorizeWithPolicy` (renamed from `AuthorizeWith`), it requires support by a third-party
+library to perform the validation.
+
 ## Breaking Changes
 
 ### 1. UnhandledExceptionDelegate
@@ -1109,3 +1115,7 @@ GraphQL.NET v5 it is enabled by default as part of the `DocumentValidator.CoreRu
 ### 46. `ValidationContext.GetRecursiveVariables` returns null instead of an empty list
 
 This was done for the purposes of the overall strategy for reducing memory consumption.
+
+### 47. `AuthorizeWith` renamed to `AuthorizeWithPolicy`
+
+This change was made to clarify and differentiate between `AuthorizeWithRoles`

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -3,11 +3,17 @@ namespace GraphQL
     public static class AuthorizationExtensions
     {
         public const string POLICY_KEY = "Authorization__Policies";
+        public const string ROLE_KEY = "Authorization__Roles";
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
         public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string roles) { }
+        public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, string roles)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string roles) { }
         public static System.Collections.Generic.List<string>? GetPolicies(this GraphQL.Types.IProvideMetadata provider) { }
+        public static System.Collections.Generic.List<string>? GetRoles(this GraphQL.Types.IProvideMetadata provider) { }
         public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata provider) { }
     }
     [System.Flags]
@@ -194,8 +200,10 @@ namespace GraphQL
     }
     public class GraphQLAuthorizeAttribute : GraphQL.GraphQLAttribute
     {
+        public GraphQLAuthorizeAttribute() { }
         public GraphQLAuthorizeAttribute(string policy) { }
-        public string Policy { get; }
+        public string? Policy { get; set; }
+        public string? Roles { get; set; }
         public override void Modify(GraphQL.Types.IGraphType graphType) { }
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Utilities.TypeConfig type) { }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -4,12 +4,12 @@ namespace GraphQL
     {
         public const string POLICY_KEY = "Authorization__Policies";
         public const string ROLE_KEY = "Authorization__Roles";
-        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
-        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
-        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithPolicy<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
         public static TMetadataProvider AuthorizeWithPolicy<TMetadataProvider>(this TMetadataProvider provider, string policy)

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -4,14 +4,25 @@ namespace GraphQL
     {
         public const string POLICY_KEY = "Authorization__Policies";
         public const string ROLE_KEY = "Authorization__Roles";
+        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
+        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
         public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithPolicy<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
+        public static TMetadataProvider AuthorizeWithPolicy<TMetadataProvider>(this TMetadataProvider provider, string policy)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWithPolicy<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string roles) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, params string[] roles) { }
         public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, string roles)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, params string[] roles)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string roles) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, params string[] roles) { }
         public static System.Collections.Generic.List<string>? GetPolicies(this GraphQL.Types.IProvideMetadata provider) { }
         public static System.Collections.Generic.List<string>? GetRoles(this GraphQL.Types.IProvideMetadata provider) { }
         public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata provider) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3,11 +3,17 @@ namespace GraphQL
     public static class AuthorizationExtensions
     {
         public const string POLICY_KEY = "Authorization__Policies";
+        public const string ROLE_KEY = "Authorization__Roles";
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
         public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string roles) { }
+        public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, string roles)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string roles) { }
         public static System.Collections.Generic.List<string>? GetPolicies(this GraphQL.Types.IProvideMetadata provider) { }
+        public static System.Collections.Generic.List<string>? GetRoles(this GraphQL.Types.IProvideMetadata provider) { }
         public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata provider) { }
     }
     [System.Flags]
@@ -194,8 +200,10 @@ namespace GraphQL
     }
     public class GraphQLAuthorizeAttribute : GraphQL.GraphQLAttribute
     {
+        public GraphQLAuthorizeAttribute() { }
         public GraphQLAuthorizeAttribute(string policy) { }
-        public string Policy { get; }
+        public string? Policy { get; set; }
+        public string? Roles { get; set; }
         public override void Modify(GraphQL.Types.IGraphType graphType) { }
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Utilities.TypeConfig type) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -4,12 +4,12 @@ namespace GraphQL
     {
         public const string POLICY_KEY = "Authorization__Policies";
         public const string ROLE_KEY = "Authorization__Roles";
-        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
-        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
-        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithPolicy<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
         public static TMetadataProvider AuthorizeWithPolicy<TMetadataProvider>(this TMetadataProvider provider, string policy)

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -4,14 +4,25 @@ namespace GraphQL
     {
         public const string POLICY_KEY = "Authorization__Policies";
         public const string ROLE_KEY = "Authorization__Roles";
+        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
+        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
         public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        [System.Obsolete("Please use AuthorizeWithPolicy instead.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithPolicy<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
+        public static TMetadataProvider AuthorizeWithPolicy<TMetadataProvider>(this TMetadataProvider provider, string policy)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWithPolicy<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string roles) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, params string[] roles) { }
         public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, string roles)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, params string[] roles)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string roles) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, params string[] roles) { }
         public static System.Collections.Generic.List<string>? GetPolicies(this GraphQL.Types.IProvideMetadata provider) { }
         public static System.Collections.Generic.List<string>? GetRoles(this GraphQL.Types.IProvideMetadata provider) { }
         public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata provider) { }

--- a/src/GraphQL.Tests/AuthorizationTests.cs
+++ b/src/GraphQL.Tests/AuthorizationTests.cs
@@ -1,0 +1,116 @@
+using GraphQL.Types;
+
+namespace GraphQL.Tests;
+
+public class AuthorizationTests
+{
+    [Fact]
+    public void Field()
+    {
+        var field = new FieldType();
+        field.RequiresAuthorization().ShouldBeFalse();
+        field.AuthorizeWith("Policy1");
+        field.RequiresAuthorization().ShouldBeTrue();
+        field.AuthorizeWith("Policy2");
+        field.AuthorizeWith("Policy2");
+        field.AuthorizeWithRoles("Role1,Role2");
+        field.AuthorizeWithRoles("Role3, Role2");
+
+        field.RequiresAuthorization().ShouldBeTrue();
+        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2" });
+        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+    }
+
+    [Fact]
+    public void FieldBuilder()
+    {
+        var graph = new ObjectGraphType();
+        graph.Field<StringGraphType>("Field")
+            .AuthorizeWith("Policy1")
+            .AuthorizeWith("Policy2")
+            .AuthorizeWith("Policy2")
+            .AuthorizeWithRoles("Role1,Role2")
+            .AuthorizeWithRoles("Role3, Role2");
+
+        var field = graph.Fields.Find("Field");
+        field.RequiresAuthorization().ShouldBeTrue();
+        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2" });
+        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+    }
+
+    [Fact]
+    public void ConnectionBuilder()
+    {
+        var graph = new ObjectGraphType();
+        graph.Connection<StringGraphType>()
+            .Name("Field")
+            .AuthorizeWith("Policy1")
+            .AuthorizeWith("Policy2")
+            .AuthorizeWith("Policy2")
+            .AuthorizeWithRoles("Role1,Role2")
+            .AuthorizeWithRoles("Role3, Role2");
+
+        var field = graph.Fields.Find("Field");
+        field.RequiresAuthorization().ShouldBeTrue();
+        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2" });
+        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+    }
+
+    [Fact]
+    public void AutoOutputGraphType()
+    {
+        var graph = new AutoRegisteringObjectGraphType<Class1>();
+        graph.RequiresAuthorization().ShouldBeTrue();
+        graph.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
+        graph.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+
+        graph.Fields.Find("Id").RequiresAuthorization().ShouldBeFalse();
+
+        var field = graph.Fields.Find("Name");
+        field.RequiresAuthorization().ShouldBeTrue();
+        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
+        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+    }
+
+    [Fact]
+    public void SchemaBuilder()
+    {
+        var schema = Schema.For(
+            @"
+type Class1 {
+  id: String!
+  name: String!
+}",
+            configure => configure.Types.Include<Class1>());
+
+        var graph = (ObjectGraphType)schema.AllTypes["Class1"];
+        graph.RequiresAuthorization().ShouldBeTrue();
+        graph.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
+        graph.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+
+        graph.Fields.Find("id").RequiresAuthorization().ShouldBeFalse();
+
+        var field = graph.Fields.Find("name");
+        field.RequiresAuthorization().ShouldBeTrue();
+        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
+        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+    }
+
+    [GraphQLAuthorize("Policy1")]
+    [GraphQLAuthorize("Policy2")]
+    [GraphQLAuthorize("Policy2")]
+    [GraphQLAuthorize(Policy = "Policy3")]
+    [GraphQLAuthorize(Roles = "Role1,Role2")]
+    [GraphQLAuthorize(Roles = "Role3, Role2")]
+    private class Class1
+    {
+        public string Id { get; set; }
+        [GraphQLAuthorize("Policy1")]
+        [GraphQLAuthorize("Policy2")]
+        [GraphQLAuthorize("Policy2")]
+        [GraphQLAuthorize(Policy = "Policy3")]
+        [GraphQLAuthorize(Roles = "Role1,Role2")]
+        [GraphQLAuthorize(Roles = "Role3, Role2")]
+        public string Name { get; set; }
+    }
+}

--- a/src/GraphQL.Tests/AuthorizationTests.cs
+++ b/src/GraphQL.Tests/AuthorizationTests.cs
@@ -13,12 +13,15 @@ public class AuthorizationTests
         field.RequiresAuthorization().ShouldBeTrue();
         field.AuthorizeWith("Policy2");
         field.AuthorizeWith("Policy2");
+        field.AuthorizeWithPolicy("Policy3");
+        field.AuthorizeWithPolicy("Policy3");
         field.AuthorizeWithRoles("Role1,Role2");
         field.AuthorizeWithRoles("Role3, Role2");
+        field.AuthorizeWithRoles("Role1", "Role4");
 
         field.RequiresAuthorization().ShouldBeTrue();
-        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2" });
-        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
+        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3", "Role4" });
     }
 
     [Fact]
@@ -29,13 +32,16 @@ public class AuthorizationTests
             .AuthorizeWith("Policy1")
             .AuthorizeWith("Policy2")
             .AuthorizeWith("Policy2")
+            .AuthorizeWithPolicy("Policy3")
+            .AuthorizeWithPolicy("Policy3")
             .AuthorizeWithRoles("Role1,Role2")
-            .AuthorizeWithRoles("Role3, Role2");
+            .AuthorizeWithRoles("Role3, Role2")
+            .AuthorizeWithRoles("Role1", "Role4");
 
         var field = graph.Fields.Find("Field");
         field.RequiresAuthorization().ShouldBeTrue();
-        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2" });
-        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
+        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3", "Role4" });
     }
 
     [Fact]
@@ -47,13 +53,16 @@ public class AuthorizationTests
             .AuthorizeWith("Policy1")
             .AuthorizeWith("Policy2")
             .AuthorizeWith("Policy2")
+            .AuthorizeWithPolicy("Policy3")
+            .AuthorizeWithPolicy("Policy3")
             .AuthorizeWithRoles("Role1,Role2")
-            .AuthorizeWithRoles("Role3, Role2");
+            .AuthorizeWithRoles("Role3, Role2")
+            .AuthorizeWithRoles("Role1", "Role4");
 
         var field = graph.Fields.Find("Field");
         field.RequiresAuthorization().ShouldBeTrue();
-        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2" });
-        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+        field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
+        field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3", "Role4" });
     }
 
     [Fact]

--- a/src/GraphQL.Tests/AuthorizationTests.cs
+++ b/src/GraphQL.Tests/AuthorizationTests.cs
@@ -18,6 +18,7 @@ public class AuthorizationTests
         field.AuthorizeWithRoles("Role1,Role2");
         field.AuthorizeWithRoles("Role3, Role2");
         field.AuthorizeWithRoles("Role1", "Role4");
+        field.AuthorizeWithRoles("");
 
         field.RequiresAuthorization().ShouldBeTrue();
         field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });

--- a/src/GraphQL.Tests/AuthorizationTests.cs
+++ b/src/GraphQL.Tests/AuthorizationTests.cs
@@ -26,6 +26,17 @@ public class AuthorizationTests
     }
 
     [Fact]
+    public void NoRolesNoop()
+    {
+        var field = new FieldType();
+        field.AuthorizeWithRoles();
+        field.AuthorizeWithRoles("");
+        field.AuthorizeWithRoles(" ");
+        field.AuthorizeWithRoles(",");
+        field.RequiresAuthorization().ShouldBeFalse();
+    }
+
+    [Fact]
     public void FieldBuilder()
     {
         var graph = new ObjectGraphType();

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -163,8 +163,6 @@ namespace GraphQL
         /// be comma-separated and role names will be trimmed. If the underlying field already
         /// contains a role with the same name, then it will not be added twice.
         /// </summary>
-        /// <typeparam name="TSourceType"></typeparam>
-        /// <param name="builder"></param>
         /// <param name="roles"> Comma-separated list of authorization role name(s). </param>
         /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
         public static ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -81,7 +81,7 @@ namespace GraphQL
         }
 
         /// <inheritdoc cref="AuthorizeWithPolicy{TMetadataProvider}(TMetadataProvider, string)"/>
-        [Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : IProvideMetadata
             => AuthorizeWithPolicy(provider, policy);
@@ -111,7 +111,7 @@ namespace GraphQL
             foreach (var role in roles.Split(','))
             {
                 var role2 = role.Trim();
-                if (!list.Contains(role2))
+                if (role2 != "" && !list.Contains(role2))
                     list.Add(role2);
             }
 
@@ -167,7 +167,7 @@ namespace GraphQL
         }
 
         /// <inheritdoc cref="AuthorizeWith{TSourceType, TReturnType}(FieldBuilder{TSourceType, TReturnType}, string)"/>
-        [Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(
             this FieldBuilder<TSourceType, TReturnType> builder, string policy)
             => AuthorizeWithPolicy(builder, policy);
@@ -217,7 +217,7 @@ namespace GraphQL
         }
 
         /// <inheritdoc cref="AuthorizeWithPolicy{TSourceType}(ConnectionBuilder{TSourceType}, string)"/>
-        [Obsolete("Please use AuthorizeWithPolicy instead.")]
+        [Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(
             this ConnectionBuilder<TSourceType> builder, string policy)
             => AuthorizeWithPolicy(builder, policy);

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -65,7 +65,7 @@ namespace GraphQL
         /// </param>
         /// <param name="policy"> Authorization policy name. </param>
         /// <returns> The reference to the specified <paramref name="provider"/>. </returns>
-        public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
+        public static TMetadataProvider AuthorizeWithPolicy<TMetadataProvider>(this TMetadataProvider provider, string policy)
             where TMetadataProvider : IProvideMetadata
         {
             if (policy == null)
@@ -79,6 +79,12 @@ namespace GraphQL
             provider.Metadata[POLICY_KEY] = list;
             return provider;
         }
+
+        /// <inheritdoc cref="AuthorizeWithPolicy{TMetadataProvider}(TMetadataProvider, string)"/>
+        [Obsolete("Please use AuthorizeWithPolicy instead.")]
+        public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
+            where TMetadataProvider : IProvideMetadata
+            => AuthorizeWithPolicy(provider, policy);
 
         /// <summary>
         /// Adds authorization role(s) to the specified metadata provider. Roles should
@@ -114,6 +120,37 @@ namespace GraphQL
         }
 
         /// <summary>
+        /// Adds authorization role(s) to the specified metadata provider.  If the underlying field already
+        /// contains a role with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
+        /// let compiler infer the returning type to allow methods chaining.
+        /// </typeparam>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <param name="roles"> List of authorization role name(s). </param>
+        /// <returns> The reference to the specified <paramref name="provider"/>. </returns>
+        public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, params string[] roles)
+            where TMetadataProvider : IProvideMetadata
+        {
+            if (roles == null)
+                throw new ArgumentNullException(nameof(roles));
+
+            var list = GetRoles(provider) ?? new List<string>();
+
+            foreach (var role in roles)
+            {
+                if (!list.Contains(role))
+                    list.Add(role);
+            }
+
+            provider.Metadata[ROLE_KEY] = list;
+            return provider;
+        }
+
+        /// <summary>
         /// Adds authorization policy to the specified field builder. If the underlying field already contains
         /// a policy with the same name, then it will not be added twice.
         /// </summary>
@@ -122,22 +159,43 @@ namespace GraphQL
         /// <param name="builder"></param>
         /// <param name="policy"> Authorization policy name. </param>
         /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
-        public static FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(
+        public static FieldBuilder<TSourceType, TReturnType> AuthorizeWithPolicy<TSourceType, TReturnType>(
             this FieldBuilder<TSourceType, TReturnType> builder, string policy)
         {
-            builder.FieldType.AuthorizeWith(policy);
+            builder.FieldType.AuthorizeWithPolicy(policy);
             return builder;
         }
+
+        /// <inheritdoc cref="AuthorizeWith{TSourceType, TReturnType}(FieldBuilder{TSourceType, TReturnType}, string)"/>
+        [Obsolete("Please use AuthorizeWithPolicy instead.")]
+        public static FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(
+            this FieldBuilder<TSourceType, TReturnType> builder, string policy)
+            => AuthorizeWithPolicy(builder, policy);
 
         /// <summary>
         /// Adds authorization role(s) to the specified field builder. Roles should
         /// be comma-separated and role names will be trimmed. If the underlying field already
         /// contains a role with the same name, then it will not be added twice.
         /// </summary>
+        /// <param name="builder"></param>
         /// <param name="roles"> Comma-separated list of authorization role name(s). </param>
         /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
         public static FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(
             this FieldBuilder<TSourceType, TReturnType> builder, string roles)
+        {
+            builder.FieldType.AuthorizeWithRoles(roles);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds authorization role(s) to the specified field builder. If the underlying field already
+        /// contains a role with the same name, then it will not be added twice.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="roles"> List of authorization role name(s). </param>
+        /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
+        public static FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(
+            this FieldBuilder<TSourceType, TReturnType> builder, params string[] roles)
         {
             builder.FieldType.AuthorizeWithRoles(roles);
             return builder;
@@ -151,22 +209,43 @@ namespace GraphQL
         /// <param name="builder"></param>
         /// <param name="policy"> Authorization policy name. </param>
         /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
-        public static ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(
+        public static ConnectionBuilder<TSourceType> AuthorizeWithPolicy<TSourceType>(
             this ConnectionBuilder<TSourceType> builder, string policy)
         {
-            builder.FieldType.AuthorizeWith(policy);
+            builder.FieldType.AuthorizeWithPolicy(policy);
             return builder;
         }
+
+        /// <inheritdoc cref="AuthorizeWithPolicy{TSourceType}(ConnectionBuilder{TSourceType}, string)"/>
+        [Obsolete("Please use AuthorizeWithPolicy instead.")]
+        public static ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(
+            this ConnectionBuilder<TSourceType> builder, string policy)
+            => AuthorizeWithPolicy(builder, policy);
 
         /// <summary>
         /// Adds authorization role(s) to the specified connection builder. Roles should
         /// be comma-separated and role names will be trimmed. If the underlying field already
         /// contains a role with the same name, then it will not be added twice.
         /// </summary>
+        /// <param name="builder"></param>
         /// <param name="roles"> Comma-separated list of authorization role name(s). </param>
         /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
         public static ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(
             this ConnectionBuilder<TSourceType> builder, string roles)
+        {
+            builder.FieldType.AuthorizeWithRoles(roles);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds authorization role(s) to the specified connection builder. If the underlying field already
+        /// contains a role with the same name, then it will not be added twice.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="roles"> List of authorization role name(s). </param>
+        /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
+        public static ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(
+            this ConnectionBuilder<TSourceType> builder, params string[] roles)
         {
             builder.FieldType.AuthorizeWithRoles(roles);
             return builder;

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -134,9 +134,6 @@ namespace GraphQL
         /// be comma-separated and role names will be trimmed. If the underlying field already
         /// contains a role with the same name, then it will not be added twice.
         /// </summary>
-        /// <typeparam name="TSourceType"></typeparam>
-        /// <typeparam name="TReturnType"></typeparam>
-        /// <param name="builder"></param>
         /// <param name="roles"> Comma-separated list of authorization role name(s). </param>
         /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
         public static FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -15,6 +15,12 @@ namespace GraphQL
         public const string POLICY_KEY = "Authorization__Policies";
 
         /// <summary>
+        /// Metadata key name for storing authorization role names. Value of this key
+        /// is a simple list of strings.
+        /// </summary>
+        public const string ROLE_KEY = "Authorization__Roles";
+
+        /// <summary>
         /// Gets a list of authorization policy names for the specified metadata provider if any.
         /// Otherwise returns <see langword="null"/>.
         /// </summary>
@@ -26,6 +32,17 @@ namespace GraphQL
         public static List<string>? GetPolicies(this IProvideMetadata provider) => provider.GetMetadata<List<string>>(POLICY_KEY);
 
         /// <summary>
+        /// Gets a list of authorization roles names for the specified metadata provider if any.
+        /// Otherwise returns <see langword="null"/>.
+        /// </summary>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <returns> List of authorization role names applied to this metadata provider. </returns>
+        public static List<string>? GetRoles(this IProvideMetadata provider) => provider.GetMetadata<List<string>>(ROLE_KEY);
+
+        /// <summary>
         /// Gets a boolean value that determines whether any authorization policy is applied to this metadata provider.
         /// </summary>
         /// <param name="provider">
@@ -33,7 +50,7 @@ namespace GraphQL
         /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
         /// </param>
         /// <returns> <c>true</c> if any authorization policy is applied, otherwise <c>false</c>. </returns>
-        public static bool RequiresAuthorization(this IProvideMetadata provider) => GetPolicies(provider)?.Count > 0;
+        public static bool RequiresAuthorization(this IProvideMetadata provider) => GetPolicies(provider)?.Count > 0 || GetRoles(provider)?.Count > 0;
 
         /// <summary>
         /// Adds authorization policy to the specified metadata provider. If the provider already contains
@@ -64,6 +81,39 @@ namespace GraphQL
         }
 
         /// <summary>
+        /// Adds authorization role(s) to the specified metadata provider. Roles should
+        /// be comma-separated and role names will be trimmed. If the underlying field already
+        /// contains a role with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
+        /// let compiler infer the returning type to allow methods chaining.
+        /// </typeparam>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <param name="roles"> Comma-separated list of authorization role name(s). </param>
+        /// <returns> The reference to the specified <paramref name="provider"/>. </returns>
+        public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, string roles)
+            where TMetadataProvider : IProvideMetadata
+        {
+            if (roles == null)
+                throw new ArgumentNullException(nameof(roles));
+
+            var list = GetRoles(provider) ?? new List<string>();
+
+            foreach (var role in roles.Split(','))
+            {
+                var role2 = role.Trim();
+                if (!list.Contains(role2))
+                    list.Add(role2);
+            }
+
+            provider.Metadata[ROLE_KEY] = list;
+            return provider;
+        }
+
+        /// <summary>
         /// Adds authorization policy to the specified field builder. If the underlying field already contains
         /// a policy with the same name, then it will not be added twice.
         /// </summary>
@@ -80,6 +130,23 @@ namespace GraphQL
         }
 
         /// <summary>
+        /// Adds authorization role(s) to the specified field builder. Roles should
+        /// be comma-separated and role names will be trimmed. If the underlying field already
+        /// contains a role with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TSourceType"></typeparam>
+        /// <typeparam name="TReturnType"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="roles"> Comma-separated list of authorization role name(s). </param>
+        /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
+        public static FieldBuilder<TSourceType, TReturnType> AuthorizeWithRoles<TSourceType, TReturnType>(
+            this FieldBuilder<TSourceType, TReturnType> builder, string roles)
+        {
+            builder.FieldType.AuthorizeWithRoles(roles);
+            return builder;
+        }
+
+        /// <summary>
         /// Adds authorization policy to the specified connection builder. If the underlying field already
         /// contains a policy with the same name, then it will not be added twice.
         /// </summary>
@@ -91,6 +158,22 @@ namespace GraphQL
             this ConnectionBuilder<TSourceType> builder, string policy)
         {
             builder.FieldType.AuthorizeWith(policy);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds authorization role(s) to the specified connection builder. Roles should
+        /// be comma-separated and role names will be trimmed. If the underlying field already
+        /// contains a role with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TSourceType"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="roles"> Comma-separated list of authorization role name(s). </param>
+        /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
+        public static ConnectionBuilder<TSourceType> AuthorizeWithRoles<TSourceType>(
+            this ConnectionBuilder<TSourceType> builder, string roles)
+        {
+            builder.FieldType.AuthorizeWithRoles(roles);
             return builder;
         }
     }

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -142,7 +142,7 @@ namespace GraphQL
 
             foreach (var role in roles)
             {
-                if (!list.Contains(role))
+                if (role != "" && !list.Contains(role))
                     list.Add(role);
             }
 

--- a/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
@@ -32,7 +32,7 @@ namespace GraphQL
         /// A comma-separated list of the roles to apply.
         /// Role names will be trimmed before adding.
         /// </summary>
-        public string? Roles { get; set; }
+        public string? Roles { get; init; }
 
         /// <inheritdoc />
         public override void Modify(TypeConfig type)

--- a/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
@@ -26,7 +26,7 @@ namespace GraphQL
         /// <summary>
         /// The name of policy to apply.
         /// </summary>
-        public string? Policy { get; set; }
+        public string? Policy { get; init; }
 
         /// <summary>
         /// A comma-separated list of the roles to apply.

--- a/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
@@ -38,7 +38,7 @@ namespace GraphQL
         public override void Modify(TypeConfig type)
         {
             if (Policy != null)
-                type.AuthorizeWith(Policy);
+                type.AuthorizeWithPolicy(Policy);
 
             if (Roles != null)
                 type.AuthorizeWithRoles(Roles);
@@ -48,7 +48,7 @@ namespace GraphQL
         public override void Modify(FieldConfig field)
         {
             if (Policy != null)
-                field.AuthorizeWith(Policy);
+                field.AuthorizeWithPolicy(Policy);
 
             if (Roles != null)
                 field.AuthorizeWithRoles(Roles);
@@ -58,7 +58,7 @@ namespace GraphQL
         public override void Modify(IGraphType graphType)
         {
             if (Policy != null)
-                graphType.AuthorizeWith(Policy);
+                graphType.AuthorizeWithPolicy(Policy);
 
             if (Roles != null)
                 graphType.AuthorizeWithRoles(Roles);
@@ -68,7 +68,7 @@ namespace GraphQL
         public override void Modify(FieldType fieldType, bool isInputType)
         {
             if (Policy != null)
-                fieldType.AuthorizeWith(Policy);
+                fieldType.AuthorizeWithPolicy(Policy);
 
             if (Roles != null)
                 fieldType.AuthorizeWithRoles(Roles);

--- a/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
@@ -4,10 +4,17 @@ using GraphQL.Utilities;
 namespace GraphQL
 {
     /// <summary>
-    /// Attribute to apply authorization policy when using schema first approach.
+    /// Attribute to apply an authorization policy and/or roles to a graph or field.
     /// </summary>
     public class GraphQLAuthorizeAttribute : GraphQLAttribute
     {
+        /// <summary>
+        /// Creates an instance with the specified policy and/or roles.
+        /// </summary>
+        public GraphQLAuthorizeAttribute()
+        {
+        }
+
         /// <summary>
         /// Creates an instance with the specified policy name.
         /// </summary>
@@ -19,18 +26,52 @@ namespace GraphQL
         /// <summary>
         /// The name of policy to apply.
         /// </summary>
-        public string Policy { get; }
+        public string? Policy { get; set; }
+
+        /// <summary>
+        /// A comma-separated list of the roles to apply.
+        /// Role names will be trimmed before adding.
+        /// </summary>
+        public string? Roles { get; set; }
 
         /// <inheritdoc />
-        public override void Modify(TypeConfig type) => type.AuthorizeWith(Policy);
+        public override void Modify(TypeConfig type)
+        {
+            if (Policy != null)
+                type.AuthorizeWith(Policy);
+
+            if (Roles != null)
+                type.AuthorizeWithRoles(Roles);
+        }
 
         /// <inheritdoc />
-        public override void Modify(FieldConfig field) => field.AuthorizeWith(Policy);
+        public override void Modify(FieldConfig field)
+        {
+            if (Policy != null)
+                field.AuthorizeWith(Policy);
+
+            if (Roles != null)
+                field.AuthorizeWithRoles(Roles);
+        }
 
         /// <inheritdoc />
-        public override void Modify(IGraphType graphType) => graphType.AuthorizeWith(Policy);
+        public override void Modify(IGraphType graphType)
+        {
+            if (Policy != null)
+                graphType.AuthorizeWith(Policy);
+
+            if (Roles != null)
+                graphType.AuthorizeWithRoles(Roles);
+        }
 
         /// <inheritdoc />
-        public override void Modify(FieldType fieldType, bool isInputType) => fieldType.AuthorizeWith(Policy);
+        public override void Modify(FieldType fieldType, bool isInputType)
+        {
+            if (Policy != null)
+                fieldType.AuthorizeWith(Policy);
+
+            if (Roles != null)
+                fieldType.AuthorizeWithRoles(Roles);
+        }
     }
 }

--- a/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
@@ -5,6 +5,8 @@ namespace GraphQL
 {
     /// <summary>
     /// Attribute to apply an authorization policy and/or roles to a graph or field.
+    /// This attribute mimics AuthorizeAttribute from ASP.NET Core so it is something
+    /// people are likely used to, if they do any web programming in C#.
     /// </summary>
     public class GraphQLAuthorizeAttribute : GraphQLAttribute
     {

--- a/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
@@ -9,7 +9,7 @@ namespace GraphQL
     public class GraphQLAuthorizeAttribute : GraphQLAttribute
     {
         /// <summary>
-        /// Creates an instance with the specified policy and/or roles.
+        /// Creates an empty instance of <see cref="GraphQLAuthorizeAttribute"/> with no policy/roles specified.
         /// </summary>
         public GraphQLAuthorizeAttribute()
         {


### PR DESCRIPTION
This allows the role name (or multiple allowed role names) to be directly specified, bringing the `GraphQLAuthorizeAttribute` more in line with the ASP.Net `AuthorizeAttribute`.

It also will be simpler to use for those (like me) that often just wish to specify one or more roles rather than having to create policies that map to the configured roles.

Finally, as it is used in the GraphQL Server project, checking for roles is a much faster operation (probably zero-allocation), as the claim principal's `IsInRole` method can be easily called rather than having to call the asynchronous policy checker method and then using `GetAwaiter().GetResult()` to validate the policy.