### PR TITLE
user not duplicated in context

### DIFF
--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -107,6 +107,7 @@ namespace GraphQL
             Document = context.Document;
             RootValue = context.RootValue;
             UserContext = context.UserContext;
+            User = context.User;
             Operation = context.Operation;
             Variables = context.Variables;
             CancellationToken = context.CancellationToken;


### PR DESCRIPTION
we are getting a null reference on ResolveConnectionContext since it uses the the constructor of ResolveFieldContext which does not duplicate the `User` 