### PR TITLE
Fix SystemTextJson serializer to allow custom json converters for any data type

### DIFF
--- a/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
@@ -34,7 +34,7 @@ namespace GraphQL.SystemTextJson
                 }
                 else
                 {
-                    WriteValue(writer, result.Data, options);
+                    JsonSerializer.Serialize(writer, result.Data, options);
                 }
             }
         }
@@ -43,7 +43,7 @@ namespace GraphQL.SystemTextJson
         {
             if (node is ValueExecutionNode valueExecutionNode)
             {
-                WriteValue(writer, valueExecutionNode.ToValue(), options);
+                JsonSerializer.Serialize(writer, valueExecutionNode.ToValue(), options);
             }
             else if (node is ObjectExecutionNode objectExecutionNode)
             {
@@ -88,132 +88,7 @@ namespace GraphQL.SystemTextJson
             }
             else
             {
-                WriteValue(writer, node.ToValue(), options);
-            }
-        }
-
-        private static void WriteProperty(Utf8JsonWriter writer, string propertyName, object? propertyValue, JsonSerializerOptions options)
-        {
-            if (options.PropertyNamingPolicy != null)
-                propertyName = options.PropertyNamingPolicy.ConvertName(propertyName);
-            writer.WritePropertyName(propertyName);
-            WriteValue(writer, propertyValue, options);
-        }
-
-        private static void WriteValue(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
-        {
-            switch (value)
-            {
-                case null:
-                {
-                    writer.WriteNullValue();
-                    break;
-                }
-                case string s:
-                {
-                    writer.WriteStringValue(s);
-                    break;
-                }
-                case bool b:
-                {
-                    writer.WriteBooleanValue(b);
-                    break;
-                }
-                case int i:
-                {
-                    writer.WriteNumberValue(i);
-                    break;
-                }
-                case long l:
-                {
-                    writer.WriteNumberValue(l);
-                    break;
-                }
-                case float f:
-                {
-                    writer.WriteNumberValue(f);
-                    break;
-                }
-                case double d:
-                {
-                    writer.WriteNumberValue(d);
-                    break;
-                }
-                case decimal dm:
-                {
-                    writer.WriteNumberValue(dm);
-                    break;
-                }
-                case uint ui:
-                {
-                    writer.WriteNumberValue(ui);
-                    break;
-                }
-                case ulong ul:
-                {
-                    writer.WriteNumberValue(ul);
-                    break;
-                }
-                case short sh:
-                {
-                    writer.WriteNumberValue(sh);
-                    break;
-                }
-                case ushort ush:
-                {
-                    writer.WriteNumberValue(ush);
-                    break;
-                }
-                case byte bt:
-                {
-                    writer.WriteNumberValue(bt);
-                    break;
-                }
-                case sbyte sbt:
-                {
-                    writer.WriteNumberValue(sbt);
-                    break;
-                }
-                case Dictionary<string, object> dictionary:
-                {
-                    writer.WriteStartObject();
-
-                    foreach (var kvp in dictionary)
-                        WriteProperty(writer, kvp.Key, kvp.Value, options);
-
-                    writer.WriteEndObject();
-
-                    break;
-                }
-                case List<object> list:
-                {
-                    writer.WriteStartArray();
-
-                    foreach (object item in list)
-                        WriteValue(writer, item, options);
-
-                    writer.WriteEndArray();
-
-                    break;
-                }
-                case object[] list:
-                {
-                    writer.WriteStartArray();
-
-                    foreach (object item in list)
-                        WriteValue(writer, item, options);
-
-                    writer.WriteEndArray();
-
-                    break;
-                }
-                default:
-                {
-                    // TODO: Guid, BigInteger, DateTime, <Anonymous Type> fall here
-                    // Need to avoid this call by all means! The question remains open - why this API so expensive?
-                    JsonSerializer.Serialize(writer, value, options);
-                    break;
-                }
+                JsonSerializer.Serialize(writer, node.ToValue(), options);
             }
         }
 


### PR DESCRIPTION
Fixes #2257 and allows any registered JsonConverter to work properly.

It comes at a cost of an additional 50% of serialization time.  For the "middle" query below, this represents a half of a millionth of a second of processing time.  Even for the introspection query, it's only 50 millionths of a second.

"Alt" is the new code

|            Method |          Code |         Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------ |-------------- |-------------:|----------:|----------:|-------:|----------:|
|    SystemTextJson | Introspection |  79,349.3 ns | 159.36 ns | 141.27 ns |      - |     161 B |
| SystemTextJsonAlt | Introspection | 124,444.6 ns | 467.13 ns | 436.95 ns |      - |     168 B |
|    SystemTextJson |        Middle |   1,442.3 ns |   2.38 ns |   1.98 ns | 0.0229 |     152 B |
| SystemTextJsonAlt |        Middle |   2,075.8 ns |   3.94 ns |   3.68 ns | 0.0229 |     152 B |
|    SystemTextJson |         Small |     397.0 ns |   1.11 ns |   0.98 ns | 0.0238 |     152 B |
| SystemTextJsonAlt |         Small |     535.5 ns |   2.46 ns |   2.18 ns | 0.0238 |     152 B |