### PR TITLE
Introdude raw string literals

### DIFF
--- a/src/GraphQL.Benchmarks/Queries.cs
+++ b/src/GraphQL.Benchmarks/Queries.cs
@@ -2,7 +2,7 @@ namespace GraphQL.Benchmarks;
 
 public static class Queries
 {
-    public static readonly string Introspection = @"
+    public static readonly string Introspection = """
   query IntrospectionQuery {
     __schema {
       description
@@ -95,13 +95,13 @@ public static class Queries
       }
     }
   }
-";
+""";
 
     public static readonly string Hero = "{ hero { id name } }";
 
-    public static readonly string Fragments = @"
+    public static readonly string Fragments = """
 query deep {
-  human(id: ""abcd"") {
+  human(id: "abcd") {
     friends {
       ... on Droid
         {
@@ -146,70 +146,70 @@ fragment HumanData on Human {
   appearsIn
   homePlanet
 }
-";
+""";
 
-    public static readonly string VariablesLiteral = @"
+    public static readonly string VariablesLiteral = """
 {
   test(inputs: [
     {
       ints: [[1,2],[3,4,5],[6,7,8]],
       widgets: [
-        {name:""bolts1"", description:""this is a test"", amount:2.99, quantity:42},
-        {name:""bolts2"", description:""this is a test"", amount:2.99, quantity:42}
+        {name:"bolts1", description:"this is a test", amount:2.99, quantity:42},
+        {name:"bolts2", description:"this is a test", amount:2.99, quantity:42}
       ]
     },
     {
       ints: [[11,12],[13,14,15],[16,17,18]],
       widgets: [
-        {name:""bolts3"", description:""this is a test"", amount:2.99, quantity:42},
-        {name:""bolts4"", description:""this is a test"", amount:2.99, quantity:42}
+        {name:"bolts3", description:"this is a test", amount:2.99, quantity:42},
+        {name:"bolts4", description:"this is a test", amount:2.99, quantity:42}
       ]
     },
     {
       ints: [[21,12],[13,14,15],[16,17,18]],
       widgets: [
-        {name:""bolts5"", description:""this is a test"", amount:2.99, quantity:42},
-        {name:""bolts6"", description:""this is a test"", amount:2.99, quantity:42}
+        {name:"bolts5", description:"this is a test", amount:2.99, quantity:42},
+        {name:"bolts6", description:"this is a test", amount:2.99, quantity:42}
       ]
     }
   ])
 }
-";
+""";
 
-    public static readonly string VariablesDefaultVariable = @"
+    public static readonly string VariablesDefaultVariable = """
 query ($in: [MyInputObject] =
   [
     {
       ints: [[1,2],[3,4,5],[6,7,8]],
       widgets: [
-        {name:""bolts1"", description:""this is a test"", amount:2.99, quantity:42},
-        {name:""bolts2"", description:""this is a test"", amount:2.99, quantity:42}
+        {name:"bolts1", description:"this is a test", amount:2.99, quantity:42},
+        {name:"bolts2", description:"this is a test", amount:2.99, quantity:42}
       ]
     },
     {
       ints: [[11,12],[13,14,15],[16,17,18]],
       widgets: [
-        {name:""bolts3"", description:""this is a test"", amount:2.99, quantity:42},
-        {name:""bolts4"", description:""this is a test"", amount:2.99, quantity:42}
+        {name:"bolts3", description:"this is a test", amount:2.99, quantity:42},
+        {name:"bolts4", description:"this is a test", amount:2.99, quantity:42}
       ]
     },
     {
       ints: [[21,12],[13,14,15],[16,17,18]],
       widgets: [
-        {name:""bolts5"", description:""this is a test"", amount:2.99, quantity:42},
-        {name:""bolts6"", description:""this is a test"", amount:2.99, quantity:42}
+        {name:"bolts5", description:"this is a test", amount:2.99, quantity:42},
+        {name:"bolts6", description:"this is a test", amount:2.99, quantity:42}
       ]
     }
   ])
 {
   test(inputs: $in)
 }
-";
+""";
 
-    public static readonly string VariablesVariable = @"
+    public static readonly string VariablesVariable = """
 query ($in: [MyInputObject])
 {
   test(inputs: $in)
 }
-";
+""";
 }

--- a/src/GraphQL.Benchmarks/Variables.cs
+++ b/src/GraphQL.Benchmarks/Variables.cs
@@ -2,31 +2,31 @@ namespace GraphQL.Benchmarks;
 
 public static class Variables
 {
-    public static readonly string VariablesVariable = @"
-{ ""in"":
+    public static readonly string VariablesVariable = """
+{ "in":
   [
     {
-      ""ints"": [[1,2],[3,4,5],[6,7,8]],
-      ""widgets"": [
-        {""name"":""bolts1"", ""description"":""this is a test"", ""amount"":2.99, ""quantity"":42},
-        {""name"":""bolts2"", ""description"":""this is a test"", ""amount"":2.99, ""quantity"":42}
+      "ints": [[1,2],[3,4,5],[6,7,8]],
+      "widgets": [
+        {"name":"bolts1", "description":"this is a test", "amount":2.99, "quantity":42},
+        {"name":"bolts2", "description":"this is a test", "amount":2.99, "quantity":42}
       ]
     },
     {
-      ""ints"": [[11,12],[13,14,15],[16,17,18]],
-      ""widgets"": [
-        {""name"":""bolts3"", ""description"":""this is a test"", ""amount"":2.99, ""quantity"":42},
-        {""name"":""bolts4"", ""description"":""this is a test"", ""amount"":2.99, ""quantity"":42}
+      "ints": [[11,12],[13,14,15],[16,17,18]],
+      "widgets": [
+        {"name":"bolts3", "description":"this is a test", "amount":2.99, "quantity":42},
+        {"name":"bolts4", "description":"this is a test", "amount":2.99, "quantity":42}
       ]
     },
     {
-      ""ints"": [[21,12],[13,14,15],[16,17,18]],
-      ""widgets"": [
-        {""name"":""bolts5"", ""description"":""this is a test"", ""amount"":2.99, ""quantity"":42},
-        {""name"":""bolts6"", ""description"":""this is a test"", ""amount"":2.99, ""quantity"":42}
+      "ints": [[21,12],[13,14,15],[16,17,18]],
+      "widgets": [
+        {"name":"bolts5", "description":"this is a test", "amount":2.99, "quantity":42},
+        {"name":"bolts6", "description":"this is a test", "amount":2.99, "quantity":42}
       ]
     }
   ]
 }
-";
+""";
 }

--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -18,18 +18,18 @@ public class DataLoaderQueryTests : QueryTestBase
 
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
             query: "{ users { userId firstName } }",
-            expected: @"
-{ ""users"": [
+            expected: $$"""
+{ "users": [
     {
-        ""userId"": 1,
-        ""firstName"": """ + users[0].FirstName + @"""
+        "userId": 1,
+        "firstName": "{{users[0].FirstName}}"
     },
     {
-        ""userId"": 2,
-        ""firstName"": """ + users[1].FirstName + @"""
+        "userId": 2,
+        "firstName": "{{users[1].FirstName}}"
     }
 ] }
-").ConfigureAwait(false);
+""").ConfigureAwait(false);
 
         usersMock.Verify(x => x.GetAllUsersAsync(default), Times.Once);
     }
@@ -46,18 +46,18 @@ public class DataLoaderQueryTests : QueryTestBase
 
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
             query: "{ usersWithDelay { userId firstName } }",
-            expected: @"
-{ ""usersWithDelay"": [
+            expected: $$"""
+{ "usersWithDelay": [
     {
-        ""userId"": 1,
-        ""firstName"": """ + users[0].FirstName + @"""
+        "userId": 1,
+        "firstName": "{{users[0].FirstName}}"
     },
     {
-        ""userId"": 2,
-        ""firstName"": """ + users[1].FirstName + @"""
+        "userId": 2,
+        "firstName": "{{users[1].FirstName}}"
     }
 ] }
-").ConfigureAwait(false);
+""").ConfigureAwait(false);
 
         usersMock.Verify(x => x.GetAllUsersAsync(default), Times.Once);
     }
@@ -90,17 +90,17 @@ public class DataLoaderQueryTests : QueryTestBase
         }
     }
 }",
-            expected: @"
+            expected: $$"""
 {
-    ""order"": {
-        ""orderId"": 1,
-        ""user"": {
-            ""userId"": 1,
-            ""firstName"": """ + users[0].FirstName + @"""
+    "order": {
+        "orderId": 1,
+        "user": {
+            "userId": 1,
+            "firstName": "{{users[0].FirstName}}"
         }
     }
 }
-").ConfigureAwait(false);
+""").ConfigureAwait(false);
 
         ordersMock.Verify(x => x.GetOrderByIdAsync(new[] { 1 }), Times.Once);
         ordersMock.VerifyNoOtherCalls();
@@ -135,25 +135,25 @@ public class DataLoaderQueryTests : QueryTestBase
         }
     }
 }",
-            expected: @"
+            expected: $$"""
 {
-    ""orders"": [
+    "orders": [
     {
-        ""orderId"": 1,
-        ""user"": {
-            ""userId"": 1,
-            ""firstName"": """ + users[0].FirstName + @"""
+        "orderId": 1,
+        "user": {
+            "userId": 1,
+            "firstName": "{{users[0].FirstName}}"
         }
     },
     {
-        ""orderId"": 2,
-        ""user"": {
-            ""userId"": 2,
-            ""firstName"": """ + users[1].FirstName + @"""
+        "orderId": 2,
+        "user": {
+            "userId": 2,
+            "firstName": "{{users[1].FirstName}}"
         }
     }]
 }
-").ConfigureAwait(false);
+""").ConfigureAwait(false);
 
         ordersMock.Verify(x => x.GetAllOrdersAsync(), Times.Once);
         ordersMock.VerifyNoOtherCalls();
@@ -188,25 +188,25 @@ mutation {
         }
     }
 }",
-            expected: @"
+            expected: $$"""
 {
-    ""orders"": [
+    "orders": [
     {
-        ""orderId"": 1,
-        ""user"": {
-            ""userId"": 1,
-            ""firstName"": """ + users[0].FirstName + @"""
+        "orderId": 1,
+        "user": {
+            "userId": 1,
+            "firstName": "{{users[0].FirstName}}"
         }
     },
     {
-        ""orderId"": 2,
-        ""user"": {
-            ""userId"": 2,
-            ""firstName"": """ + users[1].FirstName + @"""
+        "orderId": 2,
+        "user": {
+            "userId": 2,
+            "firstName": "{{users[1].FirstName}}"
         }
     }]
 }
-").ConfigureAwait(false);
+""").ConfigureAwait(false);
 
         ordersMock.Verify(x => x.GetAllOrdersAsync(), Times.Once);
         ordersMock.VerifyNoOtherCalls();
@@ -243,41 +243,41 @@ mutation {
         }
     }
 }",
-            expected: @"
+            expected: $$"""
 {
-    ""users"": [
+    "users": [
     {
-        ""orderedItems"": [
+        "orderedItems": [
         {
-            ""orderItemId"": 1
+            "orderItemId": 1
         },
         {
-            ""orderItemId"": 2
+            "orderItemId": 2
         },
         {
-            ""orderItemId"": 3
+            "orderItemId": 3
         },
         {
-            ""orderItemId"": 4
+            "orderItemId": 4
         }]
     },
     {
-        ""orderedItems"": [
+        "orderedItems": [
         {
-            ""orderItemId"": 5
+            "orderItemId": 5
         },
         {
-            ""orderItemId"": 6
+            "orderItemId": 6
         },
         {
-            ""orderItemId"": 7
+            "orderItemId": 7
         },
         {
-            ""orderItemId"": 8
+            "orderItemId": 8
         }]
     }]
 }
-").ConfigureAwait(false);
+""").ConfigureAwait(false);
         usersMock.Verify(x => x.GetAllUsersAsync(default), Times.Once);
         usersMock.VerifyNoOtherCalls();
 
@@ -352,19 +352,19 @@ mutation {
 
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
             query: "{ specifiedUsers(ids:[1, 2, 3]) { userId firstName } }",
-            expected: @"
-{ ""specifiedUsers"": [
+            expected: $$"""
+{ "specifiedUsers": [
     {
-        ""userId"": 1,
-        ""firstName"": """ + users[0].FirstName + @"""
+        "userId": 1,
+        "firstName": "{{users[0].FirstName}}"
     },
     {
-        ""userId"": 2,
-        ""firstName"": """ + users[1].FirstName + @"""
+        "userId": 2,
+        "firstName": "{{users[1].FirstName}}"
     },
     null
 ] }
-").ConfigureAwait(false);
+""").ConfigureAwait(false);
 
         usersMock.Verify(x => x.GetUsersByIdAsync(new int[] { 1, 2, 3 }, default), Times.Once);
     }
@@ -381,18 +381,18 @@ mutation {
 
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
             query: "{ specifiedUsersWithThen(ids:[1, 2, 3]) { userId firstName } }",
-            expected: @"
-{ ""specifiedUsersWithThen"": [
+            expected: $$"""
+{ "specifiedUsersWithThen": [
     {
-        ""userId"": 1,
-        ""firstName"": """ + users[0].FirstName + @"""
+        "userId": 1,
+        "firstName": "{{users[0].FirstName}}"
     },
     {
-        ""userId"": 2,
-        ""firstName"": """ + users[1].FirstName + @"""
+        "userId": 2,
+        "firstName": "{{users[1].FirstName}}"
     }
 ] }
-").ConfigureAwait(false);
+""").ConfigureAwait(false);
 
         usersMock.Verify(x => x.GetUsersByIdAsync(new int[] { 1, 2, 3 }, default), Times.Once);
     }
@@ -409,6 +409,6 @@ mutation {
     {
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
             query: "{ exerciseListsOfLists (values:[[1, 2], [3, 4, 5]]) }",
-            expected: @"{ ""exerciseListsOfLists"": [[1, 2], [3, 4, 5]] }").ConfigureAwait(false);
+            expected: """{ "exerciseListsOfLists": [[1, 2], [3, 4, 5]] }""").ConfigureAwait(false);
     }
 }

