### PR TITLE
Throw proper exception when RequestServices is null

### DIFF
--- a/src/GraphQL/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/GraphQLBuilderExtensions.cs
@@ -649,7 +649,11 @@ namespace GraphQL
             where TDocumentListener : class, IDocumentExecutionListener
         {
             builder.Services.RegisterAsBoth<IDocumentExecutionListener, TDocumentListener>(serviceLifetime);
-            builder.ConfigureExecutionOptions(options => options.Listeners.Add(options.RequestServices!.GetRequiredService<TDocumentListener>()));
+            builder.ConfigureExecutionOptions(options =>
+            {
+                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
+                options.Listeners.Add(requestServices.GetRequiredService<TDocumentListener>());
+            });
             return builder;
         }
 
@@ -685,7 +689,11 @@ namespace GraphQL
             where TDocumentListener : class, IDocumentExecutionListener
         {
             builder.Services.RegisterAsBoth<IDocumentExecutionListener, TDocumentListener>(documentListenerFactory ?? throw new ArgumentNullException(nameof(documentListenerFactory)), serviceLifetime);
-            builder.ConfigureExecutionOptions(options => options.Listeners.Add(options.RequestServices!.GetRequiredService<TDocumentListener>()));
+            builder.ConfigureExecutionOptions(options =>
+            {
+                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
+                options.Listeners.Add(requestServices.GetRequiredService<TDocumentListener>());
+            });
             return builder;
         }
         #endregion
@@ -965,7 +973,8 @@ namespace GraphQL
             builder.Services.RegisterAsBoth<IValidationRule, TValidationRule>(ServiceLifetime.Singleton);
             builder.ConfigureExecutionOptions(options =>
             {
-                var rule = options.RequestServices!.GetRequiredService<TValidationRule>();
+                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
+                var rule = requestServices.GetRequiredService<TValidationRule>();
                 options.ValidationRules = (options.ValidationRules ?? DocumentValidator.CoreRules).Append(rule);
                 if (useForCachedDocuments)
                 {
@@ -1018,7 +1027,8 @@ namespace GraphQL
             builder.Services.RegisterAsBoth<IValidationRule, TValidationRule>(validationRuleFactory ?? throw new ArgumentNullException(nameof(validationRuleFactory)), ServiceLifetime.Singleton);
             builder.ConfigureExecutionOptions(options =>
             {
-                var rule = options.RequestServices!.GetRequiredService<TValidationRule>();
+                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
+                var rule = requestServices.GetRequiredService<TValidationRule>();
                 options.ValidationRules = (options.ValidationRules ?? DocumentValidator.CoreRules).Append(rule);
                 if (useForCachedDocuments)
                 {


### PR DESCRIPTION
Fixes issue reported at:
- https://github.com/graphql-dotnet/authorization/issues/235