### PR TITLE
Restore IDocumentCache removal as deprecated members

### DIFF
--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -334,16 +334,16 @@ Using the `IGraphQLBuilder` interface to configure the GraphQL.NET execution eng
 
 ### 5. Changes in document caching
 
-To make work with document cache more flexible and allow some advanced use-cases this component
-was moved out of the GraphQL.NET execution engine. There is no more `IDocumentCache` interface
-to implement and no more `AddDocumentCache` extension methods defined on `IGraphQLBuilder`.
-The recommended way to setup caching layer is to inherit from `IConfigureExecution` interface
+To make work with document caching more flexible and allow some advanced use-cases, this component
+was moved out of the GraphQL.NET execution engine. The `IDocumentCache` interface has been
+deprecated, as well as the `AddDocumentCache` extension methods defined on `IGraphQLBuilder`.
+The recommended way to setup caching is to inherit from the `IConfigureExecution` interface
 and register your class as its implementation. No change is required if you used `AddMemoryCache`
-extension methods before though `AddMemoryCache` method itself was marked as obsolete and you may
+extension methods before, though the `AddMemoryCache` method itself was marked as obsolete and you may
 want to switch to its replacement `UseMemoryCache`. 
 
-Other changes in `MemoryDocumentCache` that may affect you - `GetMemoryCacheEntryOptions`,
-`GetAsync` and `SetAsync` methods take `ExecutionOptions options` argument instead of `string query`.
+Note that within the revised `MemoryDocumentCache` implementation, `GetMemoryCacheEntryOptions`,
+`GetAsync` and `SetAsync` methods take an `ExecutionOptions options` argument instead of `string query`.
 
 ### 6. Obsolete members have been removed
 

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -265,6 +265,18 @@ namespace GraphQL
             "be removed in v8.")]
         public static GraphQL.DI.IGraphQLBuilder AddComplexityAnalyzer<TAnalyzer>(this GraphQL.DI.IGraphQLBuilder builder, TAnalyzer analyzer, System.Action<GraphQL.Validation.Complexity.ComplexityConfiguration, System.IServiceProvider?>? action)
             where TAnalyzer :  class, GraphQL.Validation.Complexity.IComplexityAnalyzer { }
+        [System.Obsolete("Please write custom document cache implementations based the IConfigureExecution " +
+            "interface with ConfigureExecution; this method will be removed in v8.")]
+        public static GraphQL.DI.IGraphQLBuilder AddDocumentCache<TDocumentCache>(this GraphQL.DI.IGraphQLBuilder builder)
+            where TDocumentCache :  class, GraphQL.Caching.IDocumentCache { }
+        [System.Obsolete("Please write custom document cache implementations based the IConfigureExecution " +
+            "interface with ConfigureExecution; this method will be removed in v8.")]
+        public static GraphQL.DI.IGraphQLBuilder AddDocumentCache<TDocumentCache>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, TDocumentCache> documentCacheFactory)
+            where TDocumentCache :  class, GraphQL.Caching.IDocumentCache { }
+        [System.Obsolete("Please write custom document cache implementations based the IConfigureExecution " +
+            "interface with ConfigureExecution; this method will be removed in v8.")]
+        public static GraphQL.DI.IGraphQLBuilder AddDocumentCache<TDocumentCache>(this GraphQL.DI.IGraphQLBuilder builder, TDocumentCache documentCache)
+            where TDocumentCache :  class, GraphQL.Caching.IDocumentCache { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder)
             where TDocumentExecuter :  class, GraphQL.IDocumentExecuter { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, TDocumentExecuter> documentExecuterFactory)
@@ -918,6 +930,24 @@ namespace GraphQL.Builders
         public bool IsUnidirectional { get; }
         public int? Last { get; }
         public int? PageSize { get; }
+    }
+}
+namespace GraphQL.Caching
+{
+    [System.Obsolete("Do not use; will be removed in v8")]
+    public sealed class DefaultDocumentCache : GraphQL.Caching.IDocumentCache
+    {
+        [System.Obsolete("Do not use; will be removed in v8")]
+        public static readonly GraphQL.Caching.DefaultDocumentCache Instance;
+        public System.Threading.Tasks.ValueTask<GraphQLParser.AST.GraphQLDocument?> GetAsync(string query) { }
+        public System.Threading.Tasks.ValueTask SetAsync(string query, GraphQLParser.AST.GraphQLDocument value) { }
+    }
+    [System.Obsolete("Please use the IConfigureExecution interface; this interface will be removed in v" +
+        "8.")]
+    public interface IDocumentCache
+    {
+        System.Threading.Tasks.ValueTask<GraphQLParser.AST.GraphQLDocument?> GetAsync(string query);
+        System.Threading.Tasks.ValueTask SetAsync(string query, GraphQLParser.AST.GraphQLDocument value);
     }
 }
 namespace GraphQL.Conversion

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -265,6 +265,18 @@ namespace GraphQL
             "be removed in v8.")]
         public static GraphQL.DI.IGraphQLBuilder AddComplexityAnalyzer<TAnalyzer>(this GraphQL.DI.IGraphQLBuilder builder, TAnalyzer analyzer, System.Action<GraphQL.Validation.Complexity.ComplexityConfiguration, System.IServiceProvider?>? action)
             where TAnalyzer :  class, GraphQL.Validation.Complexity.IComplexityAnalyzer { }
