### PR TITLE
Remove dependency on Nito.AsyncEx.Context

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -37,7 +37,7 @@ jobs:
           dotnet-version: |
             3.1.x
             5.0.x
-            6.0.x
+            6.0.303
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
@@ -1,14 +1,13 @@
 using GraphQL.DataLoader.Tests.Models;
 using GraphQL.DataLoader.Tests.Stores;
 using Moq;
-using Nito.AsyncEx;
 
 namespace GraphQL.DataLoader.Tests;
 
 public class BatchDataLoaderTests : DataLoaderTestBase
 {
     [Fact]
-    public void Operations_Are_Batched()
+    public async Task Operations_Are_Batched()
     {
         var mock = new Mock<IUsersStore>();
         var users = Fake.Users.Generate(2);
@@ -22,24 +21,21 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         User user2 = null;
 
         // Run within an async context to make sure we won't deadlock
-        AsyncContext.Run(async () =>
-        {
-            var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync);
+        var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync);
 
-            // Start async tasks to load by ID
-            var result1 = loader.LoadAsync(1);
-            var result2 = loader.LoadAsync(2);
+        // Start async tasks to load by ID
+        var result1 = loader.LoadAsync(1);
+        var result2 = loader.LoadAsync(2);
 
-            // Dispatch loading
-            await loader.DispatchAsync().ConfigureAwait(false);
+        // Dispatch loading
+        await loader.DispatchAsync().ConfigureAwait(false);
 
-            var task1 = result1.GetResultAsync();
-            var task2 = result2.GetResultAsync();
+        var task1 = result1.GetResultAsync();
+        var task2 = result2.GetResultAsync();
 
-            // Now await tasks
-            user1 = await task1.ConfigureAwait(false);
-            user2 = await task2.ConfigureAwait(false);
-        });
+        // Now await tasks
+        user1 = await task1.ConfigureAwait(false);
+        user2 = await task2.ConfigureAwait(false);
 
         user1.ShouldNotBeNull();
         user2.ShouldNotBeNull();
@@ -52,7 +48,7 @@ public class BatchDataLoaderTests : DataLoaderTestBase
     }
 
     [Fact]
-    public void Batched_Honors_MaxBatchSize()
+    public async Task Batched_Honors_MaxBatchSize()
     {
         var mock = new Mock<IUsersStore>();
         var users = Fake.Users.Generate(4);
@@ -68,34 +64,30 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         User user4 = null;
         User user5 = null;
 
-        // Run within an async context to make sure we won't deadlock
-        AsyncContext.Run(async () =>
-        {
-            var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync, null, null, 2);
+        var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync, null, null, 2);
 
-            // Start async tasks to load by ID
-            var result1 = loader.LoadAsync(1);
-            var result2 = loader.LoadAsync(2);
-            var result3 = loader.LoadAsync(3);
-            var result4 = loader.LoadAsync(4);
-            var result5 = loader.LoadAsync(5);
+        // Start async tasks to load by ID
+        var result1 = loader.LoadAsync(1);
+        var result2 = loader.LoadAsync(2);
+        var result3 = loader.LoadAsync(3);
+        var result4 = loader.LoadAsync(4);
+        var result5 = loader.LoadAsync(5);
 
-            // Dispatch loading
-            await loader.DispatchAsync().ConfigureAwait(false);
+        // Dispatch loading
+        await loader.DispatchAsync().ConfigureAwait(false);
 
-            var task1 = result1.GetResultAsync();
-            var task2 = result2.GetResultAsync();
-            var task3 = result3.GetResultAsync();
-            var task4 = result4.GetResultAsync();
-            var task5 = result5.GetResultAsync();
+        var task1 = result1.GetResultAsync();
+        var task2 = result2.GetResultAsync();
+        var task3 = result3.GetResultAsync();
+        var task4 = result4.GetResultAsync();
+        var task5 = result5.GetResultAsync();
 
-            // Now await tasks
-            user1 = await task1.ConfigureAwait(false);
-            user2 = await task2.ConfigureAwait(false);
-            user3 = await task3.ConfigureAwait(false);
-            user4 = await task4.ConfigureAwait(false);
-            user5 = await task5.ConfigureAwait(false);
-        });
+        // Now await tasks
+        user1 = await task1.ConfigureAwait(false);
+        user2 = await task2.ConfigureAwait(false);
+        user3 = await task3.ConfigureAwait(false);
+        user4 = await task4.ConfigureAwait(false);
+        user5 = await task5.ConfigureAwait(false);
 
         user1.ShouldNotBeNull();
         user2.ShouldNotBeNull();
