### PR TITLE
Use SourceFieldResolver for top-level nodes of subscriptions

### DIFF
--- a/docs2/site/docs/getting-started/subscriptions.md
+++ b/docs2/site/docs/getting-started/subscriptions.md
@@ -35,14 +35,8 @@ public class ChatSubscriptions : ObjectGraphType
     {
       Name = "messageAdded",
       Type = typeof(MessageType),
-      Resolver = new FuncFieldResolver<Message>(ResolveMessage),
       StreamResolver = new SourceStreamResolver<Message>(ResolveStream)
     });
-  }
-
-  private Message ResolveMessage(IResolveFieldContext context)
-  {
-    return context.Source as Message;
   }
 
   private IObservable<Message> ResolveStream(IResolveFieldContext context)

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -1141,6 +1141,7 @@ namespace GraphQL.Execution
                 "fieldType"})]
         public virtual System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? GetSubFields(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
         protected virtual System.Threading.Tasks.Task<bool> ProcessNodeUnhandledExceptionAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, System.Exception ex) { }
+        protected virtual GraphQL.Resolvers.IFieldResolver SelectResolver(GraphQL.Execution.ExecutionNode node, GraphQL.Execution.ExecutionContext context) { }
         protected virtual System.Threading.Tasks.Task SetArrayItemNodesAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ArrayExecutionNode parent) { }
         protected virtual void SetNodeError(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, GraphQL.ExecutionError error) { }
         protected virtual void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent) { }
@@ -1610,6 +1611,11 @@ namespace GraphQL.Resolvers
     public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver
     {
         public static GraphQL.Resolvers.NameFieldResolver Instance { get; }
+        public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
+    }
+    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver
+    {
+        public static GraphQL.Resolvers.SourceFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
     public class SourceStreamMethodResolver : GraphQL.Resolvers.MemberResolver, GraphQL.Resolvers.ISourceStreamResolver

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1141,6 +1141,7 @@ namespace GraphQL.Execution
                 "fieldType"})]
         public virtual System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? GetSubFields(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node) { }
         protected virtual System.Threading.Tasks.Task<bool> ProcessNodeUnhandledExceptionAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, System.Exception ex) { }
+        protected virtual GraphQL.Resolvers.IFieldResolver SelectResolver(GraphQL.Execution.ExecutionNode node, GraphQL.Execution.ExecutionContext context) { }
         protected virtual System.Threading.Tasks.Task SetArrayItemNodesAsync(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ArrayExecutionNode parent) { }
         protected virtual void SetNodeError(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ExecutionNode node, GraphQL.ExecutionError error) { }
         protected virtual void SetSubFieldNodes(GraphQL.Execution.ExecutionContext context, GraphQL.Execution.ObjectExecutionNode parent) { }
@@ -1610,6 +1611,11 @@ namespace GraphQL.Resolvers
     public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver
     {
         public static GraphQL.Resolvers.NameFieldResolver Instance { get; }
+        public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
+    }
+    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver
+    {
+        public static GraphQL.Resolvers.SourceFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
     public class SourceStreamMethodResolver : GraphQL.Resolvers.MemberResolver, GraphQL.Resolvers.ISourceStreamResolver

--- a/src/GraphQL.DataLoader.Tests/Types/SubscriptionType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/SubscriptionType.cs
@@ -18,18 +18,10 @@ public class SubscriptionType : ObjectGraphType
         {
             Name = "orderAdded",
             Type = typeof(OrderType),
-            Resolver = new FuncFieldResolver<Order>(ResolveMessage),
             StreamResolver = new SourceStreamResolver<Order>(ResolveStream)
         });
     }
 
-    private Order ResolveMessage(IResolveFieldContext context)
-    {
-        return context.Source as Order;
-    }
-
     private IObservable<Order> ResolveStream(IResolveFieldContext context)
-    {
-        return ordersStore.GetOrderObservable();
-    }
+        => ordersStore.GetOrderObservable();
 }

--- a/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
@@ -27,7 +27,6 @@ public class ChatSubscriptions : ObjectGraphType
         {
             Name = "messageAdded",
             Type = typeof(MessageType),
-            Resolver = new FuncFieldResolver<Message>(ResolveMessage),
             StreamResolver = new SourceStreamResolver<Message>(Subscribe)
         });
 
@@ -38,7 +37,6 @@ public class ChatSubscriptions : ObjectGraphType
                 new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id" }
             ),
             Type = typeof(MessageType),
-            Resolver = new FuncFieldResolver<Message>(ResolveMessage),
             StreamResolver = new SourceStreamResolver<Message>(SubscribeById)
         });
 
