### PR TITLE
Add test for interface with no underlying object type

### DIFF
--- a/src/GraphQL.Tests/Types/InterfaceTests.cs
+++ b/src/GraphQL.Tests/Types/InterfaceTests.cs
@@ -1,0 +1,47 @@
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Types;
+
+public class InterfaceTests : QueryTestBase<InterfaceTests.MySchema>
+{
+    [Fact]
+    public void InterfaceWithNoObject()
+    {
+        AssertQuerySuccess("{ test { id } }", """
+            {
+                "test": {
+                    "id": "123"
+                }
+            }
+            """);
+    }
+
+    public class MySchema : Schema
+    {
+        public MySchema()
+        {
+            Query = new MyQuery();
+        }
+    }
+
+    public class MyQuery : ObjectGraphType
+    {
+        public MyQuery()
+        {
+            Field<NonNullGraphType<MyInterfaceType>>("test", resolve: _ => new MyObject());
+        }
+    }
+
+    public class MyInterfaceType : InterfaceGraphType<MyObject>
+    {
+        public MyInterfaceType()
+        {
+            Field("id", x => x.Id);
+        }
+    }
+
+    public class MyObject
+    {
+        public string Id { get; set; } = "123";
+    }
+}

--- a/src/GraphQL.Tests/Types/InterfaceTests.cs
+++ b/src/GraphQL.Tests/Types/InterfaceTests.cs
@@ -7,10 +7,46 @@ public class InterfaceTests : QueryTestBase<InterfaceTests.MySchema>
     [Fact]
     public void InterfaceWithNoObject()
     {
-        AssertQuerySuccess("{ test { id } }", """
+        AssertQuerySuccess(
+            """
             {
-                "test": {
+                noObjectTest {
+                    id                    # as there is no object type defined for this
+                                          # result, the interface resolver will be used
+                                          # to return "123_interface"
+                }
+            }
+            """,
+            """
+            {
+                "noObjectTest": {
                     "id": "123"
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public void InterfaceWithObject()
+    {
+        AssertQuerySuccess(
+            """
+            {
+                objectTest {
+                    ... on MyObject2 {
+                        idOnMyObject2: id   # returns "234"
+                    }
+                    idOnInterface: id       # because MyObject2 implements the interface,
+                                            # it will be resolved by MyObject2 and return
+                                            # "234" instead of "234_interface"
+                }
+            }
+            """,
+            """
+            {
+                "objectTest": {
+                    "idOnMyObject2": "234",
+                    "idOnInterface": "234"
                 }
             }
             """);
@@ -21,6 +57,7 @@ public class InterfaceTests : QueryTestBase<InterfaceTests.MySchema>
         public MySchema()
         {
             Query = new MyQuery();
+            RegisterType(new MyObject2GraphType());
         }
     }
 
@@ -28,7 +65,27 @@ public class InterfaceTests : QueryTestBase<InterfaceTests.MySchema>
     {
         public MyQuery()
         {
-            Field<NonNullGraphType<MyInterfaceType>>("test", resolve: _ => new MyObject());
+            Field<NonNullGraphType<MyInterfaceType>>("noObjectTest", resolve: _ => new MyObject());
+            Field<MyInterfaceType2>("objectTest", resolve: _ => new MyObject2());
+        }
+    }
+
+    public class MyInterfaceType2 : InterfaceGraphType<MyObject2>
+    {
+        public MyInterfaceType2()
+        {
+            Field<StringGraphType>("id")
+                .Resolve(ctx => ctx.Source.Id + "_interface");
+        }
+    }
+
+    public class MyObject2GraphType : ObjectGraphType<MyObject2>
+    {
+        public MyObject2GraphType()
+        {
+            Name = "MyObject2";
+            Field<StringGraphType>("id");
+            Interface<MyInterfaceType2>();
         }
     }
 
@@ -36,12 +93,18 @@ public class InterfaceTests : QueryTestBase<InterfaceTests.MySchema>
     {
         public MyInterfaceType()
         {
-            Field("id", x => x.Id);
+            Field("id", x => x.Id)
+                .Resolve(ctx => ctx.Source.Id + "_interface");
         }
     }
 
     public class MyObject
     {
         public string Id { get; set; } = "123";
+    }
+
+    public class MyObject2
+    {
+        public string Id { get; set; } = "234";
     }
 }

--- a/src/GraphQL.Tests/Types/InterfaceTests.cs
+++ b/src/GraphQL.Tests/Types/InterfaceTests.cs
@@ -20,7 +20,7 @@ public class InterfaceTests : QueryTestBase<InterfaceTests.MySchema>
             """
             {
                 "noObjectTest": {
-                    "id": "123"
+                    "id": "123_interface"
                 }
             }
             """);


### PR DESCRIPTION
Based on what I can see in the GraphQL spec, it is allowed by the spec to have an interface where there are no object types that implement the interface.

> GraphQL interfaces represent a list of named fields and their arguments. GraphQL objects can then implement these interfaces which requires that the object type will define all fields defined by those interfaces.

Note word "can".  It does say this also: 

> Result Coercion
>
> The interface type should have some way of determining which object a given result corresponds to. Once it has done so, the result coercion of the interface is the same as the result coercion of the object.

But I take this to mean in the context of the application.  (and it says "should", not "required")  Since we can define field resolvers on an interface, they can be executed on that basis, and so it is not _necessary_ to relate a result to the object type.

This logic is most useful in GraphQL.NET with the `AutoRegisteringInterfaceGraphType` class, I believe, as .NET's interfaces don't need to be mapped to a class to be useful, and this behavior mimics that.

This PR simply asserts the existing behavior with a new test, and does not change any code/behavior.  However, this code is at odds with the `throws_when_unable_to_determine_object_type` test.  The reason both tests pass currently is because the check for the code only executes when the field referencing the interface is a nullable field (which is a bug).

How should we address this?

1. Allow any type returned from a field to be passed to an interface resolver.  Bad for diagnosing issues, as a cast may occur within the execution framework before it hits a resolver, without a clear indication of what the trouble is.
2. Same as above, but add IsTypeOf to IInterfaceGraphType so that it can be assured that the type is compatible, with the default implementation to return `true` for anything that matches `<T>` in `InterfaceGraphType<T>`, and `false` otherwise.
3. Add IsTypeOf, but always return `false` by default, requiring that there is an object graph type for any returned value.  Within `AutoRegisteringInterfaceGraphType.IsTypeOf`, return `true` appropriately.
4. Always require an object graph type for any returned value.

I suggest option 3 above.  This is probably most compatible with our existing behavior.