### PR TITLE
Add ConfigureAwait(false) to tests

### DIFF
--- a/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
@@ -251,9 +251,9 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         var task3 = result3.GetResultAsync();
 
         // Now await tasks
-        user1 = await task1;
-        user2 = await task2;
-        user3 = await task3;
+        user1 = await task1.ConfigureAwait(false);
+        user2 = await task2.ConfigureAwait(false);
+        user3 = await task3.ConfigureAwait(false);
 
         // Load key 3 again.
         var result3b = loader.LoadAsync(3);
@@ -263,9 +263,9 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         task3b.Status.ShouldBe(TaskStatus.RanToCompletion,
             "Should be cached because it was requested in the first batch even though it wasn't in the result dictionary");
 
-        await loader.DispatchAsync();
+        await loader.DispatchAsync().ConfigureAwait(false);
 
-        var user3b = await task3b;
+        var user3b = await task3b.ConfigureAwait(false);
 
         user3.ShouldBeSameAs(nullObjectUser, "The DataLoader should use the supplied default value");
 
@@ -301,9 +301,9 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         Exception ex = await Should.ThrowAsync<ArgumentException>(async () =>
         {
             // Now await tasks
-            var user1 = await task1.GetResultAsync();
-            var user2 = await task2.GetResultAsync();
-        });
+            var user1 = await task1.GetResultAsync().ConfigureAwait(false);
+            var user2 = await task2.GetResultAsync().ConfigureAwait(false);
+        }).ConfigureAwait(false);
 
         var actualException = Should.Throw<ArgumentException>(() =>
         {
@@ -340,13 +340,13 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         Exception ex = await Should.ThrowAsync<ApplicationException>(async () =>
         {
             // Now await tasks
-            var user1 = await task1.GetResultAsync();
+            var user1 = await task1.GetResultAsync().ConfigureAwait(false);
         });
 
         Exception ex2 = await Should.ThrowAsync<ApplicationException>(async () =>
         {
             // Now await tasks
-            var user2 = await task2.GetResultAsync();
+            var user2 = await task2.GetResultAsync().ConfigureAwait(false);
         });
 
         mock.Verify(x => x.GetUsersByIdAsync(new[] { 1, 2 }, default));
@@ -371,14 +371,14 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         var result2 = loader.LoadAsync(1);
 
         // Dispatch loading
-        await loader.DispatchAsync();
+        await loader.DispatchAsync().ConfigureAwait(false);
 
         var task1 = result1.GetResultAsync();
         var task2 = result2.GetResultAsync();
 
         // Now await tasks
-        var user1 = await task1;
-        var user1b = await task2;
+        var user1 = await task1.ConfigureAwait(false);
+        var user1b = await task2.ConfigureAwait(false);
 
         user1.ShouldBeSameAs(users[0]);
         user1b.ShouldBeSameAs(users[0]);
@@ -391,13 +391,13 @@ public class BatchDataLoaderTests : DataLoaderTestBase
     public async Task Returns_Null_For_Null_Reference_Types()
     {
         var loader = new BatchDataLoader<object, string>((_, _) => throw new Exception());
-        (await loader.LoadAsync(null).GetResultAsync()).ShouldBeNull();
+        (await loader.LoadAsync(null).GetResultAsync().ConfigureAwait(false)).ShouldBeNull();
     }
 
     [Fact]
     public async Task Returns_Null_For_Null_Value_Types()
     {
         var loader = new BatchDataLoader<int?, string>((_, _) => throw new Exception());
-        (await loader.LoadAsync(null).GetResultAsync()).ShouldBeNull();
+        (await loader.LoadAsync(null).GetResultAsync().ConfigureAwait(false)).ShouldBeNull();
     }
 }

--- a/src/GraphQL.DataLoader.Tests/CollectionBatchLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/CollectionBatchLoaderTests.cs
@@ -26,13 +26,13 @@ public class CollectionBatchLoaderTests : DataLoaderTestBase
         var result2 = loader.LoadAsync(2);
 
         // Dispatch loading
-        await loader.DispatchAsync();
+        await loader.DispatchAsync().ConfigureAwait(false);
 
         var task1 = result1.GetResultAsync();
         var task2 = result2.GetResultAsync();
 
-        var user1Orders = await task1;
-        var user2Orders = await task2;
+        var user1Orders = await task1.ConfigureAwait(false);
+        var user2Orders = await task2.ConfigureAwait(false);
 
         user1Orders.ShouldNotBeNull();
         user2Orders.ShouldNotBeNull();
@@ -67,13 +67,13 @@ public class CollectionBatchLoaderTests : DataLoaderTestBase
         var result2 = loader.LoadAsync(2);
 
         // Dispatch loading
-        await loader.DispatchAsync();
+        await loader.DispatchAsync().ConfigureAwait(false);
 
         var task1 = result1.GetResultAsync();
         var task2 = result2.GetResultAsync();
 
-        var user1Orders = await task1;
-        var user2Orders = await task2;
+        var user1Orders = await task1.ConfigureAwait(false);
+        var user2Orders = await task2.ConfigureAwait(false);
 
         user1Orders.ShouldNotBeNull();
         user2Orders.ShouldNotBeNull();
@@ -94,7 +94,7 @@ public class CollectionBatchLoaderTests : DataLoaderTestBase
         //task3.Status.ShouldNotBe(TaskStatus.RanToCompletion, "Result should already be cached");
 
         // Dispatch loading
-        await loader.DispatchAsync();
+        await loader.DispatchAsync().ConfigureAwait(false);
 
         var user1bOrders = await task1b;
         var user2bOrders = await task2b;
@@ -134,14 +134,14 @@ public class CollectionBatchLoaderTests : DataLoaderTestBase
         var result2 = loader.LoadAsync(1);
 
         // Dispatch loading
-        await loader.DispatchAsync();
+        await loader.DispatchAsync().ConfigureAwait(false);
 
         var task1 = result1.GetResultAsync();
         var task2 = result2.GetResultAsync();
 
         // Now await tasks
-        var user1Orders = await task1;
-        var user1bOrders = await task2;
+        var user1Orders = await task1.ConfigureAwait(false);
+        var user1bOrders = await task2.ConfigureAwait(false);
 
         mock.Verify(x => x.GetOrdersByUserIdAsync(new[] { 1 }, default), Times.Once,
             "The keys passed to the fetch delegate should be de-duplicated");
@@ -151,13 +151,13 @@ public class CollectionBatchLoaderTests : DataLoaderTestBase
     public async Task Returns_Null_For_Null_Reference_Types()
     {
         var loader = new CollectionBatchDataLoader<object, string>((_, _) => throw new Exception());
-        (await loader.LoadAsync(null).GetResultAsync()).ShouldBeNull();
+        (await loader.LoadAsync(null).GetResultAsync().ConfigureAwait(false)).ShouldBeNull();
     }
 
     [Fact]
     public async Task Returns_Null_For_Null_Value_Types()
     {
         var loader = new CollectionBatchDataLoader<int?, string>((_, _) => throw new Exception());
-        (await loader.LoadAsync(null).GetResultAsync()).ShouldBeNull();
+        (await loader.LoadAsync(null).GetResultAsync().ConfigureAwait(false)).ShouldBeNull();
     }
 }

