### PR TITLE
Code-First Federation 2 support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0
+
+# Install dotnet 3.1, 5.0 and 6.0 sdks
+RUN curl -sLO https://dot.net/v1/dotnet-install.sh \
+    && chmod +x ./dotnet-install.sh \
+    && ./dotnet-install.sh --channel 3.1 --install-dir /usr/share/dotnet \
+    && ./dotnet-install.sh --channel 5.0 --install-dir /usr/share/dotnet \
+    && ./dotnet-install.sh --channel 6.0 --install-dir /usr/share/dotnet \
+    && rm ./dotnet-install.sh
+
+# Install procps (for ".NET Core Attach")
+RUN apt-get update \
+    && apt-get install -y procps

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json
+{
+  "name": "graphql-dotnet-dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // BUG: remove after https://github.com/microsoft/vscode-remote-release/issues/7958 is fixed
+      "BUILDKIT_INLINE_CACHE": "0"
+    }
+  },
+  "features": {
+    // https://containers.dev/features
+    "ghcr.io/devcontainers/features/git": {}
+  },
+  "settings": {
+    "omnisharp.useModernNet": true
+  },
+  "extensions": [
+    "ms-dotnettools.csharp",
+    "eamodio.gitlens",
+    "mhutchie.git-graph",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "ms-dotnettools.csharp",
+    "eamodio.gitlens",
+    "mhutchie.git-graph",
+    "ms-vscode-remote.remote-containers",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "dotnet-test-explorer.enableTelemetry": false,
-  "dotnet-test-explorer.testProjectPath": "src"
+  "dotnet-test-explorer.testProjectPath": "src",
+  "omnisharp.defaultLaunchSolution": "GraphQL.sln"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,16 +1,21 @@
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "dotnet",
-    "isShellCommand": true,
     "args": [],
     "tasks": [
         {
-            "taskName": "build",
+            "label": "build",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
+                "build",
                 "${workspaceRoot}/src/GraphQL.Harness/GraphQL.Harness.csproj"
             ],
-            "isBuildCommand": true,
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
         }
     ]
 }

--- a/src/GraphQL.ApiTests/ApiApprovalTests.cs
+++ b/src/GraphQL.ApiTests/ApiApprovalTests.cs
@@ -18,6 +18,7 @@ public class ApiApprovalTests
     [InlineData(typeof(MicrosoftDI.ScopedFieldBuilderExtensions))]
     [InlineData(typeof(Caching.MemoryDocumentCache))]
     [InlineData(typeof(DataLoader.DataLoaderContext))]
+    [InlineData(typeof(Federation.IFederationResolver))]
     public void PublicApi(Type type)
     {
         string baseDir = AppDomain.CurrentDomain.BaseDirectory;

--- a/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
+++ b/src/GraphQL.ApiTests/GraphQL.ApiTests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
     <ProjectReference Include="..\GraphQL.MemoryCache\GraphQL.MemoryCache.csproj" />
     <ProjectReference Include="..\GraphQL.DataLoader\GraphQL.DataLoader.csproj" />
+    <ProjectReference Include="..\GraphQL.Federation\GraphQL.Federation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQL.ApiTests/GraphQL.Federation.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.Federation.approved.txt
@@ -1,0 +1,132 @@
+namespace GraphQL.Federation.Attributes
+{
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    public class ExternalAttribute : GraphQL.GraphQLAttribute
+    {
+        public ExternalAttribute() { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    public class InaccessibleAttribute : GraphQL.GraphQLAttribute
+    {
+        public InaccessibleAttribute() { }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true)]
+    public class KeyAttribute : GraphQL.GraphQLAttribute
+    {
+        public KeyAttribute(string fields) { }
+        public KeyAttribute(params string[] fields) { }
+        public bool Resolvable { get; set; }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    public class OverrideAttribute : GraphQL.GraphQLAttribute
+    {
+        public OverrideAttribute(string from) { }
+        public string From { get; }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    public class ProvidesAttribute : GraphQL.GraphQLAttribute
+    {
+        public ProvidesAttribute(string fields) { }
+        public ProvidesAttribute(params string[] fields) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    public class RequiresAttribute : GraphQL.GraphQLAttribute
+    {
+        public RequiresAttribute(string fields) { }
+        public RequiresAttribute(params string[] fields) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    public class ShareableAttribute : GraphQL.GraphQLAttribute
+    {
+        public ShareableAttribute() { }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+}
+namespace GraphQL.Federation.Enums
+{
+    [System.Flags]
+    public enum FederationDirectiveEnum
+    {
+        Key = 1,
+        Shareable = 2,
+        Inaccessible = 4,
+        Override = 8,
+        External = 16,
+        Provides = 32,
+        Requires = 64,
+    }
+}
+namespace GraphQL.Federation.Extensions
+{
+    public class FederatedSchemaBuilder : GraphQL.Utilities.SchemaBuilder
+    {
+        public FederatedSchemaBuilder() { }
+        public override GraphQL.Types.Schema Build(string typeDefinitions) { }
+    }
+    public static class FederatedSchemaHelper
+    {
+        public static GraphQL.Types.Schema For(string typeDefinitions, System.Action<GraphQL.Federation.Extensions.FederatedSchemaBuilder>? configure = null) { }
+        public static GraphQL.Types.Schema For<TFederatedSchemaBuilder>(string typeDefinitions, System.Action<TFederatedSchemaBuilder>? configure = null)
+            where TFederatedSchemaBuilder : GraphQL.Federation.Extensions.FederatedSchemaBuilder, new () { }
+    }
+    public static class FederationFieldExtensions
+    {
+        public static void External(this GraphQL.Types.FieldType fieldType) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> External<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> fieldBuilder) { }
+        public static void Inaccessible(this GraphQL.Types.FieldType fieldType) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Inaccessible<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> fieldBuilder) { }
+        public static void Override(this GraphQL.Types.FieldType fieldType, string from) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Override<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> fieldBuilder, string from) { }
+        public static void Provides(this GraphQL.Types.FieldType fieldType, string[] fields) { }
+        public static void Provides(this GraphQL.Types.FieldType fieldType, string fields) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Provides<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields) { }
+        public static void Requires(this GraphQL.Types.FieldType fieldType, string[] fields) { }
+        public static void Requires(this GraphQL.Types.FieldType fieldType, string fields) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Requires<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields) { }
+        public static void Shareable(this GraphQL.Types.FieldType fieldType) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Shareable<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> fieldBuilder) { }
+    }
+    public static class FederationGraphQLBuilderExtensions
+    {
+        public static GraphQL.DI.IGraphQLBuilder AddFederation(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.Federation.Enums.FederationDirectiveEnum import, bool addFields = true, GraphQL.Utilities.SchemaPrinterOptions? schemaPrinterOptions = null) { }
+    }
+    public static class FederationGraphTypeExtensions
+    {
+        public static GraphQL.Builders.FieldBuilder<T, object> AddEntities<T>(this GraphQL.Types.ComplexGraphType<T> graphType) { }
+        public static GraphQL.Builders.FieldBuilder<T, object> AddServices<T>(this GraphQL.Types.ComplexGraphType<T> graphType) { }
+        public static void Inaccessible(this GraphQL.Types.IGraphType graphType) { }
+        public static void Key(this GraphQL.Types.IObjectGraphType graphType, string[] fields, bool resolvable = true) { }
+        public static void Key(this GraphQL.Types.IObjectGraphType graphType, string fields, bool resolvable = true) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, GraphQL.Federation.IFederationResolver resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TSourceType>> resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TSourceType>> resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TSourceType> resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Utilities.TypeConfig typeConfig, GraphQL.Federation.IFederationResolver resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Utilities.TypeConfig typeConfig, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TSourceType>> resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Utilities.TypeConfig typeConfig, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TSourceType>> resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Utilities.TypeConfig typeConfig, System.Func<GraphQL.IResolveFieldContext, TSourceType, TSourceType> resolver) { }
+        public static void Shareable(this GraphQL.Types.IGraphType graphType) { }
+    }
+}
+namespace GraphQL.Federation
+{
+    public class FuncFederationResolver<TSourceType> : GraphQL.Federation.IFederationResolver
+    {
+        public FuncFederationResolver(System.Func<GraphQL.IResolveFieldContext, TSourceType, object?> resolve) { }
+        public System.Type SourceType { get; }
+        public object? Resolve(GraphQL.IResolveFieldContext context, object source) { }
+    }
+    public interface IFederationResolver
+    {
+        System.Type SourceType { get; }
+        object? Resolve(GraphQL.IResolveFieldContext context, object source);
+    }
+}

--- a/src/GraphQL.Federation.Tests/BaseCodeFirstGraphQLTest.cs
+++ b/src/GraphQL.Federation.Tests/BaseCodeFirstGraphQLTest.cs
@@ -1,0 +1,15 @@
+using GraphQL.Federation.Tests.Fixtures;
+
+namespace GraphQL.Federation.Tests;
+
+public abstract class BaseCodeFirstGraphQLTest : BaseTest
+{
+    protected readonly IServiceProvider Services;
+    protected readonly GraphQL.Types.Schema Schema;
+
+    protected BaseCodeFirstGraphQLTest(CodeFirstFixture codeFirstFixture)
+    {
+        Services = codeFirstFixture.Services;
+        Schema = codeFirstFixture.Schema;
+    }
+}

--- a/src/GraphQL.Federation.Tests/BaseSchemaFirstGraphQLTest.cs
+++ b/src/GraphQL.Federation.Tests/BaseSchemaFirstGraphQLTest.cs
@@ -1,0 +1,15 @@
+using GraphQL.Federation.Tests.Fixtures;
+
+namespace GraphQL.Federation.Tests;
+
+public abstract class BaseSchemaFirstGraphQLTest : BaseTest
+{
+    protected readonly IServiceProvider Services;
+    protected readonly GraphQL.Types.Schema Schema;
+
+    protected BaseSchemaFirstGraphQLTest(SchemaFirstFixture serviceProviderFixture)
+    {
+        Services = serviceProviderFixture.Services;
+        Schema = serviceProviderFixture.Schema;
+    }
+}

--- a/src/GraphQL.Federation.Tests/BaseTest.cs
+++ b/src/GraphQL.Federation.Tests/BaseTest.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+
+namespace GraphQL.Federation.Tests;
+
+public abstract class BaseTest
+{
+    protected static void WaitForDebugger()
+    {
+        while (!Debugger.IsAttached)
+        {
+            Thread.Sleep(100);
+        }
+    }
+}

