### PR TITLE
Add IConfigureExecution

### DIFF
--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -109,11 +109,9 @@ namespace GraphQL
         [System.Obsolete("Use the constructor that accepts IConfigureExecution; this constructor will be re" +
             "moved in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configurations) { }
-        public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configurations) { }
         [System.Obsolete("Use the constructor that accepts IConfigureExecution; this constructor will be re" +
             "moved in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configurations, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }
-        [System.Obsolete("Added for DI compatibility only; this constructor will be removed in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configurations, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> optionsConfigurations) { }
         protected virtual GraphQL.Execution.ExecutionContext BuildExecutionContext(GraphQL.ExecutionOptions options, GraphQLParser.AST.GraphQLDocument document, GraphQLParser.AST.GraphQLOperationDefinition operation, GraphQL.Validation.Variables variables, GraphQL.Instrumentation.Metrics metrics) { }
         public virtual System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options) { }
@@ -253,7 +251,6 @@ namespace GraphQL
     }
     public static class GraphQLBuilderExtensions
     {
-        public static GraphQL.DI.IGraphQLBuilder AddApolloTracingResults(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoClrMappings(this GraphQL.DI.IGraphQLBuilder builder, bool mapInputTypes = true, bool mapOutputTypes = true) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoSchema<TQueryClrType>(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.IConfigureAutoSchema>? configure = null) { }
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder) { }
@@ -349,7 +346,7 @@ namespace GraphQL
             where TValidationRule :  class, GraphQL.Validation.IValidationRule { }
         public static GraphQL.DI.IServiceRegister Configure<TOptions>(this GraphQL.DI.IServiceRegister services, System.Action<TOptions>? action)
             where TOptions :  class, new () { }
-        public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>>, GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> action) { }
+        public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, GraphQL.DI.ExecutionDelegate, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecutionOptions(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.ExecutionOptions> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecutionOptions(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureSchema(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Types.ISchema> action) { }
@@ -927,6 +924,7 @@ namespace GraphQL.Conversion
 }
 namespace GraphQL.DI
 {
+    public delegate System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecutionDelegate(GraphQL.ExecutionOptions options);
     public abstract class GraphQLBuilderBase : GraphQL.DI.IGraphQLBuilder
     {
         protected GraphQLBuilderBase() { }
@@ -935,9 +933,8 @@ namespace GraphQL.DI
     }
     public interface IConfigureExecution
     {
-        System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> next, GraphQL.ExecutionOptions executionOptions);
+        System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options, GraphQL.DI.ExecutionDelegate next);
     }
-    [System.Obsolete("Use IConfigureExecution; will be removed in v6")]
     public interface IConfigureExecutionOptions
     {
         System.Threading.Tasks.Task ConfigureAsync(GraphQL.ExecutionOptions executionOptions);
@@ -1352,7 +1349,6 @@ namespace GraphQL.Instrumentation
             public string? ReturnType { get; set; }
         }
     }
-    [System.Obsolete("Use AddApolloTracingResults instead; will be removed in v6")]
     public class ApolloTracingDocumentExecuter : GraphQL.DocumentExecuter
     {
         public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -1351,6 +1351,7 @@ namespace GraphQL.Instrumentation
     }
     public class ApolloTracingDocumentExecuter : GraphQL.DocumentExecuter
     {
+        [System.Obsolete("Use constructor that accepts IConfigureExecution also; will be removed in v6")]
         public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }
         public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configureExecutions, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions) { }
         public override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options) { }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -106,8 +106,15 @@ namespace GraphQL
         public DocumentExecuter() { }
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer) { }
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache) { }
+        [System.Obsolete("Use the constructor that accepts IConfigureExecution; this constructor will be re" +
+            "moved in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configurations) { }
+        public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configurations) { }
+        [System.Obsolete("Use the constructor that accepts IConfigureExecution; this constructor will be re" +
+            "moved in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configurations, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }
+        [System.Obsolete("Added for DI compatibility only; this constructor will be removed in v6")]
+        public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configurations, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> optionsConfigurations) { }
         protected virtual GraphQL.Execution.ExecutionContext BuildExecutionContext(GraphQL.ExecutionOptions options, GraphQLParser.AST.GraphQLDocument document, GraphQLParser.AST.GraphQLOperationDefinition operation, GraphQL.Validation.Variables variables, GraphQL.Instrumentation.Metrics metrics) { }
         public virtual System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options) { }
         protected virtual GraphQLParser.AST.GraphQLOperationDefinition? GetOperation(string? operationName, GraphQLParser.AST.GraphQLDocument document) { }
@@ -246,6 +253,7 @@ namespace GraphQL
     }
     public static class GraphQLBuilderExtensions
     {
+        public static GraphQL.DI.IGraphQLBuilder AddApolloTracingResults(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoClrMappings(this GraphQL.DI.IGraphQLBuilder builder, bool mapInputTypes = true, bool mapOutputTypes = true) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoSchema<TQueryClrType>(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.IConfigureAutoSchema>? configure = null) { }
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder) { }
@@ -341,6 +349,7 @@ namespace GraphQL
             where TValidationRule :  class, GraphQL.Validation.IValidationRule { }
         public static GraphQL.DI.IServiceRegister Configure<TOptions>(this GraphQL.DI.IServiceRegister services, System.Action<TOptions>? action)
             where TOptions :  class, new () { }
+        public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>>, GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecutionOptions(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.ExecutionOptions> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecutionOptions(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureSchema(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Types.ISchema> action) { }
@@ -924,6 +933,11 @@ namespace GraphQL.DI
         public abstract GraphQL.DI.IServiceRegister Services { get; }
         protected virtual void RegisterDefaultServices() { }
     }
+    public interface IConfigureExecution
+    {
+        System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> next, GraphQL.ExecutionOptions executionOptions);
+    }
+    [System.Obsolete("Use IConfigureExecution; will be removed in v6")]
     public interface IConfigureExecutionOptions
     {
         System.Threading.Tasks.Task ConfigureAsync(GraphQL.ExecutionOptions executionOptions);
@@ -1338,9 +1352,11 @@ namespace GraphQL.Instrumentation
             public string? ReturnType { get; set; }
         }
     }
