### PR TITLE
Bump setup-dotnet action version

### DIFF
--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -40,7 +40,7 @@ jobs:
           path: docs2/public/**
           if-no-files-found: error
       - name: Setup .NET Core 6.0 SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: '6.0.x'
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.3
       with:
          dotnet-version: '6.0.102'
          source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json

--- a/.github/workflows/publish-code.yml
+++ b/.github/workflows/publish-code.yml
@@ -47,7 +47,7 @@ jobs:
           path: docs2/public/**
           if-no-files-found: error
       - name: Setup .NET Core 6.0 SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: '6.0.x'
           source-url: https://api.nuget.org/v3/index.json

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
       - name: Setup .NET Core SDKs
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: |
             3.1.x


### PR DESCRIPTION
https://github.com/marketplace/actions/setup-net-core-sdk

@zcsizmadia , regarding #3329 - no more `include-prerelease` option. Use `dotnet-quality` instead.