### PR TITLE
Add AutoSchema type

### DIFF
--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -414,6 +414,7 @@ namespace GraphQL
     public interface IConfigureAutoSchema
     {
         GraphQL.DI.IGraphQLBuilder Builder { get; }
+        System.Type SchemaType { get; }
     }
     public interface IDocumentExecuter
     {
@@ -1699,6 +1700,10 @@ namespace GraphQL.Types
         protected virtual GraphQL.Types.TypeInformation GetTypeInformation(System.Reflection.MemberInfo memberInfo) { }
         protected virtual GraphQL.Types.TypeInformation GetTypeInformation(System.Reflection.ParameterInfo parameterInfo) { }
         protected virtual System.Collections.Generic.IEnumerable<GraphQL.Types.FieldType> ProvideFields() { }
+    }
+    public class AutoSchema<TQueryClrType> : GraphQL.Types.Schema
+    {
+        public AutoSchema(System.IServiceProvider serviceProvider) { }
     }
     public class BigIntGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -414,6 +414,7 @@ namespace GraphQL
     public interface IConfigureAutoSchema
     {
         GraphQL.DI.IGraphQLBuilder Builder { get; }
+        System.Type SchemaType { get; }
     }
     public interface IDocumentExecuter
     {
@@ -1699,6 +1700,10 @@ namespace GraphQL.Types
         protected virtual GraphQL.Types.TypeInformation GetTypeInformation(System.Reflection.MemberInfo memberInfo) { }
         protected virtual GraphQL.Types.TypeInformation GetTypeInformation(System.Reflection.ParameterInfo parameterInfo) { }
         protected virtual System.Collections.Generic.IEnumerable<GraphQL.Types.FieldType> ProvideFields() { }
+    }
+    public class AutoSchema<TQueryClrType> : GraphQL.Types.Schema
+    {
+        public AutoSchema(System.IServiceProvider serviceProvider) { }
     }
     public class BigIntGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL/IConfigureAutoSchema.cs
+++ b/src/GraphQL/IConfigureAutoSchema.cs
@@ -16,6 +16,7 @@ namespace GraphQL
 
         /// <summary>
         /// Returns the type of constructed schema, which can be used to type match prior to additional configurations.
+        /// Usually it is always <see cref="AutoSchema{TQueryClrType}"/>.
         /// </summary>
         Type SchemaType { get; }
     }

--- a/src/GraphQL/IConfigureAutoSchema.cs
+++ b/src/GraphQL/IConfigureAutoSchema.cs
@@ -1,4 +1,5 @@
 using GraphQL.DI;
+using GraphQL.Types;
 
 namespace GraphQL
 {
@@ -12,15 +13,23 @@ namespace GraphQL
         /// Returns a <see cref="IGraphQLBuilder"/> reference that can be used to configure the schema or service provider.
         /// </summary>
         IGraphQLBuilder Builder { get; }
+
+        /// <summary>
+        /// Returns the type of constructed schema, which can be used to type match prior to additional configurations.
+        /// </summary>
+        Type SchemaType { get; }
     }
 
-    internal class ConfigureAutoSchema : IConfigureAutoSchema
+    internal class ConfigureAutoSchema<TQueryClrType> : IConfigureAutoSchema
     {
         public ConfigureAutoSchema(IGraphQLBuilder baseBuilder)
         {
             Builder = baseBuilder;
+            SchemaType = typeof(AutoSchema<TQueryClrType>);
         }
 
         public IGraphQLBuilder Builder { get; }
+
+        public Type SchemaType { get; }
     }
 }

--- a/src/GraphQL/Types/AutoSchema.cs
+++ b/src/GraphQL/Types/AutoSchema.cs
@@ -1,0 +1,19 @@
+using GraphQL.Utilities;
+
+namespace GraphQL.Types;
+
+/// <summary>
+/// A schema with a Query type that is initialized to an instance
+/// of <see cref="AutoRegisteringObjectGraphType{TSourceType}"/>
+/// with <typeparamref name="TQueryClrType"/> as the query clr type.
+/// </summary>
+public class AutoSchema<TQueryClrType> : Schema
+{
+    /// <summary>
+    /// Initializes a new instance from the specified service provider.
+    /// </summary>
+    public AutoSchema(IServiceProvider serviceProvider) : base(serviceProvider, true)
+    {
+        Query = serviceProvider.GetRequiredService<AutoRegisteringObjectGraphType<TQueryClrType>>();
+    }
+}


### PR DESCRIPTION
I ran into an issue with some of my code using the auto-schema builder methods in that the `.WithMutation` and `.WithSubscription` code applied to all configured schemas, not just the auto-built schema.

Of course most of the builder methods apply to all configured schemas, but the builder methods are designed to allow for multiple schemas, and with the use of `ConfigureSchema` or `ConfigureExecution` to discriminate between multiple schemas and provide tailored execution for each one.

But it seems to me that it is a bug for this scenario:

```cs
.AddSchema<MySchema1>() // where MySchema1 derives from Schema
.AddAutoSchema<MyQuery2>(s => s.WithMutation<MyMutation2>()); // where MyQuery2 is a CLR type
//in this scenario, mySchema1.Mutation is also set to AutoRegisteringOutputGraphType<MyMutation2>,
//even overriding any configuration within the MySchema1 constructor
```

With this change each auto-schema now has its own class so that any additional configurations can be applied like:

```cs
.ConfigureSchema(schema => {
    if (schema is AutoSchema<MyQuery2>)
    {
        // register type mappings or whatever
    }
});
```

It is also now possible to register multiple auto-schemas at once.

```cs
.AddAutoSchema<MySchema1>()
.AddAutoSchema<MySchema2>(s => s.WithMutation<MyMutation2>());

app.UseGraphQL<AutoSchema<MySchema1>>("/graphql/1");
app.UseGraphQL<AutoSchema<MySchema2>>("/graphql/2");
```

There are two breaking changes here: previously the auto-schema would be registered within the DI framework as `Schema` and `ISchema`.  Now it is registered as `AutoSchema<TClrType>` and `ISchema`.  This is more serious, as if someone wrote this code in a server project it will not work anymore:

```cs
// breaks this code
app.UseGraphQL<Schema>();
// would not break this code
app.UseGraphQL<ISchema>();
```

The second breaking change is that a member was added to `IConfigureAutoSchema`.  It is rather unlikely that anyone would have a custom implementation of that interface.

We should decide if this is worthy of a breaking change in a v5 minor release, considering the bug and the fact that v5 is relatively new, as is the auto-schema functionality, or if it should go in v6.  I'm okay either way.

We could also implement a patch for v5 with less breaking changes: implement the breaking change for `IConfigureAutoSchema`, but do not add the `AutoSchema<TClrType>` until v6.  This seems rather a poor patch, as it would only fix conflicts between auto-schemas and non-auto-schemas, and not conflicts between two auto-schemas.  It could also possibly conflict with other schemas such as schema-first schemas (if `Schema.For` returns `Schema`).