--- a/src/GraphQL.Harness.Tests/BasicTests.cs
+++ b/src/GraphQL.Harness.Tests/BasicTests.cs
@@ -12,11 +12,11 @@ public class BasicTests : SystemTestBase<Startup>
         {
             var input = new GraphQLRequest
             {
-                Query = @"{ hero { name} }"
+                Query = "{ hero { name} }"
             };
             scenario.Post.Json(input).ToUrl("/graphql");
             scenario.StatusCodeShouldBe(HttpStatusCode.OK);
-            scenario.GraphQL().ShouldBeSuccess(@"{ ""hero"": { ""name"": ""R2-D2"" }}");
+            scenario.GraphQL().ShouldBeSuccess("""{ "hero": { "name": "R2-D2" }}""");
         }).ConfigureAwait(false);
     }
 }

--- a/src/GraphQL.Tests/AuthorizationTests.cs
+++ b/src/GraphQL.Tests/AuthorizationTests.cs
@@ -124,14 +124,14 @@ public class AuthorizationTests
     [Fact]
     public void SchemaBuilder()
     {
-        var schema = Schema.For(
-            @"
+        var schema = Schema.For("""
 type Class1 {
   id: String!
   name: String!
   value: String!
   public: String!
-}",
+}
+""",
             configure => configure.Types.Include<Class1>());
 
         var graph = (ObjectGraphType)schema.AllTypes["Class1"];

--- a/src/GraphQL.Tests/Bugs/ArrayOfArrayTest.cs
+++ b/src/GraphQL.Tests/Bugs/ArrayOfArrayTest.cs
@@ -7,19 +7,21 @@ public class ArrayOfArrayTest : QueryTestBase<ArrayOfArraySchema>
     [Fact]
     public void ArrayOfArray_Should_Return_As_Is()
     {
-        var query = @"
+        var query = """
 mutation {
   create(input: {ints: [[1],[2,2],[3,3,3]] })
   {
     ints
   }
 }
-";
-        var expected = @"{
-  ""create"": {
-    ""ints"": [[1],[2,2],[3,3,3]]
+""";
+        var expected = """
+{
+  "create": {
+    "ints": [[1],[2,2],[3,3,3]]
   }
-}";
+}
+""";
         AssertQuerySuccess(query, expected, null);
     }
 }

--- a/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
+++ b/src/GraphQL.Tests/Bugs/BubbleUpTheNullToNextNullable.cs
@@ -8,7 +8,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void Nullable_field_resolve_to_null_should_not_bubble_up_the_null()
     {
         const string QUERY = "{ nullableDataGraph { nullable } }";
-        const string EXPECTED = @"{ ""nullableDataGraph"": { ""nullable"": null } }";
+        const string EXPECTED = """{ "nullableDataGraph": { "nullable": null } }""";
         var data = new Data { Nullable = null };
         var errors = Array.Empty<ExecutionError>();
 
@@ -19,7 +19,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void NonNull_field_resolve_with_non_null_value_should_not_throw_error()
     {
         const string QUERY = "{ nullableDataGraph { nonNullable } }";
-        const string EXPECTED = @"{ ""nullableDataGraph"": { ""nonNullable"": ""data"" } }";
+        const string EXPECTED = """{ "nullableDataGraph": { "nonNullable": "data" } }""";
         var data = new Data { NonNullable = "data" };
         var errors = Array.Empty<ExecutionError>();
 
@@ -30,7 +30,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void NonNull_field_resolve_to_null_should_bubble_up_null_to_parent()
     {
         const string QUERY = "{ nullableDataGraph { nonNullable } }";
-        const string EXPECTED = @"{ ""nullableDataGraph"": null }";
+        const string EXPECTED = """{ "nullableDataGraph": null }""";
         var data = new Data { NonNullable = null };
         var errors = new[]
         {
@@ -48,7 +48,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void NonNull_field_resolve_to_null_should_bubble_up_the_null_to_first_nullable_parent_in_chain_of_nullable()
     {
         const string QUERY = "{ nullableDataGraph { nullableNest { nonNullable } } }";
-        const string EXPECTED = @"{ ""nullableDataGraph"": { ""nullableNest"": null } }";
+        const string EXPECTED = """{ "nullableDataGraph": { "nullableNest": null } }""";
         var data = new Data { NullableNest = new Data { NonNullable = null } };
         var errors = new[]
         {
@@ -66,7 +66,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void NonNull_field_resolve_to_null_should_bubble_up_the_null_to_first_nullable_parent_in_chain_of_non_null_fields()
     {
         const string QUERY = "{ nullableDataGraph { nonNullableNest { nonNullable } } }";
-        const string EXPECTED = @"{ ""nullableDataGraph"": null }";
+        const string EXPECTED = """{ "nullableDataGraph": null }""";
         var data = new Data { NonNullableNest = new Data { NonNullable = null } };
         var errors = new[]
         {
@@ -102,7 +102,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void ListOfNonNull_containing_null_should_bubble_up_the_null()
     {
         const string QUERY = "{ nonNullableDataGraph { listOfNonNullable } }";
-        const string EXPECTED = @"{ ""nonNullableDataGraph"": { ""listOfNonNullable"": null } }";
+        const string EXPECTED = """{ "nonNullableDataGraph": { "listOfNonNullable": null } }""";
         var data = new Data { ListOfStrings = new List<string> { "text", null, null } };
         var errors = new[]
         {
@@ -126,7 +126,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void NonNullList_resolve_to_null_should_bubble_up_the_null()
     {
         const string QUERY = "{ nullableDataGraph { nonNullableList } }";
-        const string EXPECTED = @"{ ""nullableDataGraph"": null }";
+        const string EXPECTED = """{ "nullableDataGraph": null }""";
         var data = new Data { ListOfStrings = null };
         var errors = new[]
         {
@@ -162,7 +162,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void NoNullListOfNonNull_contains_null_should_bubble_up_the_null()
     {
         const string QUERY = "{ nullableDataGraph { nonNullableListOfNonNullable } }";
-        const string EXPECTED = @"{ ""nullableDataGraph"": null }";
+        const string EXPECTED = """{ "nullableDataGraph": null }""";
         var data = new Data { ListOfStrings = new List<string> { "text", null, null } };
         var errors = new[]
         {
@@ -186,7 +186,7 @@ public class BubbleUpTheNullToNextNullable : QueryTestBase<BubbleNullSchema>
     public void NonNullListOfNonNull_resolve_to_null_should_bubble_up_the_null()
     {
         const string QUERY = "{ nullableDataGraph { nonNullableListOfNonNullable } }";
-        const string EXPECTED = @"{ ""nullableDataGraph"": null }";
+        const string EXPECTED = """{ "nullableDataGraph": null }""";
         var data = new Data { ListOfStrings = null };
         var errors = new[]
         {

--- a/src/GraphQL.Tests/Bugs/Bug1046.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1046.cs
@@ -25,13 +25,13 @@ public class Bug1046
         var response = new DocumentExecuter().ExecuteAsync(_ =>
         {
             _.Schema = schema;
-            _.Query = @"
+            _.Query = """
 query {
   inst {
     id
   }
 }
-";
+""";
         }).Result;
         response.Data.ShouldNotBeNull();
     }

--- a/src/GraphQL.Tests/Bugs/Bug1156.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1156.cs
@@ -7,7 +7,7 @@ public class Bug1156 : QueryTestBase<Bug1156Schema>
     [Fact]
     public void duplicated_type_names_should_throw_error()
     {
-        var query = @"
+        var query = """
 {
     type1 {
         field1A
@@ -18,10 +18,11 @@ public class Bug1156 : QueryTestBase<Bug1156Schema>
         field2A
         field2B
     }
-}";
+}
+""";
         var result = AssertQueryWithErrors(query, null, expectedErrorCount: 1, executed: false);
         result.Errors[0].Message.ShouldBe("Error executing document.");
-        result.Errors[0].InnerException.Message.ShouldBe(@"Unable to register GraphType 'Type2' with the name 'MyType'. The name 'MyType' is already registered to 'Type1'. Check your schema configuration.");
+        result.Errors[0].InnerException.Message.ShouldBe("Unable to register GraphType 'Type2' with the name 'MyType'. The name 'MyType' is already registered to 'Type1'. Check your schema configuration.");
     }
 }
 

--- a/src/GraphQL.Tests/Bugs/Bug118SpacesInTypeNameTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug118SpacesInTypeNameTests.cs
@@ -7,13 +7,13 @@ public class Bug118SpacesInTypeNameTests : QueryTestBase<MutationSchema>
     [Fact]
     public void supports_partially_nullable_inputs_when_parent_non_null()
     {
-        var inputs = @"{ ""input_0"": { ""id"": ""123"", ""foo"": null, ""bar"": null } }".ToInputs();
-        var query = @"
+        var inputs = """{ "input_0": { "id": "123", "foo": null, "bar": null } }""".ToInputs();
+        var query = """
 mutation M($input_0: MyInput!) {
   run(input: $input_0)
 }
-";
-        var expected = @"{ ""run"": ""123"" }";
+""";
+        var expected = """{ "run": "123" }""";
         AssertQuerySuccess(query, expected, inputs);
     }
 }

--- a/src/GraphQL.Tests/Bugs/Bug1205VeryLongInt.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1205VeryLongInt.cs
@@ -50,9 +50,11 @@ public class Bug1205VeryLongInt : QueryTestBase<Bug1205VeryLongIntSchema>
     public void Very_Long_Number_Should_Return_As_Is_For_Long()
     {
         var query = "{ long }";
-        var expected = @"{
-  ""long"": 636474637870330463
-}";
+        var expected = """
+{
+  "long": 636474637870330463
+}
+""";
         AssertQuerySuccess(query, expected);
     }
 
@@ -60,9 +62,11 @@ public class Bug1205VeryLongInt : QueryTestBase<Bug1205VeryLongIntSchema>
     public void Very_Long_Number_In_Input_Should_Work_For_Long()
     {
         var query = "{ long_with_arg(in:636474637870330463) }";
-        var expected = @"{
-  ""long_with_arg"": 636474637870330463
-}";
+        var expected = """
+{
+  "long_with_arg": 636474637870330463
+}
+""";
         AssertQuerySuccess(query, expected);
     }
 
@@ -106,9 +110,11 @@ public class Bug1205VeryLongInt : QueryTestBase<Bug1205VeryLongIntSchema>
     public void Very_Very_Long_Number_Should_Return_As_Is_For_BigInteger()
     {
         var query = "{ bigint }";
-        var expected = @"{
-  ""bigint"": 636474637870330463636474637870330463636474637870330463
-}";
+        var expected = """
+{
+  "bigint": 636474637870330463636474637870330463636474637870330463
+}
+""";
         AssertQuerySuccess(query, expected);
     }
 
@@ -116,9 +122,11 @@ public class Bug1205VeryLongInt : QueryTestBase<Bug1205VeryLongIntSchema>
     public void Very__Very_Long_Number_In_Input_Should_Work_For_BigInteger()
     {
         var query = "{ bigint_with_arg(in:636474637870330463636474637870330463636474637870330463) }";
-        var expected = @"{
-  ""bigint_with_arg"": 636474637870330463636474637870330463636474637870330463
-}";
+        var expected = """
+{
+  "bigint_with_arg": 636474637870330463636474637870330463636474637870330463
+}
+""";
         AssertQuerySuccess(query, expected);
     }
 }

--- a/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug138DecimalPrecisionTests.cs
@@ -11,13 +11,13 @@ public class Bug138DecimalPrecisionTests : QueryTestBase<DecimalSchema>
 #endif
     public void double_to_decimal_does_not_lose_precision()
     {
-        var query = @"
+        var query = """
                 mutation SetState{
                     set(request:24.15)
                 }
-            ";
+            """;
 
-        var expected = @"{ ""set"": 24.15 }";
+        var expected = """{ "set": 24.15 }""";
 
         AssertQuerySuccess(query, expected);
     }

--- a/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1699InvalidEnum.cs
@@ -28,105 +28,105 @@ public class Bug1699InvalidEnum : QueryTestBase<Bug1699InvalidEnumSchema>
     }
 
     [Fact]
-    public void Simple_Enum() => AssertQuerySuccess("{ grumpy }", @"{ ""grumpy"": ""GRUMPY"" }");
+    public void Simple_Enum() => AssertQuerySuccess("{ grumpy }", """{ "grumpy": "GRUMPY" }""");
 
     [Fact]
-    public void Enum_From_Number() => AssertQuerySuccess("{ enumByNumber }", @"{ ""enumByNumber"": ""HAPPY"" }");
+    public void Enum_From_Number() => AssertQuerySuccess("{ enumByNumber }", """{ "enumByNumber": "HAPPY" }""");
 
     [Fact]
-    public void Custom_Enum_Numbered_From_Name() => AssertQuerySuccess("{ customEnumSleepy }", @"{ ""customEnumSleepy"": ""ISSLEEPY"" }");
+    public void Custom_Enum_Numbered_From_Name() => AssertQuerySuccess("{ customEnumSleepy }", """{ "customEnumSleepy": "ISSLEEPY" }""");
 
     [Fact]
-    public void String_Enum() => AssertQueryWithError("{ sleepy }", @"{ ""sleepy"": null }", "Error trying to resolve field 'sleepy'.", 1, 3, "sleepy", exception: new InvalidOperationException());
+    public void String_Enum() => AssertQueryWithError("{ sleepy }", """{ "sleepy": null }""", "Error trying to resolve field 'sleepy'.", 1, 3, "sleepy", exception: new InvalidOperationException());
 
     [Fact]
-    public void Int_Enum() => AssertQuerySuccess("{ happy }", @"{ ""happy"": ""HAPPY"" }");
+    public void Int_Enum() => AssertQuerySuccess("{ happy }", """{ "happy": "HAPPY" }""");
 
     [Fact]
-    public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", @"{ ""invalidEnum"": null }", "Error trying to resolve field 'invalidEnum'.", 1, 3, "invalidEnum", exception: new InvalidOperationException());
+    public void Invalid_Enum() => AssertQueryWithError("{ invalidEnum }", """{ "invalidEnum": null }""", "Error trying to resolve field 'invalidEnum'.", 1, 3, "invalidEnum", exception: new InvalidOperationException());
 
     // TODO: does not yet fully meet spec (does not return members of the enum that are able to be serialized, with nulls and individual errors for unserializable values)
     [Fact]
-    public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", @"{ ""invalidEnumWithinList"": [ ""HAPPY"", ""SLEEPY"", null ] }", "Error trying to resolve field 'invalidEnumWithinList'.", 1, 3, new object[] { "invalidEnumWithinList", 2 }, exception: new InvalidOperationException());
+    public void Invalid_Enum_Within_List() => AssertQueryWithError("{ invalidEnumWithinList }", """{ "invalidEnumWithinList": [ "HAPPY", "SLEEPY", null ] }""", "Error trying to resolve field 'invalidEnumWithinList'.", 1, 3, new object[] { "invalidEnumWithinList", 2 }, exception: new InvalidOperationException());
 
     [Fact]
-    public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", @"{ ""invalidEnumWithinNonNullList"": null }", "Error trying to resolve field 'invalidEnumWithinNonNullList'.", 1, 3, new object[] { "invalidEnumWithinNonNullList", 2 }, exception: new InvalidOperationException());
+    public void Invalid_Enum_Within_NonNullList() => AssertQueryWithError("{ invalidEnumWithinNonNullList }", """{ "invalidEnumWithinNonNullList": null }""", "Error trying to resolve field 'invalidEnumWithinNonNullList'.", 1, 3, new object[] { "invalidEnumWithinNonNullList", 2 }, exception: new InvalidOperationException());
 
     [Fact]
-    public void Input_EnumList() => AssertQuerySuccess("{ inputList(arg: [SLEEPY]) }", @"{ ""inputList"": ""Sleepy"" }");
+    public void Input_EnumList() => AssertQuerySuccess("{ inputList(arg: [SLEEPY]) }", """{ "inputList": "Sleepy" }""");
 
     [Fact]
-    public void Input_EnumList_Variable() => AssertQuerySuccess("query($arg: [Bug1699Enum]) { inputList(arg: $arg) }", @"{ ""inputList"": ""Sleepy"" }", @"{""arg"":[""SLEEPY""]}".ToInputs());
+    public void Input_EnumList_Variable() => AssertQuerySuccess("query($arg: [Bug1699Enum]) { inputList(arg: $arg) }", """{ "inputList": "Sleepy" }""", """{"arg":["SLEEPY"]}""".ToInputs());
 
     [Fact]
-    public void Input_CustomEnumList() => AssertQuerySuccess("query($arg: [Bug1699CustomEnum]) { inputListCustom(arg: $arg) }", @"{ ""inputListCustom"": ""ISDOPEY"" }", @"{""arg"":[""ISDOPEY""]}".ToInputs());
+    public void Input_CustomEnumList() => AssertQuerySuccess("query($arg: [Bug1699CustomEnum]) { inputListCustom(arg: $arg) }", """{ "inputListCustom": "ISDOPEY" }""", """{"arg":["ISDOPEY"]}""".ToInputs());
 
     [Fact]
-    public void Input_Enum_Valid() => AssertQuerySuccess("{ inputEnum(arg: SLEEPY) }", @"{ ""inputEnum"": ""SLEEPY"" }");
+    public void Input_Enum_Valid() => AssertQuerySuccess("{ inputEnum(arg: SLEEPY) }", """{ "inputEnum": "SLEEPY" }""");
 
     [Fact]
-    public void Input_Enum_Valid2() => AssertQuerySuccess("{ input(arg: SLEEPY) }", @"{ ""input"": ""Sleepy"" }");
+    public void Input_Enum_Valid2() => AssertQuerySuccess("{ input(arg: SLEEPY) }", """{ "input": "Sleepy" }""");
 
     [Fact]
     public void Input_Enum_InvalidEnum() => AssertQueryWithError("{ input(arg: DOPEY) }", null, "Argument \u0027arg\u0027 has invalid value. Expected type \u0027Bug1699Enum\u0027, found DOPEY.", 1, 9, null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
 
     [Fact]
-    public void Input_Enum_InvalidString() => AssertQueryWithError(@"{ input(arg: ""SLEEPY"") }", null, "Argument \u0027arg\u0027 has invalid value. Expected type \u0027Bug1699Enum\u0027, found \u0022SLEEPY\u0022.", 1, 9, null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
+    public void Input_Enum_InvalidString() => AssertQueryWithError("""{ input(arg: "SLEEPY") }""", null, "Argument \u0027arg\u0027 has invalid value. Expected type \u0027Bug1699Enum\u0027, found \u0022SLEEPY\u0022.", 1, 9, null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
 
     [Fact]
-    public void Input_Enum_InvalidInt() => AssertQueryWithError(@"{ input(arg: 2) }", null, "Argument \u0027arg\u0027 has invalid value. Expected type \u0027Bug1699Enum\u0027, found 2.", 1, 9, null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
+    public void Input_Enum_InvalidInt() => AssertQueryWithError("{ input(arg: 2) }", null, "Argument \u0027arg\u0027 has invalid value. Expected type \u0027Bug1699Enum\u0027, found 2.", 1, 9, null, code: "ARGUMENTS_OF_CORRECT_TYPE", number: ArgumentsOfCorrectTypeError.NUMBER, executed: false);
 
     [Fact]
-    public void Input_Enum_Valid_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum!) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", "{\"arg\":\"GRUMPY\"}".ToInputs());
+    public void Input_Enum_Valid_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum!) { input(arg: $arg) }", """{ "input": "Grumpy" }""", """{"arg":"GRUMPY"}""".ToInputs());
 
     [Fact]
-    public void Input_Enum_Valid_Default_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum = GRUMPY) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", null);
+    public void Input_Enum_Valid_Default_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum = GRUMPY) { input(arg: $arg) }", """{ "input": "Grumpy" }""", null);
 
     [Fact]
-    public void Input_Enum_Valid_Default_Required_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum! = GRUMPY) { input(arg: $arg) }", @"{ ""input"": ""Grumpy"" }", null);
+    public void Input_Enum_Valid_Default_Required_Variable() => AssertQuerySuccess("query($arg: Bug1699Enum! = GRUMPY) { input(arg: $arg) }", """{ "input": "Grumpy" }""", null);
 
     [Fact]
-    public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 1, 7, null, exception: new InvalidOperationException(), code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}", number: "5.8", executed: false);
+    public void Input_Enum_InvalidEnum_Variable() => AssertQueryWithError("query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u0027DOPEY\u0027 to \u0027Bug1699Enum\u0027", 1, 7, null, exception: new InvalidOperationException(), code: "INVALID_VALUE", inputs: "{\"arg\":\"DOPEY\"}", number: "5.8", executed: false);
 
     [Fact]
-    public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError(@"query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 1, 7, null, exception: new InvalidOperationException(), code: "INVALID_VALUE", inputs: "{\"arg\":2}", number: "5.8", executed: false);
+    public void Input_Enum_InvalidInt_Variable() => AssertQueryWithError("query($arg: Bug1699Enum!) { input(arg: $arg) }", null, "Variable \u0027$arg\u0027 is invalid. Unable to convert \u00272\u0027 to \u0027Bug1699Enum\u0027", 1, 7, null, exception: new InvalidOperationException(), code: "INVALID_VALUE", inputs: "{\"arg\":2}", number: "5.8", executed: false);
 
     [Fact]
-    public void Input_Enum_UndefinedDefault() => AssertQuerySuccess("{ input }", @"{ ""input"": ""Grumpy"" }");
+    public void Input_Enum_UndefinedDefault() => AssertQuerySuccess("{ input }", """{ "input": "Grumpy" }""");
 
     [Fact]
-    public void Input_Enum_SetDefault() => AssertQuerySuccess("{ inputWithDefault }", @"{ ""inputWithDefault"": ""Happy"" }");
+    public void Input_Enum_SetDefault() => AssertQuerySuccess("{ inputWithDefault }", """{ "inputWithDefault": "Happy" }""");
 
     [Fact]
-    public void Input_Enum_OverrideDefault() => AssertQuerySuccess("{ inputWithDefault(arg: SLEEPY) }", @"{ ""inputWithDefault"": ""Sleepy"" }");
+    public void Input_Enum_OverrideDefault() => AssertQuerySuccess("{ inputWithDefault(arg: SLEEPY) }", """{ "inputWithDefault": "Sleepy" }""");
 
     // For non-nullable struct types, GetArgument coerces null to default(T), which is Grumpy
     [Fact]
-    public void Input_Enum_NullDefault() => AssertQuerySuccess("{ inputWithDefault(arg: null) }", @"{ ""inputWithDefault"": ""Grumpy"" }");
+    public void Input_Enum_NullDefault() => AssertQuerySuccess("{ inputWithDefault(arg: null) }", """{ "inputWithDefault": "Grumpy" }""");
 
     [Fact]
-    public void Input_Enum_NullDefault_Nullable() => AssertQuerySuccess("{ inputWithDefaultNullable(arg: null) }", @"{ ""inputWithDefaultNullable"": null }");
+    public void Input_Enum_NullDefault_Nullable() => AssertQuerySuccess("{ inputWithDefaultNullable(arg: null) }", """{ "inputWithDefaultNullable": null }""");
 
     [Fact]
-    public void Input_Enum_MissingRequired() => AssertQueryWithError(@"{ inputRequired }", null, "Argument \u0027arg\u0027 of type \u0027Bug1699Enum!\u0027 is required for field \u0027inputRequired\u0027 but not provided.", 1, 3, null, code: "PROVIDED_NON_NULL_ARGUMENTS", number: ProvidedNonNullArgumentsError.NUMBER, executed: false);
+    public void Input_Enum_MissingRequired() => AssertQueryWithError("{ inputRequired }", null, "Argument \u0027arg\u0027 of type \u0027Bug1699Enum!\u0027 is required for field \u0027inputRequired\u0027 but not provided.", 1, 3, null, code: "PROVIDED_NON_NULL_ARGUMENTS", number: ProvidedNonNullArgumentsError.NUMBER, executed: false);
 
     [Fact]
-    public void Input_Enum_RequiredWithDefault() => AssertQuerySuccess("{ inputRequiredWithDefault }", @"{ ""inputRequiredWithDefault"": ""Happy"" }");
+    public void Input_Enum_RequiredWithDefault() => AssertQuerySuccess("{ inputRequiredWithDefault }", """{ "inputRequiredWithDefault": "Happy" }""");
 
     [Fact]
-    public void Custom_Enum() => AssertQuerySuccess("{ customEnum }", @"{ ""customEnum"": ""ISHAPPY"" }");
+    public void Custom_Enum() => AssertQuerySuccess("{ customEnum }", """{ "customEnum": "ISHAPPY" }""");
 
     [Fact]
-    public void Custom_Enum_Input() => AssertQuerySuccess("{ customEnumInput (arg: ISHAPPY) }", @"{ ""customEnumInput"": ""Happy"" }");
+    public void Custom_Enum_Input() => AssertQuerySuccess("{ customEnumInput (arg: ISHAPPY) }", """{ "customEnumInput": "Happy" }""");
 
     [Fact]
-    public void Custom_Enum_Input_Variable() => AssertQuerySuccess("query($arg: Bug1699CustomEnum!) { customEnumInput (arg: $arg) }", @"{ ""customEnumInput"": ""Happy"" }", @"{ ""arg"": ""ISHAPPY"" }".ToInputs());
+    public void Custom_Enum_Input_Variable() => AssertQuerySuccess("query($arg: Bug1699CustomEnum!) { customEnumInput (arg: $arg) }", """{ "customEnumInput": "Happy" }""", """{ "arg": "ISHAPPY" }""".ToInputs());
 
     [Fact]
-    public void Custom_Enum_Input_Num() => AssertQuerySuccess("{ customEnumInput (arg: ISSLEEPY) }", @"{ ""customEnumInput"": ""Sleepy"" }");
+    public void Custom_Enum_Input_Num() => AssertQuerySuccess("{ customEnumInput (arg: ISSLEEPY) }", """{ "customEnumInput": "Sleepy" }""");
 
     [Fact]
-    public void Custom_Enum_Input_Num_Variable() => AssertQuerySuccess("query($arg: Bug1699CustomEnum!) { customEnumInput (arg: $arg) }", @"{ ""customEnumInput"": ""Sleepy"" }", @"{ ""arg"": ""ISSLEEPY"" }".ToInputs());
+    public void Custom_Enum_Input_Num_Variable() => AssertQuerySuccess("query($arg: Bug1699CustomEnum!) { customEnumInput (arg: $arg) }", """{ "customEnumInput": "Sleepy" }""", """{ "arg": "ISSLEEPY" }""".ToInputs());
 }
 
 public class Bug1699InvalidEnumSchema : Schema

--- a/src/GraphQL.Tests/Bugs/Bug1767InvalidByte.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1767InvalidByte.cs
@@ -30,10 +30,10 @@ public class Bug1767InvalidByte : QueryTestBase<Bug1767Schema>
     }
 
     [Fact]
-    public void Input_Byte_Valid_Variable() => AssertQuerySuccess("query($arg: Byte!) { input(arg: $arg) }", @"{ ""input"": ""2"" }", "{\"arg\":2}".ToInputs());
+    public void Input_Byte_Valid_Variable() => AssertQuerySuccess("query($arg: Byte!) { input(arg: $arg) }", """{ "input": "2" }""", """{"arg":2}""".ToInputs());
 
     [Fact]
-    public void Input_Byte_Valid_Argument() => AssertQuerySuccess("query { input(arg: 2) }", @"{ ""input"": ""2"" }", "{\"arg\":2}".ToInputs());
+    public void Input_Byte_Valid_Argument() => AssertQuerySuccess("query { input(arg: 2) }", """{ "input": "2" }""", """{"arg":2}""".ToInputs());
 
     [Fact]
     public void Input_Byte_Invalid_Variable() => AssertQueryWithError("query($arg: Byte!) { input(arg: $arg) }", null, "Variable '$arg' is invalid. Unable to convert '300' to 'Byte'", 1, 7, null, new OverflowException(), "INVALID_VALUE", "{\"arg\":300}", "5.8", executed: false);

--- a/src/GraphQL.Tests/Bugs/Bug1831.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1831.cs
@@ -9,10 +9,10 @@ namespace GraphQL.Tests.Bugs;
 public class Bug1831 : QueryTestBase<Bug1831Schema>
 {
     [Fact]
-    public void TestVariableObject() => AssertQuerySuccess("query($arg: Bug1831Input!) { test1 (arg: $arg) }", @"{ ""test1"": ""ok"" }", @"{ ""arg"": { ""id"": ""id"", ""rows"": [{""id"": ""id1"", ""name"": ""name1""}, {""id"": ""id2"", ""name"": ""name2""}]} }".ToInputs());
+    public void TestVariableObject() => AssertQuerySuccess("query($arg: Bug1831Input!) { test1 (arg: $arg) }", """{ "test1": "ok" }""", """{ "arg": { "id": "id", "rows": [{"id": "id1", "name": "name1"}, {"id": "id2", "name": "name2"}]} }""".ToInputs());
 
     [Fact]
-    public void TestLiteralObject() => AssertQuerySuccess("{ test1 (arg: { id: \"id\", rows: [ {id: \"id1\", name: \"name1\"}, {id: \"id2\", name: \"name2\"}]}) }", @"{ ""test1"": ""ok"" }");
+    public void TestLiteralObject() => AssertQuerySuccess("""{ test1 (arg: { id: "id", rows: [ {id: "id1", name: "name1"}, {id: "id2", name: "name2"}]}) }""", """{ "test1": "ok" }""");
 
     [Theory]
     [InlineData("null")]

--- a/src/GraphQL.Tests/Bugs/Bug1889.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1889.cs
@@ -7,8 +7,8 @@ public class Bug1889WithCovariant : QueryTestBase<CovariantSchema>
     [Fact]
     public void supports_covariant_schemas()
     {
-        string query = @"query { a { r { value } } }";
-        string expected = @"{ ""a"": { ""r"": { ""value"": ""spec"" } } }";
+        string query = "query { a { r { value } } }";
+        string expected = """{ "a": { "r": { "value": "spec" } } }""";
 
         AssertQuerySuccess(query, expected);
     }

--- a/src/GraphQL.Tests/Bugs/Bug2159.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2159.cs
@@ -6,49 +6,49 @@ namespace GraphQL.Tests.Bugs;
 public class Bug2159 : QueryTestBase<Bug2159Schema>
 {
     [Fact]
-    public void Direct_Literal_Default() => AssertQuerySuccess("{ testValue }", @"{ ""testValue"": ""defaultValue"" }");
+    public void Direct_Literal_Default() => AssertQuerySuccess("{ testValue }", """{ "testValue": "defaultValue" }""");
 
     [Fact]
-    public void Direct_Literal_Specified() => AssertQuerySuccess("{ testValue(arg: \"hello\") }", @"{ ""testValue"": ""hello"" }");
+    public void Direct_Literal_Specified() => AssertQuerySuccess("""{ testValue(arg: "hello") }""", """{ "testValue": "hello" }""");
 
     [Fact]
-    public void Direct_Literal_Null() => AssertQuerySuccess("{ testValue(arg: null) }", @"{ ""testValue"": null }");
+    public void Direct_Literal_Null() => AssertQuerySuccess("{ testValue(arg: null) }", """{ "testValue": null }""");
 
     [Fact]
-    public void Direct_Variable_FieldDefault() => AssertQuerySuccess("query($input: String) { testValue(arg: $input) }", @"{ ""testValue"": ""defaultValue"" }");
+    public void Direct_Variable_FieldDefault() => AssertQuerySuccess("query($input: String) { testValue(arg: $input) }", """{ "testValue": "defaultValue" }""");
 
     [Fact]
-    public void Direct_Variable_VarDefault() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", @"{ ""testValue"": ""varDefault"" }");
+    public void Direct_Variable_VarDefault() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", """{ "testValue": "varDefault" }""");
 
     [Fact]
-    public void Direct_Variable_Specified() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", @"{ ""testValue"": ""hello"" }", "{\"input\":\"hello\"}".ToInputs());
+    public void Direct_Variable_Specified() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", """{ "testValue": "hello" }""", """{"input":"hello"}""".ToInputs());
 
     [Fact]
-    public void Direct_Variable_Null() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", @"{ ""testValue"": null }", "{\"input\":null}".ToInputs());
+    public void Direct_Variable_Null() => AssertQuerySuccess("query($input: String = \"varDefault\") { testValue(arg: $input) }", """{ "testValue": null }""", """{"input":null}""".ToInputs());
 
     [Fact]
-    public void Object_Literal_Default() => AssertQuerySuccess("{ testObject }", @"{ ""testObject"": ""defaultValue"" }");
+    public void Object_Literal_Default() => AssertQuerySuccess("{ testObject }", """{ "testObject": "defaultValue" }""");
 
     [Fact]
-    public void Object_Literal_Specified() => AssertQuerySuccess("{ testObject(arg: {value:\"hello\"}) }", @"{ ""testObject"": ""hello"" }");
+    public void Object_Literal_Specified() => AssertQuerySuccess("""{ testObject(arg: {value:"hello"}) }""", """{ "testObject": "hello" }""");
 
     [Fact]
-    public void Object_Literal_Null() => AssertQuerySuccess("{ testObject(arg: {value:null}) }", @"{ ""testObject"": null }");
+    public void Object_Literal_Null() => AssertQuerySuccess("{ testObject(arg: {value:null}) }", """{ "testObject": null }""");
 
     [Fact]
-    public void Object_Variable_Default() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", @"{ ""testObject"": ""defaultFieldValue"" }", "{\"input\":{}}".ToInputs());
+    public void Object_Variable_Default() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", """{ "testObject": "defaultFieldValue" }""", """{"input":{}}""".ToInputs());
 
     [Fact]
-    public void Object_Variable_Specified() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", @"{ ""testObject"": ""hello"" }", "{\"input\":{\"value\":\"hello\"}}".ToInputs());
+    public void Object_Variable_Specified() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", """{ "testObject": "hello" }""", "{\"input\":{\"value\":\"hello\"}}".ToInputs());
 
     [Fact]
-    public void Object_Variable_Null() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", @"{ ""testObject"": null }", "{\"input\":{\"value\":null}}".ToInputs());
+    public void Object_Variable_Null() => AssertQuerySuccess("query($input: Bug2159Object) { testObject(arg: $input) }", """{ "testObject": null }""", """{"input":{"value":null}}""".ToInputs());
 
     [Fact]
-    public void HasArgument_NoDefault_None() => AssertQuerySuccess("{ hasArgumentNoDefault }", @"{ ""hasArgumentNoDefault"": false }");
+    public void HasArgument_NoDefault_None() => AssertQuerySuccess("{ hasArgumentNoDefault }", """{ "hasArgumentNoDefault": false }""");
 
     [Fact]
-    public void HasArgument_NoDefault_UnsetVariable() => AssertQuerySuccess("query($input: Boolean) { hasArgumentNoDefault(arg: $input) }", @"{ ""hasArgumentNoDefault"": false }");
+    public void HasArgument_NoDefault_UnsetVariable() => AssertQuerySuccess("query($input: Boolean) { hasArgumentNoDefault(arg: $input) }", """{ "hasArgumentNoDefault": false }""");
 
     [Fact]
     public void HasArgument_NoDefault_Set() => AssertQuerySuccess("{ hasArgumentNoDefault(arg: true) }", @"{ ""hasArgumentNoDefault"": true }");

--- a/src/GraphQL.Tests/Bugs/Bug2509.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2509.cs
@@ -8,19 +8,21 @@ public class RecordTest : QueryTestBase<RecordSchema>
     [Fact]
     public void Record_Should_Return_As_Is()
     {
-        var query = @"
+        var query = """
 {
   search(input: {})
   {
     id
   }
 }
-";
-        var expected = @"{
-  ""search"": {
-    ""id"": null
+""";
+        var expected = """
+{
+  "search": {
+    "id": null
   }
-}";
+}
+""";
         AssertQuerySuccess(query, expected, null);
     }
 }

--- a/src/GraphQL.Tests/Bugs/Bug2553.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2553.cs
@@ -21,17 +21,19 @@ public class Bug2553
         var writer = new GraphQLSerializer(options);
         string json = writer.Serialize(executionResult);
 
-        json.ShouldBeCrossPlatJson(@"{
-                ""errors"": [{
-                    ""message"":""An error occurred."",
-                    ""extensions"": {
-                        ""violations"": {
-                            ""message"":""An error occurred on field Email."",
-                            ""field"":""Email""
+        json.ShouldBeCrossPlatJson("""
+            {
+                "errors": [{
+                    "message":"An error occurred.",
+                    "extensions": {
+                        "violations": {
+                            "message":"An error occurred on field Email.",
+                            "field":"Email"
                         }
                     }
                 }]
-            }");
+            }
+            """);
     }
 }
 

--- a/src/GraphQL.Tests/Bugs/Bug271DateTimeInStringGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug271DateTimeInStringGraphTypeTests.cs
@@ -7,9 +7,9 @@ public class Bug271DateTimeInStringGraphTypeTests : QueryTestBase<VariablesSchem
     [Fact]
     public void supports_date_inputs_inside_string_fields()
     {
-        var query = @"query q($input: TestInputObject) { fieldWithObjectInput(input: $input) }";
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"a\\\":\\\"2017-01-27T15:19:53.000Z\\\",\\\"b\\\":[\\\"bar\\\"],\\\"c\\\":\\\"baz\\\"}\" }";
-        var inputs = @"{ ""input"": { ""a"": ""2017-01-27T15:19:53.000Z"", ""b"": [""bar""], ""c"": ""baz""} }".ToInputs();
+        var query = "query q($input: TestInputObject) { fieldWithObjectInput(input: $input) }";
+        var expected = """{ "fieldWithObjectInput": "{\"a\":\"2017-01-27T15:19:53.000Z\",\"b\":[\"bar\"],\"c\":\"baz\"}" }""";
+        var inputs = """{ "input": { "a": "2017-01-27T15:19:53.000Z", "b": ["bar"], "c": "baz"} }""".ToInputs();
         AssertQuerySuccess(query, expected, inputs);
     }
 }

--- a/src/GraphQL.Tests/Bugs/Bug2839NewtonsoftJson.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2839NewtonsoftJson.cs
@@ -38,7 +38,7 @@ public class Bug2839NewtonsoftJson
         });
 
         var str = writer.Serialize(result);
-        str.ShouldBeCrossPlatJson("{\"data\":{\"test\":{\"this-is-a-string\":\"String Value\",\"this-is-a-date-time\":\"2022-Jan-04\"}}}");
+        str.ShouldBeCrossPlatJson("""{"data":{"test":{"this-is-a-string":"String Value","this-is-a-date-time":"2022-Jan-04"}}}""");
     }
 
     public class TestQuery : ObjectGraphType

--- a/src/GraphQL.Tests/Bugs/Bug2839SystemTextJson.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2839SystemTextJson.cs
@@ -30,7 +30,7 @@ public class Bug2839SystemTextJson
         });
 
         var str = writer.Serialize(result);
-        str.ShouldBeCrossPlatJson("{\"data\":{\"TEST\":{\"THISISASTRING\":\"String Value\",\"THISISADATETIME\":\"2022-Jan-04\"}}}");
+        str.ShouldBeCrossPlatJson("""{"data":{"TEST":{"THISISASTRING":"String Value","THISISADATETIME":"2022-Jan-04"}}}""");
     }
 
     public class TestQuery : ObjectGraphType

--- a/src/GraphQL.Tests/Bugs/Bug2958DecimalPrecisionTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug2958DecimalPrecisionTests.cs
@@ -20,15 +20,17 @@ public class Bug2958DecimalPrecisionTests : QueryTestBase<DecimalSchema>
     [ClassData(typeof(Bug2958DecimalPrecisionTestData))]
     public void double_to_decimal_does_not_lose_precision(IGraphQLTextSerializer serializer)
     {
-        string request = @"{
-""operationName"": ""TestMutation"",
-""variables"": {
-  ""input"": {
-    ""discount"": 12345678901234.56
+        string request = """
+{
+  "operationName": "TestMutation",
+  "variables": {
+  "input": {
+    "discount": 12345678901234.56
     }
-},
-""query"": ""mutation TestMutation($input: MutationType!)""
-}";
+  },
+  "query": "mutation TestMutation($input: MutationType!)"
+}
+""";
 
         var inputs = serializer.Deserialize<GraphQLRequest>(request);
         inputs.Variables.ShouldNotBeNull();

--- a/src/GraphQL.Tests/Bugs/Bug3100.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3100.cs
@@ -31,7 +31,7 @@ public class Bug3100
         var actual = serializer.Serialize(result);
 
         // verify the result
-        actual.ShouldBe(@"{""data"":{""class2"":[{""id"":""test""}]}}");
+        actual.ShouldBe("""{"data":{"class2":[{"id":"test"}]}}""");
     }
 
     private class MyAutoGraphType<T> : AutoRegisteringObjectGraphType<T>

--- a/src/GraphQL.Tests/Bugs/Bug3194.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3194.cs
@@ -8,8 +8,7 @@ public class Bug3194
     [Fact]
     public async Task InheritedMethodsWork()
     {
-        var schema = Schema.For(
-            @"
+        var schema = Schema.For("""
 schema {
   query: Query
 }
@@ -18,7 +17,7 @@ type Query {
   hello: String!    # test inherited method
   hello2: String!   # test inherited property
 }
-",
+""",
             c => c.Types.Include(typeof(QueryType)));
         schema.Initialize();
         var queryType = schema.AllTypes["Query"].ShouldBeAssignableTo<IComplexGraphType>();

--- a/src/GraphQL.Tests/Bugs/Bug956.cs
+++ b/src/GraphQL.Tests/Bugs/Bug956.cs
@@ -9,8 +9,8 @@ public class Bug956 : QueryTestBase<Bug956Schema>
     [Fact]
     public void base64_should_Convert_to_binary()
     {
-        var query = @"{ get(base64: ""R3JhcGhRTCE="") }";
-        AssertQuerySuccess(query, @"{""get"": ""R3JhcGhRTCE=""}");
+        var query = """{ get(base64: "R3JhcGhRTCE=") }""";
+        AssertQuerySuccess(query, """{"get": "R3JhcGhRTCE="}""");
     }
 }
 

--- a/src/GraphQL.Tests/Bugs/BugAliasedInputFieldInList.cs
+++ b/src/GraphQL.Tests/Bugs/BugAliasedInputFieldInList.cs
@@ -12,7 +12,7 @@ public class BugAliasedInputFieldInList : QueryTestBase<AliasedInputFieldSchema>
                 multipleEntities: [{ aField: 3 fieldAlias: 4 }]
             ) }";
 
-        string expected = @"{ ""mutateMyEntity"": true }";
+        string expected = """{ "mutateMyEntity": true }""";
 
         AssertQuerySuccess(query, expected, null);
     }

--- a/src/GraphQL.Tests/Bugs/BugNestedCollection.cs
+++ b/src/GraphQL.Tests/Bugs/BugNestedCollection.cs
@@ -7,27 +7,28 @@ public class Bug850MutationAlias : QueryTestBase<NestedMutationSchema>
     [Fact]
     public void supports_nested_objects()
     {
-        var inputs =
-           @"{  ""program"":
-                    {   ""name"": ""TEST Program"",
-                        ""modifiedBy"": ""TEST"",
-                        ""isActive"": true,
-                        ""description"": ""Testing from graphql explorer"",
-                        ""messageNamespace"": ""http://foo.bar"",
-                        ""messageRoot"": ""Foo"",
-                        ""steps"": [
-                                    { ""programStepDefinitionId"": 1,
-                                      ""sequenceOrder"": 1,
-                                      ""properties"": [ {""stepPropertyId"": 1, ""propertyValue"": ""60"" } ] },
-                                    { ""programStepDefinitionId"": 2,
-                                      ""sequenceOrder"": 2,
-                                      ""properties"": [] }
-                        ]  }}"
+        var inputs = """
+{  "program":
+    {   "name": "TEST Program",
+        "modifiedBy": "TEST",
+        "isActive": true,
+        "description": "Testing from graphql explorer",
+        "messageNamespace": "http://foo.bar",
+        "messageRoot": "Foo",
+        "steps": [
+                    { "programStepDefinitionId": 1,
+                        "sequenceOrder": 1,
+                        "properties": [ {"stepPropertyId": 1, "propertyValue": "60" } ] },
+                    { "programStepDefinitionId": 2,
+                        "sequenceOrder": 2,
+                        "properties": [] }
+        ]  }}
+"""
                 .ToInputs();
 
         string query = @"mutation createProgram($program: ProgramInput!) { createProgram(program: $program) }";
 
-        string expected = @"{ ""createProgram"": true }";
+        string expected = """{ "createProgram": true }""";
 
         AssertQuerySuccess(query, expected, inputs);
     }

--- a/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
+++ b/src/GraphQL.Tests/Bugs/Bug_nested_type_names_dont_conflict.cs
@@ -13,13 +13,13 @@ public class Bug_nested_type_names_dont_conflict :
 
         try
         {
-            var inputs = @"{ ""input_0"": { ""id"": ""123""} }".ToInputs();
-            var query = @"
+            var inputs = """{ "input_0": { "id": "123"} }""".ToInputs();
+            var query = """
 mutation M($input_0: Bug_nested_type_names_dont_conflict_MyInputClass_MyInput!) {
   run(input: $input_0)
 }
-";
-            var expected = @"{ ""run"": ""123"" }";
+""";
+            var expected = """{ "run": "123" }""";
             AssertQuerySuccess(query, expected, inputs);
         }
         finally

--- a/src/GraphQL.Tests/Bugs/Issue1004.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1004.cs
@@ -7,9 +7,9 @@ public class Issue1004 : QueryTestBase<DescriptionFromInterfaceSchema>
     [Fact]
     public void Should_Return_Field_Description_From_Interface_If_Not_Overridden()
     {
-        var query = @"
+        var query = """
 {
-  __type(name: ""Query"")
+  __type(name: "Query")
   {
     fields
     {
@@ -17,22 +17,24 @@ public class Issue1004 : QueryTestBase<DescriptionFromInterfaceSchema>
     }
   }
 }
-";
-        var expected = @"{
-  ""__type"": {
-    ""fields"": [
+""";
+        var expected = """
+{
+  "__type": {
+    "fields": [
       {
-        ""description"": ""Very important field1""
+        "description": "Very important field1"
       },
       {
-        ""description"": ""Not so important""
+        "description": "Not so important"
       },
       {
-        ""description"": null
+        "description": null
       }
     ]
   }
-}";
+}
+""";
         AssertQuerySuccess(query, expected, null);
     }
 }

--- a/src/GraphQL.Tests/Bugs/Issue2357_TestSamples.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2357_TestSamples.cs
@@ -9,37 +9,37 @@ public class Issue2357_TestSamples : QueryTestBase<Issue2357_TestSamples.MySchem
     [Fact]
     public void output_null()
     {
-        AssertQuerySuccess("{ testDbOutputNull }", "{\"testDbOutputNull\": null}");
+        AssertQuerySuccess("{ testDbOutputNull }", """{"testDbOutputNull": null}""");
     }
 
     [Fact]
     public void output_value()
     {
-        AssertQuerySuccess("{ testDbOutputValue }", "{\"testDbOutputValue\": \"123\"}");
+        AssertQuerySuccess("{ testDbOutputValue }", """{"testDbOutputValue": "123"}""");
     }
 
     [Fact]
     public void input_literal_null()
     {
-        AssertQuerySuccess("{ testDbInput(arg:null) }", "{\"testDbInput\": \"0\"}");
+        AssertQuerySuccess("{ testDbInput(arg:null) }", """{"testDbInput": "0"}""");
     }
 
     [Fact]
     public void input_literal_value()
     {
-        AssertQuerySuccess("{ testDbInput(arg:\"123\") }", "{\"testDbInput\": \"123\"}");
+        AssertQuerySuccess("{ testDbInput(arg:\"123\") }", """{"testDbInput": "123"}""");
     }
 
     [Fact]
     public void input_value_null()
     {
-        AssertQuerySuccess("query ($arg: DbId) { testDbInput(arg:$arg) }", "{\"testDbInput\": \"0\"}", "{\"arg\":null}".ToInputs());
+        AssertQuerySuccess("query ($arg: DbId) { testDbInput(arg:$arg) }", """{"testDbInput": "0"}""", """{"arg":null}""".ToInputs());
     }
 
     [Fact]
     public void input_value_value()
     {
-        AssertQuerySuccess("query ($arg: DbId) { testDbInput(arg:$arg) }", "{\"testDbInput\": \"123\"}", "{\"arg\":\"123\"}".ToInputs());
+        AssertQuerySuccess("query ($arg: DbId) { testDbInput(arg:$arg) }", """{"testDbInput": "123"}""", """{"arg":"123"}""".ToInputs());
     }
 
     public class MySchema : Schema

--- a/src/GraphQL.Tests/Bugs/Issue2387_OverrideBuiltInScalars.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2387_OverrideBuiltInScalars.cs
@@ -65,7 +65,7 @@ public class Issue2387_OverrideBuiltInScalars : QueryTestBase<Issue2387_Override
     {
         var schema = BuildSchemaFirst();
         var json = await schema.ExecuteAsync(_ => _.Query = "{ testOutput }").ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testOutput\": 124}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testOutput": 124}}""");
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class Issue2387_OverrideBuiltInScalars : QueryTestBase<Issue2387_Override
     {
         var schema = BuildSchemaFirst();
         var json = await schema.ExecuteAsync(_ => _.Query = "{ testInput(arg:123) }").ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testInput\": \"122\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testInput": "122"}}""");
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class Issue2387_OverrideBuiltInScalars : QueryTestBase<Issue2387_Override
             _.Query = "query ($arg: Int!) { testInput(arg:$arg) }";
             _.Variables = "{\"arg\":123}".ToInputs();
         }).ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testInput\": \"122\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testInput": "122"}}""");
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class Issue2387_OverrideBuiltInScalars : QueryTestBase<Issue2387_Override
     {
         var schema = BuildSchemaFirst();
         var json = await schema.ExecuteAsync(_ => _.Query = "{ testOutputString }").ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testOutputString\": \"output-hello\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testOutputString": "output-hello"}}""");
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class Issue2387_OverrideBuiltInScalars : QueryTestBase<Issue2387_Override
     {
         var schema = BuildSchemaFirst();
         var json = await schema.ExecuteAsync(_ => _.Query = "{ testInputString(arg:\"hello\") }").ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testInputString\": \"input-hello\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testInputString": "input-hello"}}""");
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class Issue2387_OverrideBuiltInScalars : QueryTestBase<Issue2387_Override
             _.Query = "query ($arg: String!) { testInputString(arg:$arg) }";
             _.Variables = "{\"arg\":\"hello\"}".ToInputs();
         }).ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testInputString\": \"input-hello\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testInputString": "input-hello"}}""");
     }
 
     private Schema BuildSchemaFirst()

--- a/src/GraphQL.Tests/Bugs/Issue2392_OverrideBuiltInScalars_Alt.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2392_OverrideBuiltInScalars_Alt.cs
@@ -41,21 +41,21 @@ public class Issue2392_OverrideBuiltInScalars_Alt : QueryTestBase<Issue2392_Over
     public void codefirst_output_string()
     {
         Replace(Schema);
-        AssertQuerySuccess("{ testOutputString }", "{\"testOutputString\": \"output-hello\"}");
+        AssertQuerySuccess("{ testOutputString }", """{"testOutputString": "output-hello"}""");
     }
 
     [Fact]
     public void codefirst_parseliteral_string()
     {
         Replace(Schema);
-        AssertQuerySuccess("{ testInputString(arg:\"hello\") }", "{\"testInputString\": \"input-hello\"}");
+        AssertQuerySuccess("{ testInputString(arg:\"hello\") }", """{"testInputString": "input-hello"}""");
     }
 
     [Fact]
     public void codefirst_parsevalue_string()
     {
         Replace(Schema);
-        AssertQuerySuccess("query ($arg: String) { testInputString(arg:$arg) }", "{\"testInputString\": \"input-hello\"}", "{\"arg\":\"hello\"}".ToInputs());
+        AssertQuerySuccess("query ($arg: String) { testInputString(arg:$arg) }", """{"testInputString": "input-hello"}""", """{"arg":"hello"}""".ToInputs());
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class Issue2392_OverrideBuiltInScalars_Alt : QueryTestBase<Issue2392_Over
     {
         var schema = BuildSchemaFirst();
         var json = await schema.ExecuteAsync(_ => _.Query = "{ testOutput }").ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testOutput\": 124}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testOutput": 124}}""");
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class Issue2392_OverrideBuiltInScalars_Alt : QueryTestBase<Issue2392_Over
     {
         var schema = BuildSchemaFirst();
         var json = await schema.ExecuteAsync(_ => _.Query = "{ testInput(arg:123) }").ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testInput\": \"122\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testInput": "122"}}""");
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class Issue2392_OverrideBuiltInScalars_Alt : QueryTestBase<Issue2392_Over
             _.Query = "query ($arg: Int!) { testInput(arg:$arg) }";
             _.Variables = "{\"arg\":123}".ToInputs();
         }).ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testInput\": \"122\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testInput": "122"}}""");
     }
 
     [Fact]