@@ -116,7 +108,7 @@ public class BatchDataLoaderTests : DataLoaderTestBase
     }
 
     [Fact]
-    public void Results_Are_Cached()
+    public async Task Results_Are_Cached()
     {
         var mock = new Mock<IUsersStore>();
         var users = Fake.Users.Generate(2);
@@ -130,37 +122,33 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         User user2 = null;
         User user3 = null;
 
-        // Run within an async context to make sure we won't deadlock
-        AsyncContext.Run(async () =>
-        {
-            var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync);
+        var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync);
 
-            // Start async tasks to load by ID
-            var result1 = loader.LoadAsync(1);
-            var result2 = loader.LoadAsync(2);
+        // Start async tasks to load by ID
+        var result1 = loader.LoadAsync(1);
+        var result2 = loader.LoadAsync(2);
 
-            // Dispatch loading
-            await loader.DispatchAsync().ConfigureAwait(false);
+        // Dispatch loading
+        await loader.DispatchAsync().ConfigureAwait(false);
 
-            var task1 = result1.GetResultAsync();
-            var task2 = result2.GetResultAsync();
+        var task1 = result1.GetResultAsync();
+        var task2 = result2.GetResultAsync();
 
-            // Now await tasks
-            user1 = await task1.ConfigureAwait(false);
-            user2 = await task2.ConfigureAwait(false);
+        // Now await tasks
+        user1 = await task1.ConfigureAwait(false);
+        user2 = await task2.ConfigureAwait(false);
 
-            var result3 = loader.LoadAsync(1);
+        var result3 = loader.LoadAsync(1);
 
-            //testing status meaningless with new design
-            var task3 = result3.GetResultAsync();
-            task3.Status.ShouldBe(TaskStatus.RanToCompletion,
-                "Task should already be complete because value comes from cache");
+        //testing status meaningless with new design
+        var task3 = result3.GetResultAsync();
+        task3.Status.ShouldBe(TaskStatus.RanToCompletion,
+            "Task should already be complete because value comes from cache");
 
-            // This should not actually run the fetch delegate again
-            await loader.DispatchAsync().ConfigureAwait(false);
+        // This should not actually run the fetch delegate again
+        await loader.DispatchAsync().ConfigureAwait(false);
 
-            user3 = await task3.ConfigureAwait(false);
-        });
+        user3 = await task3.ConfigureAwait(false);
 
         user3.ShouldBeSameAs(user1);
 
@@ -168,7 +156,7 @@ public class BatchDataLoaderTests : DataLoaderTestBase
     }
 
     [Fact]
-    public void NonExistent_Key_Will_Return_Default_Value()
+    public async Task NonExistent_Key_Will_Return_Default_Value()
     {
         var mock = new Mock<IUsersStore>();
         var users = Fake.Users.Generate(2);
@@ -183,30 +171,26 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         User user2 = null;
         User user3 = null;
 
-        // Run within an async context to make sure we won't deadlock
-        AsyncContext.Run(async () =>
-        {
-            // There is no user with the ID of 3
-            // 3 will not be in the returned Dictionary, so the DataLoader should use the specified default value
-            var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync, defaultValue: nullObjectUser);
+        // There is no user with the ID of 3
+        // 3 will not be in the returned Dictionary, so the DataLoader should use the specified default value
+        var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync, defaultValue: nullObjectUser);
 
-            // Start async tasks to load by ID
-            var result1 = loader.LoadAsync(1);
-            var result2 = loader.LoadAsync(2);
-            var result3 = loader.LoadAsync(3);
+        // Start async tasks to load by ID
+        var result1 = loader.LoadAsync(1);
+        var result2 = loader.LoadAsync(2);
+        var result3 = loader.LoadAsync(3);
 
-            // Dispatch loading
-            await loader.DispatchAsync().ConfigureAwait(false);
+        // Dispatch loading
+        await loader.DispatchAsync().ConfigureAwait(false);
 
-            var task1 = result1.GetResultAsync();
-            var task2 = result2.GetResultAsync();
-            var task3 = result3.GetResultAsync();
+        var task1 = result1.GetResultAsync();
+        var task2 = result2.GetResultAsync();
+        var task3 = result3.GetResultAsync();
 
-            // Now await tasks
-            user1 = await task1.ConfigureAwait(false);
-            user2 = await task2.ConfigureAwait(false);
-            user3 = await task3.ConfigureAwait(false);
-        });
+        // Now await tasks
+        user1 = await task1.ConfigureAwait(false);
+        user2 = await task2.ConfigureAwait(false);
+        user3 = await task3.ConfigureAwait(false);
 
         user1.ShouldNotBeNull();
         user2.ShouldNotBeNull();