--- a/src/GraphQL.Federation.Tests/CodeFirstFederationTest.cs
+++ b/src/GraphQL.Federation.Tests/CodeFirstFederationTest.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using GraphQL.DataLoader;
+using GraphQL.Federation.Tests.Fixtures;
+using GraphQL.SystemTextJson;
+using GraphQL.Tests;
+
+namespace GraphQL.Federation.Tests;
+
+// dotnet test GraphQL.Federation.Tests --filter DisplayName~GraphQL.Federation.Tests.CodeFirstFederationTest.ServiceTest
+// dotnet test GraphQL.Federation.Tests --filter DisplayName~GraphQL.Federation.Tests.CodeFirstFederationTest.EntitiesTest
+[Collection(nameof(CodeFirstCollectionDefinition))]
+public class CodeFirstFederationTest : BaseCodeFirstGraphQLTest
+{
+    public CodeFirstFederationTest(CodeFirstFixture codeFirstFixture)
+        : base(codeFirstFixture)
+    { }
+
+    [Fact]
+    public async Task ServiceTest()
+    {
+        // WaitForDebugger();
+
+        var json = await Schema.ExecuteAsync(new GraphQLSerializer(), options =>
+        {
+            options.Listeners.Add(new DataLoaderDocumentListener(new DataLoaderContextAccessor()));
+            options.ThrowOnUnhandledException = true;
+            options.Query = """
+                query {
+                  _service {
+                    sdl
+                  }
+                }
+                """;
+        }).ConfigureAwait(false);
+
+        var sdl = JsonDocument.Parse(json).RootElement
+            .GetProperty("data")
+            .GetProperty("_service")
+            .GetProperty("sdl")
+            .GetString();
+
+        sdl.ShouldBeCrossPlat("""
+            schema {
+              query: TestQuery
+            }
+
+            type DirectivesTestDto @key(fields: "id") @shareable @inaccessible {
+              id: Int!
+              shareable: String @shareable
+              inaccessible: String @inaccessible
+              override: String @override(from: "OtherSubgraph")
+              external: String @external
+              provides: String @provides(fields: "foo bar")
+              requires: String @requires(fields: "foo bar")
+            }
+
+            type ExternalResolvableTestDto @key(fields: "id") {
+              id: Int!
+              external: String @external
+              extended: String! @requires(fields: "external")
+            }
+
+            type ExternalTestDto @key(fields: "id", resolvable: false) {
+              id: Int!
+            }
+
+            type FederatedTestDto @key(fields: "id") {
+              id: Int!
+              name: String @deprecated(reason: "Test deprecation reason 01.")
+              externalTestId: Int!
+              externalResolvableTestId: Int!
+              externalTest: ExternalTestDto! @deprecated(reason: "Test deprecation reason 02.")
+              externalResolvableTest: ExternalResolvableTestDto! @provides(fields: "external")
+            }
+
+            type TestQuery {
+              directivesTest: DirectivesTestDto!
+            }
+
+
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires"])
+            """);
+    }
+
+    [Fact]
+    public async Task EntitiesTest()
+    {
+        // WaitForDebugger();
+
+        var json = await Schema.ExecuteAsync(new GraphQLSerializer(), options =>
+        {
+            options.Listeners.Add(new DataLoaderDocumentListener(new DataLoaderContextAccessor()));
+            options.ThrowOnUnhandledException = true;
+            options.Query = """
+                query {
+                  _entities(representations: [{ __typename: "FederatedTestDto", id: 1 }, { __typename: "FederatedTestDto", id: 3 }, { __typename: "ExternalResolvableTestDto", id: 123, external: "asdfgh" }]) {
+                    ... on FederatedTestDto {
+                      name
+                      externalTest {
+                        id
+                      }
+                      externalResolvableTest {
+                        id
+                        external
+                        extended
+                      }
+                    }
+                    ... on ExternalResolvableTestDto {
+                      id
+                      extended
+                    }
+                  }
+                }
+                """;
+        }).ConfigureAwait(false);
+
+        json.ShouldBeCrossPlatJson("""
+            {
+              "data": {
+                "_entities": [
+                  {
+                    "name": "111",
+                    "externalTest": {
+                      "id": 4
+                    },
+                    "externalResolvableTest": {
+                      "id": 7,
+                      "external": "external-7",
+                      "extended": "external-7"
+                    }
+                  },
+                  {
+                    "name": "333",
+                    "externalTest": {
+                      "id": 6
+                    },
+                    "externalResolvableTest": {
+                      "id": 9,
+                      "external": "external-9",
+                      "extended": "external-9"
+                    }
+                  },
+                  {
+                    "id": 123,
+                    "extended": "asdfgh"
+                  }
+                ]
+              }
+            }
+            """);
+    }
+}

--- a/src/GraphQL.Federation.Tests/Fixtures/CodeFirstCollectionDefinition.cs
+++ b/src/GraphQL.Federation.Tests/Fixtures/CodeFirstCollectionDefinition.cs
@@ -1,0 +1,5 @@
+namespace GraphQL.Federation.Tests.Fixtures;
+
+[CollectionDefinition(nameof(CodeFirstCollectionDefinition))]
+public class CodeFirstCollectionDefinition : ICollectionFixture<CodeFirstFixture>
+{ }

--- a/src/GraphQL.Federation.Tests/Fixtures/CodeFirstFixture.cs
+++ b/src/GraphQL.Federation.Tests/Fixtures/CodeFirstFixture.cs
@@ -1,0 +1,39 @@
+using GraphQL.Federation.Enums;
+using GraphQL.Federation.Extensions;
+using GraphQL.Federation.Tests.Schema;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Federation.Tests.Fixtures;
+
+public class CodeFirstFixture
+{
+    public readonly IServiceProvider Services;
+    public readonly GraphQL.Types.Schema Schema;
+
+
+    public CodeFirstFixture()
+    {
+        var sc = new ServiceCollection();
+
+        sc.AddGraphQL(builder => builder
+            .AddSystemTextJson()
+            .AddDataLoader()
+            .AddSchema<TestSchema>()
+            .AddGraphTypes(typeof(TestSchema).Assembly)
+            .AddClrTypeMappings(typeof(TestSchema).Assembly)
+            .AddAutoClrMappings()
+            .AddFederation(FederationDirectiveEnum.Key
+                | FederationDirectiveEnum.Shareable
+                | FederationDirectiveEnum.Inaccessible
+                | FederationDirectiveEnum.Override
+                | FederationDirectiveEnum.External
+                | FederationDirectiveEnum.Provides
+                | FederationDirectiveEnum.Requires,
+                addFields: true,
+                schemaPrinterOptions: new() { IncludeDeprecationReasons = true }));
+
+        Services = sc.BuildServiceProvider();
+
+        Schema = Services.GetService<TestSchema>();
+    }
+}

--- a/src/GraphQL.Federation.Tests/Fixtures/SchemaFirstCollectionDefinition.cs
+++ b/src/GraphQL.Federation.Tests/Fixtures/SchemaFirstCollectionDefinition.cs
@@ -1,0 +1,5 @@
+namespace GraphQL.Federation.Tests.Fixtures;
+
+[CollectionDefinition(nameof(SchemaFirstCollectionDefinition))]
+public class SchemaFirstCollectionDefinition : ICollectionFixture<SchemaFirstFixture>
+{ }

--- a/src/GraphQL.Federation.Tests/Fixtures/SchemaFirstFixture.cs
+++ b/src/GraphQL.Federation.Tests/Fixtures/SchemaFirstFixture.cs
@@ -1,0 +1,86 @@
+using GraphQL.DataLoader;
+using GraphQL.Federation.Enums;
+using GraphQL.Federation.Extensions;
+using GraphQL.Federation.Tests.Schema.External;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Federation.Tests.Fixtures;
+
+public class SchemaFirstFixture
+{
+    public readonly IServiceProvider Services;
+    public readonly GraphQL.Types.Schema Schema;
+
+    public SchemaFirstFixture()
+    {
+        var sc = new ServiceCollection();
+
+        sc.AddGraphQL(builder => builder
+            .AddSystemTextJson()
+            .AddDataLoader()
+            .AddFederation(FederationDirectiveEnum.Key
+                | FederationDirectiveEnum.Shareable
+                | FederationDirectiveEnum.Inaccessible
+                | FederationDirectiveEnum.Override
+                | FederationDirectiveEnum.External
+                | FederationDirectiveEnum.Provides
+                | FederationDirectiveEnum.Requires,
+                addFields: true,
+                schemaPrinterOptions: new() { IncludeDeprecationReasons = true }));
+
+        Services = sc.BuildServiceProvider();
+
+        Schema = FederatedSchemaHelper.For("""
+            type Query {
+              _noop: String
+            }
+            type SchemaFirstExternalResolvableTestDto @key(fields: "id") {
+              id: Int!
+              external: String @external
+              extended: String! @requires(fields: "external")
+            }
+            type SchemaFirstExternalTestDto @key(fields: "id", resolvable: false) {
+              id: Int!
+            }
+            type SchemaFirstFederatedTestDto @key(fields: "id") {
+              id: Int!
+              name: String
+              externalTestId: Int!
+              externalResolvableTestId: Int!
+              externalTest: SchemaFirstExternalTestDto! @deprecated(reason: "Test deprecation reason 04.")
+              externalResolvableTest: SchemaFirstExternalResolvableTestDto! @provides(fields: "external")
+            }
+            """,
+            builder =>
+            {
+                builder.ServiceProvider = Services;
+                builder.Types.Include<SchemaFirstExternalResolvableTestDto>();
+                builder.Types.Include<SchemaFirstExternalTestDto>();
+                builder.Types.Include<SchemaFirstFederatedTestDto>();
+
+                builder.Types.For(nameof(SchemaFirstExternalResolvableTestDto))
+                   .IsTypeOf<SchemaFirstExternalResolvableTestDto>();
+                builder.Types.For(nameof(SchemaFirstFederatedTestDto))
+                   .IsTypeOf<SchemaFirstFederatedTestDto>();
+
+                builder.Types.For(nameof(SchemaFirstExternalResolvableTestDto))
+                    .ResolveReference<SchemaFirstExternalResolvableTestDto>((ctx, rep) => rep);
+                builder.Types.For(nameof(SchemaFirstFederatedTestDto))
+                    .ResolveReference<SchemaFirstFederatedTestDto>((ctx, rep) =>
+                    {
+                        var accessor = ctx.RequestServices.GetRequiredService<IDataLoaderContextAccessor>();
+                        return accessor.Context.GetOrAddBatchLoader<int, SchemaFirstFederatedTestDto>(
+                            "SchemaFirstFederatedTestDto.ResolveReference",
+                            (items) =>
+                            {
+                                return Task.FromResult<IDictionary<int, SchemaFirstFederatedTestDto>>(new Dictionary<int, SchemaFirstFederatedTestDto>
+                                {
+                                    [1] = new() { Id = 1, Name = "111", ExternalTestId = 4, ExternalResolvableTestId = 7 },
+                                    [2] = new() { Id = 2, Name = "222", ExternalTestId = 5, ExternalResolvableTestId = 8 },
+                                    [3] = new() { Id = 3, Name = "333", ExternalTestId = 6, ExternalResolvableTestId = 9 },
+                                });
+                            }).LoadAsync(rep.Id);
+                    });
+            });
+    }
+}

