### PR TITLE
Fix NestedFragmentsComparer

### DIFF
--- a/src/GraphQL.Tests/Complexity/ComplexityTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityTests.cs
@@ -143,6 +143,65 @@ fragment comparisonFields on Character {
         withFrag.TotalQueryDepth.ShouldBe(woFrag.TotalQueryDepth);
     }
 
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/3191
+    [Fact]
+    public void nested_fragments_2()
+    {
+        var result = AnalyzeComplexity(@"
+{
+  car(id: 1)
+  {
+    ...lastUpdated
+    ...optionsOnCar
+  }
+}
+
+fragment optionsOnCar on Car
+{
+  options
+  {
+    edges
+    {
+      node
+      {
+        ...optionDetail
+      }
+    }
+  }
+}
+
+fragment optionPrice on Option
+{
+  price
+}
+
+fragment lastUpdated on Car
+{
+  updatedAt
+}
+
+fragment optionDetail on Option
+{
+  name
+  ...optionPrice
+  optionContents(first: 9999999)
+  {
+    edges
+    {
+      node
+      {
+        optionContent
+        {
+          name
+        }
+      }
+    }
+  }
+}");
+
+        result.Complexity.ShouldBe(1839999841); // WOW! :)
+    }
+
     [Fact]
     public void absurdly_huge_query()
     {


### PR DESCRIPTION
fixes #3191 

Comparison sequence before fix:

optionPrice optionsOnCar -1
lastUpdated optionsOnCar 0
optionDetail lastUpdated 0
optionPrice optionsOnCar -1
lastUpdated optionsOnCar 0
optionDetail lastUpdated 0

Result:

optionPrice
optionsOnCar
lastUpdated
optionDetail

Comparison sequence after fix:

optionPrice optionsOnCar -1
lastUpdated optionsOnCar -1
lastUpdated optionPrice 0
optionDetail optionsOnCar -1
optionDetail lastUpdated 1

Result:

optionPrice
lastUpdated
optionDetail
optionsOnCar

