### PR TITLE
Improve field description inheritance performance

### DIFF
--- a/src/GraphQL.Tests/Bugs/Issue1004.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1004.cs
@@ -53,7 +53,7 @@ public class Issue1004Query : ObjectGraphType
         IsTypeOf = o => true;
         Field<StringGraphType>("field1").Resolve(_ => throw null);
         Field<StringGraphType>("field2").Description("Not so important").Resolve(_ => throw null);
-        Field<StringGraphType>("nonInterfaceField").Resolve(_ => throw null);
+        Field<StringGraphType>("nonInterfaceField").Resolve(_ => throw null); // https://github.com/graphql-dotnet/graphql-dotnet/pull/3352
         Interface<Issue1004Interface>();
     }
 }

--- a/src/GraphQL.Tests/Bugs/Issue1004.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1004.cs
@@ -26,6 +26,9 @@ public class Issue1004 : QueryTestBase<DescriptionFromInterfaceSchema>
       },
       {
         ""description"": ""Not so important""
+      },
+      {
+        ""description"": null
       }
     ]
   }
@@ -50,6 +53,7 @@ public class Issue1004Query : ObjectGraphType
         IsTypeOf = o => true;
         Field<StringGraphType>("field1").Resolve(_ => throw null);
         Field<StringGraphType>("field2").Description("Not so important").Resolve(_ => throw null);
+        Field<StringGraphType>("nonInterfaceField").Resolve(_ => throw null);
         Interface<Issue1004Interface>();
     }
 }

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
@@ -107,4 +107,49 @@ public class SchemaTypesTests
             Should.Throw<InvalidOperationException>(() => Initialize(schema, serviceProvider, null));
         }
     }
+
+    [Fact]
+    public void can_retrieve_owner_for_field_with_multiple_owners()
+    {
+        var schema = new Schema
+        {
+            NameConverter = new CamelCaseNameConverter()
+        };
+        var field = new FieldType { Name = "field1", Type = typeof(IntGraphType) };
+
+        // Object 1
+        var graphType1 = new ObjectGraphType
+        {
+            Name = "MyObject1"
+        };
+        graphType1.AddField(field);
+        schema.RegisterType(graphType1);
+
+        // Object 2
+        var graphType2 = new ObjectGraphType
+        {
+            Name = "MyObject2"
+        };
+        graphType2.AddField(field);
+        schema.RegisterType(graphType2);
+
+        schema.Initialize();
+
+        var owner = schema.AllTypes.GetFieldOwner(field);
+        owner.ShouldBeOneOf(graphType1, graphType2);
+    }
+
+    [Fact]
+    public void unknown_field_has_no_owner()
+    {
+        var schema = new Schema
+        {
+            NameConverter = new CamelCaseNameConverter()
+        };
+
+        schema.Initialize();
+
+        var owner = schema.AllTypes.GetFieldOwner(new FieldType { Name = "field1", Type = typeof(IntGraphType) });
+        owner.ShouldBeNull();
+    }
 }

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
@@ -107,49 +107,4 @@ public class SchemaTypesTests
             Should.Throw<InvalidOperationException>(() => Initialize(schema, serviceProvider, null));
         }
     }
-
-    [Fact]
-    public void can_retrieve_owner_for_field_with_multiple_owners()
-    {
-        var schema = new Schema
-        {
-            NameConverter = new CamelCaseNameConverter()
-        };
-        var field = new FieldType { Name = "field1", Type = typeof(IntGraphType) };
-
-        // Object 1
-        var graphType1 = new ObjectGraphType
-        {
-            Name = "MyObject1"
-        };
-        graphType1.AddField(field);
-        schema.RegisterType(graphType1);
-
-        // Object 2
-        var graphType2 = new ObjectGraphType
-        {
-            Name = "MyObject2"
-        };
-        graphType2.AddField(field);
-        schema.RegisterType(graphType2);
-
-        schema.Initialize();
-
-        var owner = schema.AllTypes.GetFieldOwner(field);
-        owner.ShouldBeOneOf(graphType1, graphType2);
-    }
-
-    [Fact]
-    public void unknown_field_has_no_owner()
-    {
-        var schema = new Schema
-        {
-            NameConverter = new CamelCaseNameConverter()
-        };
-
-        schema.Initialize();
-
-        var owner = schema.AllTypes.GetFieldOwner(new FieldType { Name = "field1", Type = typeof(IntGraphType) });
-        owner.ShouldBeNull();
-    }
 }