--- a/src/GraphQL.Federation.Tests/GraphQL.Federation.Tests.csproj
+++ b/src/GraphQL.Federation.Tests/GraphQL.Federation.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../Tests.props" />
+
+  <PropertyGroup Condition="'$(SingleTestPlatform)' == 'true'">
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SingleTestPlatform)' != 'true' and '$(OS)' == 'Windows_NT'">
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;net48</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SingleTestPlatform)' != 'true' and '$(OS)' != 'Windows_NT'">
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.20" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GraphQL.MicrosoftDI\GraphQL.MicrosoftDI.csproj" />
+    <ProjectReference Include="..\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+    <ProjectReference Include="..\GraphQL.DataLoader\GraphQL.DataLoader.csproj" />
+    <ProjectReference Include="..\GraphQL.Federation\GraphQL.Federation.csproj" />
+    <ProjectReference Include="..\GraphQL.Tests\GraphQL.Tests.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/src/GraphQL.Federation.Tests/Schema/External/ExternalResolvableTestDto.cs
+++ b/src/GraphQL.Federation.Tests/Schema/External/ExternalResolvableTestDto.cs
@@ -1,0 +1,12 @@
+using GraphQL.Federation.Attributes;
+
+namespace GraphQL.Federation.Tests.Schema.External;
+
+[Key(nameof(Id))]
+public class ExternalResolvableTestDto
+{
+    public int Id { get; set; }
+
+    [External]
+    public string External { get; set; }
+}

--- a/src/GraphQL.Federation.Tests/Schema/External/ExternalResolvableTestType.cs
+++ b/src/GraphQL.Federation.Tests/Schema/External/ExternalResolvableTestType.cs
@@ -1,0 +1,16 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Tests.Schema.External;
+
+public sealed class ExternalResolvableTestType : AutoRegisteringObjectGraphType<ExternalResolvableTestDto>
+{
+    public ExternalResolvableTestType()
+    {
+        this.ResolveReference((ctx, rep) => rep);
+
+        Field<NonNullGraphType<StringGraphType>>("Extended")
+            .Resolve(ctx => ctx.Source.External)
+            .Requires(nameof(ExternalResolvableTestDto.External));
+    }
+}

--- a/src/GraphQL.Federation.Tests/Schema/External/ExternalTestDto.cs
+++ b/src/GraphQL.Federation.Tests/Schema/External/ExternalTestDto.cs
@@ -1,0 +1,9 @@
+using GraphQL.Federation.Attributes;
+
+namespace GraphQL.Federation.Tests.Schema.External;
+
+[Key(nameof(Id), Resolvable = false)]
+public class ExternalTestDto
+{
+    public int Id { get; set; }
+}

--- a/src/GraphQL.Federation.Tests/Schema/External/SchemaFirstExternalResolvableTestDto.cs
+++ b/src/GraphQL.Federation.Tests/Schema/External/SchemaFirstExternalResolvableTestDto.cs
@@ -1,0 +1,11 @@
+namespace GraphQL.Federation.Tests.Schema.External;
+
+public class SchemaFirstExternalResolvableTestDto
+{
+    public int Id { get; set; }
+
+    public string External { get; set; }
+
+    public string Extended(IResolveFieldContext ctx) =>
+        ((SchemaFirstExternalResolvableTestDto)ctx.Source).External;
+}

--- a/src/GraphQL.Federation.Tests/Schema/External/SchemaFirstExternalTestDto.cs
+++ b/src/GraphQL.Federation.Tests/Schema/External/SchemaFirstExternalTestDto.cs
@@ -1,0 +1,6 @@
+namespace GraphQL.Federation.Tests.Schema.External;
+
+public class SchemaFirstExternalTestDto
+{
+    public int Id { get; set; }
+}

--- a/src/GraphQL.Federation.Tests/Schema/External/SchemaFirstFederatedTestDto.cs
+++ b/src/GraphQL.Federation.Tests/Schema/External/SchemaFirstFederatedTestDto.cs
@@ -1,0 +1,24 @@
+namespace GraphQL.Federation.Tests.Schema.External;
+
+public class SchemaFirstFederatedTestDto
+{
+    public int Id { get; set; }
+    [GraphQLMetadata(DeprecationReason = "Test deprecation reason 03.")]
+    public string Name { get; set; }
+
+    public int ExternalTestId { get; set; }
+    public int ExternalResolvableTestId { get; set; }
+
+    public SchemaFirstExternalTestDto ExternalTest(IResolveFieldContext ctx) =>
+        new()
+        {
+            Id = ((SchemaFirstFederatedTestDto)ctx.Source).ExternalTestId
+        };
+
+    public SchemaFirstExternalResolvableTestDto ExternalResolvableTest(IResolveFieldContext ctx) =>
+        new()
+        {
+            Id = ((SchemaFirstFederatedTestDto)ctx.Source).ExternalResolvableTestId,
+            External = "qwerty"
+        };
+}

--- a/src/GraphQL.Federation.Tests/Schema/Output/DirectivesTestDto.cs
+++ b/src/GraphQL.Federation.Tests/Schema/Output/DirectivesTestDto.cs
@@ -1,0 +1,23 @@
+using GraphQL.Federation.Attributes;
+
+namespace GraphQL.Federation.Tests.Schema.Output;
+
+[Key(nameof(Id))]
+[Shareable]
+[Inaccessible]
+public class DirectivesTestDto
+{
+    public int Id { get; set; }
+    [Shareable]
+    public string Shareable { get; set; }
+    [Inaccessible]
+    public string Inaccessible { get; set; }
+    [Override("OtherSubgraph")]
+    public string Override { get; set; }
+    [External]
+    public string External { get; set; }
+    [Provides("Foo", "Bar")]
+    public string Provides { get; set; }
+    [Requires("foo bar")]
+    public string Requires { get; set; }
+}

--- a/src/GraphQL.Federation.Tests/Schema/Output/FederatedTestDto.cs
+++ b/src/GraphQL.Federation.Tests/Schema/Output/FederatedTestDto.cs
@@ -1,0 +1,14 @@
+using GraphQL.Federation.Attributes;
+
+namespace GraphQL.Federation.Tests.Schema.Output;
+
+[Key(nameof(Id))]
+public class FederatedTestDto
+{
+    public int Id { get; set; }
+    [GraphQLMetadata(DeprecationReason = "Test deprecation reason 01.")]
+    public string Name { get; set; }
+
+    public int ExternalTestId { get; set; }
+    public int ExternalResolvableTestId { get; set; }
+}

--- a/src/GraphQL.Federation.Tests/Schema/Output/FederatedTestType.cs
+++ b/src/GraphQL.Federation.Tests/Schema/Output/FederatedTestType.cs
@@ -1,0 +1,40 @@
+using GraphQL.DataLoader;
+using GraphQL.Federation.Extensions;
+using GraphQL.Federation.Tests.Schema.External;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Tests.Schema.Output;
+
+public sealed class FederatedTestType : AutoRegisteringObjectGraphType<FederatedTestDto>
+{
+    public FederatedTestType(IDataLoaderContextAccessor accessor)
+    {
+        // this.ResolveReference((ctx, rep) => new() { Id = rep.Id, Name = $"{rep.Id}{rep.Id}{rep.Id}", ExternalTestId = 4 - rep.Id });
+        this.ResolveReference((ctx, rep) => accessor.Context.GetOrAddBatchLoader<int, FederatedTestDto>(
+            $"{nameof(FederatedTestDto)}-ResolveReference",
+            (items) =>
+            {
+                return Task.FromResult<IDictionary<int, FederatedTestDto>>(new Dictionary<int, FederatedTestDto>
+                {
+                    [1] = new() { Id = 1, Name = "111", ExternalTestId = 4, ExternalResolvableTestId = 7 },
+                    [2] = new() { Id = 2, Name = "222", ExternalTestId = 5, ExternalResolvableTestId = 8 },
+                    [3] = new() { Id = 3, Name = "333", ExternalTestId = 6, ExternalResolvableTestId = 9 },
+                });
+            }).LoadAsync(rep.Id));
+
+        Field<NonNullGraphType<GraphQLClrOutputTypeReference<ExternalTestDto>>>("ExternalTest")
+            .Resolve(ctx => new ExternalTestDto
+            {
+                Id = ctx.Source.ExternalTestId
+            })
+            .DeprecationReason("Test deprecation reason 02.");
+
+        Field<NonNullGraphType<GraphQLClrOutputTypeReference<ExternalResolvableTestDto>>>("ExternalResolvableTest")
+            .Resolve(ctx => new ExternalResolvableTestDto
+            {
+                Id = ctx.Source.ExternalResolvableTestId,
+                External = $"external-{ctx.Source.ExternalResolvableTestId}"
+            })
+            .Provides(nameof(ExternalResolvableTestDto.External));
+    }
+}

--- a/src/GraphQL.Federation.Tests/Schema/TestQuery.cs
+++ b/src/GraphQL.Federation.Tests/Schema/TestQuery.cs
@@ -1,0 +1,16 @@
+using GraphQL.Federation.Tests.Schema.Output;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Tests.Schema;
+
+public class TestQuery : ObjectGraphType
+{
+    public TestQuery()
+    {
+        // this.AddServices();
+        // this.AddEntities();
+
+        Field<NonNullGraphType<GraphQLClrOutputTypeReference<DirectivesTestDto>>>("directivesTest")
+            .Resolve(context => new DirectivesTestDto());
+    }
+}

