### PR TITLE
Authorization update

### DIFF
--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -602,9 +602,10 @@ There are a number of other minor issues fixed; see these links for more details
 - https://github.com/graphql-dotnet/graphql-dotnet/issues/3002
 - https://github.com/graphql-dotnet/graphql-dotnet/pull/3004
 
-### 20. `AuthorizeWithRoles` added in GraphQL 5.1.0
+### 20. `Authorize` and `AuthorizeWithRoles` added in GraphQL 5.1.0
 
 This allows for specifying roles rather than just policies that can be used to validate a request.
+`Authorize` can be used to specify that authentication is required, without specifying any specific roles or policies.
 As with `AuthorizeWithPolicy` (renamed from `AuthorizeWith`), it requires support by a third-party
 library to perform the validation.
 

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -605,7 +605,7 @@ There are a number of other minor issues fixed; see these links for more details
 ### 20. `Authorize` and `AuthorizeWithRoles` added in GraphQL 5.1.0
 
 This allows for specifying roles rather than just policies that can be used to validate a request.
-`Authorize` can be used to specify that authentication is required, without specifying any specific roles or policies.
+`Authorize` can be used to specify that only authentication is required, without specifying any specific roles or policies.
 As with `AuthorizeWithPolicy` (renamed from `AuthorizeWith`), it requires support by a third-party
 library to perform the validation.
 

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -602,7 +602,7 @@ There are a number of other minor issues fixed; see these links for more details
 - https://github.com/graphql-dotnet/graphql-dotnet/issues/3002
 - https://github.com/graphql-dotnet/graphql-dotnet/pull/3004
 
-### 20. `Authorize` and `AuthorizeWithRoles` added in GraphQL 5.1.0
+### 20. `Authorize` and `AuthorizeWithRoles` extension methods added in GraphQL 5.1.0
 
 This allows for specifying roles rather than just policies that can be used to validate a request.
 `Authorize` can be used to specify that only authentication is required, without specifying any specific roles or policies.

--- a/docs2/site/docs/migrations/migration5.md
+++ b/docs2/site/docs/migrations/migration5.md
@@ -602,7 +602,7 @@ There are a number of other minor issues fixed; see these links for more details
 - https://github.com/graphql-dotnet/graphql-dotnet/issues/3002
 - https://github.com/graphql-dotnet/graphql-dotnet/pull/3004
 