+    [System.Obsolete("Use AddApolloTracingResults instead; will be removed in v6")]
     public class ApolloTracingDocumentExecuter : GraphQL.DocumentExecuter
     {
         public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }
+        public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configureExecutions, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions) { }
         public override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options) { }
     }
     public static class ApolloTracingExtensions

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -109,11 +109,9 @@ namespace GraphQL
         [System.Obsolete("Use the constructor that accepts IConfigureExecution; this constructor will be re" +
             "moved in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configurations) { }
-        public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configurations) { }
         [System.Obsolete("Use the constructor that accepts IConfigureExecution; this constructor will be re" +
             "moved in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configurations, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }
-        [System.Obsolete("Added for DI compatibility only; this constructor will be removed in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configurations, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> optionsConfigurations) { }
         protected virtual GraphQL.Execution.ExecutionContext BuildExecutionContext(GraphQL.ExecutionOptions options, GraphQLParser.AST.GraphQLDocument document, GraphQLParser.AST.GraphQLOperationDefinition operation, GraphQL.Validation.Variables variables, GraphQL.Instrumentation.Metrics metrics) { }
         public virtual System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options) { }
@@ -253,7 +251,6 @@ namespace GraphQL
     }
     public static class GraphQLBuilderExtensions
     {
-        public static GraphQL.DI.IGraphQLBuilder AddApolloTracingResults(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoClrMappings(this GraphQL.DI.IGraphQLBuilder builder, bool mapInputTypes = true, bool mapOutputTypes = true) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoSchema<TQueryClrType>(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.IConfigureAutoSchema>? configure = null) { }
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder) { }
@@ -349,7 +346,7 @@ namespace GraphQL
             where TValidationRule :  class, GraphQL.Validation.IValidationRule { }
         public static GraphQL.DI.IServiceRegister Configure<TOptions>(this GraphQL.DI.IServiceRegister services, System.Action<TOptions>? action)
             where TOptions :  class, new () { }
-        public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>>, GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> action) { }
+        public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, GraphQL.DI.ExecutionDelegate, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecutionOptions(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.ExecutionOptions> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecutionOptions(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureSchema(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Types.ISchema> action) { }
@@ -927,6 +924,7 @@ namespace GraphQL.Conversion
 }
 namespace GraphQL.DI
 {
+    public delegate System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecutionDelegate(GraphQL.ExecutionOptions options);
     public abstract class GraphQLBuilderBase : GraphQL.DI.IGraphQLBuilder
     {
         protected GraphQLBuilderBase() { }
@@ -935,9 +933,8 @@ namespace GraphQL.DI
     }
     public interface IConfigureExecution
     {
-        System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> next, GraphQL.ExecutionOptions executionOptions);
+        System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options, GraphQL.DI.ExecutionDelegate next);
     }
-    [System.Obsolete("Use IConfigureExecution; will be removed in v6")]
     public interface IConfigureExecutionOptions
     {
         System.Threading.Tasks.Task ConfigureAsync(GraphQL.ExecutionOptions executionOptions);
@@ -1352,7 +1349,6 @@ namespace GraphQL.Instrumentation
             public string? ReturnType { get; set; }
         }
     }
-    [System.Obsolete("Use AddApolloTracingResults instead; will be removed in v6")]
     public class ApolloTracingDocumentExecuter : GraphQL.DocumentExecuter
     {
         public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1351,6 +1351,7 @@ namespace GraphQL.Instrumentation
     }
     public class ApolloTracingDocumentExecuter : GraphQL.DocumentExecuter
     {
+        [System.Obsolete("Use constructor that accepts IConfigureExecution also; will be removed in v6")]
         public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }
         public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configureExecutions, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions) { }
         public override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -106,8 +106,15 @@ namespace GraphQL
         public DocumentExecuter() { }
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer) { }
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache) { }
+        [System.Obsolete("Use the constructor that accepts IConfigureExecution; this constructor will be re" +
+            "moved in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configurations) { }
+        public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configurations) { }
+        [System.Obsolete("Use the constructor that accepts IConfigureExecution; this constructor will be re" +
+            "moved in v6")]
         public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configurations, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }
+        [System.Obsolete("Added for DI compatibility only; this constructor will be removed in v6")]
+        public DocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configurations, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> optionsConfigurations) { }
         protected virtual GraphQL.Execution.ExecutionContext BuildExecutionContext(GraphQL.ExecutionOptions options, GraphQLParser.AST.GraphQLDocument document, GraphQLParser.AST.GraphQLOperationDefinition operation, GraphQL.Validation.Variables variables, GraphQL.Instrumentation.Metrics metrics) { }
         public virtual System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options) { }
         protected virtual GraphQLParser.AST.GraphQLOperationDefinition? GetOperation(string? operationName, GraphQLParser.AST.GraphQLDocument document) { }
@@ -246,6 +253,7 @@ namespace GraphQL
     }
     public static class GraphQLBuilderExtensions
     {
+        public static GraphQL.DI.IGraphQLBuilder AddApolloTracingResults(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoClrMappings(this GraphQL.DI.IGraphQLBuilder builder, bool mapInputTypes = true, bool mapOutputTypes = true) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoSchema<TQueryClrType>(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.IConfigureAutoSchema>? configure = null) { }
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder) { }
@@ -341,6 +349,7 @@ namespace GraphQL
             where TValidationRule :  class, GraphQL.Validation.IValidationRule { }
         public static GraphQL.DI.IServiceRegister Configure<TOptions>(this GraphQL.DI.IServiceRegister services, System.Action<TOptions>? action)
             where TOptions :  class, new () { }
+        public static GraphQL.DI.IGraphQLBuilder ConfigureExecution(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>>, GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecutionOptions(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.ExecutionOptions> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureExecutionOptions(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task> action) { }
         public static GraphQL.DI.IGraphQLBuilder ConfigureSchema(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Types.ISchema> action) { }
@@ -924,6 +933,11 @@ namespace GraphQL.DI
         public abstract GraphQL.DI.IServiceRegister Services { get; }
         protected virtual void RegisterDefaultServices() { }
     }
+    public interface IConfigureExecution
+    {
+        System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(System.Func<GraphQL.ExecutionOptions, System.Threading.Tasks.Task<GraphQL.ExecutionResult>> next, GraphQL.ExecutionOptions executionOptions);
+    }
+    [System.Obsolete("Use IConfigureExecution; will be removed in v6")]
     public interface IConfigureExecutionOptions
     {
         System.Threading.Tasks.Task ConfigureAsync(GraphQL.ExecutionOptions executionOptions);
@@ -1338,9 +1352,11 @@ namespace GraphQL.Instrumentation
             public string? ReturnType { get; set; }
         }
     }
+    [System.Obsolete("Use AddApolloTracingResults instead; will be removed in v6")]
     public class ApolloTracingDocumentExecuter : GraphQL.DocumentExecuter
     {
         public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector) { }
+        public ApolloTracingDocumentExecuter(GraphQL.Execution.IDocumentBuilder documentBuilder, GraphQL.Validation.IDocumentValidator documentValidator, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer, GraphQL.Caching.IDocumentCache documentCache, GraphQL.Execution.IExecutionStrategySelector executionStrategySelector, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecution> configureExecutions, System.Collections.Generic.IEnumerable<GraphQL.DI.IConfigureExecutionOptions> configureExecutionOptions) { }
         public override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(GraphQL.ExecutionOptions options) { }
     }
     public static class ApolloTracingExtensions

--- a/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
@@ -114,4 +114,26 @@ query {
         var resultString = serializer.Serialize(result);
         resultString.ShouldStartWith(@"{""data"":{""hero"":{""name"":""R2-D2""}},""extensions"":{""tracing"":{""version"":1,""startTime"":""");
     }
+
+    [Fact]
+    public async Task AddApolloTracingResults_Works()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<StarWarsData>();
+        serviceCollection.AddGraphQL(b => b
+            .AddSelfActivatingSchema<StarWarsSchema>()
+            .AddMetrics(true)
+            .AddApolloTracingResults()
+            .AddSystemTextJson());
+        using var provider = serviceCollection.BuildServiceProvider();
+        var executer = provider.GetRequiredService<IDocumentExecuter<ISchema>>();
+        var serializer = provider.GetRequiredService<IGraphQLTextSerializer>();
+        var result = await executer.ExecuteAsync(new ExecutionOptions
+        {
+            Query = "{ hero { name } }",
+            RequestServices = provider,
+        }).ConfigureAwait(false);
+        var resultString = serializer.Serialize(result);
+        resultString.ShouldStartWith(@"{""data"":{""hero"":{""name"":""R2-D2""}},""extensions"":{""tracing"":{""version"":1,""startTime"":""");
+    }
 }

