### PR TITLE
Update ResolveType to include schema

### DIFF
--- a/docs2/site/docs/getting-started/interfaces.md
+++ b/docs2/site/docs/getting-started/interfaces.md
@@ -117,27 +117,17 @@ that implements an Interface you are required to alter the Interface for that ne
 ```csharp
 public class CharacterInterface : InterfaceGraphType<StarWarsCharacter>
 {
-  public CharacterInterface(
-    DroidType droidType,
-    HumanType humanType)
+  public CharacterInterface()
   {
     Name = "Character";
 
     ...
 
-    ResolveType = obj =>
+    ResolveType = (obj, schema) => obj switch
     {
-        if (obj is Droid)
-        {
-            return droidType;
-        }
-
-        if (obj is Human)
-        {
-            return humanType;
-        }
-
-        throw new ArgumentOutOfRangeException($"Could not resolve graph type for {obj.GetType().Name}");
+        Droid _ => schema.AllTypes[typeof(DroidType)] as IObjectGraphType,
+        Class2 _ => schema.AllTypes[typeof(HumanType)] as IObjectGraphType,
+        _ => throw new ArgumentOutOfRangeException($"Could not resolve graph type for {obj.GetType().Name}"),
     };
   }
 }

--- a/docs2/site/docs/getting-started/interfaces.md
+++ b/docs2/site/docs/getting-started/interfaces.md
@@ -126,7 +126,7 @@ public class CharacterInterface : InterfaceGraphType<StarWarsCharacter>
     ResolveType = (obj, schema) => obj switch
     {
         Droid _ => schema.AllTypes[typeof(DroidType)] as IObjectGraphType,
-        Class2 _ => schema.AllTypes[typeof(HumanType)] as IObjectGraphType,
+        Human _ => schema.AllTypes[typeof(HumanType)] as IObjectGraphType,
         _ => throw new ArgumentOutOfRangeException($"Could not resolve graph type for {obj.GetType().Name}"),
     };
   }

--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -281,4 +281,4 @@ ResolveType = (obj, schema) => obj switch
 
 Of course the `ResolveType` delegate is not necessary if `IsTypeOf` is implemented for all of the
 types of the union, and `ObjectGraphType<T>` has a default implementation; so it should be rare
-that `ResolveType` is necessary at all.
+that `ResolveType` is necessary at all. See Interfaces in the documentation for more details.

--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -254,3 +254,31 @@ This change was done for better discoverability and usability of extension metho
 ### 8. `IResolveFieldContext.User` property added
 
 Custom implementations of `IResolveFieldContext` must implement the new `User` property.
+
+### 9. `ResolveType` property of `UnionGraphType` and `InterfaceGraphType` now includes the schema.
+
+This change is necessary to be able to pull graph types from the schema when used when graph types
+are registered within the DI engine as transient (the recommended and default method).
+
+```csharp
+// v5
+ResolveType = obj => ...;
+
+// v7
+ResolveType = (obj, schema) => ...;
+```
+
+In order to pull types from the schema, you may use code like this:
+
+```csharp
+ResolveType = (obj, schema) => obj switch
+{
+    Class1 _ => schema.AllTypes[typeof(Class1Type)] as IObjectGraphType,   // by CLR type
+    Class2 _ => schema.AllTypes["Class2Type"] as IObjectGraphType,         // by name
+    _ => null,
+};
+```
+
+Of course the `ResolveType` delegate is not necessary if `IsTypeOf` is implemented for all of the
+types of the union, and `ObjectGraphType<T>` has a default implementation; so it should be rare
+that `ResolveType` is necessary at all.

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -1976,7 +1976,7 @@ namespace GraphQL.Types
     public interface IAbstractGraphType : GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         GraphQL.Types.PossibleTypes PossibleTypes { get; }
-        System.Func<object, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
+        System.Func<object, GraphQL.Types.ISchema, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
         void AddPossibleType(GraphQL.Types.IObjectGraphType type);
     }
     public interface IComplexGraphType : GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
@@ -2111,7 +2111,7 @@ namespace GraphQL.Types
     {
         public InterfaceGraphType() { }
         public GraphQL.Types.PossibleTypes PossibleTypes { get; }
-        public System.Func<object, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
+        public System.Func<object, GraphQL.Types.ISchema, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
         public void AddPossibleType(GraphQL.Types.IObjectGraphType type) { }
     }
     public class Interfaces : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
@@ -2322,6 +2322,7 @@ namespace GraphQL.Types
         public int Count { get; }
         protected virtual System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> Dictionary { get; }
         public GraphQL.Types.IGraphType? this[GraphQLParser.ROM typeName] { get; }
+        public GraphQL.Types.IGraphType? this[System.Type graphType] { get; }
         protected virtual GraphQL.Types.FieldType SchemaMetaFieldType { get; }
         protected virtual GraphQL.Types.FieldType TypeMetaFieldType { get; }
         protected virtual GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
@@ -2433,7 +2434,7 @@ namespace GraphQL.Types
     {
         public UnionGraphType() { }
         public GraphQL.Types.PossibleTypes PossibleTypes { get; }
-        public System.Func<object, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
+        public System.Func<object, GraphQL.Types.ISchema, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
         public System.Collections.Generic.IEnumerable<System.Type> Types { get; set; }
         public void AddPossibleType(GraphQL.Types.IObjectGraphType type) { }
         public void Type(System.Type type) { }
@@ -2700,7 +2701,7 @@ namespace GraphQL.Utilities
         public string? Description { get; set; }
         public System.Func<object, bool>? IsTypeOfFunc { get; set; }
         public string Name { get; }
-        public System.Func<object, GraphQL.Types.IObjectGraphType>? ResolveType { get; set; }
+        public System.Func<object, GraphQL.Types.ISchema, GraphQL.Types.IObjectGraphType>? ResolveType { get; set; }
         public System.Type? Type { get; set; }
         public GraphQL.Utilities.FieldConfig FieldFor(string fieldName) { }
         public void IsTypeOf<T>() { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1969,7 +1969,7 @@ namespace GraphQL.Types
     public interface IAbstractGraphType : GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         GraphQL.Types.PossibleTypes PossibleTypes { get; }
-        System.Func<object, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
+        System.Func<object, GraphQL.Types.ISchema, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
         void AddPossibleType(GraphQL.Types.IObjectGraphType type);
     }
     public interface IComplexGraphType : GraphQL.Types.IGraphType, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
@@ -2104,7 +2104,7 @@ namespace GraphQL.Types
     {
         public InterfaceGraphType() { }
         public GraphQL.Types.PossibleTypes PossibleTypes { get; }
-        public System.Func<object, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
+        public System.Func<object, GraphQL.Types.ISchema, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
         public void AddPossibleType(GraphQL.Types.IObjectGraphType type) { }
     }
     public class Interfaces : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
@@ -2315,6 +2315,7 @@ namespace GraphQL.Types
         public int Count { get; }
         protected virtual System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> Dictionary { get; }
         public GraphQL.Types.IGraphType? this[GraphQLParser.ROM typeName] { get; }
+        public GraphQL.Types.IGraphType? this[System.Type graphType] { get; }
         protected virtual GraphQL.Types.FieldType SchemaMetaFieldType { get; }
         protected virtual GraphQL.Types.FieldType TypeMetaFieldType { get; }
         protected virtual GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
@@ -2419,7 +2420,7 @@ namespace GraphQL.Types
     {
         public UnionGraphType() { }
         public GraphQL.Types.PossibleTypes PossibleTypes { get; }
-        public System.Func<object, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
+        public System.Func<object, GraphQL.Types.ISchema, GraphQL.Types.IObjectGraphType?>? ResolveType { get; set; }
         public System.Collections.Generic.IEnumerable<System.Type> Types { get; set; }
         public void AddPossibleType(GraphQL.Types.IObjectGraphType type) { }
         public void Type(System.Type type) { }
@@ -2686,7 +2687,7 @@ namespace GraphQL.Utilities
         public string? Description { get; set; }
         public System.Func<object, bool>? IsTypeOfFunc { get; set; }
         public string Name { get; }
-        public System.Func<object, GraphQL.Types.IObjectGraphType>? ResolveType { get; set; }
+        public System.Func<object, GraphQL.Types.ISchema, GraphQL.Types.IObjectGraphType>? ResolveType { get; set; }
         public System.Type? Type { get; set; }
         public GraphQL.Utilities.FieldConfig FieldFor(string fieldName) { }
         public void IsTypeOf<T>() { }

--- a/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
+++ b/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
@@ -142,7 +142,7 @@ public class EmptyInterfaceSchema : Schema
         Query = new ObjectGraphType { Name = "Query" };
         Query.AddField(new FieldType { Name = "field", ResolvedType = new StringGraphType() });
 
-        var iface = new InterfaceGraphType { Name = "Empty", ResolveType = _ => null };
+        var iface = new InterfaceGraphType { Name = "Empty", ResolveType = (_, _) => null };
         RegisterType(iface);
         Query.ResolvedInterfaces.Add(iface);
     }
@@ -154,7 +154,7 @@ public class SchemaWithDuplicateInterfaceFields : Schema
     {
         Query = new ObjectGraphType { Name = "Query" };
 
-        var iface = new InterfaceGraphType { Name = "Dup", ResolveType = _ => null };
+        var iface = new InterfaceGraphType { Name = "Dup", ResolveType = (_, _) => null };
         iface.AddField(new FieldType { Name = "field", ResolvedType = new StringGraphType() });
         iface.AddField(new FieldType { Name = "field_2", ResolvedType = new StringGraphType() }); // bypass HasField check
         iface.Fields.List[1].Name = "field";

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -353,7 +353,7 @@ public class AnInterfaceType : InterfaceGraphType
     {
         Name = "AnInterfaceType";
         Field<StringGraphType>("name");
-        ResolveType = value => null;
+        ResolveType = (_, _) => null;
     }
 }
 
@@ -460,7 +460,7 @@ public class AUnionType : UnionGraphType
         Name = "AUnion";
         Type<WithoutIsTypeOf1Type>();
         Type<WithoutIsTypeOf2Type>();
-        ResolveType = value => null;
+        ResolveType = (_, _) => null;
     }
 }
 

--- a/src/GraphQL.Tests/Types/UnionGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/UnionGraphTypeTests.cs
@@ -1,0 +1,72 @@
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Types;
+
+public class UnionGraphTypeTests
+{
+    /// <summary>
+    /// This test ensures that ResolveType can pull instances by the CLR type of the graph type from the schema.
+    /// </summary>
+    [Fact]
+    public async Task ResolveTypeDelegate()
+    {
+        var schema = new Schema();
+        var queryType = new ObjectGraphType
+        {
+            Name = "Query",
+        };
+        queryType.Field<MyUnion>("Test1").Resolve(context => new Class1 { Name1 = "hello" });
+        queryType.Field<MyUnion>("Test2").Resolve(context => new Class2 { Name2 = "hello" });
+        schema.Query = queryType;
+        schema.Initialize();
+
+        var ret = await schema.ExecuteAsync(o =>
+        {
+            o.Schema = schema;
+            o.Query = "{ test1 { ...union } test2 { ...union } } fragment union on MyUnion { ... on Class1Type { name1 } ... on Class2Type { name2 } }";
+        }).ConfigureAwait(false);
+
+        ret.ShouldBeCrossPlatJson("{\"data\":{\"test1\":{\"name1\":\"hello\"},\"test2\":{\"name2\":\"hello\"}}}");
+    }
+
+    private class MyUnion : UnionGraphType
+    {
+        public MyUnion()
+        {
+            Type<Class1Type>();
+            Type<Class2Type>();
+            ResolveType = (obj, schema) => obj switch
+            {
+                Class1 _ => schema.AllTypes[typeof(Class1Type)] as IObjectGraphType,
+                Class2 _ => schema.AllTypes["Class2Type"] as IObjectGraphType,
+                _ => null,
+            };
+        }
+    }
+
+    private class Class1
+    {
+        public string Name1 { get; set; }
+    }
+
+    private class Class2
+    {
+        public string Name2 { get; set; }
+    }
+
+    public class Class1Type : ObjectGraphType
+    {
+        public Class1Type()
+        {
+            Field<StringGraphType>("Name1");
+        }
+    }
+
+    public class Class2Type : ObjectGraphType
+    {
+        public Class2Type()
+        {
+            Field<StringGraphType>("Name2");
+        }
+    }
+}

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -224,7 +224,7 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     {
         var schema = Schema.For(
             fileName.ReadSDL(),
-            builder => builder.Types.ForAll(config => config.ResolveType = _ => null)
+            builder => builder.Types.ForAll(config => config.ResolveType = (_, _) => null)
         );
 
         schema.AllTypes.Count.ShouldBe(expectedCount);
@@ -237,7 +237,7 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
             "PetComplex".ReadSDL(),
             builder =>
             {
-                builder.Types.ForAll(config => config.ResolveType = _ => null);
+                builder.Types.ForAll(config => config.ResolveType = (_, _) => null);
                 builder.IgnoreComments = false;
             }
         );

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderFromGitHubTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderFromGitHubTests.cs
@@ -11,14 +11,14 @@ public class SchemaBuilderFromGitHubTests
         protected override UnionGraphType ToUnionType(GraphQLUnionTypeDefinition unionDef)
         {
             var type = base.ToUnionType(unionDef);
-            type.ResolveType = _ => null;
+            type.ResolveType = (_, _) => null;
             return type;
         }
 
         protected override InterfaceGraphType ToInterfaceType(GraphQLInterfaceTypeDefinition interfaceDef)
         {
             var type = base.ToInterfaceType(interfaceDef);
-            type.ResolveType = _ => null;
+            type.ResolveType = (_, _) => null;
             return type;
         }
     }

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderNestedTypesTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderNestedTypesTests.cs
@@ -57,7 +57,7 @@ public class SchemaBuilderNestedTypesTests : SchemaBuilderTestBase
             ";
 
         Builder.Types.Include<DroidType>("Droid");
-        Builder.Types.For("Droid").ResolveType = obj => new GraphQLTypeReference("Droid");
+        Builder.Types.For("Droid").ResolveType = (_, _) => new GraphQLTypeReference("Droid");
         Builder.Types.Include<Query>();
 
         var query = @"{ hero { id name friend { name } } }";

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -1902,7 +1902,7 @@ type Zebra {
         {
             Name = "IFoo";
             Description = "This is a Foo interface type";
-            ResolveType = _ => null;
+            ResolveType = (_, _) => null;
             Field<StringGraphType>("str").Description("This is of type String");
         }
     }
@@ -1912,7 +1912,7 @@ type Zebra {
         public BaazInterfaceType()
         {
             Name = "Baaz";
-            ResolveType = _ => null;
+            ResolveType = (_, _) => null;
             Field<IntGraphType>("int").Description("This is of type Integer");
         }
     }
@@ -1944,7 +1944,7 @@ type Zebra {
         public SingleUnion()
         {
             Name = "SingleUnion";
-            ResolveType = obj => null;
+            ResolveType = (_, _) => null;
             Type<FooType>();
         }
     }
@@ -1954,7 +1954,7 @@ type Zebra {
         public MultipleUnion()
         {
             Name = "MultipleUnion";
-            ResolveType = obj => null;
+            ResolveType = (_, _) => null;
             Type<FooType>();
             Type<BarType>();
         }

--- a/src/GraphQL.Tests/Validation/ValidationSchema.cs
+++ b/src/GraphQL.Tests/Validation/ValidationSchema.cs
@@ -95,7 +95,7 @@ public class CatOrDog : UnionGraphType
     {
         Type<Cat>();
         Type<Dog>();
-        ResolveType = value => null;
+        ResolveType = (_, _) => null;
     }
 }
 

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -392,6 +392,12 @@ namespace GraphQL.Types
         /// <summary>
         /// Returns a graph type instance from the lookup table by its .NET type.
         /// </summary>
+        public IGraphType? this[Type graphType]
+            => Dictionary.Values.SingleOrDefault(obj => obj.GetType() == graphType);
+
+        /// <summary>
+        /// Returns a graph type instance from the lookup table by its .NET type.
+        /// </summary>
         /// <param name="type">The .NET type of the graph type.</param>
         private IGraphType? FindGraphType(Type type)
         {

--- a/src/GraphQL/Types/Composite/IAbstractGraphType.cs
+++ b/src/GraphQL/Types/Composite/IAbstractGraphType.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Types
         /// Gets or sets a delegate that can be used to determine the proper graph type for the specified object value. See
         /// <see cref="AbstractGraphTypeExtensions.GetObjectType(IAbstractGraphType, object, ISchema)"/> for more details.
         /// </summary>
-        Func<object, IObjectGraphType?>? ResolveType { get; set; }
+        Func<object, ISchema, IObjectGraphType?>? ResolveType { get; set; }
 
         /// <summary>
         /// Returns a set of possible types for this abstract graph type.
@@ -50,7 +50,7 @@ namespace GraphQL.Types
         public static IObjectGraphType? GetObjectType(this IAbstractGraphType abstractType, object value, ISchema schema)
         {
             var result = abstractType.ResolveType != null
-                ? abstractType.ResolveType(value)
+                ? abstractType.ResolveType(value, schema)
                 : GetTypeOf(abstractType, value);
 
             if (result is GraphQLTypeReference reference)

--- a/src/GraphQL/Types/Composite/InterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/InterfaceGraphType.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Types
         public PossibleTypes PossibleTypes { get; } = new PossibleTypes();
 
         /// <inheritdoc/>
-        public Func<object, IObjectGraphType?>? ResolveType { get; set; }
+        public Func<object, ISchema, IObjectGraphType?>? ResolveType { get; set; }
 
         /// <inheritdoc/>
         public void AddPossibleType(IObjectGraphType type)

--- a/src/GraphQL/Types/Composite/UnionGraphType.cs
+++ b/src/GraphQL/Types/Composite/UnionGraphType.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Types
         public PossibleTypes PossibleTypes { get; } = new PossibleTypes();
 
         /// <inheritdoc/>
-        public Func<object, IObjectGraphType?>? ResolveType { get; set; }
+        public Func<object, ISchema, IObjectGraphType?>? ResolveType { get; set; }
 
         /// <inheritdoc/>
         public void AddPossibleType(IObjectGraphType type)

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaBuilder.cs
@@ -165,7 +165,7 @@ namespace GraphQL.Utilities.Federation
                 union.AddPossibleType(e!);
             }
 
-            union.ResolveType = x =>
+            union.ResolveType = (x, schema) =>
             {
                 if (x is Dictionary<string, object> dict && dict.TryGetValue("__typename", out object? typeName))
                 {

--- a/src/GraphQL/Utilities/TypeConfig.cs
+++ b/src/GraphQL/Utilities/TypeConfig.cs
@@ -51,7 +51,7 @@ namespace GraphQL.Utilities
         public string? DeprecationReason { get; set; }
 
         /// <inheritdoc cref="IAbstractGraphType.ResolveType"/>
-        public Func<object, IObjectGraphType>? ResolveType { get; set; }
+        public Func<object, ISchema, IObjectGraphType>? ResolveType { get; set; }
 
         /// <inheritdoc cref="IObjectGraphType.IsTypeOf"/>
         public Func<object, bool>? IsTypeOfFunc { get; set; }


### PR DESCRIPTION
Another problem, which this PR neither hurts nor solves, is that when using the `ResolveType` delegate of `UnionGraphType`, the delegate must return an instance of a graph type.  But since graph types are transients, it cannot be passed into the union graph type via DI.  (It can be, but it will be an un-initialized instance, so fields' `ResolvedType` properties will be null, causing a NRE.)  The easy solution is to manually register the referenced graph type as a singleton.  Having the graph type as a singleton prevents using multiple schemas with the same graph type, and prevents using the schema as a scoped instance -- the latter can cause the multithreading issues we have seen before.  Both of those scenarios will now throw an exception with this PR.

There are a couple solutions to this issue:
1. Pass `SchemaTypes` (or `ISchema`) to the delegate, so the proper graph type can be pulled from there.
2. Have the delegate return `Type` instances rather than `IGraphType` instances.  But this may prevent usage from dynamic schemas.  So I don't think that's an option either.
3. Have the delegate return a string representing the name of the graph type to use.  Not my preferred solution.

_Originally posted by @Shane32 in https://github.com/graphql-dotnet/graphql-dotnet/pull/3248#discussion_r927783159_