### PR TITLE
Add type integrity check when existing types are found

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug1156.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1156.cs
@@ -21,7 +21,7 @@ public class Bug1156 : QueryTestBase<Bug1156Schema>
 }";
         var result = AssertQueryWithErrors(query, null, expectedErrorCount: 1, executed: false);
         result.Errors[0].Message.ShouldBe("Error executing document.");
-        result.Errors[0].InnerException.Message.ShouldBe(@"Unable to register GraphType 'GraphQL.Tests.Bugs.Type2' with the name 'MyType'. The name 'MyType' is already registered to 'GraphQL.Tests.Bugs.Type1'. Check your schema configuration.");
+        result.Errors[0].InnerException.Message.ShouldBe(@"Unable to register GraphType 'Type2' with the name 'MyType'. The name 'MyType' is already registered to 'Type1'. Check your schema configuration.");
     }
 }
 

--- a/src/GraphQL.Tests/Bugs/Bug2279.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2279.cs
@@ -12,7 +12,7 @@ public class Bug2279DuplicateType : QueryTestBase<Bug2279Schema>
         var e = Should.Throw<InvalidOperationException>(() => s.Initialize());
         var t1 = typeof(Bug2279GraphType<int>).FullName;
         var t2 = typeof(Bug2279GraphType<string>).FullName;
-        e.Message.ShouldBe(@$"Unable to register GraphType '{t1}' with the name 'Bug2279GraphType_1'. The name 'Bug2279GraphType_1' is already registered to '{t2}'. Check your schema configuration.");
+        e.Message.ShouldBe(@$"Unable to register GraphType 'Bug2279GraphType<Int32>' with the name 'Bug2279GraphType_1'. The name 'Bug2279GraphType_1' is already registered to 'Bug2279GraphType<String>'. Check your schema configuration.");
     }
 }
 

--- a/src/GraphQL.Tests/Bugs/Bug3331.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3331.cs
@@ -1,7 +1,6 @@
 using GraphQL.Conversion;
 using GraphQL.Resolvers;
 using GraphQL.Types;
-using Shouldly;
 
 namespace GraphQL.Tests.Bugs;
 
@@ -30,7 +29,7 @@ public class Bug3331
             .Message.ShouldBe("A different instance of the type 'MyObject' has already been registered within the schema. Please use the same instance for all references within the schema, or use GraphQLTypeReference to reference a type instantiated elsewhere.");
 
         // Must have 2 instances