--- a/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
@@ -116,7 +116,7 @@ query {
     }
 
     [Fact]
-    public async Task AddApolloTracingResults_Works()
+    public async Task AddApolloTracing_Works()
     {
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddSingleton<StarWarsData>();

--- a/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
@@ -114,26 +114,4 @@ query {
         var resultString = serializer.Serialize(result);
         resultString.ShouldStartWith(@"{""data"":{""hero"":{""name"":""R2-D2""}},""extensions"":{""tracing"":{""version"":1,""startTime"":""");
     }
-
-    [Fact]
-    public async Task AddApolloTracing_Works()
-    {
-        var serviceCollection = new ServiceCollection();
-        serviceCollection.AddSingleton<StarWarsData>();
-        serviceCollection.AddGraphQL(b => b
-            .AddSelfActivatingSchema<StarWarsSchema>()
-            .AddMetrics(true)
-            .AddApolloTracingResults()
-            .AddSystemTextJson());
-        using var provider = serviceCollection.BuildServiceProvider();
-        var executer = provider.GetRequiredService<IDocumentExecuter<ISchema>>();
-        var serializer = provider.GetRequiredService<IGraphQLTextSerializer>();
-        var result = await executer.ExecuteAsync(new ExecutionOptions
-        {
-            Query = "{ hero { name } }",
-            RequestServices = provider,
-        }).ConfigureAwait(false);
-        var resultString = serializer.Serialize(result);
-        resultString.ShouldStartWith(@"{""data"":{""hero"":{""name"":""R2-D2""}},""extensions"":{""tracing"":{""version"":1,""startTime"":""");
-    }
 }

--- a/src/GraphQL/DI/IConfigureExecution.cs
+++ b/src/GraphQL/DI/IConfigureExecution.cs
@@ -12,8 +12,13 @@ namespace GraphQL.DI
         /// <remarks>
         /// <see cref="ExecutionOptions.RequestServices"/> can be used to resolve other services from the dependency injection framework.
         /// </remarks>
-        Task<ExecutionResult> ExecuteAsync(Func<ExecutionOptions, Task<ExecutionResult>> next, ExecutionOptions executionOptions);
+        Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next);
     }
+    
+    /// <summary>
+    /// A function that can process a GraphQL document.
+    /// </summary>
+    public delegate Task<ExecutionResult> ExecutionDelegate(ExecutionOptions options);
 
     internal class ConfigureExecution : IConfigureExecution
     {

--- a/src/GraphQL/DI/IConfigureExecution.cs
+++ b/src/GraphQL/DI/IConfigureExecution.cs
@@ -24,7 +24,7 @@ namespace GraphQL.DI
     {
         private readonly Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> _action;
 
-        public ConfigureExecution(Func<Func<ExecutionOptions, Task<ExecutionResult>>, ExecutionOptions, Task<ExecutionResult>> action)
+        public ConfigureExecution(Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> action)
         {
             _action = action;
         }

--- a/src/GraphQL/DI/IConfigureExecution.cs
+++ b/src/GraphQL/DI/IConfigureExecution.cs
@@ -1,0 +1,30 @@
+namespace GraphQL.DI
+{
+    /// <summary>
+    /// Allows configuration of document execution, adding or replacing default behavior.
+    /// This configuration generally happens in <see cref="IDocumentExecuter.ExecuteAsync" /> implementations.
+    /// </summary>
+    public interface IConfigureExecution
+    {
+        /// <summary>
+        /// Called when the document begins executing, passing in a delegate to continue execution.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ExecutionOptions.RequestServices"/> can be used to resolve other services from the dependency injection framework.
+        /// </remarks>
+        Task<ExecutionResult> ExecuteAsync(Func<ExecutionOptions, Task<ExecutionResult>> next, ExecutionOptions executionOptions);
+    }
+
+    internal class ConfigureExecution : IConfigureExecution
+    {
+        private readonly Func<Func<ExecutionOptions, Task<ExecutionResult>>, ExecutionOptions, Task<ExecutionResult>> _action;
+
+        public ConfigureExecution(Func<Func<ExecutionOptions, Task<ExecutionResult>>, ExecutionOptions, Task<ExecutionResult>> action)
+        {
+            _action = action;
+        }
+
+        public Task<ExecutionResult> ExecuteAsync(Func<ExecutionOptions, Task<ExecutionResult>> next, ExecutionOptions executionOptions)
+            => _action(next, executionOptions);
+    }
+}

--- a/src/GraphQL/DI/IConfigureExecution.cs
+++ b/src/GraphQL/DI/IConfigureExecution.cs
@@ -22,7 +22,7 @@ namespace GraphQL.DI
 
     internal class ConfigureExecution : IConfigureExecution
     {
-        private readonly Func<Func<ExecutionOptions, Task<ExecutionResult>>, ExecutionOptions, Task<ExecutionResult>> _action;
+        private readonly Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> _action;
 
         public ConfigureExecution(Func<Func<ExecutionOptions, Task<ExecutionResult>>, ExecutionOptions, Task<ExecutionResult>> action)
         {

--- a/src/GraphQL/DI/IConfigureExecution.cs
+++ b/src/GraphQL/DI/IConfigureExecution.cs
@@ -14,7 +14,7 @@ namespace GraphQL.DI
         /// </remarks>
         Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next);
     }
-    
+
     /// <summary>
     /// A function that can process a GraphQL document.
     /// </summary>

--- a/src/GraphQL/DI/IConfigureExecution.cs
+++ b/src/GraphQL/DI/IConfigureExecution.cs
@@ -29,7 +29,7 @@ namespace GraphQL.DI
             _action = action;
         }
 
-        public Task<ExecutionResult> ExecuteAsync(Func<ExecutionOptions, Task<ExecutionResult>> next, ExecutionOptions executionOptions)
-            => _action(next, executionOptions);
+        public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
+            => _action(options, next);
     }
 }