+        [System.Obsolete("Please write custom document cache implementations based the IConfigureExecution " +
+            "interface with ConfigureExecution; this method will be removed in v8.")]
+        public static GraphQL.DI.IGraphQLBuilder AddDocumentCache<TDocumentCache>(this GraphQL.DI.IGraphQLBuilder builder)
+            where TDocumentCache :  class, GraphQL.Caching.IDocumentCache { }
+        [System.Obsolete("Please write custom document cache implementations based the IConfigureExecution " +
+            "interface with ConfigureExecution; this method will be removed in v8.")]
+        public static GraphQL.DI.IGraphQLBuilder AddDocumentCache<TDocumentCache>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, TDocumentCache> documentCacheFactory)
+            where TDocumentCache :  class, GraphQL.Caching.IDocumentCache { }
+        [System.Obsolete("Please write custom document cache implementations based the IConfigureExecution " +
+            "interface with ConfigureExecution; this method will be removed in v8.")]
+        public static GraphQL.DI.IGraphQLBuilder AddDocumentCache<TDocumentCache>(this GraphQL.DI.IGraphQLBuilder builder, TDocumentCache documentCache)
+            where TDocumentCache :  class, GraphQL.Caching.IDocumentCache { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder)
             where TDocumentExecuter :  class, GraphQL.IDocumentExecuter { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, TDocumentExecuter> documentExecuterFactory)
@@ -918,6 +930,24 @@ namespace GraphQL.Builders
         public bool IsUnidirectional { get; }
         public int? Last { get; }
         public int? PageSize { get; }
+    }
+}
+namespace GraphQL.Caching
+{
+    [System.Obsolete("Do not use; will be removed in v8")]
+    public sealed class DefaultDocumentCache : GraphQL.Caching.IDocumentCache
+    {
+        [System.Obsolete("Do not use; will be removed in v8")]
+        public static readonly GraphQL.Caching.DefaultDocumentCache Instance;
+        public System.Threading.Tasks.ValueTask<GraphQLParser.AST.GraphQLDocument?> GetAsync(string query) { }
+        public System.Threading.Tasks.ValueTask SetAsync(string query, GraphQLParser.AST.GraphQLDocument value) { }
+    }
+    [System.Obsolete("Please use the IConfigureExecution interface; this interface will be removed in v" +
+        "8.")]
+    public interface IDocumentCache
+    {
+        System.Threading.Tasks.ValueTask<GraphQLParser.AST.GraphQLDocument?> GetAsync(string query);
+        System.Threading.Tasks.ValueTask SetAsync(string query, GraphQLParser.AST.GraphQLDocument value);
     }
 }
 namespace GraphQL.Conversion

--- a/src/GraphQL/Caching/DefaultDocumentCache.cs
+++ b/src/GraphQL/Caching/DefaultDocumentCache.cs
@@ -1,0 +1,26 @@
+using GraphQLParser.AST;
+
+namespace GraphQL.Caching
+{
+    /// <summary>
+    /// The default implementation of <see cref="IDocumentCache"/> which
+    /// does not provide caching services.
+    /// </summary>
+    [Obsolete("Do not use; will be removed in v8")]
+    public sealed class DefaultDocumentCache : IDocumentCache
+    {
+        private DefaultDocumentCache() { }
+
+        /// <summary>
+        /// Provides a static instance of this class.
+        /// </summary>
+        [Obsolete("Do not use; will be removed in v8")]
+        public static readonly DefaultDocumentCache Instance = new();
+
+        /// <inheritdoc/>
+        public ValueTask<GraphQLDocument?> GetAsync(string query) => default;
+
+        /// <inheritdoc/>
+        public ValueTask SetAsync(string query, GraphQLDocument value) => default;
+    }
+}

