### PR TITLE
Fix package versioning

### DIFF
--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - develop
+      - versioning
     paths:
       - src/**
       - .github/workflows/**

--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - develop
-      - versioning
     paths:
       - src/**
       - .github/workflows/**

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>5.0.0-preview</VersionPrefix>
+    <NextVersion>6.0.0</NextVersion>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
+  <!--Workaround for https://github.com/NuGet/Home/issues/5556 and https://github.com/NuGet/Home/issues/5525-->
   <Target Name="UseExplicitPackageVersions" BeforeTargets="GenerateNuspec">
     <ItemGroup>
       <_ProjectReferenceWithExplicitPackageVersion Include="@(ProjectReference->'%(FullPath)')" Condition="'%(ProjectReference.PackageVersion)' != ''" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -15,4 +15,19 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
+  <Target Name="UseExplicitPackageVersions" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_ProjectReferenceWithExplicitPackageVersion Include="@(ProjectReference->'%(FullPath)')" Condition="'%(ProjectReference.PackageVersion)' != ''" />
+      <_ProjectReferenceWithExactPackageVersion Include="@(ProjectReference->'%(FullPath)')" Condition="'%(ProjectReference.ExactVersion)' == 'true'" />
+      <_ProjectReferenceWithReassignedVersion Include="@(_ProjectReferencesWithVersions)" Condition="'%(Identity)' != '' And '@(_ProjectReferenceWithExplicitPackageVersion)' == '@(_ProjectReferencesWithVersions)'">
+        <ProjectVersion>@(_ProjectReferenceWithExplicitPackageVersion->'%(PackageVersion)')</ProjectVersion>
+      </_ProjectReferenceWithReassignedVersion>
+      <_ProjectReferenceWithReassignedVersion Include="@(_ProjectReferencesWithVersions)" Condition="'%(Identity)' != '' And '@(_ProjectReferenceWithExactPackageVersion)' == '@(_ProjectReferencesWithVersions)'">
+        <ProjectVersion>[@(_ProjectReferencesWithVersions->'%(ProjectVersion)')]</ProjectVersion>
+      </_ProjectReferenceWithReassignedVersion>
+      <_ProjectReferencesWithVersions Remove="@(_ProjectReferenceWithReassignedVersion)" />
+      <_ProjectReferencesWithVersions Include="@(_ProjectReferenceWithReassignedVersion)" />
+    </ItemGroup>
+  </Target>
+  
 </Project>

--- a/src/GraphQL.DataLoader/GraphQL.DataLoader.csproj
+++ b/src/GraphQL.DataLoader/GraphQL.DataLoader.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
+    <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQL.MemoryCache/GraphQL.MemoryCache.csproj
+++ b/src/GraphQL.MemoryCache/GraphQL.MemoryCache.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
+    <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GraphQL.MicrosoftDI/GraphQL.MicrosoftDI.csproj
+++ b/src/GraphQL.MicrosoftDI/GraphQL.MicrosoftDI.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
+    <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQL.NewtonsoftJson/GraphQL.NewtonsoftJson.csproj
+++ b/src/GraphQL.NewtonsoftJson/GraphQL.NewtonsoftJson.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
+    <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
+++ b/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
+    <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 


### PR DESCRIPTION
This, for example, restricts GraphQL.DataLoader to use only GraphQL 5.x versions.  Specifically, the matching version that was published, and any version up to but excluding the next major version number.  This will prevent GraphQL.DataLoader 5.3.3 from being compatible with GraphQL 7.0.0, and indirectly prevents #3229 from happening in the future.  A similar change should be made in the server repo.

See:
- https://github.com/NuGet/Home/issues/5556
- https://github.com/NuGet/Home/issues/5525