@@ -112,15 +112,15 @@ public class Issue2392_OverrideBuiltInScalars_Alt : QueryTestBase<Issue2392_Over
     {
         var schema = BuildSchemaFirst();
         var json = await schema.ExecuteAsync(_ => _.Query = "{ testOutputString }").ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testOutputString\": \"output-hello\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testOutputString": "output-hello"}}""");
     }
 
     [Fact]
     public async Task schemafirst_parseliteral_string()
     {
         var schema = BuildSchemaFirst();
-        var json = await schema.ExecuteAsync(_ => _.Query = "{ testInputString(arg:\"hello\") }").ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testInputString\": \"input-hello\"}}");
+        var json = await schema.ExecuteAsync(_ => _.Query = """{ testInputString(arg:"hello") }""").ConfigureAwait(false);
+        json.ShouldBeCrossPlatJson("""{"data":{"testInputString": "input-hello"}}""");
     }
 
     [Fact]
@@ -130,9 +130,9 @@ public class Issue2392_OverrideBuiltInScalars_Alt : QueryTestBase<Issue2392_Over
         var json = await schema.ExecuteAsync(_ =>
         {
             _.Query = "query ($arg: String!) { testInputString(arg:$arg) }";
-            _.Variables = "{\"arg\":\"hello\"}".ToInputs();
+            _.Variables = """{"arg":"hello"}""".ToInputs();
         }).ConfigureAwait(false);
-        json.ShouldBeCrossPlatJson("{\"data\":{\"testInputString\": \"input-hello\"}}");
+        json.ShouldBeCrossPlatJson("""{"data":{"testInputString": "input-hello"}}""");
     }
 
     private Schema BuildSchemaFirst()

--- a/src/GraphQL.Tests/Bugs/Issue3370.cs
+++ b/src/GraphQL.Tests/Bugs/Issue3370.cs
@@ -9,8 +9,8 @@ public class Issue3370_LiteralObjectsWithNoEntriesDoNotValidate
     {
         var schema = new Schema { Query = new TestQuery() };
 
-        var result1 = await schema.ExecuteAsync(options => options.Query = @"{test(input: {}) { stringValue }}").ConfigureAwait(false);
-        result1.ShouldBeCrossPlatJson("{\"errors\":[{\"message\":\"Argument \\u0027input\\u0027 has invalid value. Missing required field \\u0027prop1\\u0027 of type \\u0027String\\u0027.\",\"locations\":[{\"line\":1,\"column\":7}],\"extensions\":{\"code\":\"ARGUMENTS_OF_CORRECT_TYPE\",\"codes\":[\"ARGUMENTS_OF_CORRECT_TYPE\"],\"number\":\"5.6.1\"}}]}");
+        var result1 = await schema.ExecuteAsync(options => options.Query = "{test(input: {}) { stringValue }}").ConfigureAwait(false);
+        result1.ShouldBeCrossPlatJson("""{"errors":[{"message":"Argument \u0027input\u0027 has invalid value. Missing required field \u0027prop1\u0027 of type \u0027String\u0027.","locations":[{"line":1,"column":7}],"extensions":{"code":"ARGUMENTS_OF_CORRECT_TYPE","codes":["ARGUMENTS_OF_CORRECT_TYPE"],"number":"5.6.1"}}]}""");
     }
 
     [Fact]
@@ -20,10 +20,10 @@ public class Issue3370_LiteralObjectsWithNoEntriesDoNotValidate
 
         var result2 = await schema.ExecuteAsync(options =>
         {
-            options.Query = @"query($input: TestInputType!){test(input: $input) { stringValue }}";
+            options.Query = "query($input: TestInputType!){test(input: $input) { stringValue }}";
             options.Variables = @"{ ""input"": {}}".ToInputs();
         }).ConfigureAwait(false);
-        result2.ShouldBeCrossPlatJson("{\"errors\":[{\"message\":\"Variable \\u0027$input.prop1\\u0027 is invalid. No value provided for a non-null variable.\",\"locations\":[{\"line\":1,\"column\":7}],\"extensions\":{\"code\":\"INVALID_VALUE\",\"codes\":[\"INVALID_VALUE\"],\"number\":\"5.8\"}}]}");
+        result2.ShouldBeCrossPlatJson("""{"errors":[{"message":"Variable \u0027$input.prop1\u0027 is invalid. No value provided for a non-null variable.","locations":[{"line":1,"column":7}],"extensions":{"code":"INVALID_VALUE","codes":["INVALID_VALUE"],"number":"5.8"}}]}""");
     }
 
     public class TestQuery : ObjectGraphType

--- a/src/GraphQL.Tests/Conversion/FieldNameConverterTests.cs
+++ b/src/GraphQL.Tests/Conversion/FieldNameConverterTests.cs
@@ -33,7 +33,7 @@ public class NameConverterTests : BasicQueryTestBase
             _.Schema = build_schema();
             _.Query = "{ peRsoN { name } }";
         },
-        @"{ ""peRsoN"": { ""name"": ""Quinn"" } }");
+        """{ "peRsoN": { "name": "Quinn" } }""");
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class NameConverterTests : BasicQueryTestBase
             _.Schema = build_schema();
             _.Query = "{ peRsoN { Na: name } }";
         },
-        @"{ ""peRsoN"": { ""Na"": ""Quinn"" } }");
+        """{ "peRsoN": { "Na": "Quinn" } }""");
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class NameConverterTests : BasicQueryTestBase
             _.Schema = build_schema(converter);
             _.Query = "{ PeRsoN { naME: Name } }";
         },
-        @"{ ""PeRsoN"": { ""naME"": ""Quinn"" } }");
+        """{ "PeRsoN": { "naME": "Quinn" } }""");
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public class NameConverterTests : BasicQueryTestBase
             _.Schema = build_schema(converter);
             _.Query = "{ PeRsoN { naME: Name } }";
         },
-        @"{ ""PeRsoN"": { ""naME"": ""Quinn"" } }");
+        """{ "PeRsoN": { "naME": "Quinn" } }""");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Execution/InputsTests.cs
+++ b/src/GraphQL.Tests/Execution/InputsTests.cs
@@ -73,12 +73,14 @@ public class InputsTests : QueryTestBase<EnumMutationSchema>
         var inputs = @"{ ""userId"": 1000000000000000001 }".ToInputs();
 
         AssertQuerySuccess(
-            @"query aQuery($userId: Long!) { getLongUser(userId: $userId) { idLong }}",
-            @"{
-                  ""getLongUser"": {
-                    ""idLong"": 1000000000000000001
-                  }
-                }", inputs);
+            "query aQuery($userId: Long!) { getLongUser(userId: $userId) { idLong }}",
+            """
+            {
+                "getLongUser": {
+                "idLong": 1000000000000000001
+                }
+            }
+            """, inputs);
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -154,12 +154,12 @@ public class Variables_With_Inline_Structs_Tests : QueryTestBase<VariablesSchema
     [Fact]
     public void executes_with_complex_input()
     {
-        var query = @"
+        var query = """
             {
-              fieldWithObjectInput(input: {a: ""foo"", b: [""bar""], c: ""baz""})
+              fieldWithObjectInput(input: {a: "foo", b: ["bar"], c: "baz"})
             }
