### PR TITLE
Add IResolveFieldContext.User

### DIFF
--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - develop
+      - add_user
     paths:
       - src/**
       - .github/workflows/**

--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - develop
-      - add_user
     paths:
       - src/**
       - .github/workflows/**

--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -250,3 +250,7 @@ were moved into `GraphQL` namespace. Also class names were changed:
 - `GraphQL.SystemTextJson.GraphQLBuilderExtensions` -> `GraphQL.SystemTextJsonGraphQLBuilderExtensions`
 
 This change was done for better discoverability and usability of extension methods when configuring DI.
+
+### 8. `IResolveFieldContext.User` property added
+
+Custom implementations of `IResolveFieldContext` must implement the new `User` property.

--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -96,7 +96,7 @@ Note that global attributes may also be added to the `GlobalSwitches.GlobalAttri
 
 ### 8. `ExecutionOptions.User` property added and available to validation rules and field resolvers
 
-You may pass an `IPrincipal` instance into `ExecutionOptions` and it will be fed through to
+You may pass a `ClaimsPrincipal` instance into `ExecutionOptions` and it will be fed through to
 `ValidationContext.User`, `IExecutionContext.User` and `IResolveFieldContext.User` so the value
 is accessible by validation rules, document listeners, field middleware and field resolvers.
 

--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -94,6 +94,16 @@ adjust the return value of the `Priority` property of the attribute.
 
 Note that global attributes may also be added to the `GlobalSwitches.GlobalAttributes` collection.
 
+### 8. `ExecutionOptions.User` property added and available to validation rules and field resolvers
+
+You may pass an `IPrincipal` instance into `ExecutionOptions` and it will be fed through to
+`ValidationContext.User`, `IExecutionContext.User` and `IResolveFieldContext.User` so the value
+is accessible by validation rules, document listeners, field middleware and field resolvers.
+
+This property is similar in nature to the ASP.NET Core `HttpContext.User` propery, not being
+used by the GraphQL.NET engine internally but merely being a convenience property similar to
+`RequestServices` and `UserContext` for use by separate authentication packages.
+
 ## Breaking Changes
 
 ### 1. `DataLoaderPair<TKey, T>.Loader` property removed

--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -100,7 +100,7 @@ You may pass a `ClaimsPrincipal` instance into `ExecutionOptions` and it will be
 `ValidationContext.User`, `IExecutionContext.User` and `IResolveFieldContext.User` so the value
 is accessible by validation rules, document listeners, field middleware and field resolvers.
 
-This property is similar in nature to the ASP.NET Core `HttpContext.User` propery, not being
+This property is similar in nature to the ASP.NET Core `HttpContext.User` property, not being
 used by the GraphQL.NET engine internally but merely being a convenience property similar to
 `RequestServices` and `UserContext` for use by separate authentication packages.
 

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -2882,6 +2882,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Inputs Variables { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentSpread> GetFragmentSpreads(GraphQLParser.AST.GraphQLSelectionSet node) { }
@@ -2917,6 +2918,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Inputs Variables { get; set; }
     }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -149,7 +149,7 @@ namespace GraphQL
         public GraphQL.Types.ISchema? Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? ValidationRules { get; set; }
         public GraphQL.Inputs? Variables { get; set; }
@@ -458,7 +458,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; }
-        System.Security.Principal.IPrincipal? User { get; }
+        System.Security.Claims.ClaimsPrincipal? User { get; }
         GraphQL.Validation.Variables Variables { get; }
     }
     public interface IResolveFieldContext<out TSource> : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -610,7 +610,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         public System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; }
-        public System.Security.Principal.IPrincipal? User { get; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; }
         public GraphQL.Validation.Variables Variables { get; }
     }
@@ -642,7 +642,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         public System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Validation.Variables Variables { get; set; }
     }
@@ -1073,7 +1073,7 @@ namespace GraphQL.Execution
         public GraphQL.Types.ISchema Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Validation.Variables Variables { get; set; }
         protected virtual void ClearContext() { }
@@ -1183,7 +1183,7 @@ namespace GraphQL.Execution
         GraphQL.Types.ISchema Schema { get; }
         bool ThrowOnUnhandledException { get; }
         System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; }
-        System.Security.Principal.IPrincipal? User { get; }
+        System.Security.Claims.ClaimsPrincipal? User { get; }
         GraphQL.Validation.Variables Variables { get; }
     }
     public interface IExecutionStrategy
@@ -2882,7 +2882,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Inputs Variables { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentSpread> GetFragmentSpreads(GraphQLParser.AST.GraphQLSelectionSet node) { }
@@ -2918,7 +2918,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Inputs Variables { get; set; }
     }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -149,6 +149,7 @@ namespace GraphQL
         public GraphQL.Types.ISchema? Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? ValidationRules { get; set; }
         public GraphQL.Inputs? Variables { get; set; }
@@ -457,6 +458,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; }
+        System.Security.Principal.IPrincipal? User { get; }
         GraphQL.Validation.Variables Variables { get; }
     }
     public interface IResolveFieldContext<out TSource> : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -608,6 +610,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         public System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; }
+        public System.Security.Principal.IPrincipal? User { get; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; }
         public GraphQL.Validation.Variables Variables { get; }
     }
@@ -639,6 +642,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         public System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Validation.Variables Variables { get; set; }
     }
@@ -1069,6 +1073,7 @@ namespace GraphQL.Execution
         public GraphQL.Types.ISchema Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Validation.Variables Variables { get; set; }
         protected virtual void ClearContext() { }
@@ -1178,6 +1183,7 @@ namespace GraphQL.Execution
         GraphQL.Types.ISchema Schema { get; }
         bool ThrowOnUnhandledException { get; }
         System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; }
+        System.Security.Principal.IPrincipal? User { get; }
         GraphQL.Validation.Variables Variables { get; }
     }
     public interface IExecutionStrategy

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -149,7 +149,7 @@ namespace GraphQL
         public GraphQL.Types.ISchema? Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? ValidationRules { get; set; }
         public GraphQL.Inputs? Variables { get; set; }
@@ -458,7 +458,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; }
-        System.Security.Principal.IPrincipal? User { get; }
+        System.Security.Claims.ClaimsPrincipal? User { get; }
         GraphQL.Validation.Variables Variables { get; }
     }
     public interface IResolveFieldContext<out TSource> : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -610,7 +610,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         public System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; }
-        public System.Security.Principal.IPrincipal? User { get; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; }
         public GraphQL.Validation.Variables Variables { get; }
     }
@@ -642,7 +642,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         public System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Validation.Variables Variables { get; set; }
     }
@@ -1073,7 +1073,7 @@ namespace GraphQL.Execution
         public GraphQL.Types.ISchema Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Validation.Variables Variables { get; set; }
         protected virtual void ClearContext() { }
@@ -1183,7 +1183,7 @@ namespace GraphQL.Execution
         GraphQL.Types.ISchema Schema { get; }
         bool ThrowOnUnhandledException { get; }
         System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; }
-        System.Security.Principal.IPrincipal? User { get; }
+        System.Security.Claims.ClaimsPrincipal? User { get; }
         GraphQL.Validation.Variables Variables { get; }
     }
     public interface IExecutionStrategy
@@ -2868,7 +2868,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Inputs Variables { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentSpread> GetFragmentSpreads(GraphQLParser.AST.GraphQLSelectionSet node) { }
@@ -2904,7 +2904,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
-        public System.Security.Principal.IPrincipal? User { get; set; }
+        public System.Security.Claims.ClaimsPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Inputs Variables { get; set; }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -149,6 +149,7 @@ namespace GraphQL
         public GraphQL.Types.ISchema? Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? ValidationRules { get; set; }
         public GraphQL.Inputs? Variables { get; set; }
@@ -457,6 +458,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; }
+        System.Security.Principal.IPrincipal? User { get; }
         GraphQL.Validation.Variables Variables { get; }
     }
     public interface IResolveFieldContext<out TSource> : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -608,6 +610,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         public System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; }
+        public System.Security.Principal.IPrincipal? User { get; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; }
         public GraphQL.Validation.Variables Variables { get; }
     }
@@ -639,6 +642,7 @@ namespace GraphQL
                 "Field",
                 "FieldType"})]
         public System.Collections.Generic.Dictionary<string, System.ValueTuple<GraphQLParser.AST.GraphQLField, GraphQL.Types.FieldType>>? SubFields { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Validation.Variables Variables { get; set; }
     }
@@ -1069,6 +1073,7 @@ namespace GraphQL.Execution
         public GraphQL.Types.ISchema Schema { get; set; }
         public bool ThrowOnUnhandledException { get; set; }
         public System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Validation.Variables Variables { get; set; }
         protected virtual void ClearContext() { }
@@ -1178,6 +1183,7 @@ namespace GraphQL.Execution
         GraphQL.Types.ISchema Schema { get; }
         bool ThrowOnUnhandledException { get; }
         System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> UnhandledExceptionDelegate { get; }
+        System.Security.Principal.IPrincipal? User { get; }
         GraphQL.Validation.Variables Variables { get; }
     }
     public interface IExecutionStrategy

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2868,6 +2868,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
         public GraphQL.Validation.TypeInfo TypeInfo { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Inputs Variables { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentSpread> GetFragmentSpreads(GraphQLParser.AST.GraphQLSelectionSet node) { }
@@ -2903,6 +2904,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; set; }
         public System.Collections.Generic.IEnumerable<GraphQL.Validation.IValidationRule>? Rules { get; set; }
         public GraphQL.Types.ISchema Schema { get; set; }
+        public System.Security.Principal.IPrincipal? User { get; set; }
         public System.Collections.Generic.IDictionary<string, object?> UserContext { get; set; }
         public GraphQL.Inputs Variables { get; set; }
     }

--- a/src/GraphQL.Benchmarks/Benchmarks/DetailedBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/DetailedBenchmark.cs
@@ -259,7 +259,8 @@ public class DetailedBenchmark : IBenchmark
                 ThrowOnUnhandledException = true,
                 UnhandledExceptionDelegate = _ => Task.CompletedTask,
                 MaxParallelExecutionCount = int.MaxValue,
-                RequestServices = null
+                RequestServices = null,
+                User = null,
             };
             return _parallelExecutionStrategy.ExecuteAsync(context).Result;
         }

--- a/src/GraphQL.MicrosoftDI/ScopedResolveConnectionContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveConnectionContextAdapter.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Builders;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
@@ -76,5 +77,7 @@ namespace GraphQL.MicrosoftDI
         public string? Before => _baseContext.Before;
 
         public int? PageSize => _baseContext.PageSize;
+
+        public IPrincipal? User => _baseContext.User;
     }
 }

--- a/src/GraphQL.MicrosoftDI/ScopedResolveConnectionContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveConnectionContextAdapter.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Builders;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
@@ -78,6 +78,6 @@ namespace GraphQL.MicrosoftDI
 
         public int? PageSize => _baseContext.PageSize;
 
-        public IPrincipal? User => _baseContext.User;
+        public ClaimsPrincipal? User => _baseContext.User;
     }
 }

--- a/src/GraphQL.MicrosoftDI/ScopedResolveFieldContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveFieldContextAdapter.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -80,5 +81,7 @@ namespace GraphQL.MicrosoftDI
         object? IResolveFieldContext.Source => _baseContext.Source;
 
         public IExecutionArrayPool ArrayPool => _baseContext.ArrayPool;
+
+        public IPrincipal? User => _baseContext.User;
     }
 }

--- a/src/GraphQL.MicrosoftDI/ScopedResolveFieldContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveFieldContextAdapter.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -82,6 +82,6 @@ namespace GraphQL.MicrosoftDI
 
         public IExecutionArrayPool ArrayPool => _baseContext.ArrayPool;
 
-        public IPrincipal? User => _baseContext.User;
+        public ClaimsPrincipal? User => _baseContext.User;
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -153,6 +153,7 @@ namespace GraphQL
                             Operation = operation,
                             UserContext = options.UserContext,
                             RequestServices = options.RequestServices,
+                            User = options.User,
                             CancellationToken = options.CancellationToken,
                             Schema = options.Schema,
                             Metrics = metrics,

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -282,6 +282,7 @@ namespace GraphQL
                 UnhandledExceptionDelegate = options.UnhandledExceptionDelegate,
                 MaxParallelExecutionCount = options.MaxParallelExecutionCount,
                 RequestServices = options.RequestServices,
+                User = options.User,
             };
 
             context.ExecutionStrategy = SelectExecutionStrategy(context);

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
 using GraphQL.Validation;
@@ -97,7 +97,7 @@ namespace GraphQL.Execution
         public IServiceProvider? RequestServices { get; set; }
 
         /// <inheritdoc/>
-        public IPrincipal? User { get; set; }
+        public ClaimsPrincipal? User { get; set; }
 
         /// <inheritdoc/>
         public TElement[] Rent<TElement>(int minimumLength)

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
 using GraphQL.Validation;
@@ -40,6 +41,7 @@ namespace GraphQL.Execution
             MaxParallelExecutionCount = context.MaxParallelExecutionCount;
             InputExtensions = context.InputExtensions;
             RequestServices = context.RequestServices;
+            User = context.User;
         }
 
         /// <inheritdoc/>
@@ -95,6 +97,9 @@ namespace GraphQL.Execution
         public IServiceProvider? RequestServices { get; set; }
 
         /// <inheritdoc/>
+        public IPrincipal? User { get; set; }
+
+        /// <inheritdoc/>
         public TElement[] Rent<TElement>(int minimumLength)
         {
             var array = System.Buffers.ArrayPool<TElement>.Shared.Rent(minimumLength);
@@ -145,6 +150,7 @@ namespace GraphQL.Execution
             //MaxParallelExecutionCount = null;
             //Extensions = null;
             //RequestServices = null;
+            //User = null;
 
             // arrays rented after the execution context has been 'disposed' will still rent just fine, but will
             // not be returned to the pool (since Dispose has already been run) and will be garbage collected.

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Execution;
 using GraphQL.Types;
 using GraphQL.Validation;
@@ -74,6 +74,6 @@ namespace GraphQL
         /// <summary>
         /// Gets or sets security information for the executing request.
         /// </summary>
-        public IPrincipal? User { get; set; }
+        public ClaimsPrincipal? User { get; set; }
     }
 }

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Execution;
 using GraphQL.Types;
 using GraphQL.Validation;
@@ -69,5 +70,10 @@ namespace GraphQL
         /// from your dependency injection framework.
         /// </summary>
         public IServiceProvider? RequestServices { get; set; }
+
+        /// <summary>
+        /// Gets or sets security information for the executing request.
+        /// </summary>
+        public IPrincipal? User { get; set; }
     }
 }

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
 using GraphQL.Validation;
@@ -96,5 +97,10 @@ namespace GraphQL.Execution
         /// from your dependency injection framework.
         /// </summary>
         IServiceProvider? RequestServices { get; }
+
+        /// <summary>
+        /// Gets security information for the executing request.
+        /// </summary>
+        IPrincipal? User { get; }
     }
 }

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
 using GraphQL.Validation;
@@ -101,6 +101,6 @@ namespace GraphQL.Execution
         /// <summary>
         /// Gets security information for the executing request.
         /// </summary>
-        IPrincipal? User { get; }
+        ClaimsPrincipal? User { get; }
     }
 }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Conversion;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
@@ -107,6 +108,9 @@ namespace GraphQL
         /// Can be used to return lists of data from field resolvers.
         /// </summary>
         IExecutionArrayPool ArrayPool { get; }
+
+        /// <inheritdoc cref="IExecutionContext.User"/>
+        IPrincipal? User { get; }
     }
 
     /// <inheritdoc cref="IResolveFieldContext"/>

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Conversion;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
@@ -110,7 +110,7 @@ namespace GraphQL
         IExecutionArrayPool ArrayPool { get; }
 
         /// <inheritdoc cref="IExecutionContext.User"/>
-        IPrincipal? User { get; }
+        ClaimsPrincipal? User { get; }
     }
 
     /// <inheritdoc cref="IResolveFieldContext"/>

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -133,5 +134,8 @@ namespace GraphQL
 
         /// <inheritdoc/>
         public IExecutionArrayPool ArrayPool => _executionContext;
+
+        /// <inheritdoc/>
+        public IPrincipal? User => _executionContext.User;
     }
 }

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -136,6 +136,6 @@ namespace GraphQL
         public IExecutionArrayPool ArrayPool => _executionContext;
 
         /// <inheritdoc/>
-        public IPrincipal? User => _executionContext.User;
+        public ClaimsPrincipal? User => _executionContext.User;
     }
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -82,7 +82,7 @@ namespace GraphQL
         public IExecutionArrayPool ArrayPool { get; set; }
 
         /// <inheritdoc/>
-        public IPrincipal? User { get; set; }
+        public ClaimsPrincipal? User { get; set; }
 
         /// <summary>
         /// Initializes a new instance with all fields set to their default values.

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -79,6 +80,9 @@ namespace GraphQL
 
         /// <inheritdoc/>
         public IExecutionArrayPool ArrayPool { get; set; }
+
+        /// <inheritdoc/>
+        public IPrincipal? User { get; set; }
 
         /// <summary>
         /// Initializes a new instance with all fields set to their default values.

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -102,6 +102,6 @@ namespace GraphQL
         public IExecutionArrayPool ArrayPool => _baseContext.ArrayPool;
 
         /// <inheritdoc/>
-        public IPrincipal? User => _baseContext.User;
+        public ClaimsPrincipal? User => _baseContext.User;
     }
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -99,5 +100,8 @@ namespace GraphQL
 
         /// <inheritdoc/>
         public IExecutionArrayPool ArrayPool => _baseContext.ArrayPool;
+
+        /// <inheritdoc/>
+        public IPrincipal? User => _baseContext.User;
     }
 }

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -65,6 +65,7 @@ namespace GraphQL.Validation
             context.Operation = options.Operation;
             context.Metrics = options.Metrics;
             context.RequestServices = options.RequestServices;
+            context.User = options.User;
             context.CancellationToken = options.CancellationToken;
 
             return ValidateAsyncCoreAsync(context, options.Rules ?? CoreRules);

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Security.Principal;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -28,6 +29,7 @@ namespace GraphQL.Validation
             Extensions = null!;
             RequestServices = null!;
             Metrics = null!;
+            User = null;
         }
 
         /// <summary>
@@ -74,6 +76,9 @@ namespace GraphQL.Validation
 
         /// <inheritdoc cref="ExecutionOptions.RequestServices"/>
         public IServiceProvider? RequestServices { get; set; }
+
+        /// <inheritdoc cref="ExecutionOptions.User"/>
+        public IPrincipal? User { get; set; }
 
         /// <summary>
         /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -1,5 +1,5 @@
 using System.Collections;
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
@@ -78,7 +78,7 @@ namespace GraphQL.Validation
         public IServiceProvider? RequestServices { get; set; }
 
         /// <inheritdoc cref="ExecutionOptions.User"/>
-        public IPrincipal? User { get; set; }
+        public ClaimsPrincipal? User { get; set; }
 
         /// <summary>
         /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;

--- a/src/GraphQL/Validation/ValidationOptions.cs
+++ b/src/GraphQL/Validation/ValidationOptions.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
 using GraphQLParser.AST;
@@ -61,6 +62,9 @@ namespace GraphQL.Validation
 
         /// <inheritdoc cref="ExecutionOptions.RequestServices"/>
         public IServiceProvider? RequestServices { get; init; } = null;
+
+        /// <inheritdoc cref="ExecutionOptions.User"/>
+        public IPrincipal? User { get; init; } = null;
 
         /// <summary>
         /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;

--- a/src/GraphQL/Validation/ValidationOptions.cs
+++ b/src/GraphQL/Validation/ValidationOptions.cs
@@ -1,4 +1,4 @@
-using System.Security.Principal;
+using System.Security.Claims;
 using GraphQL.Instrumentation;
 using GraphQL.Types;
 using GraphQLParser.AST;
@@ -64,7 +64,7 @@ namespace GraphQL.Validation
         public IServiceProvider? RequestServices { get; init; } = null;
 
         /// <inheritdoc cref="ExecutionOptions.User"/>
-        public IPrincipal? User { get; init; } = null;
+        public ClaimsPrincipal? User { get; init; } = null;
 
         /// <summary>
         /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;


### PR DESCRIPTION
See https://github.com/graphql-dotnet/server/issues/314

Matches `HttpContext.User` except that it is nullable.

It might be better to default `User` to a static implementation of an anonymous user, sorta like ASP.NET Core does, so it does not need to be nullable.

This feature allows separation of the execution which defines the user from the validation rule which validates the request against the user, rather than requiring AsyncLocal to provide this mechanism.