### PR TITLE
Release DataLoaderList for cached DataLoaderPair entries

### DIFF
--- a/docs2/site/docs/migrations/migration6.md
+++ b/docs2/site/docs/migrations/migration6.md
@@ -13,5 +13,5 @@ memory usage is reduced by freeing unnecessary references after obtaining the re
 
 ### 1. `DataLoaderPair<TKey, T>.Loader` property removed
 
-This property was not used internally and is not normally exposed accessible from user code.
+This property was not used internally and should not be necessary by user code or custom implementations.
 Removal was necessary as the value is released after the result is set.

--- a/docs2/site/docs/migrations/migration6.md
+++ b/docs2/site/docs/migrations/migration6.md
@@ -1,0 +1,17 @@
+# Migrating from v5.x to v6.x
+
+See [issues](https://github.com/graphql-dotnet/graphql-dotnet/issues?q=milestone%3A6.0+is%3Aissue+is%3Aclosed) and [pull requests](https://github.com/graphql-dotnet/graphql-dotnet/pulls?q=is%3Apr+milestone%3A6.0+is%3Aclosed) done in v6.
+
+## New Features
+
+### 1. Reduced memory usage for data loader results
+
+Especially noteworthy when a data loader is configured with caching enabled and a singleton lifetime,
+memory usage is reduced by freeing unnecessary references after obtaining the results.
+
+## Breaking Changes
+
+### 1. `DataLoaderPair<TKey, T>.Loader` property removed
+
+This property was not used internally and is not normally exposed accessible from user code.
+Removal was necessary as the value is released after the result is set.

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -88,6 +88,8 @@
       - title: Migration Guides
         dir: migrations
         items:
+          - title: Migration Guide [v5 -> v6]
+            file: migration6.md
           - title: Migration Guide [v4 -> v5]
             file: migration5.md
           - title: Migration Guide [v3 -> v4]

--- a/src/GraphQL.ApiTests/GraphQL.DataLoader.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.DataLoader.approved.txt
@@ -81,7 +81,6 @@ namespace GraphQL.DataLoader
         public DataLoaderPair(GraphQL.DataLoader.IDataLoader loader, TKey key) { }
         public bool IsResultSet { get; }
         public TKey Key { get; }
-        public GraphQL.DataLoader.IDataLoader Loader { get; }
         public T Result { get; }
         public System.Threading.Tasks.Task<T> GetResultAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public void SetResult(T value) { }

--- a/src/GraphQL.DataLoader/DataLoaderPair.cs
+++ b/src/GraphQL.DataLoader/DataLoaderPair.cs
@@ -85,6 +85,7 @@ namespace GraphQL.DataLoader
 
         async Task<object?> IDataLoaderResult.GetResultAsync(CancellationToken cancellationToken)
         {
+            // same code as above; prevents an additional allocation
             var loader = _loader;
             if (loader != null)
                 await loader.DispatchAsync(cancellationToken).ConfigureAwait(false);

--- a/src/GraphQL.DataLoader/DataLoaderPair.cs
+++ b/src/GraphQL.DataLoader/DataLoaderPair.cs
@@ -87,11 +87,7 @@ namespace GraphQL.DataLoader
         {
             var loader = _loader;
             if (loader != null)
-            {
-                // it does not matter if there are simultaneous calls to DispatchAsync as DataLoaderList
-                // protects against double calls to DispatchAsync
                 await loader.DispatchAsync(cancellationToken).ConfigureAwait(false);
-            }
             return Result;
         }
     }

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -122,6 +122,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "migrations", "migrations", 
 		..\docs2\site\docs\migrations\migration3.md = ..\docs2\site\docs\migrations\migration3.md
 		..\docs2\site\docs\migrations\migration4.md = ..\docs2\site\docs\migrations\migration4.md
 		..\docs2\site\docs\migrations\migration5.md = ..\docs2\site\docs\migrations\migration5.md
+		..\docs2\site\docs\migrations\migration6.md = ..\docs2\site\docs\migrations\migration6.md
 		..\docs2\site\docs\migrations\v0_11_0.md = ..\docs2\site\docs\migrations\v0_11_0.md
 		..\docs2\site\docs\migrations\v0_8_0.md = ..\docs2\site\docs\migrations\v0_8_0.md
 	EndProjectSection


### PR DESCRIPTION
If a DataLoaderBase is used as a singleton, so that entries are cached project-wide, then the individual DataLoaderPair entries retain unnecessary references to DataLoaderList classes.

This PR releases the reference to DataLoaderList after the result has been set.

Also added some memory barriers to be sure the result is read after the check to see if the result has been set.  This may be necessary now that the 'await' is not always called, which would have an implicit memory barrier.

The breaking change is that the `Loader` property has been removed from `DataLoaderPair`.  I can't really imagine a way that the property would be needed.