-            ";
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"a\\\":\\\"foo\\\",\\\"b\\\":[\\\"bar\\\"],\\\"c\\\":\\\"baz\\\"}\" }";
+            """;
+        var expected = """{ "fieldWithObjectInput": "{\"a\":\"foo\",\"b\":[\"bar\"],\"c\":\"baz\"}" }""";
 
         AssertQuerySuccess(query, expected);
     }
@@ -167,12 +167,12 @@ public class Variables_With_Inline_Structs_Tests : QueryTestBase<VariablesSchema
     [Fact]
     public void properly_parses_single_value_to_list()
     {
-        var query = @"
+        var query = """
             {
-              fieldWithObjectInput(input: {a: ""foo"", b: ""bar"", c: ""baz""})
+              fieldWithObjectInput(input: {a: "foo", b: "bar", c: "baz"})
             }
-            ";
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"a\\\":\\\"foo\\\",\\\"b\\\":[\\\"bar\\\"],\\\"c\\\":\\\"baz\\\"}\" }";
+            """;
+        var expected = """{ "fieldWithObjectInput": "{\"a\":\"foo\",\"b\":[\"bar\"],\"c\":\"baz\"}" }""";
 
         AssertQuerySuccess(query, expected);
     }
@@ -180,11 +180,11 @@ public class Variables_With_Inline_Structs_Tests : QueryTestBase<VariablesSchema
     [Fact]
     public void fail_on_incorrect_value()
     {
-        var query = @"
+        var query = """
             {
-              fieldWithObjectInput(input: [""foo"", ""bar"", ""baz""])
+              fieldWithObjectInput(input: ["foo", "bar", "baz"])
             }