--- a/src/GraphQL/DI/IConfigureExecutionOptions.cs
+++ b/src/GraphQL/DI/IConfigureExecutionOptions.cs
@@ -4,8 +4,7 @@ namespace GraphQL.DI // TODO: think about namespaces!
     /// Allows configuration of execution options immediately prior to executing a document.
     /// This configuration generally happens in <see cref="IDocumentExecuter.ExecuteAsync" /> implementations.
     /// </summary>
-    [Obsolete("Use IConfigureExecution; will be removed in v6")]
-    public interface IConfigureExecutionOptions
+    public interface IConfigureExecutionOptions // TODO: remove in v6
     {
         /// <summary>
         /// Configures execution options immediately prior to executing a document.
@@ -16,9 +15,7 @@ namespace GraphQL.DI // TODO: think about namespaces!
         Task ConfigureAsync(ExecutionOptions executionOptions);
     }
 
-#pragma warning disable CS0618 // Type or member is obsolete
     internal sealed class ConfigureExecutionOptions : IConfigureExecutionOptions // implement IConfigureExecution for v6
-#pragma warning restore CS0618 // Type or member is obsolete
     {
         private readonly Func<ExecutionOptions, Task> _action;
 

--- a/src/GraphQL/DI/IConfigureExecutionOptions.cs
+++ b/src/GraphQL/DI/IConfigureExecutionOptions.cs
@@ -64,6 +64,6 @@ namespace GraphQL.DI // TODO: think about namespaces!
         }
 
         public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
-            => _action(executionOptions, next);
+            => _action(options, next);
     }
 }

--- a/src/GraphQL/DI/IConfigureExecutionOptions.cs
+++ b/src/GraphQL/DI/IConfigureExecutionOptions.cs
@@ -63,7 +63,7 @@ namespace GraphQL.DI // TODO: think about namespaces!
             }
         }
 
-        public Task<ExecutionResult> ExecuteAsync(ExecutionOptions executionOptions, ExecutionDelegate next)
+        public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
             => _action(executionOptions, next);
     }
 }

