### PR TITLE
Expand error message in GraphType.Initialize

### DIFF
--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -399,7 +399,7 @@ public class ComplexGraphTypeTests
         var schema2 = new Schema() { Query = type };
         Should.Throw<InvalidOperationException>(
             () => schema2.Initialize())
-            .Message.ShouldBe("This graph type 'Query' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.");
+            .Message.ShouldBe("This graph type 'ComplexType<String>' with name 'Query' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Types/UnionGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/UnionGraphTypeTests.cs
@@ -22,7 +22,7 @@ public class UnionGraphTypeTests
         var schema2 = new Schema() { Query = queryType2 };
         Should.Throw<InvalidOperationException>(
             () => schema2.Initialize())
-            .Message.ShouldBe("This graph type 'UnionType' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.");
+            .Message.ShouldBe("This graph type 'UnionGraphType' with name 'UnionType' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.");
     }
 
     public class Type1 : ObjectGraphType<Model1>

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -30,7 +30,7 @@ namespace GraphQL.Types
         public virtual void Initialize(ISchema schema)
         {
             if (_initialized)
-                throw new InvalidOperationException($"This graph type '{Name}' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.");
+                throw new InvalidOperationException($"This graph type '{GetType().GetFriendlyName()}' with name '{Name}' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.");
             _initialized = true;
         }
 


### PR DESCRIPTION
A little help for #3351. I aligned the error text with one from `IsValidInterfaceFor` method.