-            ";
+            """;
         var expected = "{ \"fieldWithObjectInput\": null }";
 
         var result = AssertQueryWithErrors(query, expected, rules: Enumerable.Empty<IValidationRule>(), expectedErrorCount: 1, executed: true);
@@ -204,9 +204,9 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void executes_with_complex_input()
     {
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"a\\\":\\\"foo\\\",\\\"b\\\":[\\\"bar\\\"],\\\"c\\\":\\\"baz\\\"}\" }";
+        var expected = """{ "fieldWithObjectInput": "{\"a\":\"foo\",\"b\":[\"bar\"],\"c\":\"baz\"}" }""";
 
-        var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": [""bar""], ""c"": ""baz"" } }".ToInputs();
+        var inputs = """{ "input": { "a": "foo", "b": ["bar"], "c": "baz" } }""".ToInputs();
 
         AssertQuerySuccess(_query, expected, inputs);
     }
@@ -214,9 +214,9 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void properly_parses_single_value_to_list()
     {
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"a\\\":\\\"foo\\\",\\\"b\\\":[\\\"bar\\\"],\\\"c\\\":\\\"baz\\\"}\" }";
+        var expected = """{ "fieldWithObjectInput": "{\"a\":\"foo\",\"b\":[\"bar\"],\"c\":\"baz\"}" }""";
 
-        var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": ""bar"", ""c"": ""baz"" } }".ToInputs();
+        var inputs = """{ "input": { "a": "foo", "b": "bar", "c": "baz" } }""".ToInputs();
 
         AssertQuerySuccess(_query, expected, inputs);
     }
@@ -224,9 +224,9 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void properly_parses_multiple_values_to_list()
     {
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"a\\\":\\\"foo\\\",\\\"b\\\":[\\\"bar\\\",\\\"qux\\\"],\\\"c\\\":\\\"baz\\\"}\" }";
+        var expected = """{ "fieldWithObjectInput": "{\"a\":\"foo\",\"b\":[\"bar\",\"qux\"],\"c\":\"baz\"}" }""";
 
-        var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": [""bar"", ""qux""], ""c"": ""baz"" } }".ToInputs();
+        var inputs = """{ "input": { "a": "foo", "b": ["bar", "qux"], "c": "baz" } }""".ToInputs();
 
         AssertQuerySuccess(_query, expected, inputs);
     }
@@ -240,7 +240,7 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
                 }
             ";
 
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"a\\\":\\\"foo\\\",\\\"b\\\":[\\\"bar\\\"],\\\"c\\\":\\\"baz\\\"}\" }";
+        var expected = """{ "fieldWithObjectInput": "{\"a\":\"foo\",\"b\":[\"bar\"],\"c\":\"baz\"}" }""";
 
         AssertQuerySuccess(queryWithDefaults, expected);
     }
@@ -248,9 +248,9 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void executes_with_complex_scalar_input()
     {
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"c\\\":\\\"foo\\\",\\\"d\\\":\\\"DeserializedValue\\\"}\" }";
+        var expected = """{ "fieldWithObjectInput": "{\"c\":\"foo\",\"d\":\"DeserializedValue\"}" }""";
 
-        var inputs = @"{ ""input"": { ""c"": ""foo"", ""d"": ""SerializedValue"" } }".ToInputs();
+        var inputs = """{ "input": { "c": "foo", "d": "SerializedValue" } }""".ToInputs();
 
         AssertQuerySuccess(_query, expected, inputs);
     }
@@ -260,7 +260,7 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     {
         const string expected = null;
 
-        var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": ""bar"", ""c"": null } }".ToInputs();
+        var inputs = """{ "input": { "a": "foo", "b": "bar", "c": null } }""".ToInputs();
 
         var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1, executed: false);
 
@@ -274,7 +274,7 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     {
         const string expected = null;
 
-        var inputs = @"{ ""input"": ""foo bar"" }".ToInputs();
+        var inputs = """{ "input": "foo bar" }""".ToInputs();
 
         var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1, executed: false);
 
@@ -322,7 +322,7 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
                 }
             ";
 
-        var expected = "{ \"fieldWithObjectInput\": \"{\\\"b\\\":[\\\"bar\\\",\\\"qux\\\"],\\\"c\\\":\\\"foo\\\",\\\"d\\\":\\\"DeserializedValue\\\"}\" }";
+        var expected = """{ "fieldWithObjectInput": "{\"b\":[\"bar\",\"qux\"],\"c\":\"foo\",\"d\":\"DeserializedValue\"}" }""";
 
         var inputs = @"{ ""argB"": [""bar"", ""qux""], ""argC"": ""foo"", ""argD"": ""SerializedValue"" }".ToInputs();
 
@@ -434,13 +434,13 @@ public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
             ";
 
         // value is: "a"
-        var expected = @"
+        var expected = """
             {
-              ""fieldWithNullableStringInput"": ""\""a\""""
+              "fieldWithNullableStringInput": "\"a\""
             }
-            ";
+            """;
 
-        var inputs = @"{""value"": ""a""}".ToInputs();
+        var inputs = """{"value": "a"}""".ToInputs();
 
         AssertQuerySuccess(query, expected, inputs);
     }

