### PR TITLE
Fix error message when no query is defined

### DIFF
--- a/src/GraphQL.Tests/Execution/ExecutionStrategyTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionStrategyTests.cs
@@ -1,0 +1,27 @@
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Execution;
+
+public class ExecutionStrategyTests
+{
+    [Theory]
+    [InlineData("query { test }", "Schema is not configured for queries")]
+    [InlineData("mutation { test }", "Schema is not configured for mutations")]
+    [InlineData("subscription { test }", "Schema is not configured for subscriptions")]
+    public async Task Refuses_Null_Root_Type(string query, string expectedErrorMessage)
+    {
+        var schema = new Schema();
+        schema.Initialize();
+        var executer = new DocumentExecuter();
+        var result = await executer.ExecuteAsync(new ExecutionOptions
+        {
+            Query = query,
+            Schema = schema,
+        }).ConfigureAwait(false);
+        result.Data.ShouldBeNull();
+        //todo: the document should fail validation and Executed should return false
+        //see: https://github.com/graphql/graphql-spec/pull/955
+        result.Executed.ShouldBeTrue();
+        result.Errors.ShouldHaveSingleItem().Message.ShouldBe(expectedErrorMessage);
+    }
+}

--- a/src/GraphQL.Tests/Execution/ExecutionStrategyTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionStrategyTests.cs
@@ -19,7 +19,7 @@ public class ExecutionStrategyTests
             Schema = schema,
         }).ConfigureAwait(false);
         result.Data.ShouldBeNull();
-        //todo: the document should fail validation and Executed should return false
+        //TODO: the document should fail validation and Executed should return false
         //see: https://github.com/graphql/graphql-spec/pull/955
         result.Executed.ShouldBeTrue();
         result.Errors.ShouldHaveSingleItem().Message.ShouldBe(expectedErrorMessage);

--- a/src/GraphQL.Tests/Files/JSON/AppliedDirectivesResult.json
+++ b/src/GraphQL.Tests/Files/JSON/AppliedDirectivesResult.json
@@ -313,6 +313,22 @@
           ]
         },
         {
+          "name": "Query",
+          "appliedDirectives": [],
+          "fields": [
+            {
+              "name": "dummy",
+              "appliedDirectives": [],
+              "args": []
+            }
+          ]
+        },
+        {
+          "name": "Int",
+          "appliedDirectives": [],
+          "fields": null
+        },
+        {
           "name": "RootMutation",
           "appliedDirectives": [
             {

--- a/src/GraphQL.Tests/Introspection/AppliedDirectivesTests.cs
+++ b/src/GraphQL.Tests/Introspection/AppliedDirectivesTests.cs
@@ -26,6 +26,12 @@ public class AppliedDirectivesTests
     {
         public AppliedSchema()
         {
+            var query = new ObjectGraphType
+            {
+                Name = "Query"
+            };
+            query.Field<IntGraphType>("dummy");
+            Query = query;
             Mutation = new RootMutation();
             Directives.Register(new TraitsDirective());
             this.ApplyDirective("traits", "quality", "high");

--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -152,10 +152,13 @@ public class SchemaIntrospectionTests
     [ClassData(typeof(GraphQLSerializersTestData))]
     public async Task validate_non_null_schema(IGraphQLTextSerializer serializer)
     {
+        var query = new ObjectGraphType { Name = "Query" };
+        query.Field<IntGraphType>("dummy");
+        var schema = new TestSchema() { Query = query };
         var documentExecuter = new DocumentExecuter();
         var executionResult = await documentExecuter.ExecuteAsync(_ =>
         {
-            _.Schema = new TestSchema();
+            _.Schema = schema;
             _.Query = InputObjectBugQuery;
         }).ConfigureAwait(false);
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -50,6 +50,11 @@ namespace GraphQL.Execution
             {
                 case OperationType.Query:
                     type = context.Schema.Query;
+                    // note that per the GraphQL specification, a query root type is required; but currently
+                    // the schema validation check is disabled to allow for test schemas
+                    // that only contain a mutation or subscription root type.
+                    if (type == null)
+                        throw new InvalidOperationError("Schema is not configured for queries").AddLocation(context.Operation, context.Document);
                     break;
 
                 case OperationType.Mutation:


### PR DESCRIPTION
Currently a `ARGUMENT_NULL` error is returned to the client when a query request arrives for a schema with no root query type.  This PR aligns the error message with the similar case for mutation and subscription types, until such time as we decide to disallow schemas without a root query type (in accordance with the spec).

Note that there is an upcoming RFC to the spec for a validation rule to address this condition:
https://github.com/graphql/graphql-spec/pull/955