-        Assert.Equal(3, MyObjectGraphType.SharedInstanceCounter);
+        MyObjectGraphType.SharedInstanceCounter.ShouldBe(3);
     }
 
     private static void RegisterGenericQueryGraphTypes(Schema schema, ObjectGraphType queryGraphType,

--- a/src/GraphQL.Tests/Bugs/Bug3331.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3331.cs
@@ -2,50 +2,10 @@ using GraphQL.Conversion;
 using GraphQL.Resolvers;
 using GraphQL.Types;
 
-namespace GraphQL.Tests.Types.Collections;
+namespace GraphQL.Tests.Bugs;
 
-public partial class SchemaTypesTests
+public class Bug3331
 {
-    [Fact]
-    public void throws_exception_when_multiple_type_instances_exists_simple()
-    {
-        var schema = new Schema
-        {
-            NameConverter = new CamelCaseNameConverter()
-        };
-
-        var queryGraphType = new ObjectGraphType
-        {
-            Name = "Query"
-        };
-
-        schema.RegisterType(queryGraphType);
-
-        // Object 1
-        var graphType1 = new ObjectGraphType
-        {
-            Name = "MyObject"
-        };
-
-        graphType1.Field<IntGraphType>("int");
-
-        queryGraphType.Field("first", graphType1);
-
-        // Object 2
-        var graphType2 = new ObjectGraphType
-        {
-            Name = "MyObject"
-        };
-
-        graphType2.Field<IntGraphType>("int");
-        graphType2.Field<StringGraphType>("string");
-
-        queryGraphType.Field("second", graphType2);
-
-        // Test
-        Assert.Throws<InvalidOperationException>(() => schema.Initialize());
-    }
-
     [Fact]
     public void throws_exception_when_multiple_type_instances_exists_complex()
     {

--- a/src/GraphQL.Tests/Bugs/Bug3331.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3331.cs
@@ -1,6 +1,7 @@
 using GraphQL.Conversion;
 using GraphQL.Resolvers;
 using GraphQL.Types;
+using Shouldly;
 
 namespace GraphQL.Tests.Bugs;
 
@@ -25,7 +26,8 @@ public class Bug3331
 
         schema.Query = queryGraphType;
 
-        Assert.Throws<InvalidOperationException>(() => schema.Initialize());
+        Should.Throw<InvalidOperationException>(() => schema.Initialize())
+            .Message.ShouldBe("A different instance of the type 'MyObject' has already been registered within the schema. Please use the same instance for all references within the schema, or use GraphQLTypeReference to reference a type instantiated elsewhere.");
 
         // Must have 2 instances
         Assert.Equal(3, MyObjectGraphType.SharedInstanceCounter);

--- a/src/GraphQL.Tests/Bugs/Issue1927ResolvedTypeWithType.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1927ResolvedTypeWithType.cs
@@ -7,7 +7,7 @@ public class Issue1927ResolvedTypeWithType
     [Fact]
     public void test_outputs()
     {
-        var innerObject = new ObjectGraphType();
+        var innerObject = new ObjectGraphType() { Name = "inner" };
         innerObject.AddField(new FieldType { Name = "test", ResolvedType = new StringGraphType(), Type = typeof(StringGraphType) });
         var list = new ListGraphType(innerObject);
         var obj = new ObjectGraphType();
@@ -22,7 +22,7 @@ public class Issue1927ResolvedTypeWithType
     [Fact]
     public void test_inputs()
     {
-        var innerObject = new InputObjectGraphType();
+        var innerObject = new InputObjectGraphType() { Name = "inner" };
         innerObject.AddField(new FieldType { Name = "test", ResolvedType = new StringGraphType(), Type = typeof(StringGraphType) });
         var list = new ListGraphType(innerObject);
         var inputObj = new InputObjectGraphType();

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace GraphQL.Tests.Types.Collections;
 
-public class SchemaTypesTests
+public partial class SchemaTypesTests
 {
     [Fact]
     public void does_not_request_instance_more_than_once()

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
@@ -83,7 +83,8 @@ public class SchemaTypesTests
         queryGraphType.Field("second", graphType2);
 
         // Test
-        Assert.Throws<InvalidOperationException>(() => schema.Initialize());
+        Should.Throw<InvalidOperationException>(() => schema.Initialize())
+            .Message.ShouldBe("A different instance of the type 'MyObject' has already been registered within the schema. Please use the same instance for all references within the schema, or use GraphQLTypeReference to reference a type instantiated elsewhere.");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.typechecking.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.typechecking.cs
@@ -7,7 +7,47 @@ namespace GraphQL.Tests.Types.Collections;
 public partial class SchemaTypesTests
 {
     [Fact]
-    public void throws_exception_when_multiple_type_instances_exists()
+    public void throws_exception_when_multiple_type_instances_exists_simple()
+    {
+        var schema = new Schema
+        {
+            NameConverter = new CamelCaseNameConverter()
+        };
+
+        var queryGraphType = new ObjectGraphType
+        {
+            Name = "Query"
+        };
+
+        schema.RegisterType(queryGraphType);
+
+        // Object 1
+        var graphType1 = new ObjectGraphType
+        {
+            Name = "MyObject"
+        };
+
+        graphType1.Field<IntGraphType>("int");
+
+        queryGraphType.Field("first", graphType1);
+
+        // Object 2
+        var graphType2 = new ObjectGraphType
+        {
+            Name = "MyObject"
+        };
+
+        graphType2.Field<IntGraphType>("int");
+        graphType2.Field<StringGraphType>("string");
+
+        queryGraphType.Field("second", graphType2);
+
+        // Test
+        Assert.Throws<InvalidOperationException>(() => schema.Initialize());
+    }
+
+    [Fact]
+    public void throws_exception_when_multiple_type_instances_exists_complex()
     {
         var schema = new Schema
         {

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.typechecking.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.typechecking.cs
@@ -1,0 +1,173 @@
+using GraphQL.Conversion;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Types.Collections;
+
+public partial class SchemaTypesTests
+{
+    [Fact]
+    public void throws_exception_when_multiple_type_instances_exists()
+    {
+        var schema = new Schema
+        {
+            NameConverter = new CamelCaseNameConverter()
+        };
+
+        var queryGraphType = new ObjectGraphType
+        {
+            Name = "Query"
+        };
+
+        schema.RegisterType(queryGraphType);
+
+        RegisterGenericQueryGraphTypes(schema, queryGraphType, "MyObject", "MyObjects");
+
+        schema.Query = queryGraphType;
+
+        Assert.Throws<InvalidOperationException>(() => schema.Initialize());
+
+        // Must have 2 instances
+        Assert.Equal(3, MyObjectGraphType.SharedInstanceCounter);
+    }
+
+    private static void RegisterGenericQueryGraphTypes(Schema schema, ObjectGraphType queryGraphType,
+        string singular, string plural)
+    {
+        // Important: instance 1
+        var objectGraphType = new MyObjectGraphType();
+        schema.RegisterType(objectGraphType);
+
+        // Note: we register different types on purpose here (the generic method registers a 2nd instance)
+        queryGraphType.Field<MyObjectGraphType>(singular)
+            .Arguments(new QueryArguments(
+                new QueryArgument(typeof(Guid?).GetGraphTypeFromType(true)) { Name = "Id" }))
+            .Resolve(context => new MyObject
+            {
+                Id = Guid.NewGuid(),
+                Name = "test"
+            });
+
+        // This uses instance 1
+        var objectDataResultGraphType = CreateDataResultObjectGraphType<MyObject>(singular, objectGraphType, null);
+        schema.RegisterType(objectDataResultGraphType);
+
+        queryGraphType.Field(plural, objectDataResultGraphType)
+            .Arguments(new QueryArguments(
+                new QueryArgument(typeof(int?).GetGraphTypeFromType(true)) { Name = "Skip" },
+                new QueryArgument(typeof(int?).GetGraphTypeFromType(true)) { Name = "Take" }))
+            .Resolve(context =>
+            {
+                var dataResult = new DataResult<MyObject>
+                {
+                    Skip = 0,
+                    Take = 10,
+                    Total = 2
+                };
+
+                dataResult.Data.AddRange(new[]
+                {
+                    new MyObject
+                    {
+                        Id = Guid.Parse("96b8c7b5-d542-4d70-a0cf-b0bbc0db119f"),
+                        Name = "test1"
+                    },
+                    new MyObject
+                    {
+                        Id = Guid.Parse("b405cb58-b966-4926-a989-90a76217af66"),
+                        Name = "test2"
+                    },
+                });
+
+                return dataResult;
+            });
+    }
+
+    private static IObjectGraphType CreateDataResultObjectGraphType<TEntity>(string name, IObjectGraphType objectGraphType, FuncFieldResolver<DataResult<MyObject>, List<TEntity>> fieldResolver)
+    {
+        var graphType = new ObjectGraphType
+        {
+            Name = $"{name}DataResult"
+        };
+
+        // Total
+        graphType.AddField(new FieldType
+        {
+            Name = nameof(DataResult<MyObject>.Total),
+            ResolvedType = new LongGraphType(),
+        });
+
+        // Offset
+        graphType.AddField(new FieldType
+        {
+            Name = nameof(DataResult<MyObject>.Skip),
+            ResolvedType = new IntGraphType(),
+        });
+
+        // Take
+        graphType.AddField(new FieldType
+        {
+            Name = nameof(DataResult<MyObject>.Take),
+            ResolvedType = new IntGraphType(),
+        });
+
+        // Data
+        graphType.AddField(new FieldType
+        {
+            Name = nameof(DataResult<MyObject>.Data),
+            ResolvedType = new ListGraphType(objectGraphType),
+            Resolver = fieldResolver
+        });
+
+        return graphType;
+    }
+
+    public class MyObject
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class MyObjectGraphType : ObjectGraphType<MyObject>
+    {
+        public static int SharedInstanceCounter = 1;
+
+        public MyObjectGraphType()
+        {
+            Field(p => p.Id);
+            Field(p => p.Name);
+
+            InstanceCounter = SharedInstanceCounter++;
+        }
+
+        public int InstanceCounter { get; }
+    }
+
+    public class DataResult<TResult>
+    {
+        public DataResult()
+        {
+            Data = new List<TResult>();
+        }
+
+        public long Total { get; set; }
+
+        public int Skip { get; set; }
+
+        public int Take { get; set; }
+
+        public List<TResult> Data { get; private set; }
+    }
+
+    public class DataResultGraphType<TType, TGraphType> : ObjectGraphType<DataResult<TType>>
+        where TGraphType : IGraphType
+    {
+        public DataResultGraphType()
+        {
+            Field(x => x.Skip);
+            Field(x => x.Take);
+            Field(x => x.Total);
+            Field(x => x.Data);
+        }
+    }
+}

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -672,7 +672,7 @@ Make sure that your ServiceProvider is configured correctly.");
 
             if (existingType.GetType() != newType.GetType())
             {
-                throw new InvalidOperationException($@"Unable to register GraphType '{newType.GetType().FullName}' with the name '{newType.Name}'. The name '{newType.Name}' is already registered to '{existingType.GetType().FullName}'. Check your schema configuration.");
+                throw new InvalidOperationException($@"Unable to register GraphType '{newType.GetType().GetFriendlyName()}' with the name '{newType.Name}'. The name '{newType.Name}' is already registered to '{existingType.GetType().GetFriendlyName()}'. Check your schema configuration.");
             }
 
             // All other types are considered "potentially wrong" when being re-registered, throw detailed exception
@@ -885,7 +885,7 @@ Make sure that your ServiceProvider is configured correctly.");
                 else
                 {
                     // Fatal schema configuration error.
-                    throw new InvalidOperationException($@"Unable to register GraphType '{type.FullName}' with the name '{typeName}'. The name '{typeName}' is already registered to '{existingGraphType.GetType().FullName}'. Check your schema configuration.");
+                    throw new InvalidOperationException($@"Unable to register GraphType '{type.GetFriendlyName()}' with the name '{typeName}'. The name '{typeName}' is already registered to '{existingGraphType.GetType().GetFriendlyName()}'. Check your schema configuration.");
                 }
             }
             else

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -189,7 +189,7 @@ namespace GraphQL.Types
                 {
                     if (this[name] == null)
                     {
-                        AddType(graphType, context);
+                        AddTypeIfNotRegistered(graphType, context);
                     }
                 },
                 graphTypeMappings,
@@ -603,7 +603,7 @@ Make sure that your ServiceProvider is configured correctly.");
             context.InFlightRegisteredTypes.Push(namedType);
             try
             {
-                AddType(resolvedType, context);
+                AddTypeIfNotRegistered(resolvedType, context);
             }
             finally
             {
@@ -664,15 +664,15 @@ Make sure that your ServiceProvider is configured correctly.");
                 return;
             }
 
-            if (existingType.GetType() != newType.GetType())
-            {
-                throw new InvalidOperationException($"Type '{existingType.GetType().Name}' is already registered but being re-registered using different type '{newType.GetType().Name}'");
-            }
-
             // Ignore scalars
             if (existingType is ScalarGraphType && newType is ScalarGraphType)
             {
                 return;
+            }
+
+            if (existingType.GetType() != newType.GetType())
+            {
+                throw new InvalidOperationException($@"Unable to register GraphType '{newType.GetType().FullName}' with the name '{newType.Name}'. The name '{newType.Name}' is already registered to '{existingType.GetType().FullName}'. Check your schema configuration.");
             }
 
             // All other types are considered "potentially wrong" when being re-registered, throw detailed exception

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -238,7 +238,13 @@ namespace GraphQL.Types
                 yield return instance;
 
             foreach (var type in schema.AdditionalTypes)
-                yield return (IGraphType)serviceProvider.GetRequiredService(type.GetNamedType());
+            {
+                var type2 = type.GetNamedType();
+                if (typeof(ScalarGraphType).IsAssignableFrom(type2))
+                {
+                    yield return (IGraphType)serviceProvider.GetRequiredService(type2);
+                }
+            }
 
             //TODO: According to the specification, Query is a required type. But if you uncomment these lines, then the mass of tests begin to fail, because they do not set Query.
             // if (Query == null)

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -189,7 +189,7 @@ namespace GraphQL.Types
                 {
                     if (this[name] == null)
                     {
-                        AddTypeIfNotRegistered(graphType, context);
+                        AddType(graphType, context);
                     }
                 },
                 graphTypeMappings,
@@ -603,7 +603,7 @@ Make sure that your ServiceProvider is configured correctly.");
             context.InFlightRegisteredTypes.Push(namedType);
             try
             {
-                AddTypeIfNotRegistered(resolvedType, context);
+                AddType(resolvedType, context);
             }
             finally
             {


### PR DESCRIPTION
This PR adds type integrity checks when a type is (accidentally) registered twice.

This fixes #3331. For example, in my case it was not applying the name conversion (camelCase) to the 2nd object causing runtime issues.

Example of an exception being thrown. This should give the developer some pointers to look for registration issues.

```
Type 'MyObjectGraphType' has field 'id', but this cannot be found on the new type. New type has:
- Id
- Name

Make sure to use the same type instances when registering the same type
```

Question: this PR causes 1 unit tests for a bug (Issue1927ResolvedTypeWithType, test_outputs) to fail. How would you like to deal with this?
