### PR TITLE
More raw string literals [part 2]

### DIFF
--- a/src/GraphQL.Benchmarks/Benchmarks/SerializationBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/SerializationBenchmark.cs
@@ -54,28 +54,30 @@ public class SerializationBenchmark : IBenchmark
 
         _introspectionResult = ExecuteQuery(_schema, Queries.Introspection);
         _smallResult = ExecuteQuery(_schema, Queries.Hero);
-        _middleResult = ExecuteQuery(_schema, @"{
-  hero
-  {
-    name
-    id
-    friends
-    {
-      id
-      name
-      friends
-      {
-        id
-        name
-        friends
+        _middleResult = ExecuteQuery(_schema, """
         {
-          id
-          name
+          hero
+          {
+            name
+            id
+            friends
+            {
+              id
+              name
+              friends
+              {
+                id
+                name
+                friends
+                {
+                  id
+                  name
+                }
+              }
+            }
+          }
         }
-      }
-    }
-  }
-}");
+        """);
         _stream = Stream.Null;
     }
 

--- a/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
+++ b/src/GraphQL.DataLoader.Tests/DataLoaderQueryTests.cs
@@ -80,27 +80,28 @@ public class DataLoaderQueryTests : QueryTestBase
             .ReturnsAsync(users.ToDictionary(x => x.UserId));
 
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
-            query: @"
-{
-    order(orderId: 1) {
-        orderId
-        user {
-            userId
-            firstName
-        }
-    }
-}",
+            query: """
+            {
+                order(orderId: 1) {
+                    orderId
+                    user {
+                        userId
+                        firstName
+                    }
+                }
+            }
+            """,
             expected: $$"""
-{
-    "order": {
-        "orderId": 1,
-        "user": {
-            "userId": 1,
-            "firstName": "{{users[0].FirstName}}"
-        }
-    }
-}
-""").ConfigureAwait(false);
+            {
+                "order": {
+                    "orderId": 1,
+                    "user": {
+                        "userId": 1,
+                        "firstName": "{{users[0].FirstName}}"
+                    }
+                }
+            }
+            """).ConfigureAwait(false);
 
         ordersMock.Verify(x => x.GetOrderByIdAsync(new[] { 1 }), Times.Once);
         ordersMock.VerifyNoOtherCalls();
@@ -125,35 +126,36 @@ public class DataLoaderQueryTests : QueryTestBase
             .ReturnsAsync(users.ToDictionary(x => x.UserId));
 
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
-            query: @"
-{
-    orders {
-        orderId
-        user {
-            userId
-            firstName
-        }
-    }
-}",
+            query: """
+            {
+                orders {
+                    orderId
+                    user {
+                        userId
+                        firstName
+                    }
+                }
+            }
+            """,
             expected: $$"""
-{
-    "orders": [
-    {
-        "orderId": 1,
-        "user": {
-            "userId": 1,
-            "firstName": "{{users[0].FirstName}}"
-        }
-    },
-    {
-        "orderId": 2,
-        "user": {
-            "userId": 2,
-            "firstName": "{{users[1].FirstName}}"
-        }
-    }]
-}
-""").ConfigureAwait(false);
+            {
+                "orders": [
+                {
+                    "orderId": 1,
+                    "user": {
+                        "userId": 1,
+                        "firstName": "{{users[0].FirstName}}"
+                    }
+                },
+                {
+                    "orderId": 2,
+                    "user": {
+                        "userId": 2,
+                        "firstName": "{{users[1].FirstName}}"
+                    }
+                }]
+            }
+            """).ConfigureAwait(false);
 
         ordersMock.Verify(x => x.GetAllOrdersAsync(), Times.Once);
         ordersMock.VerifyNoOtherCalls();
@@ -178,35 +180,36 @@ public class DataLoaderQueryTests : QueryTestBase
             .ReturnsAsync(users.ToDictionary(x => x.UserId));
 
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
-            query: @"
-mutation {
-    orders {
-        orderId
-        user {
-            userId
-            firstName
-        }
-    }
-}",
+            query: """
+            mutation {
+                orders {
+                    orderId
+                    user {
+                        userId
+                        firstName
+                    }
+                }
+            }
+            """,
             expected: $$"""
-{
-    "orders": [
-    {
-        "orderId": 1,
-        "user": {
-            "userId": 1,
-            "firstName": "{{users[0].FirstName}}"
-        }
-    },
-    {
-        "orderId": 2,
-        "user": {
-            "userId": 2,
-            "firstName": "{{users[1].FirstName}}"
-        }
-    }]
-}
-""").ConfigureAwait(false);
+            {
+                "orders": [
+                {
+                    "orderId": 1,
+                    "user": {
+                        "userId": 1,
+                        "firstName": "{{users[0].FirstName}}"
+                    }
+                },
+                {
+                    "orderId": 2,
+                    "user": {
+                        "userId": 2,
+                        "firstName": "{{users[1].FirstName}}"
+                    }
+                }]
+            }
+            """).ConfigureAwait(false);
 
         ordersMock.Verify(x => x.GetAllOrdersAsync(), Times.Once);
         ordersMock.VerifyNoOtherCalls();
@@ -235,49 +238,50 @@ mutation {
             .ReturnsAsync(orderItems.ToLookup(x => x.OrderId));
 
         await AssertQuerySuccessAsync<DataLoaderTestSchema>(
-            query: @"
-{
-    users {
-        orderedItems {
-            orderItemId
-        }
-    }
-}",
+            query: """
+            {
+                users {
+                    orderedItems {
+                        orderItemId
+                    }
+                }
+            }
+            """,
             expected: $$"""
-{
-    "users": [
-    {
-        "orderedItems": [
-        {
-            "orderItemId": 1
-        },
-        {
-            "orderItemId": 2
-        },
-        {
-            "orderItemId": 3
-        },
-        {
-            "orderItemId": 4
-        }]
-    },
-    {
-        "orderedItems": [
-        {
-            "orderItemId": 5
-        },
-        {
-            "orderItemId": 6
-        },
-        {
-            "orderItemId": 7
-        },
-        {
-            "orderItemId": 8
-        }]
-    }]
-}
-""").ConfigureAwait(false);
+            {
+                "users": [
+                {
+                    "orderedItems": [
+                    {
+                        "orderItemId": 1
+                    },
+                    {
+                        "orderItemId": 2
+                    },
+                    {
+                        "orderItemId": 3
+                    },
+                    {
+                        "orderItemId": 4
+                    }]
+                },
+                {
+                    "orderedItems": [
+                    {
+                        "orderItemId": 5
+                    },
+                    {
+                        "orderItemId": 6
+                    },
+                    {
+                        "orderItemId": 7
+                    },
+                    {
+                        "orderItemId": 8
+                    }]
+                }]
+            }
+            """).ConfigureAwait(false);
         usersMock.Verify(x => x.GetAllUsersAsync(default), Times.Once);
         usersMock.VerifyNoOtherCalls();
 
@@ -312,30 +316,31 @@ mutation {
             .ReturnsAsync(products.ToDictionary(x => x.ProductId));
 
         var result = await ExecuteQueryAsync<DataLoaderTestSchema>(
-            query: @"
-{
-    orders {
-        orderId
-        orderedOn
-        user {
-            userId
-            firstName
-            lastName
-            email
-        }
-        items {
-            orderItemId
-            quantity
-            unitPrice
-            product {
-                productId
-                name
-                price
-                description
+            query: """
+            {
+                orders {
+                    orderId
+                    orderedOn
+                    user {
+                        userId
+                        firstName
+                        lastName
+                        email
+                    }
+                    items {
+                        orderItemId
+                        quantity
+                        unitPrice
+                        product {
+                            productId
+                            name
+                            price
+                            description
+                        }
+                    }
+                }
             }
-        }
-    }
-}").ConfigureAwait(false);
+            """).ConfigureAwait(false);
 
         result.Errors.ShouldBeNull();
     }

--- a/src/GraphQL.Tests/Bugs/Bug68NonNullEnumGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug68NonNullEnumGraphTypeTests.cs
@@ -141,7 +141,7 @@ public class EnumType<T> : EnumerationGraphType
     private static string DeriveEnumValueName(string name)
     {
         return Regex
-          .Replace(name, @"([A-Z])([A-Z][a-z])|([a-z0-9])([A-Z])", "$1$3_$2$4")
+          .Replace(name, "([A-Z])([A-Z][a-z])|([a-z0-9])([A-Z])", "$1$3_$2$4")
           .ToUpperInvariant();
     }
 }

--- a/src/GraphQL.Tests/Bugs/BugNestedCollection.cs
+++ b/src/GraphQL.Tests/Bugs/BugNestedCollection.cs
@@ -26,7 +26,7 @@ public class Bug850MutationAlias : QueryTestBase<NestedMutationSchema>
 """
                 .ToInputs();
 
-        string query = @"mutation createProgram($program: ProgramInput!) { createProgram(program: $program) }";
+        string query = "mutation createProgram($program: ProgramInput!) { createProgram(program: $program) }";
 
         string expected = """{ "createProgram": true }""";
 

--- a/src/GraphQL.Tests/Bugs/Issue1189.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1189.cs
@@ -5,21 +5,21 @@ namespace GraphQL.Tests.Bugs;
 
 public class Issue1189 : SchemaBuilderTestBase
 {
-    private const string _typeDefinitions = @"
-                  type Droid {
-                    id: String!
-                    name: String!
-                    friend: Character
-                  }
+    private const string _typeDefinitions = """
+        type Droid {
+          id: String!
+          name: String!
+          friend: Character
+        }
 
-                  type Character {
-                    name: String!
-                  }
+        type Character {
+          name: String!
+        }
 
-                  type Query {
-                    hero: Droid
-                  }
-                ";
+        type Query {
+          hero: Droid
+        }
+        """;
 
     private const string _query = "{ hero { id name friend { name } } }";
 

--- a/src/GraphQL.Tests/Bugs/Issue1354.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1354.cs
@@ -16,7 +16,7 @@ public sealed class Issue1354 : QueryTestBase<ValueTypeSchema>
     public void should_throw_on_unknown_property()
     {
         var query = "query { seconds1 }";
-        var expected = @"{ ""seconds1"": null }";
+        var expected = """{ "seconds1": null }""";
         var result = AssertQueryWithErrors(query, expected, root: TimeSpan.FromSeconds(42), renderErrors: false, expectedErrorCount: 1);
         result.Errors[0].InnerException.ShouldBeOfType<InvalidOperationException>();
     }

--- a/src/GraphQL.Tests/Bugs/Issue1874.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1874.cs
@@ -8,28 +8,30 @@ public class Issue1874 : QueryTestBase<Issue1874Schema>
     [Fact]
     public void byte_array_should_work()
     {
-        var query = @"
-                query BytesRequest($bytesHolder: Issue1874InputBytesType) {
-                    bytes(bytesObject: $bytesHolder) {
-                        bytes
-                    }
-                }";
+        var query = """
+            query BytesRequest($bytesHolder: Issue1874InputBytesType) {
+              bytes(bytesObject: $bytesHolder) {
+                bytes
+              }
+            }
+            """;
 
-        AssertQuerySuccess(query, @"{ ""bytes"": { ""bytes"": [1, 2, 3, 4] } }", @"{ ""bytesHolder"": { ""bytes"": [1, 2, 3, 4] } }".ToInputs());
+        AssertQuerySuccess(query, """{ "bytes": { "bytes": [1, 2, 3, 4] } }""", """{ "bytesHolder": { "bytes": [1, 2, 3, 4] } }""".ToInputs());
     }
 
     [Fact]
     public void string_should_work()
     {
-        var query = @"
-                query BytesRequest($bytesHolder: Issue1874Input64BytesType) {
-                    bytes64(bytesObject: $bytesHolder) {
-                        bytes
-                    }
-                }";
+        var query = """
+            query BytesRequest($bytesHolder: Issue1874Input64BytesType) {
+              bytes64(bytesObject: $bytesHolder) {
+                bytes
+              }
+            }
+            """;
 
         var str1234 = System.Convert.ToBase64String(new byte[] { 1, 2, 3, 4 });
-        AssertQuerySuccess(query, @"{ ""bytes64"": { ""bytes"": """ + str1234 + @""" } }", (@"{ ""bytesHolder"": { ""bytes"": """ + str1234 + @""" } }").ToInputs());
+        AssertQuerySuccess(query, $$"""{ "bytes64": { "bytes": "{{str1234}}" } }""", $$"""{ "bytesHolder": { "bytes": "{{str1234}}" } }""".ToInputs());
     }
 
     [Fact]
@@ -37,14 +39,15 @@ public class Issue1874 : QueryTestBase<Issue1874Schema>
     {
         var str1234 = System.Convert.ToBase64String(new byte[] { 1, 2, 3, 4 });
 
-        var query = @"
-                query BytesRequest {
-                    bytes64(bytesObject: { bytes: """ + str1234 + @"""}) {
-                        bytes
-                    }
-                }";
+        var query = $$"""
+            query BytesRequest {
+                bytes64(bytesObject: { bytes: "{{str1234}}"}) {
+                    bytes
+                }
+            }
+            """;
 
-        AssertQuerySuccess(query, @"{ ""bytes64"": { ""bytes"": """ + str1234 + @""" } }");
+        AssertQuerySuccess(query, $$"""{ "bytes64": { "bytes": "{{str1234}}" } }""");
     }
 }
 

--- a/src/GraphQL.Tests/Bugs/Issue1981.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1981.cs
@@ -8,34 +8,39 @@ public class Issue1981 : QueryTestBase<Issue1981Schema>
     [Fact]
     public void Should_Provide_Directives_In_Resolver()
     {
-        var query = @"query Q($var1: Boolean!, $var2: Boolean! = true)
-{
-  fieldWith2Literal @skip(if: false) @include(if: true)
-  fieldWithVariable @include(if: $var1)
-  fieldWithVariableDefault @include(if: $var2)
-  fieldWithoutDirectives
-}
-";
-        var expected = @"{
-  ""fieldWith2Literal"": ""1"",
-  ""fieldWithVariable"": ""2"",
-  ""fieldWithVariableDefault"": ""3"",
-  ""fieldWithoutDirectives"": ""4""
-}";
-        AssertQuerySuccess(query, expected, @"{ ""var1"": true }".ToInputs());
+        var query = """
+        query Q($var1: Boolean!, $var2: Boolean! = true)
+        {
+          fieldWith2Literal @skip(if: false) @include(if: true)
+          fieldWithVariable @include(if: $var1)
+          fieldWithVariableDefault @include(if: $var2)
+          fieldWithoutDirectives
+        }
+        """;
+        var expected = """
+        {
+          "fieldWith2Literal": "1",
+          "fieldWithVariable": "2",
+          "fieldWithVariableDefault": "3",
+          "fieldWithoutDirectives": "4"
+        }
+        """;
+        AssertQuerySuccess(query, expected, """{ "var1": true }""".ToInputs());
     }
 
     [Fact]
     public void Should_Ignore_Unknown_Directives()
     {
-        var query = @"
-{
-  fieldWithoutDirectives @unknown
-}
-";
-        var expected = @"{
-  ""fieldWithoutDirectives"": ""4""
-}";
+        var query = """
+        {
+          fieldWithoutDirectives @unknown
+        }
+        """;
+        var expected = """
+        {
+          "fieldWithoutDirectives": "4"
+        }
+        """;
         // empty validation rules to bypass validation error from KnownDirectivesInAllowedLocations
         AssertQuerySuccess(query, expected, rules: Array.Empty<IValidationRule>());
     }

--- a/src/GraphQL.Tests/Bugs/Issue2275.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2275.cs
@@ -12,28 +12,34 @@ public class Issue2275
         var executionResult = await documentExecuter.ExecuteAsync(_ =>
         {
             _.Schema = new Issue2275Schema();
-            _.Query = @"query($data:Input!) {
-                                request(data: $data)
-                }";
-            _.Variables = serializer.Deserialize<Inputs>(@"{
-                    ""data"": {
-                        ""clientId"": 2,
-                        ""filters"": [{
-                            ""key"": ""o"",
-                            ""value"": 25
+            _.Query = """
+                query($data:Input!) {
+                  request(data: $data)
+                }
+                """;
+            _.Variables = serializer.Deserialize<Inputs>("""
+                {
+                    "data": {
+                        "clientId": 2,
+                        "filters": [{
+                            "key": "o",
+                            "value": 25
                         }]
                     }
-                }");
+                }
+                """);
         }).ConfigureAwait(false);
 
         var json = serializer.Serialize(executionResult);
         executionResult.Errors.ShouldBeNull();
 
-        json.ShouldBe(@"{
-  ""data"": {
-    ""request"": ""2: [o=25]""
-  }
-}");
+        json.ShouldBe("""
+        {
+          "data": {
+            "request": "2: [o=25]"
+          }
+        }
+        """);
     }
 
     private class Issue2275Schema : Schema

--- a/src/GraphQL.Tests/Bugs/Issue2387_OverrideBuiltInScalars.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2387_OverrideBuiltInScalars.cs
@@ -118,13 +118,14 @@ public class Issue2387_OverrideBuiltInScalars : QueryTestBase<Issue2387_Override
 
     private Schema BuildSchemaFirst()
     {
-        var typeDefs = @"
-type Query {
-  testOutput: Int!
-  testInput(arg: Int!): ID!
-  testOutputString: String!
-  testInputString(arg: String!): ID!
-}";
+        var typeDefs = """
+            type Query {
+              testOutput: Int!
+              testInput(arg: Int!): ID!
+              testOutputString: String!
+              testInputString(arg: String!): ID!
+            }
+            """;
         var schema = GraphQL.Types.Schema.For(typeDefs, config => config.Types.Include<SchemaFirstRoot>());
         schema.RegisterType(new MyIntGraphType());
         schema.RegisterType<MyStringGraphType>();

--- a/src/GraphQL.Tests/Bugs/Issue2392_OverrideBuiltInScalars_Alt.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2392_OverrideBuiltInScalars_Alt.cs
@@ -137,13 +137,14 @@ public class Issue2392_OverrideBuiltInScalars_Alt : QueryTestBase<Issue2392_Over
 
     private Schema BuildSchemaFirst()
     {
-        var typeDefs = @"
-type Query {
-  testOutput: Int!
-  testInput(arg: Int!): ID!
-  testOutputString: String!
-  testInputString(arg: String!): ID!
-}";
+        var typeDefs = """
+            type Query {
+              testOutput: Int!
+              testInput(arg: Int!): ID!
+              testOutputString: String!
+              testInputString(arg: String!): ID!
+            }
+            """;
         var schema = GraphQL.Types.Schema.For(typeDefs, config => config.Types.Include<SchemaFirstRoot>());
 
         Replace(schema);

--- a/src/GraphQL.Tests/Bugs/Issue2932_DemoDIGraphType.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2932_DemoDIGraphType.cs
@@ -30,10 +30,9 @@ public class Issue2932_DemoDIGraphType : QueryTestBase<Issue2932_DemoDIGraphType
         //
         // note: this is just an example of what can be done, and does not necessarily indicate a preferred programming pattern
 
-        AssertQuerySuccess(
-            @"
+        AssertQuerySuccess("""
 {
-  example (id: 1, name: ""john doe"") {
+  example (id: 1, name: "john doe") {
     id
     name
     children
@@ -45,22 +44,22 @@ public class Issue2932_DemoDIGraphType : QueryTestBase<Issue2932_DemoDIGraphType
     counter3: counter
   }
 }
-",
-            @"
+""",
+"""
 {
-  ""example"": {
-    ""id"": ""1"",
-    ""name"": ""john doe"",
-    ""children"": [""Happy"",""Dopey"",""Grumpy""],
-    ""service2Test"": 2,
-    ""counter1"": 0,
-    ""counter2"": 1,
-    ""scopedCounter1"": 0,
-    ""scopedCounter2"": 0,
-    ""counter3"": 2
+  "example": {
+    "id": "1",
+    "name": "john doe",
+    "children": ["Happy","Dopey","Grumpy"],
+    "service2Test": 2,
+    "counter1": 0,
+    "counter2": 1,
+    "scopedCounter1": 0,
+    "scopedCounter2": 0,
+    "counter3": 2
   }
 }
-");
+""");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Bugs/Issue3370.cs
+++ b/src/GraphQL.Tests/Bugs/Issue3370.cs
@@ -21,7 +21,7 @@ public class Issue3370_LiteralObjectsWithNoEntriesDoNotValidate
         var result2 = await schema.ExecuteAsync(options =>
         {
             options.Query = "query($input: TestInputType!){test(input: $input) { stringValue }}";
-            options.Variables = @"{ ""input"": {}}".ToInputs();
+            options.Variables = """{ "input": {}}""".ToInputs();
         }).ConfigureAwait(false);
         result2.ShouldBeCrossPlatJson("""{"errors":[{"message":"Variable \u0027$input.prop1\u0027 is invalid. No value provided for a non-null variable.","locations":[{"line":1,"column":7}],"extensions":{"code":"INVALID_VALUE","codes":["INVALID_VALUE"],"number":"5.8"}}]}""");
     }

--- a/src/GraphQL.Tests/Bugs/Issue899.cs
+++ b/src/GraphQL.Tests/Bugs/Issue899.cs
@@ -7,26 +7,28 @@ public class Issue899 : QueryTestBase<Issue899Schema>
     [Fact]
     public void Issue899_Should_Work()
     {
-        var query = @"
-query {
-  level1(arg1: ""1"") {
-    level2(arg2: ""2"") {
-      level3(arg3: ""3"") {
-        level4(arg4: ""4"")
-      }
-    }
-  }
-}
-";
-        var expected = @"{
-  ""level1"": {
-    ""level2"": [[{
-      ""level3"": [{
-        ""level4"": ""X""
-      }]
-    }]]
-  }
-}";
+        var query = """
+        query {
+          level1(arg1: "1") {
+            level2(arg2: "2") {
+              level3(arg3: "3") {
+                level4(arg4: "4")
+              }
+            }
+          }
+        }
+        """;
+        var expected = """
+        {
+          "level1": {
+            "level2": [[{
+              "level3": [{
+                "level4": "X"
+              }]
+            }]]
+          }
+        }
+        """;
         AssertQuerySuccess(query, expected, null);
     }
 }

--- a/src/GraphQL.Tests/Bugs/ListWithNullablesTest.cs
+++ b/src/GraphQL.Tests/Bugs/ListWithNullablesTest.cs
@@ -7,16 +7,18 @@ public class ListWithNullablesTest : QueryTestBase<ListWithNullablesSchema>
     [Fact]
     public void Can_Accept_Null_List_From_Literal()
     {
-        var query = @"
-                query _ {
-                  list {
-                    value
-                  }
-                }";
-        var expected = @"
-                {
-                    ""list"": [{ ""value"": ""one""}, null, { ""value"": ""three"" }]
-                }";
+        var query = """
+            query _ {
+                list {
+                value
+                }
+            }
+            """;
+        var expected = """
+            {
+                "list": [{ "value": "one"}, null, { "value": "three" }]
+            }
+            """;
         AssertQuerySuccess(query, expected);
     }
 }

--- a/src/GraphQL.Tests/Bugs/NullArguments.cs
+++ b/src/GraphQL.Tests/Bugs/NullArguments.cs
@@ -7,25 +7,27 @@ public class NullArguments : QueryTestBase<NullMutationSchema>
     [Fact]
     public void Supports_partially_nullable_fields_on_arguments()
     {
-        var query = @"
-mutation {
-  run(input: {id:null, foo:null,bar:null})
-}
-";
-        var expected = @"{
-  ""run"": ""idfoobar""
-}";
+        var query = """
+            mutation {
+              run(input: {id:null, foo:null,bar:null})
+            }
+            """;
+        var expected = """
+            {
+              "run": "idfoobar"
+            }
+            """;
         AssertQuerySuccess(query, expected, null);
     }
 
     [Fact]
     public void Supports_non_null_int()
     {
-        var query = @"
-mutation {
-  run(input: {id:105, foo:null,bar:{id: null, foo:""a"", bar:{id:101}}})
-}
-";
+        var query = """
+            mutation {
+              run(input: {id:105, foo:null,bar:{id: null, foo:"a", bar:{id:101}}})
+            }
+            """;
 
         var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1, executed: false);
 
@@ -38,11 +40,11 @@ mutation {
     [Fact]
     public void Supports_non_null_string()
     {
-        var query = @"
-mutation {
-  run(input: {id:105, foo:null,bar:{id: 1, foo:null, bar:{id:101}}})
-}
-";
+        var query = """
+            mutation {
+              run(input: {id:105, foo:null,bar:{id: 1, foo:null, bar:{id:101}}})
+            }
+            """;
 
         var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1, executed: false);
 
@@ -55,11 +57,11 @@ mutation {
     [Fact]
     public void Supports_non_null_object()
     {
-        var query = @"
-mutation {
-  run(input: {id:105, foo:null,bar:{id: 1, foo:""abc"", bar:null}})
-}
-";
+        var query = """
+            mutation {
+              run(input: {id:105, foo:null,bar:{id: 1, foo:"abc", bar:null}})
+            }
+            """;
 
         var result = AssertQueryWithErrors(query, null, null, expectedErrorCount: 1, executed: false);
 

--- a/src/GraphQL.Tests/Bugs/NullableInputListTests.cs
+++ b/src/GraphQL.Tests/Bugs/NullableInputListTests.cs
@@ -7,28 +7,32 @@ public class NullableInputListTests : QueryTestBase<TestSchema>
     [Fact]
     public void Can_Accept_Null_List_From_Literal()
     {
-        var query = @"
-                query _ {
-                  example(testInputs:null)
-                }";
-        var expected = @"
-                {
-                    ""example"": ""null""
-                }";
+        var query = """
+            query _ {
+              example(testInputs:null)
+            }
+            """;
+        var expected = """
+            {
+              "example": "null"
+            }
+            """;
         AssertQuerySuccess(query, expected);
     }
 
     [Fact]
     public void Can_Accept_Null_List_From_Input()
     {
-        var query = @"
-                query _($inputs:[TestInput]) {
-                  example(testInputs: $inputs)
-                }";
-        var expected = @"
-                {
-                    ""example"": ""null""
-                }";
+        var query = """
+            query _($inputs:[TestInput]) {
+              example(testInputs: $inputs)
+            }
+            """;
+        var expected = """
+            {
+              "example": "null"
+            }
+            """;
         AssertQuerySuccess(query, expected, variables: new Inputs(new Dictionary<string, object>
         {
             { "inputs", null }

--- a/src/GraphQL.Tests/Bugs/PascalCaseTests.cs
+++ b/src/GraphQL.Tests/Bugs/PascalCaseTests.cs
@@ -9,7 +9,7 @@ public sealed class PascalCaseTests : QueryTestBase<PascalCaseSchema>
     public void get_argument_camel_to_pascal_case()
     {
         var query = "{ Query(ArgumentValue: 42) }";
-        var expectedResult = @"{ ""Query"": 42 }";
+        var expectedResult = """{ "Query": 42 }""";
         AssertQuery(query, CreateQueryResult(expectedResult), null, null, nameConverter: PascalCaseNameConverter.Instance);
     }
 }

--- a/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
+++ b/src/GraphQL.Tests/Bugs/ScalarsInputTest.cs
@@ -7,9 +7,9 @@ public class ScalarsInputTest : QueryTestBase<SchemaForScalars>
     [Fact]
     public void Scalars_Should_Return_As_Is()
     {
-        var query = @"
+        var query = """
 mutation {
-  create(input: {float1: 1.3, floatFromInt: 1, id1:""8dfab389-a6f7-431d-ab4e-aa693cc53edf"", id2:""8dfab389-a6f7-431d-ab4e-aa693cc53ede"", uint: 3147483647, uintArray: [3147483640], short: -21000, shortArray: [20000] ushort: 61000, ushortArray: [65000], ulong: 4000000000000, ulongArray: [1234567890123456789], byte: 50, byteArray: [1,2,3], sbyte: -60, sbyteArray: [-1,2,-3], dec: 39614081257132168796771975168, decZero: 12.10, decArray: [1,39614081257132168796771975168,3] })
+  create(input: {float1: 1.3, floatFromInt: 1, id1:"8dfab389-a6f7-431d-ab4e-aa693cc53edf", id2:"8dfab389-a6f7-431d-ab4e-aa693cc53ede", uint: 3147483647, uintArray: [3147483640], short: -21000, shortArray: [20000] ushort: 61000, ushortArray: [65000], ulong: 4000000000000, ulongArray: [1234567890123456789], byte: 50, byteArray: [1,2,3], sbyte: -60, sbyteArray: [-1,2,-3], dec: 39614081257132168796771975168, decZero: 12.10, decArray: [1,39614081257132168796771975168,3] })
   {
     float1
     floatFromInt
@@ -70,116 +70,118 @@ mutation {
     decArray
   }
 }
-";
-        var expected = @"{
-  ""data"": {
-    ""create"": {
-      ""float1"": 1.2999999523162842,
-      ""floatFromInt"": 1,
-      ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
-      ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
-      ""uint"": 3147483647,
-      ""uintArray"": [
+""";
+        var expected = """
+{
+  "data": {
+    "create": {
+      "float1": 1.2999999523162842,
+      "floatFromInt": 1,
+      "id1": "8dfab389-a6f7-431d-ab4e-aa693cc53edf",
+      "id2": "8dfab389-a6f7-431d-ab4e-aa693cc53ede",
+      "uint": 3147483647,
+      "uintArray": [
         3147483640
       ],
-      ""short"": -21000,
-      ""shortArray"": [
+      "short": -21000,
+      "shortArray": [
         20000
       ],
-      ""ushort"": 61000,
-      ""ushortArray"": [
+      "ushort": 61000,
+      "ushortArray": [
         65000
       ],
-      ""ulong"": 4000000000000,
-      ""ulongArray"": [
+      "ulong": 4000000000000,
+      "ulongArray": [
         1234567890123456789
       ],
-      ""byte"": 50,
-      ""byteArray"": [
+      "byte": 50,
+      "byteArray": [
         1,
         2,
         3
       ],
-      ""sbyte"": -60,
-      ""sbyteArray"": [
+      "sbyte": -60,
+      "sbyteArray": [
         -1,
         2,
         -3
       ],
-      ""dec"": 39614081257132168796771975168,
-      ""decZero"": 12.10,
-      ""decArray"": [
+      "dec": 39614081257132168796771975168,
+      "decZero": 12.10,
+      "decArray": [
         1,
         39614081257132168796771975168,
         3
       ]
     },
-    ""create_with_defaults"": {
-      ""float1"": 1.2999999523162842,
-      ""floatFromInt"": 1,
-      ""id1"": ""8dfab389-a6f7-431d-ab4e-aa693cc53edf"",
-      ""id2"": ""8dfab389-a6f7-431d-ab4e-aa693cc53ede"",
-      ""uint"": 3147483647,
-      ""uintArray"": [
+    "create_with_defaults": {
+      "float1": 1.2999999523162842,
+      "floatFromInt": 1,
+      "id1": "8dfab389-a6f7-431d-ab4e-aa693cc53edf",
+      "id2": "8dfab389-a6f7-431d-ab4e-aa693cc53ede",
+      "uint": 3147483647,
+      "uintArray": [
         3147483640
       ],
-      ""short"": -21000,
-      ""shortArray"": [
+      "short": -21000,
+      "shortArray": [
         20000
       ],
-      ""ushort"": 61000,
-      ""ushortArray"": [
+      "ushort": 61000,
+      "ushortArray": [
         65000
       ],
-      ""ulong"": 4000000000000,
-      ""ulongArray"": [
+      "ulong": 4000000000000,
+      "ulongArray": [
         1234567890123456789
       ],
-      ""byte"": 50,
-      ""byteArray"": [
+      "byte": 50,
+      "byteArray": [
         1,
         2,
         3
       ],
-      ""sbyte"": -60,
-      ""sbyteArray"": [
+      "sbyte": -60,
+      "sbyteArray": [
         -1,
         2,
         -3
       ],
-      ""dec"": 39614081257132168796771975168,
-      ""decZero"": 12.10,
-      ""decArray"": [
+      "dec": 39614081257132168796771975168,
+      "decZero": 12.10,
+      "decArray": [
         1,
         39614081257132168796771975168,
         3
       ]
     }
   }
-}";
+}
+""";
         AssertQuery(query, expected, null, null);
     }
 
     [Fact]
     public void Should_Accept_Int_As_Int_In_Literal()
     {
-        var query = @"mutation { int(number: 100) }";
-        var expected = @"{ ""int"": 100 }";
+        var query = "mutation { int(number: 100) }";
+        var expected = """{ "int": 100 }""";
         AssertQuerySuccess(query, expected, null, null);
     }
 
     [Fact]
     public void Should_Accept_Long_As_Long_In_Literal()
     {
-        var query = @"mutation { long(number: 100) }";
-        var expected = @"{ ""long"": 100 }";
+        var query = "mutation { long(number: 100) }";
+        var expected = """{ "long": 100 }""";
         AssertQuerySuccess(query, expected, null, null);
     }
 
     [Fact]
     public void Should_Not_Accept_String_As_Int_In_Literal()
     {
-        var query = @"mutation { int(number: ""100"") }";
+        var query = """mutation { int(number: "100") }""";
         string expected = null;
         var result = AssertQueryWithErrors(query, expected, expectedErrorCount: 1, executed: false);
         result.Errors[0].Message.ShouldBe("Argument 'number' has invalid value. Expected type 'Int', found \"100\".");
@@ -188,16 +190,16 @@ mutation {
     [Fact]
     public void Should_Not_Accept_String_As_Int_In_Variable()
     {
-        var query = @"mutation AAA($val : Int!) { int(number: $val) }";
-        var expected = @"{ ""int"": 100 }";
-        var result = AssertQueryWithErrors(query, expected, variables: @"{ ""val"": ""100"" }".ToInputs(), expectedErrorCount: 1, executed: false);
-        result.Errors[0].Message.ShouldBe(@"Variable '$val' is invalid. Unable to convert '100' to 'Int'");
+        var query = "mutation AAA($val : Int!) { int(number: $val) }";
+        var expected = """{ "int": 100 }""";
+        var result = AssertQueryWithErrors(query, expected, variables: """{ "val": "100" }""".ToInputs(), expectedErrorCount: 1, executed: false);
+        result.Errors[0].Message.ShouldBe("Variable '$val' is invalid. Unable to convert '100' to 'Int'");
     }
 
     [Fact]
     public void Should_Not_Accept_String_As_Long_In_Literal()
     {
-        var query = @"mutation { long(number: ""100"") }";
+        var query = """mutation { long(number: "100") }""";
         string expected = null;
         var result = AssertQueryWithErrors(query, expected, expectedErrorCount: 1, executed: false);
         result.Errors[0].Message.ShouldBe("Argument 'number' has invalid value. Expected type 'Long', found \"100\".");
@@ -206,10 +208,10 @@ mutation {
     [Fact]
     public void Should_Not_Accept_String_As_Long_In_Variable()
     {
-        var query = @"mutation AAA($val : Long!) { long(number: $val) }";
-        var expected = @"{ ""long"": 100 }";
-        var result = AssertQueryWithErrors(query, expected, variables: @"{ ""val"": ""100"" }".ToInputs(), expectedErrorCount: 1, executed: false);
-        result.Errors[0].Message.ShouldBe(@"Variable '$val' is invalid. Unable to convert '100' to 'Long'");
+        var query = "mutation AAA($val : Long!) { long(number: $val) }";
+        var expected = """{ "long": 100 }""";
+        var result = AssertQueryWithErrors(query, expected, variables: """{ "val": "100" }""".ToInputs(), expectedErrorCount: 1, executed: false);
+        result.Errors[0].Message.ShouldBe("Variable '$val' is invalid. Unable to convert '100' to 'Long'");
     }
 }
 

--- a/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
@@ -61,57 +61,76 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
     [Fact]
     public void should_resolve_in_query()
     {
-        AssertQuerySuccess(
-            @"{ parent {
-                  connection1 {
-                    totalCount
-                    edges { cursor node { field1 field2 } }
-                    items { field1 field2 }
-                  }
-                }}",
-            @"{ ""parent"": {
-                ""connection1"": {
-                  ""totalCount"": 3,
-                  ""edges"": [
-                    { ""cursor"": ""1"", ""node"": { ""field1"": ""one"", ""field2"": 1 } },
-                    { ""cursor"": ""2"", ""node"": { ""field1"": ""two"", ""field2"": 2 } },
-                    { ""cursor"": ""3"", ""node"": { ""field1"": ""three"", ""field2"": 3 } }
+        AssertQuerySuccess("""
+            {
+              parent {
+                connection1 {
+                  totalCount
+                  edges { cursor node { field1 field2 } }
+                  items { field1 field2 }
+                }
+              }
+            }
+            """,
+            """
+            {
+              "parent": {
+                "connection1": {
+                  "totalCount": 3,
+                  "edges": [
+                    { "cursor": "1", "node": { "field1": "one", "field2": 1 } },
+                    { "cursor": "2", "node": { "field1": "two", "field2": 2 } },
+                    { "cursor": "3", "node": { "field1": "three", "field2": 3 } }
                   ],
-                  ""items"": [
-                    { ""field1"": ""one"", ""field2"": 1 },
-                    { ""field1"": ""two"", ""field2"": 2 },
-                    { ""field1"": ""three"", ""field2"": 3 }
+                  "items": [
+                    { "field1": "one", "field2": 1 },
+                    { "field1": "two", "field2": 2 },
+                    { "field1": "three", "field2": 3 }
                   ]
-                } } }");
+                }
+              }
+            }
+            """
+        );
     }
 
     [Fact]
     public void should_yield_pagination_information()
     {
-        AssertQuerySuccess(
-            @"{ parent {
-                  connection2(first: 1, after: ""1"") {
-                    totalCount
-                    pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
-                    edges { cursor node { field1 field2 } }
-                    items { field1 field2 }
-                  } }}",
-            @"{ ""parent"": {
-                ""connection2"": {
-                  ""totalCount"": 3,
-                  ""pageInfo"": {
-                    ""hasNextPage"": true,
-                    ""hasPreviousPage"": true,
-                    ""startCursor"": ""2"",
-                    ""endCursor"": ""2""
+        AssertQuerySuccess("""
+            {
+              parent {
+                connection2(first: 1, after: "1") {
+                  totalCount
+                  pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+                  edges { cursor node { field1 field2 } }
+                  items { field1 field2 }
+                }
+              }
+            }
+            """,
+            """
+            {
+              "parent": {
+                "connection2": {
+                  "totalCount": 3,
+                  "pageInfo": {
+                    "hasNextPage": true,
+                    "hasPreviousPage": true,
+                    "startCursor": "2",
+                    "endCursor": "2"
                   },
-                  ""edges"": [
-                    { ""cursor"": ""2"", ""node"": { ""field1"": ""TWO"", ""field2"": 22 } }
+                  "edges": [
+                    { "cursor": "2", "node": { "field1": "TWO", "field2": 22 } }
                   ],
-                  ""items"": [
-                    { ""field1"": ""TWO"", ""field2"": 22 }
+                  "items": [
+                    { "field1": "TWO", "field2": 22 }
                   ]
-                } } }");
+                }
+              }
+            }
+            """
+        );
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Complexity/ComplexityBasicTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityBasicTests.cs
@@ -14,10 +14,11 @@ public class ComplexityBasicTests : ComplexityTestBase
     [Fact]
     public void zero_depth_query()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A #1
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A #1
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(0);
         res.Complexity.ShouldBe(1);
     }
@@ -25,12 +26,13 @@ query {
     [Fact]
     public void one_depth_query_A()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A { #2
-    B #2
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A { #2
+                B #2
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(1);
         res.Complexity.ShouldBe(4);
     }
@@ -38,14 +40,15 @@ query {
     [Fact]
     public void one_depth_query_B()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A { #2
-    B #2
-    C #2
-    D #2
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A { #2
+                B #2
+                C #2
+                D #2
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(1);
         res.Complexity.ShouldBe(8);
     }
@@ -53,14 +56,15 @@ query {
     [Fact]
     public void two_depth_query_A()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A {   #2
-    B { #4
-      C #4
-    }
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A {   #2
+                B { #4
+                  C #4
+                }
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(2);
         res.Complexity.ShouldBe(10);
     }
@@ -68,17 +72,18 @@ query {
     [Fact]
     public void two_depth_query_B()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  F     #1
-  A {   #2
-    B   #2
-    D { #4
-      C #4
-      E #4
-    }
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              F     #1
+              A {   #2
+                B   #2
+                D { #4
+                  C #4
+                  E #4
+                }
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(2);
         res.Complexity.ShouldBe(17);
     }
@@ -86,16 +91,17 @@ query {
     [Fact]
     public void three_depth_query()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A {     #2
-    B {   #4
-      C { #8
-        D #8
-      }
-    }
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A {     #2
+                B {   #4
+                  C { #8
+                    D #8
+                  }
+                }
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(3);
         res.Complexity.ShouldBe(22);
     }
@@ -103,18 +109,19 @@ query {
     [Fact]
     public void three_depth_query_wide()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A { #2
-    B #2
-  }
-  C { #2
-    D #2
-  }
-  E { #2
-    F #2
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A { #2
+                B #2
+              }
+              C { #2
+                D #2
+              }
+              E { #2
+                F #2
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(3);
         res.Complexity.ShouldBe(12);
     }

--- a/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityMetaDataTests.cs
@@ -17,24 +17,24 @@ public class ComplexityMetaDataTests : IClassFixture<ComplexityMetaDataFixture>
     [Fact]
     public async Task MetaData_ShouldBe_Used()
     {
-        var result = await _fixture.AnalyzeAsync(@"
-query {
-    hero { #2
-        id #0
-        name #2
-        friends { #4
-            id #0
-            name #4
-            f1: friends { #12
-                name #12
+        var result = await _fixture.AnalyzeAsync("""
+            query {
+                hero { #2
+                    id #0
+                    name #2
+                    friends { #4
+                        id #0
+                        name #4
+                        f1: friends { #12
+                            name #12
+                        }
+                        f2: friends { #12
+                            name #12
+                        }
+                    }
+                }
             }
-            f2: friends { #12
-                name #12
-            }
-        }
-    }
-}
-").ConfigureAwait(false);
+            """).ConfigureAwait(false);
 
         result.Complexity.ShouldBe(60);
         result.TotalQueryDepth.ShouldBe(4);
@@ -43,34 +43,34 @@ query {
     [Fact]
     public async Task MetaData_With_Fragments_ShouldBe_Used()
     {
-        var result = await _fixture.AnalyzeAsync(@"
-query {
-    hero { #2
-        id #0
-        name #2
-        ...friendsRoot #132(4/2*66)
-    }
-}
+        var result = await _fixture.AnalyzeAsync("""
+            query {
+                hero { #2
+                    id #0
+                    name #2
+                    ...friendsRoot #132(4/2*66)
+                }
+            }
 
-fragment friendsRoot on Hero {
-    friends { #3
-        ...friendsIdName #27(9/2*6)
-        f1: friends { #9
-            name #9
-        }
-        f2: friends { #9
-            name #9
-        }
-    }
-}
+            fragment friendsRoot on Hero {
+                friends { #3
+                    ...friendsIdName #27(9/2*6)
+                    f1: friends { #9
+                        name #9
+                    }
+                    f2: friends { #9
+                        name #9
+                    }
+                }
+            }
 
-fragment friendsIdName on Hero {
-    friends { #3
-        id #0
-        name #3
-    }
-}
-").ConfigureAwait(false);
+            fragment friendsIdName on Hero {
+                friends { #3
+                    id #0
+                    name #3
+                }
+            }
+            """).ConfigureAwait(false);
 
         result.Complexity.ShouldBe(136);
         result.TotalQueryDepth.ShouldBe(5);

--- a/src/GraphQL.Tests/Complexity/ComplexityTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityTests.cs
@@ -5,26 +5,28 @@ public class ComplexityTests : ComplexityTestBase
     [Fact]
     public void inline_fragments_test()
     {
-        var withFrag = AnalyzeComplexity(@"
-query withInlineFragment {
-  profiles(handles: [""dnetguru""]) {
-    handle
-    ... on User {
-      friends {
-        count
-      }
-    }
-  }
-}");
-        var woFrag = AnalyzeComplexity(@"
-query withoutFragments {
-  profiles(handles: [""dnetguru""]) {
-    handle
-    friends {
-      count
-    }
-  }
-}");
+        var withFrag = AnalyzeComplexity("""
+            query withInlineFragment {
+              profiles(handles: ["dnetguru"]) {
+                handle
+                ... on User {
+                  friends {
+                    count
+                  }
+                }
+              }
+            }
+            """);
+        var woFrag = AnalyzeComplexity("""
+            query withoutFragments {
+              profiles(handles: ["dnetguru"]) {
+                handle
+                friends {
+                  count
+                }
+              }
+            }
+            """);
 
         withFrag.Complexity.ShouldBe(woFrag.Complexity);
         withFrag.TotalQueryDepth.ShouldBe(woFrag.TotalQueryDepth);
@@ -33,40 +35,42 @@ query withoutFragments {
     [Fact]
     public void fragments_test()
     {
-        var withFrag = AnalyzeComplexity(@"
-{
-  leftComparison: hero(episode: EMPIRE) {
-    ...comparisonFields
-  }
-  rightComparison: hero(episode: JEDI) {
-    ...comparisonFields
-  }
-}
+        var withFrag = AnalyzeComplexity("""
+            {
+              leftComparison: hero(episode: EMPIRE) {
+                ...comparisonFields
+              }
+              rightComparison: hero(episode: JEDI) {
+                ...comparisonFields
+              }
+            }
 
-fragment comparisonFields on Character {
-  name
-  appearsIn
-  friends {
-    name
-  }
-}");
-        var woFrag = AnalyzeComplexity(@"
-{
-  leftComparison: hero(episode: EMPIRE) {
-    name
-    appearsIn
-    friends {
-      name
-    }
-  }
-  rightComparison: hero(episode: JEDI) {
-    name
-    appearsIn
-    friends {
-      name
-    }
-  }
-}");
+            fragment comparisonFields on Character {
+              name
+              appearsIn
+              friends {
+                name
+              }
+            }
+            """);
+        var woFrag = AnalyzeComplexity("""
+            {
+              leftComparison: hero(episode: EMPIRE) {
+                name
+                appearsIn
+                friends {
+                  name
+                }
+              }
+              rightComparison: hero(episode: JEDI) {
+                name
+                appearsIn
+                friends {
+                  name
+                }
+              }
+            }
+            """);
 
         withFrag.Complexity.ShouldBe(woFrag.Complexity);
         withFrag.TotalQueryDepth.ShouldBe(woFrag.TotalQueryDepth);
@@ -75,35 +79,37 @@ fragment comparisonFields on Character {
     [Fact]
     public void fragment_test_nested()
     {
-        var withFrag = AnalyzeComplexity(@"
-			{
-			  A {
-			    W {
-			      ...X
-			    }
-			  }
-			}
+        var withFrag = AnalyzeComplexity("""
+            {
+              A {
+                W {
+                  ...X
+                }
+              }
+            }
 
-			fragment X on Y {
-			  B
-			  C
-			  D {
-			    E
-			  }
-			}");
+            fragment X on Y {
+              B
+              C
+              D {
+                E
+              }
+            }
+            """);
 
-        var woFrag = AnalyzeComplexity(@"
-			{
-			  A {
-			    W {
-			      B
-			      C
-			      D {
-			        E
-			      }
-			    }
-			  }
-		    }");
+        var woFrag = AnalyzeComplexity("""
+            {
+              A {
+                W {
+                  B
+                  C
+                  D {
+                    E
+                  }
+                }
+              }
+            }
+            """);
 
         withFrag.Complexity.ShouldBe(woFrag.Complexity);
         withFrag.TotalQueryDepth.ShouldBe(woFrag.TotalQueryDepth);
@@ -113,31 +119,35 @@ fragment comparisonFields on Character {
     [Fact]
     public void nested_fragments()
     {
-        var withFrag = AnalyzeComplexity(@"query SomeDroids {
-                  droid(id: ""3"") {
-                    ...DroidFragment
-                  }
-               }
+        var withFrag = AnalyzeComplexity("""
+            query SomeDroids {
+              droid(id: "3") {
+                ...DroidFragment
+              }
+            }
 
-               fragment DroidFragment on Droid {
-                 name
-                 ... nestedNameFragment1
-               }
+            fragment DroidFragment on Droid {
+              name
+              ... nestedNameFragment1
+            }
 
-               fragment nestedNameFragment1 on Droid {
-                 ... nestedNameFragment2
-                 name
-               }
+            fragment nestedNameFragment1 on Droid {
+              ... nestedNameFragment2
+              name
+            }
 
-               fragment nestedNameFragment2 on Droid {
-                 name
-            }");
+            fragment nestedNameFragment2 on Droid {
+              name
+            }
+            """);
 
-        var woFrag = AnalyzeComplexity(@"query SomeDroids {
-                  droid(id: ""3"") {
-                    name
-                  }
-               }");
+        var woFrag = AnalyzeComplexity("""
+            query SomeDroids {
+              droid(id: "3") {
+                name
+              }
+            }
+            """);
 
         withFrag.Complexity.ShouldBe(4/*woFrag.Complexity*/); // TODO: 4 != 2 but may be OK
         withFrag.TotalQueryDepth.ShouldBe(woFrag.TotalQueryDepth);
@@ -147,57 +157,58 @@ fragment comparisonFields on Character {
     [Fact]
     public void nested_fragments_2()
     {
-        var result = AnalyzeComplexity(@"
-{
-  car(id: 1)
-  {
-    ...lastUpdated
-    ...optionsOnCar
-  }
-}
+        var result = AnalyzeComplexity("""
+            {
+              car(id: 1)
+              {
+                ...lastUpdated
+                ...optionsOnCar
+              }
+            }
 
-fragment optionsOnCar on Car
-{
-  options
-  {
-    edges
-    {
-      node
-      {
-        ...optionDetail
-      }
-    }
-  }
-}
+            fragment optionsOnCar on Car
+            {
+              options
+              {
+                edges
+                {
+                  node
+                  {
+                    ...optionDetail
+                  }
+                }
+              }
+            }
 
-fragment optionPrice on Option
-{
-  price
-}
+            fragment optionPrice on Option
+            {
+              price
+            }
 
-fragment lastUpdated on Car
-{
-  updatedAt
-}
+            fragment lastUpdated on Car
+            {
+              updatedAt
+            }
 
-fragment optionDetail on Option
-{
-  name
-  ...optionPrice
-  optionContents(first: 9999999)
-  {
-    edges
-    {
-      node
-      {
-        optionContent
-        {
-          name
-        }
-      }
-    }
-  }
-}");
+            fragment optionDetail on Option
+            {
+              name
+              ...optionPrice
+              optionContents(first: 9999999)
+              {
+                edges
+                {
+                  node
+                  {
+                    optionContent
+                    {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+            """);
 
         result.Complexity.ShouldBe(1839999848); // WOW! :)
     }
@@ -208,40 +219,40 @@ fragment optionDetail on Option
     [InlineData(false)]
     public void nested_fragments_3(bool reverse)
     {
-        var frag1 = @"
-fragment frag1 on QueryType
-{
-  ...frag4
-}
-";
-        var frag2 = @"
-fragment frag2 on QueryType
-{
-  ...frag3
-}
-";
-        var otherFrags = @"
-fragment frag3 on QueryType
-{
-  ...frag5
-}
+        var frag1 = """
+            fragment frag1 on QueryType
+            {
+              ...frag4
+            }
+            """;
+        var frag2 = """
+            fragment frag2 on QueryType
+            {
+              ...frag3
+            }
+            """;
+        var otherFrags = """
+            fragment frag3 on QueryType
+            {
+              ...frag5
+            }
 
-fragment frag5 on QueryType
-{
-  __typename
-}
+            fragment frag5 on QueryType
+            {
+              __typename
+            }
 
-fragment frag4 on QueryType
-{
-  __typename
-}
+            fragment frag4 on QueryType
+            {
+              __typename
+            }
 
-query fragmentTest
-{
-  ...frag1
-  ...frag2
-}
-";
+            query fragmentTest
+            {
+              ...frag1
+              ...frag2
+            }
+            """;
         var result = AnalyzeComplexity(reverse
             ? frag1 + frag2 + otherFrags
             : frag2 + frag1 + otherFrags);
@@ -252,28 +263,28 @@ query fragmentTest
     [Fact]
     public void duplicate_fragment_ok()
     {
-        var query = @"
-query carFragmentTest
-{
-  car(id: 1)
-  {
-    name
-    ... carInfo
-    ... carInfo
-  }
-}
+        var query = """
+            query carFragmentTest
+            {
+              car(id: 1)
+              {
+                name
+                ... carInfo
+                ... carInfo
+              }
+            }
 
-fragment carInfo on Car
-{
-    ...pricing
-    ...pricing
-}
+            fragment carInfo on Car
+            {
+                ...pricing
+                ...pricing
+            }
 
-fragment pricing on Car
-{
-  msrp
-}
-";
+            fragment pricing on Car
+            {
+              msrp
+            }
+            """;
         var result = AnalyzeComplexity(query);
 
         result.Complexity.ShouldBe(6);
@@ -283,36 +294,37 @@ fragment pricing on Car
     [Fact]
     public void no_fragment_cycle()
     {
-        var query = @"
-query carFragmentTest
-{
-  car(id: 1)
-  {
-    name
-    ... carInfo
-  }
-}
+        var query = """
+            query carFragmentTest
+            {
+              car(id: 1)
+              {
+                name
+                ... carInfo
+              }
+            }
 
-fragment carInfo on Car
-{
-    ...pricing
-    ... detail
-}
+            fragment carInfo on Car
+            {
+                ...pricing
+                ... detail
+            }
 
-fragment pricing on Car
-{
-  msrp
-}
+            fragment pricing on Car
+            {
+              msrp
+            }
 
-fragment detail on Car
-{
-  ... furtherDetail
-}
+            fragment detail on Car
+            {
+              ... furtherDetail
+            }
 
-fragment furtherDetail on Car
-{
-  ... pricing
-}";
+            fragment furtherDetail on Car
+            {
+              ... pricing
+            }
+            """;
         var result = AnalyzeComplexity(query);
 
         result.Complexity.ShouldBe(4);

--- a/src/GraphQL.Tests/Complexity/ComplexityTestsWithLimits.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityTestsWithLimits.cs
@@ -5,12 +5,13 @@ public class ComplexityTestsWithLimits : ComplexityTestBase
     [Fact]
     public void simple_query_avec_limit()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A(first: 10) {
-    B
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A(first: 10) {
+                B
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(1);
         res.Complexity.ShouldBe(20);
     }
@@ -18,10 +19,11 @@ query {
     [Fact]
     public void argument_ignored_when_no_subselection()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A(first: 10)
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A(first: 10)
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(0);
         res.Complexity.ShouldBe(1);
     }
@@ -29,14 +31,15 @@ query {
     [Fact]
     public void two_depth_query_A_limited()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  A(id: ""iyIGiygiyg"") {
-    B {
-      C
-    }
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              A(id: "iyIGiygiyg") {
+                B {
+                  C
+                }
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(2);
         res.Complexity.ShouldBe(5);
     }
@@ -44,17 +47,18 @@ query {
     [Fact]
     public void two_depth_query_B_limited()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  F
-  A {
-    B
-    D(first: 3) {
-      C
-      E
-    }
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              F
+              A {
+                B
+                D(first: 3) {
+                  C
+                  E
+                }
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(2);
         res.Complexity.ShouldBe(23);
     }
@@ -62,17 +66,18 @@ query {
     [Fact]
     public void last_value_ignored_when_first_exits()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  F
-  A {
-    B
-    D(last:100, first: 3) {
-      C
-      E
-    }
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              F
+              A {
+                B
+                D(last:100, first: 3) {
+                  C
+                  E
+                }
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(2);
         res.Complexity.ShouldBe(23);
     }
@@ -80,16 +85,17 @@ query {
     [Fact]
     public void first_and_last_value_ignored_when_id_exists()
     {
-        var res = AnalyzeComplexity(@"
-query {
-  F
-  A {
-    B
-    D(last:100, id:10, first: 3) {
-      C
-    }
-  }
-}");
+        var res = AnalyzeComplexity("""
+            query {
+              F
+              A {
+                B
+                D(last:100, id:10, first: 3) {
+                  C
+                }
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(2);
         res.Complexity.ShouldBe(9);
     }
@@ -97,21 +103,22 @@ query {
     [Fact]
     public void fragments_with_limits_handled()
     {
-        var res = AnalyzeComplexity(@"
-{
-  F
-  A {
-    B
-    ...X
-  }
-}
+        var res = AnalyzeComplexity("""
+            {
+              F
+              A {
+                B
+                ...X
+              }
+            }
 
-fragment X on Y {
-  D(first: 3) {
-    C
-    E
-  }
-}");
+            fragment X on Y {
+              D(first: 3) {
+                C
+                E
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(2);
         res.Complexity.ShouldBe(23);
     }
@@ -119,49 +126,50 @@ fragment X on Y {
     [Fact]
     public void issue344()
     {
-        var res = AnalyzeComplexity(@"
-query myQuery($id: Int) {
-  data(id: $id) {
-    a1
-    a2 {
-      b1 {
-        c1
-      }
-    }
-    a3 {
-      ...Y
-    }
-    a4 {
-      ...Y
-    }
-  }
-  some1: someList(byType: 1) {
-    ... X
-  }
-  some2: someList(byType: 2) {
-    ... X
-  }
-  some3: someList(byType: 3) {
-    ... X
-  }
-  some4: someList(byType: 4) {
-    ... X
-  }
-  some5: someList(byType: 5) {
-    ... X
-  }
-}
+        var res = AnalyzeComplexity("""
+            query myQuery($id: Int) {
+              data(id: $id) {
+                a1
+                a2 {
+                  b1 {
+                    c1
+                  }
+                }
+                a3 {
+                  ...Y
+                }
+                a4 {
+                  ...Y
+                }
+              }
+              some1: someList(byType: 1) {
+                ... X
+              }
+              some2: someList(byType: 2) {
+                ... X
+              }
+              some3: someList(byType: 3) {
+                ... X
+              }
+              some4: someList(byType: 4) {
+                ... X
+              }
+              some5: someList(byType: 5) {
+                ... X
+              }
+            }
 
-fragment X on FirstGraphType {
-  a1
-}
+            fragment X on FirstGraphType {
+              a1
+            }
 
-fragment Y on SecondGraphType {
-  b1 {
-    c1
-    c2
-  }
-}");
+            fragment Y on SecondGraphType {
+              b1 {
+                c1
+                c2
+              }
+            }
+            """);
         res.TotalQueryDepth.ShouldBe(12);
         res.Complexity.ShouldBe(60);
     }

--- a/src/GraphQL.Tests/Complexity/ComplexityValidationTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityValidationTests.cs
@@ -7,12 +7,13 @@ public class ComplexityValidationTest : ComplexityTestBase
     [Fact]
     public void should_work_when_complexity_within_params()
     {
-        var query = @"
-                query HeroNameQuery {
-                  hero {
-                    name
-                  }
-                }";
+        var query = """
+            query HeroNameQuery {
+              hero {
+              name
+              }
+            }
+            """;
 
         var complexityConfiguration = new ComplexityConfiguration { FieldImpact = 2, MaxComplexity = 6, MaxDepth = 1 };
         var res = Execute(complexityConfiguration, query);
@@ -23,17 +24,18 @@ public class ComplexityValidationTest : ComplexityTestBase
     [Fact]
     public void error_when_too_nested()
     {
-        var query = @"
-                query FriendsOfFriends {
-                  hero {
-                    friends {
-                      friends {
-                        id
-                        name
-                      }
-                    }
+        var query = """
+            query FriendsOfFriends {
+              hero {
+              friends {
+                friends {
+                  id
+                  name
                   }
-                }";
+                }
+              }
+            }
+            """;
 
         var complexityConfiguration = new ComplexityConfiguration { MaxDepth = 2 };
         var res = Execute(complexityConfiguration, query);
@@ -46,14 +48,15 @@ public class ComplexityValidationTest : ComplexityTestBase
     [Fact]
     public void fail_when_too_complex()
     {
-        var query = @"
-                query BasicQuery {
-                  hero {
-                    id
-                    name
-                    appearsIn
-                  }
-                }";
+        var query = """
+            query BasicQuery {
+              hero {
+              id
+              name
+              appearsIn
+              }
+            }
+            """;
 
         var complexityConfiguration = new ComplexityConfiguration { FieldImpact = 5, MaxComplexity = 10 };
         var res = Execute(complexityConfiguration, query);
@@ -66,20 +69,21 @@ public class ComplexityValidationTest : ComplexityTestBase
     [Fact]
     public void fail_when_too_complex_and_nested()
     {
-        var query = @"
-                query FriendsOfFriends {
-                  hero {
-                    friends {
-                      id
-                      name
-                      appearsIn
-                      friends {
-                        id
-                        name
-                      }
-                    }
+        var query = """
+            query FriendsOfFriends {
+              hero {
+                friends {
+                  id
+                  name
+                  appearsIn
+                  friends {
+                    id
+                    name
                   }
-                }";
+                }
+              }
+            }
+            """;
 
         var complexityConfiguration = new ComplexityConfiguration
         {

--- a/src/GraphQL.Tests/Errors/ErrorCodeTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorCodeTests.cs
@@ -44,7 +44,7 @@ public class ErrorCodeTests : QueryTestBase<ErrorCodeTests.TestSchema>
         var result = await Executer.ExecuteAsync(_ =>
         {
             _.Schema = Schema;
-            _.Query = @"{ secondSync }";
+            _.Query = "{ secondSync }";
         }).ConfigureAwait(false);
 
         result.Errors.Count.ShouldBe(1);

--- a/src/GraphQL.Tests/Errors/ErrorExtensionsTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorExtensionsTests.cs
@@ -20,7 +20,7 @@ public class ErrorExtensionsTests : QueryTestBase<ErrorExtensionsTests.TestSchem
         error.Path = new[] { "firstSync" };
         errors.Add(error);
 
-        var expectedResult = @"{ ""firstSync"": null}";
+        var expectedResult = """{ "firstSync": null}""";
 
         AssertQuery(query, CreateQueryResult(expectedResult, errors), null, null);
     }

--- a/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
+++ b/src/GraphQL.Tests/Errors/ErrorLocationTests.cs
@@ -52,7 +52,7 @@ public class ErrorLocationTests : QueryTestBase<ErrorLocationTests.TestSchema>
         var result = await Executer.ExecuteAsync(_ =>
         {
             _.Schema = Schema;
-            _.Query = @"{ testSub { one two } }";
+            _.Query = "{ testSub { one two } }";
         }).ConfigureAwait(false);
 
         result.Errors.Count.ShouldBe(1);
@@ -66,7 +66,7 @@ public class ErrorLocationTests : QueryTestBase<ErrorLocationTests.TestSchema>
         var result = await Executer.ExecuteAsync(_ =>
         {
             _.Schema = Schema;
-            _.Query = @"{ testSubList { one two } }";
+            _.Query = "{ testSubList { one two } }";
         }).ConfigureAwait(false);
 
         result.Errors.Count.ShouldBe(1);
@@ -85,9 +85,7 @@ public class ErrorLocationTests : QueryTestBase<ErrorLocationTests.TestSchema>
 
         AssertQueryIgnoreErrors(
             "{ testasync }",
-            CreateQueryResult(@"{
-   ""testasync"": null
-}", errors),
+            CreateQueryResult("""{ "testasync": null }""", errors),
             expectedErrorCount: 1,
             renderErrors: true);
     }

--- a/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
+++ b/src/GraphQL.Tests/Errors/UnhandledExceptionTests.cs
@@ -9,11 +9,11 @@ public class UnhandledExceptionTests : SchemaBuilderTestBase
     [Fact]
     public void rethrows_unhandled_exception()
     {
-        var def = @"
-                type Query {
-                  hello: Int
-                }
-            ";
+        var def = """
+            type Query {
+              hello: Int
+            }
+            """;
 
         Builder.Types.Include<Query>();
 
@@ -31,11 +31,11 @@ public class UnhandledExceptionTests : SchemaBuilderTestBase
     [Fact]
     public void unhandled_exception_delegate_can_rethrow_custom_exception()
     {
-        var def = @"
-                type Query {
-                  hello2: Int
-                }
-            ";
+        var def = """
+            type Query {
+              hello2: Int
+            }
+            """;
 
         Builder.Types.Include<Query>();
 
@@ -62,11 +62,11 @@ public class UnhandledExceptionTests : SchemaBuilderTestBase
     [Fact]
     public void unhandled_exception_delegate_can_rethrow_custom_message_from_field_resolver()
     {
-        var def = @"
-                type Query {
-                  hello2: Int
-                }
-            ";
+        var def = """
+            type Query {
+              hello2: Int
+            }
+            """;
 
         Builder.Types.Include<Query>();
 
@@ -93,11 +93,11 @@ public class UnhandledExceptionTests : SchemaBuilderTestBase
     [Fact]
     public void unhandled_exception_delegate_can_rethrow_custom_message_from_document_listener()
     {
-        var def = @"
-                type Query {
-                  hello2: Int
-                }
-            ";
+        var def = """
+            type Query {
+              hello2: Int
+            }
+            """;
 
         Builder.Types.Include<Query>();
 

--- a/src/GraphQL.Tests/Execution/AbstractInputTests.cs
+++ b/src/GraphQL.Tests/Execution/AbstractInputTests.cs
@@ -7,12 +7,12 @@ public class AbstractInputTests : QueryTestBase<AbstractInputSchema>
     [Fact]
     public void throws_literals()
     {
-        var query = @"
-mutation M {
-  run(input: { id: ""123"" })
-}
-";
-        var expected = @"{ ""run"": null }";
+        var query = """
+            mutation M {
+              run(input: { id: "123" })
+            }
+            """;
+        var expected = """{ "run": null }""";
         var res = AssertQueryWithErrors(query, expected, expectedErrorCount: 1);
         res.Errors[0].Code.ShouldBe("INVALID_OPERATION");
     }

--- a/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
+++ b/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
@@ -7,7 +7,7 @@ public class AbstractTypeErrorTests : QueryTestBase<AbstractSchema>
     [Fact]
     public void throws_when_unable_to_determine_object_type()
     {
-        var result = AssertQueryWithErrors("{ pets { name } }", @"{ ""pets"": null }", expectedErrorCount: 1);
+        var result = AssertQueryWithErrors("{ pets { name } }", """{ "pets": null }""", expectedErrorCount: 1);
         var error = result.Errors.First();
         error.Message.ShouldBe("Error trying to resolve field 'pets'.");
         error.InnerException.ShouldNotBeNull();

--- a/src/GraphQL.Tests/Execution/Cancellation/CancellationTests.cs
+++ b/src/GraphQL.Tests/Execution/Cancellation/CancellationTests.cs
@@ -54,7 +54,7 @@ public class CancellationTests : QueryTestBase<CancellationSchema>
     public void cancellation_token_in_context()
     {
         using var tokenSource = new CancellationTokenSource();
-        AssertQuerySuccess("{one}", @"{ ""one"": ""one"" }", cancellationToken: tokenSource.Token);
+        AssertQuerySuccess("{one}", """{ "one": "one" }""", cancellationToken: tokenSource.Token);
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Execution/Directives/DirectivesTests.cs
+++ b/src/GraphQL.Tests/Execution/Directives/DirectivesTests.cs
@@ -41,55 +41,55 @@ public class DirectiveScalarTests : QueryTestBase<DirectiveSchema>
     [Fact]
     public void works_without_directives()
     {
-        AssertQuerySuccess("{a, b}", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+        AssertQuerySuccess("{a, b}", """{"a": "a", "b": "b"}""", null, _data);
     }
 
     [Fact]
     public void works_on_scalars()
     {
-        AssertQuerySuccess("{a, b @include(if: true) }", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+        AssertQuerySuccess("{a, b @include(if: true) }", """{"a": "a", "b": "b"}""", null, _data);
     }
 
     [Fact]
     public void if_false_omits_on_scalar()
     {
-        AssertQuerySuccess("{a, b @include(if: false) }", @"{""a"": ""a""}", null, _data);
+        AssertQuerySuccess("{a, b @include(if: false) }", """{"a": "a"}""", null, _data);
     }
 
     [Fact]
     public void skip_false_includes_scalar()
     {
-        AssertQuerySuccess("{a, b @skip(if: false) }", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+        AssertQuerySuccess("{a, b @skip(if: false) }", """{"a": "a", "b": "b"}""", null, _data);
     }
 
     [Fact]
     public void skip_true_omits_scalar()
     {
-        AssertQuerySuccess("{a, b @skip(if: true) }", @"{""a"": ""a""}", null, _data);
+        AssertQuerySuccess("{a, b @skip(if: true) }", """{"a": "a"}""", null, _data);
     }
 
     [Fact]
     public void skip_true_include_true_omits_scalar()
     {
-        AssertQuerySuccess("{a, b @skip(if: true) @include(if: true) }", @"{""a"": ""a""}", null, _data);
+        AssertQuerySuccess("{a, b @skip(if: true) @include(if: true) }", """{"a": "a"}""", null, _data);
     }
 
     [Fact]
     public void skip_false_include_false_omits_scalar()
     {
-        AssertQuerySuccess("{a, b @skip(if: false) @include(if: false) }", @"{""a"": ""a""}", null, _data);
+        AssertQuerySuccess("{a, b @skip(if: false) @include(if: false) }", """{"a": "a"}""", null, _data);
     }
 
     [Fact]
     public void skip_true_include_false_omits_scalar()
     {
-        AssertQuerySuccess("{a, b @skip(if: true) @include(if: false) }", @"{""a"": ""a""}", null, _data);
+        AssertQuerySuccess("{a, b @skip(if: true) @include(if: false) }", """{"a": "a"}""", null, _data);
     }
 
     [Fact]
     public void skip_false_include_true_includes_scalar()
     {
-        AssertQuerySuccess("{a, b @skip(if: false) @include(if: true) }", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+        AssertQuerySuccess("{a, b @skip(if: false) @include(if: true) }", """{"a": "a", "b": "b"}""", null, _data);
     }
 }
 
@@ -100,7 +100,7 @@ public class DirectiveFragmentTests : QueryTestBase<DirectiveSchema>
     [Fact]
     public void if_false_omits_fragment_spread()
     {
-        AssertQuerySuccess(@"
+        AssertQuerySuccess("""
             query Q {
               a
               ...Frag @include(if: false)
@@ -108,14 +108,19 @@ public class DirectiveFragmentTests : QueryTestBase<DirectiveSchema>
             fragment Frag on TestType {
               b
             }
-            ",
-        @"{""a"": ""a""}", null, _data);
+            """,
+            """
+            {
+              "a": "a"
+            }
+            """,
+        null, _data);
     }
 
     [Fact]
     public void if_true_includes_fragment_spread()
     {
-        AssertQuerySuccess(@"
+        AssertQuerySuccess("""
             query Q {
               a
               ...Frag @include(if: true)
@@ -123,13 +128,20 @@ public class DirectiveFragmentTests : QueryTestBase<DirectiveSchema>
             fragment Frag on TestType {
               b
             }
-            ", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+            """,
+            """
+            {
+              "a": "a",
+              "b": "b"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void skip_false_includes_fragment_spread()
     {
-        AssertQuerySuccess(@"
+        AssertQuerySuccess("""
             query Q {
               a
               ...Frag @skip(if: false)
@@ -137,13 +149,20 @@ public class DirectiveFragmentTests : QueryTestBase<DirectiveSchema>
             fragment Frag on TestType {
               b
             }
-            ", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+            """,
+            """
+            {
+              "a": "a",
+              "b":"b"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void skip_true_omits_fragment_spread()
     {
-        AssertQuerySuccess(@"
+        AssertQuerySuccess("""
             query Q {
               a
               ...Frag @skip(if: true)
@@ -151,114 +170,172 @@ public class DirectiveFragmentTests : QueryTestBase<DirectiveSchema>
             fragment Frag on TestType {
               b
             }
-            ", @"{""a"": ""a""}", null, _data);
+            """,
+            """
+            {
+              "a": "a"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void if_false_omits_inline_fragment()
     {
-        AssertQuerySuccess(@"
+        AssertQuerySuccess("""
             query Q {
               a
               ... on TestType @include(if: false) {
                 b
               }
             }
-            ", @"{""a"": ""a""}", null, _data);
+            """,
+            """
+            {
+              "a": "a"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void if_true_includes_inline_fragment()
     {
-        AssertQuerySuccess(@"
+        AssertQuerySuccess("""
             query Q {
               a
               ... on TestType @include(if: true) {
                 b
               }
             }
-            ", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+            """,
+            """
+            {
+              "a": "a",
+              "b": "b"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void skip_true_omits_inline_fragment()
     {
-        AssertQuerySuccess(@"
+        AssertQuerySuccess("""
             query Q {
               a
               ... on TestType @skip(if: true) {
                 b
               }
             }
-            ", @"{""a"": ""a""}", null, _data);
+            """,
+            """
+            {
+              "a": "a"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void skip_false_includes_inline_fragment()
     {
-        AssertQuerySuccess(@"
+        AssertQuerySuccess("""
             query Q {
               a
               ... on TestType @skip(if: false) {
                 b
               }
             }
-            ", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+            """,
+            """
+            {
+              "a": "a",
+              "b": "b"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void if_false_omits_fragment()
     {
-        AssertQuerySuccess(@"
-                query Q {
-                  a
-                  ...Frag @include(if: false)
-                }
-                fragment Frag on TestType {
-                  b
-                }
-            ", @"{""a"": ""a""}", null, _data);
+        AssertQuerySuccess("""
+            query Q {
+              a
+              ...Frag @include(if: false)
+            }
+            fragment Frag on TestType {
+              b
+            }
+            """,
+            """
+            {
+              "a": "a"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void if_true_includes_fragment()
     {
-        AssertQuerySuccess(@"
-                query Q {
-                  a
-                  ...Frag @include(if: true)
-                }
-                fragment Frag on TestType {
-                  b
-                }
-            ", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+        AssertQuerySuccess("""
+            query Q {
+              a
+              ...Frag @include(if: true)
+            }
+            fragment Frag on TestType {
+              b
+            }
+            """,
+            """
+            {
+              "a": "a",
+              "b": "b"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void skip_false_includes_fragment()
     {
-        AssertQuerySuccess(@"
-                query Q {
-                  a
-                  ...Frag @skip(if: false)
-                }
-                fragment Frag on TestType {
-                  b
-                }
-            ", @"{""a"": ""a"", ""b"": ""b""}", null, _data);
+        AssertQuerySuccess("""
+            query Q {
+              a
+              ...Frag @skip(if: false)
+            }
+            fragment Frag on TestType {
+              b
+            }
+            """,
+            """
+            {
+              "a": "a",
+              "b": "b"
+            }
+            """,
+            null, _data);
     }
 
     [Fact]
     public void skip_true_omits_fragment()
     {
-        AssertQuerySuccess(@"
-                query Q {
-                  a
-                  ...Frag @skip(if: true)
-                }
-                fragment Frag on TestType {
-                  b
-                }
-            ", @"{""a"": ""a""}", null, _data);
+        AssertQuerySuccess("""
+            query Q {
+              a
+              ...Frag @skip(if: true)
+            }
+            fragment Frag on TestType {
+              b
+            }
+            """,
+            """
+            {
+              "a": "a"
+            }
+            """,
+            null, _data);
     }
 }

--- a/src/GraphQL.Tests/Execution/InputConversionTestsBase.cs
+++ b/src/GraphQL.Tests/Execution/InputConversionTestsBase.cs
@@ -74,7 +74,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void converts_small_numbers_to_int()
     {
-        var json = @"{""a"": 1}";
+        var json = """{"a": 1}""";
         var inputs = VariablesToInputs(json);
         inputs["a"].ShouldBe(1);
         inputs["a"].GetType().ShouldBe(typeof(int));
@@ -83,7 +83,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void converts_large_numbers_to_long()
     {
-        var json = @"{""a"": 1000000000000000001}";
+        var json = """{"a": 1000000000000000001}""";
         var inputs = VariablesToInputs(json);
         inputs["a"].ShouldBe(1000000000000000001);
         inputs["a"].GetType().ShouldBe(typeof(long));
@@ -92,7 +92,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_and_specific_object()
     {
-        var json = @"{""a"": 1, ""b"": ""2""}";
+        var json = """{"a": 1, "b": "2"}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -110,7 +110,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_array()
     {
-        var json = @"{""a"": 1, ""b"": ""2"", ""c"": [""foo""]}";
+        var json = """{"a": 1, "b": "2", "c": ["foo"]}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -132,7 +132,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_nullable_array()
     {
-        var json = @"{""a"": 1, ""b"": ""2"", ""c"": [""foo""], ""f"": [1,null]}";
+        var json = """{"a": 1, "b": "2", "c": ["foo"], "f": [1,null]}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -150,7 +150,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_nested_nullable_array()
     {
-        var json = @"{""a"": 1, ""b"": ""2"", ""c"": [""foo""], ""g"": [[1,null], [null, 1]]}";
+        var json = """{"a": 1, "b": "2", "c": ["foo"], "g": [[1,null], [null, 1]]}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -174,7 +174,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_nullable_int()
     {
-        var json = @"{""a"": 1, ""b"": ""2"", ""d"": ""5""}";
+        var json = """{"a": 1, "b": "2", "d": "5"}""";
         var inputs = VariablesToInputs(json);
         inputs.ShouldNotBeNull();
         var myInput = inputs.ToObject<MyInput>();
@@ -185,7 +185,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_read_long()
     {
-        var json = @"{""j"": 89429901947254093 }";
+        var json = """{"j": 89429901947254093 }""";
         var inputs = VariablesToInputs(json);
         inputs.ShouldNotBeNull();
         var myInput = inputs.ToObject<MyInput>();
@@ -196,7 +196,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_int_to_double()
     {
-        var json = @"{""i"": 1 }";
+        var json = """{"i": 1 }""";
         var inputs = VariablesToInputs(json);
         inputs.ShouldNotBeNull();
         var myInput = inputs.ToObject<MyInput>();
@@ -207,7 +207,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_guid()
     {
-        var json = @"{""a"": 1, ""b"": ""2"", ""e"": ""920a1b6d-f75a-4594-8567-e2c457b29cc0""}";
+        var json = """{"a": 1, "b": "2", "e": "920a1b6d-f75a-4594-8567-e2c457b29cc0"}""";
         var inputs = VariablesToInputs(json);
         inputs.ShouldNotBeNull();
         var myInput = inputs.ToObject<MyInput>();
@@ -218,7 +218,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_enum_string()
     {
-        var json = @"{""a"": ""three""}";
+        var json = """{"a": "three"}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -234,7 +234,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_enum_string_exact()
     {
-        var json = @"{""a"": ""Two""}";
+        var json = """{"a": "Two"}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -249,7 +249,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_enum_number()
     {
-        var json = @"{""a"": ""2""}";
+        var json = """{"a": "2"}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -265,7 +265,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_enum_long_number()
     {
-        var json = @"{""a"": 2, ""b"": 2}";
+        var json = """{"a": 2, "b": 2}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -278,7 +278,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_child_object_list()
     {
-        var json = @"{""a"": ""foo"", ""b"":[{""a"": ""bar""}], ""c"": ""baz""}";
+        var json = """{"a": "foo", "b":[{"a": "bar"}], "c": "baz"}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -292,7 +292,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_child_object()
     {
-        var json = @"{ ""input"": {""a"": ""foo"", ""b"":[{""a"": ""bar""}], ""c"": ""baz""}}";
+        var json = """{ "input": {"a": "foo", "b":[{"a": "bar"}], "c": "baz"}}""";
 
         var inputs = VariablesToInputs(json);
 
@@ -306,7 +306,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_utc_date_to_datetime_with_correct_kind()
     {
-        var json = @"{ ""h"": ""2016-10-21T13:32:15.753Z"" }";
+        var json = """{ "h": "2016-10-21T13:32:15.753Z" }""";
         var expected = DateTime.SpecifyKind(DateTime.Parse("2016-10-21T13:32:15.753"), DateTimeKind.Utc);
 
         var inputs = VariablesToInputs(json);
@@ -319,7 +319,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_unspecified_date_to_datetime_with_correct_kind()
     {
-        var json = @"{ ""h"": ""2016-10-21T13:32:15"" }";
+        var json = """{ "h": "2016-10-21T13:32:15" }""";
         var expected = DateTime.SpecifyKind(DateTime.Parse("2016-10-21T13:32:15"), DateTimeKind.Unspecified);
 
         var inputs = VariablesToInputs(json);
@@ -332,7 +332,7 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_custom_converter()
     {
-        var json = @"{ ""name1"": ""tom"", ""age1"": 10 }";
+        var json = """{ "name1": "tom", "age1": 10 }""";
 
         var inputs = VariablesToInputs(json);
 

--- a/src/GraphQL.Tests/Execution/InputsTests.cs
+++ b/src/GraphQL.Tests/Execution/InputsTests.cs
@@ -7,70 +7,75 @@ public class InputsTests : QueryTestBase<EnumMutationSchema>
     [Fact]
     public void mutation_input()
     {
-        AssertQuerySuccess(
-            @"
-                 mutation createUser {
-                  createUser(userInput:{
-                    profileImage:""myimage.png"",
-                    gender: Female
-                  }){
-                    id
-                    gender
-                    profileImage
-                  }
-                }
-                ",
-            @"{
-                  ""createUser"": {
-                    ""id"": 1,
-                    ""gender"": ""Female"",
-                    ""profileImage"": ""myimage.png""
-                  }
-                }");
+        AssertQuerySuccess("""
+            mutation createUser {
+              createUser(userInput: {
+                profileImage:"myimage.png",
+                gender: Female
+              }){
+                id
+                gender
+                profileImage
+              }
+            }
+            """,
+            """
+            {
+              "createUser": {
+                "id": 1,
+                "gender": "Female",
+                "profileImage": "myimage.png"
+              }
+            }
+            """);
     }
 
     [Fact]
     public void mutation_input_from_variables()
     {
-        var inputs = @"{ ""userInput"": { ""profileImage"": ""myimage.png"", ""gender"": ""Female"" } }".ToInputs();
+        var inputs = """{ "userInput": { "profileImage": "myimage.png", "gender": "Female" } }""".ToInputs();
 
-        AssertQuerySuccess(
-            @"
-                mutation createUser($userInput: UserInput!) {
-                  createUser(userInput: $userInput){
-                    id
-                    gender
-                    profileImage
-                  }
-                }
-                ",
-            @"{
-                  ""createUser"": {
-                    ""id"": 1,
-                    ""gender"": ""Female"",
-                    ""profileImage"": ""myimage.png""
-                   }
-                }", inputs);
+        AssertQuerySuccess("""
+            mutation createUser($userInput: UserInput!) {
+              createUser(userInput: $userInput) {
+                id
+                gender
+                profileImage
+              }
+            }
+            """,
+            """
+            {
+              "createUser": {
+                "id": 1,
+                "gender": "Female",
+                "profileImage": "myimage.png"
+              }
+            }
+            """,
+            inputs);
     }
 
     [Fact]
     public void query_can_get_enum_argument()
     {
         AssertQuerySuccess(
-            @"{ user { id, gender, printGender(g: Male) }}",
-            @"{
-                  ""user"": {
-                    ""id"": 1,
-                    ""gender"": ""Male"",
-                    ""printGender"": ""gender: Male""
-                  }
-                }");
+            "{ user { id, gender, printGender(g: Male) }}",
+            """
+            {
+              "user": {
+                "id": 1,
+                "gender": "Male",
+                "printGender": "gender: Male"
+                }
+            }
+            """);
     }
 
     [Fact]
     public void query_can_get_long_variable()
     {
-        var inputs = @"{ ""userId"": 1000000000000000001 }".ToInputs();
+        var inputs = """{ "userId": 1000000000000000001 }""".ToInputs();
 
         AssertQuerySuccess(
             "query aQuery($userId: Long!) { getLongUser(userId: $userId) { idLong }}",
@@ -80,33 +85,39 @@ public class InputsTests : QueryTestBase<EnumMutationSchema>
                 "idLong": 1000000000000000001
                 }
             }
-            """, inputs);
+            """,
+            inputs);
     }
 
     [Fact]
     public void query_can_get_long_inline()
     {
         AssertQuerySuccess(
-            @"query aQuery { getLongUser(userId: 1000000000000000001) { idLong }}",
-            @"{
-                  ""getLongUser"": {
-                    ""idLong"": 1000000000000000001
-                  }
-                }");
+            "query aQuery { getLongUser(userId: 1000000000000000001) { idLong }}",
+            """
+            {
+              "getLongUser": {
+                "idLong": 1000000000000000001
+              }
+            }
+            """);
     }
 
     [Fact]
     public void query_can_get_int_variable()
     {
-        var inputs = @"{ ""userId"": 3 }".ToInputs();
+        var inputs = """{ "userId": 3 }""".ToInputs();
 
         AssertQuerySuccess(
-            @"query aQuery($userId: Int!) { getIntUser(userId: $userId) { id }}",
-            @"{
-                  ""getIntUser"": {
-                    ""id"": 3
-                  }
-                }", inputs);
+            "query aQuery($userId: Int!) { getIntUser(userId: $userId) { id }}",
+            """
+            {
+              "getIntUser": {
+                "id": 3
+              }
+            }
+            """,
+            inputs);
     }
 }
 

--- a/src/GraphQL.Tests/Execution/LongTests.cs
+++ b/src/GraphQL.Tests/Execution/LongTests.cs
@@ -18,11 +18,13 @@ public class LongTests
         var json = serializer.Serialize(executionResult);
         executionResult.Errors.ShouldBeNull();
 
-        json.ShouldBe(@"{
-  ""data"": {
-    ""testField"": 9223372036854775807
-  }
-}");
+        json.ShouldBe("""
+            {
+              "data": {
+                "testField": 9223372036854775807
+              }
+            }
+            """);
     }
 
     private class LongSchema : Schema

--- a/src/GraphQL.Tests/Execution/MutationTests.cs
+++ b/src/GraphQL.Tests/Execution/MutationTests.cs
@@ -218,44 +218,45 @@ public class MutationTests : QueryTestBase<MutationSchema>
     [Fact]
     public void evaluates_mutations_serially()
     {
-        var query = @"
-                mutation M {
-                  first: immediatelyChangeTheNumber(newNumber: 1) {
-                    theNumber
-                  }
-                  second: immediatelyChangeTheNumber(newNumber: 2) {
-                    theNumber
-                  }
-                  third: immediatelyChangeTheNumber(newNumber: 3) {
-                    theNumber
-                  }
-                  fourth: immediatelyChangeTheNumber(newNumber: 4) {
-                    theNumber
-                  }
-                  fifth: immediatelyChangeTheNumber(newNumber: 5) {
-                    theNumber
-                  }
-                }
-            ";
+        var query = """
+            mutation M {
+              first: immediatelyChangeTheNumber(newNumber: 1) {
+                theNumber
+              }
+              second: immediatelyChangeTheNumber(newNumber: 2) {
+                theNumber
+              }
+              third: immediatelyChangeTheNumber(newNumber: 3) {
+                theNumber
+              }
+              fourth: immediatelyChangeTheNumber(newNumber: 4) {
+                theNumber
+              }
+              fifth: immediatelyChangeTheNumber(newNumber: 5) {
+                theNumber
+              }
+            }
+            """;
 
-        var expected = @"
-                {
-                  ""first"": {
-                    ""theNumber"": 1
-                  },
-                  ""second"": {
-                    ""theNumber"": 2
-                  },
-                  ""third"": {
-                    ""theNumber"": 3
-                  },
-                  ""fourth"": {
-                    ""theNumber"": 4
-                  },
-                  ""fifth"": {
-                    ""theNumber"": 5
-                  }
-                }";
+        var expected = """
+            {
+              "first": {
+                "theNumber": 1
+              },
+              "second": {
+                "theNumber": 2
+              },
+              "third": {
+                "theNumber": 3
+              },
+              "fourth": {
+                "theNumber": 4
+              },
+              "fifth": {
+                "theNumber": 5
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected, root: new Root(6, DateTime.Now));
     }
@@ -263,46 +264,47 @@ public class MutationTests : QueryTestBase<MutationSchema>
     [Fact]
     public async Task evaluates_mutations_correctly_in_the_presence_of_a_failed_mutation()
     {
-        var query = @"
-                mutation M {
-                  first: immediatelyChangeTheNumber(newNumber: 1) {
-                    theNumber
-                  }
-                  second: promiseToChangeTheNumber(newNumber: 2) {
-                    theNumber
-                  }
-                  third: failToChangeTheNumber(newNumber: 3) {
-                    theNumber
-                  }
-                  fourth: promiseToChangeTheNumber(newNumber: 4) {
-                    theNumber
-                  }
-                  fifth: immediatelyChangeTheNumber(newNumber: 5) {
-                    theNumber
-                  }
-                  sixth: promiseAndFailToChangeTheNumber(newNumber: 6) {
-                    theNumber
-                  }
-                }
-            ";
+        var query = """
+            mutation M {
+              first: immediatelyChangeTheNumber(newNumber: 1) {
+                theNumber
+              }
+              second: promiseToChangeTheNumber(newNumber: 2) {
+                theNumber
+              }
+              third: failToChangeTheNumber(newNumber: 3) {
+                theNumber
+              }
+              fourth: promiseToChangeTheNumber(newNumber: 4) {
+                theNumber
+              }
+              fifth: immediatelyChangeTheNumber(newNumber: 5) {
+                theNumber
+              }
+              sixth: promiseAndFailToChangeTheNumber(newNumber: 6) {
+                theNumber
+              }
+            }
+            """;
 
-        var expected = @"
-                {
-                  ""first"": {
-                    ""theNumber"": 1
-                  },
-                  ""second"": {
-                    ""theNumber"": 2
-                  },
-                  ""third"": null,
-                  ""fourth"": {
-                    ""theNumber"": 4
-                  },
-                  ""fifth"": {
-                    ""theNumber"": 5
-                  },
-                  ""sixth"": null
-                }";
+        var expected = """
+            {
+              "first": {
+                "theNumber": 1
+              },
+              "second": {
+                "theNumber": 2
+              },
+              "third": null,
+              "fourth": {
+                "theNumber": 4
+              },
+              "fifth": {
+                "theNumber": 5
+              },
+              "sixth": null
+            }
+            """;
 
         var result = await AssertQueryWithErrorsAsync(query, expected, root: new Root(6, DateTime.Now), expectedErrorCount: 2).ConfigureAwait(false);
         result.Errors.First().InnerException.Message.ShouldBe("Cannot change the number 3");
@@ -313,44 +315,45 @@ public class MutationTests : QueryTestBase<MutationSchema>
     [Fact]
     public void evaluates_datetime_mutations_serially()
     {
-        var query = @"
-                mutation M {
-                  first: immediatelyChangeTheDateTime(newDateTime: ""2017-01-27T15:19:53.123Z"") {
-                    theDateTime
-                  }
-                  second: immediatelyChangeTheDateTime(newDateTime: ""2017-02-27T15:19:53.123Z"") {
-                    theDateTime
-                  }
-                  third: immediatelyChangeTheDateTime(newDateTime: ""2017-03-27T15:19:53.123Z"") {
-                    theDateTime
-                  }
-                  fourth: immediatelyChangeTheDateTime(newDateTime: ""2017-04-27T15:19:53.123-5:00"") {
-                    theDateTime
-                  }
-                  fifth: immediatelyChangeTheDateTime(newDateTime: ""2017-05-27T15:19:53.123+2:00"") {
-                    theDateTime
-                  }
-                }
-            ";
+        var query = """
+            mutation M {
+              first: immediatelyChangeTheDateTime(newDateTime: "2017-01-27T15:19:53.123Z") {
+                theDateTime
+              }
+              second: immediatelyChangeTheDateTime(newDateTime: "2017-02-27T15:19:53.123Z") {
+                theDateTime
+              }
+              third: immediatelyChangeTheDateTime(newDateTime: "2017-03-27T15:19:53.123Z") {
+                theDateTime
+              }
+              fourth: immediatelyChangeTheDateTime(newDateTime: "2017-04-27T15:19:53.123-5:00") {
+                theDateTime
+              }
+              fifth: immediatelyChangeTheDateTime(newDateTime: "2017-05-27T15:19:53.123+2:00") {
+                theDateTime
+              }
+            }
+            """;
 
-        var expected = @"
-                {
-                  ""first"": {
-                    ""theDateTime"": ""2017-01-27T15:19:53.123Z""
-                  },
-                  ""second"": {
-                    ""theDateTime"": ""2017-02-27T15:19:53.123Z""
-                  },
-                  ""third"": {
-                    ""theDateTime"": ""2017-03-27T15:19:53.123Z""
-                  },
-                  ""fourth"": {
-                    ""theDateTime"": ""2017-04-27T20:19:53.123Z""
-                  },
-                  ""fifth"": {
-                    ""theDateTime"": ""2017-05-27T13:19:53.123Z""
-                  }
-                }";
+        var expected = """
+            {
+              "first": {
+                "theDateTime": "2017-01-27T15:19:53.123Z"
+              },
+              "second": {
+                "theDateTime": "2017-02-27T15:19:53.123Z"
+              },
+              "third": {
+                "theDateTime": "2017-03-27T15:19:53.123Z"
+              },
+              "fourth": {
+                "theDateTime": "2017-04-27T20:19:53.123Z"
+              },
+              "fifth": {
+                "theDateTime": "2017-05-27T13:19:53.123Z"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected, root: new Root(6, DateTime.Now));
     }
@@ -358,46 +361,47 @@ public class MutationTests : QueryTestBase<MutationSchema>
     [Fact]
     public async Task evaluates_datetime_mutations_correctly_in_the_presence_of_a_failed_mutation()
     {
-        var query = @"
-                mutation M {
-                  first: immediatelyChangeTheDateTime(newDateTime: ""2017-01-27T15:19:53.123Z"") {
-                    theDateTime
-                  }
-                  second: promiseToChangeTheDateTime(newDateTime: ""2017-02-27T15:19:53.123Z"") {
-                    theDateTime
-                  }
-                  third: failToChangeTheDateTime(newDateTime: ""2017-03-27T15:19:53.123Z"") {
-                    theDateTime
-                  }
-                  fourth: promiseToChangeTheDateTime(newDateTime: ""2017-04-27T15:19:53.123-5:00"") {
-                    theDateTime
-                  }
-                  fifth: immediatelyChangeTheDateTime(newDateTime: ""2017-05-27T15:19:53.123+2:00"") {
-                    theDateTime
-                  }
-                  sixth: promiseAndFailToChangeTheDateTime(newDateTime: ""2017-06-27T15:19:53.123Z"") {
-                    theDateTime
-                  }
-                }
-            ";
+        var query = """
+            mutation M {
+              first: immediatelyChangeTheDateTime(newDateTime: "2017-01-27T15:19:53.123Z") {
+                theDateTime
+              }
+              second: promiseToChangeTheDateTime(newDateTime: "2017-02-27T15:19:53.123Z") {
+                theDateTime
+              }
+              third: failToChangeTheDateTime(newDateTime: "2017-03-27T15:19:53.123Z") {
+                theDateTime
+              }
+              fourth: promiseToChangeTheDateTime(newDateTime: "2017-04-27T15:19:53.123-5:00") {
+                theDateTime
+              }
+              fifth: immediatelyChangeTheDateTime(newDateTime: "2017-05-27T15:19:53.123+2:00") {
+                theDateTime
+              }
+              sixth: promiseAndFailToChangeTheDateTime(newDateTime: "2017-06-27T15:19:53.123Z") {
+                theDateTime
+              }
+            }
+            """;
 
-        var expected = @"
-                {
-                  ""first"": {
-                    ""theDateTime"": ""2017-01-27T15:19:53.123Z""
-                  },
-                  ""second"": {
-                    ""theDateTime"": ""2017-02-27T15:19:53.123Z""
-                  },
-                  ""third"": null,
-                  ""fourth"": {
-                    ""theDateTime"": ""2017-04-27T20:19:53.123Z""
-                  },
-                  ""fifth"": {
-                    ""theDateTime"": ""2017-05-27T13:19:53.123Z""
-                  },
-                  ""sixth"": null
-                }";
+        var expected = """
+            {
+              "first": {
+                "theDateTime": "2017-01-27T15:19:53.123Z"
+              },
+              "second": {
+                "theDateTime": "2017-02-27T15:19:53.123Z"
+              },
+              "third": null,
+              "fourth": {
+                "theDateTime": "2017-04-27T20:19:53.123Z"
+              },
+              "fifth": {
+                "theDateTime": "2017-05-27T13:19:53.123Z"
+              },
+              "sixth": null
+            }
+            """;
 
         var result = await AssertQueryWithErrorsAsync(query, expected, root: new Root(6, DateTime.Now), expectedErrorCount: 2).ConfigureAwait(false);
         result.Errors.First().InnerException.Message.ShouldBe("Cannot change the datetime");
@@ -408,19 +412,21 @@ public class MutationTests : QueryTestBase<MutationSchema>
     [Fact]
     public void successfully_handles_guidgraphtype()
     {
-        var query = @"
-                mutation M {
-                  passGuidGraphType(guid: ""085A38AD-907B-4625-AFEE-67EFC71217DE"") {
-                    theGuid
-                  }
-                }
-            ";
+        var query = """
+            mutation M {
+              passGuidGraphType(guid: "085A38AD-907B-4625-AFEE-67EFC71217DE") {
+                theGuid
+              }
+            }
+            """;
 
-        var expected = @"{
-                    ""passGuidGraphType"": {
-                        ""theGuid"": ""085a38ad-907b-4625-afee-67efc71217de""
-                    }
-                }";
+        var expected = """
+            {
+              "passGuidGraphType": {
+                "theGuid": "085a38ad-907b-4625-afee-67efc71217de"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected, root: new Root(6, DateTime.Now));
     }

--- a/src/GraphQL.Tests/Execution/Performance/ListPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/ListPerformanceTests.cs
@@ -73,32 +73,32 @@ public class ListPerformanceTests : QueryTestBase<ListPerformanceSchema>
     [Fact(Skip = "Benchmarks only, these numbers are machine dependant.")]
     public async Task Executes_MultipleProperties_Are_Performant()
     {
-        var query = @"
-                query AQuery {
-                    people {
-                        name
-                        name1:name
-                        name2:name
-                        name3:name
-                        name4:name
-                        name5:name
-                        name6:name
-                        name7:name
-                        name8:name
-                        name9:name
-                        name10:name
-                        name11:name
-                        name12:name
-                        name13:name
-                        name14:name
-                        name15:name
-                        name16:name
-                        name17:name
-                        name18:name
-                        name19:name
-                    }
-                }
-            ";
+        var query = """
+            query AQuery {
+              people {
+                name
+                name1:name
+                name2:name
+                name3:name
+                name4:name
+                name5:name
+                name6:name
+                name7:name
+                name8:name
+                name9:name
+                name10:name
+                name11:name
+                name12:name
+                name13:name
+                name14:name
+                name15:name
+                name16:name
+                name17:name
+                name18:name
+                name19:name
+              }
+            }
+            """;
 
         var smallListTimer = new Stopwatch();
 
@@ -127,13 +127,13 @@ public class ListPerformanceTests : QueryTestBase<ListPerformanceSchema>
     [Fact(Skip = "Benchmarks only, these numbers are machine dependant.")]
     public async Task Executes_SimpleLists_Are_Performant()
     {
-        var query = @"
-                query AQuery {
-                    people {
-                        name
-                    }
-                }
-            ";
+        var query = """
+            query AQuery {
+              people {
+                name
+              }
+            }
+            """;
 
         var smallListTimer = new Stopwatch();
 
@@ -162,25 +162,25 @@ public class ListPerformanceTests : QueryTestBase<ListPerformanceSchema>
     [Fact(Skip = "Benchmarks only, these numbers are machine dependant.")]
     public async Task Executes_UnionLists_Are_Performant()
     {
-        var query = @"
-                query AQuery {
-                    people {
-                      __typename
-                      name
-                      pets {
-                        __typename
-                        ... on Dog {
-                          name
-                          barks
-                        },
-                        ... on Cat {
-                          name
-                          meows
-                        }
-                      }
-                    }
+        var query = """
+            query AQuery {
+              people {
+                __typename
+                name
+                pets {
+                  __typename
+                  ... on Dog {
+                    name
+                    barks
+                  },
+                  ... on Cat {
+                    name
+                    meows
+                  }
                 }
-            ";
+              }
+            }
+            """;
 
         var smallListTimer = new Stopwatch();
 

--- a/src/GraphQL.Tests/Execution/Performance/StarWarsPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/StarWarsPerformanceTests.cs
@@ -17,19 +17,19 @@ public class StarWarsPerformanceTests : StarWarsTestBase
     // [Fact]
     public void Executes_StarWarsBasicQuery_Performant()
     {
-        var query = @"
-                query HeroNameAndFriendsQuery {
-                  hero {
-                    id
-                    name
-                    appearsIn
-                    friends {
-                      name
-                      appearsIn
-                    }
-                  }
+        var query = """
+            query HeroNameAndFriendsQuery {
+              hero {
+                id
+                name
+                appearsIn
+                friends {
+                  name
+                  appearsIn
                 }
-            ";
+              }
+            }
+            """;
 
         var smallListTimer = new Stopwatch();
         ExecutionResult runResult2 = null;

--- a/src/GraphQL.Tests/Execution/Performance/ThreadPerformanceTests.cs
+++ b/src/GraphQL.Tests/Execution/Performance/ThreadPerformanceTests.cs
@@ -65,12 +65,12 @@ public class ThreadPerformanceTests : QueryTestBase<ThreadPerformanceTests.Threa
     // [Fact]
     public void Executes_IsQuickerThanTotalTaskTime()
     {
-        var query = @"
-                query HeroNameAndFriendsQuery {
-                  halfSecond,
-                  quarterSecond
-                }
-            ";
+        var query = """
+            query HeroNameAndFriendsQuery {
+              halfSecond,
+              quarterSecond
+            }
+            """;
 
         var smallListTimer = new Stopwatch();
         smallListTimer.Start();
@@ -91,27 +91,27 @@ public class ThreadPerformanceTests : QueryTestBase<ThreadPerformanceTests.Threa
     [Fact]
     public async Task Mutations_RunSynchronously()
     {
-        var query = @"
-                mutation Multiple {
-                  m1:setFive
-                  m2:setFive
-                  m3:setOne
-                  m4:setOne
-                  m5:setOne
-                  m6:setFive
-                  m7:setFive
-                  m8:setFive
-                  m9:setFive
-                  m10:setOne
-                  m11:setFive
-                  m12:setOne
-                  m13:setFive
-                  m14:setOne
-                  m15:setFive
-                  m16:setOne
-                  m17:setFive
-                }
-            ";
+        var query = """
+            mutation Multiple {
+              m1:setFive
+              m2:setFive
+              m3:setOne
+              m4:setOne
+              m5:setOne
+              m6:setFive
+              m7:setFive
+              m8:setFive
+              m9:setFive
+              m10:setOne
+              m11:setFive
+              m12:setOne
+              m13:setFive
+              m14:setOne
+              m15:setFive
+              m16:setOne
+              m17:setFive
+            }
+            """;
 
         var result = await Executer.ExecuteAsync(_ =>
         {

--- a/src/GraphQL.Tests/Execution/RegisteredInstanceTests.cs
+++ b/src/GraphQL.Tests/Execution/RegisteredInstanceTests.cs
@@ -32,8 +32,8 @@ public class RegisteredInstanceTests : BasicQueryTestBase
 
         AssertQuerySuccess(
             schema,
-            @"{ retail { catalog { products { name } } } }",
-            @"{ ""retail"": { ""catalog"": { ""products"": [ { ""name"": ""Book"" }] } } }"
+            "{ retail { catalog { products { name } } } }",
+            """{ "retail": { "catalog": { "products": [ { "name": "Book" }] } } }"""
         );
     }
 
@@ -55,8 +55,8 @@ public class RegisteredInstanceTests : BasicQueryTestBase
 
         AssertQuerySuccess(
             schema,
-            @"{ hero { name friends { name } } }",
-            @"{ ""hero"": { ""name"": ""Quinn"", ""friends"": [ { ""name"": ""Jaime"" }, { ""name"": ""Joe"" }] } }",
+            "{ hero { name friends { name } } }",
+            """{ "hero": { "name": "Quinn", "friends": [ { "name": "Jaime" }, { "name": "Joe" }] } }""",
             root: new SomeObject { Name = "Quinn" });
     }
 
@@ -84,63 +84,71 @@ public class RegisteredInstanceTests : BasicQueryTestBase
 
         AssertQuerySuccess(
             schema,
-            @"{ hero {
+            """
+            { hero {
                     ... on Person { name }
                     ... on Robot { name }
-                } }",
-            @"{ ""hero"": { ""name"" : ""Quinn"" }}",
+                } }
+            """,
+            """{ "hero": { "name" : "Quinn" }}""",
             root: new SomeObject { Name = "Quinn" });
     }
 
     [Fact]
     public void build_nested_type_with_list()
     {
-        build_schema("list").ShouldBeCrossPlat(@"schema {
-  query: root
-}
+        build_schema("list").ShouldBeCrossPlat("""
+            schema {
+              query: root
+            }
 
-type NestedObjType {
-  intField: Int
-}
+            type NestedObjType {
+              intField: Int
+            }
 
-type root {
-  listOfObjField: [NestedObjType]
-}
-");
+            type root {
+              listOfObjField: [NestedObjType]
+            }
+
+            """);
     }
 
     [Fact]
     public void build_nested_type_with_non_null()
     {
-        build_schema("non-null").ShouldBeCrossPlat(@"schema {
-  query: root
-}
+        build_schema("non-null").ShouldBeCrossPlat("""
+            schema {
+              query: root
+            }
 
-type NestedObjType {
-  intField: Int
-}
+            type NestedObjType {
+              intField: Int
+            }
 
-type root {
-  listOfObjField: NestedObjType!
-}
-");
+            type root {
+              listOfObjField: NestedObjType!
+            }
+
+            """);
     }
 
     [Fact]
     public void build_nested_type_with_base()
     {
-        build_schema("none").ShouldBeCrossPlat(@"schema {
-  query: root
-}
+        build_schema("none").ShouldBeCrossPlat("""
+            schema {
+              query: root
+            }
 
-type NestedObjType {
-  intField: Int
-}
+            type NestedObjType {
+              intField: Int
+            }
 
-type root {
-  listOfObjField: NestedObjType
-}
-");
+            type root {
+              listOfObjField: NestedObjType
+            }
+
+            """);
     }
 
     private string build_schema(string propType)

--- a/src/GraphQL.Tests/Execution/RepeatedSubfieldsIntegrationTests.cs
+++ b/src/GraphQL.Tests/Execution/RepeatedSubfieldsIntegrationTests.cs
@@ -78,27 +78,30 @@ public class RepeatedSubfieldsIntegrationTests : BasicQueryTestBase
         AssertQuerySuccess(_ =>
         {
             _.Schema = schema;
-            _.Query = @"
+            _.Query = """
                 {
                   person {
                     business { id name }
                     business { id address { id street city state } }
                   }
-                }";
-        },
-        @"{
-              ""person"": {
-                ""business"": {
-                  ""id"": ""4"",
-                  ""name"": ""Stuntman Express"",
-                  ""address"": {
-                    ""id"": ""123"",
-                    ""street"": ""Las Vegas Blvd"",
-                    ""city"": ""Las Vegas"",
-                    ""state"": ""NV""
-                  }
                 }
+                """;
+        },
+        """
+        {
+          "person": {
+            "business": {
+              "id": "4",
+              "name": "Stuntman Express",
+              "address": {
+              "id": "123",
+              "street": "Las Vegas Blvd",
+              "city": "Las Vegas",
+              "state": "NV"
               }
-            }");
+            }
+          }
+        }
+        """);
     }
 }

--- a/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
+++ b/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
@@ -204,7 +204,7 @@ public class ResolveFieldContextTests
         options.Listeners.Add(new VerifyUserDocumentListener { ShouldBeAuthenticated = isAuthenticated });
         var result = await executer.ExecuteAsync(options).ConfigureAwait(false);
         var resultText = new SystemTextJson.GraphQLSerializer().Serialize(result);
-        resultText.ShouldBe(isAuthenticated ? @"{""data"":{""isAuthenticated"":true}}" : @"{""data"":{""isAuthenticated"":false}}");
+        resultText.ShouldBe(isAuthenticated ? """{"data":{"isAuthenticated":true}}""" : """{"data":{"isAuthenticated":false}}""");
     }
 
     private class VerifyUserDocumentListener : DocumentExecutionListenerBase

--- a/src/GraphQL.Tests/Execution/SerialExecutionStrategyTests.cs
+++ b/src/GraphQL.Tests/Execution/SerialExecutionStrategyTests.cs
@@ -53,28 +53,30 @@ public class SerialExecutionStrategyTests
             Query = "mutation { families { leader_dataLoader { lastName name } leader { lastName name } } }",
         };
         await documentExecuter.ExecuteAsync(executionOptions).ConfigureAwait(false);
-        sb.ToString().ShouldBeCrossPlat(@"families
-families.0.leader_dataLoader
-families.0.leader
-families.0.leader.lastName
-families.0.leader.name
-families.1.leader_dataLoader
-families.1.leader
-families.1.leader.lastName
-families.1.leader.name
-families.2.leader_dataLoader
-families.2.leader
-families.2.leader.lastName
-families.2.leader.name
-families.0.leader_dataLoader-completed
-families.1.leader_dataLoader-completed
-families.2.leader_dataLoader-completed
-families.0.leader_dataLoader.lastName
-families.0.leader_dataLoader.name
-families.1.leader_dataLoader.lastName
-families.1.leader_dataLoader.name
-families.2.leader_dataLoader.lastName
-families.2.leader_dataLoader.name
-");
+        sb.ToString().ShouldBeCrossPlat("""
+            families
+            families.0.leader_dataLoader
+            families.0.leader
+            families.0.leader.lastName
+            families.0.leader.name
+            families.1.leader_dataLoader
+            families.1.leader
+            families.1.leader.lastName
+            families.1.leader.name
+            families.2.leader_dataLoader
+            families.2.leader
+            families.2.leader.lastName
+            families.2.leader.name
+            families.0.leader_dataLoader-completed
+            families.1.leader_dataLoader-completed
+            families.2.leader_dataLoader-completed
+            families.0.leader_dataLoader.lastName
+            families.0.leader_dataLoader.name
+            families.1.leader_dataLoader.lastName
+            families.1.leader_dataLoader.name
+            families.2.leader_dataLoader.lastName
+            families.2.leader_dataLoader.name
+
+            """);
     }
 }

--- a/src/GraphQL.Tests/Execution/VariablesTests.cs
+++ b/src/GraphQL.Tests/Execution/VariablesTests.cs
@@ -195,11 +195,11 @@ public class Variables_With_Inline_Structs_Tests : QueryTestBase<VariablesSchema
 
 public class UsingVariablesTests : QueryTestBase<VariablesSchema>
 {
-    private const string _query = @"
-            query q($input: TestInputObject) {
-              fieldWithObjectInput(input: $input)
-            }
-        ";
+    private const string _query = """
+        query q($input: TestInputObject) {
+          fieldWithObjectInput(input: $input)
+        }
+        """;
 
     [Fact]
     public void executes_with_complex_input()
@@ -234,11 +234,11 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void uses_default_value_when_not_provided()
     {
-        var queryWithDefaults = @"
-                query q($input: TestInputObject = {a: ""foo"", b: [""bar""] c: ""baz""}) {
-                  fieldWithObjectInput(input: $input)
-                }
-            ";
+        var queryWithDefaults = """
+            query q($input: TestInputObject = {a: "foo", b: ["bar"] c: "baz"}) {
+              fieldWithObjectInput(input: $input)
+            }
+            """;
 
         var expected = """{ "fieldWithObjectInput": "{\"a\":\"foo\",\"b\":[\"bar\"],\"c\":\"baz\"}" }""";
 
@@ -290,7 +290,7 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     {
         const string expected = null;
 
-        var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": ""bar"" } }".ToInputs();
+        var inputs = """{ "input": { "a": "foo", "b": "bar" } }""".ToInputs();
 
         var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1, executed: false);
 
@@ -304,7 +304,7 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     {
         const string expected = null;
 
-        var inputs = @"{ ""input"": { ""a"": ""foo"", ""b"": ""bar"", ""c"": ""baz"", ""e"": ""dog"" } }".ToInputs();
+        var inputs = """{ "input": { "a": "foo", "b": "bar", "c": "baz", "e": "dog" } }""".ToInputs();
 
         var result = AssertQueryWithErrors(_query, expected, inputs, expectedErrorCount: 1, executed: false);
 
@@ -316,15 +316,15 @@ public class UsingVariablesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void executes_with_injected_input_variables()
     {
-        var query = @"
-                query q($argB: [String!]!, $argC: String!, $argD: ComplexScalar) {
-                  fieldWithObjectInput(input: { b: $argB, c: $argC, d: $argD,  })
-                }
-            ";
+        var query = """
+            query q($argB: [String!]!, $argC: String!, $argD: ComplexScalar) {
+              fieldWithObjectInput(input: { b: $argB, c: $argC, d: $argD,  })
+            }
+            """;
 
         var expected = """{ "fieldWithObjectInput": "{\"b\":[\"bar\",\"qux\"],\"c\":\"foo\",\"d\":\"DeserializedValue\"}" }""";
 
-        var inputs = @"{ ""argB"": [""bar"", ""qux""], ""argC"": ""foo"", ""argD"": ""SerializedValue"" }".ToInputs();
+        var inputs = """{ "argB": ["bar", "qux"], "argC": "foo", "argD": "SerializedValue" }""".ToInputs();
 
         AssertQuerySuccess(query, expected, inputs);
     }
@@ -335,17 +335,17 @@ public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_nullable_int_input_to_be_omitted()
     {
-        var query = @"
-{
-  fieldWithNullableIntInput
-}
-";
+        var query = """
+        {
+          fieldWithNullableIntInput
+        }
+        """;
 
-        var expected = @"
-{
-  ""fieldWithNullableIntInput"": 0
-}
-";
+        var expected = """
+        {
+          "fieldWithNullableIntInput": 0
+        }
+        """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -353,17 +353,17 @@ public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_nullable_inputs_to_be_omitted()
     {
-        var query = @"
+        var query = """
             {
               fieldWithNullableStringInput
             }
-            ";
+            """;
 
-        var expected = @"
+        var expected = """
             {
-              ""fieldWithNullableStringInput"": ""null""
+              "fieldWithNullableStringInput": "null"
             }
-            ";
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -371,17 +371,17 @@ public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_nullable_inputs_to_be_omitted_in_a_variable()
     {
-        var query = @"
-                query SetsNullable($value: String) {
-                  fieldWithNullableStringInput(input: $value)
-                }
-            ";
-
-        var expected = @"
-            {
-              ""fieldWithNullableStringInput"": ""null""
+        var query = """
+            query SetsNullable($value: String) {
+              fieldWithNullableStringInput(input: $value)
             }
-            ";
+            """;
+
+        var expected = """
+            {
+              "fieldWithNullableStringInput": "null"
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -389,17 +389,17 @@ public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_nullable_inputs_to_be_omitted_in_an_unlisted_variable()
     {
-        var query = @"
-                query SetsNullable {
-                  fieldWithNullableStringInput(input: $value)
-                }
-            ";
-
-        var expected = @"
-            {
-              ""fieldWithNullableStringInput"": ""null""
+        var query = """
+            query SetsNullable {
+              fieldWithNullableStringInput(input: $value)
             }
-            ";
+            """;
+
+        var expected = """
+            {
+              "fieldWithNullableStringInput": "null"
+            }
+            """;
 
         AssertQuerySuccess(query, expected, rules: Enumerable.Empty<IValidationRule>());
     }
@@ -407,19 +407,19 @@ public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_nullable_inputs_to_be_set_to_null_in_a_variable()
     {
-        var query = @"
-                query SetsNullable($value: String) {
-                  fieldWithNullableStringInput(input: $value)
-                }
-            ";
-
-        var expected = @"
-            {
-              ""fieldWithNullableStringInput"": ""null""
+        var query = """
+            query SetsNullable($value: String) {
+              fieldWithNullableStringInput(input: $value)
             }
-            ";
+            """;
 
-        var inputs = @"{""value"": null}".ToInputs();
+        var expected = """
+            {
+              "fieldWithNullableStringInput": "null"
+            }
+            """;
+
+        var inputs = """{"value": null}""".ToInputs();
 
         AssertQuerySuccess(query, expected, inputs);
     }
@@ -427,11 +427,11 @@ public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_nullable_inputs_to_be_set_to_a_value_in_a_variable()
     {
-        var query = @"
-                query SetsNullable($value: String) {
-                  fieldWithNullableStringInput(input: $value)
-                }
-            ";
+        var query = """
+            query SetsNullable($value: String) {
+              fieldWithNullableStringInput(input: $value)
+            }
+            """;
 
         // value is: "a"
         var expected = """
@@ -448,18 +448,18 @@ public class HandlesNullableScalarsTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_nullable_inputs_to_be_set_to_a_value_directly()
     {
-        var query = @"
+        var query = """
             {
-              fieldWithNullableStringInput(input: ""a"")
+              fieldWithNullableStringInput(input: "a")
             }
-            ";
+            """;
 
         // value is: "a"
-        var expected = @"
+        var expected = """
             {
-              ""fieldWithNullableStringInput"": ""\""a\""""
+              "fieldWithNullableStringInput": "\"a\""
             }
-            ";
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -470,11 +470,11 @@ public class HandlesNonNullScalarTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void does_not_allow_non_nullable_inputs_to_be_omitted_in_a_variable()
     {
-        var query = @"
+        var query = """
             query SetsNonNullable($value: String!) {
               fieldWithNonNullableStringInput(input: $value)
             }
-            ";
+            """;
 
         string expected = null;
 
@@ -488,15 +488,15 @@ public class HandlesNonNullScalarTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void does_not_allow_non_nullable_inputs_to_be_set_to_null_in_a_variable()
     {
-        var query = @"
+        var query = """
             query SetsNonNullable($value: String!) {
               fieldWithNonNullableStringInput(input: $value)
             }
-            ";
+            """;
 
         string expected = null;
 
-        var inputs = @"{""value"": null}".ToInputs();
+        var inputs = """{"value": null}""".ToInputs();
 
         var result = AssertQueryWithErrors(query, expected, inputs, expectedErrorCount: 1, executed: false);
 
@@ -508,19 +508,19 @@ public class HandlesNonNullScalarTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_non_nullable_inputs_to_be_set_to_a_value_in_a_variable()
     {
-        var query = @"
-                query SetsNullable($value: String) {
-                  fieldWithNullableStringInput(input: $value)
-                }
-            ";
-
-        var expected = @"
-            {
-              ""fieldWithNullableStringInput"": ""\""a\""""
+        var query = """
+            query SetsNullable($value: String) {
+              fieldWithNullableStringInput(input: $value)
             }
-            ";
+            """;
 
-        var inputs = @"{""value"": ""a""}".ToInputs();
+        var expected = """
+            {
+              "fieldWithNullableStringInput": "\"a\""
+            }
+            """;
+
+        var inputs = """{"value": "a"}""".ToInputs();
 
         AssertQuerySuccess(query, expected, inputs);
     }
@@ -528,17 +528,17 @@ public class HandlesNonNullScalarTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_non_nullable_inputs_to_be_set_to_a_value_directly()
     {
-        var query = @"
+        var query = """
             {
-              fieldWithNullableStringInput(input: ""a"")
+              fieldWithNullableStringInput(input: "a")
             }
-            ";
+            """;
 
-        var expected = @"
+        var expected = """
             {
-              ""fieldWithNullableStringInput"": ""\""a\""""
+              "fieldWithNullableStringInput": "\"a\""
             }
-            ";
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -546,22 +546,22 @@ public class HandlesNonNullScalarTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void allows_custom_scalar_that_resolves_to_an_object()
     {
-        var query = @"
+        var query = """
             query SetsCustomScalarInput($input: JsonScalarReturningObject) {
               fieldWithCustomScalarInput(input: $input)
             }
-            ";
+            """;
 
-        var expected = @"
+        var expected = """
             {
-              ""fieldWithCustomScalarInput"": ""bear-cat, dog, bird""
+              "fieldWithCustomScalarInput": "bear-cat, dog, bird"
             }
-            ";
+            """;
 
-        var jsonInput = @"{ ""stringProperty"": ""bear"", ""arrayProperty"": [""cat"", ""dog"", ""bird""] }";
+        var jsonInput = """{ "stringProperty": "bear", "arrayProperty": ["cat", "dog", "bird"] }""";
         var jsonInputEncoded = JsonEncodedText.Encode(jsonInput);
 
-        var inputs = $@"{{ ""input"": ""{jsonInputEncoded}"" }}".ToInputs();
+        var inputs = $$"""{ "input": "{{jsonInputEncoded}}" }""".ToInputs();
 
         AssertQuerySuccess(query, expected, inputs);
     }
@@ -572,17 +572,17 @@ public class ArgumentDefaultValuesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void when_no_argument_provided()
     {
-        var query = @"
+        var query = """
             {
               fieldWithDefaultArgumentValue
             }
-            ";
+            """;
 
-        var expected = @"
+        var expected = """
             {
-              ""fieldWithDefaultArgumentValue"": ""\""Hello World\""""
+              "fieldWithDefaultArgumentValue": "\"Hello World\""
             }
-            ";
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -590,17 +590,17 @@ public class ArgumentDefaultValuesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void when_nullable_variable_provided()
     {
-        var query = @"
+        var query = """
             query optionalVariable($optional:String) {
               fieldWithDefaultArgumentValue(input: $optional)
             }
-            ";
+            """;
 
-        var expected = @"
+        var expected = """
             {
-              ""fieldWithDefaultArgumentValue"": ""\""Hello World\""""
+              "fieldWithDefaultArgumentValue": "\"Hello World\""
             }
-            ";
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -608,17 +608,17 @@ public class ArgumentDefaultValuesTests : QueryTestBase<VariablesSchema>
     [Fact]
     public void when_argument_provided_cannot_be_parsed()
     {
-        var query = @"
-            {
-              fieldWithDefaultArgumentValue(input: WRONG_TYPE)
-            }
-            ";
+        var query = """
+{
+  fieldWithDefaultArgumentValue(input: WRONG_TYPE)
+}
+""";
 
         var error = new ValidationError(default, ArgumentsOfCorrectTypeError.NUMBER, "Argument \u0027input\u0027 has invalid value. Expected type \u0027String\u0027, found WRONG_TYPE.")
         {
             Code = "ARGUMENTS_OF_CORRECT_TYPE",
         };
-        error.AddLocation(new Location(3, 45));
+        error.AddLocation(new Location(2, 33));
 
         var expected = new ExecutionResult
         {

--- a/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/ApolloTracingTests.cs
@@ -11,15 +11,16 @@ public class ApolloTracingTests : StarWarsTestBase
     [Fact]
     public void extension_has_expected_format()
     {
-        var query = @"
-query {
-  hero {
-    name
-    friends {
-      name
-    }
-  }
-}";
+        var query = """
+            query {
+              hero {
+                name
+                friends {
+                  name
+                }
+              }
+            }
+            """;
 
         var start = DateTime.UtcNow;
         Schema.FieldMiddleware.Use(new InstrumentFieldsMiddleware());
@@ -68,23 +69,25 @@ query {
     public void serialization_should_have_correct_case(IGraphQLTextSerializer writer)
     {
         var trace = new ApolloTrace(new DateTime(2019, 12, 05, 15, 38, 00, DateTimeKind.Utc), 102.5);
-        var expected = @"{
-  ""version"": 1,
-  ""startTime"": ""2019-12-05T15:38:00Z"",
-  ""endTime"": ""2019-12-05T15:38:00.1025Z"",
-  ""duration"": 102500000,
-  ""parsing"": {
-    ""startOffset"": 0,
-    ""duration"": 0
-  },
-  ""validation"": {
-    ""startOffset"": 0,
-    ""duration"": 0
-  },
-  ""execution"": {
-    ""resolvers"": []
-  }
-}";
+        var expected = """
+        {
+          "version": 1,
+          "startTime": "2019-12-05T15:38:00Z",
+          "endTime": "2019-12-05T15:38:00.1025Z",
+          "duration": 102500000,
+          "parsing": {
+            "startOffset": 0,
+            "duration": 0
+          },
+          "validation": {
+            "startOffset": 0,
+            "duration": 0
+          },
+          "execution": {
+            "resolvers": []
+          }
+        }
+        """;
 
         var result = writer.Serialize(trace);
 
@@ -133,11 +136,11 @@ query {
         var resultString = serializer.Serialize(result);
         if (enable || enableAfter || enableBefore)
         {
-            resultString.ShouldStartWith(@"{""data"":{""hero"":{""name"":""R2-D2""}},""extensions"":{""tracing"":{""version"":1,""startTime"":""");
+            resultString.ShouldStartWith("""{"data":{"hero":{"name":"R2-D2"}},"extensions":{"tracing":{"version":1,"startTime":"2""");
         }
         else
         {
-            resultString.ShouldBe(@"{""data"":{""hero"":{""name"":""R2-D2""}}}");
+            resultString.ShouldBe("""{"data":{"hero":{"name":"R2-D2"}}}""");
         }
     }
 }

--- a/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Introspection/SchemaIntrospectionTests.cs
@@ -177,21 +177,22 @@ public class SchemaIntrospectionTests
             ignoreWhiteSpaceDifferences: true);
     }
 
-    public static readonly string InputObjectBugQuery = @"
-query test {
-    __type(name:""SomeInput"") {
-        inputFields {
-            type {
-                name,
-                description
-                ofType {
-                    kind,
-                    name
+    public static readonly string InputObjectBugQuery = """
+        query test {
+            __type(name:"SomeInput") {
+                inputFields {
+                    type {
+                        name,
+                        description
+                        ofType {
+                            kind,
+                            name
+                        }
+                    }
                 }
             }
         }
-    }
-}";
+        """;
 
     public static readonly string InputObjectBugResult = "{\r\n \"data\": {\r\n  \"__type\": {\r\n    \"inputFields\": [\r\n      {\r\n        \"type\": {\r\n          \"name\": \"String\",\r\n          \"description\": null,\r\n          \"ofType\": null\r\n        }\r\n      }\r\n    ]\r\n  }\r\n }\r\n}";
 

--- a/src/GraphQL.Tests/Language/CommentTests.cs
+++ b/src/GraphQL.Tests/Language/CommentTests.cs
@@ -10,12 +10,13 @@ public class CommentTests
     [Fact]
     public void operation_comment_should_be_null()
     {
-        const string query = @"
-query _ {
-    person {
-        name
-    }
-}";
+        const string query = """
+            query _ {
+                person {
+                    name
+                }
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Operation().Comments.ShouldBeNull();
@@ -24,12 +25,14 @@ query _ {
     [Fact]
     public void operation_comment_should_not_be_null()
     {
-        const string query = @"#comment
-query _ {
-    person {
-        name
-    }
-}";
+        const string query = """
+            #comment
+            query _ {
+                person {
+                    name
+                }
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Operation().Comments[0].Value.ShouldBe("comment");
@@ -38,12 +41,13 @@ query _ {
     [Fact]
     public void field_comment_should_be_null()
     {
-        const string query = @"
-query _ {
-    person {
-        name
-    }
-}";
+        const string query = """
+            query _ {
+                person {
+                    name
+                }
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Operation()
@@ -56,14 +60,15 @@ query _ {
     [Fact]
     public void field_comment_should_not_be_null()
     {
-        const string query = @"
-query _ {
-    #comment1
-    person {
-        #comment2
-        name
-    }
-}";
+        const string query = """
+            query _ {
+                #comment1
+                person {
+                    #comment2
+                    name
+                }
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Operation()
@@ -76,17 +81,18 @@ query _ {
     [Fact]
     public void fragmentdefinition_comment_should_not_be_null()
     {
-        const string query = @"
-query _ {
-    person {
-        ...human
-    }
-}
+        const string query = """
+            query _ {
+                person {
+                    ...human
+                }
+            }
 
-#comment
-fragment human on person {
-        name
-}";
+            #comment
+            fragment human on person {
+                    name
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Definitions.OfType<GraphQLFragmentDefinition>().First().Comments[0].Value.ShouldBe("comment");
@@ -95,17 +101,18 @@ fragment human on person {
     [Fact]
     public void fragmentspread_comment_should_not_be_null()
     {
-        const string query = @"
-query _ {
-    person {
-        #comment
-        ...human
-    }
-}
+        const string query = """
+            query _ {
+                person {
+                    #comment
+                    ...human
+                }
+            }
 
-fragment human on person {
-        name
-}";
+            fragment human on person {
+                    name
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Operation()
@@ -116,15 +123,16 @@ fragment human on person {
     [Fact]
     public void inlinefragment_comment_should_not_be_null()
     {
-        const string query = @"
-query _ {
-    person {
-        #comment
-        ... on human {
-            name
-        }
-    }
-}";
+        const string query = """
+            query _ {
+                person {
+                    #comment
+                    ... on human {
+                        name
+                    }
+                }
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Operation()
@@ -135,14 +143,15 @@ query _ {
     [Fact]
     public void argument_comment_should_not_be_null()
     {
-        const string query = @"
-query _ {
-    person(
-        #comment
-        _where: ""foo"") {
-        name
-    }
-}";
+        const string query = """
+            query _ {
+                person(
+                    #comment
+                    _where: "foo") {
+                    name
+                }
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Operation()
@@ -153,14 +162,15 @@ query _ {
     [Fact]
     public void variable_comment_should_not_be_null()
     {
-        const string query = @"
-query _(
-    #comment
-    $id: ID) {
-    person {
-        name
-    }
-}";
+        const string query = """
+            query _(
+                #comment
+                $id: ID) {
+                person {
+                    name
+                }
+            }
+            """;
 
         var document = _builder.Build(query);
         document.Operation()

--- a/src/GraphQL.Tests/Language/ShowDownTests.cs
+++ b/src/GraphQL.Tests/Language/ShowDownTests.cs
@@ -5,20 +5,20 @@ namespace GraphQL.Tests.Language;
 
 public class ShowDownTests
 {
-    private const string _query = @"
-       query SomeDroids {
-          r2d2: droid(id: ""3"") {
+    private const string _query = """
+        query SomeDroids {
+          r2d2: droid(id: "3") {
             ...DroidFragment
           }
 
-          c3po: droid(id: ""4"") {
+          c3po: droid(id: "4") {
             ...DroidFragment
           }
-       }
-       fragment DroidFragment on Droid {
-         name
-       }
-";
+        }
+        fragment DroidFragment on Droid {
+          name
+        }
+        """;
     //        [Fact]
     public void core_builder()
     {

--- a/src/GraphQL.Tests/PersistedQueries/AutomaticPersistedQueriesTests.cs
+++ b/src/GraphQL.Tests/PersistedQueries/AutomaticPersistedQueriesTests.cs
@@ -26,7 +26,7 @@ public class AutomaticPersistedQueriesTests : IClassFixture<AutomaticPersistedQu
         var result = await _fixture.ExecuteAsync(opt => opt.Query = "query { ping }").ConfigureAwait(false);
 
         result.Errors.ShouldBeNull();
-        _fixture.Serialize(result).ShouldBe(@"{""data"":{""ping"":""pong""}}");
+        _fixture.Serialize(result).ShouldBe("""{"data":{"ping":"pong"}}""");
     }
 
     private void AssertError(ExecutionResult result, string code, string message)
@@ -124,11 +124,11 @@ public class AutomaticPersistedQueriesTests : IClassFixture<AutomaticPersistedQu
             opt.Extensions = extentions;
         }).ConfigureAwait(false);
         result.Errors.ShouldBeNull();
-        _fixture.Serialize(result).ShouldBe(@"{""data"":{""ping"":""pong""}}");
+        _fixture.Serialize(result).ShouldBe("""{"data":{"ping":"pong"}}""");
 
         result = await _fixture.ExecuteAsync(opt => opt.Extensions = extentions).ConfigureAwait(false);
         result.Errors.ShouldBeNull();
-        _fixture.Serialize(result).ShouldBe(@"{""data"":{""ping"":""pong""}}");
+        _fixture.Serialize(result).ShouldBe("""{"data":{"ping":"pong"}}""");
     }
 }
 

--- a/src/GraphQL.Tests/Serialization/ExecutionErrorTests.cs
+++ b/src/GraphQL.Tests/Serialization/ExecutionErrorTests.cs
@@ -12,7 +12,7 @@ public class ExecutionErrorTests
     {
         var error = new ExecutionError("some error 1");
 
-        var expected = @"{""message"": ""some error 1""}";
+        var expected = """{"message": "some error 1"}""";
 
         var actual = serializer.Serialize(error);
 
@@ -59,7 +59,7 @@ public class ExecutionErrorTests
     {
         var errors = new ExecutionError[] { new ExecutionError("some error 1"), new ExecutionError("some error 2") };
 
-        var expected = @"[{""message"": ""some error 1""}, {""message"": ""some error 2""}]";
+        var expected = """[{"message": "some error 1"}, {"message": "some error 2"}]""";
 
         var actual = serializer.Serialize(errors);
 
@@ -82,7 +82,7 @@ public class ExecutionErrorTests
         };
         executionResult.Errors.Add(executionError);
 
-        var expected = @"{ ""errors"": [{ ""message"": ""Error testing index"", ""path"": [ ""parent"", 23, ""child"" ] }] }";
+        var expected = """{ "errors": [{ "message": "Error testing index", "path": [ "parent", 23, "child" ] }] }""";
 
         var actual = serializer.Serialize(executionResult);
 

--- a/src/GraphQL.Tests/Serialization/ExecutionResultTests.cs
+++ b/src/GraphQL.Tests/Serialization/ExecutionResultTests.cs
@@ -16,7 +16,7 @@ public class ExecutionResultTests
         var executionResult = new ExecutionResult
         {
             Executed = true,
-            Data = @"{ ""someType"": { ""someProperty"": ""someValue"" } }".ToDictionary().ToExecutionTree(),
+            Data = """{ "someType": { "someProperty": "someValue" } }""".ToDictionary().ToExecutionTree(),
             Errors = new ExecutionErrors
             {
                 new ExecutionError("some error 1"),
@@ -24,31 +24,33 @@ public class ExecutionResultTests
             },
             Extensions = new Dictionary<string, object>
             {
-                { "someExtension", new { someProperty = "someValue", someOtherPropery = 1 } }
+                { "someExtension", new { someProperty = "someValue", someOtherProperty = 1 } }
             }
         };
 
-        var expected = @"{
-              ""errors"": [
-                {
-                  ""message"": ""some error 1""
-                },
-                {
-                  ""message"": ""some error 2""
-                }
+        var expected = """
+            {
+              "errors": [
+              {
+                "message": "some error 1"
+              },
+              {
+                "message": "some error 2"
+              }
               ],
-              ""data"": {
-                ""someType"": {
-                    ""someProperty"": ""someValue""
+              "data": {
+                "someType": {
+                  "someProperty": "someValue"
                 }
               },
-              ""extensions"": {
-                ""someExtension"": {
-                  ""someProperty"": ""someValue"",
-                  ""someOtherPropery"": 1
+              "extensions": {
+                "someExtension": {
+                  "someProperty": "someValue",
+                  "someOtherProperty": 1
                 }
               }
-            }";
+            }
+            """;
 
         var actual = serializer.Serialize(executionResult);
 
@@ -61,9 +63,7 @@ public class ExecutionResultTests
     {
         var executionResult = new ExecutionResult { Executed = true };
 
-        var expected = @"{
-              ""data"": null
-            }";
+        var expected = """{"data": null}""";
 
         var actual = serializer.Serialize(executionResult);
 
@@ -86,9 +86,11 @@ public class ExecutionResultTests
             }
         };
 
-        var expected = @"{
-              ""errors"": [{""message"":""some error 1""},{""message"":""some error 2""}]
-            }";
+        var expected = """
+            {
+              "errors": [{"message":"some error 1"},{"message":"some error 2"}]
+            }
+            """;
 
         var actual = serializer.Serialize(executionResult);
 
@@ -107,7 +109,7 @@ public class ExecutionResultTests
             Executed = true
         };
 
-        var expected = @"{ ""data"": {} }";
+        var expected = """{ "data": {} }""";
 
         var actual = serializer.Serialize(executionResult);
 
@@ -126,7 +128,7 @@ public class ExecutionResultTests
             Executed = false
         };
 
-        var expected = @"{ }";
+        var expected = "{ }";
 
         var actual = writer.Serialize(executionResult);
 
@@ -145,7 +147,7 @@ public class ExecutionResultTests
             Executed = true
         };
 
-        var expected = @"{ ""data"": null }";
+        var expected = """{ "data": null }""";
 
         var actual = serializer.Serialize(executionResult);
 

--- a/src/GraphQL.Tests/Serialization/GraphQLRequestTests.cs
+++ b/src/GraphQL.Tests/Serialization/GraphQLRequestTests.cs
@@ -206,7 +206,7 @@ public class GraphQLRequestTests : DeserializationTestBase
     [ClassData(typeof(GraphQLSerializersTestData))]
     public void Reads_GraphQLRequest_List_NotCaseSensitive(IGraphQLTextSerializer serializer)
     {
-        var test = @"{""VARIABLES"":{""date"":""2015-12-22T10:10:10+03:00""},""query"":""test""}";
+        var test = """{"VARIABLES":{"date":"2015-12-22T10:10:10+03:00"},"query":"test"}""";
         var actual = serializer.Deserialize<List<GraphQLRequest>>(test);
         actual.Count.ShouldBe(1);
         actual[0].Query.ShouldBe("test");

--- a/src/GraphQL.Tests/Serialization/NewtonsoftJson/InputsConverterTests.cs
+++ b/src/GraphQL.Tests/Serialization/NewtonsoftJson/InputsConverterTests.cs
@@ -56,14 +56,14 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_SimpleValues()
     {
-        string json = @"
-                {
-                    ""int"": 123,
-                    ""double"": 123.456,
-                    ""string"": ""string"",
-                    ""bool"": true
-                }
-            ";
+        string json = """
+            {
+              "int": 123,
+              "double": 123.456,
+              "string": "string",
+              "bool": true
+            }
+            """;
 
         var actual = Deserialize<Inputs>(json);
 
@@ -76,11 +76,11 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_Simple_Null()
     {
-        string json = @"
-                {
-                    ""string"": null
-                }
-            ";
+        string json = """
+            {
+              "string": null
+            }
+            """;
 
         var actual = Deserialize<Inputs>(json);
 
@@ -90,11 +90,11 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_Array()
     {
-        string json = @"
-                {
-                    ""values"": [1, 2, 3]
-                }
-            ";
+        string json = """
+            {
+              "values": [1, 2, 3]
+            }
+            """;
 
         var actual = Deserialize<Inputs>(json);
 
@@ -104,11 +104,11 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_Array_in_Array()
     {
-        string json = @"
-                {
-                    ""values"": [[1,2,3]]
-                }
-            ";
+        string json = """
+            {
+              "values": [[1,2,3]]
+            }
+            """;
 
         var actual = Deserialize<Inputs>(json);
 
@@ -120,16 +120,16 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_ComplexValue()
     {
-        string json = @"
-                {
-                    ""complex"": {
-                        ""int"": 123,
-                        ""double"": 123.456,
-                        ""string"": ""string"",
-                        ""bool"": true
-                    }
-                }
-            ";
+        string json = """
+            {
+              "complex": {
+                "int": 123,
+                "double": 123.456,
+                "string": "string",
+                "bool": true
+              }
+            }
+            """;
 
         var actual = Deserialize<Inputs>(json);
 
@@ -143,18 +143,18 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_MixedValue()
     {
-        string json = @"
-                {
-                    ""int"": 123,
-                    ""complex"": {
-                        ""int"": 123,
-                        ""double"": 123.456,
-                        ""string"": ""string"",
-                        ""bool"": true
-                    },
-                    ""bool"": true
-                }
-            ";
+        string json = """
+            {
+              "int": 123,
+              "complex": {
+                 "int": 123,
+                 "double": 123.456,
+                 "string": "string",
+                 "bool": true
+              },
+              "bool": true
+            }
+            """;
 
         var actual = Deserialize<Inputs>(json);
 
@@ -171,18 +171,18 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_Nested_SimpleValues()
     {
-        string json = @"
-                {
-                    ""value1"": ""string"",
-                    ""dictionary"": {
-                        ""int"": 123,
-                        ""double"": 123.456,
-                        ""string"": ""string"",
-                        ""bool"": true
-                    },
-                    ""value2"": 123
-                }
-            ";
+        string json = """
+            {
+              "value1": "string",
+              "dictionary": {
+                "int": 123,
+                "double": 123.456,
+                "string": "string",
+                "bool": true
+              },
+              "value2": 123
+            }
+            """;
 
         var actual = Deserialize<Nested>(json);
 
@@ -201,12 +201,13 @@ public class InputsConverterTests
 
         string json = Serialize(source);
 
-        json.ShouldBeCrossPlatJson(
-            @"{
-  ""Value1"": null,
-  ""Dictionary"": null,
-  ""Value2"": 123
-}".Trim());
+        json.ShouldBeCrossPlatJson("""
+            {
+              "Value1": null,
+              "Dictionary": null,
+              "Value2": 123
+            }
+            """.Trim());
     }
 
     [Fact]
@@ -225,15 +226,16 @@ public class InputsConverterTests
 
         string json = Serialize(source);
 
-        json.ShouldBeCrossPlatJson(
-            @"{
-  ""Value1"": ""string"",
-  ""Dictionary"": {
-    ""int"": 123,
-    ""string"": ""string""
-  },
-  ""Value2"": 123
-}".Trim());
+        json.ShouldBeCrossPlatJson("""
+            {
+              "Value1": "string",
+              "Dictionary": {
+                "int": 123,
+                "string": "string"
+              },
+              "Value2": 123
+            }
+            """.Trim());
     }
 
     [Fact]
@@ -251,14 +253,15 @@ public class InputsConverterTests
 
         string json = Serialize(source);
 
-        json.ShouldBeCrossPlatJson(
-            @"{
-  ""Value1"": ""string"",
-  ""Dictionary"": {
-    ""string"": null
-  },
-  ""Value2"": 123
-}".Trim());
+        json.ShouldBeCrossPlatJson("""
+            {
+              "Value1": "string",
+              "Dictionary": {
+                "string": null
+              },
+              "Value2": 123
+            }
+            """.Trim());
     }
 
     [Fact]
@@ -281,18 +284,19 @@ public class InputsConverterTests
 
         string json = Serialize(source);
 
-        json.ShouldBeCrossPlatJson(
-            @"{
-  ""Value1"": ""string"",
-  ""Dictionary"": {
-    ""int"": 123,
-    ""string"": ""string"",
-    ""complex"": {
-      ""double"": 1.123
-    }
-  },
-  ""Value2"": 123
-}".Trim());
+        json.ShouldBeCrossPlatJson("""
+            {
+              "Value1": "string",
+              "Dictionary": {
+                "int": 123,
+                "string": "string",
+                "complex": {
+                  "double": 1.123
+                }
+              },
+              "Value2": 123
+            }
+            """.Trim());
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Serialization/OperationMessageTests.cs
+++ b/src/GraphQL.Tests/Serialization/OperationMessageTests.cs
@@ -67,7 +67,7 @@ public class OperationMessageTests : DeserializationTestBase
     {
         var message = new OperationMessage();
         var actual = serializer.Serialize(message);
-        var expected = @"{}";
+        var expected = "{}";
         actual.ShouldBeCrossPlatJson(expected);
     }
 }

--- a/src/GraphQL.Tests/Serialization/SystemTextJson/GraphQLSerializerTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJson/GraphQLSerializerTests.cs
@@ -55,10 +55,10 @@ public class GraphQLSerializerTests
         }).ConfigureAwait(false);
 
         // typically a value of 1.0000m would be serialized as 1.0000
-        new GraphQLSerializer().Serialize(result).ShouldBe(@"{""data"":{""hero"":1.0000}}");
+        new GraphQLSerializer().Serialize(result).ShouldBe("""{"data":{"hero":1.0000}}""");
 
         // tests that a custom converter can be registered for the decimal data type; here it serializes 1.0000m as 1
-        new GraphQLSerializer(o => o.Converters.Add(new SampleDecimalConverter())).Serialize(result).ShouldBe(@"{""data"":{""hero"":1}}");
+        new GraphQLSerializer(o => o.Converters.Add(new SampleDecimalConverter())).Serialize(result).ShouldBe("""{"data":{"hero":1}}""");
     }
 
     private class SampleDecimalConverter : JsonConverter<decimal>

--- a/src/GraphQL.Tests/Serialization/SystemTextJson/InputsConverterTests.cs
+++ b/src/GraphQL.Tests/Serialization/SystemTextJson/InputsConverterTests.cs
@@ -43,14 +43,14 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_SimpleValues()
     {
-        string json = @"
-                {
-                    ""int"": 123,
-                    ""double"": 123.456,
-                    ""string"": ""string"",
-                    ""bool"": true
-                }
-            ";
+        string json = """
+            {
+              "int": 123,
+              "double": 123.456,
+              "string": "string",
+              "bool": true
+            }
+            """;
 
         var actual = JsonSerializer.Deserialize<Inputs>(json, _options);
 
@@ -63,11 +63,11 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_Simple_Null()
     {
-        string json = @"
-                {
-                    ""string"": null
-                }
-            ";
+        string json = """
+            {
+              "string": null
+            }
+            """;
 
         var actual = JsonSerializer.Deserialize<Inputs>(json, _options);
 
@@ -77,11 +77,11 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_Array()
     {
-        string json = @"
-                {
-                    ""values"": [1, 2, 3]
-                }
-            ";
+        string json = """
+            {
+              "values": [1, 2, 3]
+            }
+            """;
 
         var actual = JsonSerializer.Deserialize<Inputs>(json, _options);
 
@@ -91,11 +91,11 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_Array_in_Array()
     {
-        string json = @"
-                {
-                    ""values"": [[1,2,3]]
-                }
-            ";
+        string json = """
+            {
+              "values": [[1,2,3]]
+            }
+            """;
 
         var actual = JsonSerializer.Deserialize<Inputs>(json, _options);
 
@@ -107,16 +107,16 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_ComplexValue()
     {
-        string json = @"
-                {
-                    ""complex"": {
-                        ""int"": 123,
-                        ""double"": 123.456,
-                        ""string"": ""string"",
-                        ""bool"": true
-                    }
-                }
-            ";
+        string json = """
+            {
+              "complex": {
+                "int": 123,
+                "double": 123.456,
+                "string": "string",
+                "bool": true
+              }
+            }
+            """;
 
         var actual = JsonSerializer.Deserialize<Inputs>(json, _options);
 
@@ -130,18 +130,18 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_MixedValue()
     {
-        string json = @"
-                {
-                    ""int"": 123,
-                    ""complex"": {
-                        ""int"": 123,
-                        ""double"": 123.456,
-                        ""string"": ""string"",
-                        ""bool"": true
-                    },
-                    ""bool"": true
-                }
-            ";
+        string json = """
+            {
+              "int": 123,
+              "complex": {
+                "int": 123,
+                "double": 123.456,
+                "string": "string",
+                "bool": true
+              },
+              "bool": true
+            }
+            """;
 
         var actual = JsonSerializer.Deserialize<Inputs>(json, _options);
 
@@ -158,18 +158,18 @@ public class InputsConverterTests
     [Fact]
     public void Deserialize_Nested_SimpleValues()
     {
-        string json = @"
-                {
-                    ""value1"": ""string"",
-                    ""dictionary"": {
-                        ""int"": 123,
-                        ""double"": 123.456,
-                        ""string"": ""string"",
-                        ""bool"": true
-                    },
-                    ""value2"": 123
-                }
-            ";
+        string json = """
+            {
+              "value1": "string",
+              "dictionary": {
+                "int": 123,
+                "double": 123.456,
+                "string": "string",
+                "bool": true
+              },
+              "value2": 123
+            }
+            """;
 
         var actual = JsonSerializer.Deserialize<Nested>(json, _options);
 
@@ -188,12 +188,13 @@ public class InputsConverterTests
 
         string json = JsonSerializer.Serialize(source, _options);
 
-        json.ShouldBeCrossPlatJson(
-            @"{
-  ""value1"": null,
-  ""dictionary"": null,
-  ""value2"": 123
-}".Trim());
+        json.ShouldBeCrossPlatJson("""
+            {
+              "value1": null,
+              "dictionary": null,
+              "value2": 123
+            }
+            """.Trim());
     }
 
     [Fact]
@@ -212,15 +213,16 @@ public class InputsConverterTests
 
         string json = JsonSerializer.Serialize(source, _options);
 
-        json.ShouldBeCrossPlatJson(
-            @"{
-  ""value1"": ""string"",
-  ""dictionary"": {
-    ""int"": 123,
-    ""string"": ""string""
-  },
-  ""value2"": 123
-}".Trim());
+        json.ShouldBeCrossPlatJson("""
+            {
+              "value1": "string",
+              "dictionary": {
+                "int": 123,
+                "string": "string"
+              },
+              "value2": 123
+            }
+            """.Trim());
     }
 
     [Fact]
@@ -238,14 +240,15 @@ public class InputsConverterTests
 
         string json = JsonSerializer.Serialize(source, _options);
 
-        json.ShouldBeCrossPlatJson(
-            @"{
-  ""value1"": ""string"",
-  ""dictionary"": {
-    ""string"": null
-  },
-  ""value2"": 123
-}".Trim());
+        json.ShouldBeCrossPlatJson("""
+            {
+              "value1": "string",
+              "dictionary": {
+                "string": null
+              },
+              "value2": 123
+            }
+            """.Trim());
     }
 
     [Fact]
@@ -268,18 +271,19 @@ public class InputsConverterTests
 
         string json = JsonSerializer.Serialize(source, _options);
 
-        json.ShouldBeCrossPlatJson(
-            @"{
-  ""value1"": ""string"",
-  ""dictionary"": {
-    ""int"": 123,
-    ""string"": ""string"",
-    ""complex"": {
-      ""double"": 1.123
-    }
-  },
-  ""value2"": 123
-}".Trim());
+        json.ShouldBeCrossPlatJson("""
+            {
+              "value1": "string",
+              "dictionary": {
+                "int": 123,
+                "string": "string",
+                "complex": {
+                  "double": 1.123
+                }
+              },
+              "value2": 123
+            }
+            """.Trim());
     }
 
     private class Nested

--- a/src/GraphQL.Tests/StarWars/StarWarsBasicQueryTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsBasicQueryTests.cs
@@ -5,19 +5,21 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void identifies_r2_as_the_hero()
     {
-        var query = @"
-                query HeroNameQuery {
-                  hero {
-                    name
-                  }
-                }
-            ";
-
-        var expected = @"{
-              ""hero"": {
-                ""name"": ""R2-D2""
+        var query = """
+            query HeroNameQuery {
+              hero {
+                name
               }
-            }";
+            }
+            """;
+
+        var expected = """
+            {
+              "hero": {
+                "name": "R2-D2"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -25,19 +27,21 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void can_query_without_query_name()
     {
-        var query = @"
-               {
-                  hero {
-                    name
-                  }
-               }
-            ";
-
-        var expected = @"{
-              ""hero"": {
-                ""name"": ""R2-D2""
+        var query = """
+            {
+              hero {
+                name
               }
-            }";
+            }
+            """;
+
+        var expected = """
+            {
+              "hero": {
+                "name": "R2-D2"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -45,32 +49,34 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void can_query_for_the_id_and_friends_of_r2()
     {
-        var query = @"
-                query HeroNameAndFriendsQuery {
-                  hero {
-                    id
-                    name
-                    friends {
-                      name
-                    }
-                  }
+        var query = """
+            query HeroNameAndFriendsQuery {
+              hero {
+                id
+                name
+                friends {
+                  name
                 }
-            ";
+              }
+            }
+            """;
 
-        var expected = @"{
-              ""hero"": {
-                ""id"": ""3"",
-                ""name"": ""R2-D2"",
-                ""friends"": [
+        var expected = """
+            {
+              "hero": {
+                "id": "3",
+                "name": "R2-D2",
+                "friends": [
                   {
-                    ""name"": ""Luke""
+                    "name": "Luke"
                   },
                   {
-                    ""name"": ""C-3PO""
+                    "name": "C-3PO"
                   }
                 ]
               }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -78,21 +84,23 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void can_query_for_humans()
     {
-        var query = @"
-               {
-                  human(id: ""1"") {
-                    name
-                    homePlanet
-                  }
-               }
-            ";
-
-        var expected = @"{
-              ""human"": {
-                ""name"": ""Luke"",
-                ""homePlanet"": ""Tatooine""
+        var query = """
+            {
+              human(id: "1") {
+                name
+                homePlanet
               }
-            }";
+            }
+            """;
+
+        var expected = """
+            {
+              "human": {
+                "name": "Luke",
+                "homePlanet": "Tatooine"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -100,27 +108,29 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void can_query_for_friends_of_humans()
     {
-        var query = @"
-               {
-                  human(id: ""1"") {
-                    name
-                    friends {
-                      name
-                      appearsIn
-                    }
-                  }
-               }
-            ";
+        var query = """
+            {
+              human(id: "1") {
+                name
+                friends {
+                  name
+                  appearsIn
+                }
+              }
+            }
+            """;
 
-        var expected = @"{
-              ""human"": {
-                ""name"": ""Luke"",
-                ""friends"": [
-                  {""name"":""R2-D2"", ""appearsIn"":[""NEWHOPE"",""EMPIRE"",""JEDI""]},
-                  {""name"":""C-3PO"", ""appearsIn"":[""NEWHOPE"",""EMPIRE"",""JEDI""]}
+        var expected = """
+            {
+              "human": {
+                "name": "Luke",
+                "friends": [
+                  {"name":"R2-D2", "appearsIn":["NEWHOPE","EMPIRE","JEDI"]},
+                  {"name":"C-3PO", "appearsIn":["NEWHOPE","EMPIRE","JEDI"]}
                 ]
               }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -128,64 +138,65 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void can_query_for_connected_friends_of_humans()
     {
-        var query = @"
-               {
-                  human(id: ""1"") {
-                    name
-                    friendsConnection {
-                      totalCount
-                      edges {
-                        node {
-                          name
-                          appearsIn
-                        }
-                        cursor
-                      },
-                      pageInfo {
-                        endCursor
-                        hasNextPage
-                      }
+        var query = """
+            {
+              human(id: "1") {
+                name
+                friendsConnection {
+                  totalCount
+                  edges {
+                    node {
+                      name
+                      appearsIn
                     }
-                  }
-               }
-            ";
-
-        var expected = @"{
-                ""human"": {
-                  ""name"": ""Luke"",
-                  ""friendsConnection"": {
-                    ""totalCount"": 2,
-                    ""edges"": [
-                      {
-                        ""node"": {
-                          ""name"": ""R2-D2"",
-                          ""appearsIn"": [
-                            ""NEWHOPE"",
-                            ""EMPIRE"",
-                            ""JEDI""
-                          ]
-                        },
-                        ""cursor"": ""Mw==""
-                      },
-                      {
-                        ""node"": {
-                          ""name"": ""C-3PO"",
-                          ""appearsIn"": [
-                            ""NEWHOPE"",
-                            ""EMPIRE"",
-                            ""JEDI""
-                          ]
-                        },
-                        ""cursor"": ""NA==""
-                      }
-                    ],
-                    ""pageInfo"": {
-                      ""endCursor"": ""NA=="",
-                      ""hasNextPage"": false
-                    }
+                  cursor
+                },
+                pageInfo {
+                  endCursor
+                  hasNextPage
                   }
                 }
-              }";
+              }
+            }
+            """;
+
+        var expected = """
+            {
+              "human": {
+                "name": "Luke",
+                "friendsConnection": {
+                  "totalCount": 2,
+                  "edges": [
+                  {
+                    "node": {
+                      "name": "R2-D2",
+                      "appearsIn": [
+                        "NEWHOPE",
+                        "EMPIRE",
+                        "JEDI"
+                      ]
+                    },
+                    "cursor": "Mw=="
+                  },
+                  {
+                    "node": {
+                      "name": "C-3PO",
+                      "appearsIn": [
+                        "NEWHOPE",
+                        "EMPIRE",
+                        "JEDI"
+                      ]
+                    },
+                    "cursor": "NA=="
+                  }],
+                  "pageInfo": {
+                    "endCursor": "NA==",
+                    "hasNextPage": false
+                  }
+                }
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -193,19 +204,21 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void can_query_for_droids()
     {
-        var query = @"
-               {
-                  droid(id: ""4"") {
-                    name
-                  }
-               }
-            ";
-
-        var expected = @"{
-              ""droid"": {
-                ""name"": ""C-3PO""
+        var query = """
+            {
+              droid(id: "4") {
+                name
               }
-            }";
+            }
+            """;
+
+        var expected = """
+            {
+              "droid": {
+                "name": "C-3PO"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -213,11 +226,11 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void can_query_for_connected_friends_of_droids_second_page()
     {
-        var query = @"
+        var query = """
                {
-                  droid(id: ""3"") {
+                  droid(id: "3") {
                     name
-                    friendsConnection(first: 1, after: ""NA=="") {
+                    friendsConnection(first: 1, after: "NA==") {
                       totalCount
                       edges {
                         node {
@@ -233,33 +246,35 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
                     }
                   }
                }
-            ";
+            """;
 
-        var expected = @"{
-                ""droid"": {
-                  ""name"": ""R2-D2"",
-                  ""friendsConnection"": {
-                    ""totalCount"": 1,
-                    ""edges"": [
+        var expected = """
+            {
+                "droid": {
+                  "name": "R2-D2",
+                  "friendsConnection": {
+                    "totalCount": 1,
+                    "edges": [
                       {
-                        ""node"": {
-                          ""name"": ""C-3PO"",
-                          ""appearsIn"": [
-                            ""NEWHOPE"",
-                            ""EMPIRE"",
-                            ""JEDI""
+                        "node": {
+                          "name": "C-3PO",
+                          "appearsIn": [
+                            "NEWHOPE",
+                            "EMPIRE",
+                            "JEDI"
                           ]
                         },
-                        ""cursor"": ""NA==""
+                        "cursor": "NA=="
                       }
                     ],
-                    ""pageInfo"": {
-                      ""endCursor"": ""NA=="",
-                      ""hasNextPage"": false
+                    "pageInfo": {
+                      "endCursor": "NA==",
+                      "hasNextPage": false
                     }
                   }
                 }
-              }";
+              }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -267,20 +282,21 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void create_generic_query_that_fetches_luke()
     {
-        var query = @"
-                query humanQuery($id: String!) {
-                  human(id: $id) {
-                    name
-                  }
-                }
-            ";
-
-        var expected = @"{
-              ""human"": {
-                ""name"": ""Luke""
+        var query = """
+            query humanQuery($id: String!) {
+              human(id: $id) {
+                name
               }
             }
-            ";
+            """;
+
+        var expected = """
+            {
+              "human": {
+                "name": "Luke"
+              }
+            }
+            """;
 
         var inputs = new Inputs(new Dictionary<string, object> { { "id", "1" } });
 
@@ -290,26 +306,28 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void query_same_root_field_using_alias()
     {
-        var query = @"
+        var query = """
                query SomeDroids {
-                  r2d2: droid(id: ""3"") {
+                  r2d2: droid(id: "3") {
                     name
                   }
 
-                  c3po: droid(id: ""4"") {
+                  c3po: droid(id: "4") {
                     name
                   }
                }
-            ";
+            """;
 
-        var expected = @"{
-              ""r2d2"": {
-                ""name"": ""R2-D2""
+        var expected = """
+            {
+              "r2d2": {
+                "name": "R2-D2"
               },
-              ""c3po"": {
-                ""name"": ""C-3PO""
+              "c3po": {
+                "name": "C-3PO"
               }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -317,14 +335,16 @@ public class StarWarsBasicQueryTests : StarWarsTestBase
     [Fact]
     public void can_add_new_human()
     {
-        var mutation = @"mutation ($human:HumanInput!){ createHuman(human: $human) { name homePlanet } }";
+        var mutation = "mutation ($human:HumanInput!){ createHuman(human: $human) { name homePlanet } }";
 
-        var expected = @"{
-              ""createHuman"": {
-                ""name"": ""Boba Fett"",
-                ""homePlanet"": ""Kamino""
+        var expected = """
+            {
+              "createHuman": {
+                "name": "Boba Fett",
+                "homePlanet": "Kamino"
               }
-            }";
+            }
+            """;
 
         var data = new Dictionary<string, object>
         {

--- a/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsFragmentTests.cs
@@ -9,29 +9,31 @@ public class StarWarsFragmentTests : StarWarsTestBase
     [Fact]
     public void use_fragment_spread_to_avoid_duplicate_content()
     {
-        var query = @"
-               query SomeDroids {
-                  r2d2: droid(id: ""3"") {
-                    ...DroidFragment
-                  }
-
-                  c3po: droid(id: ""4"") {
-                    ...DroidFragment
-                  }
-               }
-               fragment DroidFragment on Droid {
-                 name
-               }
-            ";
-
-        var expected = @"{
-              ""r2d2"": {
-                ""name"": ""R2-D2""
-              },
-              ""c3po"": {
-                ""name"": ""C-3PO""
+        var query = """
+            query SomeDroids {
+              r2d2: droid(id: "3") {
+                ...DroidFragment
               }
-            }";
+
+              c3po: droid(id: "4") {
+                ...DroidFragment
+              }
+            }
+            fragment DroidFragment on Droid {
+              name
+            }
+            """;
+
+        var expected = """
+            {
+              "r2d2": {
+                "name": "R2-D2"
+              },
+              "c3po": {
+                "name": "C-3PO"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -39,21 +41,23 @@ public class StarWarsFragmentTests : StarWarsTestBase
     [Fact]
     public void use_inline_fragment_on_interface()
     {
-        var query = @"
-               query SomeDroids {
-                  r2d2: droid(id: ""3"") {
-                    ... on Character {
-                      name
-                    }
-                  }
-               }
-            ";
-
-        var expected = @"{
-              ""r2d2"": {
-                ""name"": ""R2-D2""
+        var query = """
+            query SomeDroids {
+              r2d2: droid(id: "3") {
+                ... on Character {
+                  name
+                }
               }
-            }";
+            }
+            """;
+
+        var expected = """
+            {
+              "r2d2": {
+                "name": "R2-D2"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -61,21 +65,23 @@ public class StarWarsFragmentTests : StarWarsTestBase
     [Fact]
     public void use_unnamed_inline_fragment_on_interface()
     {
-        var query = @"
-               query SomeDroids {
-                  r2d2: droid(id: ""3"") {
-                    ... {
-                      name
-                    }
-                  }
-               }
-            ";
-
-        var expected = @"{
-              ""r2d2"": {
-                ""name"": ""R2-D2""
+        var query = """
+            query SomeDroids {
+              r2d2: droid(id: "3") {
+                ... {
+                  name
+                }
               }
-            }";
+            }
+            """;
+
+        var expected = """
+            {
+              "r2d2": {
+                "name": "R2-D2"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -83,20 +89,20 @@ public class StarWarsFragmentTests : StarWarsTestBase
     [Fact]
     public void use_undefined_fragment()
     {
-        var query = @"
-                query someDroids {
-                    r2d2: droid(id: ""3"") {
-                        ...unknown_fragment
-                        name
-                    }
-               }
-            ";
+        var query = """
+            query someDroids {
+              r2d2: droid(id: "3") {
+                ...unknown_fragment
+                name
+              }
+            }
+            """;
         var errors = new ExecutionErrors();
         var error = new ValidationError(query, KnownFragmentNamesError.NUMBER, "Unknown fragment 'unknown_fragment'.")
         {
             Code = "KNOWN_FRAGMENT_NAMES"
         };
-        error.AddLocation(new Location(4, 25));
+        error.AddLocation(new Location(3, 5));
         errors.Add(error);
 
         AssertQuery(query, CreateQueryResult(null, errors, executed: false), null, null);

--- a/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsIntrospectionTests.cs
@@ -7,7 +7,7 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     {
         var query = "{ hero { __typename name } }";
 
-        var expected = @"{ ""hero"": { ""__typename"": ""Droid"", ""name"": ""R2-D2"" } }";
+        var expected = """{ "hero": { "__typename": "Droid", "name": "R2-D2" } }""";
 
         AssertQuerySuccess(query, expected);
     }
@@ -15,21 +15,23 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     [Fact]
     public void allows_querying_schema_for_an_object_kind()
     {
-        var query = @"
-                query IntrospectionDroidKindQuery {
-                  __type(name: ""Droid"") {
-                    name,
-                    kind
-                  }
-                }
-            ";
-
-        var expected = @"{
-              ""__type"": {
-                ""name"": ""Droid"",
-                ""kind"": ""OBJECT""
+        var query = """
+            query IntrospectionDroidKindQuery {
+              __type(name: "Droid") {
+                name,
+                kind
               }
-            }";
+            }
+            """;
+
+        var expected = """
+            {
+              "__type": {
+                "name": "Droid",
+                "kind": "OBJECT"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -37,21 +39,23 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     [Fact]
     public void allows_querying_schema_for_an_interface_kind()
     {
-        var query = @"
+        var query = """
             query IntrospectionCharacterKindQuery {
-              __type(name: ""Character"") {
+              __type(name: "Character") {
                 name
                 kind
               }
             }
-            ";
+            """;
 
-        var expected = @"{
-              ""__type"": {
-                ""name"": ""Character"",
-                ""kind"": ""INTERFACE""
+        var expected = """
+            {
+              "__type": {
+                "name": "Character",
+                "kind": "INTERFACE"
               }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -59,29 +63,31 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     [Fact]
     public void allows_querying_schema_for_possibleTypes_of_an_interface()
     {
-        var query = @"
+        var query = """
             query IntrospectionCharacterKindQuery {
-              __type(name: ""Character"") {
+              __type(name: "Character") {
                 name
                 kind
-                  possibleTypes {
-                    name,
-                    kind
-                  }
+                possibleTypes {
+                  name,
+                  kind
+                }
               }
             }
-            ";
+            """;
 
-        var expected = @"{
-              ""__type"": {
-                ""name"": ""Character"",
-                ""kind"": ""INTERFACE"",
-                ""possibleTypes"": [
-                  { ""name"": ""Human"", ""kind"": ""OBJECT"" },
-                  { ""name"": ""Droid"", ""kind"": ""OBJECT"" }
+        var expected = """
+            {
+              "__type": {
+                "name": "Character",
+                "kind": "INTERFACE",
+                "possibleTypes": [
+                  { "name": "Human", "kind": "OBJECT" },
+                  { "name": "Droid", "kind": "OBJECT" }
                 ]
               }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -89,9 +95,9 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     [Fact]
     public void allows_querying_the_schema_for_object_fields()
     {
-        var query = @"
+        var query = """
             query IntrospectionDroidFieldsQuery {
-              __type(name: ""Droid"") {
+              __type(name: "Droid") {
                 name
                 fields {
                     name
@@ -102,57 +108,59 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
                 }
               }
             }
-            ";
+            """;
 
-        var expected = @"{
-                ""__type"": {
-                  ""name"": ""Droid"",
-                  ""fields"": [
+        var expected = """
+            {
+                "__type": {
+                  "name": "Droid",
+                  "fields": [
                     {
-                      ""name"": ""id"",
-                      ""type"": {
-                        ""name"": null,
-                        ""kind"": ""NON_NULL""
+                      "name": "id",
+                      "type": {
+                        "name": null,
+                        "kind": "NON_NULL"
                       }
                     },
                     {
-                      ""name"": ""name"",
-                      ""type"": {
-                        ""name"": ""String"",
-                        ""kind"": ""SCALAR""
+                      "name": "name",
+                      "type": {
+                        "name": "String",
+                        "kind": "SCALAR"
                       }
                     },
                     {
-                      ""name"": ""friends"",
-                      ""type"": {
-                        ""name"": null,
-                        ""kind"": ""LIST""
+                      "name": "friends",
+                      "type": {
+                        "name": null,
+                        "kind": "LIST"
                       }
                     },
                     {
-                      ""name"": ""friendsConnection"",
-                      ""type"": {
-                        ""name"": ""CharacterInterfaceConnection"",
-                        ""kind"": ""OBJECT""
+                      "name": "friendsConnection",
+                      "type": {
+                        "name": "CharacterInterfaceConnection",
+                        "kind": "OBJECT"
                       }
                     },
                     {
-                      ""name"": ""appearsIn"",
-                      ""type"": {
-                        ""name"": null,
-                        ""kind"": ""LIST""
+                      "name": "appearsIn",
+                      "type": {
+                        "name": null,
+                        "kind": "LIST"
                       }
                     },
                     {
-                      ""name"": ""primaryFunction"",
-                      ""type"": {
-                        ""name"": ""String"",
-                        ""kind"": ""SCALAR""
+                      "name": "primaryFunction",
+                      "type": {
+                        "name": "String",
+                        "kind": "SCALAR"
                       }
                     }
                   ]
                 }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -160,20 +168,22 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     [Fact]
     public void allows_querying_the_schema_for_documentation()
     {
-        var query = @"
+        var query = """
             query IntrospectionDroidDescriptionQuery {
-              __type(name: ""Droid"") {
+              __type(name: "Droid") {
                 name
                 description
               }
             }
-            ";
-        var expected = @"{
-              ""__type"": {
-                ""name"": ""Droid"",
-                ""description"": ""A mechanical creature in the Star Wars universe.""
+            """;
+        var expected = """
+            {
+              "__type": {
+                "name": "Droid",
+                "description": "A mechanical creature in the Star Wars universe."
               }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -181,7 +191,7 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     [Fact]
     public void allows_querying_the_schema()
     {
-        var query = @"
+        var query = """
             query SchemaIntrospectionQuery {
               __schema {
                 types { name, kind }
@@ -196,127 +206,129 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
                 }
               }
             }
-            ";
-        var expected = @"{
-                ""__schema"": {
-                    ""types"": [
+            """;
+        var expected = """
+            {
+                "__schema": {
+                    "types": [
                     {
-                        ""name"": ""__Schema"",
-                        ""kind"": ""OBJECT""
+                        "name": "__Schema",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""String"",
-                        ""kind"": ""SCALAR""
+                        "name": "String",
+                        "kind": "SCALAR"
                     },
                     {
-                        ""name"": ""__Type"",
-                        ""kind"": ""OBJECT""
+                        "name": "__Type",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""__TypeKind"",
-                        ""kind"": ""ENUM""
+                        "name": "__TypeKind",
+                        "kind": "ENUM"
                     },
                     {
-                        ""name"": ""__Field"",
-                        ""kind"": ""OBJECT""
+                        "name": "__Field",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""__InputValue"",
-                        ""kind"": ""OBJECT""
+                        "name": "__InputValue",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""Boolean"",
-                        ""kind"": ""SCALAR""
+                        "name": "Boolean",
+                        "kind": "SCALAR"
                     },
                     {
-                        ""name"": ""__EnumValue"",
-                        ""kind"": ""OBJECT""
+                        "name": "__EnumValue",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""__Directive"",
-                        ""kind"": ""OBJECT""
+                        "name": "__Directive",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""__DirectiveLocation"",
-                        ""kind"": ""ENUM""
+                        "name": "__DirectiveLocation",
+                        "kind": "ENUM"
                     },
                     {
-                        ""name"": ""Query"",
-                        ""kind"": ""OBJECT""
+                        "name": "Query",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""Character"",
-                        ""kind"": ""INTERFACE""
+                        "name": "Character",
+                        "kind": "INTERFACE"
                     },
                     {
-                        ""name"": ""CharacterInterfaceConnection"",
-                        ""kind"": ""OBJECT""
+                        "name": "CharacterInterfaceConnection",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""Int"",
-                        ""kind"": ""SCALAR""
+                        "name": "Int",
+                        "kind": "SCALAR"
                     },
                     {
-                        ""name"": ""PageInfo"",
-                        ""kind"": ""OBJECT""
+                        "name": "PageInfo",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""CharacterInterfaceEdge"",
-                        ""kind"": ""OBJECT""
+                        "name": "CharacterInterfaceEdge",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""Episode"",
-                        ""kind"": ""ENUM""
+                        "name": "Episode",
+                        "kind": "ENUM"
                     },
                     {
-                        ""name"": ""Human"",
-                        ""kind"": ""OBJECT""
+                        "name": "Human",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""Droid"",
-                        ""kind"": ""OBJECT""
+                        "name": "Droid",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""Mutation"",
-                        ""kind"": ""OBJECT""
+                        "name": "Mutation",
+                        "kind": "OBJECT"
                     },
                     {
-                        ""name"": ""HumanInput"",
-                        ""kind"": ""INPUT_OBJECT""
+                        "name": "HumanInput",
+                        "kind": "INPUT_OBJECT"
                     }
                     ],
-                    ""queryType"": {
-                      ""name"": ""Query"",
-                      ""kind"": ""OBJECT""
+                    "queryType": {
+                      "name": "Query",
+                      "kind": "OBJECT"
                     },
-                    ""mutationType"": {
-                      ""name"": ""Mutation""
+                    "mutationType": {
+                      "name": "Mutation"
                     },
-                    ""directives"": [
+                    "directives": [
                     {
-                        ""name"": ""include"",
-                        ""description"": ""Directs the executor to include this field or fragment only when the 'if' argument is true."",
-                        ""onOperation"": false,
-                        ""onFragment"": true,
-                        ""onField"": true
-                    },
-                    {
-                        ""name"": ""skip"",
-                        ""description"": ""Directs the executor to skip this field or fragment when the 'if' argument is true."",
-                        ""onOperation"": false,
-                        ""onFragment"": true,
-                        ""onField"": true
+                        "name": "include",
+                        "description": "Directs the executor to include this field or fragment only when the 'if' argument is true.",
+                        "onOperation": false,
+                        "onFragment": true,
+                        "onField": true
                     },
                     {
-                        ""name"": ""deprecated"",
-                        ""description"": ""Marks an element of a GraphQL schema as no longer supported."",
-                        ""onOperation"": false,
-                        ""onFragment"": false,
-                        ""onField"": false
+                        "name": "skip",
+                        "description": "Directs the executor to skip this field or fragment when the 'if' argument is true.",
+                        "onOperation": false,
+                        "onFragment": true,
+                        "onField": true
+                    },
+                    {
+                        "name": "deprecated",
+                        "description": "Marks an element of a GraphQL schema as no longer supported.",
+                        "onOperation": false,
+                        "onFragment": false,
+                        "onField": false
                     }
                     ]
                 }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -325,13 +337,14 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     [Fact]
     public void allow_querying_input_object_type_fields()
     {
-        var query = @"{
-  __type(name: ""HumanInput"") {
-    fields { name }
-    inputFields { name }
-  }
-}
-            ";
+        var query = """
+            {
+              __type(name: "HumanInput") {
+                fields { name }
+                inputFields { name }
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, "HumanInputIntrospectionResult".ReadJsonResult());
     }
@@ -339,7 +352,7 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
     [Fact]
     public void allows_querying_field_args()
     {
-        var query = @"
+        var query = """
             query SchemaIntrospectionQuery {
               __schema {
                 queryType {
@@ -362,55 +375,57 @@ public class StarWarsIntrospectionTests : StarWarsTestBase
                 }
               }
             }
-            ";
-        var expected = @"{
-              ""__schema"": {
-                ""queryType"": {
-                  ""fields"": [
+            """;
+        var expected = """
+            {
+              "__schema": {
+                "queryType": {
+                  "fields": [
                     {
-                      ""name"": ""hero"",
-                      ""args"": []
+                      "name": "hero",
+                      "args": []
                     },
                     {
-                      ""name"": ""human"",
-                      ""args"": [
+                      "name": "human",
+                      "args": [
                         {
-                          ""name"": ""id"",
-                          ""description"": ""id of the human"",
-                          ""type"": {
-                            ""name"": null,
-                            ""kind"": ""NON_NULL"",
-                            ""ofType"": {
-                              ""name"": ""String"",
-                              ""kind"": ""SCALAR""
+                          "name": "id",
+                          "description": "id of the human",
+                          "type": {
+                            "name": null,
+                            "kind": "NON_NULL",
+                            "ofType": {
+                              "name": "String",
+                              "kind": "SCALAR"
                             }
                           },
-                          ""defaultValue"": null
+                          "defaultValue": null
                         }
                       ]
                     },
                     {
-                      ""name"": ""droid"",
-                      ""args"": [
+                      "name": "droid",
+                      "args": [
                         {
-                          ""name"": ""id"",
-                          ""description"": ""id of the droid"",
-                          ""type"": {
-                            ""name"": null,
-                            ""kind"": ""NON_NULL"",
-                            ""ofType"": {
-                              ""name"": ""String"",
-                              ""kind"": ""SCALAR""
+                          "name": "id",
+                          "description": "id of the droid",
+                          "type": {
+                            "name": null,
+                            "kind": "NON_NULL",
+                            "ofType": {
+                              "name": "String",
+                              "kind": "SCALAR"
                             }
                           },
-                          ""defaultValue"": null
+                          "defaultValue": null
                         }
                       ]
                     }
                   ]
                 }
               }
-            }";
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }

--- a/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
+++ b/src/GraphQL.Tests/StarWars/StarWarsSubFieldsTest.cs
@@ -18,22 +18,22 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             ctx.SubFields.Keys.ShouldContain("friends");
             return new List<Human>();
         });
-        var query = @"
-                {
-                    listOfHumans {
-                        id
-                        friends {
-                            name
-                        }
-                    }
+        var query = """
+            {
+              listOfHumans {
+                id
+                friends {
+                  name
                 }
-            ";
+              }
+            }
+            """;
 
-        var expected = @"
-                {
-                    ""listOfHumans"": []
-                }
-            ";
+        var expected = """
+            {
+              "listOfHumans": []
+            }
+            """;
         AssertQuerySuccess(query, expected);
     }
 
@@ -48,21 +48,21 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             return null;
         });
 
-        var query = @"
-                {
-                    singleHuman {
-                        id
-                        friends {
-                            name
-                        }
-                    }
+        var query = """
+            {
+              singleHuman {
+                id
+                friends {
+                  name
                 }
-            ";
-        var expected = @"
-                {
-                    ""singleHuman"": null
-                }
-            ";
+              }
+            }
+            """;
+        var expected = """
+            {
+              "singleHuman": null
+            }
+            """;
         AssertQuerySuccess(query, expected);
     }
 
@@ -76,22 +76,22 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             ctx.SubFields.Keys.ShouldContain("friends");
             return new List<Human>();
         });
-        var query = @"
-                {
-                    listOfCharacters {
-                        id
-                        friends {
-                            name
-                        }
-                    }
+        var query = """
+            {
+              listOfCharacters {
+                id
+                friends {
+                  name
                 }
-            ";
+              }
+            }
+            """;
 
-        var expected = @"
-                {
-                    ""listOfCharacters"": []
-                }
-            ";
+        var expected = """
+            {
+              "listOfCharacters": []
+            }
+            """;
         AssertQuerySuccess(query, expected);
     }
 
@@ -105,22 +105,22 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
            ctx.SubFields.Keys.ShouldContain("friends");
            return Task.FromResult<object>(null);
        });
-        var query = @"
-                {
-                    singleCharacter {
-                        id
-                        friends {
-                            name
-                        }
-                    }
+        var query = """
+            {
+              singleCharacter {
+                id
+                friends {
+                  name
                 }
-            ";
+              }
+            }
+            """;
 
-        var expected = @"
-                {
-                    ""singleCharacter"": null
-                }
-            ";
+        var expected = """
+            {
+              "singleCharacter": null
+            }
+            """;
         AssertQuerySuccess(query, expected);
     }
 
@@ -133,16 +133,16 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             return 1;
         });
 
-        var query = @"
-                {
-                    someNumber
-                }
-            ";
-        var expected = @"
-                {
-                    ""someNumber"": 1
-                }
-            ";
+        var query = """
+            {
+              someNumber
+            }
+            """;
+        var expected = """
+            {
+              "someNumber": 1
+            }
+            """;
         AssertQuerySuccess(query, expected);
     }
 
@@ -155,16 +155,16 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             return new[] { 1, 2 };
         });
 
-        var query = @"
-                {
-                    someNumbers
-                }
-            ";
-        var expected = @"
-                {
-                    ""someNumbers"": [1,2]
-                }
-            ";
+        var query = """
+            {
+              someNumbers
+            }
+            """;
+        var expected = """
+            {
+              "someNumbers": [1,2]
+            }
+            """;
         AssertQuerySuccess(query, expected);
     }
 
@@ -179,27 +179,27 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             return new Human { Id = "1", Name = "Luke" };
         });
 
-        var query = @"
-                query Luke {
-                    luke {
-                        ...HumanData
-                    }
-                }
+        var query = """
+            query Luke {
+              luke {
+                ...HumanData
+              }
+            }
 
-                fragment HumanData on Human {
-                    id
-                    name
-                }
-            ";
+            fragment HumanData on Human {
+              id
+              name
+            }
+            """;
 
-        var expected = @"
-                {
-                    ""luke"": {
-                        ""id"": ""1"",
-                        ""name"": ""Luke""
-                    }
-                }
-            ";
+        var expected = """
+            {
+              "luke": {
+                "id": "1",
+                "name": "Luke"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -215,26 +215,26 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             return new Human { Id = "1", Name = "Luke" };
         });
 
-        var query = @"
-                query Luke {
-                    luke {
-                        ...on Human
-                        {
-                            id
-                            name
-                        }
-                    }
-                }
-            ";
-
-        var expected = @"
+        var query = """
+            query Luke {
+              luke {
+                ...on Human
                 {
-                    ""luke"": {
-                        ""id"": ""1"",
-                        ""name"": ""Luke""
-                    }
+                  id
+                  name
                 }
-            ";
+              }
+            }
+            """;
+
+        var expected = """
+            {
+              "luke": {
+                "id": "1",
+                "name": "Luke"
+              }
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -250,32 +250,33 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             return new[] { new Human { Id = "1", Name = "Luke" }, new Human { Id = "2", Name = "Luke Copy" } };
         });
 
-        var query = @"
-                query Luke {
-                    lukes {
-                        ...HumanData
-                    }
-                }
+        var query = """
+            query Luke {
+              lukes {
+                ...HumanData
+              }
+            }
 
-                fragment HumanData on Human {
-                    id
-                    name
-                }
-            ";
+            fragment HumanData on Human {
+              id
+              name
+            }
+            """;
 
-        var expected = @"
+        var expected = """
+            {
+              "lukes": [
                 {
-                    ""lukes"": [
-                    {
-                        ""id"": ""1"",
-                        ""name"": ""Luke""
-                    },
-                    {
-                        ""id"": ""2"",
-                        ""name"": ""Luke Copy""
-                    }
-                ]}
-            ";
+                  "id": "1",
+                  "name": "Luke"
+                },
+                {
+                  "id": "2",
+                  "name": "Luke Copy"
+                }
+              ]
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }
@@ -291,31 +292,32 @@ public class StarWarsSubFieldsTests : StarWarsTestBase
             return new[] { new Human { Id = "1", Name = "Luke" }, new Human { Id = "2", Name = "Luke Copy" } };
         });
 
-        var query = @"
-                query Luke {
-                    lukes {
-                        ... on Human
-                        {
-                            id
-                            name
-                        }
-                    }
-                }
-            ";
-
-        var expected = @"
+        var query = """
+            query Luke {
+              lukes {
+                ... on Human
                 {
-                    ""lukes"": [
-                    {
-                        ""id"": ""1"",
-                        ""name"": ""Luke""
-                    },
-                    {
-                        ""id"": ""2"",
-                        ""name"": ""Luke Copy""
-                    }
-                ]}
-            ";
+                  id
+                  name
+                }
+              }
+            }
+            """;
+
+        var expected = """
+            {
+              "lukes": [
+                {
+                  "id": "1",
+                  "name": "Luke"
+                },
+                {
+                  "id": "2",
+                  "name": "Luke Copy"
+                }
+              ]
+            }
+            """;
 
         AssertQuerySuccess(query, expected);
     }

--- a/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
@@ -23,8 +23,8 @@ public class SubscriptionExecutionStrategyTests
         result.Perf.ShouldBeNull();
         Source.Next("hello");
         Source.Next("testing");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""test"": ""hello"" } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""test"": ""testing"" } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "test": "hello" } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "test": "testing" } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -36,7 +36,7 @@ public class SubscriptionExecutionStrategyTests
         result.Perf.ShouldNotBeNull();
         Source.Next("hello");
         var result2 = Observer.ShouldHaveResult();
-        result2.ShouldBeSimilarTo(@"{ ""data"": { ""test"": ""hello"" } }");
+        result2.ShouldBeSimilarTo("""{ "data": { "test": "hello" } }""");
         result2.Perf.ShouldBeNull();
         Observer.ShouldHaveNoMoreResults();
     }
@@ -46,11 +46,11 @@ public class SubscriptionExecutionStrategyTests
     {
         var result = await ExecuteAsync("subscription { testWithInitialExtensions }").ConfigureAwait(false);
         result.ShouldBeSuccessful();
-        result.Extensions.ShouldBeSimilarTo(@"{ ""alpha"": ""beta"" }");
+        result.Extensions.ShouldBeSimilarTo("""{ "alpha": "beta" }""");
         Source.Next("hello");
         Source.Next("testing");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testWithInitialExtensions"": ""hello"" } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testWithInitialExtensions"": ""testing"" } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testWithInitialExtensions": "hello" } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testWithInitialExtensions": "testing" } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -60,7 +60,7 @@ public class SubscriptionExecutionStrategyTests
         var result = await ExecuteAsync("subscription { testWithInitialError(custom: false) }").ConfigureAwait(false);
         result.ShouldNotBeSuccessful();
         result.Executed.ShouldBeTrue();
-        result.ShouldBeSimilarTo(@"{ ""errors"":[{ ""message"":""Could not resolve source stream for field \u0027testWithInitialError\u0027."",""locations"":[{ ""line"":1,""column"":16}],""path"":[""testWithInitialError""],""extensions"":{ ""code"":""APPLICATION"",""codes"":[""APPLICATION""]} }],""data"":null}");
+        result.ShouldBeSimilarTo("""{ "errors":[{ "message":"Could not resolve source stream for field \u0027testWithInitialError\u0027.","locations":[{ "line":1,"column":16}],"path":["testWithInitialError"],"extensions":{ "code":"APPLICATION","codes":["APPLICATION"]} }],"data":null}""");
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public class SubscriptionExecutionStrategyTests
         var result = await ExecuteAsync("subscription { testWithInitialError(custom: true) }").ConfigureAwait(false);
         result.ShouldNotBeSuccessful();
         result.Executed.ShouldBeTrue();
-        result.ShouldBeSimilarTo(@"{ ""errors"":[{ ""message"":""Handled custom exception: InitialException"",""locations"":[{ ""line"":1,""column"":16}],""path"":[""testWithInitialError""],""extensions"":{ ""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]} }],""data"":null}");
+        result.ShouldBeSimilarTo("""{ "errors":[{ "message":"Handled custom exception: InitialException","locations":[{ "line":1,"column":16}],"path":["testWithInitialError"],"extensions":{ "code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]} }],"data":null}""");
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class SubscriptionExecutionStrategyTests
         var result = await ExecuteAsync("subscription { testWithExecutionError }").ConfigureAwait(false);
         result.ShouldNotBeSuccessful();
         result.Executed.ShouldBeTrue();
-        result.ShouldBeSimilarTo(@"{""errors"":[{""message"":""Test error"",""locations"":[{""line"":1,""column"":16}],""path"":[""testWithExecutionError""]}],""data"":null}");
+        result.ShouldBeSimilarTo("""{"errors":[{"message":"Test error","locations":[{"line":1,"column":16}],"path":["testWithExecutionError"]}],"data":null}""");
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public class SubscriptionExecutionStrategyTests
         result.ShouldBeSuccessful();
         Source.Next("hello");
         Source.Next("testing");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""name"": ""hello"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""name"": ""testing"" } } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "name": "hello" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "name": "testing" } } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -100,8 +100,8 @@ public class SubscriptionExecutionStrategyTests
         result.ShouldBeSuccessful();
         Source.Next("hello");
         Source.Next("testing");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""nameWithExtension"": ""hello"" } }, ""extensions"": { ""alpha"": ""hello"" } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""nameWithExtension"": ""testing"" } }, ""extensions"": { ""alpha"": ""testing"" }  }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "nameWithExtension": "hello" } }, "extensions": { "alpha": "hello" } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "nameWithExtension": "testing" } }, "extensions": { "alpha": "testing" }  }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -117,11 +117,11 @@ public class SubscriptionExecutionStrategyTests
         Source.Next("testing");
         Source.Next("application");
         Source.Next("success");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""nameMayThrowError"": ""hello"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: Custom error"",""locations"":[{""line"":1,""column"":33}],""path"":[""testComplex"",""nameMayThrowError""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}],""data"":null}");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""nameMayThrowError"": ""testing"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Error trying to resolve field \u0027nameMayThrowError\u0027."",""locations"":[{""line"":1,""column"":33}],""path"":[""testComplex"",""nameMayThrowError""],""extensions"":{""code"":""APPLICATION"",""codes"":[""APPLICATION""]}}],""data"":null}");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""nameMayThrowError"": ""success"" } } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "nameMayThrowError": "hello" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: Custom error","locations":[{"line":1,"column":33}],"path":["testComplex","nameMayThrowError"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}],"data":null}""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "nameMayThrowError": "testing" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Error trying to resolve field \u0027nameMayThrowError\u0027.","locations":[{"line":1,"column":33}],"path":["testComplex","nameMayThrowError"],"extensions":{"code":"APPLICATION","codes":["APPLICATION"]}}],"data":null}""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "nameMayThrowError": "success" } } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -136,11 +136,11 @@ public class SubscriptionExecutionStrategyTests
         Source.Next("testing");
         Source.Next("application");
         Source.Next("success");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""nameMayThrowErrorNullable"": ""hello"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: Custom error"",""locations"":[{""line"":1,""column"":33}],""path"":[""testComplex"",""nameMayThrowErrorNullable""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}],""data"":{""testComplex"":{""id"":""SampleId"",""nameMayThrowErrorNullable"":null}}}");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""nameMayThrowErrorNullable"": ""testing"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Error trying to resolve field \u0027nameMayThrowErrorNullable\u0027."",""locations"":[{""line"":1,""column"":33}],""path"":[""testComplex"",""nameMayThrowErrorNullable""],""extensions"":{""code"":""APPLICATION"",""codes"":[""APPLICATION""]}}],""data"":{""testComplex"":{""id"":""SampleId"",""nameMayThrowErrorNullable"":null}}}");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""nameMayThrowErrorNullable"": ""success"" } } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "nameMayThrowErrorNullable": "hello" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: Custom error","locations":[{"line":1,"column":33}],"path":["testComplex","nameMayThrowErrorNullable"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}],"data":{"testComplex":{"id":"SampleId","nameMayThrowErrorNullable":null}}}""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "nameMayThrowErrorNullable": "testing" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Error trying to resolve field \u0027nameMayThrowErrorNullable\u0027.","locations":[{"line":1,"column":33}],"path":["testComplex","nameMayThrowErrorNullable"],"extensions":{"code":"APPLICATION","codes":["APPLICATION"]}}],"data":{"testComplex":{"id":"SampleId","nameMayThrowErrorNullable":null}}}""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "nameMayThrowErrorNullable": "success" } } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -157,11 +157,11 @@ public class SubscriptionExecutionStrategyTests
         Source.Next("testing");
         Source.Error(new InvalidOperationException("SourceError"));
         Source.Next("success");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""name"": ""hello"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Response stream error for field \u0027testComplex\u0027."",""locations"":[{""line"":1,""column"":16}],""path"":[""testComplex""],""extensions"":{""code"":""APPLICATION"",""codes"":[""APPLICATION""]}}]}");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""name"": ""testing"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: SourceError"",""locations"":[{""line"":1,""column"":16}],""path"":[""testComplex""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}]}");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""id"": ""SampleId"", ""name"": ""success"" } } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "name": "hello" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Response stream error for field \u0027testComplex\u0027.","locations":[{"line":1,"column":16}],"path":["testComplex"],"extensions":{"code":"APPLICATION","codes":["APPLICATION"]}}]}""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "name": "testing" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: SourceError","locations":[{"line":1,"column":16}],"path":["testComplex"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}]}""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "id": "SampleId", "name": "success" } } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -176,9 +176,9 @@ public class SubscriptionExecutionStrategyTests
         Source.Next("hello");
         Source.Next(null!);
         Source.Next("testing");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testNullHandling"": { ""id"": ""SampleId"", ""name"": ""hello"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: Cannot return null for a non-null type. Field: testNullHandling, Type: MyWidget!."",""locations"":[{""line"":1,""column"":16}],""path"":[""testNullHandling""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}],""data"":null}");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testNullHandling"": { ""id"": ""SampleId"", ""name"": ""testing"" } } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testNullHandling": { "id": "SampleId", "name": "hello" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: Cannot return null for a non-null type. Field: testNullHandling, Type: MyWidget!.","locations":[{"line":1,"column":16}],"path":["testNullHandling"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}],"data":null}""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testNullHandling": { "id": "SampleId", "name": "testing" } } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -190,9 +190,9 @@ public class SubscriptionExecutionStrategyTests
         Source.Next("hello");
         Source.Next(null!);
         Source.Next("testing");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testNullHandlingNullable"": { ""id"": ""SampleId"", ""name"": ""hello"" } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{""data"":{""testNullHandlingNullable"":null}}");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testNullHandlingNullable"": { ""id"": ""SampleId"", ""name"": ""testing"" } } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testNullHandlingNullable": { "id": "SampleId", "name": "hello" } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{"data":{"testNullHandlingNullable":null}}""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testNullHandlingNullable": { "id": "SampleId", "name": "testing" } } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -201,7 +201,7 @@ public class SubscriptionExecutionStrategyTests
     {
         var result = await ExecuteAsync("subscription { notSubscriptionField }").ConfigureAwait(false);
         result.ShouldNotBeSuccessful();
-        result.ShouldBeSimilarTo(@"{""errors"":[{""message"":""Handled custom exception: Stream resolver not set for field \u0027notSubscriptionField\u0027."",""locations"":[{""line"":1,""column"":16}],""path"":[""notSubscriptionField""],""extensions"":{""code"":""INVALID_OPERATION"",""codes"":[""INVALID_OPERATION""]}}],""data"":null}");
+        result.ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: Stream resolver not set for field \u0027notSubscriptionField\u0027.","locations":[{"line":1,"column":16}],"path":["notSubscriptionField"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}],"data":null}""");
     }
 
     public int Counter = 0;
@@ -222,8 +222,8 @@ public class SubscriptionExecutionStrategyTests
         Counter.ShouldBe(22);
         Source.Next("testing");
         Counter.ShouldBe(33);
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": {""name"": ""hello"", ""getCounter"": 12 } } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": {""name"": ""testing"", ""getCounter"": 23 } } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": {"name": "hello", "getCounter": 12 } } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": {"name": "testing", "getCounter": 23 } } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -245,9 +245,9 @@ public class SubscriptionExecutionStrategyTests
         Source.Next("testing");
         cts.Cancel();
         Source.Next("success");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""test"": ""hello"" } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""test"": ""testing"" } }");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""test"": ""success"" } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "test": "hello" } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "test": "testing" } }""");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "test": "success" } }""");
         Observer.ShouldHaveNoMoreResults();
     }
 
@@ -272,7 +272,7 @@ public class SubscriptionExecutionStrategyTests
         var result = await ExecuteAsync("subscription { testComplex { validateServiceProvider } }", o => o.UserContext["provider"] = o.RequestServices).ConfigureAwait(false);
         result.ShouldBeSuccessful();
         Source.Next("hello");
-        Observer.ShouldHaveResult().ShouldBeSimilarTo(@"{ ""data"": { ""testComplex"": { ""validateServiceProvider"": true } } }");
+        Observer.ShouldHaveResult().ShouldBeSimilarTo("""{ "data": { "testComplex": { "validateServiceProvider": true } } }""");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Subscription/SubscriptionSchemaWithReflection.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionSchemaWithReflection.cs
@@ -5,26 +5,26 @@ namespace GraphQL.Tests.Subscription;
 
 public static class SubscriptionSchemaWithReflection
 {
-    private const string TypeDefs = @"
-            type MessageFrom {
-                id: String
-                displayName: String
-            }
+    private const string TypeDefs = """
+        type MessageFrom {
+            id: String
+            displayName: String
+        }
 
-            type Message {
-                from: MessageFrom
-                content: String
-                sentAt: String
-            }
+        type Message {
+            from: MessageFrom
+            content: String
+            sentAt: String
+        }
 
-            type Subscription {
-                messageAdded : Message
-                messageAddedByUser(id: String!) : Message
-                messageAddedAsync : Message
-                messageAddedByUserAsync(id: String!) : Message
-                messageGetAll : [Message]
-            }
-        ";
+        type Subscription {
+            messageAdded : Message
+            messageAddedByUser(id: String!) : Message
+            messageAddedAsync : Message
+            messageAddedByUserAsync(id: String!) : Message
+            messageGetAll : [Message]
+        }
+        """;
 
     public static Chat Chat { get; set; }
     public static ISchema Schema { get; set; }

--- a/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
@@ -513,14 +513,14 @@ public class AutoRegisteringInterfaceGraphTypeTests
     }
 
     [Theory]
-    [InlineData("{find(type:CAT){id name}}", @"{""data"":{""find"":{""id"":""10"",""name"":""Fluffy""}}}")]
-    [InlineData("{find(type:DOG){id name}}", @"{""data"":{""find"":{""id"":""20"",""name"":""Shadow""}}}")]
-    [InlineData("{find(type:CAT){id name ... on Cat { lives } ... on Dog { isLarge }}}", @"{""data"":{""find"":{""id"":""10"",""name"":""Fluffy"",""lives"":9}}}")]
-    [InlineData("{find(type:DOG){id name ... on Cat { lives } ... on Dog { isLarge }}}", @"{""data"":{""find"":{""id"":""20"",""name"":""Shadow"",""isLarge"":true}}}")]
-    [InlineData("{cat{id name}}", @"{""data"":{""cat"":{""id"":""10"",""name"":""Fluffy""}}}")]
-    [InlineData("{dog{id name}}", @"{""data"":{""dog"":{""id"":""20"",""name"":""Shadow""}}}")]
-    [InlineData("{cat{...frag}} fragment frag on IAnimal { id name }", @"{""data"":{""cat"":{""id"":""10"",""name"":""Fluffy""}}}")]
-    [InlineData("{dog{...frag}} fragment frag on IAnimal { id name }", @"{""data"":{""dog"":{""id"":""20"",""name"":""Shadow""}}}")]
+    [InlineData("{find(type:CAT){id name}}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
+    [InlineData("{find(type:DOG){id name}}", """{"data":{"find":{"id":"20","name":"Shadow"}}}""")]
+    [InlineData("{find(type:CAT){id name ... on Cat { lives } ... on Dog { isLarge }}}", """{"data":{"find":{"id":"10","name":"Fluffy","lives":9}}}""")]
+    [InlineData("{find(type:DOG){id name ... on Cat { lives } ... on Dog { isLarge }}}", """{"data":{"find":{"id":"20","name":"Shadow","isLarge":true}}}""")]
+    [InlineData("{cat{id name}}", """{"data":{"cat":{"id":"10","name":"Fluffy"}}}""")]
+    [InlineData("{dog{id name}}", """{"data":{"dog":{"id":"20","name":"Shadow"}}}""")]
+    [InlineData("{cat{...frag}} fragment frag on IAnimal { id name }", """{"data":{"cat":{"id":"10","name":"Fluffy"}}}""")]
+    [InlineData("{dog{...frag}} fragment frag on IAnimal { id name }", """{"data":{"dog":{"id":"20","name":"Shadow"}}}""")]
     public async Task EndToEndTest(string query, string expected)
     {
         var services = new ServiceCollection();
@@ -543,8 +543,8 @@ public class AutoRegisteringInterfaceGraphTypeTests
     }
 
     [Theory]
-    [InlineData("{find(type:CAT){id name}}", @"{""data"":{""find"":{""id"":""10"",""name"":""Fluffy""}}}")]
-    [InlineData("{find(type:CAT){ ...frag }} fragment frag on IAnimal {id name}", @"{""data"":{""find"":{""id"":""10"",""name"":""Fluffy""}}}")]
+    [InlineData("{find(type:CAT){id name}}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
+    [InlineData("{find(type:CAT){ ...frag }} fragment frag on IAnimal {id name}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
     public async Task ExecutesQueryWithInterfaceOnly(string query, string expected)
     {
         var services = new ServiceCollection();
@@ -567,11 +567,11 @@ public class AutoRegisteringInterfaceGraphTypeTests
     }
 
     [Theory]
-    [InlineData("{find(type:CAT){id name}}", @"{""data"":{""find"":{""id"":""10"",""name"":""Fluffy""}}}")]
-    [InlineData("{find(type:CAT){ ...frag }} fragment frag on IAnimal { id name }", @"{""data"":{""find"":{""id"":""10"",""name"":""Fluffy""}}}")]
-    [InlineData("{find(type:CAT){ ...frag }} fragment frag on Dog { isLarge }", @"{""data"":{""find"":{}}}")]
-    [InlineData("{find(type:CAT){ ... on Dog { isLarge } }}", @"{""data"":{""find"":{}}}")]
-    [InlineData("{find(type:CAT){ id name ... on Dog { isLarge } }}", @"{""data"":{""find"":{""id"":""10"",""name"":""Fluffy""}}}")]
+    [InlineData("{find(type:CAT){id name}}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
+    [InlineData("{find(type:CAT){ ...frag }} fragment frag on IAnimal { id name }", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
+    [InlineData("{find(type:CAT){ ...frag }} fragment frag on Dog { isLarge }", """{"data":{"find":{}}}""")]
+    [InlineData("{find(type:CAT){ ... on Dog { isLarge } }}", """{"data":{"find":{}}}""")]
+    [InlineData("{find(type:CAT){ id name ... on Dog { isLarge } }}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
     public async Task ExecutesQueryWithInterfaceOnly2(string query, string expected)
     {
         var services = new ServiceCollection();

--- a/src/GraphQL.Tests/Types/AutoSchemaTests.cs
+++ b/src/GraphQL.Tests/Types/AutoSchemaTests.cs
@@ -6,9 +6,9 @@ namespace GraphQL.Tests.Types;
 public class AutoSchemaTests
 {
     [Theory]
-    [InlineData("{hero}", @"{""data"":{""hero"":""Luke Skywalker""}}")]
-    [InlineData(@"mutation {hero(name:""Darth Vader"")}", @"{""data"":{""hero"":""Darth Vader""}}")]
-    [InlineData("{droids{name}}", @"{""data"":{""droids"":[{""name"":""R2D2""},{""name"":""C3PO""}]}}")]
+    [InlineData("{hero}", """{"data":{"hero":"Luke Skywalker"}}""")]
+    [InlineData("""mutation {hero(name:"Darth Vader")}""", """{"data":{"hero":"Darth Vader"}}""")]
+    [InlineData("{droids{name}}", """{"data":{"droids":[{"name":"R2D2"},{"name":"C3PO"}]}}""")]
     public async Task AutoSchemaWorks(string query, string expectedResult)
     {
         // sample configuration of DI

--- a/src/GraphQL.Tests/Types/CustomScalarTests.cs
+++ b/src/GraphQL.Tests/Types/CustomScalarTests.cs
@@ -159,7 +159,7 @@ public class CustomScalarTests : QueryTestBase<CustomScalarSchema>
     {
         // verify that within lists of non-null values, errors are returned properly
         var query = "{ listNonNullInvalid }";
-        var response = @"{ ""listNonNullInvalid"": null}";
+        var response = """{ "listNonNullInvalid": null}""";
         var result = AssertQueryWithErrors(query, response, expectedErrorCount: 1);
         var errorIndex = 1;
         // index should be 1 here because custom scalar will convert ["hello", "internalNull"] to ["hello", null]

--- a/src/GraphQL.Tests/Types/ListGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ListGraphTypeTests.cs
@@ -24,7 +24,7 @@ public class ListGraphTypeTests : QueryTestBase<ListSchema>
     {
         AssertQuerySuccess(
             "{ list(ints: [1, 2, 3]) }",
-            @"{ ""list"": [ 1, 2, 3] }");
+            """{ "list": [ 1, 2, 3] }""");
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class ListGraphTypeTests : QueryTestBase<ListSchema>
     {
         AssertQuerySuccess(
             "{ list(ints: 1) }",
-            @"{ ""list"": [ 1 ] }");
+            """{ "list": [ 1 ] }""");
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class ListGraphTypeTests : QueryTestBase<ListSchema>
     {
         AssertQuerySuccess(
             "{ list(ints: []) }",
-            @"{ ""list"": [ ] }");
+            """{ "list": [ ] }""");
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class ListGraphTypeTests : QueryTestBase<ListSchema>
     {
         AssertQuerySuccess(
             "{ listOfLists(ints: [1, [1, 2], [1, 2, 3], []]) }",
-            @"{ ""listOfLists"": [ [1], [1, 2], [1, 2, 3], [] ] }");
+            """{ "listOfLists": [ [1], [1, 2], [1, 2, 3], [] ] }""");
     }
 }
 

--- a/src/GraphQL.Tests/Types/Vector3ScalarTests.cs
+++ b/src/GraphQL.Tests/Types/Vector3ScalarTests.cs
@@ -10,49 +10,49 @@ public class Vector3ScalarTests : QueryTestBase<Vector3ScalarTests.Vector3Scalar
     [Fact]
     public void test_parseliteral_string()
     {
-        AssertQuerySuccess(@"{ input(arg: ""1,2,3"") }", @"{ ""input"": ""=1=2=3="" }");
+        AssertQuerySuccess("""{ input(arg: "1,2,3") }""", """{ "input": "=1=2=3=" }""");
     }
 
     [Fact]
     public void test_parseliteral_structured()
     {
-        AssertQuerySuccess(@"{ input(arg: {x:1,y:2,z:3}) }", @"{ ""input"": ""=1=2=3="" }");
+        AssertQuerySuccess("{ input(arg: {x:1,y:2,z:3}) }", """{ "input": "=1=2=3=" }""");
     }
 
     [Fact]
     public void test_parsevalue_string()
     {
-        AssertQuerySuccess(@"query($arg: Vector3) { input(arg: $arg) }", @"{ ""input"": ""=1=2=3="" }", @"{ ""arg"": ""1,2,3"" }".ToInputs());
+        AssertQuerySuccess("query($arg: Vector3) { input(arg: $arg) }", """{ "input": "=1=2=3=" }""", """{ "arg": "1,2,3" }""".ToInputs());
     }
 
     [Fact]
     public void test_parsevalue_structured()
     {
-        AssertQuerySuccess(@"query($arg: Vector3) { input(arg: $arg) }", @"{ ""input"": ""=1=2=3="" }", @"{ ""arg"": { ""x"": 1, ""y"": 2, ""z"": 3 } }".ToInputs());
+        AssertQuerySuccess("query($arg: Vector3) { input(arg: $arg) }", """{ "input": "=1=2=3=" }""", """{ "arg": { "x": 1, "y": 2, "z": 3 } }""".ToInputs());
     }
 
     [Fact]
     public void test_default()
     {
-        AssertQuerySuccess(@"{ input }", @"{ ""input"": ""=7=8=9="" }");
+        AssertQuerySuccess("{ input }", """{ "input": "=7=8=9=" }""");
     }
 
     [Fact]
     public void test_output()
     {
-        AssertQuerySuccess(@"{ output }", @"{ ""output"": { ""x"": 4, ""y"": 5, ""z"": 6 } }");
+        AssertQuerySuccess("{ output }", """{ "output": { "x": 4, "y": 5, "z": 6 } }""");
     }
 
     [Fact]
     public void test_loopback_with_value()
     {
-        AssertQuerySuccess(@"{ loopback(arg: ""11,12,13"") }", @"{ ""loopback"": { ""x"": 11, ""y"": 12, ""z"": 13 } }");
+        AssertQuerySuccess("""{ loopback(arg: "11,12,13") }""", """{ "loopback": { "x": 11, "y": 12, "z": 13 } }""");
     }
 
     [Fact]
     public void test_loopback_with_null()
     {
-        AssertQuerySuccess(@"{ loopback }", @"{ ""loopback"": null }");
+        AssertQuerySuccess("{ loopback }", """{ "loopback": null }""");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Utilities/CustomGraphQLAttributeTests.cs
+++ b/src/GraphQL.Tests/Utilities/CustomGraphQLAttributeTests.cs
@@ -8,16 +8,16 @@ public class CustomGraphQLAttributeTests : SchemaBuilderTestBase
     [Fact]
     public void can_set_metadata_from_custom_attribute()
     {
-        var defs = @"
-                type Post {
-                    id: ID!
-                    title: String!
-                }
+        var defs = """
+            type Post {
+              id: ID!
+              title: String!
+            }
 
-                type Query {
-                    post(id: ID!): Post
-                }
-            ";
+            type Query {
+              post(id: ID!): Post
+            }
+            """;
 
         Builder.Types.Include<PostWithExtraAttributesType>();
         Builder.Types.Include<Post>();
@@ -33,23 +33,23 @@ public class CustomGraphQLAttributeTests : SchemaBuilderTestBase
     [Fact]
     public void impl_type_sets_isTypeOfFunc()
     {
-        var defs = @"
-                interface IUniqueElement
-                {
-                    id: ID!
-                }
+        var defs = """
+            interface IUniqueElement
+            {
+              id: ID!
+            }
 
-                type ABlog implements IUniqueElement
-                {
-                    id: ID!
-                    name: String!
-                }
+            type ABlog implements IUniqueElement
+            {
+              id: ID!
+              name: String!
+            }
 
-                type Query
-                {
-                    blog(id: ID!): ABlog
-                }
-            ";
+            type Query
+            {
+              blog(id: ID!): ABlog
+            }
+            """;
 
         Builder.Types.Include<ResolvingClassForABlog>();
 
@@ -65,23 +65,23 @@ public class CustomGraphQLAttributeTests : SchemaBuilderTestBase
     [Fact]
     public void impl_type_sets_default_isTypeOfFunc()
     {
-        var defs = @"
-                interface IUniqueElement
-                {
-                    id: ID!
-                }
+        var defs = """
+            interface IUniqueElement
+            {
+              id: ID!
+            }
 
-                type ABlog implements IUniqueElement
-                {
-                    id: ID!
-                    name: String!
-                }
+            type ABlog implements IUniqueElement
+            {
+              id: ID!
+              name: String!
+            }
 
-                type Query
-                {
-                    blog(id: ID!): ABlog
-                }
-            ";
+            type Query
+            {
+              blog(id: ID!): ABlog
+            }
+            """;
 
         Builder.Types.Include<ABlog, ABlog>();
 

--- a/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/FederatedSchemaBuilderTests.cs
@@ -15,29 +15,31 @@ public class FederatedSchemaBuilderTests : FederatedSchemaBuilderTestBase
     [Fact]
     public void returns_sdl()
     {
-        var definitions = @"
-                extend type Query {
-                    me: User
-                }
+        var definitions = """
+            extend type Query {
+              me: User
+            }
 
-                type User @key(fields: ""id"") {
-                    id: ID! @external
-                    username: String!
-                }
-            ";
+            type User @key(fields: "id") {
+              id: ID! @external
+              username: String!
+            }
+            """;
 
         var query = "{ _service { sdl } }";
 
-        var sdl = @"extend type Query {
-  me: User
-}
+        var sdl = """
+            extend type Query {
+              me: User
+            }
 
-type User @key(fields: ""id"") {
-  id: ID! @external
-  username: String!
-}
-";
-        var expected = @"{ ""_service"": { ""sdl"" : """ + JsonEncodedText.Encode(sdl) + @""" } }";
+            type User @key(fields: "id") {
+              id: ID! @external
+              username: String!
+            }
+
+            """;
+        var expected = $$"""{ "_service": { "sdl" : "{{JsonEncodedText.Encode(sdl)}}" } }""";
 
         AssertQuery(_ =>
         {
@@ -50,20 +52,20 @@ type User @key(fields: ""id"") {
     [Fact]
     public void entity_query()
     {
-        var definitions = @"
-                extend type Query {
-                    me: User
-                }
+        var definitions = """
+            extend type Query {
+              me: User
+            }
 
-                type User @key(fields: ""id"") {
-                    id: ID!
-                    username: String!
-                }
-            ";
+            type User @key(fields: "id") {
+              id: ID!
+              username: String!
+            }
+            """;
 
         Builder.Types.For("User").ResolveReferenceAsync(ctx => Task.FromResult(new User { Id = "123", Username = "Quinn" }));
 
-        var query = @"
+        var query = """
                 query ($_representations: [_Any!]!) {
                     _entities(representations: $_representations) {
                         ... on User {
@@ -71,10 +73,11 @@ type User @key(fields: ""id"") {
                             username
                         }
                     }
-                }";
+                }
+                """;
 
-        var variables = @"{ ""_representations"": [{ ""__typename"": ""User"", ""id"": ""123"" }] }";
-        var expected = @"{ ""_entities"": [{ ""__typename"": ""User"", ""id"" : ""123"", ""username"": ""Quinn"" }] }";
+        var variables = """{ "_representations": [{ "__typename": "User", "id": "123" }] }""";
+        var expected = """{ "_entities": [{ "__typename": "User", "id" : "123", "username": "Quinn" }] }""";
 
         AssertQuery(_ =>
         {
@@ -92,37 +95,40 @@ type User @key(fields: ""id"") {
     [InlineData("...on User { ...TypeAndId }", true)]
     public void result_includes_typename(string selectionSet, bool includeFragment)
     {
-        var definitions = @"
-                extend type Query {
-                    me: User
-                }
+        var definitions = """
+            extend type Query {
+              me: User
+            }
 
-                type User @key(fields: ""id"") {
-                    id: ID!
-                    username: String!
-                }
-            ";
+            type User @key(fields: "id") {
+              id: ID!
+              username: String!
+            }
+            """;
 
         Builder.Types.For("User").ResolveReferenceAsync(ctx => Task.FromResult(new User { Id = "123", Username = "Quinn" }));
 
-        var query = @$"
-                query ($_representations: [_Any!]!) {{
-                    _entities(representations: $_representations) {{
-                        {selectionSet}
-                    }}
-                }}";
+        var query = $$"""
+                query ($_representations: [_Any!]!) {
+                  _entities(representations: $_representations) {
+                    {{selectionSet}}
+                  }
+                }
+                """;
         if (includeFragment)
         {
-            query += @"
+            query += """
+
                 fragment TypeAndId on User {
                     __typename
                     id
                 }
-                ";
+
+                """;
         }
 
-        var variables = @"{ ""_representations"": [{ ""__typename"": ""User"", ""id"": ""123"" }] }";
-        var expected = @"{ ""_entities"": [{ ""__typename"": ""User"", ""id"" : ""123""}] }";
+        var variables = """{ "_representations": [{ "__typename": "User", "id": "123" }] }""";
+        var expected = """{ "_entities": [{ "__typename": "User", "id" : "123"}] }""";
 
         AssertQuery(_ =>
         {
@@ -136,20 +142,20 @@ type User @key(fields: ""id"") {
     [Fact]
     public void input_types_and_types_without_key_directive_are_not_added_to_entities_union()
     {
-        var definitions = @"
-                input UserInput {
-                    limit: Int!
-                    offset: Int
-                }
+        var definitions = """
+            input UserInput {
+              limit: Int!
+              offset: Int
+            }
 
-                type Comment {
-                    id: ID!
-                }
+            type Comment {
+              id: ID!
+            }
 
-                type User @key(fields: ""id"") {
-                    id: ID! @external
-                }
-            ";
+            type User @key(fields: "id") {
+              id: ID! @external
+            }
+            """;
 
         var query = "{ __schema { types { name kind possibleTypes { name } } } }";
 
@@ -173,15 +179,15 @@ type User @key(fields: ""id"") {
     [Fact]
     public void resolve_reference_is_not_trying_to_await_for_each_field_individialy_and_plays_well_with_dataloader_issue_1565()
     {
-        var definitions = @"
-                extend type Query {
-                    user(id: ID!): User
-                }
-                type User @key(fields: ""id"") {
-                    id: ID!
-                    username: String!
-                }
-            ";
+        var definitions = """
+            extend type Query {
+              user(id: ID!): User
+            }
+            type User @key(fields: "id") {
+              id: ID!
+              username: String!
+            }
+            """;
 
         var users = new List<User> {
             new User { Id = "1", Username = "One" },
@@ -206,17 +212,18 @@ type User @key(fields: ""id"") {
             return Task.FromResult(loader.LoadAsync(id));
         });
 
-        string query = @"
-        {
-            _entities(representations: [{__typename: ""User"", id: ""1"" }, {__typename: ""User"", id: ""2"" }]) {
-                ... on User {
-                    id
-                    username
+        string query = """
+            {
+                _entities(representations: [{__typename: "User", id: "1" }, {__typename: "User", id: "2" }]) {
+                    ... on User {
+                        id
+                        username
+                    }
                 }
             }
-        }";
+            """;
 
-        var expected = @"{ ""_entities"": [{ ""__typename"": ""User"", ""id"" : ""1"", ""username"": ""One"" }, { ""__typename"": ""User"", ""id"" : ""2"", ""username"": ""Two"" }] }";
+        var expected = """{ "_entities": [{ "__typename": "User", "id" : "1", "username": "One" }, { "__typename": "User", "id" : "2", "username": "Two" }] }""";
 
         AssertQuery(_ =>
         {

--- a/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/Federation/FederatedSchemaPrinterTests.cs
@@ -6,8 +6,8 @@ namespace GraphQL.Tests.Utilities.Federation;
 public class FederatedSchemaPrinterTests
 {
     [Theory]
-    [InlineData(@"type X @key(fields: ""id"") { id: ID! }", "type Query")]
-    [InlineData(@"schema { query: MyQuery } type MyQuery type X @key(fields: ""id"") { id: ID! }", "type MyQuery")]
+    [InlineData("""type X @key(fields: "id") { id: ID! }""", "type Query")]
+    [InlineData("""schema { query: MyQuery } type MyQuery type X @key(fields: "id") { id: ID! }""", "type MyQuery")]
     public void PrintObject_ReturnsEmptyString_GivenQueryTypeHasOnlyFederatedFields(string definitions, string expected)
     {
         // Arrange

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderExecutionTests.cs
@@ -32,12 +32,12 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task schema_first_generate_exception_with_normal_stack_trace_for_method()
     {
-        var schema = Schema.For(@"
+        var schema = Schema.For("""
                 type Query {
-                    method: String!
-                    property: Int!
+                  method: String!
+                  property: Int!
                 }
-                ", builder => builder.Types.Include<Query>());
+                """, builder => builder.Types.Include<Query>());
 
         var executor = new DocumentExecuter();
         var result = await executor.ExecuteAsync(options =>
@@ -64,12 +64,12 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task schema_first_generate_exception_with_normal_stack_trace_for_property()
     {
-        var schema = Schema.For(@"
+        var schema = Schema.For("""
                 type Query {
-                    method: String!
-                    property: Int!
+                  method: String!
+                  property: Int!
                 }
-                ", builder => builder.Types.Include<Query>());
+                """, builder => builder.Types.Include<Query>());
 
         var executor = new DocumentExecuter();
         var result = await executor.ExecuteAsync(options =>
@@ -96,16 +96,16 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task issue_1155_throws()
     {
-        var schema = Schema.For(@"
+        var schema = Schema.For("""
                 type Test {
-                    id: ID!
-                    name: String!
+                  id: ID!
+                  name: String!
                 }
 
                 type Query {
-                    test: Test!
+                  test: Test!
                 }
-                ", builder => builder.Types.Include<Query>());
+                """, builder => builder.Types.Include<Query>());
 
         var executor = new DocumentExecuter();
         var result = await executor.ExecuteAsync(options =>
@@ -123,16 +123,16 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task issue_1155_with_custom_root_does_not_throw()
     {
-        var schema = Schema.For(@"
+        var schema = Schema.For("""
                 type Test {
-                    id: ID!
-                    name: String!
+                  id: ID!
+                  name: String!
                 }
 
                 type Query {
-                    test: Test!
+                  test: Test!
                 }
-                ", builder => builder.Types.Include<Query>());
+                """, builder => builder.Types.Include<Query>());
 
         var executor = new DocumentExecuter();
         var result = await executor.ExecuteAsync(options =>
@@ -152,59 +152,59 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void issue_1155_throws_on_build_if_AllowUnknownTypes_disabled()
     {
-        Should.Throw<InvalidOperationException>(() => Schema.For(@"
-                type Test {
-                    id: ID!
-                    name: String!
-                }
+        Should.Throw<InvalidOperationException>(() => Schema.For("""
+            type Test {
+              id: ID!
+              name: String!
+            }
 
-                type Query {
-                    test: Test!
-                }
-                ", builder =>
-        {
-            builder.AllowUnknownTypes = false;
-            builder.Types.Include<Query>();
-        })).Message.ShouldBe("Unknown type 'Test'. Verify that you have configured SchemaBuilder correctly.");
+            type Query {
+              test: Test!
+            }
+            """, builder =>
+            {
+                builder.AllowUnknownTypes = false;
+                builder.Types.Include<Query>();
+            })).Message.ShouldBe("Unknown type 'Test'. Verify that you have configured SchemaBuilder correctly.");
     }
 
     [Fact]
     public void issue_1155_throws_on_build_if_AllowUnknownFields_disabled_1()
     {
-        Should.Throw<InvalidOperationException>(() => Schema.For(@"
-                type Test {
-                    id: ID!
-                    name: String!
-                }
+        Should.Throw<InvalidOperationException>(() => Schema.For("""
+            type Test {
+              id: ID!
+              name: String!
+            }
 
-                type Query {
-                    test: Test!
-                }
-                ", builder =>
-               {
-                   builder.AllowUnknownFields = false;
-                   builder.Types.Include<Query>();
-               })).Message.ShouldBe("Unknown field 'Test.id' has no resolver. Verify that you have configured SchemaBuilder correctly.");
+            type Query {
+              test: Test!
+            }
+            """, builder =>
+            {
+                builder.AllowUnknownFields = false;
+                builder.Types.Include<Query>();
+            })).Message.ShouldBe("Unknown field 'Test.id' has no resolver. Verify that you have configured SchemaBuilder correctly.");
     }
 
     [Fact]
     public void issue_1155_throws_on_build_if_AllowUnknownFields_disabled_2()
     {
-        Should.Throw<InvalidOperationException>(() => Schema.For(@"
-                type Test {
-                    id: ID!
-                    name: String!
-                }
+        Should.Throw<InvalidOperationException>(() => Schema.For("""
+            type Test {
+              id: ID!
+              name: String!
+            }
 
-                type Query {
-                    test: Test!
-                }
-                ", builder =>
-        {
-            builder.AllowUnknownFields = false;
-            builder.Types.Include<Query>();
-            builder.Types.Include<Test>();
-        })).Message.ShouldBe("Unknown field 'Test.name' has no resolver. Verify that you have configured SchemaBuilder correctly.");
+            type Query {
+              test: Test!
+            }
+            """, builder =>
+            {
+                builder.AllowUnknownFields = false;
+                builder.Types.Include<Query>();
+                builder.Types.Include<Test>();
+            })).Message.ShouldBe("Unknown field 'Test.name' has no resolver. Verify that you have configured SchemaBuilder correctly.");
     }
 
     [Fact]
@@ -267,22 +267,22 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void can_execute_resolver()
     {
-        var defs = @"
-                type Post {
-                    id: ID!
-                    title: String!
-                }
+        var defs = """
+            type Post {
+              id: ID!
+              title: String!
+            }
 
-                type Query {
-                    post(id: ID!): Post
-                }
-            ";
+            type Query {
+              post(id: ID!): Post
+            }
+            """;
 
         Builder.Types.Include<PostQueryType>();
 
-        var query = @"query Posts($id: ID!) { post(id: $id) { id title } }";
-        var expected = @"{ ""post"": { ""id"" : ""1"", ""title"": ""Post One"" } }";
-        var variables = @"{ ""id"": ""1"" }";
+        var query = "query Posts($id: ID!) { post(id: $id) { id title } }";
+        var expected = """{ "post": { "id" : "1", "title": "Post One" } }""";
+        var variables = """{ "id": "1" }""";
 
         AssertQuery(_ =>
         {
@@ -296,16 +296,16 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void can_provide_field_description()
     {
-        var defs = @"
-                type Post {
-                    id: ID!
-                    title: String!
-                }
+        var defs = """
+            type Post {
+              id: ID!
+              title: String!
+            }
 
-                type Query {
-                    post(id: ID!): Post
-                }
-            ";
+            type Query {
+              post(id: ID!): Post
+            }
+            """;
 
         Builder.Types.Include<PostQueryRenamedType>();
         var schema = Builder.Build(defs);
@@ -317,22 +317,22 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void can_execute_renamed_field()
     {
-        var defs = @"
-                type Post {
-                    id: ID!
-                    title: String!
-                }
+        var defs = """
+            type Post {
+              id: ID!
+              title: String!
+            }
 
-                type Query {
-                    post(id: ID!): Post
-                }
-            ";
+            type Query {
+              post(id: ID!): Post
+            }
+            """;
 
         Builder.Types.Include<PostQueryRenamedType>();
 
-        var query = @"query Posts($id: ID!) { post(id: $id) { id title } }";
-        var expected = @"{ ""post"": { ""id"" : ""1"", ""title"": ""Post One"" } }";
-        var variables = @"{ ""id"": ""1"" }";
+        var query = "query Posts($id: ID!) { post(id: $id) { id title } }";
+        var expected = """{ "post": { "id" : "1", "title": "Post One" } }""";
+        var variables = """{ "id": "1" }""";
 
         AssertQuery(_ =>
         {
@@ -346,37 +346,37 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void can_execute_interfaces()
     {
-        var defs = @"
-                enum PetKind {
-                    CAT
-                    DOG
-                }
+        var defs = """
+            enum PetKind {
+              CAT
+              DOG
+            }
 
-                interface Pet {
-                    name: String!
-                }
+            interface Pet {
+              name: String!
+            }
 
-                type Dog implements Pet {
-                    name: String!
-                    barks: Boolean!
-                }
+            type Dog implements Pet {
+              name: String!
+              barks: Boolean!
+            }
 
-                type Cat implements Pet {
-                    name: String!
-                    meows: Boolean!
-                }
+            type Cat implements Pet {
+              name: String!
+              meows: Boolean!
+            }
 
-                type Query {
-                    pet(type: PetKind = DOG): Pet
-                }
-            ";
+            type Query {
+              pet(type: PetKind = DOG): Pet
+            }
+            """;
 
         Builder.Types.For("Dog").IsTypeOf<Dog>();
         Builder.Types.For("Cat").IsTypeOf<Cat>();
         Builder.Types.Include<PetQueryType>();
 
-        var query = @"{ pet { name } }";
-        var expected = @"{ ""pet"": { ""name"" : ""Eli"" } }";
+        var query = "{ pet { name } }";
+        var expected = """{ "pet": { "name" : "Eli" } }""";
 
         AssertQuery(_ =>
         {
@@ -390,30 +390,30 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void schemabuilder_should_throw_on_invalid_default_value()
     {
-        var defs = @"
-                enum PetKind {
-                    CAT
-                    DOG
-                }
+        var defs = """
+            enum PetKind {
+              CAT
+              DOG
+            }
 
-                interface Pet {
-                    name: String!
-                }
+            interface Pet {
+              name: String!
+            }
 
-                type Dog implements Pet {
-                    name: String!
-                    barks: Boolean!
-                }
+            type Dog implements Pet {
+              name: String!
+              barks: Boolean!
+            }
 
-                type Cat implements Pet {
-                    name: String!
-                    meows: Boolean!
-                }
+            type Cat implements Pet {
+              name: String!
+              meows: Boolean!
+            }
 
-                type Query {
-                    pet(type: PetKind = DOGGY): Pet
-                }
-            ";
+            type Query {
+              pet(type: PetKind = DOGGY): Pet
+            }
+            """;
 
         Builder.Types.For("Dog").IsTypeOf<Dog>();
         Builder.Types.For("Cat").IsTypeOf<Cat>();
@@ -425,11 +425,11 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task minimal_schema()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  hello: String
-                }
-            ");
+        var schema = Schema.For("""
+            type Query {
+              hello: String
+            }
+            """);
 
         var root = new { Hello = "Hello World!" };
         var result = await ExecuteAsync(schema, _ =>
@@ -447,11 +447,11 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task can_use_source_without_params()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  source: Boolean
-                }
-            ", _ => _.Types.Include<ParametersType>());
+        var schema = Schema.For("""
+            type Query {
+              source: Boolean
+            }
+            """, _ => _.Types.Include<ParametersType>());
 
         var result = await ExecuteAsync(schema, _ =>
         {
@@ -459,7 +459,7 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
             _.Root = new { Hello = "World" };
         }).ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""source"": true }");
+        var expectedResult = CreateQueryResult("""{ "source": true }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);
@@ -468,15 +468,15 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task can_use_resolvefieldcontext_without_params()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  resolve: String
-                }
-            ", _ => _.Types.Include<ParametersType>());
+        var schema = Schema.For("""
+            type Query {
+              resolve: String
+            }
+            """, _ => _.Types.Include<ParametersType>());
 
         var result = await ExecuteAsync(schema, _ => _.Query = "{ resolve }").ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""resolve"": ""Resolved"" }");
+        var expectedResult = CreateQueryResult("""{ "resolve": "Resolved" }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);
@@ -485,15 +485,15 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task can_use_resolvefieldcontext_with_params()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  resolveWithParam(id: String): String
-                }
-            ", _ => _.Types.Include<ParametersType>());
+        var schema = Schema.For("""
+            type Query {
+              resolveWithParam(id: String): String
+            }
+            """, _ => _.Types.Include<ParametersType>());
 
-        var result = await ExecuteAsync(schema, _ => _.Query = @"{ resolveWithParam(id: ""abcd"") }").ConfigureAwait(false);
+        var result = await ExecuteAsync(schema, _ => _.Query = """{ resolveWithParam(id: "abcd") }""").ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""resolveWithParam"": ""Resolved abcd"" }");
+        var expectedResult = CreateQueryResult("""{ "resolveWithParam": "Resolved abcd" }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);
@@ -502,19 +502,19 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task can_use_usercontext()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  userContext: String
-                }
-            ", _ => _.Types.Include<ParametersType>());
+        var schema = Schema.For("""
+            type Query {
+              userContext: String
+            }
+            """, _ => _.Types.Include<ParametersType>());
 
         var result = await ExecuteAsync(schema, _ =>
         {
-            _.Query = @"{ userContext }";
+            _.Query = "{ userContext }";
             _.UserContext = new MyUserContext { Name = "Quinn" };
         }).ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""userContext"": ""Quinn"" }");
+        var expectedResult = CreateQueryResult("""{ "userContext": "Quinn" }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);
@@ -523,19 +523,19 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task can_use_inherited_usercontext()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  userContext: String
-                }
-            ", _ => _.Types.Include<ParametersType>());
+        var schema = Schema.For("""
+            type Query {
+              userContext: String
+            }
+            """, _ => _.Types.Include<ParametersType>());
 
         var result = await ExecuteAsync(schema, _ =>
         {
-            _.Query = @"{ userContext }";
+            _.Query = "{ userContext }";
             _.UserContext = new ChildMyUserContext { Name = "Quinn" };
         }).ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""userContext"": ""Quinn"" }");
+        var expectedResult = CreateQueryResult("""{ "userContext": "Quinn" }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);
@@ -544,20 +544,20 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void can_use_null_as_default_value()
     {
-        var schema = Schema.For(@"
-                input HumanInput {
-                  name: String!
-                  homePlanet: String = null
-                }
+        var schema = Schema.For("""
+            input HumanInput {
+              name: String!
+              homePlanet: String = null
+            }
 
-                type Human {
-                  id: String!
-                }
+            type Human {
+              id: String!
+            }
 
-                type Mutation {
-                  createHuman(human: HumanInput!): Human
-                }
-            ");
+            type Mutation {
+              createHuman(human: HumanInput!): Human
+            }
+            """);
 
         var type = (InputObjectGraphType)schema.AllTypes.First(t => t.Name == "HumanInput");
         type.GetField("homePlanet").DefaultValue.ShouldBeNull();
@@ -566,19 +566,19 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task can_use_usercontext_with_params()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  userContextWithParam(id: String): String
-                }
-            ", _ => _.Types.Include<ParametersType>());
+        var schema = Schema.For("""
+            type Query {
+              userContextWithParam(id: String): String
+            }
+            """, _ => _.Types.Include<ParametersType>());
 
         var result = await ExecuteAsync(schema, _ =>
         {
-            _.Query = @"{ userContextWithParam(id: ""abcd"") }";
+            _.Query = """{ userContextWithParam(id: "abcd") }""";
             _.UserContext = new MyUserContext { Name = "Quinn" };
         }).ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""userContextWithParam"": ""Quinn abcd"" }");
+        var expectedResult = CreateQueryResult("""{ "userContextWithParam": "Quinn abcd" }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);
@@ -587,20 +587,20 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task can_use_context_source_usercontext()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  three: Boolean
-                }
-            ", _ => _.Types.Include<ParametersType>());
+        var schema = Schema.For("""
+            type Query {
+              three: Boolean
+            }
+            """, _ => _.Types.Include<ParametersType>());
 
         var result = await ExecuteAsync(schema, _ =>
         {
-            _.Query = @"{ three }";
+            _.Query = "{ three }";
             _.Root = new { Hello = "World" };
             _.UserContext = new MyUserContext { Name = "Quinn" };
         }).ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""three"": true }");
+        var expectedResult = CreateQueryResult("""{ "three": true }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);
@@ -609,20 +609,20 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task can_use_context_source_usercontext_with_params()
     {
-        var schema = Schema.For(@"
-                type Query {
-                  four(id: Int): Boolean
-                }
-            ", _ => _.Types.Include<ParametersType>());
+        var schema = Schema.For("""
+            type Query {
+              four(id: Int): Boolean
+            }
+            """, _ => _.Types.Include<ParametersType>());
 
         var result = await ExecuteAsync(schema, _ =>
         {
-            _.Query = @"{ four(id: 123) }";
+            _.Query = "{ four(id: 123) }";
             _.Root = new { Hello = "World" };
             _.UserContext = new MyUserContext { Name = "Quinn" };
         }).ConfigureAwait(false);
 
-        var expectedResult = CreateQueryResult(@"{ ""four"": true }");
+        var expectedResult = CreateQueryResult("""{ "four": true }""");
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 
         result.ShouldBe(serializedExpectedResult);
@@ -631,26 +631,26 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void can_execute_complex_schema()
     {
-        var defs = @"
-                type Post {
-                    id: ID!
-                    title: String!
-                }
-                type Blog {
-                    title: String!
-                    post(id: ID!, unused: Long!): Post
-                }
-                type Query {
-                    blog(id: ID!): Blog
-                }
-            ";
+        var defs = """
+            type Post {
+              id: ID!
+              title: String!
+            }
+            type Blog {
+              title: String!
+              post(id: ID!, unused: Long!): Post
+            }
+            type Query {
+              blog(id: ID!): Blog
+            }
+            """;
 
         Builder.Types.Include<BlogQueryType>();
         Builder.Types.Include<Blog>();
 
-        var query = @"query Posts($blogId: ID!, $postId: ID!){ blog(id: $blogId){ title post(id: $postId, unused: 0) { id title } } }";
-        var expected = @"{ ""blog"": { ""title"": ""New blog"", ""post"": { ""id"" : ""1"", ""title"": ""Post One"" } } }";
-        var variables = @"{ ""blogId"": ""1"", ""postId"": ""1"" }";
+        var query = "query Posts($blogId: ID!, $postId: ID!){ blog(id: $blogId){ title post(id: $postId, unused: 0) { id title } } }";
+        var expected = """{ "blog": { "title": "New blog", "post": { "id" : "1", "title": "Post One" } } }""";
+        var variables = """{ "blogId": "1", "postId": "1" }""";
 
         AssertQuery(_ =>
         {
@@ -664,21 +664,21 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public void does_not_require_scalar_fields_to_be_defined()
     {
-        var defs = @"
-                type Person {
-                    name: String!
-                    age: Int!
-                }
-                type Query {
-                    me: Person
-                }
-            ";
+        var defs = """
+            type Person {
+              name: String!
+              age: Int!
+            }
+            type Query {
+              me: Person
+            }
+            """;
 
         Builder.Types.Include<PeopleQueryType>();
         Builder.Types.Include<PersonQueryType>();
 
-        var query = @"{ me { name age } }";
-        var expected = @"{ ""me"": { ""name"": ""Quinn"", ""age"": 100 } }";
+        var query = "{ me { name age } }";
+        var expected = """{ "me": { "name": "Quinn", "age": 100 } }""";
 
         AssertQuery(_ =>
         {
@@ -691,35 +691,35 @@ public class SchemaBuilderExecutionTests : SchemaBuilderTestBase
     [Fact]
     public async Task resolves_union_references_when_union_defined_first()
     {
-        var schema = Schema.For(@"
-                union Pet = Dog | Cat
+        var schema = Schema.For("""
+            union Pet = Dog | Cat
 
-                enum PetKind {
-                    CAT
-                    DOG
-                }
+            enum PetKind {
+              CAT
+              DOG
+            }
 
-                type Query {
-                    pet(type: PetKind = DOG): Pet
-                }
+            type Query {
+              pet(type: PetKind = DOG): Pet
+            }
 
-                type Dog {
-                    name: String!
-                }
+            type Dog {
+              name: String!
+            }
 
-                type Cat {
-                    name: String!
-                }
-            ", _ =>
-        {
-            _.Types.For("Dog").IsTypeOf<Dog>();
-            _.Types.For("Cat").IsTypeOf<Cat>();
-            _.Types.Include<PetQueryType>();
-        });
+            type Cat {
+              name: String!
+            }
+            """, _ =>
+            {
+                _.Types.For("Dog").IsTypeOf<Dog>();
+                _.Types.For("Cat").IsTypeOf<Cat>();
+                _.Types.Include<PetQueryType>();
+            });
 
-        var result = await ExecuteAsync(schema, _ => _.Query = @"{ pet { ... on Dog { name } } }").ConfigureAwait(false);
+        var result = await ExecuteAsync(schema, _ => _.Query = "{ pet { ... on Dog { name } } }").ConfigureAwait(false);
 
-        var expected = @"{ ""pet"": { ""name"" : ""Eli"" } }";
+        var expected = """{ "pet": { "name" : "Eli" } }""";
         var expectedResult = CreateQueryResult(expected);
         var serializedExpectedResult = Serializer.Serialize(expectedResult);
 

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderNestedTypesTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderNestedTypesTests.cs
@@ -7,27 +7,27 @@ public class SchemaBuilderNestedTypesTests : SchemaBuilderTestBase
     [Fact]
     public void supports_nested_graph_types()
     {
-        var defs = @"
-              type Droid {
-                  id: String
-                  name: String
-                  friend: Character
-              }
+        var defs = """
+            type Droid {
+              id: String
+              name: String
+              friend: Character
+            }
 
-              type Character {
-                  name: String
-              }
+            type Character {
+              name: String
+            }
 
-              type Query {
-                  hero: Droid
-              }
-            ";
+            type Query {
+              hero: Droid
+            }
+            """;
 
         Builder.Types.Include<DroidType, Droid>("Droid");
         Builder.Types.Include<Query>();
 
-        var query = @"{ hero { id name friend { name } } }";
-        var expected = @"{ ""hero"": { ""id"" : ""1"", ""name"": ""R2-D2"", ""friend"": { ""name"": ""C3-PO"" } } }";
+        var query = "{ hero { id name friend { name } } }";
+        var expected = """{ "hero": { "id" : "1", "name": "R2-D2", "friend": { "name": "C3-PO" } } }""";
 
         AssertQuery(_ =>
         {
@@ -40,28 +40,28 @@ public class SchemaBuilderNestedTypesTests : SchemaBuilderTestBase
     [Fact]
     public void supports_type_references_in_resolve_type()
     {
-        var defs = @"
-              type Droid {
-                  id: String
-                  name: String
-                  friend: Character
-              }
+        var defs = """
+            type Droid {
+              id: String
+              name: String
+              friend: Character
+            }
 
-              type Character {
-                  name: String
-              }
+            type Character {
+              name: String
+            }
 
-              type Query {
-                  hero: Droid
-              }
-            ";
+            type Query {
+              hero: Droid
+            }
+            """;
 
         Builder.Types.Include<DroidType>("Droid");
         Builder.Types.For("Droid").ResolveType = obj => new GraphQLTypeReference("Droid");
         Builder.Types.Include<Query>();
 
-        var query = @"{ hero { id name friend { name } } }";
-        var expected = @"{ ""hero"": { ""id"" : ""1"", ""name"": ""R2-D2"", ""friend"": { ""name"": ""C3-PO"" } } }";
+        var query = "{ hero { id name friend { name } } }";
+        var expected = """{ "hero": { "id" : "1", "name": "R2-D2", "friend": { "name": "C3-PO" } } }""";
 
         AssertQuery(_ =>
         {

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
@@ -9,11 +9,11 @@ public class SchemaBuilderTests
     [Fact]
     public void should_set_query_by_name()
     {
-        var definitions = @"
-                type Query {
-                    id: String
-                }
-            ";
+        var definitions = """
+            type Query {
+              id: String
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -29,11 +29,11 @@ public class SchemaBuilderTests
     [Fact]
     public void should_set_mutation_by_name()
     {
-        var definitions = @"
-                type Mutation {
-                    mutate: String
-                }
-            ";
+        var definitions = """
+            type Mutation {
+              mutate: String
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -49,11 +49,11 @@ public class SchemaBuilderTests
     [Fact]
     public void should_set_subscription_by_name()
     {
-        var definitions = @"
-                type Subscription {
-                    subscribe: String
-                }
-            ";
+        var definitions = """
+            type Subscription {
+              subscribe: String
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -69,25 +69,25 @@ public class SchemaBuilderTests
     [Fact]
     public void configures_schema_from_schema_type()
     {
-        var definitions = @"
-                type MyQuery {
-                    id: String
-                }
+        var definitions = """
+            type MyQuery {
+              id: String
+            }
 
-                type MyMutation {
-                    mutate: String
-                }
+            type MyMutation {
+              mutate: String
+            }
 
-                type MySubscription {
-                    subscribe: String
-                }
+            type MySubscription {
+              subscribe: String
+            }
 
-                schema {
-                  query: MyQuery
-                  mutation: MyMutation
-                  subscription: MySubscription
-                }
-            ";
+            schema {
+              query: MyQuery
+              mutation: MyMutation
+              subscription: MySubscription
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -114,25 +114,25 @@ public class SchemaBuilderTests
     [Fact]
     public void configures_schema_from_schema_type_and_directives()
     {
-        var definitions = @"
-                type MyQuery  {
-                    id: String
-                }
+        var definitions = """
+            type MyQuery  {
+              id: String
+            }
 
-                type MyMutation @requireAuth(role: ""Admin"") {
-                    mutate: String
-                }
+            type MyMutation @requireAuth(role: "Admin") {
+              mutate: String
+            }
 
-                type MySubscription @requireAuth {
-                    subscribe: String @traits(volatile: true, documented: false, enumerated: DESC) @some @some
-                }
+            type MySubscription @requireAuth {
+              subscribe: String @traits(volatile: true, documented: false, enumerated: DESC) @some @some
+            }
 
-                schema @public {
-                  query: MyQuery
-                  mutation: MyMutation
-                  subscription: MySubscription
-                }
-            ";
+            schema @public {
+              query: MyQuery
+              mutation: MyMutation
+              subscription: MySubscription
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Directives.Register(new Directive("public", DirectiveLocation.Schema));
@@ -226,15 +226,15 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_type_with_arguments_with_dependent_default_values()
     {
-        var definitions = @"
-                type Query {
-                  post(arg: [SomeInputType] = [{ name: ""John"" }]): String
-                }
-                input SomeInputType {
-                  id: ID! = 1
-                  name: String!
-                }
-            ";
+        var definitions = """
+            type Query {
+              post(arg: [SomeInputType] = [{ name: "John" }]): String
+            }
+            input SomeInputType {
+              id: ID! = 1
+              name: String!
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -322,12 +322,12 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_case_insensitive_typed_enum()
     {
-        var definitions = @"
-                enum PetKind {
-                    CAT
-                    DOG
-                }
-            ";
+        var definitions = """
+            enum PetKind {
+              CAT
+              DOG
+            }
+            """;
 
         var schema = Schema.For(definitions, c => c.Types.Include<PetKind>());
         schema.Initialize();
@@ -342,13 +342,13 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_scalars()
     {
-        var definitions = @"
-                scalar CustomScalar
+        var definitions = """
+            scalar CustomScalar
 
-                type Query {
-                    search: CustomScalar
-                }
-            ";
+            type Query {
+              search: CustomScalar
+            }
+            """;
 
         var customScalar = new CustomScalarType();
 
@@ -369,18 +369,18 @@ public class SchemaBuilderTests
     [Fact]
     public void references_other_types()
     {
-        var definitions = @"
-                type Post {
-                  id: ID!
-                  title: String
-                  votes: Int
-                }
+        var definitions = """
+            type Post {
+              id: ID!
+              title: String
+              votes: Int
+            }
 
-                type Query {
-                  posts: [Post]
-                  post(id: ID = 1): Post
-                }
-            ";
+            type Query {
+              posts: [Post]
+              post(id: ID = 1): Post
+            }
+            """;
 
         var schema = Schema.For(definitions, builder => builder.Types.For("Query").FieldFor("post").ArgumentFor("id").DefaultValue = 999);
         schema.Initialize();
@@ -466,11 +466,11 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_input_types_with_default_values()
     {
-        var definitions = @"
-                input ReviewInput {
-                  stars: Int! = 23
-                }
-            ";
+        var definitions = """
+            input ReviewInput {
+              stars: Int! = 23
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -484,15 +484,15 @@ public class SchemaBuilderTests
     [Fact]
     public void builds_input_types_with_dependent_default_values()
     {
-        var definitions = @"
-                input SomeInputType1 {
-                  test: SomeInputType2! = { arg1: 22 }
-                }
-                input SomeInputType2 {
-                  arg1: Int
-                  arg2: Int = 30
-                }
-            ";
+        var definitions = """
+            input SomeInputType1 {
+              test: SomeInputType2! = { arg1: 22 }
+            }
+            input SomeInputType2 {
+              arg1: Int
+              arg2: Int = 30
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -515,11 +515,11 @@ public class SchemaBuilderTests
     [Fact]
     public void input_types_default_value_loops_throw1()
     {
-        var definitions = @"
-                input SomeInputType1 {
-                  test: SomeInputType1 = { }
-                }
-            ";
+        var definitions = """
+            input SomeInputType1 {
+              test: SomeInputType1 = { }
+            }
+            """;
 
         var schema = Schema.For(definitions);
         Should.Throw<InvalidOperationException>(() => schema.Initialize()).Message.ShouldBe("Default values in input types cannot contain a circular dependency loop. Please resolve dependency loop between the following types: 'SomeInputType1'.");
@@ -528,17 +528,17 @@ public class SchemaBuilderTests
     [Fact]
     public void input_types_default_value_loops_throw2()
     {
-        var definitions = @"
-                input SomeInputType1 {
-                  test: SomeInputType2 = { }
-                }
-                input SomeInputType2 {
-                  test: SomeInputType3 = { }
-                }
-                input SomeInputType3 {
-                  test: SomeInputType1 = { }
-                }
-            ";
+        var definitions = """
+            input SomeInputType1 {
+              test: SomeInputType2 = { }
+            }
+            input SomeInputType2 {
+              test: SomeInputType3 = { }
+            }
+            input SomeInputType3 {
+              test: SomeInputType1 = { }
+            }
+            """;
 
         var schema = Schema.For(definitions);
         Should.Throw<InvalidOperationException>(() => schema.Initialize()).Message.ShouldBe("Default values in input types cannot contain a circular dependency loop. Please resolve dependency loop between the following types: 'SomeInputType3', 'SomeInputType2', 'SomeInputType1'.");
@@ -549,11 +549,11 @@ public class SchemaBuilderTests
     {
         // see: https://github.com/graphql-dotnet/graphql-dotnet/pull/2696#discussion_r764975585
 
-        var definitions = @"
-                input SomeInputType1 {
-                  test: SomeInputType1 = { test: null }
-                }
-            ";
+        var definitions = """
+            input SomeInputType1 {
+              test: SomeInputType1 = { test: null }
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -563,12 +563,12 @@ public class SchemaBuilderTests
     public void builds_directives()
     {
         var definitions = """"
-                """
-                Example description
-                """
-                directive @myDirective(
-                  if: Boolean!
-                ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            """
+            Example description
+            """
+            directive @myDirective(
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
             """";
 
         var schema = Schema.For(definitions);
@@ -593,11 +593,11 @@ public class SchemaBuilderTests
     [Fact]
     public void custom_deprecation_on_type_field()
     {
-        var definitions = @"
-                type Query {
-                  stars: Int @deprecated(reason: ""a reason"")
-                }
-            ";
+        var definitions = """
+            type Query {
+              stars: Int @deprecated(reason: "a reason")
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -611,11 +611,11 @@ public class SchemaBuilderTests
     [Fact]
     public void default_deprecation_on_type_field()
     {
-        var definitions = @"
-                type Query {
-                  stars: Int @deprecated
-                }
-            ";
+        var definitions = """
+            type Query {
+              stars: Int @deprecated
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -629,12 +629,12 @@ public class SchemaBuilderTests
     [Fact]
     public void deprecate_enum_value()
     {
-        var definitions = @"
-                enum PetKind {
-                    CAT @deprecated(reason: ""dogs rule"")
-                    DOG
-                }
-            ";
+        var definitions = """
+            enum PetKind {
+              CAT @deprecated(reason: "dogs rule")
+              DOG
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -649,11 +649,11 @@ public class SchemaBuilderTests
     [Fact]
     public void deprecated_prefers_metadata_values()
     {
-        var definitions = @"
-                type Movie {
-                  movies: Int @deprecated
-                }
-            ";
+        var definitions = """
+            type Movie {
+              movies: Int @deprecated
+            }
+            """;
 
         var schema = Schema.For(definitions, _ => _.Types.Include<Movie>());
         schema.Initialize();
@@ -667,15 +667,15 @@ public class SchemaBuilderTests
     [Fact]
     public void build_extension_type()
     {
-        var definitions = @"
-                type Query {
-                    author(id: Int): String
-                }
+        var definitions = """
+            type Query {
+              author(id: Int): String
+            }
 
-                extend type Query {
-                    book(id: Int): String
-                }
-            ";
+            extend type Query {
+              book(id: Int): String
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -686,15 +686,15 @@ public class SchemaBuilderTests
     [Fact]
     public void build_extension_type_out_of_order()
     {
-        var definitions = @"
-                extend type Query {
-                    author(id: Int): String
-                }
+        var definitions = """
+            extend type Query {
+              author(id: Int): String
+            }
 
-                type Query {
-                    book(id: Int): String
-                }
-            ";
+            type Query {
+              book(id: Int): String
+            }
+            """;
 
         var schema = Schema.For(definitions);
         schema.Initialize();
@@ -705,15 +705,15 @@ public class SchemaBuilderTests
     [Fact]
     public async Task builds_with_customized_clr_type()
     {
-        var definitions = @"
-                type Query {
-                    test: MyTestType
-                }
+        var definitions = """
+            type Query {
+              test: MyTestType
+            }
 
-                type MyTestType {
-                    myTestField: ID
-                }
-            ";
+            type MyTestType {
+              myTestField: ID
+            }
+            """;
 
         var schema = Schema.For(definitions, b => b.Types.Include<TestType>());
         schema.Initialize();

--- a/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaPrinterTests.cs
@@ -59,7 +59,7 @@ public class SchemaPrinterTests
             var orderedScalars = expected
                 .OrderBy(x => x.Key, StringComparer.Ordinal)
                 .Select(x => x.Value);
-            exp = Environment.NewLine + string.Join($"{Environment.NewLine}{Environment.NewLine}", orderedScalars) + Environment.NewLine;
+            exp = Environment.NewLine + string.Join($"{Environment.NewLine}", orderedScalars) + Environment.NewLine;
         }
 
         result.Replace("\r", "").ShouldBe(exp.Replace("\r", ""));
@@ -78,10 +78,12 @@ public class SchemaPrinterTests
         arg.ResolvedType = new TestSchemaTypes().BuildGraphQLType(arg.Type, null);
 
         var result = printer.PrintDirective(skip);
-        const string expected = @"# Directs the executor to skip this field or fragment when the 'if' argument is true.
-directive @skip(
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT";
+        const string expected = """
+            # Directs the executor to skip this field or fragment when the 'if' argument is true.
+            directive @skip(
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            """;
 
         AssertEqual(result, "directive", expected, excludeScalars: true);
     }
@@ -96,13 +98,13 @@ directive @skip(
 
         var result = printer.PrintDirective(skip);
         const string expected = """"
-"""
-Directs the executor to skip this field or fragment when the 'if' argument is true.
-"""
-directive @skip(
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-"""";
+            """
+            Directs the executor to skip this field or fragment when the 'if' argument is true.
+            """
+            directive @skip(
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            """";
 
         AssertEqual(result, "directive", expected, excludeScalars: true);
     }
@@ -132,19 +134,22 @@ directive @skip(
             Arguments = new QueryArguments(new QueryArgument(new IntGraphType()) { Name = "max" })
         };
         string result = new SchemaPrinter(null).PrintDirective(d);
-        result.ShouldBe(@"directive @my(
-  max: Int
-) repeatable on FIELD | QUERY");
+        result.ShouldBe("""
+            directive @my(
+              max: Int
+            ) repeatable on FIELD | QUERY
+            """);
     }
 
     [Fact]
     public void prints_string_field()
     {
         var result = printSingleFieldSchema<StringGraphType>();
-        const string expected =
-@"type Query {
-  singleField: String
-}";
+        const string expected = """
+            type Query {
+              singleField: String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -152,10 +157,11 @@ directive @skip(
     public void prints_string_list_field()
     {
         var result = printSingleFieldSchema<ListGraphType<StringGraphType>>();
-        const string expected =
-@"type Query {
-  singleField: [String]
-}";
+        const string expected = """
+            type Query {
+              singleField: [String]
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -163,10 +169,11 @@ directive @skip(
     public void prints_non_null_string_field()
     {
         var result = printSingleFieldSchema<NonNullGraphType<StringGraphType>>();
-        const string expected =
-@"type Query {
-  singleField: String!
-}";
+        const string expected = """
+            type Query {
+              singleField: String!
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -174,10 +181,11 @@ directive @skip(
     public void prints_non_null_list_of_string_field()
     {
         var result = printSingleFieldSchema<NonNullGraphType<ListGraphType<StringGraphType>>>();
-        const string expected =
-@"type Query {
-  singleField: [String]!
-}";
+        const string expected = """
+            type Query {
+              singleField: [String]!
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -185,10 +193,11 @@ directive @skip(
     public void prints_non_null_list_of_non_null_string_field()
     {
         var result = printSingleFieldSchema<NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>>();
-        const string expected =
-@"type Query {
-  singleField: [String!]!
-}";
+        const string expected = """
+            type Query {
+              singleField: [String!]!
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -204,19 +213,24 @@ directive @skip(
         {
             {
                 "Foo",
-@"# This is a Foo object type
-type Foo {
-  # This is of type String
-  str: String
-  # This is of type Integer
-  int: Int @deprecated(reason: ""This field is now deprecated"")
-}"
+                """
+                # This is a Foo object type
+                type Foo {
+                  # This is of type String
+                  str: String
+                  # This is of type Integer
+                  int: Int @deprecated(reason: "This field is now deprecated")
+                }
+                """
             },
             {
                 "Query",
-@"type Query {
-  foo: Foo
-}"
+                """
+
+                type Query {
+                  foo: Foo
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -240,19 +254,24 @@ type Foo {
         {
             {
                 "Foo",
-@"# This is a Foo object type
-type Foo {
-  # This is of type String
-  str: String
-  # This is of type Integer
-  int: Int
-}"
+                """
+                # This is a Foo object type
+                type Foo {
+                  # This is of type String
+                  str: String
+                  # This is of type Integer
+                  int: Int
+                }
+                """
             },
             {
                 "Query",
-@"type Query {
-  foo: Foo
-}"
+                """
+
+                type Query {
+                  foo: Foo
+                }
+                """
             },
         };
         AssertEqual(print(schema, options), expected);
@@ -276,27 +295,30 @@ type Foo {
         {
             {
                 "Foo",
-""""
-"""
-This is a Foo object type
-"""
-type Foo {
-  """
-  This is of type String
-  """
-  str: String
-  """
-  This is of type Integer
-  """
-  int: Int
-}
-""""
+                """"
+                """
+                This is a Foo object type
+                """
+                type Foo {
+                  """
+                  This is of type String
+                  """
+                  str: String
+                  """
+                  This is of type Integer
+                  """
+                  int: Int
+                }
+                """"
             },
             {
                 "Query",
-@"type Query {
-  foo: Foo
-}"
+                """
+
+                type Query {
+                  foo: Foo
+                }
+                """
             },
         };
         AssertEqual(print(schema, options), expected);
@@ -321,19 +343,24 @@ type Foo {
         {
             {
                 "Foo",
-@"# This is a Foo object type
-type Foo {
-  # This is of type String
-  str: String
-  # This is of type Integer
-  int: Int
-}".Replace("int: Int", "int: Int @deprecated(reason: \"This field is now deprecated\")")
+                """
+                # This is a Foo object type
+                type Foo {
+                  # This is of type String
+                  str: String
+                  # This is of type Integer
+                  int: Int
+                }
+                """.Replace("int: Int", "int: Int @deprecated(reason: \"This field is now deprecated\")")
             },
             {
                 "Query",
-@"type Query {
-  foo: Foo
-}"
+                """
+
+                type Query {
+                  foo: Foo
+                }
+                """
             },
         };
         var result = print(schema, options);
@@ -359,27 +386,30 @@ type Foo {
         {
             {
                 "Foo",
-""""
-"""
-This is a Foo object type
-"""
-type Foo {
-  """
-  This is of type String
-  """
-  str: String
-  """
-  This is of type Integer
-  """
-  int: Int
-}
-"""".Replace("int: Int", "int: Int @deprecated(reason: \"This field is now deprecated\")")
+                """"
+                """
+                This is a Foo object type
+                """
+                type Foo {
+                  """
+                  This is of type String
+                  """
+                  str: String
+                  """
+                  This is of type Integer
+                  """
+                  int: Int
+                }
+
+                """".Replace("int: Int", "int: Int @deprecated(reason: \"This field is now deprecated\")")
             },
             {
                 "Query",
-@"type Query {
-  foo: Foo
-}"
+                """
+                type Query {
+                  foo: Foo
+                }
+                """
             },
         };
         var result = print(schema, options);
@@ -395,10 +425,11 @@ type Foo {
                 new QueryArgument<IntGraphType> { Name = "argOne" }
             });
 
-        const string expected =
-@"type Query {
-  singleField(argOne: Int): String
-}";
+        const string expected = """
+            type Query {
+              singleField(argOne: Int): String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -411,10 +442,11 @@ type Foo {
                 new QueryArgument<IntGraphType> { Name = "argOne", DefaultValue = 2 }
             });
 
-        const string expected =
-@"type Query {
-  singleField(argOne: Int = 2): String
-}";
+        const string expected = """
+            type Query {
+              singleField(argOne: Int = 2): String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -427,10 +459,11 @@ type Foo {
                 new QueryArgument<NonNullGraphType<IntGraphType>> { Name = "argOne" }
             });
 
-        const string expected =
-@"type Query {
-  singleField(argOne: Int!): String
-}";
+        const string expected = """
+            type Query {
+              singleField(argOne: Int!): String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -443,12 +476,13 @@ type Foo {
                 new QueryArgument<ListGraphType<GuidGraphType>> { Name = "arg", DefaultValue = new List<Guid>() },
             });
 
-        const string expected =
-@"scalar Guid
+        const string expected = """
+            scalar Guid
 
-type Query {
-  singleField(arg: [Guid] = []): String
-}";
+            type Query {
+              singleField(arg: [Guid] = []): String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -462,10 +496,11 @@ type Query {
                 new QueryArgument<StringGraphType> { Name = "argTwo" }
             });
 
-        const string expected =
-@"type Query {
-  singleField(argOne: Int, argTwo: String): String
-}";
+        const string expected = """
+            type Query {
+              singleField(argOne: Int, argTwo: String): String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -480,10 +515,11 @@ type Query {
                 new QueryArgument<BooleanGraphType> { Name = "argThree" }
             });
 
-        const string expected =
-@"type Query {
-  singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
-}";
+        const string expected = """
+            type Query {
+              singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -498,10 +534,11 @@ type Query {
                 new QueryArgument<BooleanGraphType> { Name = "argThree" }
             });
 
-        const string expected =
-@"type Query {
-  singleField(argOne: Int, argTwo: String = ""foo"", argThree: Boolean): String
-}";
+        const string expected = """
+            type Query {
+              singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -516,10 +553,11 @@ type Query {
                 new QueryArgument<BooleanGraphType> { Name = "argThree", DefaultValue = false }
             });
 
-        const string expected =
-@"type Query {
-  singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
-}";
+        const string expected = """
+            type Query {
+              singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
+            }
+            """;
         AssertEqual(result, "Query", expected);
     }
 
@@ -531,26 +569,28 @@ type Query {
 
         var schema = new Schema { Query = root };
 
-        AssertEqual(print(schema), "", @"
-schema {
-  query: Root
-}
+        AssertEqual(print(schema), "", """
 
-type Bar implements IFoo {
-  # This is of type String
-  str: String
-}
+            schema {
+              query: Root
+            }
 
-# This is a Foo interface type
-interface IFoo {
-  # This is of type String
-  str: String
-}
+            type Bar implements IFoo {
+              # This is of type String
+              str: String
+            }
 
-type Root {
-  bar: Bar
-}
-", excludeScalars: true);
+            # This is a Foo interface type
+            interface IFoo {
+              # This is of type String
+              str: String
+            }
+
+            type Root {
+              bar: Bar
+            }
+
+            """, excludeScalars: true);
     }
 
     [Fact]
@@ -563,29 +603,31 @@ type Root {
 
         var result = print(schema);
 
-        AssertEqual(result, "", @"
-interface Baaz {
-  # This is of type Integer
-  int: Int
-}
+        AssertEqual(result, "", """
 
-type Bar implements IFoo & Baaz {
-  # This is of type String
-  str: String
-  # This is of type Integer
-  int: Int
-}
+            interface Baaz {
+              # This is of type Integer
+              int: Int
+            }
 
-# This is a Foo interface type
-interface IFoo {
-  # This is of type String
-  str: String
-}
+            type Bar implements IFoo & Baaz {
+              # This is of type String
+              str: String
+              # This is of type Integer
+              int: Int
+            }
 
-type Query {
-  bar: Bar
-}
-", excludeScalars: true);
+            # This is a Foo interface type
+            interface IFoo {
+              # This is of type String
+              str: String
+            }
+
+            type Query {
+              bar: Bar
+            }
+
+            """, excludeScalars: true);
     }
 
     [Fact]
@@ -603,29 +645,31 @@ type Query {
             PrintDescriptionsAsComments = true,
         };
 
-        AssertEqual(print(schema, options), "", @"
-interface Baaz {
-  # This is of type Integer
-  int: Int
-}
+        AssertEqual(print(schema, options), "", """
 
-type Bar implements IFoo, Baaz {
-  # This is of type String
-  str: String
-  # This is of type Integer
-  int: Int
-}
+            interface Baaz {
+              # This is of type Integer
+              int: Int
+            }
 
-# This is a Foo interface type
-interface IFoo {
-  # This is of type String
-  str: String
-}
+            type Bar implements IFoo, Baaz {
+              # This is of type String
+              str: String
+              # This is of type Integer
+              int: Int
+            }
 
-type Query {
-  bar: Bar
-}
-", excludeScalars: true);
+            # This is a Foo interface type
+            interface IFoo {
+              # This is of type String
+              str: String
+            }
+
+            type Query {
+              bar: Bar
+            }
+
+            """, excludeScalars: true);
     }
 
     [Fact]
@@ -645,39 +689,39 @@ type Query {
 
         AssertEqual(print(schema, options), "", """"
 
-interface Baaz {
-  """
-  This is of type Integer
-  """
-  int: Int
-}
+            interface Baaz {
+              """
+              This is of type Integer
+              """
+              int: Int
+            }
 
-type Bar implements IFoo, Baaz {
-  """
-  This is of type String
-  """
-  str: String
-  """
-  This is of type Integer
-  """
-  int: Int
-}
+            type Bar implements IFoo, Baaz {
+              """
+              This is of type String
+              """
+              str: String
+              """
+              This is of type Integer
+              """
+              int: Int
+            }
 
-"""
-This is a Foo interface type
-"""
-interface IFoo {
-  """
-  This is of type String
-  """
-  str: String
-}
+            """
+            This is a Foo interface type
+            """
+            interface IFoo {
+              """
+              This is of type String
+              """
+              str: String
+            }
 
-type Query {
-  bar: Bar
-}
+            type Query {
+              bar: Bar
+            }
 
-"""", excludeScalars: true);
+            """", excludeScalars: true);
     }
 
     [Fact]
@@ -696,29 +740,31 @@ type Query {
 
         var result = print(schema, options);
 
-        AssertEqual(result, "", @"
-interface Baaz {
-  # This is of type Integer
-  int: Int
-}
+        AssertEqual(result, "", """
 
-type Bar implements IFoo & Baaz {
-  # This is of type String
-  str: String
-  # This is of type Integer
-  int: Int
-}
+            interface Baaz {
+              # This is of type Integer
+              int: Int
+            }
 
-# This is a Foo interface type
-interface IFoo {
-  # This is of type String
-  str: String
-}
+            type Bar implements IFoo & Baaz {
+              # This is of type String
+              str: String
+              # This is of type Integer
+              int: Int
+            }
 
-type Query {
-  bar: Bar
-}
-", excludeScalars: true);
+            # This is a Foo interface type
+            interface IFoo {
+              # This is of type String
+              str: String
+            }
+
+            type Query {
+              bar: Bar
+            }
+
+            """, excludeScalars: true);
     }
 
     [Fact]
@@ -739,39 +785,39 @@ type Query {
 
         AssertEqual(result, "", """"
 
-interface Baaz {
-  """
-  This is of type Integer
-  """
-  int: Int
-}
+            interface Baaz {
+              """
+              This is of type Integer
+              """
+              int: Int
+            }
 
-type Bar implements IFoo & Baaz {
-  """
-  This is of type String
-  """
-  str: String
-  """
-  This is of type Integer
-  """
-  int: Int
-}
+            type Bar implements IFoo & Baaz {
+              """
+              This is of type String
+              """
+              str: String
+              """
+              This is of type Integer
+              """
+              int: Int
+            }
 
-"""
-This is a Foo interface type
-"""
-interface IFoo {
-  """
-  This is of type String
-  """
-  str: String
-}
+            """
+            This is a Foo interface type
+            """
+            interface IFoo {
+              """
+              This is of type String
+              """
+              str: String
+            }
 
-type Query {
-  bar: Bar
-}
+            type Query {
+              bar: Bar
+            }
 
-"""", excludeScalars: true);
+            """", excludeScalars: true);
     }
 
     [Fact]
@@ -783,35 +829,37 @@ type Query {
 
         var schema = new Schema { Query = root };
 
-        AssertEqual(print(schema), "", @"
-type Bar implements IFoo {
-  # This is of type String
-  str: String
-}
+        AssertEqual(print(schema), "", """
 
-# This is a Foo object type
-type Foo {
-  # This is of type String
-  str: String
-  # This is of type Integer
-  int: Int @deprecated(reason: ""This field is now deprecated"")
-}
+            type Bar implements IFoo {
+              # This is of type String
+              str: String
+            }
 
-# This is a Foo interface type
-interface IFoo {
-  # This is of type String
-  str: String
-}
+            # This is a Foo object type
+            type Foo {
+              # This is of type String
+              str: String
+              # This is of type Integer
+              int: Int @deprecated(reason: "This field is now deprecated")
+            }
 
-union MultipleUnion = Foo | Bar
+            # This is a Foo interface type
+            interface IFoo {
+              # This is of type String
+              str: String
+            }
 
-type Query {
-  single: SingleUnion
-  multiple: MultipleUnion
-}
+            union MultipleUnion = Foo | Bar
 
-union SingleUnion = Foo
-", excludeScalars: true);
+            type Query {
+              single: SingleUnion
+              multiple: MultipleUnion
+            }
+
+            union SingleUnion = Foo
+
+            """, excludeScalars: true);
     }
 
     [Fact]
@@ -827,15 +875,20 @@ union SingleUnion = Foo
         {
             {
                 "InputType",
-@"input InputType {
-  int: Int
-}"
+                """
+                input InputType {
+                  int: Int
+                }
+                """
             },
-                            {
+            {
                 "Query",
-@"type Query {
-  str(argOne: InputType): String!
-}"
+                """
+
+                type Query {
+                  str(argOne: InputType): String!
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -855,17 +908,22 @@ union SingleUnion = Foo
         {
             {
                 "SomeInput",
-@"input SomeInput {
-  age: Int!
-  name: String!
-  isDeveloper: Boolean!
-}"
+                """
+
+                input SomeInput {
+                  age: Int!
+                  name: String!
+                  isDeveloper: Boolean!
+                }
+                """
             },
-                            {
+            {
                 "Query",
-@"type Query {
-  str(argOne: SomeInput! = { age: 42, name: ""Tom"", isDeveloper: true }, argTwo: [SomeInput] = [{ age: 12, name: ""Tom1"", isDeveloper: false }, { age: 22, name: ""Tom2"", isDeveloper: true }]): String!
-}"
+                """
+                type Query {
+                  str(argOne: SomeInput! = { age: 42, name: "Tom", isDeveloper: true }, argTwo: [SomeInput] = [{ age: 12, name: "Tom1", isDeveloper: false }, { age: 22, name: "Tom2", isDeveloper: true }]): String!
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -884,15 +942,20 @@ union SingleUnion = Foo
         {
             {
                 "SomeInput2",
-@"input SomeInput2 {
-  names: [String]
-}"
+                """
+
+                input SomeInput2 {
+                  names: [String]
+                }
+                """
             },
-                            {
+            {
                 "Query",
-@"type Query {
-  str(argOne: SomeInput2! = { names: null }): String!
-}"
+                """
+                type Query {
+                  str(argOne: SomeInput2! = { names: null }): String!
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -901,36 +964,42 @@ union SingleUnion = Foo
     [Fact]
     public void prints_input_type_with_default_as_dictionary()
     {
-        var schema = Schema.For(@"
-input SomeInput {
-  age: Int!
-  name: String!
-  isDeveloper: Boolean!
-  unused: Boolean
-}
+        var schema = Schema.For("""
 
-type Query {
-  str(argOne: SomeInput! = { age: 42, name: ""Tom"", isDeveloper: true },
-      argTwo: [SomeInput] = [{ age: 12, name: ""Tom1"", isDeveloper: false }, { age: 22, name: ""Tom2"", isDeveloper: true }]): String!
-}
-");
+            input SomeInput {
+              age: Int!
+              name: String!
+              isDeveloper: Boolean!
+              unused: Boolean
+            }
+
+            type Query {
+              str(argOne: SomeInput! = { age: 42, name: "Tom", isDeveloper: true },
+                  argTwo: [SomeInput] = [{ age: 12, name: "Tom1", isDeveloper: false }, { age: 22, name: "Tom2", isDeveloper: true }]): String!
+            }
+            """);
 
         var expected = new Dictionary<string, string>
         {
             {
                 "SomeInput",
-@"input SomeInput {
-  age: Int!
-  name: String!
-  isDeveloper: Boolean!
-  unused: Boolean
-}"
+                """
+
+                input SomeInput {
+                  age: Int!
+                  name: String!
+                  isDeveloper: Boolean!
+                  unused: Boolean
+                }
+                """
             },
-                            {
+             {
                 "Query",
-@"type Query {
-  str(argOne: SomeInput! = { age: 42, name: ""Tom"", isDeveloper: true }, argTwo: [SomeInput] = [{ age: 12, name: ""Tom1"", isDeveloper: false }, { age: 22, name: ""Tom2"", isDeveloper: true }]): String!
-}"
+                """
+                type Query {
+                  str(argOne: SomeInput! = { age: 42, name: "Tom", isDeveloper: true }, argTwo: [SomeInput] = [{ age: 12, name: "Tom1", isDeveloper: false }, { age: 22, name: "Tom2", isDeveloper: true }]): String!
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -939,29 +1008,35 @@ type Query {
     [Fact]
     public void prints_input_type_with_default_as_dictionary_null_values()
     {
-        var schema = Schema.For(@"
-input SomeInput {
-  age: Int = 2
-}
+        var schema = Schema.For("""
 
-type Query {
-  str(arg: SomeInput = { age: null }): String!
-}
-");
+            input SomeInput {
+              age: Int = 2
+            }
+
+            type Query {
+              str(arg: SomeInput = { age: null }): String!
+            }
+            """);
 
         var expected = new Dictionary<string, string>
         {
             {
                 "SomeInput",
-@"input SomeInput {
-  age: Int = 2
-}"
+                """
+
+                input SomeInput {
+                  age: Int = 2
+                }
+                """
             },
-                            {
+            {
                 "Query",
-@"type Query {
-  str(arg: SomeInput = { age: null }): String!
-}"
+                """
+                type Query {
+                  str(arg: SomeInput = { age: null }): String!
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -977,12 +1052,15 @@ type Query {
 
         var expected = new Dictionary<string, string>
         {
-            { "Odd", @"scalar Odd" },
+            { "Odd", "scalar Odd" },
             {
                 "Query",
-@"type Query {
-  odd: Odd
-}"
+                """
+
+                type Query {
+                  odd: Odd
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -1015,68 +1093,70 @@ type Query {
         {
             {
                 "Query",
-@"scalar BigInt
+                """
+                scalar BigInt
 
-scalar Byte
+                scalar Byte
 
-# The `Date` scalar type represents a year, month and day in accordance with the
-# [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
-scalar Date
+                # The `Date` scalar type represents a year, month and day in accordance with the
+                # [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+                scalar Date
 
-# The `DateTime` scalar type represents a date and time. `DateTime` expects
-# timestamps to be formatted in accordance with the
-# [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
-scalar DateTime
+                # The `DateTime` scalar type represents a date and time. `DateTime` expects
+                # timestamps to be formatted in accordance with the
+                # [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+                scalar DateTime
 
-# The `DateTimeOffset` scalar type represents a date, time and offset from UTC.
-# `DateTimeOffset` expects timestamps to be formatted in accordance with the
-# [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
-scalar DateTimeOffset
+                # The `DateTimeOffset` scalar type represents a date, time and offset from UTC.
+                # `DateTimeOffset` expects timestamps to be formatted in accordance with the
+                # [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+                scalar DateTimeOffset
 
-scalar Decimal
+                scalar Decimal
 
-scalar Guid
+                scalar Guid
 
-scalar Long
+                scalar Long
 
-# The `Milliseconds` scalar type represents a period of time represented as the
-# total number of milliseconds in range [-922337203685477, 922337203685477].
-scalar Milliseconds
+                # The `Milliseconds` scalar type represents a period of time represented as the
+                # total number of milliseconds in range [-922337203685477, 922337203685477].
+                scalar Milliseconds
 
-type Query {
-  bigint: BigInt
-  byte: Byte
-  date: Date
-  datetime: DateTime
-  datetimeoffset: DateTimeOffset
-  decimal: Decimal
-  guid: Guid
-  long: Long
-  milliseconds: Milliseconds
-  sbyte: SByte
-  seconds: Seconds
-  short: Short
-  uint: UInt
-  ulong: ULong
-  ushort: UShort
-  uri: Uri
-}
+                type Query {
+                  bigint: BigInt
+                  byte: Byte
+                  date: Date
+                  datetime: DateTime
+                  datetimeoffset: DateTimeOffset
+                  decimal: Decimal
+                  guid: Guid
+                  long: Long
+                  milliseconds: Milliseconds
+                  sbyte: SByte
+                  seconds: Seconds
+                  short: Short
+                  uint: UInt
+                  ulong: ULong
+                  ushort: UShort
+                  uri: Uri
+                }
 
-scalar SByte
+                scalar SByte
 
-# The `Seconds` scalar type represents a period of time represented as the total
-# number of seconds in range [-922337203685, 922337203685].
-scalar Seconds
+                # The `Seconds` scalar type represents a period of time represented as the total
+                # number of seconds in range [-922337203685, 922337203685].
+                scalar Seconds
 
-scalar Short
+                scalar Short
 
-scalar UInt
+                scalar UInt
 
-scalar ULong
+                scalar ULong
 
-scalar UShort
+                scalar UShort
 
-scalar Uri"
+                scalar Uri
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -1094,20 +1174,25 @@ scalar Uri"
         {
             {
                 "Query",
-@"type Query {
-  rgb: RGB
-}"
+                """
+                type Query {
+                  rgb: RGB
+                }
+                """
             },
             {
                 "RGB",
-@"enum RGB {
-  # Red!
-  RED @deprecated(reason: ""Use green!"")
-  # Green!
-  GREEN
-  # Blue!
-  BLUE
-}"
+                """
+
+                enum RGB {
+                  # Red!
+                  RED @deprecated(reason: "Use green!")
+                  # Green!
+                  GREEN
+                  # Blue!
+                  BLUE
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);
@@ -1135,20 +1220,25 @@ scalar Uri"
         {
             {
                 "Query",
-@"type Query {
-  bestColor(color: RGB = RED): RGB
-}"
+                """
+                type Query {
+                  bestColor(color: RGB = RED): RGB
+                }
+                """
             },
             {
                 "RGB",
-@"enum RGB {
-  # Red!
-  RED @deprecated(reason: ""Use green!"")
-  # Green!
-  GREEN
-  # Blue!
-  BLUE
-}"
+                """
+
+                enum RGB {
+                  # Red!
+                  RED @deprecated(reason: "Use green!")
+                  # Green!
+                  GREEN
+                  # Blue!
+                  BLUE
+                }
+                """
             },
         };
         AssertEqual(print(schema), expected);

--- a/src/GraphQL.Tests/Utilities/SchemaVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaVisitorTests.cs
@@ -11,11 +11,11 @@ public class SchemaVisitorTests : SchemaBuilderTestBase
     {
         AssertQuery(_ =>
         {
-            _.Definitions = @"
-                    type Query {
-                        hello: String @upper
-                    }
-                ";
+            _.Definitions = """
+                type Query {
+                  hello: String @upper
+                }
+                """;
             _.ConfigureBuildedSchema = schema => { schema.Directives.Register(new UpperDirective()); schema.RegisterVisitor<UppercaseDirectiveVisitor>(); };
             _.Query = "{ hello }";
             _.Root = new { Hello = "Hello World!" };
@@ -46,42 +46,42 @@ public class SchemaVisitorTests : SchemaBuilderTestBase
         Builder.Types.For("TestType").IsTypeOf<TestType>();
         Builder.Types.For("TestTypeForUnion").IsTypeOf<TestTypeForUnion>();
 
-        var schema = Builder.Build(@"
-                    type Query {
-                        hello: String
-                    }
+        var schema = Builder.Build("""
+            type Query {
+              hello: String
+            }
 
-                    interface TestInterface @description(text: ""interface""){
-                        id: ID!
-                    }
+            interface TestInterface @description(text: "interface") {
+              id: ID!
+            }
 
-                    type TestType implements TestInterface @description(text: ""type"") {
-                        id: ID!
-                        name(arg: Int @description(text: ""arg"")): String @description(text: ""field"")
-                    }
+            type TestType implements TestInterface @description(text: "type") {
+              id: ID!
+              name(arg: Int @description(text: "arg")): String @description(text: "field")
+            }
 
-                    type TestTypeForUnion {
-                        field: ID!
-                    }
+            type TestTypeForUnion {
+              field: ID!
+            }
 
-                    union TestUnion @description(text: ""union"") = TestType | TestTypeForUnion
+            union TestUnion @description(text: "union") = TestType | TestTypeForUnion
 
-                    enum TestEnum @description(text: ""enum-definition""){
-                      TESTVAL1 @description(text: ""enum-value"")
-                      TESTVAL2
-                      TESTVAL3
-                    }
+            enum TestEnum @description(text: "enum-definition"){
+              TESTVAL1 @description(text: "enum-value")
+              TESTVAL2
+              TESTVAL3
+            }
 
-                    input TestInputType @description(text: ""input-type"") {
-                        id: Int = 0 @description(text: ""input-field"")
-                    }
+            input TestInputType @description(text: "input-type") {
+              id: Int = 0 @description(text: "input-field")
+            }
 
-                    scalar TestScalar @description(text: ""scalar"")
+            scalar TestScalar @description(text: "scalar")
 
-                    schema @description(text: ""schema description"") {
-                      query: Query
-                    }
-            ");
+            schema @description(text: "schema description") {
+              query: Query
+            }
+            """);
         schema.Directives.Register(new Directive("description",
             DirectiveLocation.Schema, DirectiveLocation.Union, DirectiveLocation.Interface, DirectiveLocation.Object,
             DirectiveLocation.InputObject, DirectiveLocation.FieldDefinition, DirectiveLocation.InputFieldDefinition,

--- a/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
+++ b/src/GraphQL.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
@@ -9,127 +9,151 @@ public class ArgumentsOfCorrectTypeTests : ValidationTestBase<ArgumentsOfCorrect
     [Fact]
     public void good_int_value()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 intArgField(intArg: 2)
               }
-            }");
+            }
+            """);
     }
 
     // https://github.com/graphql-dotnet/graphql-dotnet/issues/2339
     [Fact]
     public void good_int_null_value()
     {
-        ShouldPassRule(@"{
-              complicatedArgs {
-                intArgField(intArg: null)
+        ShouldPassRule("""
+            {
+            complicatedArgs {
+              intArgField(intArg: null)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void good_boolean_value()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 booleanArgField(booleanArg: true)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void good_string_value()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
-                stringArgField(stringArg: ""foo"")
+                stringArgField(stringArg: "foo")
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void good_float_value()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 floatArgField(floatArg: 1.1)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void int_into_float()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 floatArgField(floatArg: 1)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void long_into_float()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 floatArgField(floatArg: 1000000000000000001)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void int_into_id()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 idArgField(idArg: 1)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void long_into_id()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 idArgField(idArg: 1000000000000000001)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void string_into_id()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
-                idArgField(idArg: ""someIdString"")
+                idArgField(idArg: "someIdString")
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void good_enum_value()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               dog {
                 doesKnowCommand(dogCommand: SIT)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void int_into_string()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 stringArgField(stringArg: 1)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "stringArg", "String", "1", 3, 32);
+            Rule.badValue(_, "stringArg", "String", "1", 3, 20);
         });
     }
 
@@ -142,304 +166,342 @@ public class ArgumentsOfCorrectTypeTests : ValidationTestBase<ArgumentsOfCorrect
     [Fact]
     public void float_into_string()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 stringArgField(stringArg: 1.0)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "stringArg", "String", "1.0", 3, 32);
+            Rule.badValue(_, "stringArg", "String", "1.0", 3, 20);
         });
     }
 
     [Fact]
     public void boolean_into_string()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 stringArgField(stringArg: true)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "stringArg", "String", "true", 3, 32);
+            Rule.badValue(_, "stringArg", "String", "true", 3, 20);
         });
     }
 
     [Fact]
     public void unquotedstring_into_string()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 stringArgField(stringArg: BAR)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "stringArg", "String", "BAR", 3, 32);
+            Rule.badValue(_, "stringArg", "String", "BAR", 3, 20);
         });
     }
 
     [Fact]
     public void string_into_int()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
-                intArgField(intArg: ""3"")
+                intArgField(intArg: "3")
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "intArg", "Int", "\"3\"", 3, 29);
+            Rule.badValue(_, "intArg", "Int", "\"3\"", 3, 17);
         });
     }
 
-    //        [Test]
-    //        public void big_int_into_int()
-    //        {
-    //            var query = @"{
-    //              complicatedArgs {
-    //                intArgField(intArg: 829384293849283498239482938)
-    //              }
-    //            }";
-    //
-    //            ShouldFailRule(_ =>
-    //            {
-    //                _.Query = query;
-    //                Rule.badValue(_, "intArg", "Int", "829384293849283498239482938", 3, 29);
-    //            });
-    //        }
+    [Fact]
+    public void big_int_into_int()
+    {
+        var query = """
+            {
+              complicatedArgs {
+                intArgField(intArg: 829384293849283498239482938)
+              }
+            }
+            """;
+
+        ShouldFailRule(_ =>
+        {
+            _.Query = query;
+            Rule.badValue(_, "intArg", "Int", "829384293849283498239482938", 3, 17);
+        });
+    }
 
     [Fact]
     public void unquoted_string_into_int()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 intArgField(intArg: FOO)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "intArg", "Int", "FOO", 3, 29);
+            Rule.badValue(_, "intArg", "Int", "FOO", 3, 17);
         });
     }
 
     [Fact]
     public void simple_float_into_int()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 intArgField(intArg: 3.0)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "intArg", "Int", "3.0", 3, 29);
+            Rule.badValue(_, "intArg", "Int", "3.0", 3, 17);
         });
     }
 
     [Fact]
     public void float_into_int()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 intArgField(intArg: 3.333)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "intArg", "Int", "3.333", 3, 29);
+            Rule.badValue(_, "intArg", "Int", "3.333", 3, 17);
         });
     }
 
     [Fact]
     public void string_into_float()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
-                floatArgField(floatArg: ""3.333"")
+                floatArgField(floatArg: "3.333")
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "floatArg", "Float", "\"3.333\"", 3, 31);
+            Rule.badValue(_, "floatArg", "Float", "\"3.333\"", 3, 19);
         });
     }
 
     [Fact]
     public void boolean_into_float()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 floatArgField(floatArg: true)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "floatArg", "Float", "true", 3, 31);
+            Rule.badValue(_, "floatArg", "Float", "true", 3, 19);
         });
     }
 
     [Fact]
     public void unquoted_string_into_float()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 floatArgField(floatArg: FOO)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "floatArg", "Float", "FOO", 3, 31);
+            Rule.badValue(_, "floatArg", "Float", "FOO", 3, 19);
         });
     }
 
     [Fact]
     public void int_into_boolean()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 booleanArgField(booleanArg: 2)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "booleanArg", "Boolean", "2", 3, 33);
+            Rule.badValue(_, "booleanArg", "Boolean", "2", 3, 21);
         });
     }
 
     [Fact]
     public void float_into_boolean()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 booleanArgField(booleanArg: 1.0)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "booleanArg", "Boolean", "1.0", 3, 33);
+            Rule.badValue(_, "booleanArg", "Boolean", "1.0", 3, 21);
         });
     }
 
     [Fact]
     public void string_into_boolean()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
-                booleanArgField(booleanArg: ""true"")
+                booleanArgField(booleanArg: "true")
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "booleanArg", "Boolean", "\"true\"", 3, 33);
+            Rule.badValue(_, "booleanArg", "Boolean", "\"true\"", 3, 21);
         });
     }
 
     [Fact]
     public void unquotedstring_into_boolean()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 booleanArgField(booleanArg: TRUE)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "booleanArg", "Boolean", "TRUE", 3, 33);
+            Rule.badValue(_, "booleanArg", "Boolean", "TRUE", 3, 21);
         });
     }
 
     [Fact]
     public void float_into_id()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 idArgField(idArg: 1.0)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "idArg", "ID", "1.0", 3, 28);
+            Rule.badValue(_, "idArg", "ID", "1.0", 3, 16);
         });
     }
 
     [Fact]
     public void boolean_into_id()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 idArgField(idArg: true)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "idArg", "ID", "true", 3, 28);
+            Rule.badValue(_, "idArg", "ID", "true", 3, 16);
         });
     }
 
     [Fact]
     public void unquoted_into_id()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 idArgField(idArg: SOMETHING)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "idArg", "ID", "SOMETHING", 3, 28);
+            Rule.badValue(_, "idArg", "ID", "SOMETHING", 3, 16);
         });
     }
 
     [Fact]
     public void int_into_enum()
     {
-        var query = @"{
+        var query = """
+            {
               dog {
                 doesKnowCommand(dogCommand: 2)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "dogCommand", "DogCommand", "2", 3, 33);
+            Rule.badValue(_, "dogCommand", "DogCommand", "2", 3, 21);
         });
     }
 
@@ -452,113 +514,127 @@ public class ArgumentsOfCorrectTypeTests : ValidationTestBase<ArgumentsOfCorrect
     [Fact]
     public void float_into_enum()
     {
-        var query = @"{
+        var query = """
+            {
               dog {
                 doesKnowCommand(dogCommand: 1.0)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "dogCommand", "DogCommand", "1.0", 3, 33);
+            Rule.badValue(_, "dogCommand", "DogCommand", "1.0", 3, 21);
         });
     }
 
     [Fact]
     public void string_into_enum()
     {
-        var query = @"{
+        var query = """
+            {
               dog {
-                doesKnowCommand(dogCommand: ""SIT"")
+                doesKnowCommand(dogCommand: "SIT")
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "dogCommand", "DogCommand", "\"SIT\"", 3, 33);
+            Rule.badValue(_, "dogCommand", "DogCommand", "\"SIT\"", 3, 21);
         });
     }
 
     [Fact]
     public void boolean_into_enum()
     {
-        var query = @"{
+        var query = """
+            {
               dog {
                 doesKnowCommand(dogCommand: true)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "dogCommand", "DogCommand", "true", 3, 33);
+            Rule.badValue(_, "dogCommand", "DogCommand", "true", 3, 21);
         });
     }
 
     [Fact]
     public void unknown_enum_value_into_enum()
     {
-        var query = @"{
+        var query = """
+            {
               dog {
                 doesKnowCommand(dogCommand: JUGGLE)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "dogCommand", "DogCommand", "JUGGLE", 3, 33);
+            Rule.badValue(_, "dogCommand", "DogCommand", "JUGGLE", 3, 21);
         });
     }
 
     // this is currently allowed
-    //        [Fact]
-    //        public void different_case_enum_value_into_enum()
+    //[Fact]
+    //public void different_case_enum_value_into_enum()
+    //{
+    //    var query = """
     //        {
-    //            var query = @"{
-    //              dog {
-    //                doesKnowCommand(dogCommand: sit)
-    //              }
-    //            }";
-    //
-    //            ShouldFailRule(_ =>
-    //            {
-    //                _.Query = query;
-    //                Rule.badValue(_, "dogCommand", "DogCommand", "sit", 3, 33);
-    //            });
+    //          dog {
+    //            doesKnowCommand(dogCommand: sit)
+    //          }
     //        }
+    //        """;
+
+    //    ShouldFailRule(_ =>
+    //    {
+    //        _.Query = query;
+    //        Rule.badValue(_, "dogCommand", "DogCommand", "sit", 3, 33);
+    //    });
+    //}
 
     [Fact]
     public void list_value_incorrect_item_type()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
-                stringListArgField(stringListArg: [""one"", 2])
+                stringListArgField(stringListArg: ["one", 2])
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "stringListArg", "[String]", "[\"one\", 2]", 3, 36, "In element #2: [Expected type 'String', found 2.]");
+            Rule.badValue(_, "stringListArg", "[String]", "[\"one\", 2]", 3, 24, "In element #2: [Expected type 'String', found 2.]");
         });
     }
 
     [Fact]
     public void list_value_single_value_of_incorrect_type()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 stringListArgField(stringListArg: 1)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "stringListArg", "String", "1", 3, 36);
+            Rule.badValue(_, "stringListArg", "String", "1", 3, 24);
         });
     }
 }
@@ -568,123 +644,147 @@ public class ArgumentsOfCorrectType_Valid_Non_Nullable : ValidationTestBase<Argu
     [Fact]
     public void arg_on_optional_arg()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               dog {
                 isHousetrained(atOtherHomes: true)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void no_arg_on_optional_arg()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               dog {
                 isHousetrained
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void multiple_args()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleReqs(req1: 1, req2: 2)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void multiple_args_reverse_order()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleReqs(req2: 2, req1: 1)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void no_args_on_multiple_optional()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleOpts
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void one_arg_on_multiple_optional()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleOpts(opt1: 1)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void second_arg_on_multiple_optional()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleOpts(opt2: 2)
               }
-            }");
+            }
+            """);
     }
 
     // https://github.com/graphql-dotnet/graphql-dotnet/issues/2339
     [Fact]
     public void one_null_arg_on_multiple_optional()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleOpts(opt1: null)
               }
-            }");
+            }
+            """);
     }
 
     // https://github.com/graphql-dotnet/graphql-dotnet/issues/2339
     [Fact]
     public void both_null_arg_on_multiple_optional()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleOpts(opt2: null, opt1: null)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void multiple_reqs_on_mixed()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleOptAndReq(req1: 3, req2: 4)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void multiple_reqs_and_one_opt_on_mixed()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleOptAndReq(req1: 3, req2: 4, opt1: 5)
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void all_reqs_and_opts_on_mixed()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 multipleOptAndReq(req1: 3, req2: 4, opt1: 5, opt2: 6)
               }
-            }");
+            }
+            """);
     }
 }
 
@@ -693,33 +793,37 @@ public class ArgumentsOfCorrectType_Invalid_Non_Nullable : ValidationTestBase<Ar
     [Fact]
     public void incorrect_value_type()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
-                multipleReqs(req2: ""two"", req1: ""one"")
+                multipleReqs(req2: "two", req1: "one")
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "req2", "Int", "\"two\"", 3, 30);
-            Rule.badValue(_, "req1", "Int", "\"one\"", 3, 43);
+            Rule.badValue(_, "req2", "Int", "\"two\"", 3, 18);
+            Rule.badValue(_, "req1", "Int", "\"one\"", 3, 31);
         });
     }
 
     [Fact]
     public void incorrect_value_and_missing_argument()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
-                multipleReqs(req1: ""one"")
+                multipleReqs(req1: "one")
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "req1", "Int", "\"one\"", 3, 30);
+            Rule.badValue(_, "req1", "Int", "\"one\"", 3, 18);
         });
     }
 
@@ -727,16 +831,18 @@ public class ArgumentsOfCorrectType_Invalid_Non_Nullable : ValidationTestBase<Ar
     [Fact]
     public void multiple_args_with_one_null()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 multipleReqs(req1: null)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "req1", "Int", "null", 3, 30, "Expected 'Int!', found null.");
+            Rule.badValue(_, "req1", "Int", "null", 3, 18, "Expected 'Int!', found null.");
         });
     }
 
@@ -744,16 +850,18 @@ public class ArgumentsOfCorrectType_Invalid_Non_Nullable : ValidationTestBase<Ar
     [Fact]
     public void multiple_args_with_second_null()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 multipleReqs(req2: null)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "req2", "Int", "null", 3, 30, "Expected 'Int!', found null.");
+            Rule.badValue(_, "req2", "Int", "null", 3, 18, "Expected 'Int!', found null.");
         });
     }
 
@@ -761,17 +869,19 @@ public class ArgumentsOfCorrectType_Invalid_Non_Nullable : ValidationTestBase<Ar
     [Fact]
     public void multiple_args_with_both_null()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 multipleReqs(req2: null, req1: null)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "req2", "Int", "null", 3, 30, "Expected 'Int!', found null.");
-            Rule.badValue(_, "req1", "Int", "null", 3, 42, "Expected 'Int!', found null.");
+            Rule.badValue(_, "req2", "Int", "null", 3, 18, "Expected 'Int!', found null.");
+            Rule.badValue(_, "req1", "Int", "null", 3, 30, "Expected 'Int!', found null.");
         });
     }
 }
@@ -781,31 +891,37 @@ public class ArgumentsOfCorrectType_valid_input_object : ValidationTestBase<Argu
     [Fact]
     public void optional_arg_despite_required_field_in_type()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 complexArgField
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void partial_object_only_required()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 complexArgField(complexArg: { requiredField: true })
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void partial_object_required_field_can_be_false()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 complexArgField(complexArg: { requiredField: false })
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
@@ -813,55 +929,63 @@ public class ArgumentsOfCorrectType_valid_input_object : ValidationTestBase<Argu
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"{
+            _.Query = """
+            {
               complicatedArgs {
                 complexArgField(complexArg: { })
               }
-            }";
-            Rule.badValue(_, "complexArg", "Boolean", "null", 3, 33, "Missing required field 'requiredField' of type 'Boolean'.");
+            }
+            """;
+            Rule.badValue(_, "complexArg", "Boolean", "null", 3, 21, "Missing required field 'requiredField' of type 'Boolean'.");
         });
     }
 
     [Fact]
     public void partial_object_including_required()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 complexArgField(complexArg: { requiredField: true, intField: 4 })
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void full_object()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 complexArgField(complexArg: {
                   requiredField: true,
                   intField: 4,
-                  stringField: ""foo"",
+                  stringField: "foo",
                   booleanField: false,
-                  stringListField: [""one"", ""two""]
+                  stringListField: ["one", "two"]
                 })
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void full_object_with_fields_in_different_order()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               complicatedArgs {
                 complexArgField(complexArg: {
-                  stringListField: [""one"", ""two""],
+                  stringListField: ["one", "two"],
                   booleanField: false,
                   requiredField: true,
-                  stringField: ""foo""
+                  stringField: "foo"
                   intField: 4,
                 })
               }
-            }");
+            }
+            """);
     }
 }
 
@@ -870,54 +994,60 @@ public class ArgumentsOfCorrectType_invalid_input_object_value : ValidationTestB
     [Fact]
     public void partial_object_missing_required()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 complexArgField(complexArg: { intField: 4 })
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "complexArg", "ComplexInput", "{intField: 4}", 3, 33, "Missing required field 'requiredField' of type 'Boolean'.");
+            Rule.badValue(_, "complexArg", "ComplexInput", "{intField: 4}", 3, 21, "Missing required field 'requiredField' of type 'Boolean'.");
         });
     }
 
     [Fact]
     public void partial_object_invalid_field_type()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 complexArgField(complexArg: {
-                  stringListField: [""one"", 2],
+                  stringListField: ["one", 2],
                   requiredField: true,
                 })
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "complexArg", "ComplexInput", "{stringListField: [\"one\", 2], requiredField: true}", 3, 33, "In field 'stringListField': [In element #2: [Expected type 'String', found 2.]]");
+            Rule.badValue(_, "complexArg", "ComplexInput", "{stringListField: [\"one\", 2], requiredField: true}", 3, 21, "In field 'stringListField': [In element #2: [Expected type 'String', found 2.]]");
         });
     }
 
     [Fact]
     public void partial_object_unknown_field_arg()
     {
-        var query = @"{
+        var query = """
+            {
               complicatedArgs {
                 complexArgField(complexArg: {
                   requiredField: true,
-                  unknownField: ""value""
+                  unknownField: "value"
                 })
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "complexArg", "ComplexInput", "{requiredField: true, unknownField: \"value\"}", 3, 33, "In field 'unknownField': Unknown field.");
+            Rule.badValue(_, "complexArg", "ComplexInput", "{requiredField: true, unknownField: \"value\"}", 3, 21, "In field 'unknownField': Unknown field.");
         });
     }
 }
@@ -927,30 +1057,34 @@ public class ArgumentsOfCorrectType_directive_arguments : ValidationTestBase<Arg
     [Fact]
     public void with_directives_of_valid_types()
     {
-        ShouldPassRule(@"{
+        ShouldPassRule("""
+            {
               dog @include(if: true) {
                 name
               }
               human @skip(if: false) {
                 name
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
     public void with_directives_with_incorrect_types()
     {
-        var query = @"{
-              dog @include(if: ""yes"") {
+        var query = """
+            {
+              dog @include(if: "yes") {
                 name @skip(if: ENUM)
               }
-            }";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            Rule.badValue(_, "if", "Boolean", "\"yes\"", 2, 28);
-            Rule.badValue(_, "if", "Boolean", "ENUM", 3, 28);
+            Rule.badValue(_, "if", "Boolean", "\"yes\"", 2, 16);
+            Rule.badValue(_, "if", "Boolean", "ENUM", 3, 16);
         });
     }
 }

--- a/src/GraphQL.Tests/Validation/DefaultValuesOfCorrectTypeTests.cs
+++ b/src/GraphQL.Tests/Validation/DefaultValuesOfCorrectTypeTests.cs
@@ -8,45 +8,46 @@ public class DefaultValuesOfCorrectTypeTests : ValidationTestBase<DefaultValuesO
     [Fact]
     public void variables_with_no_default_values()
     {
-        ShouldPassRule(@"
-              query NullableValues($a: Int, $b: String, $c: ComplexInput) {
-                dog { name }
-              }
-            ");
+        ShouldPassRule("""
+            query NullableValues($a: Int, $b: String, $c: ComplexInput) {
+              dog { name }
+            }
+            """);
     }
 
     [Fact]
     public void required_variables_without_default_values()
     {
-        ShouldPassRule(@"
-              query RequiredValues($a: Int!, $b: String!) {
-                dog { name }
-              }
-            ",
+        ShouldPassRule("""
+            query RequiredValues($a: Int!, $b: String!) {
+              dog { name }
+            }
+            """,
         "{ \"a\": 1, \"b\": \"\" }");
     }
 
     [Fact]
     public void variables_with_valid_default_values()
     {
-        ShouldPassRule(@"
-              query WithDefaultValues(
-                $a: Int = 1,
-                $b: String = ""ok"",
-                $c: ComplexInput = { requiredField: true, intField: 3 }
+        ShouldPassRule("""
+            query WithDefaultValues(
+              $a: Int = 1,
+              $b: String = "ok",
+              $c: ComplexInput = { requiredField: true, intField: 3 }
               ) {
-                  dog { name }
-                }
-            ");
+              dog { name }
+            }
+            """);
     }
 
     [Fact]
     public void allows_required_variables_with_default_values()
     {
-        ShouldPassRule(@"
-                query UnreachableDefaultValues($a: Int! = 3, $b: String! = ""default"") {
-                    dog { name }
-                }");
+        ShouldPassRule("""
+            query UnreachableDefaultValues($a: Int! = 3, $b: String! = "default") {
+              dog { name }
+            }
+            """);
     }
 
     [Fact]
@@ -54,21 +55,22 @@ public class DefaultValuesOfCorrectTypeTests : ValidationTestBase<DefaultValuesO
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                    query InvalidDefaultValues(
-                        $a: Int = ""one"",
-                        $b: String = 4,
-                        $c: ComplexInput = ""notverycomplex""
-                    ) {
-                      dog { name }
-                    }";
+            _.Query = """
+                query InvalidDefaultValues(
+                  $a: Int = "one",
+                  $b: String = 4,
+                  $c: ComplexInput = "notverycomplex"
+                ) {
+                  dog { name }
+                }
+                """;
 
-            _.Error(BadValueForDefaultArgMessage("a", "Int", "\"one\"", "Expected type 'Int', found \"one\"."), 3, 35);
-            _.Error(BadValueForDefaultArgMessage("b", "String", "4", "Expected type 'String', found 4."), 4, 38);
-            _.Error(BadValueForDefaultArgMessage("c", "ComplexInput", "\"notverycomplex\"", "Expected 'ComplexInput', found not an object."), 5, 44);
-            _.Error("Variable '$a' is invalid. Error coercing default value.", 3, 25);
-            _.Error("Variable '$b' is invalid. Error coercing default value.", 4, 25);
-            _.Error("Variable '$c' is invalid. Error coercing default value.", 5, 25);
+            _.Error(BadValueForDefaultArgMessage("a", "Int", "\"one\"", "Expected type 'Int', found \"one\"."), 2, 13);
+            _.Error(BadValueForDefaultArgMessage("b", "String", "4", "Expected type 'String', found 4."), 3, 16);
+            _.Error(BadValueForDefaultArgMessage("c", "ComplexInput", "\"notverycomplex\"", "Expected 'ComplexInput', found not an object."), 4, 22);
+            _.Error("Variable '$a' is invalid. Error coercing default value.", 2, 3);
+            _.Error("Variable '$b' is invalid. Error coercing default value.", 3, 3);
+            _.Error("Variable '$c' is invalid. Error coercing default value.", 4, 3);
         });
     }
 
@@ -77,12 +79,13 @@ public class DefaultValuesOfCorrectTypeTests : ValidationTestBase<DefaultValuesO
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                    query MissingRequiredField($a: ComplexInput = {intField: 3}) {
-                      dog { name }
-                    }";
+            _.Query = """
+                query MissingRequiredField($a: ComplexInput = {intField: 3}) {
+                  dog { name }
+                }
+                """;
 
-            _.Error(BadValueForDefaultArgMessage("a", "ComplexInput", "{intField: 3}", "Missing required field 'requiredField' of type 'Boolean'."), 2, 67);
+            _.Error(BadValueForDefaultArgMessage("a", "ComplexInput", "{intField: 3}", "Missing required field 'requiredField' of type 'Boolean'."), 1, 47);
         });
     }
 
@@ -91,12 +94,13 @@ public class DefaultValuesOfCorrectTypeTests : ValidationTestBase<DefaultValuesO
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                    query InvalidItem($a: [String] = [""one"", 2]) {
-                      dog { name }
-                    }";
-            _.Error(BadValueForDefaultArgMessage("a", "[String]", "[\"one\", 2]", "In element #2: [Expected type 'String', found 2.]"), 2, 54);
-            _.Error("Variable '$a' is invalid. Error coercing default value.", 2, 39);
+            _.Query = """
+                query InvalidItem($a: [String] = ["one", 2]) {
+                  dog { name }
+                }
+                """;
+            _.Error(BadValueForDefaultArgMessage("a", "[String]", "[\"one\", 2]", "In element #2: [Expected type 'String', found 2.]"), 1, 34);
+            _.Error("Variable '$a' is invalid. Error coercing default value.", 1, 19);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/FieldsOnCorrectTypeTests.cs
+++ b/src/GraphQL.Tests/Validation/FieldsOnCorrectTypeTests.cs
@@ -8,64 +8,64 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     [Fact]
     public void object_field_selection()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment objectFieldSelection on Dog {
                 __typename
                 name
               }
-            ");
+            """);
     }
 
     [Fact]
     public void aliased_object_field_selection()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment aliasedObjectFieldSelection on Dog {
                 tn : __typename
                 otherName : name
               }
-            ");
+            """);
     }
 
     [Fact]
     public void interface_field_selection()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment interfaceFieldSelection on Pet {
                 __typename
                 name
               }
-            ");
+            """);
     }
 
     [Fact]
     public void aliased_interface_field_selection()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment interfaceFieldSelection on Pet {
                 otherName : name
               }
-            ");
+            """);
     }
 
     [Fact]
     public void lying_alias_selection()
     {
-        ShouldPassRule(@"
-              fragment lyingAliasSelection on Dog {
-                name : nickname
-              }
-            ");
+        ShouldPassRule("""
+            fragment lyingAliasSelection on Dog {
+              name : nickname
+            }
+            """);
     }
 
     [Fact]
     public void ignores_fields_on_unknown_type()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment unknownSelection on UnknownType {
                 unknownField
               }
-            ");
+            """);
     }
 
     [Fact]
@@ -73,18 +73,18 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment typeKnownAgain on Pet {
-                    unknown_pet_field {
-                      ... on Cat {
-                        unknown_cat_field
-                      }
+            _.Query = """
+                fragment typeKnownAgain on Pet {
+                  unknown_pet_field {
+                    ... on Cat {
+                      unknown_cat_field
                     }
                   }
-                ";
+                }
+                """;
 
-            undefinedField(_, "unknown_pet_field", "Pet", line: 3, column: 21);
-            undefinedField(_, "unknown_cat_field", "Cat", line: 5, column: 25);
+            undefinedField(_, "unknown_pet_field", "Pet", line: 2, column: 3);
+            undefinedField(_, "unknown_cat_field", "Cat", line: 4, column: 7);
         });
     }
 
@@ -93,13 +93,13 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment fieldNotDefined on Dog {
-                    meowVolume
-                  }
-                ";
+            _.Query = """
+                fragment fieldNotDefined on Dog {
+                  meowVolume
+                }
+                """;
 
-            undefinedField(_, "meowVolume", "Dog", suggestedFields: new[] { "barkVolume" }, line: 3, column: 21);
+            undefinedField(_, "meowVolume", "Dog", suggestedFields: new[] { "barkVolume" }, line: 2, column: 3);
         });
     }
 
@@ -108,15 +108,15 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment deepFieldNotDefined on Dog {
-                    unknown_field {
-                      deeper_unknown_field
-                    }
+            _.Query = """
+                fragment deepFieldNotDefined on Dog {
+                  unknown_field {
+                    deeper_unknown_field
                   }
-                ";
+                }
+                """;
 
-            undefinedField(_, "unknown_field", "Dog", line: 3, column: 21);
+            undefinedField(_, "unknown_field", "Dog", line: 2, column: 3);
         });
     }
 
@@ -125,15 +125,15 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment subFieldNotDefined on Human {
-                    pets {
-                      unknown_field
-                    }
+            _.Query = """
+                fragment subFieldNotDefined on Human {
+                  pets {
+                    unknown_field
                   }
-                ";
+                }
+                """;
 
-            undefinedField(_, "unknown_field", "Pet", line: 4, column: 23);
+            undefinedField(_, "unknown_field", "Pet", line: 3, column: 5);
         });
     }
 
@@ -142,15 +142,15 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment fieldNotDefined on Pet {
-                    ... on Dog {
-                      meowVolume
-                    }
+            _.Query = """
+                fragment fieldNotDefined on Pet {
+                  ... on Dog {
+                    meowVolume
                   }
-                ";
+                }
+                """;
 
-            undefinedField(_, "meowVolume", "Dog", suggestedFields: new[] { "barkVolume" }, line: 4, column: 23);
+            undefinedField(_, "meowVolume", "Dog", suggestedFields: new[] { "barkVolume" }, line: 3, column: 5);
         });
     }
 
@@ -159,13 +159,13 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment aliasedFieldTargetNotDefined on Dog {
-                    volume : mooVolume
-                  }
-                ";
+            _.Query = """
+                fragment aliasedFieldTargetNotDefined on Dog {
+                  volume : mooVolume
+                }
+                """;
 
-            undefinedField(_, "mooVolume", "Dog", suggestedFields: new[] { "barkVolume" }, line: 3, column: 21);
+            undefinedField(_, "mooVolume", "Dog", suggestedFields: new[] { "barkVolume" }, line: 2, column: 3);
         });
     }
 
@@ -174,13 +174,13 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment aliasedLyingFieldTargetNotDefined on Dog {
-                    barkVolume : kawVolume
-                  }
-                ";
+            _.Query = """
+                fragment aliasedLyingFieldTargetNotDefined on Dog {
+                  barkVolume : kawVolume
+                }
+                """;
 
-            undefinedField(_, "kawVolume", "Dog", suggestedFields: new[] { "barkVolume" }, line: 3, column: 21);
+            undefinedField(_, "kawVolume", "Dog", suggestedFields: new[] { "barkVolume" }, line: 2, column: 3);
         });
     }
 
@@ -189,13 +189,13 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment notDefinedOnInterface on Pet {
-                    tailLength
-                  }
-                ";
+            _.Query = """
+                fragment notDefinedOnInterface on Pet {
+                  tailLength
+                }
+                """;
 
-            undefinedField(_, "tailLength", "Pet", line: 3, column: 21);
+            undefinedField(_, "tailLength", "Pet", line: 2, column: 3);
         });
     }
 
@@ -204,24 +204,24 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment definedOnImplementorsButNotInterface on Pet {
-                    nickname
-                  }
-                ";
+            _.Query = """
+                fragment definedOnImplementorsButNotInterface on Pet {
+                  nickname
+                }
+                """;
 
-            undefinedField(_, "nickname", "Pet", suggestedTypes: new[] { "Dog", "Cat" }, line: 3, column: 21);
+            undefinedField(_, "nickname", "Pet", suggestedTypes: new[] { "Dog", "Cat" }, line: 2, column: 3);
         });
     }
 
     [Fact]
     public void meta_field_selection_on_union()
     {
-        ShouldPassRule(@"
-              fragment directFieldSelectionOnUnion on CatOrDog {
-                __typename
-              }
-            ");
+        ShouldPassRule("""
+            fragment directFieldSelectionOnUnion on CatOrDog {
+              __typename
+            }
+            """);
     }
 
     [Fact]
@@ -229,13 +229,13 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment directFieldSelectionOnUnion on CatOrDog {
-                    directField
-                  }
-                ";
+            _.Query = """
+                fragment directFieldSelectionOnUnion on CatOrDog {
+                  directField
+                }
+                """;
 
-            undefinedField(_, "directField", "CatOrDog", line: 3, column: 21);
+            undefinedField(_, "directField", "CatOrDog", line: 2, column: 3);
         });
     }
 
@@ -244,22 +244,22 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment definedOnImplementorsQueriedOnUnion on CatOrDog {
-                    name
-                  }
-                ";
+            _.Query = """
+                fragment definedOnImplementorsQueriedOnUnion on CatOrDog {
+                  name
+                }
+                """;
 
             undefinedField(_, "name", "CatOrDog",
                 suggestedTypes: new[] { "Canine", "Being", "Pet", "Cat", "Dog" },
-                line: 3, column: 21);
+                line: 2, column: 3);
         });
     }
 
     [Fact]
     public void valid_field_in_inline_fragment()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment objectFieldSelection on Pet {
                 ... on Dog {
                   name
@@ -268,7 +268,7 @@ public class FieldsOnCorrectTypeTests : ValidationTestBase<FieldsOnCorrectType, 
                   name
                 }
               }
-            ");
+            """);
     }
 
     private void undefinedField(

--- a/src/GraphQL.Tests/Validation/FragmentsOnCompositeTypesTests.cs
+++ b/src/GraphQL.Tests/Validation/FragmentsOnCompositeTypesTests.cs
@@ -8,55 +8,55 @@ public class FragmentsOnCompositeTypesTests : ValidationTestBase<FragmentsOnComp
     [Fact]
     public void object_is_valid_fragment_type()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment validFragment on Dog {
                 barks
               }
-            ");
+            """);
     }
 
     [Fact]
     public void interface_is_valid_fragment_type()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment validFragment on Pet {
                 name
               }
-            ");
+            """);
     }
 
     [Fact]
     public void object_is_valid_inline_fragment_type()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment validFragment on Pet {
                 ... on Dog {
                   barks
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void inline_fragment_without_type_is_valid()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment validFragment on Pet {
                 ... {
                   name
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void union_is_valid_fragment_type()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment validFragment on CatOrDog {
                 __typename
               }
-            ");
+            """);
     }
 
     [Fact]
@@ -64,12 +64,12 @@ public class FragmentsOnCompositeTypesTests : ValidationTestBase<FragmentsOnComp
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment scalarFragment on Boolean {
-                    bad
-                  }
-                ";
-            error(_, "scalarFragment", "Boolean", 2, 46);
+            _.Query = """
+                fragment scalarFragment on Boolean {
+                  bad
+                }
+                """;
+            error(_, "scalarFragment", "Boolean", 1, 28);
         });
     }
 
@@ -78,12 +78,12 @@ public class FragmentsOnCompositeTypesTests : ValidationTestBase<FragmentsOnComp
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment scalarFragment on FurColor {
-                    bad
-                  }
-                ";
-            error(_, "scalarFragment", "FurColor", 2, 46);
+            _.Query = """
+                fragment scalarFragment on FurColor {
+                  bad
+                }
+                """;
+            error(_, "scalarFragment", "FurColor", 1, 28);
         });
     }
 
@@ -92,12 +92,12 @@ public class FragmentsOnCompositeTypesTests : ValidationTestBase<FragmentsOnComp
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment inputFragment on ComplexInput {
-                    stringField
-                  }
-                ";
-            error(_, "inputFragment", "ComplexInput", 2, 45);
+            _.Query = """
+                fragment inputFragment on ComplexInput {
+                  stringField
+                }
+                """;
+            error(_, "inputFragment", "ComplexInput", 1, 27);
         });
     }
 
@@ -106,14 +106,14 @@ public class FragmentsOnCompositeTypesTests : ValidationTestBase<FragmentsOnComp
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  fragment invalidFragment on Pet {
-                    ... on String {
-                      barks
-                    }
+            _.Query = """
+                fragment invalidFragment on Pet {
+                  ... on String {
+                    barks
                   }
-                ";
-            _.Error(FragmentsOnCompositeTypesError.InlineFragmentOnNonCompositeErrorMessage("String"), 3, 28);
+                }
+                """;
+            _.Error(FragmentsOnCompositeTypesError.InlineFragmentOnNonCompositeErrorMessage("String"), 2, 10);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/InputFieldsAndArgumentsOfCorrectLengthRequiredTests.cs
+++ b/src/GraphQL.Tests/Validation/InputFieldsAndArgumentsOfCorrectLengthRequiredTests.cs
@@ -9,12 +9,13 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     [Fact]
     public void good_literal_input_field_length()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
-                complexArgField2(complexArg: { requiredField: true, stringField: ""aaaa"" })
+                complexArgField2(complexArg: { requiredField: true, stringField: "aaaa" })
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
@@ -22,12 +23,14 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   complicatedArgs {
                     complexArgField2(complexArg: { requiredField: true, stringField: $value })
                   }
-                }";
+                }
+                """;
             _.Variables = new Dictionary<string, object> { ["value"] = "aaaa" }.ToInputs();
         });
     }
@@ -37,16 +40,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   complicatedArgs {
-                    complexArgField2(complexArg: { requiredField: true, stringField: ""aa"" })
+                    complexArgField2(complexArg: { requiredField: true, stringField: "aa" })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (2). Length must be in range [3, 7].",
-               line: 4,
-               column: 73);
+               line: 3,
+               column: 57);
         });
     }
 
@@ -55,16 +59,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   complicatedArgs {
                     complexArgField2(complexArg: { requiredField: true, stringField: $value })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (2). Length must be in range [3, 7].",
                line: 4,
-               column: 73);
+               column: 57);
             _.Variables = new Dictionary<string, object> { ["value"] = "aa" }.ToInputs();
         });
     }
@@ -74,16 +80,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   complicatedArgs {
-                    complexArgField2(complexArg: { requiredField: true, stringField: ""aaaaaaaa"" })
+                    complexArgField2(complexArg: { requiredField: true, stringField: "aaaaaaaa" })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (8). Length must be in range [3, 7].",
-               line: 4,
-               column: 73);
+               line: 3,
+               column: 57);
         });
     }
 
@@ -92,16 +99,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
-                {
+            _.Query = """
+               query q($value: String)
+               {
                   complicatedArgs {
                     complexArgField2(complexArg: { requiredField: true, stringField: $value })
                   }
-                }";
+               }
+               """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (8). Length must be in range [3, 7].",
                line: 4,
-               column: 73);
+               column: 58);
             _.Variables = new Dictionary<string, object> { ["value"] = "aaaaaaaa" }.ToInputs();
         });
     }
@@ -111,16 +120,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   complicatedArgs {
                     complexArgField2(complexArg: { requiredField: true, stringField: null })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (null). Length must be in range [3, 7].",
-               line: 4,
-               column: 73);
+               line: 3,
+               column: 57);
         });
     }
 
@@ -129,16 +139,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   complicatedArgs {
                     complexArgField2(complexArg: { requiredField: true, stringField: $value })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (null). Length must be in range [3, 7].",
                line: 4,
-               column: 73);
+               column: 57);
             _.Variables = new Dictionary<string, object> { ["value"] = null }.ToInputs();
         });
     }
@@ -150,13 +162,15 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"query q($complex: ComplexInput2!)
+            _.Query = """
+                query q($complex: ComplexInput2!)
                 {
                   complicatedArgs {
                     complexArgField2(complexArg: $complex)
                   }
-                }";
-            _.Variables = @"{ ""complex"": { ""requiredField"": true, ""stringField"": ""aaaa"" } }".ToInputs();
+                }
+                """;
+            _.Variables = """{ "complex": { "requiredField": true, "stringField": "aaaa" } }""".ToInputs();
         });
     }
 
@@ -165,17 +179,19 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($complex: ComplexInput2!)
+            _.Query = """
+                query q($complex: ComplexInput2!)
                 {
                   complicatedArgs {
                     complexArgField2(complexArg: $complex)
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Variable 'complex.stringField' has invalid length (2). Length must be in range [3, 7].",
                line: 1,
                column: 9);
-            _.Variables = @"{ ""complex"": { ""requiredField"": true, ""stringField"": ""aa"" } }".ToInputs();
+            _.Variables = """{ "complex": { "requiredField": true, "stringField": "aa" } }""".ToInputs();
         });
     }
 
@@ -184,17 +200,19 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($complex: ComplexInput2!)
+            _.Query = """
+                query q($complex: ComplexInput2!)
                 {
                   complicatedArgs {
                     complexArgField2(complexArg: $complex)
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Variable 'complex.stringField' has invalid length (8). Length must be in range [3, 7].",
                line: 1,
                column: 9);
-            _.Variables = @"{ ""complex"": { ""requiredField"": true, ""stringField"": ""aaaaaaaa"" } }".ToInputs();
+            _.Variables = """{ "complex": { "requiredField": true, "stringField": "aaaaaaaa" } }""".ToInputs();
         });
     }
 
@@ -203,17 +221,19 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($complex: ComplexInput2!)
+            _.Query = """
+                query q($complex: ComplexInput2!)
                 {
                   complicatedArgs {
                     complexArgField2(complexArg: $complex)
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Variable '$complex.stringField' is invalid. Received a null input for a non-null variable.",
                line: 1,
                column: 9);
-            _.Variables = @"{ ""complex"": { ""requiredField"": true, ""stringField"": null } }".ToInputs();
+            _.Variables = """{ "complex": { "requiredField": true, "stringField": null } }""".ToInputs();
         });
     }
 
@@ -222,12 +242,13 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     [Fact]
     public void good_literal_argument_length()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
-              human2(id: ""aaa"") {
+              human2(id: "aaa") {
                 id
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
@@ -235,12 +256,14 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   human2(id: $value) {
                     id
                   }
-                }";
+                }
+                """;
             _.Variables = new Dictionary<string, object> { ["value"] = "aaa" }.ToInputs();
         });
     }
@@ -250,16 +273,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
-                  human2(id: ""a"") {
+                  human2(id: "a") {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (1). Length must be in range [2, 5].",
-               line: 3,
-               column: 26);
+               line: 2,
+               column: 10);
         });
     }
 
@@ -268,16 +292,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   human2(id: $value) {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (1). Length must be in range [2, 5].",
                line: 3,
-               column: 26);
+               column: 10);
             _.Variables = new Dictionary<string, object> { ["value"] = "a" }.ToInputs();
         });
     }
@@ -287,16 +313,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
-                  human2(id: ""aaaaaa"") {
+                  human2(id: "aaaaaa") {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (6). Length must be in range [2, 5].",
-               line: 3,
-               column: 26);
+               line: 2,
+               column: 10);
         });
     }
 
@@ -305,16 +332,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   human2(id: $value) {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (6). Length must be in range [2, 5].",
                line: 3,
-               column: 26);
+               column: 10);
             _.Variables = new Dictionary<string, object> { ["value"] = "aaaaaa" }.ToInputs();
         });
     }
@@ -324,16 +353,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   human2(id: null) {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (null). Length must be in range [2, 5].",
-               line: 3,
-               column: 26);
+               line: 2,
+               column: 10);
         });
     }
 
@@ -342,16 +372,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthRequiredTests : ValidationTes
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   human2(id: $value) {
                     id
-                  }
-                }";
+                   }
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (null). Length must be in range [2, 5].",
                line: 3,
-               column: 26);
+               column: 10);
             _.Variables = new Dictionary<string, object> { ["value"] = null }.ToInputs();
         });
     }

--- a/src/GraphQL.Tests/Validation/InputFieldsAndArgumentsOfCorrectLengthTests.cs
+++ b/src/GraphQL.Tests/Validation/InputFieldsAndArgumentsOfCorrectLengthTests.cs
@@ -9,12 +9,13 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     [Fact]
     public void good_literal_input_field_length()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
-                complexArgField(complexArg: { requiredField: true, stringField: ""aaaa"" })
+                complexArgField(complexArg: { requiredField: true, stringField: "aaaa" })
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
@@ -22,12 +23,14 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   complicatedArgs {
                     complexArgField(complexArg: { requiredField: true, stringField: $value })
                   }
-                }";
+                }
+                """;
             _.Variables = new Dictionary<string, object> { ["value"] = "aaaa" }.ToInputs();
         });
     }
@@ -37,16 +40,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   complicatedArgs {
-                    complexArgField(complexArg: { requiredField: true, stringField: ""aa"" })
+                    complexArgField(complexArg: { requiredField: true, stringField: "aa" })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (2). Length must be in range [3, 7].",
-               line: 4,
-               column: 72);
+               line: 3,
+               column: 56);
         });
     }
 
@@ -55,16 +59,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   complicatedArgs {
                     complexArgField(complexArg: { requiredField: true, stringField: $value })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (2). Length must be in range [3, 7].",
                line: 4,
-               column: 72);
+               column: 56);
             _.Variables = new Dictionary<string, object> { ["value"] = "aa" }.ToInputs();
         });
     }
@@ -74,16 +80,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   complicatedArgs {
-                    complexArgField(complexArg: { requiredField: true, stringField: ""aaaaaaaa"" })
+                    complexArgField(complexArg: { requiredField: true, stringField: "aaaaaaaa" })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (8). Length must be in range [3, 7].",
-               line: 4,
-               column: 72);
+               line: 3,
+               column: 56);
         });
     }
 
@@ -92,16 +99,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   complicatedArgs {
                     complexArgField(complexArg: { requiredField: true, stringField: $value })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (8). Length must be in range [3, 7].",
                line: 4,
-               column: 72);
+               column: 56);
             _.Variables = new Dictionary<string, object> { ["value"] = "aaaaaaaa" }.ToInputs();
         });
     }
@@ -111,16 +120,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   complicatedArgs {
                     complexArgField(complexArg: { requiredField: true, stringField: null })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (null). Length must be in range [3, 7].",
-               line: 4,
-               column: 72);
+               line: 3,
+               column: 56);
         });
     }
 
@@ -129,16 +139,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   complicatedArgs {
                     complexArgField(complexArg: { requiredField: true, stringField: $value })
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "ObjectField 'stringField' has invalid length (null). Length must be in range [3, 7].",
                line: 4,
-               column: 72);
+               column: 56);
             _.Variables = new Dictionary<string, object> { ["value"] = null }.ToInputs();
         });
     }
@@ -150,13 +162,15 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"query q($complex: ComplexInput!)
+            _.Query = """
+                query q($complex: ComplexInput!)
                 {
                   complicatedArgs {
                     complexArgField(complexArg: $complex)
                   }
-                }";
-            _.Variables = @"{ ""complex"": { ""requiredField"": true, ""stringField"": ""aaaa"" } }".ToInputs();
+                }
+                """;
+            _.Variables = """{ "complex": { "requiredField": true, "stringField": "aaaa" } }""".ToInputs();
         });
     }
 
@@ -165,17 +179,19 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($complex: ComplexInput!)
+            _.Query = """
+                query q($complex: ComplexInput!)
                 {
                   complicatedArgs {
                     complexArgField(complexArg: $complex)
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Variable 'complex.stringField' has invalid length (2). Length must be in range [3, 7].",
                line: 1,
                column: 9);
-            _.Variables = @"{ ""complex"": { ""requiredField"": true, ""stringField"": ""aa"" } }".ToInputs();
+            _.Variables = """{ "complex": { "requiredField": true, "stringField": "aa" } }""".ToInputs();
         });
     }
 
@@ -184,17 +200,19 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($complex: ComplexInput!)
+            _.Query = """
+                query q($complex: ComplexInput!)
                 {
                   complicatedArgs {
                     complexArgField(complexArg: $complex)
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Variable 'complex.stringField' has invalid length (8). Length must be in range [3, 7].",
                line: 1,
                column: 9);
-            _.Variables = @"{ ""complex"": { ""requiredField"": true, ""stringField"": ""aaaaaaaa"" } }".ToInputs();
+            _.Variables = """{ "complex": { "requiredField": true, "stringField": "aaaaaaaa" } }""".ToInputs();
         });
     }
 
@@ -203,17 +221,19 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($complex: ComplexInput!)
+            _.Query = """
+                query q($complex: ComplexInput!)
                 {
                   complicatedArgs {
                     complexArgField(complexArg: $complex)
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Variable 'complex.stringField' has invalid length (null). Length must be in range [3, 7].",
                line: 1,
                column: 9);
-            _.Variables = @"{ ""complex"": { ""requiredField"": true, ""stringField"": null } }".ToInputs();
+            _.Variables = """{ "complex": { "requiredField": true, "stringField": null } }""".ToInputs();
         });
     }
 
@@ -222,12 +242,13 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     [Fact]
     public void good_literal_argument_length()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
-              human(id: ""aaa"") {
+              human(id: "aaa") {
                 id
               }
-            }");
+            }
+            """);
     }
 
     [Fact]
@@ -235,12 +256,14 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   human(id: $value) {
                     id
                   }
-                }";
+                }
+                """;
             _.Variables = new Dictionary<string, object> { ["value"] = "aaa" }.ToInputs();
         });
     }
@@ -250,16 +273,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
-                  human(id: ""a"") {
+                  human(id: "a") {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (1). Length must be in range [2, 5].",
-               line: 3,
-               column: 25);
+               line: 2,
+               column: 9);
         });
     }
 
@@ -268,16 +292,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   human(id: $value) {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (1). Length must be in range [2, 5].",
                line: 3,
-               column: 25);
+               column: 9);
             _.Variables = new Dictionary<string, object> { ["value"] = "a" }.ToInputs();
         });
     }
@@ -287,16 +313,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
-                  human(id: ""aaaaaa"") {
+                  human(id: "aaaaaa") {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (6). Length must be in range [2, 5].",
-               line: 3,
-               column: 25);
+               line: 2,
+               column: 9);
         });
     }
 
@@ -305,16 +332,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   human(id: $value) {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (6). Length must be in range [2, 5].",
                line: 3,
-               column: 25);
+               column: 9);
             _.Variables = new Dictionary<string, object> { ["value"] = "aaaaaa" }.ToInputs();
         });
     }
@@ -324,16 +353,17 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   human(id: null) {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (null). Length must be in range [2, 5].",
-               line: 3,
-               column: 25);
+               line: 2,
+               column: 9);
         });
     }
 
@@ -342,16 +372,18 @@ public class InputFieldsAndArgumentsOfCorrectLengthTests : ValidationTestBase<In
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"query q($value: String)
+            _.Query = """
+                query q($value: String)
                 {
                   human(id: $value) {
                     id
                   }
-                }";
+                }
+                """;
             _.Error(
                message: "Argument 'id' has invalid length (null). Length must be in range [2, 5].",
                line: 3,
-               column: 25);
+               column: 9);
             _.Variables = new Dictionary<string, object> { ["value"] = null }.ToInputs();
         });
     }

--- a/src/GraphQL.Tests/Validation/KnownArgumentNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/KnownArgumentNamesTests.cs
@@ -8,67 +8,67 @@ public class KnownArgumentNamesTests : ValidationTestBase<KnownArgumentNames, Va
     [Fact]
     public void single_arg_is_known()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment argOnRequiredArg on Dog {
                 doesKnowCommand(dogCommand: SIT)
               }
-            ");
+            """);
     }
 
     [Fact]
     public void no_args_are_known()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment multipleArgs on ComplicatedArgs {
                 noArgsField
               }
-            ");
+            """);
     }
 
     [Fact]
     public void multiple_args_are_known()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment multipleArgs on ComplicatedArgs {
                 multipleReqs(req1: 1, req2: 2)
               }
-            ");
+            """);
     }
 
     [Fact]
     public void ignores_args_of_unknown_fields()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment argOnUnknownField on Dog {
                 unknownField(unknownArg: SIT)
               }
-            ");
+            """);
     }
 
     [Fact]
     public void multiple_args_in_reverse_order_are_known()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment multipleArgsReverseOrder on ComplicatedArgs {
                 multipleReqs(req2: 2, req1: 1)
               }
-            ");
+            """);
     }
 
     [Fact]
     public void no_args_on_optional_arg()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment noArgOnOptionalArg on Dog {
                 isHousetrained
               }
-            ");
+            """);
     }
 
     [Fact]
     public void args_are_known_deeply()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               {
                 dog {
                   doesKnowCommand(dogCommand: SIT)
@@ -81,17 +81,17 @@ public class KnownArgumentNamesTests : ValidationTestBase<KnownArgumentNames, Va
                   }
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void directive_args_are_known()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               {
                 dog @skip(if: true)
               }
-            ");
+            """);
     }
 
     [Fact]
@@ -99,12 +99,12 @@ public class KnownArgumentNamesTests : ValidationTestBase<KnownArgumentNames, Va
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment multipleArgs on ComplicatedArgs {
                     noArgsField(first: 1)
                   }
-                ";
-            _.Error(KnownArgumentNamesError.UnknownArgMessage("first", "noArgsField", "ComplicatedArgs", null), 3, 33);
+                """;
+            _.Error(KnownArgumentNamesError.UnknownArgMessage("first", "noArgsField", "ComplicatedArgs", null), 2, 17);
         });
     }
 
@@ -113,12 +113,12 @@ public class KnownArgumentNamesTests : ValidationTestBase<KnownArgumentNames, Va
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   {
                     dog @skip(unless: true)
                   }
-                ";
-            _.Error(KnownArgumentNamesError.UnknownDirectiveArgMessage("unless", "skip", null), 3, 31);
+                """;
+            _.Error(KnownArgumentNamesError.UnknownDirectiveArgMessage("unless", "skip", null), 2, 15);
         });
     }
 
@@ -127,13 +127,13 @@ public class KnownArgumentNamesTests : ValidationTestBase<KnownArgumentNames, Va
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment oneGoodArgOneInvalidArg on Dog {
                     doesKnowCommand(whoknows: 1, dogCommand: SIT, unknown: true)
                   }
-                ";
-            _.Error(KnownArgumentNamesError.UnknownArgMessage("whoknows", "doesKnowCommand", "Dog", null), 3, 37);
-            _.Error(KnownArgumentNamesError.UnknownArgMessage("unknown", "doesKnowCommand", "Dog", null), 3, 67);
+                """;
+            _.Error(KnownArgumentNamesError.UnknownArgMessage("whoknows", "doesKnowCommand", "Dog", null), 2, 21);
+            _.Error(KnownArgumentNamesError.UnknownArgMessage("unknown", "doesKnowCommand", "Dog", null), 2, 51);
         });
     }
 
@@ -142,7 +142,7 @@ public class KnownArgumentNamesTests : ValidationTestBase<KnownArgumentNames, Va
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   {
                     dog {
                       doesKnowCommand(unknown: true)
@@ -155,9 +155,9 @@ public class KnownArgumentNamesTests : ValidationTestBase<KnownArgumentNames, Va
                       }
                     }
                   }
-                ";
-            _.Error(KnownArgumentNamesError.UnknownArgMessage("unknown", "doesKnowCommand", "Dog", null), 4, 39);
-            _.Error(KnownArgumentNamesError.UnknownArgMessage("unknown", "doesKnowCommand", "Dog", null), 9, 43);
+                """;
+            _.Error(KnownArgumentNamesError.UnknownArgMessage("unknown", "doesKnowCommand", "Dog", null), 3, 23);
+            _.Error(KnownArgumentNamesError.UnknownArgMessage("unknown", "doesKnowCommand", "Dog", null), 8, 27);
         });
     }
 }

--- a/src/GraphQL.Tests/Validation/KnownDirectivesTests.cs
+++ b/src/GraphQL.Tests/Validation/KnownDirectivesTests.cs
@@ -18,7 +18,7 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
     [Fact]
     public void with_no_directives()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Foo {
                 name
                 ...Frag
@@ -26,13 +26,13 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
               fragment Frag on Dog {
                 name
               }
-            ");
+            """);
     }
 
     [Fact]
     public void with_known_directives()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               {
                 dog @include(if: true) {
                   name
@@ -41,7 +41,7 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
                   name
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
@@ -49,14 +49,14 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   {
-                    dog @unknown(directive: ""value"") {
+                    dog @unknown(directive: "value") {
                       name
                     }
                   }
-                ";
-            unknownDirective(_, "unknown", 3, 25);
+                """;
+            unknownDirective(_, "unknown", 2, 9);
         });
     }
 
@@ -65,29 +65,29 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   {
-                    dog @unknown(directive: ""value"") {
+                    dog @unknown(directive: "value") {
                       name
                     }
-                    human @unknown(directive: ""value"") {
+                    human @unknown(directive: "value") {
                       name
-                      pets @unknown(directive: ""value"") {
+                      pets @unknown(directive: "value") {
                         name
                       }
                     }
                   }
-                ";
-            unknownDirective(_, "unknown", 3, 25);
-            unknownDirective(_, "unknown", 6, 27);
-            unknownDirective(_, "unknown", 8, 28);
+                """;
+            unknownDirective(_, "unknown", 2, 9);
+            unknownDirective(_, "unknown", 5, 11);
+            unknownDirective(_, "unknown", 7, 12);
         });
     }
 
     [Fact]
     public void with_well_placed_directives()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Foo @onQuery {
                 name @include(if: true)
                 ...Frag @include(if: true)
@@ -98,7 +98,7 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
               mutation Bar @onMutation {
                 someField
               }
-            ");
+            """);
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo @include(if: true) {
                     name @onQuery
                     ...Frag @onQuery
@@ -115,12 +115,12 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
                   mutation Bar @onQuery {
                     someField
                   }
-                ";
+                """;
 
-            misplacedDirective(_, "include", DirectiveLocation.Query, 2, 29);
-            misplacedDirective(_, "onQuery", DirectiveLocation.Field, 3, 26);
-            misplacedDirective(_, "onQuery", DirectiveLocation.FragmentSpread, 4, 29);
-            misplacedDirective(_, "onQuery", DirectiveLocation.Mutation, 7, 32);
+            misplacedDirective(_, "include", DirectiveLocation.Query, 1, 13);
+            misplacedDirective(_, "onQuery", DirectiveLocation.Field, 2, 10);
+            misplacedDirective(_, "onQuery", DirectiveLocation.FragmentSpread, 3, 13);
+            misplacedDirective(_, "onQuery", DirectiveLocation.Mutation, 6, 16);
         });
     }
 
@@ -129,7 +129,7 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   type MyObj implements MyInterface @onObject {
                     myField(myArg: Int @onArgumentDefinition): String @onFieldDefinition
                   }
@@ -153,20 +153,20 @@ public class KnownDirectivesTests : ValidationTestBase<KnownDirectivesInAllowedL
                   schema @onSchema {
                     query: MyQuery
                   }
-                ";
-            unknownDirective(_, "onObject", 2, 53);
-            unknownDirective(_, "onArgumentDefinition", 3, 40);
-            unknownDirective(_, "onFieldDefinition", 3, 71);
-            unknownDirective(_, "onScalar", 6, 35);
-            unknownDirective(_, "onInterface", 8, 41);
-            unknownDirective(_, "onArgumentDefinition", 9, 40);
-            unknownDirective(_, "onFieldDefinition", 9, 71);
-            unknownDirective(_, "onUnion", 12, 33);
-            unknownDirective(_, "onEnum", 14, 31);
-            unknownDirective(_, "onEnumValue", 15, 30);
-            unknownDirective(_, "onInputObject", 18, 33);
-            unknownDirective(_, "onInputFieldDefinition", 19, 34);
-            unknownDirective(_, "onSchema", 22, 26);
+                """;
+            unknownDirective(_, "onObject", 1, 37);
+            unknownDirective(_, "onArgumentDefinition", 2, 24);
+            unknownDirective(_, "onFieldDefinition", 2, 55);
+            unknownDirective(_, "onScalar", 5, 19);
+            unknownDirective(_, "onInterface", 7, 25);
+            unknownDirective(_, "onArgumentDefinition", 8, 24);
+            unknownDirective(_, "onFieldDefinition", 8, 55);
+            unknownDirective(_, "onUnion", 11, 17);
+            unknownDirective(_, "onEnum", 13, 15);
+            unknownDirective(_, "onEnumValue", 14, 14);
+            unknownDirective(_, "onInputObject", 17, 17);
+            unknownDirective(_, "onInputFieldDefinition", 18, 18);
+            unknownDirective(_, "onSchema", 21, 10);
         });
     }
 }

--- a/src/GraphQL.Tests/Validation/KnownFragmentNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/KnownFragmentNamesTests.cs
@@ -8,7 +8,7 @@ public class KnownFragmentNamesTests : ValidationTestBase<KnownFragmentNames, Va
     [Fact]
     public void known_fragment_names_are_valid()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
           human(id: 4) {
             ...HumanFields1
@@ -30,7 +30,7 @@ public class KnownFragmentNamesTests : ValidationTestBase<KnownFragmentNames, Va
         fragment HumanFields3 on Human {
           name
         }
-      ");
+      """);
     }
 
     [Fact]
@@ -38,23 +38,23 @@ public class KnownFragmentNamesTests : ValidationTestBase<KnownFragmentNames, Va
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          {
-            human(id: 4) {
-              ...UnknownFragment1
-              ... on Human {
+            _.Query = """
+            {
+              human(id: 4) {
+                ...UnknownFragment1
+                ... on Human {
                 ...UnknownFragment2
+                }
               }
             }
-          }
-          fragment HumanFields on Human {
-            name
-            ...UnknownFragment3
-          }
-        ";
-            undefFrag(_, "UnknownFragment1", 4, 15);
-            undefFrag(_, "UnknownFragment2", 6, 17);
-            undefFrag(_, "UnknownFragment3", 12, 13);
+            fragment HumanFields on Human {
+              name
+              ...UnknownFragment3
+            }
+            """;
+            undefFrag(_, "UnknownFragment1", 3, 5);
+            undefFrag(_, "UnknownFragment2", 5, 5);
+            undefFrag(_, "UnknownFragment3", 11, 3);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/KnownTypeNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/KnownTypeNamesTests.cs
@@ -8,7 +8,7 @@ public class KnownTypeNamesTests : ValidationTestBase<KnownTypeNames, Validation
     [Fact]
     public void known_type_names_are_valid()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Foo($var: String, $required: [String!]!) {
                 user(id: 4) {
                   pets {
@@ -20,7 +20,7 @@ public class KnownTypeNamesTests : ValidationTestBase<KnownTypeNames, Validation
               fragment PetFields on Pet {
                 name
               }
-            ",
+            """,
         "{ \"required\": [\"\"] }");
     }
 
@@ -29,20 +29,21 @@ public class KnownTypeNamesTests : ValidationTestBase<KnownTypeNames, Validation
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                    query Foo($var: Abcd!) {
-                        user(id: 4) {
-                            pets {
-                                ... on Pet { name },
-                                ...PetFields
-                            }
+            _.Query = """
+                query Foo($var: Abcd!) {
+                    user(id: 4) {
+                        pets {
+                            ... on Pet { name },
+                            ...PetFields
                         }
                     }
-                    fragment PetFields on Pet {
-                        name
-                    }";
-            _.Error(KnownTypeNamesError.UnknownTypeMessage("Abcd", null), 2, 37);
-            _.Error("Variable '$var' is invalid. Variable has unknown type 'Abcd'", 2, 31);
+                }
+                fragment PetFields on Pet {
+                    name
+                }
+                """;
+            _.Error(KnownTypeNamesError.UnknownTypeMessage("Abcd", null), 1, 17);
+            _.Error("Variable '$var' is invalid. Variable has unknown type 'Abcd'", 1, 11);
         });
     }
 
@@ -51,7 +52,7 @@ public class KnownTypeNamesTests : ValidationTestBase<KnownTypeNames, Validation
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($var: JumbledUpLetters) {
                     user(id: 4) {
                       name
@@ -61,11 +62,11 @@ public class KnownTypeNamesTests : ValidationTestBase<KnownTypeNames, Validation
                   fragment PetFields on Peettt {
                     name
                   }
-                ";
-            _.Error(KnownTypeNamesError.UnknownTypeMessage("JumbledUpLetters", null), 2, 35);
-            _.Error(KnownTypeNamesError.UnknownTypeMessage("Badger", null), 5, 37);
-            _.Error(KnownTypeNamesError.UnknownTypeMessage("Peettt", new[] { "Pet" }), 8, 41);
-            _.Error("Variable '$var' is invalid. Variable has unknown type 'JumbledUpLetters'", 2, 29);
+                """;
+            _.Error(KnownTypeNamesError.UnknownTypeMessage("JumbledUpLetters", null), 1, 19);
+            _.Error(KnownTypeNamesError.UnknownTypeMessage("Badger", null), 4, 21);
+            _.Error(KnownTypeNamesError.UnknownTypeMessage("Peettt", new[] { "Pet" }), 7, 25);
+            _.Error("Variable '$var' is invalid. Variable has unknown type 'JumbledUpLetters'", 1, 13);
         });
     }
 }

--- a/src/GraphQL.Tests/Validation/LoneAnonymousOperationTests.cs
+++ b/src/GraphQL.Tests/Validation/LoneAnonymousOperationTests.cs
@@ -8,37 +8,37 @@ public class LoneAnonymousOperationTests : ValidationTestBase<LoneAnonymousOpera
     [Fact]
     public void no_operations()
     {
-        ShouldPassRule(@"
-                fragment fragA on Type {
-                  field
-                }
-                ");
+        ShouldPassRule("""
+            fragment fragA on Type {
+              field
+            }
+            """);
     }
 
     [Fact]
     public void one_anon_operation()
     {
-        ShouldPassRule(@"
-                {
-                  field
-                }
-                ");
+        ShouldPassRule("""
+            {
+              field
+            }
+            """);
     }
 
     [Fact]
     public void one_named_operation()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 query Foo {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void multiple_operations()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 query Foo {
                   field
                 }
@@ -46,13 +46,13 @@ public class LoneAnonymousOperationTests : ValidationTestBase<LoneAnonymousOpera
                 query Bar {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void one_anon_with_fragment()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 {
                   ...Foo
                 }
@@ -60,13 +60,13 @@ public class LoneAnonymousOperationTests : ValidationTestBase<LoneAnonymousOpera
                 fragment Foo on Type {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void multiple_anon_operations()
     {
-        var query = @"
+        var query = """
                 {
                   fieldA
                 }
@@ -74,20 +74,20 @@ public class LoneAnonymousOperationTests : ValidationTestBase<LoneAnonymousOpera
                 {
                   fieldB
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            _.Error(LoneAnonymousOperationError.AnonOperationNotAloneMessage(), 2, 17);
-            _.Error(LoneAnonymousOperationError.AnonOperationNotAloneMessage(), 6, 17);
+            _.Error(LoneAnonymousOperationError.AnonOperationNotAloneMessage(), 1, 1);
+            _.Error(LoneAnonymousOperationError.AnonOperationNotAloneMessage(), 5, 1);
         });
     }
 
     [Fact]
     public void anon_operation_with_mutation()
     {
-        var query = @"
+        var query = """
                 {
                   fieldA
                 }
@@ -95,19 +95,19 @@ public class LoneAnonymousOperationTests : ValidationTestBase<LoneAnonymousOpera
                 mutation Foo {
                   fieldB
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            _.Error(LoneAnonymousOperationError.AnonOperationNotAloneMessage(), 2, 17);
+            _.Error(LoneAnonymousOperationError.AnonOperationNotAloneMessage(), 1, 1);
         });
     }
 
     [Fact]
     public void anon_operation_with_subscription()
     {
-        var query = @"
+        var query = """
                 {
                   fieldA
                 }
@@ -115,12 +115,12 @@ public class LoneAnonymousOperationTests : ValidationTestBase<LoneAnonymousOpera
                 subscription Foo {
                   fieldB
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            _.Error(LoneAnonymousOperationError.AnonOperationNotAloneMessage(), 2, 17);
+            _.Error(LoneAnonymousOperationError.AnonOperationNotAloneMessage(), 1, 1);
         });
     }
 }

--- a/src/GraphQL.Tests/Validation/NoFragmentCyclesTests.cs
+++ b/src/GraphQL.Tests/Validation/NoFragmentCyclesTests.cs
@@ -8,35 +8,35 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     [Fact]
     public void single_reference_is_valid()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment fragA on Dog { ...fragB }
               fragment fragB on Dog { name }
-            ");
+            """);
     }
 
     [Fact]
     public void spread_twice_is_not_circular()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment fragA on Dog { ...fragB, ...fragB }
               fragment fragB on Dog { name }
-            ");
+            """);
     }
 
     [Fact]
     public void spread_twice_indirectly_is_not_circular()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment fragA on Dog { ...fragB, ...fragC }
               fragment fragB on Dog { ...fragC }
               fragment fragC on Dog { name }
-            ");
+            """);
     }
 
     [Fact]
     public void double_spread_within_abstract_types()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment nameFragment on Pet {
                 ... on Dog { name }
                 ... on Cat { name }
@@ -45,17 +45,17 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
                 ... on Dog { ...nameFragment }
                 ... on Cat { ...nameFragment }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void does_not_false_positive_on_unknown_fragment()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment nameFragment on Pet {
                 ...UnknownFragment
               }
-            ");
+            """);
     }
 
     [Fact]
@@ -63,10 +63,10 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Human { relatives { ...fragA } },
-                ";
-            _.Error(CycleErrorMessage("fragA", Array.Empty<string>()), 2, 57);
+                """;
+            _.Error(CycleErrorMessage("fragA", Array.Empty<string>()), 1, 41);
         });
     }
 
@@ -75,10 +75,10 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Dog { ...fragA }
-                ";
-            _.Error(CycleErrorMessage("fragA", Array.Empty<string>()), 2, 43);
+                """;
+            _.Error(CycleErrorMessage("fragA", Array.Empty<string>()), 1, 27);
         });
     }
 
@@ -87,14 +87,14 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Pet {
                     ... on Dog {
                       ...fragA
                     }
                   }
-                ";
-            _.Error(CycleErrorMessage("fragA", Array.Empty<string>()), 4, 23);
+                """;
+            _.Error(CycleErrorMessage("fragA", Array.Empty<string>()), 3, 7);
         });
     }
 
@@ -103,15 +103,15 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Dog { ...fragB }
                   fragment fragB on Dog { ...fragA }
-                ";
+                """;
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragA", new[] { "fragB" });
-                e.Loc(2, 43);
-                e.Loc(3, 43);
+                e.Loc(1, 27);
+                e.Loc(2, 27);
             });
         });
     }
@@ -121,15 +121,15 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragB on Dog { ...fragA }
                   fragment fragA on Dog { ...fragB }
-                ";
+                """;
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragB", new[] { "fragA" });
-                e.Loc(2, 43);
-                e.Loc(3, 43);
+                e.Loc(1, 27);
+                e.Loc(2, 27);
             });
         });
     }
@@ -139,7 +139,7 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Pet {
                     ... on Dog {
                       ...fragB
@@ -150,12 +150,12 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
                       ...fragA
                     }
                   }
-                ";
+                """;
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragA", new[] { "fragB" });
-                e.Loc(4, 23);
-                e.Loc(9, 23);
+                e.Loc(3, 7);
+                e.Loc(8, 7);
             });
         });
     }
@@ -165,7 +165,7 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Dog { ...fragB }
                   fragment fragB on Dog { ...fragC }
                   fragment fragC on Dog { ...fragO }
@@ -174,24 +174,24 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
                   fragment fragZ on Dog { ...fragO }
                   fragment fragO on Dog { ...fragP }
                   fragment fragP on Dog { ...fragA, ...fragX }
-                ";
+                """;
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragA", new[] { "fragB", "fragC", "fragO", "fragP" });
-                e.Loc(2, 43);
-                e.Loc(3, 43);
-                e.Loc(4, 43);
-                e.Loc(8, 43);
-                e.Loc(9, 43);
+                e.Loc(1, 27);
+                e.Loc(2, 27);
+                e.Loc(3, 27);
+                e.Loc(7, 27);
+                e.Loc(8, 27);
             });
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragO", new[] { "fragP", "fragX", "fragY", "fragZ" });
-                e.Loc(8, 43);
-                e.Loc(9, 53);
-                e.Loc(5, 43);
-                e.Loc(6, 43);
-                e.Loc(7, 43);
+                e.Loc(7, 27);
+                e.Loc(8, 37);
+                e.Loc(4, 27);
+                e.Loc(5, 27);
+                e.Loc(6, 27);
             });
         });
     }
@@ -201,22 +201,22 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Dog { ...fragB, ...fragC }
                   fragment fragB on Dog { ...fragA }
                   fragment fragC on Dog { ...fragA }
-                ";
+                """;
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragA", new[] { "fragB" });
-                e.Loc(2, 43);
-                e.Loc(3, 43);
+                e.Loc(1, 27);
+                e.Loc(2, 27);
             });
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragA", new[] { "fragC" });
-                e.Loc(2, 53);
-                e.Loc(4, 43);
+                e.Loc(1, 37);
+                e.Loc(3, 27);
             });
         });
     }
@@ -226,22 +226,22 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Dog { ...fragC }
                   fragment fragB on Dog { ...fragC }
                   fragment fragC on Dog { ...fragA, ...fragB }
-                ";
+                """;
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragA", new[] { "fragC" });
-                e.Loc(2, 43);
-                e.Loc(4, 43);
+                e.Loc(1, 27);
+                e.Loc(3, 27);
             });
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragC", new[] { "fragB" });
-                e.Loc(4, 53);
-                e.Loc(3, 43);
+                e.Loc(3, 37);
+                e.Loc(2, 27);
             });
         });
     }
@@ -251,28 +251,28 @@ public class NoFragmentCyclesTests : ValidationTestBase<NoFragmentCycles, Valida
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment fragA on Dog { ...fragB }
                   fragment fragB on Dog { ...fragB, ...fragC }
                   fragment fragC on Dog { ...fragA, ...fragB }
-                ";
+                """;
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragB", Array.Empty<string>());
-                e.Loc(3, 43);
+                e.Loc(2, 27);
             });
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragA", new[] { "fragB", "fragC" });
-                e.Loc(2, 43);
-                e.Loc(3, 53);
-                e.Loc(4, 43);
+                e.Loc(1, 27);
+                e.Loc(2, 37);
+                e.Loc(3, 27);
             });
             _.Error(e =>
             {
                 e.Message = CycleErrorMessage("fragB", new[] { "fragC" });
-                e.Loc(3, 53);
-                e.Loc(4, 53);
+                e.Loc(2, 37);
+                e.Loc(3, 37);
             });
         });
     }

--- a/src/GraphQL.Tests/Validation/NoUndefinedVariablesTests.cs
+++ b/src/GraphQL.Tests/Validation/NoUndefinedVariablesTests.cs
@@ -10,11 +10,11 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String, $b: String, $c: String) {
                     field(a: $a, b: $b, c: $c)
                   }
-                ";
+                """;
         });
     }
 
@@ -23,7 +23,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String, $b: String, $c: String) {
                     field(a: $a) {
                       field(b: $b) {
@@ -31,7 +31,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                       }
                     }
                   }
-                ";
+                """;
         });
     }
 
@@ -40,7 +40,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String, $b: String, $c: String) {
                     ... on Type {
                       field(a: $a) {
@@ -52,7 +52,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                       }
                     }
                   }
-                ";
+                """;
         });
     }
 
@@ -61,7 +61,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String, $b: String, $c: String) {
                     ...FragA
                   }
@@ -78,7 +78,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragC on Type {
                     field(c: $c)
                   }
-                ";
+                """;
         });
     }
 
@@ -87,7 +87,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String) {
                     ...FragA
                   }
@@ -97,7 +97,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragA on Type {
                     field(a: $a)
                   }
-                ";
+                """;
         });
     }
 
@@ -106,7 +106,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String) {
                     ...FragA
                   }
@@ -119,7 +119,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragB on Type {
                     field(b: $b)
                   }
-                ";
+                """;
         });
     }
 
@@ -128,7 +128,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldPassRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String) {
                     ...FragA
                   }
@@ -137,7 +137,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                       ...FragA
                     }
                   }
-                ";
+                """;
         });
     }
 
@@ -146,12 +146,12 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String, $b: String, $c: String) {
                     field(a: $a, b: $b, c: $c, d: $d)
                   }
-                ";
-            undefVar(_, "d", 3, 51, "Foo", 2, 19);
+                """;
+            undefVar(_, "d", 2, 35, "Foo", 1, 3);
         });
     }
 
@@ -160,12 +160,12 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   {
                     field(a: $a)
                   }
-                ";
-            undefVar(_, "a", 3, 30, "", 2, 19);
+                """;
+            undefVar(_, "a", 2, 14, "", 1, 3);
         });
     }
 
@@ -174,13 +174,13 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($b: String) {
                     field(a: $a, b: $b, c: $c)
                   }
-                ";
-            undefVar(_, "a", 3, 30, "Foo", 2, 19);
-            undefVar(_, "c", 3, 44, "Foo", 2, 19);
+                """;
+            undefVar(_, "a", 2, 14, "Foo", 1, 3);
+            undefVar(_, "c", 2, 28, "Foo", 1, 3);
         });
     }
 
@@ -189,15 +189,15 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   {
                     ...FragA
                   }
                   fragment FragA on Type {
                     field(a: $a)
                   }
-                ";
-            undefVar(_, "a", 6, 30, "", 2, 19);
+                """;
+            undefVar(_, "a", 5, 14, "", 1, 3);
         });
     }
 
@@ -206,7 +206,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String, $b: String) {
                     ...FragA
                   }
@@ -223,8 +223,8 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragC on Type {
                     field(c: $c)
                   }
-                ";
-            undefVar(_, "c", 16, 30, "Foo", 2, 19);
+                """;
+            undefVar(_, "c", 15, 14, "Foo", 1, 3);
         });
     }
 
@@ -233,7 +233,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($b: String) {
                     ...FragA
                   }
@@ -250,9 +250,9 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragC on Type {
                     field(c: $c)
                   }
-                ";
-            undefVar(_, "a", 6, 30, "Foo", 2, 19);
-            undefVar(_, "c", 16, 30, "Foo", 2, 19);
+                """;
+            undefVar(_, "a", 5, 14, "Foo", 1, 3);
+            undefVar(_, "c", 15, 14, "Foo", 1, 3);
         });
     }
 
@@ -261,7 +261,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($a: String) {
                     ...FragAB
                   }
@@ -271,9 +271,9 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragAB on Type {
                     field(a: $a, b: $b)
                   }
-                ";
-            undefVar(_, "b", 9, 37, "Foo", 2, 19);
-            undefVar(_, "b", 9, 37, "Bar", 5, 19);
+                """;
+            undefVar(_, "b", 8, 21, "Foo", 1, 3);
+            undefVar(_, "b", 8, 21, "Bar", 4, 3);
         });
     }
 
@@ -282,7 +282,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($b: String) {
                     ...FragAB
                   }
@@ -292,9 +292,9 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragAB on Type {
                     field(a: $a, b: $b)
                   }
-                ";
-            undefVar(_, "a", 9, 30, "Foo", 2, 19);
-            undefVar(_, "b", 9, 37, "Bar", 5, 19);
+                """;
+            undefVar(_, "a", 8, 14, "Foo", 1, 3);
+            undefVar(_, "b", 8, 21, "Bar", 4, 3);
         });
     }
 
@@ -303,7 +303,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($b: String) {
                     ...FragA
                   }
@@ -316,9 +316,9 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragB on Type {
                     field(b: $b)
                   }
-                ";
-            undefVar(_, "a", 9, 30, "Foo", 2, 19);
-            undefVar(_, "b", 12, 30, "Bar", 5, 19);
+                """;
+            undefVar(_, "a", 8, 14, "Foo", 1, 3);
+            undefVar(_, "b", 11, 14, "Bar", 4, 3);
         });
     }
 
@@ -327,7 +327,7 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   query Foo($b: String) {
                     ...FragAB
                   }
@@ -342,13 +342,13 @@ public class NoUndefinedVariablesTests : ValidationTestBase<NoUndefinedVariables
                   fragment FragC on Type {
                     field2(c: $c)
                   }
-                ";
-            undefVar(_, "a", 9, 31, "Foo", 2, 19);
-            undefVar(_, "a", 11, 31, "Foo", 2, 19);
-            undefVar(_, "c", 14, 31, "Foo", 2, 19);
-            undefVar(_, "b", 9, 38, "Bar", 5, 19);
-            undefVar(_, "b", 11, 38, "Bar", 5, 19);
-            undefVar(_, "c", 14, 31, "Bar", 5, 19);
+                """;
+            undefVar(_, "a", 8, 15, "Foo", 1, 3);
+            undefVar(_, "a", 10, 15, "Foo", 1, 3);
+            undefVar(_, "c", 13, 15, "Foo", 1, 3);
+            undefVar(_, "b", 8, 22, "Bar", 4, 3);
+            undefVar(_, "b", 10, 22, "Bar", 4, 3);
+            undefVar(_, "c", 13, 15, "Bar", 4, 3);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/NoUnusedFragmentsTests.cs
+++ b/src/GraphQL.Tests/Validation/NoUnusedFragmentsTests.cs
@@ -8,53 +8,53 @@ public class NoUnusedFragmentsTests : ValidationTestBase<NoUnusedFragments, Vali
     [Fact]
     public void all_fragment_names_are_used()
     {
-        ShouldPassRule(@"
-        {
-          human(id: 4) {
-            ...HumanFields1
-            ... on Human {
-              ...HumanFields2
+        ShouldPassRule("""
+            {
+              human(id: 4) {
+                ...HumanFields1
+                ... on Human {
+                  ...HumanFields2
+                }
+              }
             }
-          }
-        }
-        fragment HumanFields1 on Human {
-          name
-          ...HumanFields3
-        }
-        fragment HumanFields2 on Human {
-          name
-        }
-        fragment HumanFields3 on Human {
-          name
-        }
-      ");
+            fragment HumanFields1 on Human {
+              name
+              ...HumanFields3
+            }
+            fragment HumanFields2 on Human {
+              name
+            }
+            fragment HumanFields3 on Human {
+              name
+            }
+            """);
     }
 
     [Fact]
     public void all_fragment_names_are_used_by_multiple_operations()
     {
-        ShouldPassRule(@"
-        query Foo {
-          human(id: 4) {
-            ...HumanFields1
-          }
-        }
-        query Bar {
-          human(id: 4) {
-            ...HumanFields2
-          }
-        }
-        fragment HumanFields1 on Human {
-          name
-          ...HumanFields3
-        }
-        fragment HumanFields2 on Human {
-          name
-        }
-        fragment HumanFields3 on Human {
-          name
-        }
-      ");
+        ShouldPassRule("""
+            query Foo {
+              human(id: 4) {
+                ...HumanFields1
+              }
+            }
+            query Bar {
+              human(id: 4) {
+                ...HumanFields2
+              }
+            }
+            fragment HumanFields1 on Human {
+              name
+              ...HumanFields3
+            }
+            fragment HumanFields2 on Human {
+              name
+            }
+            fragment HumanFields3 on Human {
+              name
+            }
+            """);
     }
 
     [Fact]
@@ -62,36 +62,36 @@ public class NoUnusedFragmentsTests : ValidationTestBase<NoUnusedFragments, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query Foo {
-            human(id: 4) {
-              ...HumanFields1
-            }
-          }
-          query Bar {
-            human(id: 4) {
-              ...HumanFields2
-            }
-          }
-          fragment HumanFields1 on Human {
-            name
-            ...HumanFields3
-          }
-          fragment HumanFields2 on Human {
-            name
-          }
-          fragment HumanFields3 on Human {
-            name
-          }
-          fragment Unused1 on Human {
-            name
-          }
-          fragment Unused2 on Human {
-            name
-          }
-        ";
-            unusedFrag(_, "Unused1", 22, 11);
-            unusedFrag(_, "Unused2", 25, 11);
+            _.Query = """
+                query Foo {
+                  human(id: 4) {
+                    ...HumanFields1
+                  }
+                }
+                query Bar {
+                  human(id: 4) {
+                    ...HumanFields2
+                  }
+                }
+                fragment HumanFields1 on Human {
+                  name
+                  ...HumanFields3
+                }
+                fragment HumanFields2 on Human {
+                  name
+                }
+                fragment HumanFields3 on Human {
+                  name
+                }
+                fragment Unused1 on Human {
+                  name
+                }
+                fragment Unused2 on Human {
+                  name
+                }
+                """;
+            unusedFrag(_, "Unused1", 21, 1);
+            unusedFrag(_, "Unused2", 24, 1);
         });
     }
 
@@ -100,38 +100,38 @@ public class NoUnusedFragmentsTests : ValidationTestBase<NoUnusedFragments, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query Foo {
-            human(id: 4) {
-              ...HumanFields1
-            }
-          }
-          query Bar {
-            human(id: 4) {
-              ...HumanFields2
-            }
-          }
-          fragment HumanFields1 on Human {
-            name
-            ...HumanFields3
-          }
-          fragment HumanFields2 on Human {
-            name
-          }
-          fragment HumanFields3 on Human {
-            name
-          }
-          fragment Unused1 on Human {
-            name
-            ...Unused2
-          }
-          fragment Unused2 on Human {
-            name
-            ...Unused1
-          }
-        ";
-            unusedFrag(_, "Unused1", 22, 11);
-            unusedFrag(_, "Unused2", 26, 11);
+            _.Query = """
+                query Foo {
+                  human(id: 4) {
+                    ...HumanFields1
+                  }
+                }
+                query Bar {
+                  human(id: 4) {
+                    ...HumanFields2
+                  }
+                }
+                fragment HumanFields1 on Human {
+                  name
+                  ...HumanFields3
+                }
+                fragment HumanFields2 on Human {
+                  name
+                }
+                fragment HumanFields3 on Human {
+                  name
+                }
+                fragment Unused1 on Human {
+                  name
+                  ...Unused2
+                }
+                fragment Unused2 on Human {
+                  name
+                  ...Unused1
+                }
+                """;
+            unusedFrag(_, "Unused1", 21, 1);
+            unusedFrag(_, "Unused2", 25, 1);
         });
     }
 
@@ -140,17 +140,17 @@ public class NoUnusedFragmentsTests : ValidationTestBase<NoUnusedFragments, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query Foo {
-            human(id: 4) {
-              ...bar
-            }
-          }
-          fragment foo on Human {
-            name
-          }
-        ";
-            unusedFrag(_, "foo", 7, 11);
+            _.Query = """
+                query Foo {
+                  human(id: 4) {
+                    ...bar
+                  }
+                }
+                fragment foo on Human {
+                  name
+                }
+                """;
+            unusedFrag(_, "foo", 6, 1);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/NoUnusedVariablesTests.cs
+++ b/src/GraphQL.Tests/Validation/NoUnusedVariablesTests.cs
@@ -8,100 +8,100 @@ public class NoUnusedVariablesTests : ValidationTestBase<NoUnusedVariables, Vali
     [Fact]
     public void uses_all_variables()
     {
-        ShouldPassRule(@"
-        query ($a: String, $b: String, $c: String) {
-          field(a: $a, b: $b, c: $c)
-        }
-      ");
+        ShouldPassRule("""
+            query ($a: String, $b: String, $c: String) {
+              field(a: $a, b: $b, c: $c)
+            }
+            """);
     }
 
     [Fact]
     public void uses_all_variables_deeply()
     {
-        ShouldPassRule(@"
-        query Foo($a: String, $b: String, $c: String) {
-          field(a: $a) {
-            field(b: $b) {
-              field(c: $c)
+        ShouldPassRule("""
+            query Foo($a: String, $b: String, $c: String) {
+              field(a: $a) {
+                field(b: $b) {
+                  field(c: $c)
+                }
+              }
             }
-          }
-        }
-      ");
+            """);
     }
 
     [Fact]
     public void uses_all_variables_deeply_in_inline_fragments()
     {
-        ShouldPassRule(@"
-        query Foo($a: String, $b: String, $c: String) {
-          ... on Type {
-            field(a: $a) {
-              field(b: $b) {
-                ... on Type {
-                  field(c: $c)
+        ShouldPassRule("""
+            query Foo($a: String, $b: String, $c: String) {
+              ... on Type {
+                field(a: $a) {
+                  field(b: $b) {
+                    ... on Type {
+                      field(c: $c)
+                    }
+                  }
                 }
               }
             }
-          }
-        }
-      ");
+            """);
     }
 
     [Fact]
     public void uses_all_variables_in_fragments()
     {
-        ShouldPassRule(@"
-        query Foo($a: String, $b: String, $c: String) {
-          ...FragA
-        }
-        fragment FragA on Type {
-          field(a: $a) {
-            ...FragB
-          }
-        }
-        fragment FragB on Type {
-          field(b: $b) {
-            ...FragC
-          }
-        }
-        fragment FragC on Type {
-          field(c: $c)
-        }
-      ");
+        ShouldPassRule("""
+            query Foo($a: String, $b: String, $c: String) {
+              ...FragA
+            }
+            fragment FragA on Type {
+              field(a: $a) {
+                ...FragB
+              }
+            }
+            fragment FragB on Type {
+              field(b: $b) {
+                ...FragC
+              }
+            }
+            fragment FragC on Type {
+              field(c: $c)
+            }
+            """);
     }
 
     [Fact]
     public void variable_used_by_fragment_in_multiple_operations()
     {
-        ShouldPassRule(@"
-        query Foo($a: String) {
-          ...FragA
-        }
-        query Bar($b: String) {
-          ...FragB
-        }
-        fragment FragA on Type {
-          field(a: $a)
-        }
-        fragment FragB on Type {
-          field(b: $b)
-        }
-      ");
+        ShouldPassRule("""
+            query Foo($a: String) {
+              ...FragA
+            }
+            query Bar($b: String) {
+              ...FragB
+            }
+            fragment FragA on Type {
+              field(a: $a)
+            }
+            fragment FragB on Type {
+              field(b: $b)
+            }
+            """);
     }
 
     [Fact]
     public void variable_used_by_recursive_fragment()
     {
-        ShouldPassRule(@"
-        query Foo($a: String) {
-          ...FragA
-        }
-        fragment FragA on Type {
-          field(a: $a) {
-            ...FragA
-          }
-        }
-      ");
+        ShouldPassRule("""
+            query Foo($a: String) {
+              ...FragA
+            }
+            fragment FragA on Type {
+              field(a: $a) {
+                ...FragA
+              }
+            }
+            """);
     }
 
     [Fact]
@@ -109,12 +109,12 @@ public class NoUnusedVariablesTests : ValidationTestBase<NoUnusedVariables, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query ($a: String, $b: String, $c: String) {
-            field(a: $a, b: $b)
-          }
-        ";
-            unusedVar(_, "c", null, 2, 42);
+            _.Query = """
+                query ($a: String, $b: String, $c: String) {
+                  field(a: $a, b: $b)
+                }
+                """;
+            unusedVar(_, "c", null, 1, 32);
         });
     }
 
@@ -123,13 +123,13 @@ public class NoUnusedVariablesTests : ValidationTestBase<NoUnusedVariables, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query Foo($a: String, $b: String, $c: String) {
-            field(b: $b)
-          }
-        ";
-            unusedVar(_, "a", "Foo", 2, 21);
-            unusedVar(_, "c", "Foo", 2, 45);
+            _.Query = """
+                query Foo($a: String, $b: String, $c: String) {
+                  field(b: $b)
+                }
+                """;
+            unusedVar(_, "a", "Foo", 1, 11);
+            unusedVar(_, "c", "Foo", 1, 35);
         });
     }
 
@@ -138,25 +138,25 @@ public class NoUnusedVariablesTests : ValidationTestBase<NoUnusedVariables, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query Foo($a: String, $b: String, $c: String) {
-            ...FragA
-          }
-          fragment FragA on Type {
-            field(a: $a) {
-              ...FragB
-            }
-          }
-          fragment FragB on Type {
-            field(b: $b) {
-              ...FragC
-            }
-          }
-          fragment FragC on Type {
-            field
-          }
-        ";
-            unusedVar(_, "c", "Foo", 2, 45);
+            _.Query = """
+                query Foo($a: String, $b: String, $c: String) {
+                  ...FragA
+                }
+                fragment FragA on Type {
+                  field(a: $a) {
+                    ...FragB
+                  }
+                }
+                fragment FragB on Type {
+                  field(b: $b) {
+                    ...FragC
+                  }
+                }
+                fragment FragC on Type {
+                  field
+                }
+                """;
+            unusedVar(_, "c", "Foo", 1, 35);
         });
     }
 
@@ -165,26 +165,26 @@ public class NoUnusedVariablesTests : ValidationTestBase<NoUnusedVariables, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query Foo($a: String, $b: String, $c: String) {
-            ...FragA
-          }
-          fragment FragA on Type {
-            field {
-              ...FragB
-            }
-          }
-          fragment FragB on Type {
-            field(b: $b) {
-              ...FragC
-            }
-          }
-          fragment FragC on Type {
-            field
-          }
-        ";
-            unusedVar(_, "a", "Foo", 2, 21);
-            unusedVar(_, "c", "Foo", 2, 45);
+            _.Query = """
+                query Foo($a: String, $b: String, $c: String) {
+                  ...FragA
+                }
+                fragment FragA on Type {
+                  field {
+                    ...FragB
+                  }
+                }
+                fragment FragB on Type {
+                  field(b: $b) {
+                    ...FragC
+                  }
+                }
+                fragment FragC on Type {
+                  field
+                }
+                """;
+            unusedVar(_, "a", "Foo", 1, 11);
+            unusedVar(_, "c", "Foo", 1, 35);
         });
     }
 
@@ -193,18 +193,18 @@ public class NoUnusedVariablesTests : ValidationTestBase<NoUnusedVariables, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query Foo($b: String) {
-            ...FragA
-          }
-          fragment FragA on Type {
-            field(a: $a)
-          }
-          fragment FragB on Type {
-            field(b: $b)
-          }
-        ";
-            unusedVar(_, "b", "Foo", 2, 21);
+            _.Query = """
+                query Foo($b: String) {
+                  ...FragA
+                }
+                fragment FragA on Type {
+                  field(a: $a)
+                }
+                fragment FragB on Type {
+                  field(b: $b)
+                }
+                """;
+            unusedVar(_, "b", "Foo", 1, 11);
         });
     }
 
@@ -213,22 +213,22 @@ public class NoUnusedVariablesTests : ValidationTestBase<NoUnusedVariables, Vali
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query Foo($b: String) {
-            ...FragA
-          }
-          query Bar($a: String) {
-            ...FragB
-          }
-          fragment FragA on Type {
-            field(a: $a)
-          }
-          fragment FragB on Type {
-            field(b: $b)
-          }
-        ";
-            unusedVar(_, "b", "Foo", 2, 21);
-            unusedVar(_, "a", "Bar", 5, 21);
+            _.Query = """
+                query Foo($b: String) {
+                  ...FragA
+                }
+                query Bar($a: String) {
+                  ...FragB
+                }
+                fragment FragA on Type {
+                  field(a: $a)
+                }
+                fragment FragB on Type {
+                  field(b: $b)
+                }
+                """;
+            unusedVar(_, "b", "Foo", 1, 11);
+            unusedVar(_, "a", "Bar", 4, 11);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/OverlappingFieldsCanBeMergedTest.cs
+++ b/src/GraphQL.Tests/Validation/OverlappingFieldsCanBeMergedTest.cs
@@ -10,112 +10,112 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Unique_fields_should_pass()
     {
-        const string query = @"
-                fragment uniqueFields on Dog {
-                    name
-                    nickname
-                }
-            ";
+        const string query = """
+            fragment uniqueFields on Dog {
+              name
+              nickname
+            }
+            """;
         ShouldPassRule(query);
     }
 
     [Fact]
     public void Identical_fields_should_pass()
     {
-        const string query = @"
-                fragment mergeIdenticalFields on Dog {
-                    name
-                    name
-                }
-            ";
+        const string query = """
+            fragment mergeIdenticalFields on Dog {
+              name
+              name
+            }
+            """;
         ShouldPassRule(query);
     }
 
     [Fact]
     public void Identical_fields_with_identical_args_should_pass()
     {
-        const string query = @"
-                fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
-                    doesKnowCommand(dogCommand: SIT)
-                    doesKnowCommand(dogCommand: SIT)
-                }
-            ";
+        const string query = """
+            fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
+              doesKnowCommand(dogCommand: SIT)
+              doesKnowCommand(dogCommand: SIT)
+            }
+            """;
         ShouldPassRule(query);
     }
 
     [Fact]
     public void Identical_fields_with_identical_directives_should_pass()
     {
-        const string query = @"
-                fragment mergeSameFieldsWithSameDirectives on Dog {
-                    name @include(if: true)
-                    name @include(if: true)
-                }
-            ";
+        const string query = """
+            fragment mergeSameFieldsWithSameDirectives on Dog {
+              name @include(if: true)
+              name @include(if: true)
+            }
+            """;
         ShouldPassRule(query);
     }
 
     [Fact]
     public void Different_args_with_different_aliases_should_pass()
     {
-        const string query = @"
-                fragment differentArgsWithDifferentAliases on Dog {
-                    knowsSit: doesKnowCommand(dogCommand: SIT)
-                    knowsDown: doesKnowCommand(dogCommand: DOWN)
-                }
-            ";
+        const string query = """
+            fragment differentArgsWithDifferentAliases on Dog {
+              knowsSit: doesKnowCommand(dogCommand: SIT)
+              knowsDown: doesKnowCommand(dogCommand: DOWN)
+            }
+            """;
         ShouldPassRule(query);
     }
 
     [Fact]
     public void Different_directives_with_different_aliases_should_pass()
     {
-        const string query = @"
-                fragment differentDirectivesWithDifferentAliases on Dog {
-                    nameIfTrue: name @include(if: true)
-                    nameIfFalse: name @include(if: false)
-                }
-            ";
+        const string query = """
+            fragment differentDirectivesWithDifferentAliases on Dog {
+              nameIfTrue: name @include(if: true)
+              nameIfFalse: name @include(if: false)
+            }
+            """;
         ShouldPassRule(query);
     }
 
     [Fact]
     public void Different_skip_or_include_directives_accepted_should_pass()
     {
-        const string query = @"
-                fragment differentDirectivesWithDifferentAliases on Dog {
-                    name @include(if: true)
-                    name @include(if: false)
-                }
-            ";
+        const string query = """
+            fragment differentDirectivesWithDifferentAliases on Dog {
+              name @include(if: true)
+              name @include(if: false)
+            }
+            """;
         ShouldPassRule(query);
     }
 
     [Fact]
     public void Same_aliases_allowed_on_non_overlapping_fields_should_pass()
     {
-        const string query = @"
-                fragment sameAliasesWithDifferentFieldTargets on Pet {
-                    ... on Dog {
-                        name
-                    }
-                    ... on Cat {
-                        name: nickname
-                    }
+        const string query = """
+            fragment sameAliasesWithDifferentFieldTargets on Pet {
+                ... on Dog {
+                    name
                 }
-            ";
+                ... on Cat {
+                    name: nickname
+                }
+            }
+            """;
         ShouldPassRule(query);
     }
 
     [Fact]
     public void Same_aliases_with_different_field_targets_should_fail()
     {
-        const string query = @"
-                fragment sameAliasesWithDifferentFieldTargets on Dog {
-                    fido: name
-                    fido: nickname
-                }
-            ";
+        const string query = """
+            fragment sameAliasesWithDifferentFieldTargets on Dog {
+                fido: name
+                fido: nickname
+            }
+            """;
         ShouldFailRule(config =>
         {
             config.Query = query;
@@ -128,8 +128,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "name and nickname are different fields"
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(4, 21));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(3, 5));
             });
         });
     }
@@ -137,12 +137,12 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Alias_masking_direct_field_access_should_fail()
     {
-        const string query = @"
-                fragment aliasMaskingDirectFieldAccess on Dog {
-                    name: nickname
-                    name
-                }
-            ";
+        const string query = """
+            fragment aliasMaskingDirectFieldAccess on Dog {
+                name: nickname
+                name
+            }
+            """;
         ShouldFailRule(config =>
         {
             config.Query = query;
@@ -155,8 +155,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "nickname and name are different fields"
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(4, 21));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(3, 5));
             });
         });
     }
@@ -164,12 +164,12 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Different_args_second_adds_an_argument_should_fail()
     {
-        const string query = @"
-                fragment conflictingArgs on Dog {
-                    doesKnowCommand
-                    doesKnowCommand(dogCommand: HEEL)
-                }
-            ";
+        const string query = """
+            fragment conflictingArgs on Dog {
+                doesKnowCommand
+                doesKnowCommand(dogCommand: HEEL)
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -183,8 +183,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "they have differing arguments"
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(4, 21));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(3, 5));
             });
         });
     }
@@ -192,12 +192,12 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Different_args_second_missing_an_argument_should_fail()
     {
-        const string query = @"
-                fragment conflictingArgs on Dog {
-                    doesKnowCommand(dogCommand: SIT)
-                    doesKnowCommand
-                }
-            ";
+        const string query = """
+            fragment conflictingArgs on Dog {
+                doesKnowCommand(dogCommand: SIT)
+                doesKnowCommand
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -211,8 +211,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "they have differing arguments"
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(4, 21));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(3, 5));
             });
         });
     }
@@ -220,12 +220,12 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Conflicting_args_should_fail()
     {
-        const string query = @"
-                fragment conflictingArgs on Dog {
-                    doesKnowCommand(dogCommand: SIT)
-                    doesKnowCommand(dogCommand: HEEL)
-                }
-            ";
+        const string query = """
+            fragment conflictingArgs on Dog {
+                doesKnowCommand(dogCommand: SIT)
+                doesKnowCommand(dogCommand: HEEL)
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -239,8 +239,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "they have differing arguments"
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(4, 21));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(3, 5));
             });
         });
     }
@@ -252,16 +252,16 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Allows_different_args_where_no_conflict_is_possible_should_pass()
     {
-        const string query = @"
-                fragment conflictingArgs on Pet {
-                    ... on Dog {
-                        name(surname: true)
-                    }
-                    ... on Cat {
-                        name
-                    }
+        const string query = """
+            fragment conflictingArgs on Pet {
+                ... on Dog {
+                    name(surname: true)
                 }
-            ";
+                ... on Cat {
+                    name
+                }
+            }
+            """;
 
         ShouldPassRule(query);
     }
@@ -269,18 +269,18 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Encounters_conflict_in_fragments_should_fail()
     {
-        const string query = @"
-                {
-                    ...A
-                    ...B
-                }
-                fragment A on Type {
-                    x: a
-                }
-                fragment B on Type {
-                    x: b
-                }
-            ";
+        const string query = """
+            {
+                ...A
+                ...B
+            }
+            fragment A on Type {
+                x: a
+            }
+            fragment B on Type {
+                x: b
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -294,8 +294,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "a and b are different fields"
                     }
                 });
-                e.Locations.Add(new Location(7, 21));
-                e.Locations.Add(new Location(10, 21));
+                e.Locations.Add(new Location(6, 5));
+                e.Locations.Add(new Location(9, 5));
             });
         });
     }
@@ -303,29 +303,29 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Reports_each_conflict_once_should_fail()
     {
-        const string query = @"
-                {
-                    f1 {
-                        ...A
-                        ...B
-                    }
-                    f2 {
-                        ...B
-                        ...A
-                    }
-                    f3 {
-                        ...A
-                        ...B
-                        x: c
-                    }
+        const string query = """
+            {
+                f1 {
+                    ...A
+                    ...B
                 }
-                fragment A on Type {
-                    x: a
+                f2 {
+                    ...B
+                    ...A
                 }
-                fragment B on Type {
-                    x: b
+                f3 {
+                    ...A
+                    ...B
+                    x: c
                 }
-            ";
+            }
+            fragment A on Type {
+                x: a
+            }
+            fragment B on Type {
+                x: b
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -339,8 +339,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "a and b are different fields"
                     }
                 });
-                e.Locations.Add(new Location(18, 21));
-                e.Locations.Add(new Location(21, 21));
+                e.Locations.Add(new Location(17, 5));
+                e.Locations.Add(new Location(20, 5));
             });
 
             config.Error(e =>
@@ -352,8 +352,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "c and a are different fields"
                     }
                 });
-                e.Locations.Add(new Location(14, 25));
-                e.Locations.Add(new Location(18, 21));
+                e.Locations.Add(new Location(13, 9));
+                e.Locations.Add(new Location(17, 5));
             });
 
             config.Error(e =>
@@ -365,8 +365,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "c and b are different fields"
                     }
                 });
-                e.Locations.Add(new Location(14, 25));
-                e.Locations.Add(new Location(21, 21));
+                e.Locations.Add(new Location(13, 9));
+                e.Locations.Add(new Location(20, 5));
             });
         });
     }
@@ -374,16 +374,16 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Deep_conflict()
     {
-        const string query = @"
-                {
-                    field {
-                        x: a
-                    },
-                    field {
-                        x: b
-                    }
+        const string query = """
+            {
+                field {
+                    x: a
+                },
+                field {
+                    x: b
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -407,10 +407,10 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         }
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(4, 25));
-                e.Locations.Add(new Location(6, 21));
-                e.Locations.Add(new Location(7, 25));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(3, 9));
+                e.Locations.Add(new Location(5, 5));
+                e.Locations.Add(new Location(6, 9));
             });
         });
     }
@@ -418,18 +418,18 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Deep_conflict_with_multiple_issues_should_fail()
     {
-        const string query = @"
-                {
-                    field {
-                        x: a
-                        y: c
-                    },
-                    field {
-                        x: b
-                        y: d
-                    }
+        const string query = """
+            {
+                field {
+                    x: a
+                    y: c
+                },
+                field {
+                    x: b
+                    y: d
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -461,12 +461,12 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         }
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(4, 25));
-                e.Locations.Add(new Location(5, 25));
-                e.Locations.Add(new Location(7, 21));
-                e.Locations.Add(new Location(8, 25));
-                e.Locations.Add(new Location(9, 25));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(3, 9));
+                e.Locations.Add(new Location(4, 9));
+                e.Locations.Add(new Location(6, 5));
+                e.Locations.Add(new Location(7, 9));
+                e.Locations.Add(new Location(8, 9));
             });
         });
     }
@@ -474,20 +474,20 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Very_deep_conflict_should_fail()
     {
-        const string query = @"
-                {
-                    field {
-                        deepField {
-                            x: a
-                        }
-                    },
-                    field {
-                        deepField {
-                            x: b
-                        }
+        const string query = """
+            {
+                field {
+                    deepField {
+                        x: a
+                    }
+                },
+                field {
+                    deepField {
+                        x: b
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -521,12 +521,12 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         }
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(4, 25));
-                e.Locations.Add(new Location(5, 29));
-                e.Locations.Add(new Location(8, 21));
-                e.Locations.Add(new Location(9, 25));
-                e.Locations.Add(new Location(10, 29));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(3, 9));
+                e.Locations.Add(new Location(4, 13));
+                e.Locations.Add(new Location(7, 5));
+                e.Locations.Add(new Location(8, 9));
+                e.Locations.Add(new Location(9, 13));
             });
         });
     }
@@ -534,23 +534,23 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Reports_deep_conflict_to_nearest_common_ancestor_should_fail()
     {
-        const string query = @"
-                {
-                    field {
-                        deepField {
-                            x: a
-                        }
-                        deepField {
-                            x: b
-                        }
-                    },
-                    field {
-                        deepField {
-                            y
-                        }
+        const string query = """
+            {
+                field {
+                    deepField {
+                        x: a
+                    }
+                    deepField {
+                        x: b
+                    }
+                },
+                field {
+                    deepField {
+                        y
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -574,10 +574,10 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         }
                     }
                 });
-                e.Locations.Add(new Location(4, 25));
-                e.Locations.Add(new Location(5, 29));
-                e.Locations.Add(new Location(7, 25));
-                e.Locations.Add(new Location(8, 29));
+                e.Locations.Add(new Location(3, 9));
+                e.Locations.Add(new Location(4, 13));
+                e.Locations.Add(new Location(6, 9));
+                e.Locations.Add(new Location(7, 13));
             });
         });
     }
@@ -585,31 +585,31 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Reports_deep_conflict_to_nearest_common_ancestor_in_fragments()
     {
-        const string query = @"
-                {
-                    field {
-                        ...F
+        const string query = """
+            {
+                field {
+                    ...F
+                }
+                field {
+                    ...F
+                }
+            }
+            fragment F on T {
+                deepField {
+                    deeperField {
+                        x: a
                     }
-                    field {
-                        ...F
+                    deeperField {
+                        x: b
+                    }
+                },
+                deepField {
+                    deeperField {
+                        y
                     }
                 }
-                fragment F on T {
-                    deepField {
-                        deeperField {
-                            x: a
-                        }
-                        deeperField {
-                            x: b
-                        }
-                    },
-                    deepField {
-                        deeperField {
-                            y
-                        }
-                    }
-                }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -633,10 +633,10 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         }
                     }
                 });
-                e.Locations.Add(new Location(12, 25));
-                e.Locations.Add(new Location(13, 29));
-                e.Locations.Add(new Location(15, 25));
-                e.Locations.Add(new Location(16, 29));
+                e.Locations.Add(new Location(11, 9));
+                e.Locations.Add(new Location(12, 13));
+                e.Locations.Add(new Location(14, 9));
+                e.Locations.Add(new Location(15, 13));
             });
         });
     }
@@ -644,30 +644,30 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Reports_deep_conflict_in_nested_fragments()
     {
-        const string query = @"
-                {
-                    field {
-                        ...F
-                    }
-                    field {
-                        ...I
-                    }
+        const string query = """
+            {
+                field {
+                    ...F
                 }
-                fragment F on T {
-                    x: a
-                    ...G
+                field {
+                    ...I
                 }
-                fragment G on T {
-                    y: c
-                }
-                fragment I on T {
-                    y: d
-                    ...J
-                }
-                fragment J on T {
-                    x: b
-                }
-            ";
+            }
+            fragment F on T {
+                x: a
+                ...G
+            }
+            fragment G on T {
+                y: c
+            }
+            fragment I on T {
+                y: d
+                ...J
+            }
+            fragment J on T {
+                x: b
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -699,12 +699,12 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         }
                     }
                 });
-                e.Locations.Add(new Location(3, 21));
-                e.Locations.Add(new Location(11, 21));
-                e.Locations.Add(new Location(15, 21));
-                e.Locations.Add(new Location(6, 21));
-                e.Locations.Add(new Location(22, 21));
-                e.Locations.Add(new Location(18, 21));
+                e.Locations.Add(new Location(2, 5));
+                e.Locations.Add(new Location(10, 5));
+                e.Locations.Add(new Location(14, 5));
+                e.Locations.Add(new Location(5, 5));
+                e.Locations.Add(new Location(21, 5));
+                e.Locations.Add(new Location(17, 5));
             });
         });
     }
@@ -712,17 +712,17 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Ignores_unknown_fragments()
     {
-        const string query = @"
-                {
-                    field
-                    ...Unknown
-                    ...Known
-                }
-                fragment Known on T {
-                    field
-                    ...OtherUnknown
-                }
-            ";
+        const string query = """
+            {
+                field
+                ...Unknown
+                ...Known
+            }
+            fragment Known on T {
+                field
+                ...OtherUnknown
+            }
+            """;
 
         ShouldPassRule(query);
     }
@@ -730,15 +730,15 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Does_not_infinite_loop_on_recursive_fragment()
     {
-        const string query = @"
-                fragment fragA on Human {
+        const string query = """
+            fragment fragA on Human {
+                name,
+                relatives {
                     name,
-                    relatives {
-                        name,
-                        ...fragA
-                    }
+                    ...fragA
                 }
-            ";
+            }
+            """;
 
         ShouldPassRule(query);
     }
@@ -746,12 +746,12 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Does_not_infinite_loop_on_immediately_recursive_fragment()
     {
-        const string query = @"
-                fragment fragA on Human {
-                    name,
-                    ...fragA
-                }
-            ";
+        const string query = """
+            fragment fragA on Human {
+                name,
+                ...fragA
+            }
+            """;
 
         ShouldPassRule(query);
     }
@@ -759,11 +759,11 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Does_not_infinite_loop_on_transitively_recursive_fragment()
     {
-        const string query = @"
-                fragment fragA on Human { name, ...fragB }
-                fragment fragB on Human { name, ...fragC }
-                fragment fragC on Human { name, ...fragA }
-            ";
+        const string query = """
+            fragment fragA on Human { name, ...fragB }
+            fragment fragB on Human { name, ...fragC }
+            fragment fragC on Human { name, ...fragA }
+            """;
 
         ShouldPassRule(query);
     }
@@ -771,13 +771,13 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     [Fact]
     public void Finds_invalid_case_even_with_immediately_recursive_fragment()
     {
-        const string query = @"
-                fragment sameAliasesWithDifferentFieldTargets on Dog {
-                    ...sameAliasesWithDifferentFieldTargets
-                    fido: name
-                    fido: nickname
-                }
-            ";
+        const string query = """
+            fragment sameAliasesWithDifferentFieldTargets on Dog {
+                ...sameAliasesWithDifferentFieldTargets
+                fido: name
+                fido: nickname
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -791,8 +791,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "name and nickname are different fields"
                     }
                 });
-                e.Locations.Add(new Location(4, 21));
-                e.Locations.Add(new Location(5, 21));
+                e.Locations.Add(new Location(3, 5));
+                e.Locations.Add(new Location(4, 5));
             });
         });
     }
@@ -802,18 +802,18 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ...on IntBox {
-                            scalar
-                        }
-                        ...on NonNullStringBox1 {
-                            scalar
-                        }
+        const string query = """
+            {
+                someBox {
+                    ...on IntBox {
+                        scalar
+                    }
+                    ...on NonNullStringBox1 {
+                        scalar
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -828,8 +828,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "they return conflicting types Int and String!"
                     }
                 });
-                e.Locations.Add(new Location(5, 29));
-                e.Locations.Add(new Location(8, 29));
+                e.Locations.Add(new Location(4, 13));
+                e.Locations.Add(new Location(7, 13));
             });
         });
     }
@@ -839,22 +839,22 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ... on SomeBox {
-                            deepBox {
-                                unrelatedField
-                            }
+        const string query = """
+            {
+                someBox {
+                    ... on SomeBox {
+                        deepBox {
+                            unrelatedField
                         }
-                        ... on StringBox {
-                            deepBox {
-                                unrelatedField
-                            }
+                    }
+                    ... on StringBox {
+                        deepBox {
+                            unrelatedField
                         }
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldPassRule(config =>
         {
@@ -868,18 +868,18 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ... on IntBox {
-                            scalar
-                        }
-                        ... on StringBox {
-                            scalar
-                        }
+        const string query = """
+            {
+                someBox {
+                    ... on IntBox {
+                        scalar
+                    }
+                    ... on StringBox {
+                        scalar
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -894,8 +894,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "they return conflicting types Int and String"
                     }
                 });
-                e.Locations.Add(new Location(5, 29));
-                e.Locations.Add(new Location(8, 29));
+                e.Locations.Add(new Location(4, 13));
+                e.Locations.Add(new Location(7, 13));
             });
         });
     }
@@ -905,50 +905,50 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ... on IntBox {
-                            deepBox {
-                                ...X
-                            }
+        const string query = """
+            {
+                someBox {
+                    ... on IntBox {
+                        deepBox {
+                            ...X
                         }
-                    }
-                    someBox {
-                        ... on StringBox {
-                            deepBox {
-                                ...Y
-                            }
-                        }
-                    }
-                    memoed: someBox {
-                        ... on IntBox {
-                            deepBox {
-                                ...X
-                            }
-                        }
-                    }
-                    memoed: someBox {
-                        ... on StringBox {
-                            deepBox {
-                                ...Y
-                            }
-                        }
-                    }
-                    other: someBox {
-                        ...X
-                    }
-                    other: someBox {
-                        ...Y
                     }
                 }
-                fragment X on SomeBox {
-                    scalar
+                someBox {
+                    ... on StringBox {
+                        deepBox {
+                            ...Y
+                        }
+                    }
                 }
-                fragment Y on SomeBox {
-                    scalar: unrelatedField
+                memoed: someBox {
+                    ... on IntBox {
+                        deepBox {
+                            ...X
+                        }
+                    }
                 }
-            ";
+                memoed: someBox {
+                    ... on StringBox {
+                        deepBox {
+                            ...Y
+                        }
+                    }
+                }
+                other: someBox {
+                    ...X
+                }
+                other: someBox {
+                    ...Y
+                }
+            }
+            fragment X on SomeBox {
+                scalar
+            }
+            fragment Y on SomeBox {
+                scalar: unrelatedField
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -973,10 +973,10 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         }
                     }
                 });
-                e.Locations.Add(new Location(31, 21));
-                e.Locations.Add(new Location(39, 21));
-                e.Locations.Add(new Location(34, 21));
-                e.Locations.Add(new Location(42, 21));
+                e.Locations.Add(new Location(30, 5));
+                e.Locations.Add(new Location(38, 5));
+                e.Locations.Add(new Location(33, 5));
+                e.Locations.Add(new Location(41, 5));
             });
         });
     }
@@ -986,18 +986,18 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ... on NonNullStringBox1 {
-                            scalar
-                        }
-                        ... on StringBox {
-                            scalar
-                        }
+        const string query = """
+            {
+                someBox {
+                    ... on NonNullStringBox1 {
+                        scalar
+                    }
+                    ... on StringBox {
+                        scalar
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -1012,8 +1012,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "they return conflicting types String! and String"
                     }
                 });
-                e.Locations.Add(new Location(5, 29));
-                e.Locations.Add(new Location(8, 29));
+                e.Locations.Add(new Location(4, 13));
+                e.Locations.Add(new Location(7, 13));
             });
         });
     }
@@ -1023,22 +1023,22 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        string query = @"
-                {
-                    someBox {
-                        ... on IntBox {
-                            box: listStringBox {
-                                scalar
-                            }
+        string query = """
+            {
+                someBox {
+                    ... on IntBox {
+                        box: listStringBox {
+                            scalar
                         }
-                        ... on StringBox {
-                            box: stringBox {
-                                scalar
-                            }
+                    }
+                    ... on StringBox {
+                        box: stringBox {
+                            scalar
                         }
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -1053,27 +1053,27 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "they return conflicting types [StringBox] and StringBox"
                     }
                 });
-                e.Locations.Add(new Location(5, 29));
-                e.Locations.Add(new Location(10, 29));
+                e.Locations.Add(new Location(4, 13));
+                e.Locations.Add(new Location(9, 13));
             });
         });
 
-        query = @"
-                {
-                    someBox {
-                        ... on IntBox {
-                            box: stringBox {
-                                scalar
-                            }
+        query = """
+            {
+                someBox {
+                    ... on IntBox {
+                        box: stringBox {
+                            scalar
                         }
-                        ... on StringBox {
-                            box: listStringBox {
-                                scalar
-                            }
+                    }
+                    ... on StringBox {
+                        box: listStringBox {
+                            scalar
                         }
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -1088,11 +1088,10 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "they return conflicting types StringBox and [StringBox]"
                     }
                 });
-                e.Locations.Add(new Location(5, 29));
-                e.Locations.Add(new Location(10, 29));
+                e.Locations.Add(new Location(4, 13));
+                e.Locations.Add(new Location(9, 13));
             });
         });
-
     }
 
     [Fact]
@@ -1100,23 +1099,23 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ... on IntBox {
-                            box: stringBox {
-                                val: scalar
-                                val: unrelatedField
-                            }
+        const string query = """
+            {
+                someBox {
+                    ... on IntBox {
+                        box: stringBox {
+                            val: scalar
+                            val: unrelatedField
                         }
-                        ... on StringBox {
-                            box: stringBox {
-                                val: scalar
-                            }
+                    }
+                    ... on StringBox {
+                        box: stringBox {
+                            val: scalar
                         }
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -1131,8 +1130,8 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         Msg = "scalar and unrelatedField are different fields"
                     }
                 });
-                e.Locations.Add(new Location(6, 33));
-                e.Locations.Add(new Location(7, 33));
+                e.Locations.Add(new Location(5, 17));
+                e.Locations.Add(new Location(6, 17));
             });
         });
     }
@@ -1142,22 +1141,22 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ... on IntBox {
-                            box: stringBox {
-                                scalar
-                            }
+        const string query = """
+            {
+                someBox {
+                    ... on IntBox {
+                        box: stringBox {
+                            scalar
                         }
-                        ... on StringBox {
-                            box: intBox {
-                                scalar
-                            }
+                    }
+                    ... on StringBox {
+                        box: intBox {
+                            scalar
                         }
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldFailRule(config =>
         {
@@ -1182,10 +1181,10 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
                         }
                     }
                 });
-                e.Locations.Add(new Location(5, 29));
-                e.Locations.Add(new Location(6, 33));
-                e.Locations.Add(new Location(10, 29));
-                e.Locations.Add(new Location(11, 33));
+                e.Locations.Add(new Location(4, 13));
+                e.Locations.Add(new Location(5, 17));
+                e.Locations.Add(new Location(9, 13));
+                e.Locations.Add(new Location(10, 17));
             });
         });
     }
@@ -1195,18 +1194,18 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ... on IntBox {
-                            scalar: unrelatedField
-                        }
-                        ... on StringBox {
-                            scalar
-                        }
+        const string query = """
+            {
+                someBox {
+                    ... on IntBox {
+                        scalar: unrelatedField
+                    }
+                    ... on StringBox {
+                        scalar
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldPassRule(config =>
         {
@@ -1220,18 +1219,18 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ...on NonNullStringBox1 {
-                            scalar
-                        }
-                        ...on NonNullStringBox2 {
-                            scalar
-                        }
+        const string query = """
+            {
+                someBox {
+                    ...on NonNullStringBox1 {
+                        scalar
+                    }
+                    ...on NonNullStringBox2 {
+                        scalar
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldPassRule(config =>
         {
@@ -1245,14 +1244,14 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
+        const string query = """
+            {
+                a
+                ... {
                     a
-                    ... {
-                        a
-                    }
                 }
-            ";
+            }
+            """;
 
         ShouldPassRule(config =>
         {
@@ -1266,18 +1265,18 @@ public class OverlappingFieldsCanBeMergedTest : ValidationTestBase<OverlappingFi
     {
         ISchema schema = new ResultTypeValidationSchema();
 
-        const string query = @"
-                {
-                    someBox {
-                        ...on UnknownType {
-                            scalar
-                        }
-                        ...on NonNullStringBox2 {
-                            scalar
-                        }
+        const string query = """
+            {
+                someBox {
+                    ...on UnknownType {
+                        scalar
+                    }
+                    ...on NonNullStringBox2 {
+                        scalar
                     }
                 }
-            ";
+            }
+            """;
 
         ShouldPassRule(config =>
         {

--- a/src/GraphQL.Tests/Validation/PossibleFragmentSpreadsTests.cs
+++ b/src/GraphQL.Tests/Validation/PossibleFragmentSpreadsTests.cs
@@ -8,98 +8,98 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     [Fact]
     public void of_the_same_object()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment objectWithinObject on Dog { ...dogFragment }
                 fragment dogFragment on Dog { barkVolume }
-            ");
+            """);
     }
 
     [Fact]
     public void of_the_same_object_with_inline_fragment()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment objectWithinObjectAnon on Dog { ... on Dog { barkVolume } }
-            ");
+            """);
     }
 
     [Fact]
     public void object_into_an_implemented_interface()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment objectWithinInterface on Pet { ...dogFragment }
                 fragment dogFragment on Dog { barkVolume }
-            ");
+            """);
     }
 
     [Fact]
     public void object_into_containing_union()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment objectWithinUnion on CatOrDog { ...dogFragment }
                 fragment dogFragment on Dog { barkVolume }
-            ");
+            """);
     }
 
     [Fact]
     public void union_into_contained_object()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment unionWithinObject on Dog { ...catOrDogFragment }
                 fragment catOrDogFragment on CatOrDog { __typename }
-            ");
+            """);
     }
 
     [Fact]
     public void union_into_overlapping_interface()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment unionWithinInterface on Pet { ...catOrDogFragment }
                 fragment catOrDogFragment on CatOrDog { __typename }
-            ");
+            """);
     }
 
     [Fact]
     public void union_into_overlapping_union()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment unionWithinUnion on DogOrHuman { ...catOrDogFragment }
                 fragment catOrDogFragment on CatOrDog { __typename }
-            ");
+            """);
     }
 
     [Fact]
     public void interface_into_implemented_object()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment interfaceWithinObject on Dog { ...petFragment }
                 fragment petFragment on Pet { name }
-            ");
+            """);
     }
 
     [Fact]
     public void interface_into_overlapping_interface()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment interfaceWithinInterface on Pet { ...beingFragment }
                 fragment beingFragment on Being { name }
-            ");
+            """);
     }
 
     [Fact]
     public void interface_into_overlapping_interface_in_inline_fragment()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment interfaceWithinInterface on Pet { ... on Being { name } }
-            ");
+            """);
     }
 
     [Fact]
     public void interface_into_overlapping_union()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment interfaceWithinUnion on CatOrDog { ...petFragment }
                 fragment petFragment on Pet { name }
-            ");
+            """);
     }
 
     [Fact]
@@ -107,11 +107,11 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                     fragment invalidObjectWithinObject on Cat { ...dogFragment }
                     fragment dogFragment on Dog { barkVolume }
-                ";
-            error(_, "dogFragment", "Cat", "Dog", 2, 65);
+                """;
+            error(_, "dogFragment", "Cat", "Dog", 1, 49);
         });
     }
 
@@ -120,12 +120,12 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidObjectWithinObjectAnon on Cat {
                     ... on Dog { barkVolume }
                   }
-                ";
-            errorAnon(_, "Cat", "Dog", 3, 21);
+                """;
+            errorAnon(_, "Cat", "Dog", 2, 5);
         });
     }
 
@@ -134,11 +134,11 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidObjectWithinInterface on Pet { ...humanFragment }
                   fragment humanFragment on Human { pets { name } }
-                ";
-            error(_, "humanFragment", "Pet", "Human", 2, 66);
+                """;
+            error(_, "humanFragment", "Pet", "Human", 1, 50);
         });
     }
 
@@ -147,11 +147,11 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidObjectWithinUnion on CatOrDog { ...humanFragment }
                   fragment humanFragment on Human { pets { name } }
-                ";
-            error(_, "humanFragment", "CatOrDog", "Human", 2, 67);
+                """;
+            error(_, "humanFragment", "CatOrDog", "Human", 1, 51);
         });
     }
 
@@ -160,11 +160,11 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidUnionWithinObject on Human { ...catOrDogFragment }
                   fragment catOrDogFragment on CatOrDog { __typename }
-                ";
-            error(_, "catOrDogFragment", "Human", "CatOrDog", 2, 64);
+                """;
+            error(_, "catOrDogFragment", "Human", "CatOrDog", 1, 48);
         });
     }
 
@@ -173,11 +173,11 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidUnionWithinInterface on Pet { ...humanOrAlienFragment }
                   fragment humanOrAlienFragment on HumanOrAlien { __typename }
-                ";
-            error(_, "humanOrAlienFragment", "Pet", "HumanOrAlien", 2, 65);
+                """;
+            error(_, "humanOrAlienFragment", "Pet", "HumanOrAlien", 1, 49);
         });
     }
 
@@ -186,11 +186,11 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidUnionWithinUnion on CatOrDog { ...humanOrAlienFragment }
                   fragment humanOrAlienFragment on HumanOrAlien { __typename }
-                ";
-            error(_, "humanOrAlienFragment", "CatOrDog", "HumanOrAlien", 2, 66);
+                """;
+            error(_, "humanOrAlienFragment", "CatOrDog", "HumanOrAlien", 1, 50);
         });
     }
 
@@ -199,11 +199,11 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidInterfaceWithinObject on Cat { ...intelligentFragment }
                   fragment intelligentFragment on Intelligent { iq }
-                ";
-            error(_, "intelligentFragment", "Cat", "Intelligent", 2, 66);
+                """;
+            error(_, "intelligentFragment", "Cat", "Intelligent", 1, 50);
         });
     }
 
@@ -212,13 +212,13 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidInterfaceWithinInterface on Pet {
                     ...intelligentFragment
                   }
                   fragment intelligentFragment on Intelligent { iq }
-                ";
-            error(_, "intelligentFragment", "Pet", "Intelligent", 3, 21);
+                """;
+            error(_, "intelligentFragment", "Pet", "Intelligent", 2, 5);
         });
     }
 
@@ -227,12 +227,12 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidInterfaceWithinInterfaceAnon on Pet {
                     ...on Intelligent { iq }
                   }
-                ";
-            errorAnon(_, "Pet", "Intelligent", 3, 21);
+                """;
+            errorAnon(_, "Pet", "Intelligent", 2, 5);
         });
     }
 
@@ -241,11 +241,11 @@ public class PossibleFragmentSpreadsTests : ValidationTestBase<PossibleFragmentS
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                   fragment invalidInterfaceWithinUnion on HumanOrAlien { ...petFragment }
                   fragment petFragment on Pet { name }
-                ";
-            error(_, "petFragment", "HumanOrAlien", "Pet", 2, 74);
+                """;
+            error(_, "petFragment", "HumanOrAlien", "Pet", 1, 58);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/ProvidedNonNullArgumentsTests.cs
+++ b/src/GraphQL.Tests/Validation/ProvidedNonNullArgumentsTests.cs
@@ -8,133 +8,133 @@ public class ProvidedNonNullArgumentsTests : ValidationTestBase<ProvidedNonNullA
     [Fact]
     public void ignores_unknown_arguments()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               {
                 dog {
                   isHousetrained(unknownArgument: true)
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void arg_on_optional_arg()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               dog {
                 isHousetrained(atOtherHomes: true)
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void no_arg_on_optional_arg()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               dog {
                 isHousetrained
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void multiple_args()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
                 multipleReqs(req1: 1, req2: 2)
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void multiple_args_reverse_order()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
                 multipleReqs(req2: 2, req1: 1)
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void no_args_on_multiple_optional()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
                 multipleOpts
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void one_arg_on_multiple_optional()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
                 multipleOpts(opt1: 1)
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void second_arg_on_multiple_optional()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
                 multipleOpts(opt2: 2)
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void multiple_reqs_on_mixed_list()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
                 multipleOptAndReq(req1: 3, req2: 4)
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void multiple_reqs_and_one_opt_on_mixed_list()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
                 multipleOptAndReq(req1: 3, req2: 4, opt1: 5)
               }
             }
-            ");
+            """);
     }
 
     [Fact]
     public void all_reqs_and_opts_on_mixed_list()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               complicatedArgs {
                 multipleOptAndReq(req1: 3, req2: 4, opt1: 5, opt2: 6)
               }
             }
-            ");
+            """);
     }
 
     [Fact]
@@ -142,13 +142,15 @@ public class ProvidedNonNullArgumentsTests : ValidationTestBase<ProvidedNonNullA
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"{
+            _.Query = """
+                {
                   complicatedArgs {
                     multipleReqs(req2: 2)
                   }
-                }";
+                }
+                """;
 
-            missingFieldArg(_, "multipleReqs", "req1", "Int!", 3, 21);
+            missingFieldArg(_, "multipleReqs", "req1", "Int!", 3, 5);
         });
     }
 
@@ -157,14 +159,16 @@ public class ProvidedNonNullArgumentsTests : ValidationTestBase<ProvidedNonNullA
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"{
+            _.Query = """
+                {
                   complicatedArgs {
                     multipleReqs
                   }
-                }";
+                }
+                """;
 
-            missingFieldArg(_, "multipleReqs", "req1", "Int!", 3, 21);
-            missingFieldArg(_, "multipleReqs", "req2", "Int!", 3, 21);
+            missingFieldArg(_, "multipleReqs", "req1", "Int!", 3, 5);
+            missingFieldArg(_, "multipleReqs", "req2", "Int!", 3, 5);
         });
     }
 
@@ -173,30 +177,32 @@ public class ProvidedNonNullArgumentsTests : ValidationTestBase<ProvidedNonNullA
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"{
+            _.Query = """
+                {
                   complicatedArgs {
-                    multipleReqs(req1: ""one"")
+                    multipleReqs(req1: "one")
                   }
-                }";
+                }
+                """;
 
-            missingFieldArg(_, "multipleReqs", "req2", "Int!", 3, 21);
+            missingFieldArg(_, "multipleReqs", "req2", "Int!", 3, 5);
         });
     }
 
     [Fact]
     public void ignores_unknown_directives()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               dog @unknown
             }
-            ");
+            """);
     }
 
     [Fact]
     public void with_directives_of_valid_types()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
             {
               dog @include(if: true) {
                 name
@@ -205,7 +211,7 @@ public class ProvidedNonNullArgumentsTests : ValidationTestBase<ProvidedNonNullA
                 name
               }
             }
-            ");
+            """);
     }
 
     [Fact]
@@ -213,15 +219,16 @@ public class ProvidedNonNullArgumentsTests : ValidationTestBase<ProvidedNonNullA
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 {
                   dog @include {
                     name @skip
                   }
-                }";
+                }
+                """;
 
-            missingDirectiveArg(_, "include", "if", "Boolean!", 3, 23);
-            missingDirectiveArg(_, "skip", "if", "Boolean!", 4, 26);
+            missingDirectiveArg(_, "include", "if", "Boolean!", 2, 7);
+            missingDirectiveArg(_, "skip", "if", "Boolean!", 3, 10);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/RequestServicesTests.cs
+++ b/src/GraphQL.Tests/Validation/RequestServicesTests.cs
@@ -46,7 +46,7 @@ public class RequestServicesTests
         // serialize to json to be sure no issues with a validation error without a number
         var serializer = provider.GetRequiredService<IGraphQLTextSerializer>();
         var resultString = serializer.Serialize(result);
-        resultString.ShouldBe(@"{""errors"":[{""message"":""Num is 1"",""extensions"":{""code"":""VALIDATION_ERROR"",""codes"":[""VALIDATION_ERROR""]}}]}");
+        resultString.ShouldBe("""{"errors":[{"message":"Num is 1","extensions":{"code":"VALIDATION_ERROR","codes":["VALIDATION_ERROR"]}}]}""");
     }
 
     private class MyValidationRule : IValidationRule

--- a/src/GraphQL.Tests/Validation/ScalarLeafTests.cs
+++ b/src/GraphQL.Tests/Validation/ScalarLeafTests.cs
@@ -8,41 +8,42 @@ public class ScalarLeafTests : ValidationTestBase<ScalarLeafs, ValidationSchema>
     [Fact]
     public void valid_scalar_selection()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment scalarSelection on Dog {
                   barks
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void object_type_missing_selection()
     {
-        var query = @"
+        var query = """
                 query directQueryOnObjectWithoutSubFields{
                   human
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
             _.Error(
                 message: RequiredSubselectionMessage("human", "Human"),
-                line: 3,
-                column: 19);
+                line: 2,
+                column: 3);
         });
     }
 
     [Fact]
     public void interface_type_missing_selection()
     {
-        var query = @"{
+        var query = """
+                {
                   human {
                     pets
                   }
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
@@ -50,112 +51,112 @@ public class ScalarLeafTests : ValidationTestBase<ScalarLeafs, ValidationSchema>
             _.Error(
                 message: RequiredSubselectionMessage("pets", "[Pet]"),
                 line: 3,
-                column: 21);
+                column: 5);
         });
     }
 
     [Fact]
     public void valid_scalar_selection_with_args()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment scalarSelectionWithArgs on Dog {
                   doesKnowCommand(dogCommand: SIT)
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void scalar_selection_not_allowed_on_boolean()
     {
-        var query = @"
+        var query = """
                 fragment scalarSelectionNotAllowedOnBoolean on Dog {
                   barks { sinceWhen }
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
             _.Error(
                 message: NoSubselectionAllowedMessage("barks", "Boolean"),
-                line: 3,
-                column: 25);
+                line: 2,
+                column: 9);
         });
     }
 
     [Fact]
     public void scalar_selection_not_allowed_on_enum()
     {
-        var query = @"
+        var query = """
                 fragment scalarSelectionsNotAllowedOnEnum on Cat {
                   furColor { inHexdec }
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
             _.Error(
                 message: NoSubselectionAllowedMessage("furColor", "FurColor"),
-                line: 3,
-                column: 28);
+                line: 2,
+                column: 12);
         });
     }
 
     [Fact]
     public void scalar_selection_not_allowed_with_args()
     {
-        var query = @"
+        var query = """
                 fragment scalarSelectionWithArgs on Dog {
                   doesKnowCommand(dogCommand: SIT) { sinceWhen }
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
             _.Error(
                 message: NoSubselectionAllowedMessage("doesKnowCommand", "Boolean"),
-                line: 3,
-                column: 52);
+                line: 2,
+                column: 36);
         });
     }
 
     [Fact]
     public void scalar_selection_not_allowed_with_directives()
     {
-        var query = @"
+        var query = """
                 fragment scalarSelectionsNotAllowedWithDirectives on Dog {
                   name @include(if: true) { isAlsoHumanName }
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
             _.Error(
                 message: NoSubselectionAllowedMessage("name", "String"),
-                line: 3,
-                column: 43);
+                line: 2,
+                column: 27);
         });
     }
 
     [Fact]
     public void scalar_selection_not_allowed_with_directives_and_args()
     {
-        var query = @"
+        var query = """
                 fragment scalarSelectionsNotAllowedWithDirectivesAndArgs on Dog {
                   doesKnowCommand(dogCommand: SIT) @include(if: true) { sinceWhen }
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
             _.Error(
                 message: NoSubselectionAllowedMessage("doesKnowCommand", "Boolean"),
-                line: 3,
-                column: 71);
+                line: 2,
+                column: 55);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/SingleRootFieldSubscriptionsTests.cs
+++ b/src/GraphQL.Tests/Validation/SingleRootFieldSubscriptionsTests.cs
@@ -34,34 +34,34 @@ public class SingleRootFieldSubscriptionsTests
     [Fact]
     public void Fails_with_more_than_one_root_field_in_anonymous_subscription()
     {
-        string query = @"
+        string query = """
                 subscription {
                     field
                     field2
                 }
-            ";
+            """;
 
         ShouldFailRule(config =>
         {
             config.Query = query;
-            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(default), 4, 21);
+            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(default), 3, 9);
         });
     }
 
     [Fact]
     public void Fails_with_more_than_one_root_field_including_introspection_in_anonymous_subscription()
     {
-        string query = @"
+        string query = """
                 subscription {
                     field
                     __typename
                 }
-            ";
+            """;
 
         ShouldFailRule(config =>
         {
             config.Query = query;
-            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(default), 4, 21);
+            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(default), 3, 9);
         });
     }
 
@@ -69,17 +69,17 @@ public class SingleRootFieldSubscriptionsTests
     public void Fails_with_more_than_one_root_field()
     {
         const string subscriptionName = "NamedSubscription";
-        const string query = @"
+        const string query = """
                 subscription NamedSubscription {
                     field
                     field2
                 }
-            ";
+            """;
 
         ShouldFailRule(config =>
         {
             config.Query = query;
-            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(new GraphQLName(subscriptionName)), 4, 21);
+            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(new GraphQLName(subscriptionName)), 3, 9);
         });
     }
 
@@ -87,17 +87,17 @@ public class SingleRootFieldSubscriptionsTests
     public void Fails_with_more_than_one_root_field_including_introspection()
     {
         const string subscriptionName = "NamedSubscription";
-        const string query = @"
+        const string query = """
                 subscription NamedSubscription {
                     field
                     __typename
                 }
-            ";
+            """;
 
         ShouldFailRule(config =>
         {
             config.Query = query;
-            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(new GraphQLName(subscriptionName)), 4, 21);
+            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(new GraphQLName(subscriptionName)), 3, 9);
         });
     }
 
@@ -105,7 +105,7 @@ public class SingleRootFieldSubscriptionsTests
     public void Fails_with_more_than_one_root_field_in_fragment_spead()
     {
         const string subscriptionName = "NamedSubscription";
-        const string query = @"
+        const string query = """
                 subscription NamedSubscription {
                     ...newMessageFields
                 }
@@ -117,12 +117,12 @@ public class SingleRootFieldSubscriptionsTests
                     }
                     disallowedSecondRootField
                 }
-            ";
+            """;
 
         ShouldFailRule(config =>
         {
             config.Query = query;
-            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(new GraphQLName(subscriptionName)), 3, 21);
+            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(new GraphQLName(subscriptionName)), 2, 9);
         });
     }
 
@@ -130,7 +130,7 @@ public class SingleRootFieldSubscriptionsTests
     public void Fails_with_more_than_one_root_field_in_inline_fragment()
     {
         const string subscriptionName = "NamedSubscription";
-        const string query = @"
+        const string query = """
                 subscription NamedSubscription {
                     ...on Subscription {
                         newMessage {
@@ -140,30 +140,30 @@ public class SingleRootFieldSubscriptionsTests
                         disallowedSecondRootField
                     }
                 }
-            ";
+            """;
 
         ShouldFailRule(config =>
         {
             config.Query = query;
-            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(new GraphQLName(subscriptionName)), 3, 21);
+            config.Error(SingleRootFieldSubscriptionsError.InvalidNumberOfRootFieldMessage(new GraphQLName(subscriptionName)), 2, 9);
         });
     }
 
     [Fact]
     public void Pass_with_one_root_field_in_fragment_spead()
     {
-        const string query = @"
+        const string query = """
                 subscription NamedSubscription {
                     ...newMessageFields
                 }
-                
+
                 fragment newMessageFields on Subscription {
                     newMessage {
                         body
                         sender
                     }
                 }
-            ";
+            """;
 
         ShouldPassRule(query);
     }
@@ -171,7 +171,7 @@ public class SingleRootFieldSubscriptionsTests
     [Fact]
     public void Pass_with_one_root_field_in_inline_fragment()
     {
-        const string query = @"
+        const string query = """
                 subscription NamedSubscription {
                     ...on Subscription {
                         newMessage {
@@ -180,7 +180,7 @@ public class SingleRootFieldSubscriptionsTests
                         }
                     }
                 }
-            ";
+            """;
 
         ShouldPassRule(query);
     }

--- a/src/GraphQL.Tests/Validation/UniqueArgumentNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/UniqueArgumentNamesTests.cs
@@ -8,92 +8,92 @@ public class UniqueArgumentNamesTests : ValidationTestBase<UniqueArgumentNames, 
     [Fact]
     public void no_arguments_on_field()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
           field
         }
-      ");
+        """);
     }
 
     [Fact]
     public void no_arguments_on_directive()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
           field @directive
         }
-      ");
+        """);
     }
 
     [Fact]
     public void argument_on_field()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
-          field(arg: ""value"")
+          field(arg: "value")
         }
-      ");
+        """);
     }
 
     [Fact]
     public void argument_on_directive()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
-          field @directive(arg: ""value"")
+          field @directive(arg: "value")
         }
-      ");
+        """);
     }
 
     [Fact]
     public void same_argument_on_two_fields()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
-          one: field(arg: ""value"")
-          two: field(arg: ""value"")
+          one: field(arg: "value")
+          two: field(arg: "value")
         }
-      ");
+        """);
     }
 
     [Fact]
     public void same_argument_on_field_and_directive()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
-          field(arg: ""value"") @directive(arg: ""value"")
+          field(arg: "value") @directive(arg: "value")
         }
-      ");
+        """);
     }
 
     [Fact]
     public void same_argument_on_two_directives()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
-          field @directive1(arg: ""value"") @directive2(arg: ""value"")
+          field @directive1(arg: "value") @directive2(arg: "value")
         }
-      ");
+        """);
     }
 
     [Fact]
     public void multiple_field_arguments()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
-          field(arg1: ""value"", arg2: ""value"", arg3: ""value"")
+          field(arg1: "value", arg2: "value", arg3: "value")
         }
-      ");
+        """);
     }
 
     [Fact]
     public void multiple_directive_arguments()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
-          field @directive(arg1: ""value"", arg2: ""value"", arg3: ""value"")
+          field @directive(arg1: "value", arg2: "value", arg3: "value")
         }
-      ");
+        """);
     }
 
     [Fact]
@@ -101,12 +101,12 @@ public class UniqueArgumentNamesTests : ValidationTestBase<UniqueArgumentNames, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          {
-            field(arg1: ""value"", arg1: ""value"")
-          }
-        ";
-            duplicateArg(_, "arg1", 3, 19, 3, 34);
+            _.Query = """
+            {
+              field(arg1: "value", arg1: "value")
+            }
+            """;
+            duplicateArg(_, "arg1", 2, 9, 2, 24);
         });
     }
 
@@ -115,13 +115,13 @@ public class UniqueArgumentNamesTests : ValidationTestBase<UniqueArgumentNames, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          {
-            field(arg1: ""value"", arg1: ""value"", arg1: ""value"")
-          }
-        ";
-            duplicateArg(_, "arg1", 3, 19, 3, 34);
-            duplicateArg(_, "arg1", 3, 19, 3, 49);
+            _.Query = """
+            {
+              field(arg1: "value", arg1: "value", arg1: "value")
+            }
+            """;
+            duplicateArg(_, "arg1", 2, 9, 2, 24);
+            duplicateArg(_, "arg1", 2, 9, 2, 39);
         });
     }
 
@@ -130,12 +130,12 @@ public class UniqueArgumentNamesTests : ValidationTestBase<UniqueArgumentNames, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          {
-            field @directive(arg1: ""value"", arg1: ""value"")
-          }
-        ";
-            duplicateArg(_, "arg1", 3, 30, 3, 45);
+            _.Query = """
+            {
+              field @directive(arg1: "value", arg1: "value")
+            }
+            """;
+            duplicateArg(_, "arg1", 2, 20, 2, 35);
         });
     }
 
@@ -144,13 +144,13 @@ public class UniqueArgumentNamesTests : ValidationTestBase<UniqueArgumentNames, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          {
-            field @directive(arg1: ""value"", arg1: ""value"", arg1: ""value"")
-          }
-        ";
-            duplicateArg(_, "arg1", 3, 30, 3, 45);
-            duplicateArg(_, "arg1", 3, 30, 3, 60);
+            _.Query = """
+            {
+              field @directive(arg1: "value", arg1: "value", arg1: "value")
+            }
+            """;
+            duplicateArg(_, "arg1", 2, 20, 2, 35);
+            duplicateArg(_, "arg1", 2, 20, 2, 50);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/UniqueDirectivesPerLocationTests.cs
+++ b/src/GraphQL.Tests/Validation/UniqueDirectivesPerLocationTests.cs
@@ -7,62 +7,62 @@ public class UniqueDirectivesPerLocationTests : ValidationTestBase<UniqueDirecti
     [Fact]
     public void no_directives()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment Test on Type {
                     field
                 }
-            ");
+            """);
     }
 
     [Fact]
     public void repeatable_directives_in_same_locations()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment Test on Type @rep @rep {
                     field @rep @rep
                 }
-            ");
+            """);
     }
 
     [Fact]
     public void unique_directives_in_different_locations()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment Test on Type @directiveA {
                     field @directiveB
                 }
-            ");
+            """);
     }
 
     [Fact]
     public void unique_directives_in_same_locations()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment Test on Type @directiveA @directiveB {
                     field @directiveA @directiveB
                 }
-            ");
+            """);
     }
 
     [Fact]
     public void same_directives_in_different_locations()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment Test on Type @directiveA {
                     field @directiveA
                 }
-            ");
+            """);
     }
 
     [Fact]
     public void same_directives_in_similar_locations()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment Test on Type {
                     field @directiveA
                     field @directiveA
                 }
-            ");
+            """);
     }
 
     [Fact]
@@ -70,13 +70,13 @@ public class UniqueDirectivesPerLocationTests : ValidationTestBase<UniqueDirecti
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 fragment Test on Type {
                     field @directive @directive
                 }
-                ";
-            duplicateDirective(_, "directive", 3, 27);
-            duplicateDirective(_, "directive", 3, 38);
+                """;
+            duplicateDirective(_, "directive", 2, 11);
+            duplicateDirective(_, "directive", 2, 22);
         });
     }
 
@@ -85,14 +85,14 @@ public class UniqueDirectivesPerLocationTests : ValidationTestBase<UniqueDirecti
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 fragment Test on Type {
                     field @directive @directive @directive
                 }
-                ";
-            duplicateDirective(_, "directive", 3, 27);
-            duplicateDirective(_, "directive", 3, 38);
-            duplicateDirective(_, "directive", 3, 49);
+                """;
+            duplicateDirective(_, "directive", 2, 11);
+            duplicateDirective(_, "directive", 2, 22);
+            duplicateDirective(_, "directive", 2, 33);
         });
     }
 
@@ -101,15 +101,15 @@ public class UniqueDirectivesPerLocationTests : ValidationTestBase<UniqueDirecti
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 fragment Test on Type {
                     field @directiveA @directiveB @directiveA @directiveB
                 }
-                ";
-            duplicateDirective(_, "directiveA", 3, 27);
-            duplicateDirective(_, "directiveB", 3, 39);
-            duplicateDirective(_, "directiveA", 3, 51);
-            duplicateDirective(_, "directiveB", 3, 63);
+                """;
+            duplicateDirective(_, "directiveA", 2, 11);
+            duplicateDirective(_, "directiveB", 2, 23);
+            duplicateDirective(_, "directiveA", 2, 35);
+            duplicateDirective(_, "directiveB", 2, 47);
         });
     }
 
@@ -118,15 +118,15 @@ public class UniqueDirectivesPerLocationTests : ValidationTestBase<UniqueDirecti
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
+            _.Query = """
                 fragment Test on Type @directive @directive {
                     field @directive @directive
                 }
-                ";
-            duplicateDirective(_, "directive", 2, 39);
-            duplicateDirective(_, "directive", 2, 50);
-            duplicateDirective(_, "directive", 3, 27);
-            duplicateDirective(_, "directive", 3, 38);
+                """;
+            duplicateDirective(_, "directive", 1, 23);
+            duplicateDirective(_, "directive", 1, 34);
+            duplicateDirective(_, "directive", 2, 11);
+            duplicateDirective(_, "directive", 2, 22);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/UniqueFragmentNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/UniqueFragmentNamesTests.cs
@@ -8,30 +8,30 @@ public class UniqueFragmentNamesTests : ValidationTestBase<UniqueFragmentNames, 
     [Fact]
     public void no_fragments()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
           field
         }
-      ");
+        """);
     }
 
     [Fact]
     public void one_fragment()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
           ...fragA
         }
         fragment fragA on Type {
           field
         }
-      ");
+        """);
     }
 
     [Fact]
     public void many_fragments()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
           ...fragA
           ...fragB
@@ -46,13 +46,13 @@ public class UniqueFragmentNamesTests : ValidationTestBase<UniqueFragmentNames, 
         fragment fragC on Type {
           fieldC
         }
-      ");
+        """);
     }
 
     [Fact]
     public void inline_fragments_are_always_unique()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         {
           ...on Type {
             fieldA
@@ -61,20 +61,20 @@ public class UniqueFragmentNamesTests : ValidationTestBase<UniqueFragmentNames, 
             fieldB
           }
         }
-      ");
+        """);
     }
 
     [Fact]
     public void fragment_and_operation_named_the_same()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
         query Foo {
           ...Foo
         }
         fragment Foo on Type {
           field
         }
-      ");
+        """);
     }
 
     [Fact]
@@ -82,19 +82,19 @@ public class UniqueFragmentNamesTests : ValidationTestBase<UniqueFragmentNames, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          {
-            ...fragA
-          }
-          fragment fragA on Type {
-            fieldA
-          }
-          fragment fragA on Type {
-            fieldB
-          }
-        ";
+            _.Query = """
+            {
+              ...fragA
+            }
+            fragment fragA on Type {
+              fieldA
+            }
+            fragment fragA on Type {
+              fieldB
+            }
+            """;
             // Note: this is failing on "fragment"; graphql-js fails on the fragment name.
-            duplicateFrag(_, "fragA", 5, 11, 8, 11);
+            duplicateFrag(_, "fragA", 4, 1, 7, 1);
         });
     }
 
@@ -103,16 +103,16 @@ public class UniqueFragmentNamesTests : ValidationTestBase<UniqueFragmentNames, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          fragment fragA on Type {
-            fieldA
-          }
-          fragment fragA on Type {
-            fieldB
-          }
-        ";
+            _.Query = """
+            fragment fragA on Type {
+              fieldA
+            }
+            fragment fragA on Type {
+              fieldB
+            }
+            """;
             // Note: this is failing on "fragment"; graphql-js fails on the fragment name.
-            duplicateFrag(_, "fragA", 2, 11, 5, 11);
+            duplicateFrag(_, "fragA", 1, 1, 4, 1);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/UniqueInputFieldNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/UniqueInputFieldNamesTests.cs
@@ -8,49 +8,49 @@ public class UniqueInputFieldNamesTests : ValidationTestBase<UniqueInputFieldNam
     [Fact]
     public void input_object_with_fields()
     {
-        ShouldPassRule(@"
-              {
-                field(arg: { f: true })
-              }
-            ");
+        ShouldPassRule("""
+            {
+              field(arg: { f: true })
+            }
+            """);
     }
 
     [Fact]
     public void same_input_object_within_two_args()
     {
-        ShouldPassRule(@"
-              {
-                field(arg1: { f: true }, arg2: { f: true })
-              }
-            ");
+        ShouldPassRule("""
+            {
+              field(arg1: { f: true }, arg2: { f: true })
+            }
+            """);
     }
 
     [Fact]
     public void multiple_input_object_fields()
     {
-        ShouldPassRule(@"
-              {
-                field(arg: { f1: ""value"", f2: ""value"", f3: ""value"" })
-              }
-            ");
+        ShouldPassRule("""
+            {
+              field(arg: { f1: "value", f2: "value", f3: "value" })
+            }
+            """);
     }
 
     [Fact]
     public void allows_for_nested_input_object_with_similar_fields()
     {
-        ShouldPassRule(@"
-              {
-                field(arg: {
+        ShouldPassRule("""
+            {
+              field(arg: {
+                deep: {
                   deep: {
-                    deep: {
-                      id: 1
-                    }
                     id: 1
                   }
                   id: 1
-                })
-              }
-            ");
+                }
+                id: 1
+              })
+            }
+            """);
     }
 
     [Fact]
@@ -58,16 +58,16 @@ public class UniqueInputFieldNamesTests : ValidationTestBase<UniqueInputFieldNam
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  {
-                    field(arg: { f1: ""value"", f1: ""value"" })
-                  }
-                ";
+            _.Query = """
+                {
+                  field(arg: { f1: "value", f1: "value" })
+                }
+                """;
             _.Error(x =>
             {
                 x.Message = UniqueInputFieldNamesError.DuplicateInputField("f1");
-                x.Loc(3, 38);
-                x.Loc(3, 51);
+                x.Loc(2, 20);
+                x.Loc(2, 33);
             });
         });
     }
@@ -77,22 +77,22 @@ public class UniqueInputFieldNamesTests : ValidationTestBase<UniqueInputFieldNam
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  {
-                    field(arg: { f1: ""value"", f1: ""value"", f1: ""value"" })
-                  }
-                ";
+            _.Query = """
+                {
+                  field(arg: { f1: "value", f1: "value", f1: "value" })
+                }
+                """;
             _.Error(x =>
             {
                 x.Message = UniqueInputFieldNamesError.DuplicateInputField("f1");
-                x.Loc(3, 38);
-                x.Loc(3, 51);
+                x.Loc(2, 20);
+                x.Loc(2, 33);
             });
             _.Error(x =>
             {
                 x.Message = UniqueInputFieldNamesError.DuplicateInputField("f1");
-                x.Loc(3, 38);
-                x.Loc(3, 64);
+                x.Loc(2, 20);
+                x.Loc(2, 46);
             });
         });
     }

--- a/src/GraphQL.Tests/Validation/UniqueOperationNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/UniqueOperationNamesTests.cs
@@ -8,37 +8,37 @@ public class UniqueOperationNamesTests : ValidationTestBase<UniqueOperationNames
     [Fact]
     public void no_operations()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 fragment fragA on Type {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void one_anon_operation()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void one_named_operation()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 query Foo {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void multiple_operations()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 query Foo {
                   field
                 }
@@ -46,13 +46,13 @@ public class UniqueOperationNamesTests : ValidationTestBase<UniqueOperationNames
                 query Bar {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void multiple_operations_of_different_types()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 query Foo {
                   field
                 }
@@ -64,13 +64,13 @@ public class UniqueOperationNamesTests : ValidationTestBase<UniqueOperationNames
                 subscription Baz {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void fragment_and_operation_named_the_same()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 query Foo {
                   ...Foo
                 }
@@ -78,13 +78,13 @@ public class UniqueOperationNamesTests : ValidationTestBase<UniqueOperationNames
                 fragment Foo on Type {
                   field
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void multiple_operations_of_same_name()
     {
-        var query = @"
+        var query = """
                 query Foo {
                   fieldA
                 }
@@ -92,19 +92,19 @@ public class UniqueOperationNamesTests : ValidationTestBase<UniqueOperationNames
                 query Foo {
                   fieldB
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            _.Error(UniqueOperationNamesError.DuplicateOperationNameMessage("Foo"), 6, 17);
+            _.Error(UniqueOperationNamesError.DuplicateOperationNameMessage("Foo"), 5, 1);
         });
     }
 
     [Fact]
     public void multiple_operations_of_same_name_of_different_types_mutation()
     {
-        var query = @"
+        var query = """
                 query Foo {
                   fieldA
                 }
@@ -112,19 +112,19 @@ public class UniqueOperationNamesTests : ValidationTestBase<UniqueOperationNames
                 mutation Foo {
                   fieldB
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            _.Error(UniqueOperationNamesError.DuplicateOperationNameMessage("Foo"), 6, 17);
+            _.Error(UniqueOperationNamesError.DuplicateOperationNameMessage("Foo"), 5, 1);
         });
     }
 
     [Fact]
     public void multiple_operations_of_same_name_of_different_types_subscription()
     {
-        var query = @"
+        var query = """
                 query Foo {
                   fieldA
                 }
@@ -132,12 +132,12 @@ public class UniqueOperationNamesTests : ValidationTestBase<UniqueOperationNames
                 subscription Foo {
                   fieldB
                 }
-                ";
+                """;
 
         ShouldFailRule(_ =>
         {
             _.Query = query;
-            _.Error(UniqueOperationNamesError.DuplicateOperationNameMessage("Foo"), 6, 17);
+            _.Error(UniqueOperationNamesError.DuplicateOperationNameMessage("Foo"), 5, 1);
         });
     }
 }

--- a/src/GraphQL.Tests/Validation/UniqueVariableNamesTests.cs
+++ b/src/GraphQL.Tests/Validation/UniqueVariableNamesTests.cs
@@ -8,10 +8,10 @@ public class UniqueVariableNamesTests : ValidationTestBase<UniqueVariableNames, 
     [Fact]
     public void unique_variable_names()
     {
-        ShouldPassRule(@"
-        query A($x: Int, $y: String) { __typename }
-        query B($x: String, $y: Int) { __typename }
-      ");
+        ShouldPassRule("""
+            query A($x: Int, $y: String) { __typename }
+            query B($x: String, $y: Int) { __typename }
+            """);
     }
 
     [Fact]
@@ -19,15 +19,15 @@ public class UniqueVariableNamesTests : ValidationTestBase<UniqueVariableNames, 
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-          query A($x: Int, $x: Int, $x: String) { __typename }
-          query B($x: String, $x: Int) { __typename }
-          query C($x: Int, $x: Int) { __typename }
-        ";
-            duplicateVariable(_, "x", 2, 19, 2, 28);
-            duplicateVariable(_, "x", 2, 19, 2, 37);
-            duplicateVariable(_, "x", 3, 19, 3, 31);
-            duplicateVariable(_, "x", 4, 19, 4, 28);
+            _.Query = """
+                query A($x: Int, $x: Int, $x: String) { __typename }
+                query B($x: String, $x: Int) { __typename }
+                query C($x: Int, $x: Int) { __typename }
+                """;
+            duplicateVariable(_, "x", 1, 9, 1, 18);
+            duplicateVariable(_, "x", 1, 9, 1, 27);
+            duplicateVariable(_, "x", 2, 9, 2, 21);
+            duplicateVariable(_, "x", 3, 9, 3, 18);
         });
     }
 

--- a/src/GraphQL.Tests/Validation/VariablesAreInputTypesTests.cs
+++ b/src/GraphQL.Tests/Validation/VariablesAreInputTypesTests.cs
@@ -8,11 +8,11 @@ public class VariablesAreInputTypesTests : ValidationTestBase<VariablesAreInputT
     [Fact]
     public void input_types_are_valid()
     {
-        ShouldPassRule(@"
-              query Foo($a: String, $b: [Boolean!]!, $c: ComplexInput) {
-                field(a: $a, b: $b, c: $c)
-              }
-            ",
+        ShouldPassRule("""
+            query Foo($a: String, $b: [Boolean!]!, $c: ComplexInput) {
+              field(a: $a, b: $b, c: $c)
+            }
+            """,
         "{ \"b\": [true] }");
     }
 
@@ -21,27 +21,27 @@ public class VariablesAreInputTypesTests : ValidationTestBase<VariablesAreInputT
     {
         ShouldFailRule(_ =>
         {
-            _.Query = @"
-                  query Foo($a: Dog, $b: [[CatOrDog!]]!, $c: Pet) {
-                    field(a: $a, b: $b, c: $c)
-                  }
-                ";
+            _.Query = """
+                query Foo($a: Dog, $b: [[CatOrDog!]]!, $c: Pet) {
+                  field(a: $a, b: $b, c: $c)
+                }
+                """;
             _.Error(
                 message: VariablesAreInputTypesError.UndefinedVarMessage("a", "Dog"),
-                line: 2,
-                column: 29);
+                line: 1,
+                column: 11);
             _.Error(
                 message: VariablesAreInputTypesError.UndefinedVarMessage("b", "[[CatOrDog!]]!"),
-                line: 2,
-                column: 38);
+                line: 1,
+                column: 20);
             _.Error(
                 message: VariablesAreInputTypesError.UndefinedVarMessage("c", "Pet"),
-                line: 2,
-                column: 58);
+                line: 1,
+                column: 40);
             _.Error(
                message: "Variable '$b' is invalid. No value provided for a non-null variable.",
-               line: 2,
-               column: 38);
+               line: 1,
+               column: 20);
         });
     }
 }

--- a/src/GraphQL.Tests/Validation/VariablesInAllowedPositionTests.cs
+++ b/src/GraphQL.Tests/Validation/VariablesInAllowedPositionTests.cs
@@ -8,20 +8,20 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
     [Fact]
     public void boolean_to_boolean()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
                 query Query($booleanArg: Boolean)
                 {
                   complicatedArgs {
                     booleanArgField(booleanArg: $booleanArg)
                   }
                 }
-                ");
+                """);
     }
 
     [Fact]
     public void boolean_to_boolean_within_fragment()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment booleanArgFrag on ComplicatedArgs {
                 booleanArgField(booleanArg: $booleanArg)
               }
@@ -31,9 +31,9 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
                   ...booleanArgFrag
                 }
               }
-            ");
+            """);
 
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($booleanArg: Boolean)
               {
                 complicatedArgs {
@@ -43,27 +43,27 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
               fragment booleanArgFrag on ComplicatedArgs {
                 booleanArgField(booleanArg: $booleanArg)
               }
-            ");
+            """);
     }
 
     [Fact]
     public void nonnull_boolean_to_boolean()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($nonNullBooleanArg: Boolean!)
               {
                 complicatedArgs {
                   booleanArgField(booleanArg: $nonNullBooleanArg)
                 }
               }
-            ",
-        "{ \"nonNullBooleanArg\": true }");
+            """,
+            """{ "nonNullBooleanArg": true }""");
     }
 
     [Fact]
     public void nonnull_boolean_to_boolean_within_fragment()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               fragment booleanArgFrag on ComplicatedArgs {
                 booleanArgField(booleanArg: $nonNullBooleanArg)
               }
@@ -73,135 +73,135 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
                   ...booleanArgFrag
                 }
               }
-            ",
-        "{ \"nonNullBooleanArg\": true }");
+            """,
+            """{ "nonNullBooleanArg": true }""");
     }
 
     [Fact]
     public void int_to_int_with_default()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($intArg: Int = 1)
               {
                 complicatedArgs {
                   nonNullIntArgField(nonNullIntArg: $intArg)
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void string_list_to_string_list()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($stringListVar: [String])
               {
                 complicatedArgs {
                   stringListArgField(stringListArg: $stringListVar)
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void nonnull_string_list_to_string_list()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($stringListVar: [String!])
               {
                 complicatedArgs {
                   stringListArgField(stringListArg: $stringListVar)
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void string_to_string_list_in_item_position()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($stringVar: String)
               {
                 complicatedArgs {
                   stringListArgField(stringListArg: [$stringVar])
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void nonnull_string_to_string_list_in_item_position()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($stringVar: String!)
               {
                 complicatedArgs {
                   stringListArgField(stringListArg: [$stringVar])
                 }
               }
-            ",
-        "{ \"stringVar\": \"\" }");
+            """,
+            """{ "stringVar": "" }""");
     }
 
     [Fact]
     public void complexinput_to_complexinput()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($complexVar: ComplexInput)
               {
                 complicatedArgs {
                   complexArgField(complexArg: $complexVar)
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void complexinput_to_complexinput_in_field_position()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($boolVar: Boolean = false)
               {
                 complicatedArgs {
                   complexArgField(complexArg: {requiredArg: $boolVar})
                 }
               }
-            ");
+            """);
     }
 
     [Fact]
     public void nullable_boolean_to_nullable_boolean_in_directive()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($boolVar: Boolean!)
               {
                 dog @include(if: $boolVar)
               }
-            ",
-        "{ \"boolVar\": true }");
+            """,
+            """{ "boolVar": true }""");
     }
 
     [Fact]
     public void boolean_to_nullable_boolean_in_directive_with_default()
     {
-        ShouldPassRule(@"
+        ShouldPassRule("""
               query Query($boolVar: Boolean = false)
               {
                 dog @include(if: $boolVar)
               }
-            ");
+            """);
     }
 
     [Fact]
     public void int_to_nonnull_int()
     {
-        var query = @"
-              query Query($intArg: Int) {
-                complicatedArgs {
-                  nonNullIntArgField(nonNullIntArg: $intArg)
-                }
+        var query = """
+            query Query($intArg: Int) {
+              complicatedArgs {
+                nonNullIntArgField(nonNullIntArg: $intArg)
               }
-            ";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
@@ -209,8 +209,8 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
             _.Error(err =>
             {
                 err.Message = BadVarPosMessage("intArg", "Int", "Int!");
-                err.Loc(2, 27);
-                err.Loc(4, 53);
+                err.Loc(1, 13);
+                err.Loc(3, 39);
             });
         });
     }
@@ -218,17 +218,17 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
     [Fact]
     public void int_to_nonnull_int_within_fragment()
     {
-        var query = @"
-              fragment nonNullIntArgFieldFrag on ComplicatedArgs {
-                nonNullIntArgField(nonNullIntArg: $intArg)
-              }
+        var query = """
+            fragment nonNullIntArgFieldFrag on ComplicatedArgs {
+              nonNullIntArgField(nonNullIntArg: $intArg)
+            }
 
-              query Query($intArg: Int) {
-                complicatedArgs {
-                  ...nonNullIntArgFieldFrag
-                }
+            query Query($intArg: Int) {
+              complicatedArgs {
+                ...nonNullIntArgFieldFrag
               }
-            ";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
@@ -236,8 +236,8 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
             _.Error(err =>
             {
                 err.Message = BadVarPosMessage("intArg", "Int", "Int!");
-                err.Loc(6, 27);
-                err.Loc(3, 51);
+                err.Loc(5, 13);
+                err.Loc(2, 37);
             });
         });
     }
@@ -245,21 +245,21 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
     [Fact]
     public void int_to_nonnull_int_within_nested_fragment()
     {
-        var query = @"
-              fragment outerFrag on ComplicatedArgs {
-                ...nonNullIntArgFieldFrag
-              }
+        var query = """
+            fragment outerFrag on ComplicatedArgs {
+              ...nonNullIntArgFieldFrag
+            }
 
-              fragment nonNullIntArgFieldFrag on ComplicatedArgs {
-                nonNullIntArgField(nonNullIntArg: $intArg)
-              }
+            fragment nonNullIntArgFieldFrag on ComplicatedArgs {
+              nonNullIntArgField(nonNullIntArg: $intArg)
+            }
 
-              query Query($intArg: Int) {
-                complicatedArgs {
-                  ...outerFrag
-                }
+            query Query($intArg: Int) {
+              complicatedArgs {
+                ...outerFrag
               }
-            ";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
@@ -267,8 +267,8 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
             _.Error(err =>
             {
                 err.Message = BadVarPosMessage("intArg", "Int", "Int!");
-                err.Loc(10, 27);
-                err.Loc(7, 51);
+                err.Loc(9, 13);
+                err.Loc(6, 37);
             });
         });
     }
@@ -276,13 +276,13 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
     [Fact]
     public void string_over_boolean()
     {
-        var query = @"
-              query Query($stringVar: String) {
-                complicatedArgs {
-                  booleanArgField(booleanArg: $stringVar)
-                }
+        var query = """
+            query Query($stringVar: String) {
+              complicatedArgs {
+                booleanArgField(booleanArg: $stringVar)
               }
-            ";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
@@ -290,8 +290,8 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
             _.Error(err =>
             {
                 err.Message = BadVarPosMessage("stringVar", "String", "Boolean");
-                err.Loc(2, 27);
-                err.Loc(4, 47);
+                err.Loc(1, 13);
+                err.Loc(3, 33);
             });
         });
     }
@@ -299,13 +299,13 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
     [Fact]
     public void string_to_string_list()
     {
-        var query = @"
-              query Query($stringVar: String) {
-                complicatedArgs {
-                  stringListArgField(stringListArg: $stringVar)
-                }
+        var query = """
+            query Query($stringVar: String) {
+              complicatedArgs {
+                stringListArgField(stringListArg: $stringVar)
               }
-            ";
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
@@ -313,8 +313,8 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
             _.Error(err =>
             {
                 err.Message = BadVarPosMessage("stringVar", "String", "[String]");
-                err.Loc(2, 27);
-                err.Loc(4, 53);
+                err.Loc(1, 13);
+                err.Loc(3, 39);
             });
         });
     }
@@ -322,11 +322,11 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
     [Fact]
     public void boolean_to_nonnull_boolean_in_directive()
     {
-        var query = @"
-              query Query($boolVar: Boolean) {
-                dog @include(if: $boolVar)
-              }
-            ";
+        var query = """
+            query Query($boolVar: Boolean) {
+              dog @include(if: $boolVar)
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
@@ -334,8 +334,8 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
             _.Error(err =>
             {
                 err.Message = BadVarPosMessage("boolVar", "Boolean", "Boolean!");
-                err.Loc(2, 27);
-                err.Loc(3, 34);
+                err.Loc(1, 13);
+                err.Loc(2, 20);
             });
         });
     }
@@ -343,11 +343,11 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
     [Fact]
     public void string_to_nonnull_boolean_in_directive()
     {
-        var query = @"
-              query Query($stringVar: String) {
-                dog @include(if: $stringVar)
-              }
-            ";
+        var query = """
+            query Query($stringVar: String) {
+              dog @include(if: $stringVar)
+            }
+            """;
 
         ShouldFailRule(_ =>
         {
@@ -355,8 +355,8 @@ public class VariablesInAllowedPositionTests : ValidationTestBase<VariablesInAll
             _.Error(err =>
             {
                 err.Message = BadVarPosMessage("stringVar", "String", "Boolean!");
-                err.Loc(2, 27);
-                err.Loc(3, 34);
+                err.Loc(1, 13);
+                err.Loc(2, 20);
             });
         });
     }


### PR DESCRIPTION
I really liked this new C#11 feature so I was not too lazy and switched all the tests to it from `@` and escape symbols. Now each JSON string is a real JSON without escapes, which can be copied unchanged and used somewhere else. There is even a syntax highlighting. The same for GraphQL requests - nomore `""` inside. 

No changes in projects besides tests.