### PR TITLE
Restrict list types in GetGraphTypeFromType

### DIFF
--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -221,6 +221,7 @@ namespace GraphQL
         public static bool EnableReadDeprecationReasonFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromXmlDocumentation { get; set; }
+        public static bool MapAllEnumerableTypes { get; set; }
         public static bool UseDeclaringTypeNames { get; set; }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter, AllowMultiple=true)]

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -221,6 +221,7 @@ namespace GraphQL
         public static bool EnableReadDeprecationReasonFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromXmlDocumentation { get; set; }
+        public static bool MapAllEnumerableTypes { get; set; }
         public static bool UseDeclaringTypeNames { get; set; }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter, AllowMultiple=true)]

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -178,7 +178,7 @@ public class GetGraphTypeFromTypeTests
     [InlineData(typeof(IReadOnlyCollection<int>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(typeof(List<int>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(typeof(int[]), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
-    [InlineData(typeof(IDictionary<int, string>), true, TypeMappingMode.OutputType, typeof(GraphQLClrOutputTypeReference<IDictionary<int, string>>))]
+    //[InlineData(typeof(IDictionary<int, string>), true, TypeMappingMode.OutputType, typeof(GraphQLClrOutputTypeReference<IDictionary<int, string>>))] //enable for v6
     [InlineData(typeof(IEnumerable<KeyValuePair<int, string>>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<KeyValuePair<int, string>>>>))]
     [InlineData(typeof(IEnumerable<int>), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>>))]
     //input mapping mode

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -179,6 +179,7 @@ public class GetGraphTypeFromTypeTests
     [InlineData(typeof(List<int>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(typeof(int[]), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(typeof(IDictionary<int, string>), true, TypeMappingMode.OutputType, typeof(GraphQLClrOutputTypeReference<IDictionary<int, string>>))]
+    [InlineData(typeof(IEnumerable<KeyValuePair<int, string>>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<KeyValuePair<int, string>>>>))]
     [InlineData(typeof(IEnumerable<int>), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>>))]
     //input mapping mode
     [InlineData(typeof(int), true, TypeMappingMode.InputType, typeof(GraphQLClrInputTypeReference<int>))]

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -178,7 +178,7 @@ public class GetGraphTypeFromTypeTests
     [InlineData(typeof(IReadOnlyCollection<int>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(typeof(List<int>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(typeof(int[]), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
-    [InlineData(typeof(IDictionary<int, string>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<KeyValuePair<int, string>>>>))]
+    [InlineData(typeof(IDictionary<int, string>), true, TypeMappingMode.OutputType, typeof(GraphQLClrOutputTypeReference<IDictionary<int, string>>))]
     [InlineData(typeof(IEnumerable<int>), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>>))]
     //input mapping mode
     [InlineData(typeof(int), true, TypeMappingMode.InputType, typeof(GraphQLClrInputTypeReference<int>))]

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -178,6 +178,7 @@ public class GetGraphTypeFromTypeTests
     [InlineData(typeof(IReadOnlyCollection<int>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(typeof(List<int>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(typeof(int[]), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>))]
+    [InlineData(typeof(IDictionary<int, string>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<KeyValuePair<int, string>>>>))] //remove for v6
     //[InlineData(typeof(IDictionary<int, string>), true, TypeMappingMode.OutputType, typeof(GraphQLClrOutputTypeReference<IDictionary<int, string>>))] //enable for v6
     [InlineData(typeof(IEnumerable<KeyValuePair<int, string>>), true, TypeMappingMode.OutputType, typeof(ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<KeyValuePair<int, string>>>>))]
     [InlineData(typeof(IEnumerable<int>), false, TypeMappingMode.OutputType, typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>>))]

--- a/src/GraphQL/Annotations/NotNullWhenAttribute.cs
+++ b/src/GraphQL/Annotations/NotNullWhenAttribute.cs
@@ -1,6 +1,6 @@
 #if NETSTANDARD2_0
 
-// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs#L107
+// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs#L69
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>

--- a/src/GraphQL/Annotations/NotNullWhenAttribute.cs
+++ b/src/GraphQL/Annotations/NotNullWhenAttribute.cs
@@ -1,0 +1,23 @@
+﻿#if NETSTANDARD2_0
+
+// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs#L107
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    /// <summary>Initializes the attribute with the specified return value condition.</summary>
+    /// <param name="returnValue">
+    /// The return value condition. If the method returns this value, the associated parameter will not be null.
+    /// </param>
+    public NotNullWhenAttribute(bool returnValue)
+    {
+        ReturnValue = returnValue;
+    }
+
+    /// <summary>Gets the return value condition.</summary>
+    public bool ReturnValue { get; }
+}
+
+#endif

--- a/src/GraphQL/Annotations/NotNullWhenAttribute.cs
+++ b/src/GraphQL/Annotations/NotNullWhenAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+#if NETSTANDARD2_0
 
 // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs#L107
 namespace System.Diagnostics.CodeAnalysis;

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -64,5 +64,16 @@ namespace GraphQL
         /// By default disabled.
         /// </summary>
         public static bool UseDeclaringTypeNames { get; set; } = false;
+
+        /// <summary>
+        /// Specifies whether to map all types that implement <see cref="IEnumerable{T}"/> to list
+        /// graph types within <see cref="TypeExtensions.GetGraphTypeFromType(Type, bool, TypeMappingMode)"/>,
+        /// or only common collection types such as <see cref="IEnumerable{T}"/>, <see cref="IList{T}"/>,
+        /// <see cref="List{T}"/> and so on.
+        /// <br/><br/>
+        /// When set to <see langword="true"/>, dictionaries are also detected as lists of
+        /// <see cref="KeyValuePair{TKey, TValue}"/> which may be unintended.
+        /// </summary>
+        public static bool MapAllEnumerableTypes { get; set; } = true;
     }
 }

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using GraphQL.Conversion;
+using GraphQL.Types;
 using GraphQL.Utilities;
 
 namespace GraphQL
@@ -69,10 +70,16 @@ namespace GraphQL
         /// Specifies whether to map all types that implement <see cref="IEnumerable{T}"/> to list
         /// graph types within <see cref="TypeExtensions.GetGraphTypeFromType(Type, bool, TypeMappingMode)"/>,
         /// or only common collection types such as <see cref="IEnumerable{T}"/>, <see cref="IList{T}"/>,
-        /// <see cref="List{T}"/> and so on.
+        /// <see cref="List{T}"/>, <see cref="IReadOnlyCollection{T}"/> and similar. <see cref="HashSet{T}"/>
+        /// and <see cref="ISet{T}"/> are also supported, but not dictionary types.
         /// <br/><br/>
         /// When set to <see langword="true"/>, dictionaries are also detected as lists of
         /// <see cref="KeyValuePair{TKey, TValue}"/> which may be unintended.
+        /// <br/><br/>
+        /// When set to <see langword="false"/>, custom collection types such as <see cref="TypeFields"/>
+        /// would not be detected and would need to be cast to the correct <see cref="IEnumerable{T}"/> type
+        /// when defining the field so that <see cref="GraphQLClrOutputTypeReference{T}"/> is generated
+        /// for the field type with the proper <see cref="IEnumerable{T}"/> type as its generic type.
         /// </summary>
         public static bool MapAllEnumerableTypes { get; set; } = true;
     }

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -148,7 +148,7 @@ namespace GraphQL
             }
             else
             {
-#pragma warning disable CS0618 // Type or member is obsolete -- remove this block for v6
+#pragma warning disable CS0618 // Type or member is obsolete
                 var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
                 if (attr != null)
                 {

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -133,14 +133,21 @@ namespace GraphQL
                 var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent array
                 graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
             }
-            else if (TryGetEnumerableElementType(type, out var clrElementType))
+#pragma warning disable CS0618 // Type or member is obsolete -- remove this block for v6
+            else if (GlobalSwitches.MapAllEnumerableTypes && IsAnIEnumerable(type))
+            {
+                var clrElementType = GetEnumerableElementType(type);
+                var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent container
+                graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
+            }
+#pragma warning disable CS0618 // Type or member is obsolete
+            else if (!GlobalSwitches.MapAllEnumerableTypes && TryGetEnumerableElementType(type, out var clrElementType))
             {
                 var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent container
                 graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
             }
             else
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
                 if (attr != null)
                 {
@@ -188,6 +195,7 @@ namespace GraphQL
                     }
                 }
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (!isNullable)
             {
@@ -230,6 +238,48 @@ namespace GraphQL
 
             return friendlyName;
         }
+
+        [Obsolete("This method along with GlobalSwitches.MapAllEnumerableTypes should be removed in v6")]
+        private static bool IsAnIEnumerable(Type type) =>
+            type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type) && !type.IsArray;
+
+        /// <summary>
+        /// Returns the type of element for a one-dimensional container type.
+        /// Throws <see cref="ArgumentOutOfRangeException"/> if the type cannot be identified
+        /// as a one-dimensional container type.
+        /// </summary>
+        [Obsolete("This method along with GlobalSwitches.MapAllEnumerableTypes should be removed in v6")]
+        private static Type GetEnumerableElementType(this Type type)
+        {
+            // prefer a known type, just in case multiple enumerable interfaces are supported
+            if (type.IsConstructedGenericType)
+            {
+                var definition = type.GetGenericTypeDefinition();
+                if (_typedContainers.Contains(definition))
+                {
+                    return type.GenericTypeArguments[0];
+                }
+            }
+
+            // see if the type supports IEnumerable<T>
+            var supportedInterfaces = type.GetInterfaces();
+            foreach (var iface in supportedInterfaces)
+            {
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    return iface.GenericTypeArguments[0];
+                }
+            }
+
+            // see if the type supports IEnumerable
+            if (typeof(IEnumerable).IsAssignableFrom(type))
+                return typeof(object);
+
+            throw new ArgumentOutOfRangeException(nameof(type), $"The element type for {type.Name} cannot be coerced effectively");
+        }
+
+        [Obsolete("This method along with GlobalSwitches.MapAllEnumerableTypes should be removed in v6")]
+        private static readonly Type[] _typedContainers = { typeof(IEnumerable<>), typeof(List<>), typeof(IList<>), typeof(ICollection<>), typeof(IReadOnlyCollection<>) };
 
         /// <summary>
         /// Returns the type of element for a one-dimensional container type.

--- a/src/GraphQL/TypeExtensions.cs
+++ b/src/GraphQL/TypeExtensions.cs
@@ -140,7 +140,7 @@ namespace GraphQL
                 var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent container
                 graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
             }
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
             else if (!GlobalSwitches.MapAllEnumerableTypes && TryGetEnumerableElementType(type, out var clrElementType))
             {
                 var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent container
@@ -148,6 +148,7 @@ namespace GraphQL
             }
             else
             {
+#pragma warning disable CS0618 // Type or member is obsolete -- remove this block for v6
                 var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
                 if (attr != null)
                 {
@@ -195,7 +196,6 @@ namespace GraphQL
                     }
                 }
             }
-#pragma warning restore CS0618 // Type or member is obsolete
 
             if (!isNullable)
             {

--- a/src/GraphQL/Types/TypeInformation.cs
+++ b/src/GraphQL/Types/TypeInformation.cs
@@ -322,7 +322,7 @@ namespace GraphQL.Types
             return type;
         }
 
-        private static readonly Type[] _listTypes = new Type[] {
+        internal static readonly Type[] EnumerableListTypes = new Type[] {
             typeof(IEnumerable<>),
             typeof(IList<>),
             typeof(List<>),
@@ -339,6 +339,6 @@ namespace GraphQL.Types
         /// types which may also be able to be cast to <see cref="IEnumerable{T}"/>.
         /// </summary>
         private bool IsRecognizedListType(Type type)
-            => Array.IndexOf(_listTypes, type.GetGenericTypeDefinition()) >= 0;
+            => Array.IndexOf(EnumerableListTypes, type.GetGenericTypeDefinition()) >= 0;
     }
 }


### PR DESCRIPTION
I keep running into this problem in my code:  `GetGraphTypeFromType` takes classes that inherit or implement a list or dictionary type and assign it a graph type mapping of the `KeyValuePair` rather than the object as a whole.

For example:
```cs
private MyInfoClass : Dictionary<string, object>
{
    public string Name => this["Name"];
}

var type = GetGraphTypeFromType(typeof(MyInfoClass), true, TypeMappingMode.OutputType);
//expected:
type == typeof(GraphQLClrOutputGraphType<MyInfoClass>)
//actual:
type == typeof(ListGraphType<GraphQLClrOutputGraphType<KeyValuePair<string, object>>>);
```

My workaround is currently as follows:

1. Apply the patch in this PR to a custom version of the `GetGraphTypeFromType` method
2. Create a class derived from `TypeInformation` and override `ConstructGraphType` to use the new method
3. Create a class dervied from `AutoRegisteringObjectGraphType` and override `GetTypeInformation` to use the new class
4. Register the new class within DI to be used when `AutoRegisteringObjectGraphType` is requested.

My suggested fix is to only detect explicit enumerable types that we have already predefined in the `TypeInformation` class:

- `IEnumerable`
- `IEnumerable<>`
- `IList<>`
- `List<>`
- `ICollection<>`
- `IReadOnlyCollection<>`
- `IReadOnlyList<>`
- `HashSet<>`
- `ISet<>`

Any derived types from those types will not be detected as a list.  This is a breaking change, and if someone is relying on the prior behavior, they will need to cast their custom return type to a detected list type.  For example:

```cs
public class People : List<Person>
{
}

var type = GetGraphTypeFromType(typeof(People), true, TypeMappingMode.OutputType);
//previously:
type == typeof(ListGraphType<GraphQLClrOutputGraphType<Person>>)
//now:
type == typeof(GraphQLClrOutputGraphType<People>)

//breaking change affects uses like this:
Field(x => x.People); //where People is of type People not of type List<Person>
```

My workaround (described above) contains almost 200 lines of code to fix this problem (mostly copied from the main library).  I suggest we fix it in the main library.  However, it is a breaking change and there may be existing code that relies on the current behavior.  As much as I would like to see it in 5.1 for my own needs, I suggest this be a change for 6.0.  I can live with my existing workaround.

An alternative option would be to make this a global option.  Even though I generally discourage global options, this really seems like a pain point (for me) that we can get rid of rather easily.