### PR TITLE
Add override for VisitOperationDefinitionAsync

### DIFF
--- a/src/GraphQL/Validation/ValidationContext.GetRecursivelyReferencedFragments.cs
+++ b/src/GraphQL/Validation/ValidationContext.GetRecursivelyReferencedFragments.cs
@@ -69,20 +69,17 @@ namespace GraphQL.Validation
 
         private sealed class GetRecursivelyReferencedFragmentsVisitor : ASTVisitor<GetRecursivelyReferencedFragmentsVisitorContext>
         {
+            protected override ValueTask VisitOperationDefinitionAsync(GraphQLOperationDefinition operationDefinition, GetRecursivelyReferencedFragmentsVisitorContext context)
+                => VisitAsync(operationDefinition.SelectionSet, context);
+
             protected override ValueTask VisitSelectionSetAsync(GraphQLSelectionSet selectionSet, GetRecursivelyReferencedFragmentsVisitorContext context)
-            {
-                return VisitAsync(selectionSet.Selections, context);
-            }
+                => VisitAsync(selectionSet.Selections, context);
 
             protected override ValueTask VisitFieldAsync(GraphQLField field, GetRecursivelyReferencedFragmentsVisitorContext context)
-            {
-                return VisitAsync(field.SelectionSet, context);
-            }
+                => VisitAsync(field.SelectionSet, context);
 
             protected override ValueTask VisitInlineFragmentAsync(GraphQLInlineFragment inlineFragment, GetRecursivelyReferencedFragmentsVisitorContext context)
-            {
-                return VisitAsync(inlineFragment.SelectionSet, context);
-            }
+                => VisitAsync(inlineFragment.SelectionSet, context);
 
             protected override async ValueTask VisitFragmentSpreadAsync(GraphQLFragmentSpread fragmentSpread, GetRecursivelyReferencedFragmentsVisitorContext context)
             {


### PR DESCRIPTION
With the addition of overriding the operation, all other node types should be skipped, I believe.