### PR TITLE
Fix SubFields property for interfaces and unions

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug3415.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3415.cs
@@ -1,0 +1,96 @@
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Bugs;
+
+public class Bug3415 : QueryTestBase<Bug3415.MySchema>
+{
+    [Fact]
+    public void Union_SubFields_WithTypename()
+    {
+        string query = """
+            query {
+                test {
+                    __typename
+                    ... on TypeA {
+                        id
+                    }
+                }
+            }
+            """;
+
+        string expected = """
+            {
+                "test": {
+                    "__typename": "TypeA",
+                    "id": "123"
+                }
+            }
+            """;
+        AssertQuerySuccess(query, expected);
+    }
+
+    [Fact]
+    public void Union_SubFields_WithoutTypename()
+    {
+        string query = """
+            query {
+                test {
+                    ... on TypeA {
+                        id
+                    }
+                }
+            }
+            """;
+
+        string expected = """
+            {
+                "test": {
+                    "id": "123"
+                }
+            }
+            """;
+        AssertQuerySuccess(query, expected);
+    }
+
+    public class MySchema : Schema
+    {
+        public MySchema()
+        {
+            Query = new MyQuery();
+        }
+    }
+
+    public class MyQuery : ObjectGraphType
+    {
+        public MyQuery()
+        {
+            Field<MyUnionGraphType>("test")
+                .Resolve(context =>
+                {
+                    _ = context.SubFields;
+                    return new MyObject();
+                });
+
+            Field<MyUnionGraphType>("test2")
+                .Resolve(context =>
+                {
+                    _ = context.SubFields;
+                    return new MyObject();
+                });
+        }
+    }
+
+    public class MyUnionGraphType : UnionGraphType
+    {
+        public MyUnionGraphType()
+        {
+            Type<AutoRegisteringObjectGraphType<MyObject>>();
+        }
+    }
+
+    [Name("TypeA")]
+    public class MyObject
+    {
+        public string Id { get; set; } = "123";
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Bug3415.cs
+++ b/src/GraphQL.Tests/Bugs/Bug3415.cs
@@ -70,13 +70,13 @@ public class Bug3415 : QueryTestBase<Bug3415.MySchema>
             Field<MyUnionGraphType>("test")
                 .Resolve(context =>
                 {
-                    context.SubFields.Count.ShouldBe(0); // we don't know concrete union member until we return it from this resolver on the next line
+                    context.SubFields.Count.ShouldBe(0); // we don't know concrete union member until we return it from this resolver on the last line
                     return new MyObject();
                 });
             Field<MyUnionGraphType>("test_with_typename")
                 .Resolve(context =>
                 {
-                    context.SubFields.Count.ShouldBe(1); // we don't know concrete union member until we return it from this resolver on the next line
+                    context.SubFields.Count.ShouldBe(1); // we don't know concrete union member until we return it from this resolver on the last line
                     context.SubFields.First().Key.ShouldBe("__typename");
                     return new MyObject();
                 });

--- a/src/GraphQL/Execution/IExecutionStrategy.cs
+++ b/src/GraphQL/Execution/IExecutionStrategy.cs
@@ -22,7 +22,11 @@ namespace GraphQL.Execution
         Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode);
 
         /// <summary>
-        /// Returns the children fields for a specified node.
+        /// Returns the children fields for a specified node. Note that this set will be completely defined only for
+        /// fields of a concrete type (i.e. not interface or union field) or when <paramref name="executionNode"/>
+        /// result was set. For interface field this method returns requested fields in terms of this interface. For
+        /// union field this method returns empty set since we don't know the concrete union member if <see cref="ExecutionNode.Result"/>
+        /// was not yet set.
         /// </summary>
         Dictionary<string, (GraphQLField field, FieldType fieldType)>? GetSubFields(ExecutionContext executionContext, ExecutionNode executionNode);
     }

--- a/src/GraphQL/Execution/IExecutionStrategy.cs
+++ b/src/GraphQL/Execution/IExecutionStrategy.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Execution
         /// fields of a concrete type (i.e. not interface or union field) or when <paramref name="executionNode"/>
         /// result was set. For interface field this method returns requested fields in terms of this interface. For
         /// union field this method returns empty set since we don't know the concrete union member if <see cref="ExecutionNode.Result"/>
-        /// was not yet set.
+        /// was not set yet.
         /// </summary>
         Dictionary<string, (GraphQLField field, FieldType fieldType)>? GetSubFields(ExecutionContext executionContext, ExecutionNode executionNode);
     }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -81,7 +81,13 @@ namespace GraphQL
         /// <summary>The path to the current executing field from the request root as it would appear in the response.</summary>
         IEnumerable<object> ResponsePath { get; }
 
-        /// <summary>Returns a list of child fields requested for the current field.</summary>
+        /// <summary>
+        /// Returns a set of child fields requested for the current field. Note that this set will be completely defined
+        /// (when called from field resolver) only for fields of a concrete type (i.e. not interface or union field). For
+        /// interface field this method returns requested fields in terms of this interface. For union field this method
+        /// returns empty set since we don't know the concrete union member until we get a concrete runtime value from
+        /// the resolver.
+        /// </summary>
         Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields { get; }
 
         /// <summary>

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -116,7 +116,8 @@ namespace GraphQL
         public IEnumerable<object> ResponsePath => _executionNode.ResponsePath;
 
         /// <inheritdoc/>
-        public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields => _subFields ??= _executionContext.ExecutionStrategy.GetSubFields(_executionContext, _executionNode);
+        public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields
+            => _subFields ??= _executionContext.ExecutionStrategy.GetSubFields(_executionContext, _executionNode);
 
         /// <inheritdoc/>
         public IDictionary<string, object?> UserContext => _executionContext.UserContext;


### PR DESCRIPTION
Demonstrates that accessing `SubFields` fails from within a field resolver of a field that is of a union graph type.