--- a/src/GraphQL/DI/IConfigureExecutionOptions.cs
+++ b/src/GraphQL/DI/IConfigureExecutionOptions.cs
@@ -44,14 +44,14 @@ namespace GraphQL.DI // TODO: think about namespaces!
     [Obsolete("Remove in v6")]
     internal sealed class ConfigureExecutionOptionsMapper : IConfigureExecution
     {
-        private readonly Func<Func<ExecutionOptions, Task<ExecutionResult>>, ExecutionOptions, Task<ExecutionResult>> _action;
+        private readonly Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> _action;
 
         public ConfigureExecutionOptionsMapper(IEnumerable<IConfigureExecutionOptions> configureExecutionOptions)
         {
             var configurations = configureExecutionOptions.ToArray();
             if (configurations.Length > 0)
             {
-                _action = async (next, options) =>
+                _action = async (options, next) =>
                 {
                     for (int i = 0; i < configurations.Length; i++)
                     {
@@ -62,11 +62,11 @@ namespace GraphQL.DI // TODO: think about namespaces!
             }
             else
             {
-                _action = (next, options) => next(options);
+                _action = (options, next) => next(options);
             }
         }
 
-        public Task<ExecutionResult> ExecuteAsync(Func<ExecutionOptions, Task<ExecutionResult>> next, ExecutionOptions executionOptions)
-            => _action(next, executionOptions);
+        public Task<ExecutionResult> ExecuteAsync(ExecutionOptions executionOptions, ExecutionDelegate next)
+            => _action(executionOptions, next);
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -123,7 +123,7 @@ namespace GraphQL
             if (options == null)
                 throw new ArgumentNullException(nameof(options));
 
-            return await _execution(options).ConfigureAwait(false);
+            return _execution(options);
         }
 
         private async Task<ExecutionResult> InternalExecuteAsync(ExecutionOptions options)

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -106,7 +106,7 @@ namespace GraphQL
 
         private Func<ExecutionOptions, Task<ExecutionResult>> BuildExecution(IEnumerable<IConfigureExecution> configurations)
         {
-            Func<ExecutionOptions, Task<ExecutionResult>> execution = InternalExecuteAsync;
+            ExecutionDelegate execution = CoreExecuteAsync;
             var configurationArray = configurations.ToArray();
             for (var i = configurationArray.Length - 1; i >= 0; i--)
             {

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -118,7 +118,7 @@ namespace GraphQL
         }
 
         /// <inheritdoc/>
-        public virtual async Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)
+        public virtual Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)
         {
             if (options == null)
                 throw new ArgumentNullException(nameof(options));

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -96,7 +96,7 @@ namespace GraphQL
         /// <see cref="IDocumentValidator"/>, <see cref="IComplexityAnalyzer"/>,
         /// <see cref="IDocumentCache"/> and a set of <see cref="IConfigureExecutionOptions"/> instances.
         /// </summary>
-        internal DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IComplexityAnalyzer complexityAnalyzer, IDocumentCache documentCache, IExecutionStrategySelector executionStrategySelector, IEnumerable<IConfigureExecution> configurations)
+        private DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IComplexityAnalyzer complexityAnalyzer, IDocumentCache documentCache, IExecutionStrategySelector executionStrategySelector, IEnumerable<IConfigureExecution> configurations)
         {
             // TODO: in v6 make this public
             _documentBuilder = documentBuilder ?? throw new ArgumentNullException(nameof(documentBuilder));

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -83,10 +83,12 @@ namespace GraphQL
         /// <see cref="IDocumentValidator"/>, <see cref="IComplexityAnalyzer"/>,
         /// <see cref="IDocumentCache"/> and a set of <see cref="IConfigureExecutionOptions"/> instances.
         /// </summary>
-        [Obsolete("Added for DI compatibility only; this constructor will be removed in v6")]
         public DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IComplexityAnalyzer complexityAnalyzer, IDocumentCache documentCache, IExecutionStrategySelector executionStrategySelector, IEnumerable<IConfigureExecution> configurations, IEnumerable<IConfigureExecutionOptions> optionsConfigurations)
+#pragma warning disable CS0618 // Type or member is obsolete
             : this(documentBuilder, documentValidator, complexityAnalyzer, documentCache, executionStrategySelector, configurations.Append(new ConfigureExecutionOptionsMapper(optionsConfigurations)))
+#pragma warning restore CS0618 // Type or member is obsolete
         {
+            // TODO: remove in v6
         }
 
         /// <summary>
@@ -94,8 +96,9 @@ namespace GraphQL
         /// <see cref="IDocumentValidator"/>, <see cref="IComplexityAnalyzer"/>,
         /// <see cref="IDocumentCache"/> and a set of <see cref="IConfigureExecutionOptions"/> instances.
         /// </summary>
-        public DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IComplexityAnalyzer complexityAnalyzer, IDocumentCache documentCache, IExecutionStrategySelector executionStrategySelector, IEnumerable<IConfigureExecution> configurations)
+        internal DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IComplexityAnalyzer complexityAnalyzer, IDocumentCache documentCache, IExecutionStrategySelector executionStrategySelector, IEnumerable<IConfigureExecution> configurations)
         {
+            // TODO: in v6 make this public
             _documentBuilder = documentBuilder ?? throw new ArgumentNullException(nameof(documentBuilder));
             _documentValidator = documentValidator ?? throw new ArgumentNullException(nameof(documentValidator));
             _complexityAnalyzer = complexityAnalyzer ?? throw new ArgumentNullException(nameof(complexityAnalyzer));

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -79,7 +79,7 @@ namespace GraphQL
         }
 
         /// <summary>
-        /// Initializes a new instance with specified <see cref="IDocumentBuilder"/>,
+        /// Initializes a new instance with the specified <see cref="IDocumentBuilder"/>,
         /// <see cref="IDocumentValidator"/>, <see cref="IComplexityAnalyzer"/>,
         /// <see cref="IDocumentCache"/> and a set of <see cref="IConfigureExecutionOptions"/> instances.
         /// </summary>

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -126,7 +126,7 @@ namespace GraphQL
             return _execution(options);
         }
 