--- a/src/GraphQL/Caching/DocumentCacheMapper.cs
+++ b/src/GraphQL/Caching/DocumentCacheMapper.cs
@@ -1,0 +1,48 @@
+using GraphQL.DI;
+using GraphQL.Validation;
+
+namespace GraphQL.Caching;
+
+/// <summary>
+/// Maps the registered <see cref="IDocumentCache"/> instance as an <see cref="IConfigureExecution"/> instance.
+/// </summary>
+[Obsolete("Remove in v8")]
+internal class DocumentCacheMapper : IConfigureExecution
+{
+    internal IDocumentCache DocumentCache { get; }
+
+    public DocumentCacheMapper(IDocumentCache documentCache)
+    {
+        DocumentCache = documentCache;
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
+    {
+        if (options.Document == null && options.Query != null)
+        {
+            var document = await DocumentCache.GetAsync(options.Query).ConfigureAwait(false);
+            if (document != null) // already in cache
+                // none of the default validation rules yet are dependent on the inputs, and the
+                // operation name is not passed to the document validator, so any successfully cached
+                // document should not need any validation rules run on it
+                options.ValidationRules = options.CachedDocumentValidationRules ?? Array.Empty<IValidationRule>();
+
+            var result = await next(options).ConfigureAwait(false);
+
+            if (result.Executed && // that is, validation was successful
+                document == null && // cache miss
+                options.Document != null)
+                await DocumentCache.SetAsync(options.Query, options.Document).ConfigureAwait(false);
+
+            return result;
+        }
+        else
+        {
+            return await next(options).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public virtual float SortOrder => 200;
+}

--- a/src/GraphQL/Caching/IDocumentCache.cs
+++ b/src/GraphQL/Caching/IDocumentCache.cs
@@ -1,0 +1,24 @@
+using GraphQLParser.AST;
+
+namespace GraphQL.Caching;
+
+/// <summary>
+/// Represents a cache of validated AST documents based on a query.
+/// </summary>
+[Obsolete($"Please use the {nameof(DI.IConfigureExecution)} interface; this interface will be removed in v8.")]
+public interface IDocumentCache
+{
+    /// <summary>
+    /// Gets a document in the cache. Must be thread-safe.
+    /// </summary>
+    /// <param name="query">As the cache key.</param>
+    /// <returns>The cached document object. Returns <see langword="null"/> if no entry is found.</returns>
+    ValueTask<GraphQLDocument?> GetAsync(string query);
+
+    /// <summary>
+    /// Sets a document in the cache. Must be thread-safe.
+    /// </summary>
+    /// <param name="query">As the cache key.</param>
+    /// <param name="value">The document object to cache.</param>
+    ValueTask SetAsync(string query, GraphQLDocument value);
+}

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using GraphQL.Caching;
 using GraphQL.DI;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
@@ -822,6 +823,49 @@ namespace GraphQL
             });
             return builder;
         }
+        #endregion
+
+        #region - AddDocumentCache -
+#pragma warning disable CS0618 // Type or member is obsolete
+        /// <summary>
+        /// Registers <typeparamref name="TDocumentCache"/> as a singleton of type <see cref="IDocumentCache"/> within the
+        /// dependency injection framework.
+        /// </summary>
+        [Obsolete($"Please write custom document cache implementations based the {nameof(DI.IConfigureExecution)} interface with {nameof(ConfigureExecution)}; this method will be removed in v8.")]
+        public static IGraphQLBuilder AddDocumentCache<TDocumentCache>(this IGraphQLBuilder builder)
+            where TDocumentCache : class, IDocumentCache
+        {
+            builder.Services.Register<IDocumentCache, TDocumentCache>(ServiceLifetime.Singleton);
+            builder.Services.TryRegister<IConfigureExecution, DocumentCacheMapper>(ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
+            return builder;
+        }
+
+        /// <summary>
+        /// Registers <paramref name="documentCache"/> as a singleton of type <see cref="IDocumentCache"/> within the
+        /// dependency injection framework.
+        /// </summary>
+        [Obsolete($"Please write custom document cache implementations based the {nameof(DI.IConfigureExecution)} interface with {nameof(ConfigureExecution)}; this method will be removed in v8.")]
+        public static IGraphQLBuilder AddDocumentCache<TDocumentCache>(this IGraphQLBuilder builder, TDocumentCache documentCache)
+            where TDocumentCache : class, IDocumentCache
+        {
+            builder.Services.Register<IDocumentCache>(documentCache ?? throw new ArgumentNullException(nameof(documentCache)));
+            builder.Services.TryRegister<IConfigureExecution, DocumentCacheMapper>(ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
+            return builder;
+        }
+
+        /// <summary>
+        /// Registers <typeparamref name="TDocumentCache"/> as a singleton of type <see cref="IDocumentCache"/> within the
+        /// dependency injection framework. The supplied factory method is used to create the document cache.
+        /// </summary>
+        [Obsolete($"Please write custom document cache implementations based the {nameof(DI.IConfigureExecution)} interface with {nameof(ConfigureExecution)}; this method will be removed in v8.")]
+        public static IGraphQLBuilder AddDocumentCache<TDocumentCache>(this IGraphQLBuilder builder, Func<IServiceProvider, TDocumentCache> documentCacheFactory)
+            where TDocumentCache : class, IDocumentCache
+        {
+            builder.Services.Register<IDocumentCache>(documentCacheFactory ?? throw new ArgumentNullException(nameof(documentCacheFactory)), ServiceLifetime.Singleton);
+            builder.Services.TryRegister<IConfigureExecution, DocumentCacheMapper>(ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
+            return builder;
+        }
+#pragma warning restore CS0618 // Type or member is obsolete
         #endregion
 
         #region - AddSerializer -


### PR DESCRIPTION
Reduces amount of changes necessary for migration to v7 when a custom document cache implementation was in use.

This was not done for `IComplexityAnalyzer` because the options were removed from `ExecutionOptions` and so there is no simple way to provide a direct replacement.

The `DocumentExecuter` constructors have not been restored because it would be necessary to restore `IComplexityAnalyzer` also.

@sungam3r Thoughts?  We don't have to merge this PR, but I feel we should make an attempt at reducing API diff between major versions when it can be avoided.