### PR TITLE
Prevent using graphtype as model

### DIFF
--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -555,3 +555,17 @@ services.AddGraphQL(b => b
     // other calls
 );
 ```
+
+### 14. Graph types cannot be used as data models
+
+From version 7.1 on, graph types cannot be used as data models. This is because the graph types are
+designed to be used as schema definitions, and not as a data model. The following classes
+will now throw an exception if a graph type is used as a data model:
+
+- `ObjectGraphType<TSourceType>`
+- `InputObjectGraphType<TSourceType>`
+- `AutoRegisteringObjectGraphType<TSourceType>`
+- `AutoRegisteringInputObjectGraphType<TSourceType>`
+
+If it is necessary to do so, you can derive from the `ObjectGraphType` or `InputObjectGraphType` classes
+instead of the generic version.

--- a/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
+++ b/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
@@ -268,21 +268,26 @@ public class BubbleNullSchema : Schema
         var query = new ObjectGraphType();
 
         query.Field<NonNullGraphType<DataGraphType>>("nonNullableDataGraph")
-            .Resolve(c => new DataGraphType { Data = c.Source as Data }
+            .Resolve(c => new DataModel { Data = c.Source as Data }
         );
 
         query.Field<DataGraphType>("nullableDataGraph")
-            .Resolve(c => new DataGraphType { Data = c.Source as Data }
+            .Resolve(c => new DataModel { Data = c.Source as Data }
         );
 
         query.Field<NonNullGraphType<ListGraphType<NonNullGraphType<DataGraphType>>>>("nonNullableListOfNonNullableDataGraph")
-            .Resolve(_ => new[] { new DataGraphType() });
+            .Resolve(_ => new[] { new DataModel() });
 
         Query = query;
     }
 }
 
-public class DataGraphType : ObjectGraphType<DataGraphType>
+public class DataModel
+{
+    public Data Data { get; set; }
+}
+
+public class DataGraphType : ObjectGraphType<DataModel>
 {
     public DataGraphType()
     {
@@ -307,13 +312,11 @@ public class DataGraphType : ObjectGraphType<DataGraphType>
             .Resolve(_ => throw new Exception("test"));
 
         Field<NonNullGraphType<DataGraphType>>("nonNullableNest")
-            .Resolve(c => new DataGraphType { Data = c.Source.Data.NonNullableNest });
+            .Resolve(c => new DataModel { Data = c.Source.Data.NonNullableNest });
 
         Field<DataGraphType>("nullableNest")
-            .Resolve(c => new DataGraphType { Data = c.Source.Data.NullableNest });
+            .Resolve(c => new DataModel { Data = c.Source.Data.NullableNest });
     }
-
-    public Data Data { get; set; }
 }
 
 public class Data

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -557,9 +557,9 @@ public class ComplexGraphTypeTests
     public void cannot_use_graphtype_as_model()
     {
         Should.Throw<InvalidOperationException>(() => new Graph2())
-            .Message.ShouldBe("Cannot use a graph type 'Graph1' as a model for graph type 'Graph2'. Please use a model rather than a graph type for TSourceType.");
+            .Message.ShouldBe("Cannot use graph type 'Graph1' as a model for graph type 'Graph2'. Please use a model rather than a graph type for TSourceType.");
         Should.Throw<InvalidOperationException>(() => new Graph4())
-            .Message.ShouldBe("Cannot use a graph type 'Graph3' as a model for graph type 'Graph4'. Please use a model rather than a graph type for TSourceType.");
+            .Message.ShouldBe("Cannot use graph type 'Graph3' as a model for graph type 'Graph4'. Please use a model rather than a graph type for TSourceType.");
     }
 
     private class Graph1 : ObjectGraphType { }

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -552,4 +552,18 @@ public class ComplexGraphTypeTests
         type.Field<IEnumerable<string>>("field13").Resolve(_ => Array.Empty<string>());
         type.Fields.Find("field13").ShouldNotBeNull().Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<GraphQLClrOutputTypeReference<string>>>));
     }
+
+    [Fact]
+    public void cannot_use_graphtype_as_model()
+    {
+        Should.Throw<InvalidOperationException>(() => new Graph2())
+            .Message.ShouldBe("Cannot use a graph type 'Graph1' as a model for graph type 'Graph2'. Please use a model rather than a graph type for TSourceType.");
+        Should.Throw<InvalidOperationException>(() => new Graph4())
+            .Message.ShouldBe("Cannot use a graph type 'Graph3' as a model for graph type 'Graph4'. Please use a model rather than a graph type for TSourceType.");
+    }
+
+    private class Graph1 : ObjectGraphType { }
+    private class Graph2 : ObjectGraphType<Graph1> { }
+    private class Graph3 : InputObjectGraphType { }
+    private class Graph4 : InputObjectGraphType<Graph3> { }
 }

--- a/src/GraphQL.Tests/Types/NonNullGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/NonNullGraphTypeTests.cs
@@ -94,15 +94,20 @@ public class NullableSchema : Schema
         var query = new ObjectGraphType();
 
         query.Field<NullableSchemaType>("nullable")
-            .Resolve(c => new NullableSchemaType { Data = c.Source as ExampleContext });
+            .Resolve(c => new DataModel { Data = c.Source as ExampleContext });
         query.Field<NonNullableSchemaType>("nonNullable")
-            .Resolve(c => new NonNullableSchemaType { Data = c.Source as ExampleContext });
+            .Resolve(c => new DataModel { Data = c.Source as ExampleContext });
 
         Query = query;
     }
 }
 
-public class NullableSchemaType : ObjectGraphType<NullableSchemaType>
+public class DataModel
+{
+    public ExampleContext Data { get; set; }
+}
+
+public class NullableSchemaType : ObjectGraphType<DataModel>
 {
     public NullableSchemaType()
     {
@@ -110,11 +115,9 @@ public class NullableSchemaType : ObjectGraphType<NullableSchemaType>
         Field<BooleanGraphType>("b").Resolve(_ => _.Source.Data.B);
         Field<StringGraphType>("c").Resolve(_ => _.Source.Data.C);
     }
-
-    public ExampleContext Data { get; set; }
 }
 
-public class NonNullableSchemaType : ObjectGraphType<NonNullableSchemaType>
+public class NonNullableSchemaType : ObjectGraphType<DataModel>
 {
     public NonNullableSchemaType()
     {
@@ -122,6 +125,4 @@ public class NonNullableSchemaType : ObjectGraphType<NonNullableSchemaType>
         Field<NonNullGraphType<BooleanGraphType>>("b").Resolve(_ => _.Source.Data.B);
         Field<NonNullGraphType<StringGraphType>>("c").Resolve(_ => _.Source.Data.C);
     }
-
-    public ExampleContext Data { get; set; }
 }

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Types
         /// <inheritdoc/>
         protected ComplexGraphType()
         {
-            if (typeof(GraphType).IsAssignableFrom(typeof(TSourceType)))
+            if (typeof(IGraphType).IsAssignableFrom(typeof(TSourceType)))
                 throw new InvalidOperationException($"Cannot use graph type '{typeof(TSourceType).Name}' as a model for graph type '{GetType().Name}'. Please use a model rather than a graph type for {nameof(TSourceType)}.");
 
             Description ??= typeof(TSourceType).Description();

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Types
         /// <inheritdoc/>
         protected ComplexGraphType()
         {
-            if (typeof(IGraphType).IsAssignableFrom(typeof(TSourceType)))
+            if (typeof(IGraphType).IsAssignableFrom(typeof(TSourceType)) && GetType() != typeof(Introspection.__Type))
                 throw new InvalidOperationException($"Cannot use graph type '{typeof(TSourceType).Name}' as a model for graph type '{GetType().Name}'. Please use a model rather than a graph type for {nameof(TSourceType)}.");
 
             Description ??= typeof(TSourceType).Description();

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Types
         protected ComplexGraphType()
         {
             if (typeof(GraphType).IsAssignableFrom(typeof(TSourceType)))
-                throw new InvalidOperationException($"Cannot use a graph type '{typeof(TSourceType).Name}' as a model for graph type '{GetType().Name}'. Please use a model rather than a graph type for {nameof(TSourceType)}.");
+                throw new InvalidOperationException($"Cannot use graph type '{typeof(TSourceType).Name}' as a model for graph type '{GetType().Name}'. Please use a model rather than a graph type for {nameof(TSourceType)}.");
 
             Description ??= typeof(TSourceType).Description();
             DeprecationReason ??= typeof(TSourceType).ObsoleteMessage();

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -17,6 +17,9 @@ namespace GraphQL.Types
         /// <inheritdoc/>
         protected ComplexGraphType()
         {
+            if (typeof(GraphType).IsAssignableFrom(typeof(TSourceType)))
+                throw new InvalidOperationException($"Cannot use a graph type '{typeof(TSourceType).Name}' as a model for graph type '{GetType().Name}'. Please use a model rather than a graph type for {nameof(TSourceType)}.");
+
             Description ??= typeof(TSourceType).Description();
             DeprecationReason ??= typeof(TSourceType).ObsoleteMessage();
         }


### PR DESCRIPTION
Implemented within `ComplexGraphType<TSourceType>`

Applies to:
- `ObjectGraphType<TSourceType>`
- `InputObjectGraphType<TSourceType>`
- `AutoRegisteringObjectGraphType<TSourceType>`
- `AutoRegisteringInputObjectGraphType<TSourceType>`