--- a/src/GraphQL.Federation.Tests/Schema/TestSchema.cs
+++ b/src/GraphQL.Federation.Tests/Schema/TestSchema.cs
@@ -1,0 +1,14 @@
+using GraphQL.Federation.Tests.Schema.Output;
+
+namespace GraphQL.Federation.Tests.Schema;
+
+public class TestSchema : GraphQL.Types.Schema
+{
+    public TestSchema(IServiceProvider provider, TestQuery query)
+        : base(provider)
+    {
+        Query = query;
+
+        this.RegisterType<FederatedTestType>();
+    }
+}

--- a/src/GraphQL.Federation.Tests/SchemaFirstFederationTest.cs
+++ b/src/GraphQL.Federation.Tests/SchemaFirstFederationTest.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using GraphQL.DataLoader;
+using GraphQL.Federation.Tests.Fixtures;
+using GraphQL.SystemTextJson;
+using GraphQL.Tests;
+
+namespace GraphQL.Federation.Tests;
+
+// dotnet test GraphQL.Federation.Tests --filter DisplayName~GraphQL.Federation.Tests.SchemaFirstFederationTest.ServiceTest
+// dotnet test GraphQL.Federation.Tests --filter DisplayName~GraphQL.Federation.Tests.SchemaFirstFederationTest.EntitiesTest
+[Collection(nameof(SchemaFirstCollectionDefinition))]
+public class SchemaFirstFederationTest : BaseSchemaFirstGraphQLTest
+{
+    public SchemaFirstFederationTest(SchemaFirstFixture schemaFirstFixture)
+        : base(schemaFirstFixture)
+    { }
+
+    [Fact]
+    public async Task ServiceTest()
+    {
+        // WaitForDebugger();
+
+        var json = await Schema.ExecuteAsync(new GraphQLSerializer(), options =>
+        {
+            options.Listeners.Add(new DataLoaderDocumentListener(new DataLoaderContextAccessor()));
+            options.ThrowOnUnhandledException = true;
+            options.Query = """
+                query {
+                  _service {
+                    sdl
+                  }
+                }
+                """;
+        }).ConfigureAwait(false);
+
+        var sdl = JsonDocument.Parse(json).RootElement
+            .GetProperty("data")
+            .GetProperty("_service")
+            .GetProperty("sdl")
+            .GetString();
+        sdl.ShouldBeCrossPlat("""
+            type Query {
+              _noop: String
+            }
+
+            type SchemaFirstExternalResolvableTestDto @key(fields: "id") {
+              id: Int!
+              external: String @external
+              extended: String! @requires(fields: "external")
+            }
+
+            type SchemaFirstExternalTestDto @key(fields: "id", resolvable: false) {
+              id: Int!
+            }
+
+            type SchemaFirstFederatedTestDto @key(fields: "id") {
+              id: Int!
+              name: String @deprecated(reason: "Test deprecation reason 03.")
+              externalTestId: Int!
+              externalResolvableTestId: Int!
+              externalTest: SchemaFirstExternalTestDto! @deprecated(reason: "Test deprecation reason 04.")
+              externalResolvableTest: SchemaFirstExternalResolvableTestDto! @provides(fields: "external")
+            }
+
+
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires"])
+            """);
+    }
+
+    [Fact]
+    public async Task EntitiesTest()
+    {
+        // WaitForDebugger();
+
+        var json = await Schema.ExecuteAsync(new GraphQLSerializer(), options =>
+        {
+            options.RequestServices = Services;
+            options.Listeners.Add(new DataLoaderDocumentListener(new DataLoaderContextAccessor()));
+            options.ThrowOnUnhandledException = true;
+            options.Query = """
+                query {
+                  _entities(representations: [{ __typename: "SchemaFirstFederatedTestDto", id: 1 }, { __typename: "SchemaFirstFederatedTestDto", id: 3 }, { __typename: "SchemaFirstExternalResolvableTestDto", id: 321, external: "zxcvbn" }]) {
+                    ... on SchemaFirstFederatedTestDto {
+                      name
+                      externalTest {
+                        id
+                      }
+                      externalResolvableTest {
+                        id
+                        external
+                        extended
+                      }
+                    }
+                    ... on SchemaFirstExternalResolvableTestDto {
+                      id
+                      extended
+                    }
+                  }
+                }
+                """;
+        }).ConfigureAwait(false);
+
+        json.ShouldBeCrossPlatJson("""
+            {
+              "data": {
+                "_entities": [
+                  {
+                    "name": "111",
+                    "externalTest": {
+                      "id": 4
+                    },
+                    "externalResolvableTest": {
+                      "id": 7,
+                      "external": "qwerty",
+                      "extended": "qwerty"
+                    }
+                  },
+                  {
+                    "name": "333",
+                    "externalTest": {
+                      "id": 6
+                    },
+                    "externalResolvableTest": {
+                      "id": 9,
+                      "external": "qwerty",
+                      "extended": "qwerty"
+                    }
+                  },
+                  {
+                    "id": 321,
+                    "extended": "zxcvbn"
+                  }
+                ]
+              }
+            }    
+            """);
+    }
+}

--- a/src/GraphQL.Federation/Attributes/ExternalAttribute.cs
+++ b/src/GraphQL.Federation/Attributes/ExternalAttribute.cs
@@ -1,0 +1,19 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Attributes;
+
+/// <summary>
+/// Adds "@external" directive.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class ExternalAttribute : GraphQLAttribute
+{
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+            throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+        fieldType.External();
+    }
+}

--- a/src/GraphQL.Federation/Attributes/InaccessibleAttribute.cs
+++ b/src/GraphQL.Federation/Attributes/InaccessibleAttribute.cs
@@ -1,0 +1,25 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Attributes;
+
+/// <summary>
+/// Adds "@inaccessible" directive.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class InaccessibleAttribute : GraphQLAttribute
+{
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType)
+    {
+        graphType.Inaccessible();
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+            throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+        fieldType.Inaccessible();
+    }
+}

--- a/src/GraphQL.Federation/Attributes/KeyAttribute.cs
+++ b/src/GraphQL.Federation/Attributes/KeyAttribute.cs
@@ -1,0 +1,37 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Attributes;
+
+/// <summary>
+/// Adds "@key" directive.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class KeyAttribute : GraphQLAttribute
+{
+    private readonly string _fields;
+
+    /// <summary> Resolvable. </summary>
+    public bool Resolvable { get; set; } = true;
+
+
+    /// <summary> .ctor </summary>
+    public KeyAttribute(string fields)
+    {
+        if (string.IsNullOrEmpty(fields))
+            throw new ArgumentNullException(nameof(fields));
+        _fields = fields;
+    }
+    /// <summary> .ctor </summary>
+    public KeyAttribute(params string[] fields)
+        : this(string.Join(" ", fields.Select(x => x.ToCamelCase())))
+    { }
+
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType)
+    {
+        if (graphType is not IObjectGraphType objectGraphType)
+            throw new ArgumentOutOfRangeException(nameof(graphType), graphType, "Only ObjectGraphType is supported.");
+        objectGraphType.Key(_fields, Resolvable);
+    }
+}

--- a/src/GraphQL.Federation/Attributes/OverrideAttribute.cs
+++ b/src/GraphQL.Federation/Attributes/OverrideAttribute.cs
@@ -1,0 +1,28 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Attributes;
+
+/// <summary>
+/// Adds "@override" directive.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class OverrideAttribute : GraphQLAttribute
+{
+    /// <summary> .ctor </summary>
+    public string From { get; }
+
+    /// <summary> .ctor </summary>
+    public OverrideAttribute(string from)
+    {
+        From = from;
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+            throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+        fieldType.Override(From);
+    }
+}

--- a/src/GraphQL.Federation/Attributes/ProvidesAttribute.cs
+++ b/src/GraphQL.Federation/Attributes/ProvidesAttribute.cs
@@ -1,0 +1,31 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Attributes;
+
+/// <summary>
+/// Adds "@provides" directive.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class ProvidesAttribute : GraphQLAttribute
+{
+    private readonly string _fields;
+
+    /// <summary> .ctor </summary>
+    public ProvidesAttribute(string fields)
+    {
+        _fields = fields;
+    }
+    /// <summary> .ctor </summary>
+    public ProvidesAttribute(params string[] fields)
+        : this(string.Join(" ", fields.Select(x => x.ToCamelCase())))
+    { }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+            throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+        fieldType.Provides(_fields);
+    }
+}

--- a/src/GraphQL.Federation/Attributes/RequiresAttribute.cs
+++ b/src/GraphQL.Federation/Attributes/RequiresAttribute.cs
@@ -1,0 +1,33 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Attributes;
+
+/// <summary>
+/// Adds "@requires" directive.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class RequiresAttribute : GraphQLAttribute
+{
+    private readonly string _fields;
+
+    /// <summary> .ctor </summary>
+    public RequiresAttribute(string fields)
+    {
+        if (string.IsNullOrEmpty(fields))
+            throw new ArgumentNullException(nameof(fields));
+        _fields = fields;
+    }
+    /// <summary> .ctor </summary>
+    public RequiresAttribute(params string[] fields)
+        : this(string.Join(" ", fields.Select(x => x.ToCamelCase())))
+    { }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+            throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+        fieldType.Requires(_fields);
+    }
+}

--- a/src/GraphQL.Federation/Attributes/ShareableAttribute.cs
+++ b/src/GraphQL.Federation/Attributes/ShareableAttribute.cs
@@ -1,0 +1,25 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Attributes;
+
+/// <summary>
+/// Adds "@shareable" directive.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class ShareableAttribute : GraphQLAttribute
+{
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType)
+    {
+        graphType.Shareable();
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+            throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+        fieldType.Shareable();
+    }
+}

--- a/src/GraphQL.Federation/Enums/FederationDirectiveEnum.cs
+++ b/src/GraphQL.Federation/Enums/FederationDirectiveEnum.cs
@@ -1,0 +1,37 @@
+namespace GraphQL.Federation.Enums;
+
+/// <summary>
+/// Enumeration of all Federation directives.
+/// </summary>
+[Flags]
+public enum FederationDirectiveEnum
+{
+    /// <summary>
+    /// @key directive.
+    /// </summary>
+    Key = 1,
+    /// <summary>
+    /// @shareable directive.
+    /// </summary>
+    Shareable = 2,
+    /// <summary>
+    /// @inaccessible directive.
+    /// </summary>
+    Inaccessible = 4,
+    /// <summary>
+    /// @override directive.
+    /// </summary>
+    Override = 8,
+    /// <summary>
+    /// @external directive.
+    /// </summary>
+    External = 16,
+    /// <summary>
+    /// @provides directive.
+    /// </summary>
+    Provides = 32,
+    /// <summary>
+    /// @requires directive.
+    /// </summary>
+    Requires = 64
+}