-        private async Task<ExecutionResult> InternalExecuteAsync(ExecutionOptions options)
+        private async Task<ExecutionResult> CoreExecuteAsync(ExecutionOptions options)
         {
             if (options.Schema == null)
                 throw new InvalidOperationException("Cannot execute request if no schema is specified");

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -104,7 +104,7 @@ namespace GraphQL
             _execution = BuildExecution(configurations);
         }
 
-        private Func<ExecutionOptions, Task<ExecutionResult>> BuildExecution(IEnumerable<IConfigureExecution> configurations)
+        private ExecutionDelegate BuildExecutionDelegate(IEnumerable<IConfigureExecution> configurations)
         {
             ExecutionDelegate execution = CoreExecuteAsync;
             var configurationArray = configurations.ToArray();

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -112,7 +112,7 @@ namespace GraphQL
             {
                 var action = configurationArray[i];
                 var nextExecution = execution;
-                execution = async options => await action.ExecuteAsync(nextExecution, options).ConfigureAwait(false);
+                execution = async options => await action.ExecuteAsync(options, nextExecution).ConfigureAwait(false);
             }
             return execution;
         }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -101,7 +101,7 @@ namespace GraphQL
             _complexityAnalyzer = complexityAnalyzer ?? throw new ArgumentNullException(nameof(complexityAnalyzer));
             _documentCache = documentCache ?? throw new ArgumentNullException(nameof(documentCache));
             _executionStrategySelector = executionStrategySelector ?? throw new ArgumentNullException(nameof(executionStrategySelector));
-            _execution = BuildExecution(configurations);
+            _execution = BuildExecutionDelegate(configurations);
         }
 
         private ExecutionDelegate BuildExecutionDelegate(IEnumerable<IConfigureExecution> configurations)

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -23,7 +23,7 @@ namespace GraphQL
         private readonly IDocumentValidator _documentValidator;
         private readonly IComplexityAnalyzer _complexityAnalyzer;
         private readonly IDocumentCache _documentCache;
-        private readonly Func<ExecutionOptions, Task<ExecutionResult>> _execution;
+        private readonly ExecutionDelegate _execution;
         private readonly IExecutionStrategySelector _executionStrategySelector;
 
         /// <summary>

--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -1099,7 +1099,7 @@ namespace GraphQL
         /// </summary>
         public static IGraphQLBuilder AddApolloTracingResults(this IGraphQLBuilder builder)
         {
-            return builder.ConfigureExecution(async (next, options) =>
+            return builder.ConfigureExecution(async (options, next) =>
             {
                 var start = DateTime.UtcNow;
                 var result = await next(options).ConfigureAwait(false);

--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -1093,21 +1093,6 @@ namespace GraphQL
             });
             return builder;
         }
-
-        /// <summary>
-        /// Configures the execution to add Apollo Tracing results to the returned <see cref="ExecutionResult"/> instance.
-        /// </summary>
-        public static IGraphQLBuilder AddApolloTracingResults(this IGraphQLBuilder builder)
-        {
-            return builder.ConfigureExecution(async (options, next) =>
-            {
-                var start = DateTime.UtcNow;
-                var result = await next(options).ConfigureAwait(false);
-                if (options.EnableMetrics)
-                    result.EnrichWithApolloTracing(start);
-                return result;
-            });
-        }
         #endregion
 
         #region - AddExecutionStrategySelector -

--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -915,9 +915,7 @@ namespace GraphQL
         /// </remarks>
         public static IGraphQLBuilder ConfigureExecutionOptions(this IGraphQLBuilder builder, Action<ExecutionOptions> action)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             builder.Services.Register<IConfigureExecutionOptions>(new ConfigureExecutionOptions(action ?? throw new ArgumentNullException(nameof(action))));
-#pragma warning restore CS0618 // Type or member is obsolete
             return builder;
         }
 
@@ -932,9 +930,7 @@ namespace GraphQL
         /// </remarks>
         public static IGraphQLBuilder ConfigureExecutionOptions(this IGraphQLBuilder builder, Func<ExecutionOptions, Task> action)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             builder.Services.Register<IConfigureExecutionOptions>(new ConfigureExecutionOptions(action ?? throw new ArgumentNullException(nameof(action))));
-#pragma warning restore CS0618 // Type or member is obsolete
             return builder;
         }
 

--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -944,7 +944,7 @@ namespace GraphQL
         /// <remarks>
         /// <see cref="ExecutionOptions.RequestServices"/> can be used within the delegate to access the service provider for this execution.
         /// </remarks>
