### PR TITLE
Add INodeWalker.CompleteAsync

### DIFF
--- a/docs2/site/docs/migrations/migration6.md
+++ b/docs2/site/docs/migrations/migration6.md
@@ -9,9 +9,11 @@ See [issues](https://github.com/graphql-dotnet/graphql-dotnet/issues?q=milestone
 Especially noteworthy when a data loader is configured with caching enabled and a singleton lifetime,
 memory usage is reduced by freeing unnecessary references after obtaining the results.
 
-### 2. Async support for validation rules
+### 2. Async support for validation rules, and new `CompleteAsync` method
 
 Particularly useful for authentication checks, now validation rules are asynchronous.
+The `CompleteAsync` method executes when all nodes have been walked, easing implementations
+which need to execute code after all operations and fragments have been walked.
 
 ## Breaking Changes
 
@@ -20,7 +22,7 @@ Particularly useful for authentication checks, now validation rules are asynchro
 This property was not used internally and should not be necessary by user code or custom implementations.
 Removal was necessary as the value is released after the result is set.
 
-### 2. `INodeVisitor` and `IVariableVisitor` members' signatures are asynchronous and end in `Async`.
+### 2. `INodeVisitor` and `IVariableVisitor` members' signatures are asynchronous and end in `Async`; `INodeVisitor.CompleteAsync` was added.
 
 Note that `MatchingNodeVisitor` has not changed, so many validation rules will not require
 any source code changes.

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2803,6 +2803,7 @@ namespace GraphQL.Validation
     {
         public BasicVisitor(params GraphQL.Validation.INodeVisitor[] visitors) { }
         public BasicVisitor(System.Collections.Generic.IList<GraphQL.Validation.INodeVisitor> visitors) { }
+        public System.Threading.Tasks.ValueTask CompleteAsync(GraphQL.Validation.BasicVisitor.State context) { }
         public override System.Threading.Tasks.ValueTask VisitAsync(GraphQLParser.AST.ASTNode? node, GraphQL.Validation.BasicVisitor.State context) { }
         public readonly struct State : GraphQLParser.Visitors.IASTVisitorContext
         {
@@ -2829,6 +2830,7 @@ namespace GraphQL.Validation
     }
     public interface INodeVisitor
     {
+        System.Threading.Tasks.ValueTask CompleteAsync(GraphQL.Validation.ValidationContext context);
         System.Threading.Tasks.ValueTask EnterAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context);
         System.Threading.Tasks.ValueTask LeaveAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context);
     }
@@ -2881,6 +2883,7 @@ namespace GraphQL.Validation
     public class TypeInfo : GraphQL.Validation.INodeVisitor
     {
         public TypeInfo(GraphQL.Types.ISchema schema) { }
+        public System.Threading.Tasks.ValueTask CompleteAsync(GraphQL.Validation.ValidationContext context) { }
         public System.Threading.Tasks.ValueTask EnterAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
         public GraphQLParser.AST.ASTNode? GetAncestor(int index) { }
         public GraphQL.Types.QueryArgument? GetArgument() { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2789,6 +2789,7 @@ namespace GraphQL.Validation
     {
         public BasicVisitor(params GraphQL.Validation.INodeVisitor[] visitors) { }
         public BasicVisitor(System.Collections.Generic.IList<GraphQL.Validation.INodeVisitor> visitors) { }
+        public System.Threading.Tasks.ValueTask CompleteAsync(GraphQL.Validation.BasicVisitor.State context) { }
         public override System.Threading.Tasks.ValueTask VisitAsync(GraphQLParser.AST.ASTNode? node, GraphQL.Validation.BasicVisitor.State context) { }
         public readonly struct State : GraphQLParser.Visitors.IASTVisitorContext
         {
@@ -2815,6 +2816,7 @@ namespace GraphQL.Validation
     }
     public interface INodeVisitor
     {
+        System.Threading.Tasks.ValueTask CompleteAsync(GraphQL.Validation.ValidationContext context);
         System.Threading.Tasks.ValueTask EnterAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context);
         System.Threading.Tasks.ValueTask LeaveAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context);
     }
@@ -2867,6 +2869,7 @@ namespace GraphQL.Validation
     public class TypeInfo : GraphQL.Validation.INodeVisitor
     {
         public TypeInfo(GraphQL.Types.ISchema schema) { }
+        public System.Threading.Tasks.ValueTask CompleteAsync(GraphQL.Validation.ValidationContext context) { }
         public System.Threading.Tasks.ValueTask EnterAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
         public GraphQLParser.AST.ASTNode? GetAncestor(int index) { }
         public GraphQL.Types.QueryArgument? GetArgument() { }

--- a/src/GraphQL/Validation/BasicVisitor.cs
+++ b/src/GraphQL/Validation/BasicVisitor.cs
@@ -43,6 +43,15 @@ namespace GraphQL.Validation
             }
         }
 