--- a/src/GraphQL.Federation/Extensions/FederatedSchemaBuilder.cs
+++ b/src/GraphQL.Federation/Extensions/FederatedSchemaBuilder.cs
@@ -1,0 +1,25 @@
+using GraphQL.Types;
+using GraphQL.Utilities;
+
+namespace GraphQL.Federation.Extensions;
+
+/// <summary>
+/// A schema builder for GraphQL federation.
+/// </summary>
+public class FederatedSchemaBuilder : SchemaBuilder
+{
+    // https://www.apollographql.com/docs/federation/federation-spec/
+    private const string FEDERATED_SDL = @"
+directive @key(fields: String!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+directive @provides(fields: String!) on FIELD_DEFINITION
+directive @requires(fields: String!) on FIELD_DEFINITION
+directive @external on FIELD_DEFINITION
+directive @shareable on FIELD_DEFINITION | OBJECT
+directive @override(from: String!) on FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT
+";
+
+    /// <inheritdoc/>
+    public override Schema Build(string typeDefinitions) =>
+        base.Build($"{FEDERATED_SDL}{Environment.NewLine}{typeDefinitions}");
+}

--- a/src/GraphQL.Federation/Extensions/FederatedSchemaHelper.cs
+++ b/src/GraphQL.Federation/Extensions/FederatedSchemaHelper.cs
@@ -1,0 +1,38 @@
+using GraphQL.Types;
+using GraphQL.Utilities;
+
+namespace GraphQL.Federation.Extensions;
+
+/// <summary>
+/// A helper for <see cref="FederatedSchemaBuilder"/>.
+/// </summary>
+public static class FederatedSchemaHelper
+{
+    /// <summary>
+    /// Builds schema from the specified string and configuration delegate.
+    /// </summary>
+    /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
+    /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
+    /// <returns>Created schema.</returns>
+    public static Schema For(
+        string typeDefinitions,
+        Action<FederatedSchemaBuilder>? configure = null) =>
+        For<FederatedSchemaBuilder>(typeDefinitions, configure);
+
+    /// <summary>
+    /// Builds schema from the specified string and configuration delegate.
+    /// </summary>
+    /// <typeparam name="TFederatedSchemaBuilder">The type of <see cref="FederatedSchemaBuilder"/> that will create the schema.</typeparam>
+    /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
+    /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
+    /// <returns>Created schema.</returns>
+    public static Schema For<TFederatedSchemaBuilder>(
+        string typeDefinitions,
+        Action<TFederatedSchemaBuilder>? configure = null)
+        where TFederatedSchemaBuilder : FederatedSchemaBuilder, new()
+    {
+        var builder = new TFederatedSchemaBuilder();
+        configure?.Invoke(builder);
+        return builder.Build(typeDefinitions);
+    }
+}

--- a/src/GraphQL.Federation/Extensions/FederatedSchemaPrinter.cs
+++ b/src/GraphQL.Federation/Extensions/FederatedSchemaPrinter.cs
@@ -1,0 +1,114 @@
+using GraphQL.Types;
+using GraphQL.Utilities;
+using GraphQLParser.AST;
+using GraphQLParser.Visitors;
+using static GraphQL.Federation.Extensions.FederationHelper;
+
+namespace GraphQL.Federation.Extensions;
+
+internal class FederatedSchemaPrinter : SchemaPrinter
+{
+    private static readonly HashSet<string> _federatedDirectives = new()
+    {
+        KEY_DIRECTIVE,
+        SHAREABLE_DIRECTIVE,
+        INACCESSIBLE_DIRECTIVE,
+        OVERRIDE_DIRECTIVE,
+        EXTERNAL_DIRECTIVE,
+        PROVIDES_DIRECTIVE,
+        REQUIRES_DIRECTIVE,
+    };
+
+    private static readonly HashSet<string> _federatedTypes = new()
+    {
+        "_Service",
+        "_Entity",
+        "_Any",
+        "_Never",
+    };
+
+    private static readonly SDLPrinter _sdlPrinter = new();
+
+
+    public FederatedSchemaPrinter(ISchema schema, SchemaPrinterOptions? options = null)
+        : base(schema, options)
+    { }
+
+
+    public string PrintFederatedSchema()
+    {
+        var result = PrintFilteredSchema(
+            directiveName => !IsBuiltInDirective(directiveName) && !IsFederatedDirective(directiveName),
+            typeName => !IsFederatedType(typeName) && IsDefinedType(typeName));
+
+        var linkSchemaExtension = Schema.GetMetadata<ASTNode>(LINK_SCHEMA_EXTENSION_METADATA);
+        return $"{result}{Environment.NewLine}{Environment.NewLine}{PrintAstNode(linkSchemaExtension)}";
+    }
+
+
+    public override string PrintObject(IObjectGraphType type)
+    {
+        Schema?.Initialize();
+
+        var interfaces = type.ResolvedInterfaces.Select(x => x.Name).ToList();
+        var delimiter = Options.OldImplementsSyntax ? ", " : " & ";
+        var implementedInterfaces = interfaces.Count > 0
+            ? $" implements {string.Join(delimiter, interfaces)}"
+            : "";
+
+        var federatedDirectives = type.IsInputObjectType()
+            ? string.Empty
+            : PrintFederatedDirectives(type);
+
+        if (type.Fields.Count > 0)
+            return $"{FormatDescription(type.Description)}type {type.Name}{implementedInterfaces}{federatedDirectives} {{{Environment.NewLine}{PrintFields(type)}{Environment.NewLine}}}";
+        else
+        {
+            return $"{FormatDescription(type.Description)}type {type.Name}{implementedInterfaces}{federatedDirectives}";
+        }
+    }
+
+    public override string PrintFields(IComplexGraphType type)
+    {
+        Schema?.Initialize();
+
+        var fields = type?.Fields
+            .Where(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name))
+            .Select(x => new
+            {
+                x.Name,
+                Type = x.ResolvedType,
+                Args = PrintArgs(x),
+                Description = FormatDescription(x.Description, "  "),
+                Deprecation = Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : string.Empty,
+                FederatedDirectives = PrintFederatedDirectives(x)
+            }).ToList();
+
+        return fields == null
+            ? string.Empty
+            : string.Join(Environment.NewLine, fields.Select(f => $"{f.Description}  {f.Name}{f.Args}: {f.Type}{f.Deprecation}{f.FederatedDirectives}"));
+    }
+
+
+    private string PrintFederatedDirectives(IProvideMetadata type)
+    {
+        var directives = type.GetMetadata<IHasDirectivesNode>(AST_METAFIELD)?.Directives;
+        if (directives == null)
+            return string.Empty;
+        var result = string.Join(" ", directives
+            .Where(x => IsFederatedDirective(x.Name.StringValue))
+            .Select(PrintAstNode));
+        return string.IsNullOrWhiteSpace(result) ? string.Empty : $" {result}";
+    }
+
+    private static string PrintAstNode(ASTNode node)
+    {
+        using var writer = new StringWriter();
+        _sdlPrinter.PrintAsync(node, writer).AsTask().GetAwaiter().GetResult();
+        return writer.ToString();
+    }
+
+    private bool IsFederatedDirective(string directiveName) => _federatedDirectives.Contains(directiveName);
+
+    private bool IsFederatedType(string typeName) => _federatedTypes.Contains(typeName);
+}

--- a/src/GraphQL.Federation/Extensions/FederationEntitiesSchemaNodeVisitor.cs
+++ b/src/GraphQL.Federation/Extensions/FederationEntitiesSchemaNodeVisitor.cs
@@ -1,0 +1,30 @@
+using GraphQL.Federation.Types;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using GraphQLParser.AST;
+using static GraphQL.Federation.Extensions.FederationHelper;
+
+namespace GraphQL.Federation.Extensions;
+
+internal class FederationEntitiesSchemaNodeVisitor : BaseSchemaNodeVisitor
+{
+    private readonly EntityType _entityType;
+
+
+    public FederationEntitiesSchemaNodeVisitor(EntityType entityType)
+    {
+        _entityType = entityType;
+    }
+
+
+    public override void VisitObject(IObjectGraphType type, ISchema schema)
+    {
+        var astMetafield = type.GetMetadata<IHasDirectivesNode>(AST_METAFIELD);
+        if (astMetafield?.Directives?.Items?.Any(x =>
+            x.Name == KEY_DIRECTIVE
+            && !x.Arguments!.Any(y => y.Name == RESOLVABLE_ARGUMENT && y.Value is GraphQLFalseBooleanValue)) == true)
+        {
+            _entityType.AddPossibleType(type);
+        }
+    }
+}

