### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,8 +8,15 @@ on:
   pull_request:
     branches: [master, develop]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,8 +11,14 @@ on:
     types:
       - opened        # when PR is opened
 
+permissions:
+  contents: read
+
 jobs:
   label:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -21,6 +21,9 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -76,6 +79,8 @@ jobs:
           files: 'src/.coverage/**/coverage.opencover.xml'
 
   buildcheck:
+    permissions:
+      contents: none
     needs:
       - test
     runs-on: ubuntu-latest

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -14,6 +14,9 @@ on:
 env:
   NODE_VERSION: '10.x'   # Node 10 LTS
 
+permissions:
+  contents: read
+
 jobs:
   buildcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/wipcheck.yml
+++ b/.github/workflows/wipcheck.yml
@@ -8,8 +8,13 @@ on:
       - synchronize   # when code is added
       - reopened      # when a closed PR is reopened
 
+permissions:
+  contents: read
+
 jobs:
   check-title:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
