### PR TITLE
Add migration note regarding RequestServices

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -621,6 +621,10 @@ You may also supply a list of strings as in the following example:
 graph.AuthorizeWithRoles("Administrators", "Managers");
 ```
 
+### 21. `RequestServices` added to `ValidationContext` in GraphQL 5.1.0
+
+This allows for validation rules to access scoped services if necessary.
+
 ## Breaking Changes
 
 ### 1. UnhandledExceptionDelegate


### PR DESCRIPTION
As 5.0.0 is only 9 days old, and 5.1.0 will likely be released today, I suggest adding this note to the 'new features' section of the migration document.

> ### 21. `RequestServices` added to `ValidationContext` in GraphQL 5.1.0
> 
> This allows for validation rules to access scoped services if necessary.
