### PR TITLE
Field's impact for ComplexityAnalyzer

### DIFF
--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2975,8 +2975,8 @@ namespace GraphQL.Validation.Complexity
 {
     public static class ComplexityAnalayzerMetadataExtensions
     {
-        public static double? GetImpact(this GraphQL.Types.IProvideMetadata? provider) { }
-        public static TMetadataProvider WithImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
+        public static double? GetComplexityImpact(this GraphQL.Types.IProvideMetadata provider) { }
+        public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
     }
     public class ComplexityAnalyzer : GraphQL.Validation.Complexity.IComplexityAnalyzer

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2973,6 +2973,12 @@ namespace GraphQL.Validation
 }
 namespace GraphQL.Validation.Complexity
 {
+    public static class ComplexityAnalayzerMetadataExtensions
+    {
+        public static double? GetImpact(this GraphQL.Types.IProvideMetadata? provider) { }
+        public static TMetadataProvider WithImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+    }
     public class ComplexityAnalyzer : GraphQL.Validation.Complexity.IComplexityAnalyzer
     {
         public ComplexityAnalyzer() { }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2977,7 +2977,7 @@ namespace GraphQL.Validation.Complexity
     {
         public ComplexityAnalyzer() { }
         protected virtual void Analyzed(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration complexityParameters, GraphQL.Validation.Complexity.ComplexityResult complexityResult) { }
-        public void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration complexityParameters) { }
+        public void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration complexityParameters, GraphQL.Types.ISchema? schema = null) { }
     }
     public class ComplexityConfiguration
     {
@@ -2996,7 +2996,7 @@ namespace GraphQL.Validation.Complexity
     }
     public interface IComplexityAnalyzer
     {
-        void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration parameters);
+        void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration parameters, GraphQL.Types.ISchema? schema = null);
     }
 }
 namespace GraphQL.Validation.Errors

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2959,6 +2959,12 @@ namespace GraphQL.Validation
 }
 namespace GraphQL.Validation.Complexity
 {
+    public static class ComplexityAnalayzerMetadataExtensions
+    {
+        public static double? GetImpact(this GraphQL.Types.IProvideMetadata? provider) { }
+        public static TMetadataProvider WithImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+    }
     public class ComplexityAnalyzer : GraphQL.Validation.Complexity.IComplexityAnalyzer
     {
         public ComplexityAnalyzer() { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2961,8 +2961,8 @@ namespace GraphQL.Validation.Complexity
 {
     public static class ComplexityAnalayzerMetadataExtensions
     {
-        public static double? GetImpact(this GraphQL.Types.IProvideMetadata? provider) { }
-        public static TMetadataProvider WithImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
+        public static double? GetComplexityImpact(this GraphQL.Types.IProvideMetadata provider) { }
+        public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
             where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
     }
     public class ComplexityAnalyzer : GraphQL.Validation.Complexity.IComplexityAnalyzer

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2963,7 +2963,7 @@ namespace GraphQL.Validation.Complexity
     {
         public ComplexityAnalyzer() { }
         protected virtual void Analyzed(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration complexityParameters, GraphQL.Validation.Complexity.ComplexityResult complexityResult) { }
-        public void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration complexityParameters) { }
+        public void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration complexityParameters, GraphQL.Types.ISchema? schema = null) { }
     }
     public class ComplexityConfiguration
     {
@@ -2982,7 +2982,7 @@ namespace GraphQL.Validation.Complexity
     }
     public interface IComplexityAnalyzer
     {
-        void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration parameters);
+        void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityConfiguration parameters, GraphQL.Types.ISchema? schema = null);
     }
 }
 namespace GraphQL.Validation.Errors

--- a/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
@@ -93,7 +93,7 @@ public class ComplexityMetaDataFixture : IDisposable
         public ComplexityQuery()
         {
             Field<Hero>("hero", resolve: _ => 0)
-                .WithImpact(2);
+                .WithComplexityImpact(2);
         }
     }
 