--- a/src/GraphQL.DataLoader.Tests/DataLoaderExtensionsTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderExtensionsTests.cs
@@ -20,7 +20,7 @@ public class DataLoaderExtensionsTests : DataLoaderTestBase
     {
         var mock = GetMockDataLoader();
         var keys = new[] { 1, 2 };
-        var users = await DataLoaderExtensions.LoadAsync(mock.Object, keys).GetResultAsync();
+        var users = await DataLoaderExtensions.LoadAsync(mock.Object, keys).GetResultAsync().ConfigureAwait(false);
 
         users.ShouldNotBeNull();
         users.Length.ShouldBe(keys.Length, "Should return array of same length as number of keys provided");
@@ -38,7 +38,7 @@ public class DataLoaderExtensionsTests : DataLoaderTestBase
     public async Task LoadAsync_MultipleKeysAsParams_CallsSingularMultipleTimes()
     {
         var mock = GetMockDataLoader();
-        var users = await DataLoaderExtensions.LoadAsync(mock.Object, 1, 2).GetResultAsync();
+        var users = await DataLoaderExtensions.LoadAsync(mock.Object, 1, 2).GetResultAsync().ConfigureAwait(false);
 
         users.ShouldNotBeNull();
         users.Length.ShouldBe(2, "Should return array of same length as number of keys provided");
@@ -79,17 +79,17 @@ public class DataLoaderExtensionsTests : DataLoaderTestBase
             var result2 = loader.LoadAsync(new int[] { 1, 2, 3 });
 
             // Dispatch loading
-            await loader.DispatchAsync();
+            await loader.DispatchAsync().ConfigureAwait(false);
             var task1 = result1.GetResultAsync();
             var task2 = result2.GetResultAsync();
 
             // Now await tasks
-            users1 = await task1;
+            users1 = await task1.ConfigureAwait(false);
             users1.ShouldNotBeNull();
             user1 = users1[0];
             user2 = users1[1];
 
-            users2 = await task2;
+            users2 = await task2.ConfigureAwait(false);
             users2.ShouldNotBeNull();
             user3 = users2[2];
         });

