### PR TITLE
Update api approvals for .NET SDK 6.0.300

### DIFF
--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup .NET Core 6.0 SDK
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.102'
+          dotnet-version: '6.0.x'
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/publish-code.yml
+++ b/.github/workflows/publish-code.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup .NET Core 6.0 SDK
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.102'
+          dotnet-version: '6.0.x'
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -37,7 +37,7 @@ jobs:
           dotnet-version: |
             3.1.x
             5.0.x
-            6.0.102
+            6.0.x
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -1149,20 +1149,10 @@ namespace GraphQL.Execution
     }
     public class ExecutionStrategyRegistration : System.IEquatable<GraphQL.Execution.ExecutionStrategyRegistration>
     {
-        protected ExecutionStrategyRegistration(GraphQL.Execution.ExecutionStrategyRegistration original) { }
         public ExecutionStrategyRegistration(GraphQL.Execution.IExecutionStrategy Strategy, GraphQLParser.AST.OperationType Operation) { }
         protected virtual System.Type EqualityContract { get; }
         public GraphQLParser.AST.OperationType Operation { get; set; }
         public GraphQL.Execution.IExecutionStrategy Strategy { get; set; }
-        public virtual GraphQL.Execution.ExecutionStrategyRegistration <Clone>$() { }
-        public void Deconstruct(out GraphQL.Execution.IExecutionStrategy Strategy, out GraphQLParser.AST.OperationType Operation) { }
-        public virtual bool Equals(GraphQL.Execution.ExecutionStrategyRegistration? other) { }
-        public override bool Equals(object? obj) { }
-        public override int GetHashCode() { }
-        protected virtual bool PrintMembers(System.Text.StringBuilder builder) { }
-        public override string ToString() { }
-        public static bool operator !=(GraphQL.Execution.ExecutionStrategyRegistration? left, GraphQL.Execution.ExecutionStrategyRegistration? right) { }
-        public static bool operator ==(GraphQL.Execution.ExecutionStrategyRegistration? left, GraphQL.Execution.ExecutionStrategyRegistration? right) { }
     }
     public class GraphQLDocumentBuilder : GraphQL.Execution.IDocumentBuilder
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1149,20 +1149,10 @@ namespace GraphQL.Execution
     }
     public class ExecutionStrategyRegistration : System.IEquatable<GraphQL.Execution.ExecutionStrategyRegistration>
     {
-        protected ExecutionStrategyRegistration(GraphQL.Execution.ExecutionStrategyRegistration original) { }
         public ExecutionStrategyRegistration(GraphQL.Execution.IExecutionStrategy Strategy, GraphQLParser.AST.OperationType Operation) { }
         protected virtual System.Type EqualityContract { get; }
         public GraphQLParser.AST.OperationType Operation { get; set; }
         public GraphQL.Execution.IExecutionStrategy Strategy { get; set; }
-        public virtual GraphQL.Execution.ExecutionStrategyRegistration <Clone>$() { }
-        public void Deconstruct(out GraphQL.Execution.IExecutionStrategy Strategy, out GraphQLParser.AST.OperationType Operation) { }
-        public virtual bool Equals(GraphQL.Execution.ExecutionStrategyRegistration? other) { }
-        public override bool Equals(object? obj) { }
-        public override int GetHashCode() { }
-        protected virtual bool PrintMembers(System.Text.StringBuilder builder) { }
-        public override string ToString() { }
-        public static bool operator !=(GraphQL.Execution.ExecutionStrategyRegistration? left, GraphQL.Execution.ExecutionStrategyRegistration? right) { }
-        public static bool operator ==(GraphQL.Execution.ExecutionStrategyRegistration? left, GraphQL.Execution.ExecutionStrategyRegistration? right) { }
     }
     public class GraphQLDocumentBuilder : GraphQL.Execution.IDocumentBuilder
     {


### PR DESCRIPTION
See:
- https://github.com/PublicApiGenerator/PublicApiGenerator/issues/207

Without this PR, api approvals will generate differently locally than within GitHub Actions (assuming that the current version of Visual Studio is installed locally).