+        /// <summary>
+        /// Executes <see cref="INodeVisitor.CompleteAsync(ValidationContext)"/> for each <see cref="INodeVisitor"/>.
+        /// </summary>
+        public async ValueTask CompleteAsync(State context)
+        {
+            for (int i = 0; i < _visitors.Count; ++i)
+                await _visitors[i].CompleteAsync(context.Context).ConfigureAwait(false);
+        }
+
         /// <inheritdoc cref="IASTVisitorContext"/>
         public readonly struct State : IASTVisitorContext
         {

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -113,7 +113,10 @@ namespace GraphQL.Validation
                                 visitors.Add(visitor);
                         }
                     }
-                    await new BasicVisitor(visitors).VisitAsync(context.Document, new BasicVisitor.State(context)).ConfigureAwait(false);
+                    var basicVisitor = new BasicVisitor(visitors);
+                    var basicVisitorState = new BasicVisitor.State(context);
+                    await basicVisitor.VisitAsync(context.Document, basicVisitorState).ConfigureAwait(false);
+                    await basicVisitor.CompleteAsync(basicVisitorState).ConfigureAwait(false);
                 }
 
                 // can report errors even without rules enabled

--- a/src/GraphQL/Validation/INodeVisitor.cs
+++ b/src/GraphQL/Validation/INodeVisitor.cs
@@ -16,5 +16,10 @@ namespace GraphQL.Validation
         /// Called when the node walker is leaving a node.
         /// </summary>
         ValueTask LeaveAsync(ASTNode node, ValidationContext context);
+
+        /// <summary>
+        /// Called when all nodes have been walked.
+        /// </summary>
+        ValueTask CompleteAsync(ValidationContext context);
     }
 }

--- a/src/GraphQL/Validation/MatchingNodeVisitor.cs
+++ b/src/GraphQL/Validation/MatchingNodeVisitor.cs
@@ -43,6 +43,9 @@ namespace GraphQL.Validation
             }
             return default;
         }
+
+        ValueTask INodeVisitor.CompleteAsync(GraphQL.Validation.ValidationContext context)
+            => default;
     }
 
     /// <summary>
@@ -89,5 +92,8 @@ namespace GraphQL.Validation
             }
             return default;
         }
+
+        ValueTask INodeVisitor.CompleteAsync(GraphQL.Validation.ValidationContext context)
+            => default;
     }
 }

--- a/src/GraphQL/Validation/NodeVisitors.cs
+++ b/src/GraphQL/Validation/NodeVisitors.cs
@@ -29,5 +29,11 @@ namespace GraphQL.Validation
             foreach (var n in _nodeVisitors)
                 await n.LeaveAsync(node, context).ConfigureAwait(false);
         }
+
+        async ValueTask INodeVisitor.CompleteAsync(ValidationContext context)
+        {
+            foreach (var n in _nodeVisitors)
+                await n.CompleteAsync(context).ConfigureAwait(false);
+        }
     }
 }

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -238,6 +238,10 @@ namespace GraphQL.Validation
             return default;
         }
 
+        /// <inheritdoc/>
+        public ValueTask CompleteAsync(ValidationContext context)
+            => default;
+
         private static FieldType? GetFieldDef(ISchema schema, IGraphType parentType, GraphQLField field)
         {
             var name = field.Name;


### PR DESCRIPTION
Facilitates executing code after all fragments and operations have been walked.  Would be used by the authorization validation rule, whereas right now it has to maintain a list and check to see if all have been walked within each `Leave` method.