### PR TITLE
Fix GraphQLName for classes named Type and GraphType

### DIFF
--- a/src/GraphQL.Tests/TypeExtensionTests.cs
+++ b/src/GraphQL.Tests/TypeExtensionTests.cs
@@ -17,4 +17,19 @@ public class TypeExtensionTests
     {
         type.IsNamedType().ShouldBe(expected);
     }
+
+    [Theory]
+    [InlineData(typeof(Type), "Type")]
+    [InlineData(typeof(Guid), "Guid")]
+    [InlineData(typeof(ScalarGraphType), "Scalar")]
+    [InlineData(typeof(NonNullGraphType<ListGraphType<IdGraphType>>), "Id")]
+    [InlineData(typeof(TestType), "Test")]
+    public void GraphQLName(Type type, string expected)
+    {
+        type.GraphQLName().ShouldBe(expected);
+    }
+
+    private class TestType
+    {
+    }
 }

--- a/src/GraphQL.Tests/TypeExtensionTests.cs
+++ b/src/GraphQL.Tests/TypeExtensionTests.cs
@@ -20,6 +20,7 @@ public class TypeExtensionTests
 
     [Theory]
     [InlineData(typeof(Type), "Type")]
+    [InlineData(typeof(GraphType), "GraphType")]
     [InlineData(typeof(Guid), "Guid")]
     [InlineData(typeof(ScalarGraphType), "Scalar")]
     [InlineData(typeof(NonNullGraphType<ListGraphType<IdGraphType>>), "Id")]

--- a/src/GraphQL/Extensions/TypeExtensions.cs
+++ b/src/GraphQL/Extensions/TypeExtensions.cs
@@ -85,6 +85,9 @@ namespace GraphQL
                 typeName = typeName.Substring(0, typeName.IndexOf('`'));
             }
 
+            if (typeName == nameof(GraphType) || typeName == nameof(Type))
+                return typeName;
+
             typeName = typeName.Replace(nameof(GraphType), nameof(Type));
 
             return typeName.EndsWith(nameof(Type), StringComparison.InvariantCulture)


### PR DESCRIPTION
Previously, an empty string would be returned, which would throw during `Name = typeof(TSource).GraphQLName();` before the name was altered via attributes.