--- a/src/GraphQL.Federation/Extensions/FederationFieldExtensions.cs
+++ b/src/GraphQL.Federation/Extensions/FederationFieldExtensions.cs
@@ -1,0 +1,123 @@
+using GraphQL.Builders;
+using GraphQL.Types;
+using GraphQLParser.AST;
+using static GraphQL.Federation.Extensions.FederationHelper;
+
+namespace GraphQL.Federation.Extensions;
+
+/// <summary>
+/// Federation extensions for Fields.
+/// </summary>
+public static class FederationFieldExtensions
+{
+    /// <summary>
+    /// Adds "@shareable" directive.
+    /// </summary>
+    public static FieldBuilder<TSourceType, TReturnType> Shareable<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder)
+    { fieldBuilder.FieldType.Shareable(); return fieldBuilder; }
+
+    /// <summary>
+    /// Adds "@inaccessible" directive.
+    /// </summary>
+    public static FieldBuilder<TSourceType, TReturnType> Inaccessible<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder)
+    { fieldBuilder.FieldType.Inaccessible(); return fieldBuilder; }
+
+    /// <summary>
+    /// Adds "@override" directive.
+    /// </summary>
+    public static FieldBuilder<TSourceType, TReturnType> Override<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string from)
+    { fieldBuilder.FieldType.Override(from); return fieldBuilder; }
+
+    /// <summary>
+    /// Adds "@external" directive.
+    /// </summary>
+    public static FieldBuilder<TSourceType, TReturnType> External<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder)
+    { fieldBuilder.FieldType.External(); return fieldBuilder; }
+
+    /// <summary>
+    /// Adds "@provides" directive.
+    /// </summary>
+    public static FieldBuilder<TSourceType, TReturnType> Provides<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields)
+    { fieldBuilder.FieldType.Provides(fields); return fieldBuilder; }
+
+    /// <summary>
+    /// Adds "@requires" directive.
+    /// </summary>
+    public static FieldBuilder<TSourceType, TReturnType> Requires<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields)
+    { fieldBuilder.FieldType.Requires(fields); return fieldBuilder; }
+
+    /// <summary>
+    /// Adds "@shareable" directive.
+    /// </summary>
+    public static void Shareable(this FieldType fieldType)
+    {
+        var astMetadata = fieldType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(SHAREABLE_DIRECTIVE) };
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+
+    /// <summary>
+    /// Adds "@inaccessible" directive.
+    /// </summary>
+    public static void Inaccessible(this FieldType fieldType)
+    {
+        var astMetadata = fieldType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(INACCESSIBLE_DIRECTIVE) };
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+
+    /// <summary>
+    /// Adds "@override" directive.
+    /// </summary>
+    public static void Override(this FieldType fieldType, string from)
+    {
+        var astMetadata = fieldType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(OVERRIDE_DIRECTIVE) };
+        directive.AddFromArgument(from);
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+
+    /// <summary>
+    /// Adds "@external" directive.
+    /// </summary>
+    public static void External(this FieldType fieldType)
+    {
+        var astMetadata = fieldType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(EXTERNAL_DIRECTIVE) };
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+
+    /// <summary>
+    /// Adds "@provides" directive.
+    /// </summary>
+    public static void Provides(this FieldType fieldType, string[] fields) =>
+        fieldType.Provides(string.Join(" ", fields.Select(x => x.ToCamelCase())));
+
+    /// <summary>
+    /// Adds "@provides" directive.
+    /// </summary>
+    public static void Provides(this FieldType fieldType, string fields)
+    {
+        var astMetadata = fieldType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(PROVIDES_DIRECTIVE) };
+        directive.AddFieldsArgument(fields.ToCamelCase());
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+
+    /// <summary>
+    /// Adds "@requires" directive.
+    /// </summary>
+    public static void Requires(this FieldType fieldType, string[] fields) =>
+        fieldType.Requires(string.Join(" ", fields.Select(x => x.ToCamelCase())));
+
+    /// <summary>
+    /// Adds "@requires" directive.
+    /// </summary>
+    public static void Requires(this FieldType fieldType, string fields)
+    {
+        var astMetadata = fieldType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(REQUIRES_DIRECTIVE) };
+        directive.AddFieldsArgument(fields.ToCamelCase());
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+}

--- a/src/GraphQL.Federation/Extensions/FederationGraphQLBuilderExtensions.cs
+++ b/src/GraphQL.Federation/Extensions/FederationGraphQLBuilderExtensions.cs
@@ -1,0 +1,48 @@
+using GraphQL.DI;
+using GraphQL.Federation.Enums;
+using GraphQL.Federation.Types;
+using GraphQL.Utilities;
+
+namespace GraphQL.Federation.Extensions;
+
+/// <summary>
+/// Federation extensions for <see cref="IGraphQLBuilder"/>.
+/// </summary>
+public static class FederationGraphQLBuilderExtensions
+{
+    /// <summary>
+    /// Registers Federation types, directives and, optionally, Query fields.
+    /// </summary>
+    /// <param name="builder"> <see cref="IGraphQLBuilder"/> instance. </param>
+    /// <param name="import"> Flags enum used to specify which Federation directives are used by subgraph. </param>
+    /// <param name="addFields"> Pass false to skip adding Federation fields to Query (true by default). </param>
+    /// <param name="schemaPrinterOptions"> SchemaPrinterOptions used to print _services { sdl }. </param>
+    public static IGraphQLBuilder AddFederation(
+        this IGraphQLBuilder builder,
+        FederationDirectiveEnum import,
+        bool addFields = true,
+        SchemaPrinterOptions? schemaPrinterOptions = null)
+    {
+        builder.Services
+            .Register(new ServiceGraphType(schemaPrinterOptions))
+            .Register<Utilities.Federation.AnyScalarGraphType>(ServiceLifetime.Singleton)
+            .Register<EntityType>(ServiceLifetime.Singleton)
+            .Register<NeverType>(ServiceLifetime.Singleton)
+            .Register<FederationEntitiesSchemaNodeVisitor>(ServiceLifetime.Singleton)
+            .Register<FederationQuerySchemaNodeVisitor>(ServiceLifetime.Singleton);
+        return builder
+            .ConfigureSchema((schema, services) =>
+            {
+                schema.BuildLinkExtension(import);
+                schema.RegisterType<ServiceGraphType>();
+                schema.RegisterType<Utilities.Federation.AnyScalarGraphType>();
+                schema.RegisterType<EntityType>();
+                schema.RegisterType<NeverType>();
+                schema.RegisterVisitor<FederationEntitiesSchemaNodeVisitor>();
+                if (addFields)
+                {
+                    schema.RegisterVisitor<FederationQuerySchemaNodeVisitor>();
+                }
+            });
+    }
+}

--- a/src/GraphQL.Federation/Extensions/FederationGraphTypeExtensions.cs
+++ b/src/GraphQL.Federation/Extensions/FederationGraphTypeExtensions.cs
@@ -1,0 +1,123 @@
+using GraphQL.Builders;
+using GraphQL.DataLoader;
+using GraphQL.Federation.Types;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using GraphQLParser.AST;
+using static GraphQL.Federation.Extensions.FederationHelper;
+
+namespace GraphQL.Federation.Extensions;
+
+/// <summary>
+/// Federation extensions for Graph Types.
+/// </summary>
+public static partial class FederationGraphTypeExtensions
+{
+    /// <summary>
+    /// Adds "_service" field. Intended to use on Query in conjunction with .AddFederation(..., addFields = false).
+    /// </summary>
+    public static FieldBuilder<T, object> AddServices<T>(this ComplexGraphType<T> graphType) =>
+        graphType.Field<NonNullGraphType<ServiceGraphType>>("_service")
+            .Resolve(context => new { });
+
+    /// <summary>
+    /// Adds "_entities" field. Intended to use on Query in conjunction with .AddFederation(..., addFields = false).
+    /// </summary>
+    public static FieldBuilder<T, object> AddEntities<T>(this ComplexGraphType<T> graphType)
+    {
+        return graphType.Field<NonNullGraphType<ListGraphType<EntityType>>>("_entities")
+            .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<Utilities.Federation.AnyScalarGraphType>>>>("representations")
+            .Resolve(FederationQuerySchemaNodeVisitor.ResolveEntities);
+    }
+
+    /// <summary>
+    /// Adds "@key" directive.
+    /// </summary>
+    public static void Key(this IObjectGraphType graphType, string[] fields, bool resolvable = true) =>
+        graphType.Key(string.Join(" ", fields.Select(x => x.ToCamelCase())), resolvable);
+
+    /// <summary>
+    /// Adds "@key" directive.
+    /// </summary>
+    public static void Key(this IObjectGraphType graphType, string fields, bool resolvable = true)
+    {
+        var astMetadata = graphType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(KEY_DIRECTIVE) };
+        directive.AddFieldsArgument(fields.ToCamelCase());
+        directive.AddResolvableArgument(resolvable);
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+
+    /// <summary>
+    /// Adds "@shareable" directive.
+    /// </summary>
+    public static void Shareable(this IGraphType graphType)
+    {
+        if (graphType.IsInputType())
+            throw new ArgumentOutOfRangeException(nameof(graphType), graphType, "Input types are not supported.");
+        var astMetadata = graphType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(SHAREABLE_DIRECTIVE) };
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+
+    /// <summary>
+    /// Adds "@inaccessible" directive.
+    /// </summary>
+    public static void Inaccessible(this IGraphType graphType)
+    {
+        if (graphType.IsInputType())
+            throw new ArgumentOutOfRangeException(nameof(graphType), graphType, "Input types are not supported.");
+        var astMetadata = graphType.BuildAstMetadata();
+        var directive = new GraphQLDirective { Name = new(INACCESSIBLE_DIRECTIVE) };
+        astMetadata!.Directives!.Items.Add(directive);
+    }
+
+
+    /// <summary>
+    /// Specifies reference resolver for the type.
+    /// </summary>
+    public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, IFederationResolver resolver) =>
+        graphType.Metadata[RESOLVER_METADATA] = resolver;
+
+    /// <summary>
+    /// Specifies reference resolver for the type.
+    /// </summary>
+    public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, Func<IResolveFieldContext, TSourceType, TSourceType> resolver) =>
+        graphType.Metadata[RESOLVER_METADATA] = new FuncFederationResolver<TSourceType>((context, source) => resolver(context, source));
+
+    /// <summary>
+    /// Specifies reference resolver for the type.
+    /// </summary>
+    public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, Func<IResolveFieldContext, TSourceType, Task<TSourceType>> resolver) =>
+        graphType.Metadata[RESOLVER_METADATA] = new FuncFederationResolver<TSourceType>((context, source) => resolver(context, source));
+
+    /// <summary>
+    /// Specifies reference resolver for the type.
+    /// </summary>
+    public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, Func<IResolveFieldContext, TSourceType, IDataLoaderResult<TSourceType>> resolver) =>
+        graphType.Metadata[RESOLVER_METADATA] = new FuncFederationResolver<TSourceType>((context, source) => resolver(context, source));
+
+    /// <summary>
+    /// Specifies reference resolver for the type.
+    /// </summary>
+    public static void ResolveReference<TSourceType>(this TypeConfig typeConfig, IFederationResolver resolver) =>
+        typeConfig.Metadata[RESOLVER_METADATA] = resolver;
+
+    /// <summary>
+    /// Specifies reference resolver for the type.
+    /// </summary>
+    public static void ResolveReference<TSourceType>(this TypeConfig typeConfig, Func<IResolveFieldContext, TSourceType, TSourceType> resolver) =>
+        typeConfig.Metadata[RESOLVER_METADATA] = new FuncFederationResolver<TSourceType>((context, source) => resolver(context, source));
+
+    /// <summary>
+    /// Specifies reference resolver for the type.
+    /// </summary>
+    public static void ResolveReference<TSourceType>(this TypeConfig typeConfig, Func<IResolveFieldContext, TSourceType, Task<TSourceType>> resolver) =>
+        typeConfig.Metadata[RESOLVER_METADATA] = new FuncFederationResolver<TSourceType>((context, source) => resolver(context, source));
+
+    /// <summary>
+    /// Specifies reference resolver for the type.
+    /// </summary>
+    public static void ResolveReference<TSourceType>(this TypeConfig typeConfig, Func<IResolveFieldContext, TSourceType, IDataLoaderResult<TSourceType>> resolver) =>
+        typeConfig.Metadata[RESOLVER_METADATA] = new FuncFederationResolver<TSourceType>((context, source) => resolver(context, source));
+}