@@ -102,12 +102,12 @@ public class ComplexityMetaDataFixture : IDisposable
         public Hero()
         {
             Field<IntGraphType>("id", resolve: context => context.Source)
-                .WithImpact(0);
+                .WithComplexityImpact(0);
 
             Field<StringGraphType>("name", resolve: context => $"Tom_{context.Source}");
 
             Field<ListGraphType<Hero>>("friends", resolve: context => new List<int> { 0, 1, 2 }.Where(x => x != context.Source).ToList())
-                .WithImpact(3);
+                .WithComplexityImpact(3);
         }
     }
 

--- a/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
@@ -1,8 +1,8 @@
-using Microsoft.Extensions.DependencyInjection;
-using GraphQL.MicrosoftDI;
-using GraphQL.Validation.Complexity;
 using GraphQL.Execution;
+using GraphQL.MicrosoftDI;
 using GraphQL.Types;
+using GraphQL.Validation.Complexity;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.Tests.Complexity;
 

--- a/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.Extensions.DependencyInjection;
+using GraphQL.MicrosoftDI;
+using GraphQL.StarWars;
+using GraphQL.Validation.Complexity;
+using GraphQL.Execution;
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Complexity;
+
+public class ComplexityMetaDataTests : IClassFixture<ComplexityMetaDataFixture>
+{
+    private readonly ComplexityMetaDataFixture _fixture;
+
+    public ComplexityMetaDataTests(ComplexityMetaDataFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void MetaData_ShouldBe_Used()
+    {
+        var result = _fixture.Analyze(@"
+query {
+    hero { #2
+        id #0
+        name #2
+        friends { #4
+            id #0
+            name #4
+            f1: friends { #12
+                name #12
+            }
+            f2: friends { #12
+                name #12
+            }
+        }
+    }
+}
+");
+        result.Complexity.ShouldBe(60);
+        result.TotalQueryDepth.ShouldBe(4);
+    }
+
+    [Fact]
+    public void MetaData_With_Fragments_ShouldBe_Used()
+    {
+        var result = _fixture.Analyze(@"
+query {
+    hero { #2
+        id #0
+        name #2
+        ...friendsRoot #132(4/2*66)
+    }
+}
+
+fragment friendsRoot on Hero {
+    friends { #3
+        ...friendsIdName #27(9/2*6)
+        f1: friends { #9
+            name #9
+        }
+        f2: friends { #9
+            name #9
+        }
+    }
+}
+
+fragment friendsIdName on Hero {
+    friends { #3
+        id #0
+        name #3
+    }
+}
+");
+        result.Complexity.ShouldBe(136);
+        result.TotalQueryDepth.ShouldBe(5);
+    }
+}
+
+public class ComplexityMetaDataFixture : IDisposable
+{
+    public class ComplexitySchema : Schema
+    {
+        public ComplexitySchema()
+        {
+            Query = new ComplexityQuery();
+        }
+    }
+
+    public class ComplexityQuery : ObjectGraphType<object>
+    {
+        public ComplexityQuery()
+        {
+            Field<Hero>("hero").WithMetadata("complexity", 2d);
+        }
+    }
+
+    public class Hero : ObjectGraphType<object>
+    {
+        public Hero()
+        {
+            Field<IdGraphType>("id").WithMetadata("complexity", 0d);
+            Field<StringGraphType>("name");
+            Field<ListGraphType<Hero>>("friends").WithMetadata("complexity", 3d);
+        }
+    }
+
+    private readonly ServiceProvider _provider;
+    private readonly ComplexityAnalyzer _analyzer;
+    private readonly IDocumentBuilder _documentBuilder;
+    private readonly ComplexityConfiguration _config;
+    private readonly ISchema _schema;
+
+    public ComplexityMetaDataFixture()
+    {
+        _provider = new ServiceCollection()
+            .AddSingleton<StarWarsData>()
+            .AddGraphQL(builder => builder
+                .AddSchema<ComplexitySchema>().AddGraphTypes()
+                .AddComplexityAnalyzer()
+            ).BuildServiceProvider();
+
+        _documentBuilder = _provider.GetRequiredService<IDocumentBuilder>();
+        _config = new();
+        _schema = _provider.GetRequiredService<ISchema>();
+        _analyzer = (ComplexityAnalyzer)_provider.GetRequiredService<IComplexityAnalyzer>();
+    }
+
+    public ComplexityResult Analyze(string query) => _analyzer.Analyze(_documentBuilder.Build(query), _config.FieldImpact ?? 2f, _config.MaxRecursionCount, _schema);
+
+    public void Dispose() => _provider.Dispose();
+}

--- a/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
@@ -92,7 +92,8 @@ public class ComplexityMetaDataFixture : IDisposable
     {
         public ComplexityQuery()
         {
-            Field<Hero>("hero", resolve: _ => 0).WithMetadata("complexity", 2d);
+            Field<Hero>("hero", resolve: _ => 0)
+                .WithMetadata("impact", 2d);
         }
     }
 
@@ -101,12 +102,12 @@ public class ComplexityMetaDataFixture : IDisposable
         public Hero()
         {
             Field<IntGraphType>("id", resolve: context => context.Source)
-                .WithMetadata("complexity", 0d);
+                .WithMetadata("impact", 0d);
 
             Field<StringGraphType>("name", resolve: context => $"Tom_{context.Source}");
 
             Field<ListGraphType<Hero>>("friends", resolve: context => new List<int> { 0, 1, 2 }.Where(x => x != context.Source).ToList())
-                .WithMetadata("complexity", 3d);
+                .WithMetadata("impact", 3d);
         }
     }
 

--- a/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
@@ -93,7 +93,7 @@ public class ComplexityMetaDataFixture : IDisposable
         public ComplexityQuery()
         {
             Field<Hero>("hero", resolve: _ => 0)
-                .WithMetadata("impact", 2d);
+                .WithImpact(2);
         }
     }
 
@@ -102,12 +102,12 @@ public class ComplexityMetaDataFixture : IDisposable
         public Hero()
         {
             Field<IntGraphType>("id", resolve: context => context.Source)
-                .WithMetadata("impact", 0d);
+                .WithImpact(0);
 
             Field<StringGraphType>("name", resolve: context => $"Tom_{context.Source}");
 
             Field<ListGraphType<Hero>>("friends", resolve: context => new List<int> { 0, 1, 2 }.Where(x => x != context.Source).ToList())
-                .WithMetadata("impact", 3d);
+                .WithImpact(3);
         }
     }
 

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -207,7 +207,7 @@ namespace GraphQL
                 if (options.ComplexityConfiguration != null && validationResult.IsValid && analyzeComplexity)
                 {
                     using (metrics.Subject("document", "Analyzing complexity"))
-                        _complexityAnalyzer.Validate(document, options.ComplexityConfiguration);
+                        _complexityAnalyzer.Validate(document, options.ComplexityConfiguration, options.Schema);
                 }
 
                 if (saveInCache && validationResult.IsValid)

