### PR TITLE
Partial fix to detect asynchronous return types within field delegates

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug3046.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3046.cs
@@ -1,0 +1,55 @@
+using GraphQL.Resolvers;
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Bugs;
+
+// https://github.com/graphql-dotnet/graphql-dotnet/issues/3046
+public class Bug3046 : QueryTestBase<Bug3046.MySchema>
+{
+    [Fact]
+    public void FailsSchemaInitialization()
+    {
+        Should.Throw<InvalidOperationException>(() => new MySchema())
+            .Message.ShouldBe("Please use the proper FuncFieldResolver constructor for asynchronous delegates, or call FieldAsync when adding your field to the graph.");
+    }
+
+    [Fact]
+    public void CreateDelegateThrows()
+    {
+        Should.Throw<InvalidOperationException>(() => new FuncFieldResolver<object>(MyFunc))
+            .Message.ShouldBe("Please use the proper FuncFieldResolver constructor for asynchronous delegates, or call FieldAsync when adding your field to the graph.");
+
+        static Task<string> MyFunc(IResolveFieldContext context) => null!;
+    }
+
+    [Fact]
+    public void CreateDelegateThrows2()
+    {
+        Should.Throw<InvalidOperationException>(() => new FuncFieldResolver<string, object>(MyFunc))
+            .Message.ShouldBe("Please use the proper FuncFieldResolver constructor for asynchronous delegates, or call FieldAsync when adding your field to the graph.");
+
+        static Task<string> MyFunc(IResolveFieldContext<string> context) => null!;
+    }
+
+    public class MySchema : Schema
+    {
+        public MySchema()
+        {
+            Query = new MyQuery();
+        }
+    }
+
+    public class MyQuery : ObjectGraphType
+    {
+        public MyQuery()
+        {
+            // note: the exception is thrown during execution of this instruction, so debugging can easily identify the incorrect code
+            Field<StringGraphType>(
+                "test1",
+                resolve: HelloAsync);
+        }
+
+        public virtual Task<string> HelloAsync(IResolveFieldContext context)
+            => Task.FromResult("Hello");
+    }
+}


### PR DESCRIPTION
See:
- #3046

Fixes this scenario, but few others:

```cs
Field<CharacterInterface>("hero", resolve: GetDroidByIdAsync);

Task<Droid> GetDroidByIdAsync(IResolveFieldContext<object> context)
    => _data.GetDroidByIdAsync("3");
```

Exceptions are thrown either during schema construction or schema initialization.  Debugging will reveal the faulty line of code.

Note that we could alter this code to accept the delegate and handle it correctly.  I elected not to do so, and require users to use the `FieldAsync` method or correct constructor.