--- a/src/GraphQL/Introspection/__Field.cs
+++ b/src/GraphQL/Introspection/__Field.cs
@@ -28,20 +28,14 @@ namespace GraphQL.Introspection
                 // https://github.com/graphql-dotnet/graphql-dotnet/issues/1004
                 if (description == null)
                 {
-                    // We have to iterate over all schema types because FieldType has no reference to the GraphType to which it belongs.
-                    foreach (var item in context.Schema.AllTypes.Dictionary)
+                    var fieldOwner = context.Schema.AllTypes.GetFieldOwner(context.Source);
+                    if (fieldOwner is IImplementInterfaces implementation && implementation.ResolvedInterfaces != null)
                     {
-                        if (item.Value is IComplexGraphType fieldOwner && fieldOwner.Fields.Contains(context.Source))
+                        foreach (var iface in implementation.ResolvedInterfaces.List)
                         {
-                            if (fieldOwner is IImplementInterfaces implementation && implementation.ResolvedInterfaces != null)
-                            {
-                                foreach (var iface in implementation.ResolvedInterfaces.List)
-                                {
-                                    var fieldFromInterface = iface.GetField(context.Source.Name);
-                                    if (fieldFromInterface?.Description != null)
-                                        return fieldFromInterface.Description;
-                                }
-                            }
+                            var fieldFromInterface = iface.GetField(context.Source.Name);
+                            if (fieldFromInterface?.Description != null)
+                                return fieldFromInterface.Description;
                         }
                     }
                 }

--- a/src/GraphQL/Introspection/__Field.cs
+++ b/src/GraphQL/Introspection/__Field.cs
@@ -21,27 +21,7 @@ namespace GraphQL.Introspection
 
             Field<NonNullGraphType<StringGraphType>>("name").Resolve(context => context.Source.Name);
 
-            Field<StringGraphType>("description").Resolve(context =>
-            {
-                string description = context.Source.Description;
-
-                // https://github.com/graphql-dotnet/graphql-dotnet/issues/1004
-                if (description == null)
-                {
-                    var fieldOwner = context.Schema.AllTypes.GetFieldOwner(context.Source);
-                    if (fieldOwner is IImplementInterfaces implementation && implementation.ResolvedInterfaces != null)
-                    {
-                        foreach (var iface in implementation.ResolvedInterfaces.List)
-                        {
-                            var fieldFromInterface = iface.GetField(context.Source.Name);
-                            if (fieldFromInterface?.Description != null)
-                                return fieldFromInterface.Description;
-                        }
-                    }
-                }
-
-                return description;
-            });
+            Field<StringGraphType>("description").Resolve(context => context.Source.Description);
 
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<__InputValue>>>>("args")
                 .ResolveAsync(async context =>

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -921,7 +921,7 @@ Make sure that your ServiceProvider is configured correctly.");
         {
             foreach (var fieldOwner in Dictionary.Values.OfType<IComplexGraphType>())
             {
-                if (fieldOwner is IImplementInterfaces implementation && implementation.ResolvedInterfaces != null)
+                if (fieldOwner is IImplementInterfaces implementation && implementation.ResolvedInterfaces.Count > 0)
                 {
                     foreach (var field in fieldOwner.Fields.Where(field => field.Description == null))
                     {


### PR DESCRIPTION
On a large-ish GraphQL schema of mine producing the schema already quite a bit of time.

I've tracked down the culprit to the following code in __Field.cs which performs description inheritance (fills in empty field descriptions from corresponding interface fields, which was added in PR #1470 as a fix for issue #1004).

```
// We have to iterate over all schema types because FieldType has no reference to the GraphType to which it belongs.
foreach (var item in context.Schema.AllTypes.Dictionary)
{
   if (item.Value is IComplexGraphType fieldOwner && fieldOwner.Fields.Contains(context.Source))
```

Looping over the whole schema is pretty inefficient, increasing with O(numberOfFieldsWithoutDescription * numberOfTypes * numberOfFields).

This PR solves that by keeping a dictionary of the fields' owners and finding a field's owning type by dictionary lookup. It brings down schema generation time from 4 seconds to 1 seconds for my scenario (and more the bigger a schema gets).

The functionality in __Field.cs is already under test via Issue1004.cs, where I've taken the liberty of extending the test a bit by adding the counter-example of a field that's empty but isn't inherited from an interface.

Note that the new SchemaTypes.BuildFieldOwners method intentionally uses the dictionary indexer (and not Dictionary.Add) to avoid breaking existing schemas that reuse fields for different types (in case someone does this). The new test case in SchemaTypesTest aims at this scenario.
