### PR TITLE
Fix error thrown for invalid operation name

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug1772.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1772.cs
@@ -1,3 +1,4 @@
+using GraphQL.Execution;
 using GraphQL.Types;
 
 namespace GraphQL.Tests.Bugs;
@@ -41,10 +42,8 @@ public class Bug1772 : QueryTestBase<Bug1772Schema>
         result.Data.ShouldBeNull();
         result.Errors.ShouldNotBeNull();
         result.Errors.Count.ShouldBe(1);
-        result.Errors[0].Message.ShouldBe("Error executing document.");
-        result.Errors[0].InnerException.ShouldNotBeNull();
-        result.Errors[0].InnerException.ShouldBeOfType<InvalidOperationException>();
-        result.Errors[0].InnerException.Message.ShouldBe($"Query does not contain operation '{operationName}'.");
+        result.Errors[0].ShouldBeOfType<InvalidOperationError>();
+        result.Errors[0].Message.ShouldBe("Query does not contain operation '" + operationName + "'.");
     }
 }
 

--- a/src/GraphQL.Tests/Bugs/Bug1772.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1772.cs
@@ -44,6 +44,7 @@ public class Bug1772 : QueryTestBase<Bug1772Schema>
         result.Errors.Count.ShouldBe(1);
         result.Errors[0].ShouldBeOfType<InvalidOperationError>();
         result.Errors[0].Message.ShouldBe("Query does not contain operation '" + operationName + "'.");
+        result.Errors[0].InnerException.ShouldBeNull();
     }
 }
 

--- a/src/GraphQL.Tests/DI.xUnit/PrepareDependencyInjectionAttribute.cs
+++ b/src/GraphQL.Tests/DI.xUnit/PrepareDependencyInjectionAttribute.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using GraphQL.DI;
-using GraphQL.Execution;
 using GraphQL.Types;
 using Xunit.Sdk;
 

--- a/src/GraphQL.Tests/DI.xUnit/PrepareDependencyInjectionAttribute.cs
+++ b/src/GraphQL.Tests/DI.xUnit/PrepareDependencyInjectionAttribute.cs
@@ -65,7 +65,7 @@ internal sealed class PrepareDependencyInjectionAttribute : BeforeAfterTestAttri
         {
             var method = _currentMethod.Value;
             return method == null || !_diAdapters.TryGetValue(method, out var stack) || stack == null || stack.Count == 0
-                ? throw new InvalidOperationError("Attempt to access IServiceProvider out of prepared DependencyInjection context.")
+                ? throw new InvalidOperationException("Attempt to access IServiceProvider out of prepared DependencyInjection context.")
                 : stack.Peek().ServiceProvider;
         }
     }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -143,12 +143,11 @@ namespace GraphQL
                 }
 
                 var operation = GetOperation(options.OperationName, document);
-                metrics.SetOperationName(operation?.Name);
-
                 if (operation == null)
                 {
                     throw new InvalidOperationError($"Query does not contain operation '{options.OperationName}'.");
                 }
+                metrics.SetOperationName(operation.Name);
 
                 IValidationResult validationResult;
                 Variables variables;

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -147,7 +147,7 @@ namespace GraphQL
 
                 if (operation == null)
                 {
-                    throw new InvalidOperationException($"Query does not contain operation '{options.OperationName}'.");
+                    throw new InvalidOperationError($"Query does not contain operation '{options.OperationName}'.");
                 }
 
                 IValidationResult validationResult;


### PR DESCRIPTION
When a request is executed with an operation name that is not listed in the document, a "client" (validation) error should be returned to the caller with friendly description, rather than a "server" error being thrown which triggers the unhandled exception delegate and returns a masked error to the caller.