-### 20. `Authorize` and `AuthorizeWithRoles` extension methods added in GraphQL 5.1.0
+### 20. `Authorize` and `AuthorizeWithRoles` extension methods added in GraphQL 5.1.0 and 5.1.1
 
 This allows for specifying roles rather than just policies that can be used to validate a request.
 `Authorize` can be used to specify that only authentication is required, without specifying any specific roles or policies.

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2,8 +2,11 @@ namespace GraphQL
 {
     public static class AuthorizationExtensions
     {
+        public const string AUTHORIZE_KEY = "Authorization__Required";
         public const string POLICY_KEY = "Authorization__Policies";
         public const string ROLE_KEY = "Authorization__Roles";
+        public static TMetadataProvider Authorize<TMetadataProvider>(this TMetadataProvider provider)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
         [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
         [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
@@ -215,7 +218,9 @@ namespace GraphQL
         public GraphQLAuthorizeAttribute(string policy) { }
         public string? Policy { get; set; }
         public string? Roles { get; set; }
+        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
         public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Utilities.TypeConfig type) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2,8 +2,11 @@ namespace GraphQL
 {
     public static class AuthorizationExtensions
     {
+        public const string AUTHORIZE_KEY = "Authorization__Required";
         public const string POLICY_KEY = "Authorization__Policies";
         public const string ROLE_KEY = "Authorization__Roles";
+        public static TMetadataProvider Authorize<TMetadataProvider>(this TMetadataProvider provider)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
         [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
         [System.Obsolete("Please use AuthorizeWithPolicy instead. Will be removed in v6.")]
@@ -215,7 +218,9 @@ namespace GraphQL
         public GraphQLAuthorizeAttribute(string policy) { }
         public string? Policy { get; set; }
         public string? Roles { get; set; }
+        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
         public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Utilities.TypeConfig type) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }

--- a/src/GraphQL.Tests/AuthorizationTests.cs
+++ b/src/GraphQL.Tests/AuthorizationTests.cs
@@ -26,14 +26,22 @@ public class AuthorizationTests
     }
 
     [Fact]
-    public void NoRolesNoop()
+    public void NoRoles()
     {
         var field = new FieldType();
         field.AuthorizeWithRoles();
         field.AuthorizeWithRoles("");
         field.AuthorizeWithRoles(" ");
         field.AuthorizeWithRoles(",");
-        field.RequiresAuthorization().ShouldBeFalse();
+        field.RequiresAuthorization().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Authorize()
+    {
+        var field = new FieldType();
+        field.Authorize();
+        field.RequiresAuthorization().ShouldBeTrue();
     }
 
     [Fact]
@@ -91,6 +99,9 @@ public class AuthorizationTests
         field.RequiresAuthorization().ShouldBeTrue();
         field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
         field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+
+        field = graph.Fields.Find("Value");
+        field.RequiresAuthorization().ShouldBeTrue();
     }
 
     [Fact]
@@ -101,6 +112,7 @@ public class AuthorizationTests
 type Class1 {
   id: String!
   name: String!
+  value: String!
 }",
             configure => configure.Types.Include<Class1>());
 
@@ -115,6 +127,9 @@ type Class1 {
         field.RequiresAuthorization().ShouldBeTrue();
         field.GetPolicies().ShouldBe(new string[] { "Policy1", "Policy2", "Policy3" });
         field.GetRoles().ShouldBe(new string[] { "Role1", "Role2", "Role3" });
+
+        field = graph.Fields.Find("value");
+        field.RequiresAuthorization().ShouldBeTrue();
     }
 
     [GraphQLAuthorize("Policy1")]
@@ -133,5 +148,7 @@ type Class1 {
         [GraphQLAuthorize(Roles = "Role1,Role2")]
         [GraphQLAuthorize(Roles = "Role3, Role2")]
         public string Name { get; set; }
+        [GraphQLAuthorize]
+        public string Value { get; set; }
     }
 }

--- a/src/GraphQL.Tests/AuthorizationTests.cs
+++ b/src/GraphQL.Tests/AuthorizationTests.cs
@@ -40,6 +40,7 @@ public class AuthorizationTests
     public void Authorize()
     {
         var field = new FieldType();
+        field.RequiresAuthorization().ShouldBeFalse();
         field.Authorize();
         field.RequiresAuthorization().ShouldBeTrue();
     }

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -21,7 +21,7 @@ namespace GraphQL
         public const string ROLE_KEY = "Authorization__Roles";
 
         /// <summary>
-        /// Metadata key name for indicating that the user must be authorized to access the resource.
+        /// Metadata key name for indicating that the user must be authorized (strictly speaking, authenticated) to access the resource.
         /// Value of this key is a boolean value.
         /// </summary>
         public const string AUTHORIZE_KEY = "Authorization__Required";

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -21,6 +21,12 @@ namespace GraphQL
         public const string ROLE_KEY = "Authorization__Roles";
 
         /// <summary>
+        /// Metadata key name for indicating that the user must be authorized to access the resource.
+        /// Value of this key is a boolean value.
+        /// </summary>
+        public const string AUTHORIZE_KEY = "Authorization__Required";
+
+        /// <summary>
         /// Gets a list of authorization policy names for the specified metadata provider if any.
         /// Otherwise returns <see langword="null"/>.
         /// </summary>
@@ -50,7 +56,22 @@ namespace GraphQL
         /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
         /// </param>
         /// <returns> <c>true</c> if any authorization policy is applied, otherwise <c>false</c>. </returns>
-        public static bool RequiresAuthorization(this IProvideMetadata provider) => GetPolicies(provider)?.Count > 0 || GetRoles(provider)?.Count > 0;
+        public static bool RequiresAuthorization(this IProvideMetadata provider)
+            => GetPolicies(provider)?.Count > 0 || GetRoles(provider)?.Count > 0 || provider.GetMetadata(AUTHORIZE_KEY, false);
+
+        /// <summary>
+        /// Adds metadata to indicate that the resource requires that the user has successfully authenticated.
+        /// </summary>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        public static TMetadataProvider Authorize<TMetadataProvider>(this TMetadataProvider provider)
+            where TMetadataProvider : IProvideMetadata
+        {
+            provider.Metadata[AUTHORIZE_KEY] = true;
+            return provider;
+        }
 
         /// <summary>
         /// Adds authorization policy to the specified metadata provider. If the provider already contains
@@ -116,6 +137,7 @@ namespace GraphQL
             }
 
             provider.Metadata[ROLE_KEY] = list;