--- a/src/GraphQL.Tests/Serialization/GraphQLRequestTests.cs
+++ b/src/GraphQL.Tests/Serialization/GraphQLRequestTests.cs
@@ -17,7 +17,7 @@ public class GraphQLRequestTests : DeserializationTestBase
             Query = "hello",
         };
 
-        var expected = @"{ ""query"": ""hello"" }";
+        var expected = """{ "query": "hello" }""";
 
         var actual = serializer.Serialize(request);
 
@@ -44,7 +44,7 @@ public class GraphQLRequestTests : DeserializationTestBase
             }),
         };
 
-        var expected = @"{ ""query"": ""hello"", ""operationName"": ""opname"", ""variables"": { ""arg1"": 1, ""arg2"": ""test"" }, ""extensions"": { ""arg1"": 2, ""arg2"": ""test2"" } }";
+        var expected = """{ "query": "hello", "operationName": "opname", "variables": { "arg1": 1, "arg2": "test" }, "extensions": { "arg1": 2, "arg2": "test2" } }""";
 
         var actual = serializer.Serialize(request);
 
@@ -80,7 +80,7 @@ public class GraphQLRequestTests : DeserializationTestBase
             Query = "hello",
         };
 
-        var expected = @"[{ ""query"": ""hello"" }]";
+        var expected = """[{ "query": "hello" }]""";
 
         var actual = serializer.Serialize(new List<GraphQLRequest> { request });
 