--- a/src/GraphQL.DataLoader.Tests/DataLoaderSubscriptionTest.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderSubscriptionTest.cs
@@ -26,7 +26,7 @@ public class DataLoaderSubscriptionTest : QueryTestBase
         ordersMock.Setup(x => x.GetOrderObservable()).Returns(orderStream);
         orderStream.OnNext(order);
 
-        var result = await ExecuteSubscribeAsync("subscription OrderAdded { orderAdded { orderId } }");
+        var result = await ExecuteSubscribeAsync("subscription OrderAdded { orderAdded { orderId } }").ConfigureAwait(false);
 
         /* Then */
         var stream = result.Streams.Values.FirstOrDefault();

--- a/src/GraphQL.DataLoader.Tests/SimpleDataLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/SimpleDataLoaderTests.cs
@@ -22,7 +22,7 @@ public class SimpleDataLoaderTests : DataLoaderTestBase
 
         var delayResult = loader.LoadAsync();
 
-        await loader.DispatchAsync();
+        await loader.DispatchAsync().ConfigureAwait(false);
 
         var result1 = await delayResult.GetResultAsync();
 
@@ -35,7 +35,7 @@ public class SimpleDataLoaderTests : DataLoaderTestBase
 
         task2.Status.ShouldBe(TaskStatus.RanToCompletion);
 
-        var result2 = await task2;
+        var result2 = await task2.ConfigureAwait(false);
 
         // Results should be the same instance
         result2.ShouldBeSameAs(result1);
@@ -70,7 +70,7 @@ public class SimpleDataLoaderTests : DataLoaderTestBase
 
         var task = result.GetResultAsync(cts.Token);
 
-        await Should.ThrowAsync<TaskCanceledException>(task);
+        await Should.ThrowAsync<TaskCanceledException>(task).ConfigureAwait(false);
 
         mock.Verify(x => x.GetAllUsersAsync(cts.Token), Times.Once);
     }
@@ -93,7 +93,7 @@ public class SimpleDataLoaderTests : DataLoaderTestBase
 
         cts.Cancel();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => result.GetResultAsync(cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => result.GetResultAsync(cts.Token)).ConfigureAwait(false);
 
         // Fetch delegate should not be called
         mock.VerifyNoOtherCalls();
@@ -138,7 +138,7 @@ public class SimpleDataLoaderTests : DataLoaderTestBase
 
         var result = loader.LoadAsync();
 
-        var ex = await Should.ThrowAsync<Exception>(() => result.GetResultAsync());
+        var ex = await Should.ThrowAsync<Exception>(() => result.GetResultAsync()).ConfigureAwait(false);
 
         ex.Message.ShouldBe("Immediate");
     }

--- a/src/GraphQL.Tests/Subscription/ObservableExtensionsTests.cs
+++ b/src/GraphQL.Tests/Subscription/ObservableExtensionsTests.cs
@@ -16,7 +16,7 @@ public class ObservableExtensionsTests
                 async (data, token) =>
                 {
                     var s = int.Parse(data);
-                    await Task.Delay(s);
+                    await Task.Delay(s).ConfigureAwait(false);
                     return data;
                 },
                 async (error, token) =>
@@ -30,7 +30,7 @@ public class ObservableExtensionsTests
         Source.Error(new Exception("abc"));
         Source.Next("300");
         Source.Completed();
-        await Observer.WaitForAsync("Next '200'. Next '0'. Error 'ApplicationException'. Next '300'. Completed. ");
+        await Observer.WaitForAsync("Next '200'. Next '0'. Error 'ApplicationException'. Next '300'. Completed. ").ConfigureAwait(false);
     }
 
     [Fact]
@@ -41,14 +41,14 @@ public class ObservableExtensionsTests
                 async (data, token) =>
                 {
                     var s = int.Parse(data);
-                    await Task.Delay(s);
+                    await Task.Delay(s).ConfigureAwait(false);
                     return data;
                 },
                 (error, token) => throw new NotSupportedException());
         observable.Subscribe(Observer);
         Source.Next("200");
         Source.Next("aa");
-        await Observer.WaitForAsync("Next '200'. Error 'FormatException'. ");
+        await Observer.WaitForAsync("Next '200'. Error 'FormatException'. ").ConfigureAwait(false);
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ObservableExtensionsTests
         observable.Subscribe(Observer);
         Source.Next("200");
         Source.Next("aa");
-        await Observer.WaitForAsync("Next '200'. Error 'FormatException'. ");
+        await Observer.WaitForAsync("Next '200'. Error 'FormatException'. ").ConfigureAwait(false);
     }
 
     [Fact]