--- a/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
+++ b/src/GraphQL.DataLoader.Tests/BatchDataLoaderTests.cs
@@ -20,7 +20,6 @@ public class BatchDataLoaderTests : DataLoaderTestBase
         User user1 = null;
         User user2 = null;
 
-        // Run within an async context to make sure we won't deadlock
         var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync);
 
         // Start async tasks to load by ID

--- a/src/GraphQL.DataLoader.Tests/DataLoaderExtensionsTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderExtensionsTests.cs
@@ -68,7 +68,6 @@ public class DataLoaderExtensionsTests : DataLoaderTestBase
         User user2 = null;
         User user3 = null;
 
-        // Run within an async context to make sure we won't deadlock
         var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync);
 
         // Start async tasks to load by ID

--- a/src/GraphQL.DataLoader.Tests/DataLoaderExtensionsTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderExtensionsTests.cs
@@ -1,7 +1,6 @@
 using GraphQL.DataLoader.Tests.Models;
 using GraphQL.DataLoader.Tests.Stores;
 using Moq;
-using Nito.AsyncEx;
 
 namespace GraphQL.DataLoader.Tests;
 
@@ -53,7 +52,7 @@ public class DataLoaderExtensionsTests : DataLoaderTestBase
     }
 
     [Fact]
-    public void LoadAsync_MultipleKeys_Works()
+    public async Task LoadAsync_MultipleKeys_Works()
     {
         var mock = new Mock<IUsersStore>();
         var users = Fake.Users.Generate(2);
@@ -70,29 +69,26 @@ public class DataLoaderExtensionsTests : DataLoaderTestBase
         User user3 = null;
 
         // Run within an async context to make sure we won't deadlock
-        AsyncContext.Run(async () =>
-        {
-            var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync);
+        var loader = new BatchDataLoader<int, User>(usersStore.GetUsersByIdAsync);
 
-            // Start async tasks to load by ID
-            var result1 = loader.LoadAsync(new int[] { 1, 2 });
-            var result2 = loader.LoadAsync(new int[] { 1, 2, 3 });
+        // Start async tasks to load by ID
+        var result1 = loader.LoadAsync(new int[] { 1, 2 });
+        var result2 = loader.LoadAsync(new int[] { 1, 2, 3 });
 
-            // Dispatch loading
-            await loader.DispatchAsync().ConfigureAwait(false);
-            var task1 = result1.GetResultAsync();
-            var task2 = result2.GetResultAsync();
+        // Dispatch loading
+        await loader.DispatchAsync().ConfigureAwait(false);
+        var task1 = result1.GetResultAsync();
+        var task2 = result2.GetResultAsync();
 
-            // Now await tasks
-            users1 = await task1.ConfigureAwait(false);
-            users1.ShouldNotBeNull();
-            user1 = users1[0];
-            user2 = users1[1];
+        // Now await tasks
+        users1 = await task1.ConfigureAwait(false);
+        users1.ShouldNotBeNull();
+        user1 = users1[0];
+        user2 = users1[1];
 
-            users2 = await task2.ConfigureAwait(false);
-            users2.ShouldNotBeNull();
-            user3 = users2[2];
-        });
+        users2 = await task2.ConfigureAwait(false);
+        users2.ShouldNotBeNull();
+        user3 = users2[2];
 
         users1.Length.ShouldBe(2, "First task with two keys should return array of two users");
         users2.Length.ShouldBe(3, "Second task with three keys should return array of three users");

--- a/src/GraphQL.DataLoader.Tests/GraphQL.DataLoader.Tests.csproj
+++ b/src/GraphQL.DataLoader.Tests/GraphQL.DataLoader.Tests.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.20" />
-    <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/GraphQL.MicrosoftDI.Tests/GraphQL.MicrosoftDI.Tests.csproj
+++ b/src/GraphQL.MicrosoftDI.Tests/GraphQL.MicrosoftDI.Tests.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.20" />
-    <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
It was only used, I believe, because of missing ConfigureAwait calls, which have been fixed, and currently there is a build error for any missing ConfigureAwaits.

Required by:
- #3265 