@@ -96,7 +96,7 @@ public class GraphQLRequestTests : DeserializationTestBase
             Query = "hello",
         };
 
-        var expected = @"[{ ""query"": ""hello"" }]";
+        var expected = """[{ "query": "hello" }]""";
 
         var actual = serializer.Serialize(new GraphQLRequest[] { request });
 

--- a/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
@@ -261,8 +261,8 @@ public class SubscriptionExecutionStrategyTests
         Source.Next("testing");
         SubscriptionObj!.Dispose();
         Source.Next("should not happen");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""test"": ""hello"" } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""test"": ""testing"" } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "test": "hello" } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "test": "testing" } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -286,11 +286,11 @@ public class SubscriptionExecutionStrategyTests
     {
         var result = await ExecuteAsync("subscription { testComplex { nameMayThrowError } }", o =>
         {
-            o.UnhandledExceptionDelegate = async context => throw new InvalidOperationException();
+            o.UnhandledExceptionDelegate = async _ => throw new InvalidOperationException();
         }).ConfigureAwait(false);
         result.ShouldBeSuccessful();
         Source.Next("custom");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Unhandled error of type InvalidOperationException""}]}");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Unhandled error of type InvalidOperationException"}]}""");
     }
 
     [Fact]
@@ -337,7 +337,7 @@ public class SubscriptionExecutionStrategyTests
         result.ShouldBeSuccessful();
         throwNow = true;
         Source.Next("test");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: Test exception"",""locations"":[{""line"":1,""column"":16}],""path"":[""test""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}]}");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: Test exception","locations":[{"line":1,"column":16}],"path":["test"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}]}""");
     }
 
     [Fact]
@@ -360,7 +360,7 @@ public class SubscriptionExecutionStrategyTests
         result.ShouldBeSuccessful();
         throwNow = true;
         Source.Next("test");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Test error"",""locations"":[{""line"":1,""column"":16}],""path"":[""test""]}]}");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Test error","locations":[{"line":1,"column":16}],"path":["test"]}]}""");
     }
 
     [Fact]
@@ -382,7 +382,7 @@ public class SubscriptionExecutionStrategyTests
         result.ShouldBeSuccessful();
         throwNow = true;
         Source.Next("test");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: Test exception"",""locations"":[{""line"":1,""column"":16}],""path"":[""test""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}],""data"":{""test"":""test""}}");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: Test exception","locations":[{"line":1,"column":16}],"path":["test"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}],"data":{"test":"test"}}""");
     }
 
     [Fact]
@@ -405,7 +405,7 @@ public class SubscriptionExecutionStrategyTests
         result.ShouldBeSuccessful();
         throwNow = true;
         Source.Next("test");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Test error"",""locations"":[{""line"":1,""column"":16}],""path"":[""test""]}],""data"":{""test"":""test""}}");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Test error","locations":[{"line":1,"column":16}],"path":["test"]}],"data":{"test":"test"}}""");
     }
 
     [Fact]
@@ -427,7 +427,7 @@ public class SubscriptionExecutionStrategyTests
         result.ShouldBeSuccessful();
         errorNow = true;
         Source.Next("test");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Test error""}]}");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Test error"}]}""");
     }
 
     [Fact]
@@ -449,7 +449,7 @@ public class SubscriptionExecutionStrategyTests
         result.ShouldBeSuccessful();
         errorNow = true;
         Source.Next("test");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Test error""}],""data"":{""test"":""test""}}");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Test error"}],"data":{"test":"test"}}""");
     }
 
     [Fact]
@@ -468,7 +468,7 @@ public class SubscriptionExecutionStrategyTests
     {
         var result = await ExecuteAsync("subscription { testObservableNull }").ConfigureAwait(false);
         result.ShouldNotBeSuccessful();
-        result.ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: No event stream returned for field \u0027testObservableNull\u0027."",""locations"":[{""line"":1,""column"":16}],""path"":[""testObservableNull""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}],""data"":null}");
+        result.ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: No event stream returned for field \u0027testObservableNull\u0027.","locations":[{"line":1,"column":16}],"path":["testObservableNull"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}],"data":null}""");
     }
 
     [Fact]
@@ -476,7 +476,7 @@ public class SubscriptionExecutionStrategyTests
     {
         var result = await ExecuteAsync("subscription { test testWithInitialExtensions }", null, false).ConfigureAwait(false);
         result.ShouldNotBeSuccessful();
-        result.ShouldBeSimilarTo(@"{""errors"":[{""message"":""Anonymous Subscription must select only one top level field."",""locations"":[{""line"":1,""column"":21}],""extensions"":{""code"":""SINGLE_ROOT_FIELD_SUBSCRIPTIONS"",""codes"":[""SINGLE_ROOT_FIELD_SUBSCRIPTIONS""],""number"":""5.2.3.1""}}]}");
+        result.ShouldBeSimilarTo("""{"errors":[{"message":"Anonymous Subscription must select only one top level field.","locations":[{"line":1,"column":21}],"extensions":{"code":"SINGLE_ROOT_FIELD_SUBSCRIPTIONS","codes":["SINGLE_ROOT_FIELD_SUBSCRIPTIONS"],"number":"5.2.3.1"}}]}""");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Types/CustomScalarTests.cs
+++ b/src/GraphQL.Tests/Types/CustomScalarTests.cs
@@ -144,14 +144,14 @@ public class CustomScalarTests : QueryTestBase<CustomScalarSchema>
     public void List_works()
     {
         // verify that within lists, custom scalars are coerced to their proper values
-        AssertQuerySuccess("{ list }", @"{ ""list"": [""hello"", null, ""externalNull"" ]}");
+        AssertQuerySuccess("{ list }", """{ "list": ["hello", null, "externalNull" ]}""");
     }
 
     [Fact]
     public void List_NonNull_works_valid()
     {
         // here we are using a custom scalar to coerce a null value to a non-null value, which is valid for a non-null type
-        AssertQuerySuccess("{ listNonNullValid }", @"{ ""listNonNullValid"": [""hello"", ""externalNull"" ]}");
+        AssertQuerySuccess("{ listNonNullValid }", """{ "listNonNullValid": ["hello", "externalNull" ]}""");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Types/NonNullGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/NonNullGraphTypeTests.cs
@@ -9,7 +9,7 @@ public class NonNullGraphTypeTests : QueryTestBase<NullableSchema>
     {
         AssertQuerySuccess(
             "{ nullable { a b c } }",
-            @"{ ""nullable"": { ""a"": 99, ""b"": true, ""c"": ""Hello world"" } }",
+            """{ "nullable": { "a": 99, "b": true, "c": "Hello world" } }""",
             root: new ExampleContext(99, true, "Hello world"));
     }
 
@@ -17,8 +17,8 @@ public class NonNullGraphTypeTests : QueryTestBase<NullableSchema>
     public void nullable_fields_without_values_never_complain()
     {
         AssertQuerySuccess(
-            @"{ nullable { a b c } }",
-            @"{ ""nullable"": { ""a"": null, ""b"": null, ""c"": null } }",
+            "{ nullable { a b c } }",
+            """{ "nullable": { "a": null, "b": null, "c": null } }""",
             root: new ExampleContext(null, null, null));
     }
 
@@ -27,7 +27,7 @@ public class NonNullGraphTypeTests : QueryTestBase<NullableSchema>
     {
         AssertQuerySuccess(
             "{ nonNullable { a b c } }",
-            @"{ ""nonNullable"": { ""a"": 99, ""b"": true, ""c"": ""Hello world"" } }",
+            """{ "nonNullable": { "a": 99, "b": true, "c": "Hello world" } }""",
             root: new ExampleContext(99, true, "Hello world"));
     }
 
@@ -36,7 +36,7 @@ public class NonNullGraphTypeTests : QueryTestBase<NullableSchema>
     {
         var result = AssertQueryWithErrors(
             "{ nonNullable { a b c } }",
-            @"{ ""nonNullable"": null }",
+            """{ "nonNullable": null }""",
             root: new ExampleContext(null, null, null),
             expectedErrorCount: 3);
 

--- a/src/GraphQL.Tests/Types/UnionGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/UnionGraphTypeTests.cs
@@ -70,7 +70,7 @@ public class UnionGraphTypeTests
         schema.Initialize();
 
         var str1 = await schema.ExecuteAsync(o => o.Query = "{ union1 { ...frag } union2 { ...frag } } fragment frag on UnionType { ... on Type1 { field1 } ... on Type2 { field2 } }").ConfigureAwait(false);
-        str1.ShouldBeCrossPlatJson(@"{""data"":{""union1"":{""field1"":1},""union2"":{""field2"":2}}}");
+        str1.ShouldBeCrossPlatJson("""{"data":{"union1":{"field1":1},"union2":{"field2":2}}}""");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -438,7 +438,7 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
             _.Root = root;
         }).ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""hello"": ""Hello World!"" }");
+        var expectedResult = CreateQueryResult("""{ "hello": "Hello World!" }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
@@ -190,14 +190,14 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_type_with_arguments()
     {
-        var definitions = @"
+        var definitions = """"
                 type Query {
-                  """"""
+                  """
                   Post description
-                  """"""
-                  post(""ID description"" id: ID = 1, ""Val description"" val: String): String
+                  """
+                  post("ID description" id: ID = 1, "Val description" val: String): String
                 }
-            ";
+            """";
 
         var schema = Schema.For(definitions, builder => builder.Types.For("Query").FieldFor("post").ArgumentFor("id").Description = "Some argument");
         schema.Initialize();
@@ -259,17 +259,17 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_interface()
     {
-        var definitions = @"
-                """"""
+        var definitions = """"
+                """
                 Example description
-                """"""
+                """
                 interface Pet {
-                    """"""
+                    """
                     ID description
-                    """"""
+                    """
                     id: ID
                 }
-            ";
+            """";
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -288,18 +288,18 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_enum()
     {
-        var definitions = @"
-                """"""
+        var definitions = """"
+                """
                 Example description
-                """"""
+                """
                 enum PetKind {
-                    """"""
+                    """
                     Cat description
-                    """"""
+                    """
                     CAT
                     DOG
                 }
-            ";
+            """";
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -409,7 +409,7 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_unions()
     {
-        var definitions = @"
+        var definitions = """"
                 type Human {
                     name: String
                 }
@@ -418,10 +418,11 @@ public class SchemaBuilderTests
                     name: String
                 }
 
-                """"""
+                """
                 Example description
-                """"""
-                union SearchResult = Human | Droid";
+                """
+                union SearchResult = Human | Droid
+                """";
 
         var schema = Schema.For(definitions, _ =>
         {
@@ -439,18 +440,18 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_input_types()
     {
-        var definitions = @"
-                """"""
+        var definitions = """"
+                """
                 Example description
-                """"""
+                """
                 input ReviewInput {
-                  """"""
+                  """
                   Stars description
-                  """"""
+                  """
                   stars: Int!
                   commentary: String
                 }