--- a/src/GraphQL/Validation/Complexity/AnalysisContext.cs
+++ b/src/GraphQL/Validation/Complexity/AnalysisContext.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Validation.Complexity
     {
         public double AvgImpact { get; set; }
 
-        public double CurrentSubSelectionImpact { get; set; }
+        public double? CurrentSubSelectionImpact { get; set; }
 
         public double CurrentEndNodeImpact { get; set; }
 

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Validation.Complexity;
 /// </summary>
 public static class ComplexityAnalayzerMetadataExtensions
 {
-    private const string COMPLEXITY_IMPACT = "complexityImpact";
+    private const string COMPLEXITY_IMPACT = "__COMPLEXITY_IMPACT__";
 
     /// <summary>
     /// Specify field's complexity impact which will be taken into account by <see cref="ComplexityAnalyzer"/>.

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
@@ -1,0 +1,28 @@
+using GraphQL.Types;
+
+namespace GraphQL.Validation.Complexity;
+
+/// <summary>
+/// Provides extension methods for working with field's impact.
+/// </summary>
+public static class ComplexityAnalayzerMetadataExtensions
+{
+    /// <summary>
+    /// Specify field's impact which will be taken into account by <see cref="ComplexityAnalyzer"/>.
+    /// </summary>
+    /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to let compiler infer the returning type to allow methods chaining. </typeparam>
+    /// <param name="provider"> Metadata provider which must implement <see cref="IProvideMetadata"/> interface. </param>
+    /// <param name="impact"> Field's impact. </param>
+    /// <returns> The reference to the specified <paramref name="provider"/>. </returns>
+    public static TMetadataProvider WithImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
+        where TMetadataProvider : IProvideMetadata
+        => provider.WithMetadata("impact", impact);
+
+    /// <summary>
+    /// Get field's impact which will be taken into account by <see cref="ComplexityAnalyzer"/>.
+    /// </summary>
+    /// <param name="provider"> Metadata provider which must implement <see cref="IProvideMetadata"/> interface. </param>
+    /// <returns> Field's impact. </returns>
+    public static double? GetImpact(this IProvideMetadata? provider)
+        => provider?.GetMetadata<double?>("impact");
+}

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
@@ -3,26 +3,28 @@ using GraphQL.Types;
 namespace GraphQL.Validation.Complexity;
 
 /// <summary>
-/// Provides extension methods for working with field's impact.
+/// Provides extension methods for working with field's complexity impact.
 /// </summary>
 public static class ComplexityAnalayzerMetadataExtensions
 {
+    private const string COMPLEXITY_IMPACT = "complexityImpact";
+
     /// <summary>
-    /// Specify field's impact which will be taken into account by <see cref="ComplexityAnalyzer"/>.
+    /// Specify field's complexity impact which will be taken into account by <see cref="ComplexityAnalyzer"/>.
     /// </summary>
     /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to let compiler infer the returning type to allow methods chaining. </typeparam>
     /// <param name="provider"> Metadata provider which must implement <see cref="IProvideMetadata"/> interface. </param>
-    /// <param name="impact"> Field's impact. </param>
+    /// <param name="impact"> Field's complexity impact. </param>
     /// <returns> The reference to the specified <paramref name="provider"/>. </returns>
-    public static TMetadataProvider WithImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
+    public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
         where TMetadataProvider : IProvideMetadata
-        => provider.WithMetadata("impact", impact);
+        => provider.WithMetadata(COMPLEXITY_IMPACT, impact);
 
     /// <summary>
-    /// Get field's impact which will be taken into account by <see cref="ComplexityAnalyzer"/>.
+    /// Get field's complexity impact which will be taken into account by <see cref="ComplexityAnalyzer"/>.
     /// </summary>
     /// <param name="provider"> Metadata provider which must implement <see cref="IProvideMetadata"/> interface. </param>
-    /// <returns> Field's impact. </returns>
-    public static double? GetImpact(this IProvideMetadata? provider)
-        => provider?.GetMetadata<double?>("impact");
+    /// <returns> Field's complexity impact. </returns>
+    public static double? GetComplexityImpact(this IProvideMetadata provider)
+        => provider.GetMetadata<double?>(COMPLEXITY_IMPACT);
 }

--- a/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
@@ -61,13 +61,14 @@ namespace GraphQL.Validation.Complexity
             var prevCurrentEndNodeImpact = context.CurrentEndNodeImpact;
 
             var fieldImpact = _visitor?.GetFieldDef()?.GetMetadata<double?>("impact") ?? context.AvgImpact;
-            context.CurrentSubSelectionImpact ??= (fieldImpact == 0 ? context.AvgImpact : fieldImpact);
+            var zeroImpact = fieldImpact < 0.001;
+            context.CurrentSubSelectionImpact ??= (zeroImpact ? context.AvgImpact : fieldImpact);
 
             if (context.FragmentMapAlreadyBuilt)
             {
                 if (field.SelectionSet == null) // leaf field
                 {
-                    context.RecordFieldComplexity(field, fieldImpact == 0 ? 0 : context.CurrentEndNodeImpact);
+                    context.RecordFieldComplexity(field, zeroImpact ? 0 : context.CurrentEndNodeImpact);
                 }
                 else
                 {
@@ -78,15 +79,15 @@ namespace GraphQL.Validation.Complexity
                         ? context.CurrentSubSelectionImpact.Value
                         : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
 
-                    context.RecordFieldComplexity(field, fieldImpact == 0 ? 0 : context.CurrentEndNodeImpact);
-                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (fieldImpact == 0 ? context.AvgImpact : fieldImpact);
+                    context.RecordFieldComplexity(field, zeroImpact ? 0 : context.CurrentEndNodeImpact);
+                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (zeroImpact ? context.AvgImpact : fieldImpact);
                 }
             }
             else
             {
                 if (field.SelectionSet == null) // leaf field
                 {
-                    context.CurrentFragmentComplexity.Complexity += fieldImpact == 0 ? 0 : context.CurrentEndNodeImpact;
+                    context.CurrentFragmentComplexity.Complexity += zeroImpact ? 0 : context.CurrentEndNodeImpact;
                 }
                 else
                 {
@@ -97,8 +98,8 @@ namespace GraphQL.Validation.Complexity
                         ? context.CurrentSubSelectionImpact.Value
                         : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
 
-                    context.CurrentFragmentComplexity.Complexity += fieldImpact == 0 ? 0 : context.CurrentEndNodeImpact;
-                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (fieldImpact == 0 ? context.AvgImpact : fieldImpact);
+                    context.CurrentFragmentComplexity.Complexity += zeroImpact ? 0 : context.CurrentEndNodeImpact;
+                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (zeroImpact ? context.AvgImpact : fieldImpact);
                 }
             }
 

--- a/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
@@ -60,7 +60,7 @@ namespace GraphQL.Validation.Complexity
             var prevCurrentSubSelectionImpact = context.CurrentSubSelectionImpact;
             var prevCurrentEndNodeImpact = context.CurrentEndNodeImpact;
 
-            var fieldImpact = _visitor?.GetFieldDef()?.GetMetadata<double?>("impact") ?? context.AvgImpact;
+            var fieldImpact = _visitor?.GetFieldDef()?.GetImpact() ?? context.AvgImpact;
             var zeroImpact = fieldImpact < 0.001;
             context.CurrentSubSelectionImpact ??= (zeroImpact ? context.AvgImpact : fieldImpact);
 

--- a/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
@@ -24,20 +24,13 @@ namespace GraphQL.Validation.Complexity
 
         public override async ValueTask VisitAsync(ASTNode? node, AnalysisContext context)
         {
-            if (_visitor != null)
+            if (node != null)
             {
-                if (node != null)
-                {
-                    _visitor.Enter(node, null!);
+                _visitor?.Enter(node, null!);
 
-                    await base.VisitAsync(node, context).ConfigureAwait(false);
-
-                    _visitor.Leave(node, null!);
-                }
-            }
-            else
-            {
                 await base.VisitAsync(node, context).ConfigureAwait(false);
+
+                _visitor?.Leave(node, null!);
             }
         }
 
@@ -60,8 +53,8 @@ namespace GraphQL.Validation.Complexity
             var prevCurrentSubSelectionImpact = context.CurrentSubSelectionImpact;
             var prevCurrentEndNodeImpact = context.CurrentEndNodeImpact;
 
-            var fieldImpact = _visitor?.GetFieldDef()?.GetImpact() ?? context.AvgImpact;
-            var zeroImpact = fieldImpact < 0.001;
+            var fieldImpact = _visitor?.GetFieldDef()?.GetComplexityImpact() ?? context.AvgImpact;
+            var zeroImpact = fieldImpact == 0;
             context.CurrentSubSelectionImpact ??= (zeroImpact ? context.AvgImpact : fieldImpact);
 
             if (context.FragmentMapAlreadyBuilt)

--- a/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
@@ -60,14 +60,14 @@ namespace GraphQL.Validation.Complexity
             var prevCurrentSubSelectionImpact = context.CurrentSubSelectionImpact;
             var prevCurrentEndNodeImpact = context.CurrentEndNodeImpact;
 
-            var fieldComplexity = _visitor?.GetFieldDef()?.GetMetadata<double?>("complexity") ?? context.AvgImpact;
-            context.CurrentSubSelectionImpact ??= (fieldComplexity == 0 ? context.AvgImpact : fieldComplexity);
+            var fieldImpact = _visitor?.GetFieldDef()?.GetMetadata<double?>("impact") ?? context.AvgImpact;
+            context.CurrentSubSelectionImpact ??= (fieldImpact == 0 ? context.AvgImpact : fieldImpact);
 
             if (context.FragmentMapAlreadyBuilt)
             {
                 if (field.SelectionSet == null) // leaf field
                 {
-                    context.RecordFieldComplexity(field, fieldComplexity == 0 ? 0 : context.CurrentEndNodeImpact);
+                    context.RecordFieldComplexity(field, fieldImpact == 0 ? 0 : context.CurrentEndNodeImpact);
                 }
                 else
                 {
@@ -78,15 +78,15 @@ namespace GraphQL.Validation.Complexity
                         ? context.CurrentSubSelectionImpact.Value
                         : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
 
-                    context.RecordFieldComplexity(field, fieldComplexity == 0 ? 0 : context.CurrentEndNodeImpact);
-                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (fieldComplexity == 0 ? context.AvgImpact : fieldComplexity);
+                    context.RecordFieldComplexity(field, fieldImpact == 0 ? 0 : context.CurrentEndNodeImpact);
+                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (fieldImpact == 0 ? context.AvgImpact : fieldImpact);
                 }
             }
             else
             {
                 if (field.SelectionSet == null) // leaf field
                 {
-                    context.CurrentFragmentComplexity.Complexity += fieldComplexity == 0 ? 0 : context.CurrentEndNodeImpact;
+                    context.CurrentFragmentComplexity.Complexity += fieldImpact == 0 ? 0 : context.CurrentEndNodeImpact;
                 }
                 else
                 {
@@ -97,8 +97,8 @@ namespace GraphQL.Validation.Complexity
                         ? context.CurrentSubSelectionImpact.Value
                         : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
 
-                    context.CurrentFragmentComplexity.Complexity += fieldComplexity == 0 ? 0 : context.CurrentEndNodeImpact;
-                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (fieldComplexity == 0 ? context.AvgImpact : fieldComplexity);
+                    context.CurrentFragmentComplexity.Complexity += fieldImpact == 0 ? 0 : context.CurrentEndNodeImpact;
+                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (fieldImpact == 0 ? context.AvgImpact : fieldImpact);
                 }
             }
 

--- a/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
@@ -1,15 +1,46 @@
+using GraphQL.Types;
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
 
 namespace GraphQL.Validation.Complexity
 {
     /// <summary>
-    /// Two-phase complexity visitor. See <see cref="ComplexityAnalyzer.Analyze(GraphQLDocument, double, int)"/>.
+    /// Two-phase complexity visitor. See <see cref="ComplexityAnalyzer.Analyze(GraphQLDocument, double, int, ISchema?)"/>.
     /// Phase 1. Calculate complexity of all fragments defined in GraphQL document; <see cref="AnalysisContext.FragmentMapAlreadyBuilt"/> is false.
     /// Phase 2. Calculate complexity of executed operation; <see cref="AnalysisContext.FragmentMapAlreadyBuilt"/> is true.
     /// </summary>
     internal class ComplexityVisitor : ASTVisitor<AnalysisContext>
     {
+        private readonly TypeInfo? _visitor;
+
+        public ComplexityVisitor()
+        {
+        }
+
+        public ComplexityVisitor(ISchema schema)
+        {
+            _visitor = new TypeInfo(schema);
+        }
+
+        public override async ValueTask VisitAsync(ASTNode? node, AnalysisContext context)
+        {
+            if (_visitor != null)
+            {
+                if (node != null)
+                {
+                    _visitor.Enter(node, null!);
+
+                    await base.VisitAsync(node, context).ConfigureAwait(false);
+
+                    _visitor.Leave(node, null!);
+                }
+            }
+            else
+            {
+                await base.VisitAsync(node, context).ConfigureAwait(false);
+            }
+        }
+
         protected override async ValueTask VisitFragmentDefinitionAsync(GraphQLFragmentDefinition fragmentDefinition, AnalysisContext context)
         {
             if (!context.FragmentMapAlreadyBuilt)
@@ -29,11 +60,14 @@ namespace GraphQL.Validation.Complexity
             var prevCurrentSubSelectionImpact = context.CurrentSubSelectionImpact;
             var prevCurrentEndNodeImpact = context.CurrentEndNodeImpact;
 
+            var fieldComplexity = _visitor?.GetFieldDef()?.GetMetadata<double?>("complexity") ?? context.AvgImpact;
+            context.CurrentSubSelectionImpact ??= (fieldComplexity == 0 ? context.AvgImpact : fieldComplexity);
+
             if (context.FragmentMapAlreadyBuilt)
             {
                 if (field.SelectionSet == null) // leaf field
                 {
-                    context.RecordFieldComplexity(field, context.CurrentEndNodeImpact);
+                    context.RecordFieldComplexity(field, fieldComplexity == 0 ? 0 : context.CurrentEndNodeImpact);
                 }
                 else
                 {
@@ -41,18 +75,18 @@ namespace GraphQL.Validation.Complexity
 
                     double? impactFromArgs = AnalysisContext.GetImpactFromArgs(field);
                     context.CurrentEndNodeImpact = impactFromArgs == null
-                        ? context.CurrentSubSelectionImpact
-                        : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact;
+                        ? context.CurrentSubSelectionImpact.Value
+                        : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
 
-                    context.RecordFieldComplexity(field, context.CurrentEndNodeImpact);
-                    context.CurrentSubSelectionImpact *= impactFromArgs ?? context.AvgImpact;
+                    context.RecordFieldComplexity(field, fieldComplexity == 0 ? 0 : context.CurrentEndNodeImpact);
+                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (fieldComplexity == 0 ? context.AvgImpact : fieldComplexity);
                 }
             }
             else
             {
                 if (field.SelectionSet == null) // leaf field
                 {
-                    context.CurrentFragmentComplexity.Complexity += context.CurrentEndNodeImpact;
+                    context.CurrentFragmentComplexity.Complexity += fieldComplexity == 0 ? 0 : context.CurrentEndNodeImpact;
                 }
                 else
                 {
@@ -60,11 +94,11 @@ namespace GraphQL.Validation.Complexity
 
                     double? impactFromArgs = AnalysisContext.GetImpactFromArgs(field);
                     context.CurrentEndNodeImpact = impactFromArgs == null
-                        ? context.CurrentSubSelectionImpact
-                        : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact;
+                        ? context.CurrentSubSelectionImpact.Value
+                        : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
 
-                    context.CurrentFragmentComplexity.Complexity += context.CurrentEndNodeImpact;
-                    context.CurrentSubSelectionImpact *= impactFromArgs ?? context.AvgImpact;
+                    context.CurrentFragmentComplexity.Complexity += fieldComplexity == 0 ? 0 : context.CurrentEndNodeImpact;
+                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (fieldComplexity == 0 ? context.AvgImpact : fieldComplexity);
                 }
             }
 
@@ -78,8 +112,17 @@ namespace GraphQL.Validation.Complexity
         {
             var fragmentComplexity = context.FragmentMap[fragmentSpread.FragmentName.Name.StringValue];
 
-            context.RecordFieldComplexity(fragmentSpread, context.CurrentSubSelectionImpact / context.AvgImpact * fragmentComplexity.Complexity);
-            context.Result.TotalQueryDepth += fragmentComplexity.Depth;
+            var complexity = (context.CurrentSubSelectionImpact ?? context.AvgImpact) / context.AvgImpact * fragmentComplexity.Complexity;
+            if (context.FragmentMapAlreadyBuilt)
+            {
+                context.RecordFieldComplexity(fragmentSpread, complexity);
+                context.Result.TotalQueryDepth += fragmentComplexity.Depth;
+            }
+            else
+            {
+                context.CurrentFragmentComplexity.Complexity += complexity;
+                context.CurrentFragmentComplexity.Depth += fragmentComplexity.Depth;
+            }
 
             await base.VisitFragmentSpreadAsync(fragmentSpread, context).ConfigureAwait(false);
         }

--- a/src/GraphQL/Validation/Complexity/IComplexityAnalyzer.cs
+++ b/src/GraphQL/Validation/Complexity/IComplexityAnalyzer.cs
@@ -1,3 +1,4 @@
+using GraphQL.Types;
 using GraphQLParser.AST;
 
 namespace GraphQL.Validation.Complexity
@@ -14,9 +15,10 @@ namespace GraphQL.Validation.Complexity
         /// </summary>
         /// <param name="document"></param>
         /// <param name="parameters"></param>
+        /// <param name="schema"></param>
         /// <exception cref="InvalidOperationException">
         /// Thrown if complexity is not within the defined range in parameters.
         /// </exception>
-        void Validate(GraphQLDocument document, ComplexityConfiguration parameters);
+        void Validate(GraphQLDocument document, ComplexityConfiguration parameters, ISchema? schema = null);
     }
 }


### PR DESCRIPTION
An ability to specify a particular field's complexity impact by means of `Field<IntGraphType>("id").WithComplexityImpact(123)`, which will be taken into account by `ComplexityAnalyzer`. It is a possible solution of the issues #1254 and #298.