@@ -77,18 +77,18 @@ public class ObservableExtensionsTests
                 async (data, token) =>
                 {
                     var s = int.Parse(data);
-                    await Task.Delay(s);
+                    await Task.Delay(s).ConfigureAwait(false);
                     return data;
                 },
                 async (error, token) =>
                 {
-                    await Task.Delay(200);
+                    await Task.Delay(200).ConfigureAwait(false);
                     return new FormatException();
                 });
         observable.Subscribe(Observer);
         Source.Next("200");
         Source.Error(new ApplicationException());
-        await Observer.WaitForAsync("Next '200'. Error 'FormatException'. ");
+        await Observer.WaitForAsync("Next '200'. Error 'FormatException'. ").ConfigureAwait(false);
     }
 
     [Fact]
@@ -99,14 +99,14 @@ public class ObservableExtensionsTests
                 async (data, token) =>
                 {
                     var s = int.Parse(data);
-                    await Task.Delay(s);
+                    await Task.Delay(s).ConfigureAwait(false);
                     return data;
                 },
                 (error, token) => throw new FormatException());
         observable.Subscribe(Observer);
         Source.Next("200");
         Source.Error(new ApplicationException());
-        await Observer.WaitForAsync("Next '200'. Error 'FormatException'. ");
+        await Observer.WaitForAsync("Next '200'. Error 'FormatException'. ").ConfigureAwait(false);
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public class ObservableExtensionsTests
                 async (data, token) =>
                 {
                     var s = int.Parse(data);
-                    await Task.Delay(s);
+                    await Task.Delay(s).ConfigureAwait(false);
                     return data;
                 },
                 (error, token) => throw error);
@@ -125,7 +125,7 @@ public class ObservableExtensionsTests
         Source.Completed();
         Source.Next("0");
         Source.Next("200");
-        await Observer.WaitForAsync("Completed. Next '0'. Next '200'. ");
+        await Observer.WaitForAsync("Completed. Next '0'. Next '200'. ").ConfigureAwait(false);
     }
 
     [Fact]
@@ -136,15 +136,15 @@ public class ObservableExtensionsTests
                 async (data, token) =>
                 {
                     var s = int.Parse(data);
-                    await Task.Delay(s);
+                    await Task.Delay(s).ConfigureAwait(false);
                     return data;
                 },
                 (error, token) => throw error);
         observable.Subscribe(Observer);
         Source.Next("10");
-        await Task.Delay(500);
+        await Task.Delay(500).ConfigureAwait(false);
         Source.Next("20");
-        await Observer.WaitForAsync("Next '10'. Next '20'. ");
+        await Observer.WaitForAsync("Next '10'. Next '20'. ").ConfigureAwait(false);
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public class ObservableExtensionsTests
         Source.Error(new InvalidTimeZoneException());
         Source.Next("c");
         Source.Completed();
-        await Task.Delay(200); // just in case, but should execute synchronously anyway
+        await Task.Delay(200).ConfigureAwait(false); // just in case, but should execute synchronously anyway
         Observer.Current.ShouldBe("Next 'test'. ");
     }
 
@@ -194,7 +194,7 @@ public class ObservableExtensionsTests
                 async (data, token) =>
                 {
                     var s = int.Parse(data);
-                    await Task.Delay(s);
+                    await Task.Delay(s).ConfigureAwait(false);
                     return data;
                 },
                 (error, token) => new ValueTask<Exception>(error));
@@ -204,7 +204,7 @@ public class ObservableExtensionsTests
         Source.Error(new ExecutionError("test")); // a completed synchronous transformation, but in the queue after one with a delay
         subscription.Dispose();
         Observer.Current.ShouldBe("");
-        await Task.Delay(1000);
+        await Task.Delay(1000).ConfigureAwait(false);
         Observer.Current.ShouldBe("");
     }
 
@@ -237,7 +237,7 @@ public class ObservableExtensionsTests
         Source.Error(new InvalidTimeZoneException());
         Source.Next("c");
         Source.Completed();
-        await Task.Delay(200); // just in case, but should execute synchronously anyway
+        await Task.Delay(200).ConfigureAwait(false); // just in case, but should execute synchronously anyway
         Observer.Current.ShouldBe("Next 'test'. Error 'DivideByZeroException'. ");
         transformed.ShouldBeFalse();
     }


### PR DESCRIPTION
Twice today different tests have failed for no apparent reason.  One seems to be a deadlock, presumably due to the synchronization context required for xUnit.  Adding `.ConfigureAwait(false)` should solve the problem.