-            ";
+            """";
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -561,14 +562,14 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_directives()
     {
-        var definitions = @"
-                """"""
+        var definitions = """"
+                """
                 Example description
-                """"""
+                """
                 directive @myDirective(
                   if: Boolean!
                 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-            ";
+            """";
 
         var schema = Schema.For(definitions);
         schema.Initialize();

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -95,12 +95,14 @@ directive @skip(
         arg.ResolvedType = new TestSchemaTypes().BuildGraphQLType(arg.Type, null);
 
         var result = printer.PrintDirective(skip);
-        const string expected = @"""""""
+        const string expected = """"
+"""
 Directs the executor to skip this field or fragment when the 'if' argument is true.
-""""""
+"""
 directive @skip(
   if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT";
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""";
 
         AssertEqual(result, "directive", expected, excludeScalars: true);
     }
@@ -274,19 +276,21 @@ type Foo {
         {
             {
                 "Foo",
-@"""""""
+""""
+"""
 This is a Foo object type
-""""""
+"""
 type Foo {
-  """"""
+  """
   This is of type String
-  """"""
+  """
   str: String
-  """"""
+  """
   This is of type Integer
-  """"""
+  """
   int: Int
-}"
+}
+""""
             },
             {
                 "Query",
@@ -355,19 +359,21 @@ type Foo {
         {
             {
                 "Foo",
-@"""""""
+""""
+"""
 This is a Foo object type
-""""""
+"""
 type Foo {
-  """"""
+  """
   This is of type String
-  """"""
+  """
   str: String
-  """"""
+  """
   This is of type Integer
-  """"""
+  """
   int: Int
-}".Replace("int: Int", "int: Int @deprecated(reason: \"This field is now deprecated\")")
+}
+"""".Replace("int: Int", "int: Int @deprecated(reason: \"This field is now deprecated\")")
             },
             {
                 "Query",
@@ -637,39 +643,41 @@ type Query {
             PrintDescriptionsAsComments = false,
         };
 
-        AssertEqual(print(schema, options), "", @"
+        AssertEqual(print(schema, options), "", """"
+
 interface Baaz {
-  """"""
+  """
   This is of type Integer
-  """"""
+  """
   int: Int
 }
 
 type Bar implements IFoo, Baaz {
-  """"""
+  """
   This is of type String
-  """"""
+  """
   str: String
-  """"""
+  """
   This is of type Integer
-  """"""
+  """
   int: Int
 }
 
-""""""
+"""
 This is a Foo interface type
-""""""
+"""
 interface IFoo {
-  """"""
+  """
   This is of type String
-  """"""
+  """
   str: String
 }
 
 type Query {
   bar: Bar
 }
-", excludeScalars: true);
+
+"""", excludeScalars: true);
     }
 
     [Fact]
@@ -729,39 +737,41 @@ type Query {
 
         var result = print(schema, options);
 
-        AssertEqual(result, "", @"
+        AssertEqual(result, "", """"
+
 interface Baaz {
-  """"""
+  """
   This is of type Integer
-  """"""
+  """
   int: Int
 }
 
 type Bar implements IFoo & Baaz {
-  """"""
+  """
   This is of type String
-  """"""
+  """
   str: String
-  """"""
+  """
   This is of type Integer
-  """"""
+  """
   int: Int
 }
 
-""""""
+"""
 This is a Foo interface type
-""""""
+"""
 interface IFoo {
-  """"""
+  """
   This is of type String
-  """"""
+  """
   str: String
 }
 
 type Query {
   bar: Bar
 }
-", excludeScalars: true);
+
+"""", excludeScalars: true);
     }
 
     [Fact]
@@ -1158,14 +1168,15 @@ scalar Uri"
         var printer = new SchemaPrinter(schema, new SchemaPrinterOptions { IncludeDescriptions = true, PrintDescriptionsAsComments = true });
         var result = Environment.NewLine + printer.PrintIntrospectionSchema();
 
-        const string expected = @"
+        const string expected = """
+
 schema {
   query: Root
 }
 
 # Marks an element of a GraphQL schema as no longer supported.
 directive @deprecated(
-  reason: String = ""No longer supported""
+  reason: String = "No longer supported"
 ) on FIELD_DEFINITION | ENUM_VALUE
 
 # Directs the executor to include this field or fragment only when the 'if' argument is true.
@@ -1325,7 +1336,8 @@ enum __TypeKind {
   # Indicates this type is a non-null. `ofType` is a valid field.
   NON_NULL
 }
-";
+
+""";
 
         AssertEqual(result, "", expected, excludeScalars: true);
     }
@@ -1343,37 +1355,38 @@ enum __TypeKind {
         var printer = new SchemaPrinter(schema, new SchemaPrinterOptions { IncludeDescriptions = true, PrintDescriptionsAsComments = false });
         var result = Environment.NewLine + printer.PrintIntrospectionSchema();
 
-        const string expected = @"
+        const string expected = """"
+
 schema {
   query: Root
 }
 
-""""""
+"""
 Marks an element of a GraphQL schema as no longer supported.
-""""""
+"""
 directive @deprecated(
-  reason: String = ""No longer supported""
+  reason: String = "No longer supported"
 ) on FIELD_DEFINITION | ENUM_VALUE
 
-""""""
+"""
 Directs the executor to include this field or fragment only when the 'if' argument is true.
-""""""
+"""
 directive @include(
   if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-""""""
+"""
 Directs the executor to skip this field or fragment when the 'if' argument is true.
-""""""
+"""
 directive @skip(
   if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-""""""
+"""
 A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 
 In some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.
-""""""
+"""
 type __Directive {
   name: String!
   description: String
@@ -1384,91 +1397,91 @@ type __Directive {
   onField: Boolean!
 }
 
-""""""
+"""
 A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.
-""""""
+"""
 enum __DirectiveLocation {
-  """"""
+  """
   Location adjacent to a query operation.
-  """"""
+  """
   QUERY
-  """"""
+  """
   Location adjacent to a mutation operation.
-  """"""
+  """
   MUTATION
-  """"""
+  """
   Location adjacent to a subscription operation.
-  """"""
+  """
   SUBSCRIPTION
-  """"""
+  """
   Location adjacent to a field.
-  """"""
+  """
   FIELD
-  """"""
+  """
   Location adjacent to a fragment definition.
-  """"""
+  """
   FRAGMENT_DEFINITION
-  """"""
+  """
   Location adjacent to a fragment spread.
-  """"""
+  """
   FRAGMENT_SPREAD
-  """"""
+  """
   Location adjacent to an inline fragment.
-  """"""
+  """
   INLINE_FRAGMENT
-  """"""
+  """
   Location adjacent to a variable definition.
-  """"""
+  """
   VARIABLE_DEFINITION
-  """"""
+  """
   Location adjacent to a schema definition.
-  """"""
+  """
   SCHEMA
-  """"""
+  """
   Location adjacent to a scalar definition.
-  """"""
+  """
   SCALAR
-  """"""
+  """
   Location adjacent to an object type definition.
-  """"""
+  """
   OBJECT
-  """"""
+  """
   Location adjacent to a field definition.
-  """"""
+  """
   FIELD_DEFINITION
-  """"""
+  """
   Location adjacent to an argument definition.
-  """"""
+  """
   ARGUMENT_DEFINITION
-  """"""
+  """
   Location adjacent to an interface definition.
-  """"""
+  """
   INTERFACE
-  """"""
+  """
   Location adjacent to a union definition.
-  """"""
+  """
   UNION
-  """"""
+  """
   Location adjacent to an enum definition
-  """"""
+  """
   ENUM
-  """"""
+  """
   Location adjacent to an enum value definition
-  """"""
+  """
   ENUM_VALUE
-  """"""
+  """
   Location adjacent to an input object type definition.
-  """"""
+  """
   INPUT_OBJECT
-  """"""
+  """
   Location adjacent to an input object field definition.
-  """"""
+  """
   INPUT_FIELD_DEFINITION
 }
 
-""""""
+"""
 One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.
-""""""
+"""
 type __EnumValue {
   name: String!
   description: String
@@ -1476,9 +1489,9 @@ type __EnumValue {
   deprecationReason: String
 }
 
-""""""
+"""
 Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.
-""""""
+"""
 type __Field {
   name: String!
   description: String
@@ -1488,51 +1501,51 @@ type __Field {
   deprecationReason: String
 }
 
-""""""
+"""
 Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.
-""""""
+"""
 type __InputValue {
   name: String!
   description: String
   type: __Type!
-  """"""
+  """
   A GraphQL-formatted string representing the default value for this input value.
-  """"""
+  """
   defaultValue: String
 }
 
-""""""
+"""
 A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
-""""""
+"""
 type __Schema {
   description: String
-  """"""
+  """
   A list of all types supported by this server.
-  """"""
+  """
   types: [__Type!]!
-  """"""
+  """
   The type that query operations will be rooted at.
-  """"""
+  """
   queryType: __Type!
-  """"""
+  """
   If this server supports mutation, the type that mutation operations will be rooted at.
-  """"""
+  """
   mutationType: __Type
-  """"""
+  """
   If this server supports subscription, the type that subscription operations will be rooted at.
-  """"""
+  """
   subscriptionType: __Type
-  """"""
+  """
   A list of all directives supported by this server.
-  """"""
+  """
   directives: [__Directive!]!
 }
 
-""""""
+"""
 The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
 
 Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
-""""""
+"""
 type __Type {
   kind: __TypeKind!
   name: String
@@ -1545,44 +1558,45 @@ type __Type {
   ofType: __Type
 }
 
-""""""
+"""
 An enum describing what kind of type a given __Type is.
-""""""
+"""
 enum __TypeKind {
-  """"""
+  """
   Indicates this type is a scalar.
-  """"""
+  """
   SCALAR
-  """"""
+  """
   Indicates this type is an object. `fields` and `possibleTypes` are valid fields.
-  """"""
+  """
   OBJECT
-  """"""
+  """
   Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.
-  """"""
+  """
   INTERFACE
-  """"""
+  """
   Indicates this type is a union. `possibleTypes` is a valid field.
-  """"""
+  """
   UNION
-  """"""
+  """
   Indicates this type is an enum. `enumValues` is a valid field.
-  """"""
+  """
   ENUM
-  """"""
+  """
   Indicates this type is an input object. `inputFields` is a valid field.
-  """"""
+  """
   INPUT_OBJECT
-  """"""
+  """
   Indicates this type is a list. `ofType` is a valid field.
-  """"""
+  """
   LIST
-  """"""
+  """
   Indicates this type is a non-null. `ofType` is a valid field.
-  """"""
+  """
   NON_NULL
 }
-";
+
+"""";
 
         AssertEqual(result, "", expected, excludeScalars: true);
     }
@@ -1602,14 +1616,15 @@ enum __TypeKind {
         var printer = new SchemaPrinter(schema, new SchemaPrinterOptions { IncludeDescriptions = true, PrintDescriptionsAsComments = true });
         var result = Environment.NewLine + printer.PrintIntrospectionSchema();
 
-        const string expected = @"
+        const string expected = """
+
 schema {
   query: Root
 }
 
 # Marks an element of a GraphQL schema as no longer supported.
 directive @deprecated(
-  reason: String = ""No longer supported""
+  reason: String = "No longer supported"
 ) on FIELD_DEFINITION | ENUM_VALUE
 
 # Directs the executor to include this field or fragment only when the 'if' argument is true.
@@ -1798,7 +1813,8 @@ enum __TypeKind {
   # Indicates this type is a non-null. `ofType` is a valid field.
   NON_NULL
 }
-";
+
+""";
 
         AssertEqual(result, "", expected, excludeScalars: true);
     }
@@ -1814,7 +1830,7 @@ enum __TypeKind {
     [Fact]
     public void sorts_schema_correctly()
     {
-        var schema = Schema.For(@"
+        var schema = Schema.For("""
 # test sorting type names
 type Zebra {
   # test sorting field names on object types
@@ -1827,7 +1843,7 @@ type Query {
   # test sorting arguments
   field2(arg2: Rutabaga, arg1: Beta): Tango
   # test sorting fields of default values
-  field3(arg3: Rutabaga = { field3: ""hello"", field2: 2 }): String
+  field3(arg3: Rutabaga = { field3: "hello", field2: 2 }): String
 }
 
 type Tango {
@@ -1859,10 +1875,12 @@ enum Beta {
   VALUE_3
   VALUE_2
 }
-");
+
+""");
         var printer = new SchemaPrinter(schema, new SchemaPrinterOptions { Comparer = new GraphQL.Introspection.AlphabeticalSchemaComparer() });
         var actual = printer.Print();
-        var expected = @"directive @test1(
+        var expected = """
+directive @test1(
   arg2: Boolean!
   arg1: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
@@ -1880,7 +1898,7 @@ enum Beta {
 type Query {
   field1(arg1: Rutabaga, arg2: Beta): Zebra
   field2(arg1: Beta, arg2: Rutabaga): Tango
-  field3(arg3: Rutabaga = { field2: 2, field3: ""hello"" }): String
+  field3(arg3: Rutabaga = { field2: 2, field3: "hello" }): String
 }
 
 input Rutabaga {
@@ -1897,7 +1915,8 @@ type Zebra {
   field2: Int
   field3: String
 }
-";
+
+""";
         actual.ShouldBe(expected, StringCompareShould.IgnoreLineEndings);
     }
 

--- a/src/GraphQL.Tests/Utilities/SchemaVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaVisitorTests.cs
@@ -19,7 +19,7 @@ public class SchemaVisitorTests : SchemaBuilderTestBase
             _.ConfigureBuildedSchema = schema => { schema.Directives.Register(new UpperDirective()); schema.RegisterVisitor<UppercaseDirectiveVisitor>(); };
             _.Query = "{ hello }";
             _.Root = new { Hello = "Hello World!" };
-            _.ExpectedResult = @"{ ""hello"": ""HELLO WORLD!"" }";
+            _.ExpectedResult = """{ "hello": "HELLO WORLD!" }""";
         });
     }
 


### PR DESCRIPTION
I found [raw string literals](https://devblogs.microsoft.com/dotnet/csharp-11-preview-updates/) very useful. Only tests changed. VS 17.4 even highlights contents of raw string literals if this literal represents json.
![изображение](https://user-images.githubusercontent.com/21261007/201436042-a7f21b04-e91f-4a8c-8b57-677f43c626c1.png)