-        public static IGraphQLBuilder ConfigureExecution(this IGraphQLBuilder builder, Func<Func<ExecutionOptions, Task<ExecutionResult>>, ExecutionOptions, Task<ExecutionResult>> action)
+        public static IGraphQLBuilder ConfigureExecution(this IGraphQLBuilder builder, Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> action)
         {
             builder.Services.Register<IConfigureExecution>(new ConfigureExecution(action));
             return builder;

--- a/src/GraphQL/Instrumentation/ApolloTracingDocumentExecuter.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingDocumentExecuter.cs
@@ -27,6 +27,7 @@ public class ApolloTracingDocumentExecuter : DocumentExecuter
         : base(documentBuilder, documentValidator, complexityAnalyzer, documentCache, configureExecutionOptions, executionStrategySelector)
     {
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// Initializes a new instance.
@@ -42,7 +43,6 @@ public class ApolloTracingDocumentExecuter : DocumentExecuter
         : base(documentBuilder, documentValidator, complexityAnalyzer, documentCache, executionStrategySelector, configureExecutions, configureExecutionOptions)
     {
     }
-#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <inheritdoc/>
     public override async Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)

--- a/src/GraphQL/Instrumentation/ApolloTracingDocumentExecuter.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingDocumentExecuter.cs
@@ -16,7 +16,7 @@ public class ApolloTracingDocumentExecuter : DocumentExecuter
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
-#pragma warning disable CS0618 // Type or member is obsolete
+    [Obsolete("Use constructor that accepts IConfigureExecution also; will be removed in v6")]
     public ApolloTracingDocumentExecuter(
         IDocumentBuilder documentBuilder,
         IDocumentValidator documentValidator,
@@ -27,7 +27,6 @@ public class ApolloTracingDocumentExecuter : DocumentExecuter
         : base(documentBuilder, documentValidator, complexityAnalyzer, documentCache, configureExecutionOptions, executionStrategySelector)
     {
     }
-#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// Initializes a new instance.

--- a/src/GraphQL/Instrumentation/ApolloTracingDocumentExecuter.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingDocumentExecuter.cs
@@ -11,6 +11,7 @@ namespace GraphQL.Instrumentation;
 /// <see cref="ApolloTracingExtensions.EnrichWithApolloTracing(GraphQL.ExecutionResult, DateTime)"/>
 /// when complete, if <see cref="ExecutionOptions.EnableMetrics"/> is enabled.
 /// </summary>
+[Obsolete("Use AddApolloTracingResults instead; will be removed in v6")]
 public class ApolloTracingDocumentExecuter : DocumentExecuter
 {
     /// <summary>
@@ -24,6 +25,21 @@ public class ApolloTracingDocumentExecuter : DocumentExecuter
         IEnumerable<IConfigureExecutionOptions> configureExecutionOptions,
         IExecutionStrategySelector executionStrategySelector)
         : base(documentBuilder, documentValidator, complexityAnalyzer, documentCache, configureExecutionOptions, executionStrategySelector)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    public ApolloTracingDocumentExecuter(
+        IDocumentBuilder documentBuilder,
+        IDocumentValidator documentValidator,
+        IComplexityAnalyzer complexityAnalyzer,
+        IDocumentCache documentCache,
+        IExecutionStrategySelector executionStrategySelector,
+        IEnumerable<IConfigureExecution> configureExecutions,
+        IEnumerable<IConfigureExecutionOptions> configureExecutionOptions)
+        : base(documentBuilder, documentValidator, complexityAnalyzer, documentCache, executionStrategySelector, configureExecutions, configureExecutionOptions)
     {
     }
 

--- a/src/GraphQL/Instrumentation/ApolloTracingDocumentExecuter.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingDocumentExecuter.cs
@@ -11,12 +11,12 @@ namespace GraphQL.Instrumentation;
 /// <see cref="ApolloTracingExtensions.EnrichWithApolloTracing(GraphQL.ExecutionResult, DateTime)"/>
 /// when complete, if <see cref="ExecutionOptions.EnableMetrics"/> is enabled.
 /// </summary>
-[Obsolete("Use AddApolloTracingResults instead; will be removed in v6")]
 public class ApolloTracingDocumentExecuter : DocumentExecuter
 {
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
     public ApolloTracingDocumentExecuter(
         IDocumentBuilder documentBuilder,
         IDocumentValidator documentValidator,
@@ -42,6 +42,7 @@ public class ApolloTracingDocumentExecuter : DocumentExecuter
         : base(documentBuilder, documentValidator, complexityAnalyzer, documentCache, executionStrategySelector, configureExecutions, configureExecutionOptions)
     {
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <inheritdoc/>
     public override async Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)


### PR DESCRIPTION
This allows for 'middleware' or 'plugin' behavior to the document executer.  This will be immediately useful for appending Apollo Tracing results, as well as implementation of Automatic Persisted Queries.

`IConfigureExecution` works similarly to "Apollo Link"s as seen below:

![image](https://user-images.githubusercontent.com/6377684/167262260-0dc112b0-24e7-4179-bc01-809312fe5978.png)

Within our library, these components are implemented similarly to this:

| Apollo | GraphQL.NET |
|---|---|
| GraphQL operation | `IDocumentExecuter` |
| Link | `IConfigureExecution` |
| Terminating Link | `GraphQLHttpMiddleware` |

(In the diagram above, Apollo Links are shown in the context of a client, but same design applies to a server.)