--- a/src/GraphQL.Federation/Extensions/FederationHelper.cs
+++ b/src/GraphQL.Federation/Extensions/FederationHelper.cs
@@ -1,0 +1,117 @@
+using GraphQL.Federation.Enums;
+using GraphQL.Types;
+using GraphQLParser.AST;
+
+namespace GraphQL.Federation.Extensions;
+
+internal static class FederationHelper
+{
+    public const string AST_METAFIELD = "__AST_MetaField__";
+    public const string RESOLVER_METADATA = "__FedResolver__";
+    public const string LINK_SCHEMA_EXTENSION_METADATA = "__FedLinkSchemaExtension__";
+
+    public const string KEY_DIRECTIVE = "key";
+    public const string SHAREABLE_DIRECTIVE = "shareable";
+    public const string INACCESSIBLE_DIRECTIVE = "inaccessible";
+    public const string OVERRIDE_DIRECTIVE = "override";
+    public const string EXTERNAL_DIRECTIVE = "external";
+    public const string PROVIDES_DIRECTIVE = "provides";
+    public const string REQUIRES_DIRECTIVE = "requires";
+    public const string FIELDS_ARGUMENT = "fields";
+    public const string FROM_ARGUMENT = "from";
+    public const string RESOLVABLE_ARGUMENT = "resolvable";
+
+    public static readonly Dictionary<FederationDirectiveEnum, string> FederationDirectiveEnumMap = new()
+    {
+        [FederationDirectiveEnum.Key] = $"@{KEY_DIRECTIVE}",
+        [FederationDirectiveEnum.Shareable] = $"@{SHAREABLE_DIRECTIVE}",
+        [FederationDirectiveEnum.Inaccessible] = $"@{INACCESSIBLE_DIRECTIVE}",
+        [FederationDirectiveEnum.Override] = $"@{OVERRIDE_DIRECTIVE}",
+        [FederationDirectiveEnum.External] = $"@{EXTERNAL_DIRECTIVE}",
+        [FederationDirectiveEnum.Provides] = $"@{PROVIDES_DIRECTIVE}",
+        [FederationDirectiveEnum.Requires] = $"@{REQUIRES_DIRECTIVE}",
+    };
+
+
+    public static void BuildLinkExtension(this ISchema schema, FederationDirectiveEnum import)
+    {
+        var linkSchemaExtension = new GraphQLSchemaExtension
+        {
+            Directives = new()
+            {
+                Items = new()
+                {
+                    new GraphQLDirective
+                    {
+                        Name = new("link"),
+                        Arguments = new()
+                        {
+                            Items = new()
+                            {
+                                new()
+                                {
+                                    Name = new("url"),
+                                    Value = new GraphQLStringValue("https://specs.apollo.dev/federation/v2.0")
+                                },
+                                new()
+                                {
+                                    Name = new("import"),
+                                    Value = new GraphQLListValue()
+                                    {
+                                        Values = Enum.GetValues(typeof(FederationDirectiveEnum))
+                                            .Cast<FederationDirectiveEnum>()
+                                            .Where(x => import.HasFlag(x))
+                                            .Select(x => new GraphQLStringValue(FederationDirectiveEnumMap[x]))
+                                            .Cast<GraphQLValue>()
+                                            .ToList()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        schema.Metadata[LINK_SCHEMA_EXTENSION_METADATA] = linkSchemaExtension;
+    }
+
+    public static IHasDirectivesNode BuildAstMetadata(this IProvideMetadata type)
+    {
+        var astMetadata = type.GetMetadata<IHasDirectivesNode>(AST_METAFIELD, () => new GraphQLObjectTypeDefinition()
+        {
+            Directives = new() { Items = new() }
+        });
+        type.Metadata[AST_METAFIELD] = astMetadata;
+        return astMetadata;
+    }
+
+    public static void AddFieldsArgument(this GraphQLDirective directive, string fields)
+    {
+        ((directive.Arguments ??= new()).Items ??= new()).Add(new()
+        {
+            Name = new(FIELDS_ARGUMENT),
+            Value = new GraphQLStringValue(fields)
+        });
+    }
+
+    public static void AddFromArgument(this GraphQLDirective directive, string from)
+    {
+        ((directive.Arguments ??= new()).Items ??= new()).Add(new()
+        {
+            Name = new(FROM_ARGUMENT),
+            Value = new GraphQLStringValue(from)
+        });
+    }
+
+    public static void AddResolvableArgument(this GraphQLDirective directive, bool resolvable)
+    {
+        if (!resolvable)
+        {
+            ((directive.Arguments ??= new()).Items ??= new()).Add(new()
+            {
+                Name = new(RESOLVABLE_ARGUMENT),
+                Value = new GraphQLFalseBooleanValue()
+            });
+        }
+    }
+}

--- a/src/GraphQL.Federation/Extensions/FederationQuerySchemaNodeVisitor.cs
+++ b/src/GraphQL.Federation/Extensions/FederationQuerySchemaNodeVisitor.cs
@@ -1,0 +1,69 @@
+using GraphQL.Federation.Types;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using static GraphQL.Federation.Extensions.FederationHelper;
+
+namespace GraphQL.Federation.Extensions;
+
+internal class FederationQuerySchemaNodeVisitor : BaseSchemaNodeVisitor
+{
+    private readonly ServiceGraphType _serviceType;
+    private readonly EntityType _entityType;
+
+
+    public FederationQuerySchemaNodeVisitor(ServiceGraphType serviceType, EntityType entityType)
+    {
+        _serviceType = serviceType;
+        _entityType = entityType;
+    }
+
+
+    public override void VisitObject(IObjectGraphType type, ISchema schema)
+    {
+        if (type == schema.Query)
+        {
+            type.AddField(new FieldType
+            {
+                Name = "_service",
+                ResolvedType = new NonNullGraphType(_serviceType),
+                Resolver = new FuncFieldResolver<object>(context => new { })
+            });
+
+            var representationsType = new NonNullGraphType(new ListGraphType(new NonNullGraphType(new Utilities.Federation.AnyScalarGraphType())));
+            type.AddField(new FieldType
+            {
+                Name = "_entities",
+                ResolvedType = new NonNullGraphType(new ListGraphType(_entityType)),
+                Arguments = new QueryArguments(
+                    new QueryArgument(representationsType) { Name = "representations" }
+                ),
+                Resolver = new FuncFieldResolver<object>(ResolveEntities)
+            });
+        }
+    }
+
+    // BUG: Authorization only works at a field level. Authorization at GraphType level doesn't work.
+    //      i.e. _entities(representations: [{ __typename: "MyType", id: 1 }]) { myField }
+    //      will only check authorization for "myField" but not for "MyType".
+    public static object ResolveEntities(IResolveFieldContext context)
+    {
+        var repMaps = context.GetArgument<List<Dictionary<string, object>>>("representations");
+        var results = new List<object?>();
+        foreach (var repMap in repMaps)
+        {
+            var typeName = repMap["__typename"].ToString();
+            var graphTypeInstance = context.Schema.AllTypes[typeName]!;
+            var resolver = graphTypeInstance.GetMetadata<IFederationResolver>(RESOLVER_METADATA);
+            if (resolver == null)
+            {
+                throw new NotImplementedException($"ResolveReference() was not provided for {graphTypeInstance.Name}.");
+            }
+
+            var rep = repMap!.ToObject(resolver.SourceType);
+            var result = resolver.Resolve(context, rep);
+            results.Add(result);
+        }
+        return results;
+    }
+}

--- a/src/GraphQL.Federation/FuncFederationResolver.cs
+++ b/src/GraphQL.Federation/FuncFederationResolver.cs
@@ -1,0 +1,23 @@
+namespace GraphQL.Federation;
+
+/// <summary>
+/// FuncFederationResolver.
+/// </summary>
+public class FuncFederationResolver<TSourceType> : IFederationResolver
+{
+    private readonly Func<IResolveFieldContext, TSourceType, object?> _resolve;
+
+    /// <inheritdoc/>
+    public Type SourceType => typeof(TSourceType);
+
+    /// <summary>
+    /// .ctor
+    /// </summary>
+    public FuncFederationResolver(Func<IResolveFieldContext, TSourceType, object?> resolve)
+    {
+        _resolve = resolve;
+    }
+
+    /// <inheritdoc/>
+    public object? Resolve(IResolveFieldContext context, object source) => _resolve(context, (TSourceType)source);
+}

--- a/src/GraphQL.Federation/GraphQL.Federation.csproj
+++ b/src/GraphQL.Federation/GraphQL.Federation.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>GraphQL Federation implementation</Description>
+    <PackageTags>GraphQL;Federation</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
+  </ItemGroup>
+
+</Project>

--- a/src/GraphQL.Federation/IFederationResolver.cs
+++ b/src/GraphQL.Federation/IFederationResolver.cs
@@ -1,0 +1,19 @@
+namespace GraphQL.Federation;
+
+/// <summary>
+/// IFederationResolver.
+/// </summary>
+public interface IFederationResolver
+{
+    /// <summary>
+    /// Type used to deserialize $representations variable item(s).
+    /// </summary>
+    Type SourceType { get; }
+
+    /// <summary>
+    /// Resolver for _service entity item(s).
+    /// </summary>
+    /// <param name="context">Contains parameters pertaining to the currently executing field.</param>
+    /// <param name="source">Deserialized item from $representations variable.</param>
+    object? Resolve(IResolveFieldContext context, object source);
+}

--- a/src/GraphQL.Federation/Types/EntityType.cs
+++ b/src/GraphQL.Federation/Types/EntityType.cs
@@ -1,0 +1,12 @@
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Types;
+
+internal class EntityType : UnionGraphType
+{
+    public EntityType()
+    {
+        Name = "_Entity";
+        Type<NeverType>();
+    }
+}

--- a/src/GraphQL.Federation/Types/NeverType.cs
+++ b/src/GraphQL.Federation/Types/NeverType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+
+namespace GraphQL.Federation.Types;
+
+internal class NeverType : ObjectGraphType
+{
+    public NeverType()
+    {
+        Name = "_Never";
+        IsTypeOf = _ => false;
+        Field<NeverType>("_never");
+    }
+}

--- a/src/GraphQL.Federation/Types/ServiceGraphType.cs
+++ b/src/GraphQL.Federation/Types/ServiceGraphType.cs
@@ -1,0 +1,20 @@
+using GraphQL.Federation.Extensions;
+using GraphQL.Types;
+using GraphQL.Utilities;
+
+namespace GraphQL.Federation.Types;
+
+internal class ServiceGraphType : ObjectGraphType
+{
+    public ServiceGraphType(SchemaPrinterOptions? schemaPrinterOptions)
+    {
+        Name = "_Service";
+
+        Field<StringGraphType>("sdl")
+            .Resolve(context =>
+            {
+                var printer = new FederatedSchemaPrinter(context.Schema, schemaPrinterOptions);
+                return printer.PrintFederatedSchema();
+            });
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug2194.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2194.cs
@@ -12,8 +12,8 @@ public class Bug2194
         CultureTestHelper.UseCultures(() =>
         {
             var printer = new SchemaPrinter(new Bug2194Schema(), new SchemaPrinterOptions { IncludeDeprecationReasons = false, IncludeDescriptions = false });
-            string printed = printer.Print();
-            printed.ShouldBe("Bug2194".ReadSDL());
+            var printed = printer.Print();
+            printed.ShouldBeCrossPlat("Bug2194".ReadSDL());
         });
     }
 

--- a/src/GraphQL.Tests/Bugs/Bug3331.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3331.cs
@@ -26,7 +26,7 @@ public class Bug3331
         schema.Query = queryGraphType;
 
         Should.Throw<InvalidOperationException>(() => schema.Initialize())
-            .Message.ShouldBe(@"A different instance of the GraphType 'MyObjectGraphType' with the name 'MyObject' has already been registered within the schema. Please use the same instance for all references within the schema, or use GraphQLTypeReference to reference a type instantiated elsewhere.
+            .Message.ShouldBeCrossPlat(@"A different instance of the GraphType 'MyObjectGraphType' with the name 'MyObject' has already been registered within the schema. Please use the same instance for all references within the schema, or use GraphQLTypeReference to reference a type instantiated elsewhere.
 To view additional trace enable GlobalSwitches.TrackGraphTypeInitialization switch.");
 
         // Must have 2 instances

--- a/src/GraphQL.Tests/Bugs/Issue2275.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2275.cs
@@ -33,7 +33,7 @@ public class Issue2275
         string json = serializer.Serialize(executionResult);
         executionResult.Errors.ShouldBeNull();
 
-        json.ShouldBe("""
+        json.ShouldBeCrossPlat("""
         {
           "data": {
             "request": "2: [o=25]"

--- a/src/GraphQL.Tests/Execution/LongTests.cs
+++ b/src/GraphQL.Tests/Execution/LongTests.cs
@@ -18,7 +18,7 @@ public class LongTests
         string json = serializer.Serialize(executionResult);
         executionResult.Errors.ShouldBeNull();
 
-        json.ShouldBe("""
+        json.ShouldBeCrossPlat("""
             {
               "data": {
                 "testField": 9223372036854775807

--- a/src/GraphQL.Tests/Introspection/AppliedDirectivesTests.cs
+++ b/src/GraphQL.Tests/Introspection/AppliedDirectivesTests.cs
@@ -19,7 +19,7 @@ public class AppliedDirectivesTests
         string json = serializer.Serialize(executionResult);
         executionResult.Errors.ShouldBeNull();
 
-        json.ShouldBe("AppliedDirectivesResult".ReadJsonResult());
+        json.ShouldBeCrossPlat("AppliedDirectivesResult".ReadJsonResult());
     }
 
     private class AppliedSchema : Schema

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
@@ -84,7 +84,7 @@ public class SchemaTypesTests
 
         // Test
         Should.Throw<InvalidOperationException>(() => schema.Initialize())
-            .Message.ShouldBe(@"A different instance of the GraphType 'ObjectGraphType' with the name 'MyObject' has already been registered within the schema. Please use the same instance for all references within the schema, or use GraphQLTypeReference to reference a type instantiated elsewhere.
+            .Message.ShouldBeCrossPlat(@"A different instance of the GraphType 'ObjectGraphType' with the name 'MyObject' has already been registered within the schema. Please use the same instance for all references within the schema, or use GraphQLTypeReference to reference a type instantiated elsewhere.
 To view additional trace enable GlobalSwitches.TrackGraphTypeInitialization switch.");
     }
 

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -134,7 +134,7 @@ public class SchemaPrinterTests
             Arguments = new QueryArguments(new QueryArgument(new IntGraphType()) { Name = "max" })
         };
         string result = new SchemaPrinter(null).PrintDirective(d);
-        result.ShouldBe("""
+        result.ShouldBeCrossPlat("""
             directive @my(
               max: Int
             ) repeatable on FIELD | QUERY

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -151,6 +151,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AotCompilation", "AotCompil
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.AotCompilationSample.CodeFirst", "GraphQL.AotCompilationSample.CodeFirst\GraphQL.AotCompilationSample.CodeFirst.csproj", "{AF935624-E6BC-4C61-99A7-DC0A829DB933}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQL.Federation", "GraphQL.Federation\GraphQL.Federation.csproj", "{255DC1CA-C3F2-4ACC-9D02-C9C2F17F70EE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQL.Federation.Tests", "GraphQL.Federation.Tests\GraphQL.Federation.Tests.csproj", "{6A945753-1FEF-4FE9-9C28-5962A546C94B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -233,6 +237,14 @@ Global
 		{AF935624-E6BC-4C61-99A7-DC0A829DB933}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF935624-E6BC-4C61-99A7-DC0A829DB933}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF935624-E6BC-4C61-99A7-DC0A829DB933}.Release|Any CPU.Build.0 = Release|Any CPU
+		{255DC1CA-C3F2-4ACC-9D02-C9C2F17F70EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{255DC1CA-C3F2-4ACC-9D02-C9C2F17F70EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{255DC1CA-C3F2-4ACC-9D02-C9C2F17F70EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{255DC1CA-C3F2-4ACC-9D02-C9C2F17F70EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A945753-1FEF-4FE9-9C28-5962A546C94B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A945753-1FEF-4FE9-9C28-5962A546C94B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A945753-1FEF-4FE9-9C28-5962A546C94B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A945753-1FEF-4FE9-9C28-5962A546C94B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Subj.

Some details on what's in the PR:

1. Added [.devcontainer](https://github.com/Mithras/graphql-dotnet/tree/master/.devcontainer) because I don't want to install 9000 SDKs and packages on my host. OmniSharp (Intellisense) is half broken though because it works only with NET 6. This is not related to Federation and I can remove it if you don't want it. Or I can try to fix OmniSharp if you are interested in developing in containers.
2. Separate [GraphQL.Federation.Tests](https://github.com/Mithras/graphql-dotnet/tree/master/src/GraphQL.Federation.Tests) project with a couple INTEGRATION tests (run in 75ms though). I'm not sure you want integration tests and you might prefer 9000 unit tests instead so I made it separate so that it's easy to get rid of. I don't mind adding unit tests, just didn't want to waste time as I'm not sure this PR will ever get reviewed/merged. The tests are pretty simple and self explanatory, see [FederationFieldTests](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL.Federation.Tests/FederationFieldTests.cs).
3. A bunch of NEW stuff under [GraphQL.Federation](https://github.com/Mithras/graphql-dotnet/tree/master/src/GraphQL/Federation) namespace.
  3.1. `Attributes.*` - All Federation 2 [directives](https://www.apollographql.com/docs/federation/federated-types/federated-directives/) as attributes.
  3.2 [Extensions.FederationFieldExtensions](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Extensions/FederationFieldExtensions.cs) - All Federation 2 [directives](https://www.apollographql.com/docs/federation/federated-types/federated-directives/) as `FieldType`/`FieldBuilder` extensions.
  3.3 [Extensions.FederationGraphTypeExtensions](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Extensions/FederationGraphTypeExtensions.cs) - All Federation 2 [directives](https://www.apollographql.com/docs/federation/federated-types/federated-directives/) as `GraphType` extensions. Also, `.AddServices()` and `.AddEntities()` to add Federation fields explicitly/manually (e.g. when you want to specify `.AuthorizeWith()` on them).
  3.4 [Extensions.FederationGraphQLBuilderExtensions](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Extensions/FederationGraphQLBuilderExtensions.cs) - `AddFederation()` extension. See [src/GraphQL.Federation.Tests/ServiceProviderFixture.cs](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL.Federation.Tests/ServiceProviderFixture.cs#L19).
  3.5 `Schema.*` - A few output types to support Federation.
  3.6. A bunch of `internal` classes.

There are a few questionable hacks:

1. [EntityType](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Schema/EntityType.cs) adds pointless [NeverType](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Schema/NeverType.cs) because that's the only way I can pass validation that triggers BEFORE I have a chance to add any Federated entities to the `EntityType` which I do in [FederationEntitiesSchemaNodeVisitor](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Extensions/FederationEntitiesSchemaNodeVisitor.cs).
2. [FederationQuerySchemaNodeVisitor](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Extensions/FederationQuerySchemaNodeVisitor.cs) adds `_service` and `_entities` in a bit of a weird way (injects GraphType instances in ctor) because it doesn't want to work otherwise. Probably something about order of when schema initializes and visitors are called.
3. [FederationQuerySchemaNodeVisitor.ResolveEntities()](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Extensions/FederationQuerySchemaNodeVisitor.cs#L40) doesn't check authorization at an entity level. Only at a field level.
4. **[Ignore]** _I also copy-pasted [GraphTypeToClrType()](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Extensions/FederationHelper.cs#L136) from our code which I feel like should be provided by `graphql-dotnet` by default but I'm not aware of any other ways of mapping Graph <-> CLR types. It's used by [FederationQuerySchemaNodeVisitor.ResolveEntities()](https://github.com/Mithras/graphql-dotnet/blob/master/src/GraphQL/Federation/Extensions/FederationQuerySchemaNodeVisitor.cs#L40)._

Hope this won't get stuck for years like https://github.com/graphql-dotnet/graphql-dotnet/pull/1669 did.