+            provider.Authorize();
             return provider;
         }
 
@@ -147,6 +169,7 @@ namespace GraphQL
             }
 
             provider.Metadata[ROLE_KEY] = list;
+            provider.Authorize();
             return provider;
         }
 

--- a/src/GraphQL/Authorization/AuthorizationExtensions.cs
+++ b/src/GraphQL/Authorization/AuthorizationExtensions.cs
@@ -57,7 +57,7 @@ namespace GraphQL
         /// </param>
         /// <returns> <c>true</c> if any authorization policy is applied, otherwise <c>false</c>. </returns>
         public static bool RequiresAuthorization(this IProvideMetadata provider)
-            => GetPolicies(provider)?.Count > 0 || GetRoles(provider)?.Count > 0 || provider.GetMetadata(AUTHORIZE_KEY, false);
+            => provider.GetMetadata(AUTHORIZE_KEY, false) || GetPolicies(provider)?.Count > 0 || GetRoles(provider)?.Count > 0;
 
         /// <summary>
         /// Adds metadata to indicate that the resource requires that the user has successfully authenticated.
@@ -98,6 +98,7 @@ namespace GraphQL
                 list.Add(policy);
 
             provider.Metadata[POLICY_KEY] = list;
+            provider.Authorize();
             return provider;
         }
 

--- a/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/GraphQL/Authorization/GraphQLAuthorizeAttribute.cs
@@ -4,9 +4,10 @@ using GraphQL.Utilities;
 namespace GraphQL
 {
     /// <summary>
-    /// Attribute to apply an authorization policy and/or roles to a graph or field.
-    /// This attribute mimics AuthorizeAttribute from ASP.NET Core so it is something
-    /// people are likely used to, if they do any web programming in C#.
+    /// Attribute to apply an authorization policy and/or roles to a graph, field or query argument.
+    /// Marks the graph, field or query argument as requiring authentication even if no policies or
+    /// roles are specified. This attribute mimics AuthorizeAttribute from ASP.NET Core so it is
+    /// something people are likely used to, if they do any web programming in C#.
     /// </summary>
     public class GraphQLAuthorizeAttribute : GraphQLAttribute
     {
@@ -39,6 +40,8 @@ namespace GraphQL
         /// <inheritdoc />
         public override void Modify(TypeConfig type)
         {
+            type.Authorize();
+
             if (Policy != null)
                 type.AuthorizeWithPolicy(Policy);
 
@@ -49,6 +52,8 @@ namespace GraphQL
         /// <inheritdoc />
         public override void Modify(FieldConfig field)
         {
+            field.Authorize();
+
             if (Policy != null)
                 field.AuthorizeWithPolicy(Policy);
 
@@ -59,6 +64,8 @@ namespace GraphQL
         /// <inheritdoc />
         public override void Modify(IGraphType graphType)
         {
+            graphType.Authorize();
+
             if (Policy != null)
                 graphType.AuthorizeWithPolicy(Policy);
 
@@ -69,11 +76,37 @@ namespace GraphQL
         /// <inheritdoc />
         public override void Modify(FieldType fieldType, bool isInputType)
         {
+            fieldType.Authorize();
+
             if (Policy != null)
                 fieldType.AuthorizeWithPolicy(Policy);
 
             if (Roles != null)
                 fieldType.AuthorizeWithRoles(Roles);
+        }
+
+        /// <inheritdoc />
+        public override void Modify(QueryArgument queryArgument)
+        {
+            queryArgument.Authorize();
+
+            if (Policy != null)
+                queryArgument.AuthorizeWithPolicy(Policy);
+
+            if (Roles != null)
+                queryArgument.AuthorizeWithRoles(Roles);
+        }
+
+        /// <inheritdoc />
+        public override void Modify(EnumValueDefinition enumValueDefinition)
+        {
+            enumValueDefinition.Authorize();
+
+            if (Policy != null)
+                enumValueDefinition.AuthorizeWithPolicy(Policy);
+
+            if (Roles != null)
+                enumValueDefinition.AuthorizeWithRoles(Roles);
         }
     }
 }


### PR DESCRIPTION
Closes #3076

This also fixes the attribute so that it applies the metadata to query arguments or enum definitions also, if it is marked on those type of objects.
