### PR TITLE
Make FieldBuilder constructor public

### DIFF
--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -827,6 +827,7 @@ namespace GraphQL.Builders
     }
     public class FieldBuilder<TSourceType, TReturnType>
     {
+        public FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -755,6 +755,7 @@ namespace GraphQL.Builders
     }
     public class ConnectionBuilder<TSourceType>
     {
+        protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
@@ -791,6 +792,7 @@ namespace GraphQL.Builders
     }
     public class ConnectionBuilder<TSourceType, TReturnType>
     {
+        protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
@@ -827,7 +829,7 @@ namespace GraphQL.Builders
     }
     public class FieldBuilder<TSourceType, TReturnType>
     {
-        public FieldBuilder(GraphQL.Types.FieldType fieldType) { }
+        protected FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -827,6 +827,7 @@ namespace GraphQL.Builders
     }
     public class FieldBuilder<TSourceType, TReturnType>
     {
+        public FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -755,6 +755,7 @@ namespace GraphQL.Builders
     }
     public class ConnectionBuilder<TSourceType>
     {
+        protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
@@ -791,6 +792,7 @@ namespace GraphQL.Builders
     }
     public class ConnectionBuilder<TSourceType, TReturnType>
     {
+        protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
@@ -827,7 +829,7 @@ namespace GraphQL.Builders
     }
     public class FieldBuilder<TSourceType, TReturnType>
     {
-        public FieldBuilder(GraphQL.Types.FieldType fieldType) { }
+        protected FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -70,7 +70,10 @@ namespace GraphQL.Builders
         /// </summary>
         public FieldType FieldType { get; protected set; }
 
-        private ConnectionBuilder(FieldType fieldType)
+        /// <summary>
+        /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
+        /// </summary>
+        protected ConnectionBuilder(FieldType fieldType)
         {
             FieldType = fieldType;
         }

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -24,7 +24,10 @@ namespace GraphQL.Builders
         /// </summary>
         public FieldType FieldType { get; protected set; }
 
-        internal ConnectionBuilder(FieldType fieldType)
+        /// <summary>
+        /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
+        /// </summary>
+        protected internal ConnectionBuilder(FieldType fieldType)
         {
             FieldType = fieldType;
         }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -34,7 +34,10 @@ namespace GraphQL.Builders
         /// </summary>
         public FieldType FieldType { get; }
 
-        private FieldBuilder(FieldType fieldType)
+        /// <summary>
+        /// Initializes a new instance for the specified <see cref="GraphQL.Types.FieldType"/>.
+        /// </summary>
+        public FieldBuilder(FieldType fieldType)
         {
             FieldType = fieldType;
         }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -35,9 +35,9 @@ namespace GraphQL.Builders
         public FieldType FieldType { get; }
 
         /// <summary>
-        /// Initializes a new instance for the specified <see cref="GraphQL.Types.FieldType"/>.
+        /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
         /// </summary>
-        public FieldBuilder(FieldType fieldType)
+        protected FieldBuilder(FieldType fieldType)
         {
             FieldType = fieldType;
         }


### PR DESCRIPTION
I need this for some of my code.  Even though all the methods are `virtual`, since the constructor is `private`, I cannot inherit the class.

@sungam3r I will merge tonight if you do not get a chance to review before then; if you have comments we can always add another PR to address them.

Thanks!