@@ -46,7 +44,6 @@ public class ChatSubscriptions : ObjectGraphType
         {
             Name = "messageAddedAsync",
             Type = typeof(MessageType),
-            Resolver = new FuncFieldResolver<Message>(ResolveMessage),
             StreamResolver = new SourceStreamResolver<Message>(SubscribeAsync)
         });
 
@@ -57,7 +54,6 @@ public class ChatSubscriptions : ObjectGraphType
                 new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id" }
             ),
             Type = typeof(MessageType),
-            Resolver = new FuncFieldResolver<Message>(ResolveMessage),
             StreamResolver = new SourceStreamResolver<Message>(SubscribeByIdAsync)
         });
 
@@ -65,15 +61,13 @@ public class ChatSubscriptions : ObjectGraphType
         {
             Name = "messageGetAll",
             Type = typeof(ListGraphType<MessageType>),
-            Resolver = new FuncFieldResolver<List<Message>>(context => context.Source as List<Message>),
-            StreamResolver = new SourceStreamResolver<List<Message>>(context => _chat.MessagesGetAll())
+            StreamResolver = new SourceStreamResolver<List<Message>>(_ => _chat.MessagesGetAll())
         });
 
         AddField(new FieldType
         {
             Name = "newMessageContent",
             Type = typeof(StringGraphType),
-            Resolver = new FuncFieldResolver<string>(context => context.Source as string),
             StreamResolver = new SourceStreamResolver<string>(context => Subscribe(context).Select(message => message.Content))
         });
     }
@@ -93,13 +87,6 @@ public class ChatSubscriptions : ObjectGraphType
 
         var messages = await _chat.MessagesAsync().ConfigureAwait(false);
         return messages.Where(message => message.From.Id == id);
-    }
-
-    private Message ResolveMessage(IResolveFieldContext context)
-    {
-        var message = context.Source as Message;
-
-        return message;
     }
 
     private IObservable<Message> Subscribe(IResolveFieldContext context)

--- a/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SubscriptionExecutionStrategy.cs
@@ -90,13 +90,15 @@ public class SubscriptionExecutionStrategy : ExecutionStrategy
 
         try
         {
-            if (node.FieldDefinition?.StreamResolver == null)
+            var resolver = node.FieldDefinition?.StreamResolver;
+
+            if (resolver == null)
             {
                 // todo: this should be caught by schema validation
                 throw new InvalidOperationException($"Stream resolver not set for field '{node.Field.Name}'.");
             }
 
-            sourceStream = await node.FieldDefinition.StreamResolver.ResolveAsync(resolveContext).ConfigureAwait(false);
+            sourceStream = await resolver.ResolveAsync(resolveContext).ConfigureAwait(false);
 
             if (sourceStream == null)
             {

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -22,7 +22,7 @@ namespace GraphQL.Resolvers
         /// <summary>
         /// Returns the static instance of the <see cref="NameFieldResolver"/> class.
         /// </summary>
-        public static NameFieldResolver Instance { get; } = new NameFieldResolver();
+        public static NameFieldResolver Instance { get; } = new();
 
         /// <inheritdoc/>
         public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => Resolve(context, context.FieldDefinition.Name);

--- a/src/GraphQL/Resolvers/SourceFieldResolver.cs
+++ b/src/GraphQL/Resolvers/SourceFieldResolver.cs
@@ -1,0 +1,17 @@
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// Returns value of <see cref="IResolveFieldContext.Source"/>.
+/// </summary>
+public sealed class SourceFieldResolver : IFieldResolver
+{
+    private SourceFieldResolver() { }
+
+    /// <summary>
+    /// Returns the static instance of the <see cref="SourceFieldResolver"/> class.
+    /// </summary>
+    public static SourceFieldResolver Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => new(context.Source);
+}

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -342,7 +342,7 @@ namespace GraphQL.Types
             string name,
             string? description = null,
             QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, object?>? resolve = null,
+            Func<IResolveFieldContext<TSourceType>, object?>? resolve = null, // TODO: remove?
             Func<IResolveFieldContext, IObservable<object?>>? subscribe = null,
             string? deprecationReason = null)
             where TGraphType : IGraphType
@@ -378,7 +378,7 @@ namespace GraphQL.Types
             string name,
             string? description = null,
             QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, object?>? resolve = null,
+            Func<IResolveFieldContext<TSourceType>, object?>? resolve = null, // TODO: remove?
             Func<IResolveFieldContext, Task<IObservable<object?>>>? subscribeAsync = null,
             string? deprecationReason = null)
             where TGraphType : IGraphType


### PR DESCRIPTION
Allows to keep `Resolver` property unspecified (`null`) for top-level nodes of subscriptions since resolvers for such nodes always return `source` object. The goal - simplify field configuration on the caller side.