### PR TITLE
Fix check for non-resolved interface type

### DIFF
--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -578,3 +578,14 @@ This prevents the situation where some graph types are not initialized and throw
 If this is causing a problem (perhaps with graph types that are dynamically generated, for instance),
 create and pull from a dictionary of instantiated types, or use `GraphQLTypeReference` to reference
 the graph type by name.
+
+### 16. Values returned from interface fields must resolve to an GraphQL object type
+
+In certain situations, validation of values returned from fields returning interface types did not
+require them to resolve to GraphQL Object types. GraphQL.NET 7.2+ now enforces this validation in all cases.
+
+### 17. `AutoRegisteringInterfaceGraphType` does not generate resolvers
+
+Due to the above validation, resolvers defined on fields of interface types are never be used by
+GraphQL.NET. As such, resolvers are not generated for fields of `AutoRegisteringInterfaceGraphType`s
+in version 7.2+.

--- a/src/GraphQL.ApiTests/net5/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net5/GraphQL.approved.txt
@@ -1765,6 +1765,8 @@ namespace GraphQL.Types
         public AutoRegisteringInterfaceGraphType(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[]? excludedProperties) { }
         protected virtual void ApplyArgumentAttributes(System.Reflection.ParameterInfo parameterInfo, GraphQL.Types.QueryArgument queryArgument) { }
         protected void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
+        [System.Obsolete("Interface graph types do not support field resolvers; use of this method is unnec" +
+            "essary.")]
         protected virtual System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
         protected virtual void ConfigureGraph() { }
         protected virtual GraphQL.Types.FieldType? CreateField(System.Reflection.MemberInfo memberInfo) { }

--- a/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net6/GraphQL.approved.txt
@@ -1765,6 +1765,8 @@ namespace GraphQL.Types
         public AutoRegisteringInterfaceGraphType(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[]? excludedProperties) { }
         protected virtual void ApplyArgumentAttributes(System.Reflection.ParameterInfo parameterInfo, GraphQL.Types.QueryArgument queryArgument) { }
         protected void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
+        [System.Obsolete("Interface graph types do not support field resolvers; use of this method is unnec" +
+            "essary.")]
         protected virtual System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
         protected virtual void ConfigureGraph() { }
         protected virtual GraphQL.Types.FieldType? CreateField(System.Reflection.MemberInfo memberInfo) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1765,6 +1765,8 @@ namespace GraphQL.Types
         public AutoRegisteringInterfaceGraphType(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[]? excludedProperties) { }
         protected virtual void ApplyArgumentAttributes(System.Reflection.ParameterInfo parameterInfo, GraphQL.Types.QueryArgument queryArgument) { }
         protected void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
+        [System.Obsolete("Interface graph types do not support field resolvers; use of this method is unnec" +
+            "essary.")]
         protected virtual System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
         protected virtual void ConfigureGraph() { }
         protected virtual GraphQL.Types.FieldType? CreateField(System.Reflection.MemberInfo memberInfo) { }

--- a/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
+++ b/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
@@ -17,7 +17,7 @@ public class AbstractTypeErrorTests : QueryTestBase<AbstractSchema>
     [Fact]
     public void throws_when_unable_to_determine_object_type_nullable()
     {
-        var result = AssertQueryWithErrors("{ pets2 { name } }", """{ "pets2": null }""", expectedErrorCount: 1);
+        var result = AssertQueryWithErrors("{ pets2 { name } }", null, expectedErrorCount: 1);
         var error = result.Errors.First();
         error.Message.ShouldBe("Error trying to resolve field 'pets2'.");
         error.InnerException.ShouldNotBeNull();

--- a/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
+++ b/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
@@ -15,13 +15,53 @@ public class AbstractTypeErrorTests : QueryTestBase<AbstractSchema>
     }
 
     [Fact]
-    public void throws_when_unable_to_determine_object_type_nullable()
+    public void throws_when_unable_to_determine_object_type_nonnull()
     {
         var result = AssertQueryWithErrors("{ pets2 { name } }", null, expectedErrorCount: 1);
         var error = result.Errors.First();
         error.Message.ShouldBe("Error trying to resolve field 'pets2'.");
         error.InnerException.ShouldNotBeNull();
         error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets2 with value '{ name = Eli }', received 'null'.");
+    }
+
+    [Fact]
+    public void throws_when_unable_to_determine_object_type_list()
+    {
+        var result = AssertQueryWithErrors("{ pets3 { name } }", """{ "pets3": [ null ] }""", expectedErrorCount: 1);
+        var error = result.Errors.First();
+        error.Message.ShouldBe("Error trying to resolve field 'pets3'.");
+        error.InnerException.ShouldNotBeNull();
+        error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets3 with value '{ name = Eli }', received 'null'.");
+    }
+
+    [Fact]
+    public void throws_when_unable_to_determine_object_type_list_nonnull()
+    {
+        var result = AssertQueryWithErrors("{ pets4 { name } }", """{ "pets4": null }""", expectedErrorCount: 1);
+        var error = result.Errors.First();
+        error.Message.ShouldBe("Error trying to resolve field 'pets4'.");
+        error.InnerException.ShouldNotBeNull();
+        error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets4 with value '{ name = Eli }', received 'null'.");
+    }
+
+    [Fact]
+    public void throws_when_unable_to_determine_object_type_nonnull_list()
+    {
+        var result = AssertQueryWithErrors("{ pets5 { name } }", """{ "pets5": [ null ] }""", expectedErrorCount: 1);
+        var error = result.Errors.First();
+        error.Message.ShouldBe("Error trying to resolve field 'pets5'.");
+        error.InnerException.ShouldNotBeNull();
+        error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets5 with value '{ name = Eli }', received 'null'.");
+    }
+
+    [Fact]
+    public void throws_when_unable_to_determine_object_type_nonnull_list_nonnull()
+    {
+        var result = AssertQueryWithErrors("{ pets6 { name } }", null, expectedErrorCount: 1);
+        var error = result.Errors.First();
+        error.Message.ShouldBe("Error trying to resolve field 'pets6'.");
+        error.InnerException.ShouldNotBeNull();
+        error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets6 with value '{ name = Eli }', received 'null'.");
     }
 }
 
@@ -41,6 +81,10 @@ public class AbstractQueryType : ObjectGraphType
         Name = "Query";
         Field<PetInterfaceType>("pets").Resolve(_ => new { name = "Eli" });
         Field<NonNullGraphType<PetInterfaceType>>("pets2").Resolve(_ => new { name = "Eli" });
+        Field<ListGraphType<PetInterfaceType>>("pets3").Resolve(_ => new[] { new { name = "Eli" } });
+        Field<ListGraphType<NonNullGraphType<PetInterfaceType>>>("pets4").Resolve(_ => new[] { new { name = "Eli" } });
+        Field<NonNullGraphType<ListGraphType<PetInterfaceType>>>("pets5").Resolve(_ => new[] { new { name = "Eli" } });
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<PetInterfaceType>>>>("pets6").Resolve(_ => new[] { new { name = "Eli" } });
     }
 }
 

--- a/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
+++ b/src/GraphQL.Tests/Execution/AbstractTypeTests.cs
@@ -13,6 +13,16 @@ public class AbstractTypeErrorTests : QueryTestBase<AbstractSchema>
         error.InnerException.ShouldNotBeNull();
         error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets with value '{ name = Eli }', received 'null'.");
     }
+
+    [Fact]
+    public void throws_when_unable_to_determine_object_type_nullable()
+    {
+        var result = AssertQueryWithErrors("{ pets2 { name } }", """{ "pets2": null }""", expectedErrorCount: 1);
+        var error = result.Errors.First();
+        error.Message.ShouldBe("Error trying to resolve field 'pets2'.");
+        error.InnerException.ShouldNotBeNull();
+        error.InnerException.Message.ShouldBe("Abstract type Pet must resolve to an Object type at runtime for field Query.pets2 with value '{ name = Eli }', received 'null'.");
+    }
 }
 
 public class PetInterfaceType : InterfaceGraphType
@@ -30,6 +40,7 @@ public class AbstractQueryType : ObjectGraphType
     {
         Name = "Query";
         Field<PetInterfaceType>("pets").Resolve(_ => new { name = "Eli" });
+        Field<NonNullGraphType<PetInterfaceType>>("pets2").Resolve(_ => new { name = "Eli" });
     }
 }
 

--- a/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
@@ -613,7 +613,7 @@ public class AutoRegisteringInterfaceGraphTypeTests
         public string Name { get; set; } = null!;
         public bool IsLarge { get; set; }
     }
-    
+
     private class NoDefaultConstructorTestClass : NoDefaultConstructorTestInterface
     {
         public NoDefaultConstructorTestClass(bool value)

--- a/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
@@ -254,22 +254,22 @@ public class AutoRegisteringInterfaceGraphTypeTests
     }
 
     [Theory]
-    [InlineData(nameof(ArgumentTestsInterface.WithNonNullString), "arg1", "hello", null, "hello")]
-    [InlineData(nameof(ArgumentTestsInterface.WithNullableString), "arg1", "hello", null, "hello")]
-    [InlineData(nameof(ArgumentTestsInterface.WithNullableString), "arg1", null, null, null)]
-    [InlineData(nameof(ArgumentTestsInterface.WithNullableString), null, null, null, null)]
-    [InlineData(nameof(ArgumentTestsInterface.WithDefaultString), "arg1", "hello", null, "hello")]
-    [InlineData(nameof(ArgumentTestsInterface.WithDefaultString), "arg1", null, null, null)]
-    [InlineData(nameof(ArgumentTestsInterface.WithDefaultString), null, null, null, "test")]
-    [InlineData(nameof(ArgumentTestsInterface.WithCancellationToken), null, null, null, true)]
-    [InlineData(nameof(ArgumentTestsInterface.WithFromServices), null, null, null, "testService")]
-    [InlineData(nameof(ArgumentTestsInterface.NamedArg), "arg1rename", "hello", null, "hello")]
-    [InlineData(nameof(ArgumentTestsInterface.IdArg), "arg1", "hello", null, "hello")]
-    [InlineData(nameof(ArgumentTestsInterface.IdIntArg), "arg1", "123", null, 123)]
-    [InlineData(nameof(ArgumentTestsInterface.IdIntArg), "arg1", 123, null, 123)]
-    [InlineData(nameof(ArgumentTestsInterface.TypedArg), "arg1", "123", null, 123)]
-    [InlineData(nameof(ArgumentTestsInterface.MultipleArgs), "arg1", "hello", 123, "hello123")]
-    public async Task Argument_ResolverTests_WithNonNullString(string fieldName, string arg1Name, object? arg1Value, int? arg2Value, object? expected)
+    [InlineData(nameof(ArgumentTestsInterface.WithNonNullString), "arg1", "hello", null)]
+    [InlineData(nameof(ArgumentTestsInterface.WithNullableString), "arg1", "hello", null)]
+    [InlineData(nameof(ArgumentTestsInterface.WithNullableString), "arg1", null, null)]
+    [InlineData(nameof(ArgumentTestsInterface.WithNullableString), null, null, null)]
+    [InlineData(nameof(ArgumentTestsInterface.WithDefaultString), "arg1", "hello", null)]
+    [InlineData(nameof(ArgumentTestsInterface.WithDefaultString), "arg1", null, null)]
+    [InlineData(nameof(ArgumentTestsInterface.WithDefaultString), null, null, null)]
+    [InlineData(nameof(ArgumentTestsInterface.WithCancellationToken), null, null, null)]
+    [InlineData(nameof(ArgumentTestsInterface.WithFromServices), null, null, null)]
+    [InlineData(nameof(ArgumentTestsInterface.NamedArg), "arg1rename", "hello", null)]
+    [InlineData(nameof(ArgumentTestsInterface.IdArg), "arg1", "hello", null)]
+    [InlineData(nameof(ArgumentTestsInterface.IdIntArg), "arg1", "123", null)]
+    [InlineData(nameof(ArgumentTestsInterface.IdIntArg), "arg1", 123, null)]
+    [InlineData(nameof(ArgumentTestsInterface.TypedArg), "arg1", "123", null)]
+    [InlineData(nameof(ArgumentTestsInterface.MultipleArgs), "arg1", "hello", 123)]
+    public async Task Argument_ResolverTests(string fieldName, string arg1Name, object? arg1Value, int? arg2Value)
     {
         var graphType = new AutoRegisteringInterfaceGraphType<ArgumentTestsInterface>();
         var fieldType = graphType.Fields.Find(fieldName).ShouldNotBeNull();
@@ -294,7 +294,8 @@ public class AutoRegisteringInterfaceGraphTypeTests
         using var provider = serviceCollection.BuildServiceProvider();
         context.RequestServices = provider;
         fieldType.Resolver.ShouldNotBeNull();
-        (await fieldType.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ShouldBe(expected);
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await fieldType.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ConfigureAwait(false);
+        ex.Message.ShouldBe("This field resolver should never be called. It is only used to prevent the default field resolver from being used.");
     }
 
     [Fact]
@@ -335,35 +336,23 @@ public class AutoRegisteringInterfaceGraphTypeTests
     }
 
     [Theory]
-    [InlineData("Field1", 1)]
-    [InlineData("Field2", 2)]
-    [InlineData("Field4", 4)]
-    [InlineData("Field6AltName", 6)]
-    [InlineData("Field7", 7)]
-    public async Task FieldResolversWork(string fieldName, object expected)
+    [InlineData("Field1")]
+    [InlineData("Field2")]
+    [InlineData("Field4")]
+    [InlineData("Field6AltName")]
+    [InlineData("Field7")]
+    public async Task FieldResolvers_Invalid(string fieldName)
     {
         var graph = new AutoRegisteringInterfaceGraphType<TestInterface>();
         var field = graph.Fields.Find(fieldName).ShouldNotBeNull();
         var resolver = field.Resolver.ShouldNotBeNull();
         var obj = new TestClass();
-        var actual = await resolver.ResolveAsync(new ResolveFieldContext
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await resolver.ResolveAsync(new ResolveFieldContext
         {
             Source = obj,
             FieldDefinition = new FieldType { Name = fieldName },
-        }).ConfigureAwait(false);
-        actual.ShouldBe(expected);
-    }
-
-    [Fact]
-    public async Task WorksWithNoDefaultConstructor()
-    {
-        var graphType = new AutoRegisteringInterfaceGraphType<NoDefaultConstructorTestInterface>();
-        var context = new ResolveFieldContext
-        {
-            Source = new NoDefaultConstructorTestClass(true)
-        };
-        (await graphType.Fields.Find("Example1")!.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ShouldBe(true);
-        (await graphType.Fields.Find("Example2")!.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ShouldBe("test");
+        }).ConfigureAwait(false)).ConfigureAwait(false);
+        ex.Message.ShouldBe("This field resolver should never be called. It is only used to prevent the default field resolver from being used.");
     }
 
     [Fact]
@@ -372,35 +361,10 @@ public class AutoRegisteringInterfaceGraphTypeTests
         var graphType = new AutoRegisteringInterfaceGraphType<NullSourceFailureTest>();
         var context = new ResolveFieldContext();
         (await Should.ThrowAsync<InvalidOperationException>(async () => await graphType.Fields.Find("Example1")!.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ConfigureAwait(false))
-            .Message.ShouldBe("IResolveFieldContext.Source is null; please use static methods when using an AutoRegisteringInterfaceGraphType as a root graph type or provide a root value.");
+            .Message.ShouldBe("This field resolver should never be called. It is only used to prevent the default field resolver from being used.");
         (await Should.ThrowAsync<InvalidOperationException>(async () => await graphType.Fields.Find("Example2")!.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ConfigureAwait(false))
-            .Message.ShouldBe("IResolveFieldContext.Source is null; please use static methods when using an AutoRegisteringInterfaceGraphType as a root graph type or provide a root value.");
+            .Message.ShouldBe("This field resolver should never be called. It is only used to prevent the default field resolver from being used.");
     }
-
-#if !NET48 // .NET Framework 4.8 does not support default interface implementation, so would not support static methods on an interface
-    [Fact]
-    public async Task WorksWithNullSource()
-    {
-        var graphType = new TestFieldSupport<NullSourceTest>();
-        var context = new ResolveFieldContext();
-        (await graphType.Fields.Find("Example1")!.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ShouldBe(true);
-        (await graphType.Fields.Find("Example2")!.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ShouldBe("test");
-        (await graphType.Fields.Find("Example3")!.Resolver!.ResolveAsync(context).ConfigureAwait(false)).ShouldBe(3);
-    }
-
-    private class TestFieldSupport<T> : AutoRegisteringInterfaceGraphType<T>
-    {
-        protected override IEnumerable<MemberInfo> GetRegisteredMembers()
-            => base.GetRegisteredMembers().Concat(typeof(T).GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public));
-    }
-
-    private interface NullSourceTest
-    {
-        public static bool Example1 { get; set; } = true;
-        public static string Example2() => "test";
-        public static int Example3 = 3;
-    }
-#endif
 
     [Fact]
     public void TestExceptionBubbling()
@@ -415,18 +379,6 @@ public class AutoRegisteringInterfaceGraphTypeTests
         graphType.Fields.Find("Id").ShouldNotBeNull();
         graphType.Fields.Find("Name").ShouldNotBeNull();
         graphType.Fields.Count.ShouldBe(2);
-    }
-
-    [Fact]
-    public async Task CustomHardcodedArgumentAttributesWork()
-    {
-        var graphType = new AutoRegisteringInterfaceGraphType<CustomHardcodedArgumentAttributeTestInterface>();
-        var fieldType = graphType.Fields.Find(nameof(CustomHardcodedArgumentAttributeTestInterface.FieldWithHardcodedValue))!;
-        var resolver = fieldType.Resolver!;
-        (await resolver.ResolveAsync(new ResolveFieldContext
-        {
-            Source = new CustomHardcodedArgumentAttributeTestClass(),
-        }).ConfigureAwait(false)).ShouldBe("85");
     }
 
     [Fact]
@@ -543,9 +495,9 @@ public class AutoRegisteringInterfaceGraphTypeTests
     }
 
     [Theory]
-    [InlineData("{find(type:CAT){id name}}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
-    [InlineData("{find(type:CAT){ ...frag }} fragment frag on IAnimal {id name}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
-    public async Task ExecutesQueryWithInterfaceOnly(string query, string expected)
+    [InlineData("{find(type:CAT){id name}}")]
+    [InlineData("{find(type:CAT){ ...frag }} fragment frag on IAnimal {id name}")]
+    public async Task RejectQueryWithInterfaceOnly(string query)
     {
         var services = new ServiceCollection();
         services.AddGraphQL(b => b
@@ -556,23 +508,23 @@ public class AutoRegisteringInterfaceGraphTypeTests
         schema.AllTypes.Select(x => x.Name).OrderBy(x => x).Where(x => !x.StartsWith("__"))
             .ShouldBe(new[] { "AnimalType", "Boolean", "IAnimal", "ID", "String", "TestQuery2" });
         var executer = provider.GetRequiredService<IDocumentExecuter>();
-        var result = await executer.ExecuteAsync(new()
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => executer.ExecuteAsync(new()
         {
             Query = query,
             RequestServices = provider,
-        }).ConfigureAwait(false);
-        var serializer = provider.GetRequiredService<IGraphQLTextSerializer>();
-        var actual = serializer.Serialize(result);
-        actual.ShouldBeCrossPlatJson(expected);
+            ThrowOnUnhandledException = true,
+        })).ConfigureAwait(false);
+        ex.Message.ShouldBe("Abstract type IAnimal must resolve to an Object type at runtime for field TestQuery2.find with value 'GraphQL.Tests.Types.AutoRegisteringInterfaceGraphTypeTests+Cat', received 'null'.");
     }
 
     [Theory]
-    [InlineData("{find(type:CAT){id name}}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
-    [InlineData("{find(type:CAT){ ...frag }} fragment frag on IAnimal { id name }", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
-    [InlineData("{find(type:CAT){ ...frag }} fragment frag on Dog { isLarge }", """{"data":{"find":{}}}""")]
-    [InlineData("{find(type:CAT){ ... on Dog { isLarge } }}", """{"data":{"find":{}}}""")]
-    [InlineData("{find(type:CAT){ id name ... on Dog { isLarge } }}", """{"data":{"find":{"id":"10","name":"Fluffy"}}}""")]
-    public async Task ExecutesQueryWithInterfaceOnly2(string query, string expected)
+    [InlineData("{find(type:CAT){__typename}}")]
+    [InlineData("{find(type:CAT){id name}}")]
+    [InlineData("{find(type:CAT){ ...frag }} fragment frag on IAnimal { id name }")]
+    [InlineData("{find(type:CAT){ ...frag }} fragment frag on Dog { isLarge }")]
+    [InlineData("{find(type:CAT){ ... on Dog { isLarge } }}")]
+    [InlineData("{find(type:CAT){ id name ... on Dog { isLarge } }}")]
+    public async Task RejectsQueryWithInterfaceOnly2(string query)
     {
         var services = new ServiceCollection();
         services.AddGraphQL(b => b
@@ -583,14 +535,13 @@ public class AutoRegisteringInterfaceGraphTypeTests
         schema.AllTypes.Select(x => x.Name).OrderBy(x => x).Where(x => !x.StartsWith("__"))
             .ShouldBe(new[] { "AnimalType", "Boolean", "Dog", "IAnimal", "ID", "String", "TestQuery3" });
         var executer = provider.GetRequiredService<IDocumentExecuter>();
-        var result = await executer.ExecuteAsync(new()
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => executer.ExecuteAsync(new()
         {
             Query = query,
             RequestServices = provider,
-        }).ConfigureAwait(false);
-        var serializer = provider.GetRequiredService<IGraphQLTextSerializer>();
-        var actual = serializer.Serialize(result);
-        actual.ShouldBeCrossPlatJson(expected);
+            ThrowOnUnhandledException = true,
+        })).ConfigureAwait(false);
+        ex.Message.ShouldBe("Abstract type IAnimal must resolve to an Object type at runtime for field TestQuery3.find with value 'GraphQL.Tests.Types.AutoRegisteringInterfaceGraphTypeTests+Cat', received 'null'.");
     }
 
     public class TestQuery
@@ -662,23 +613,7 @@ public class AutoRegisteringInterfaceGraphTypeTests
         public string Name { get; set; } = null!;
         public bool IsLarge { get; set; }
     }
-
-    public class CustomHardcodedArgumentAttributeTestClass : CustomHardcodedArgumentAttributeTestInterface
-    {
-        public string FieldWithHardcodedValue(int value) => value.ToString();
-    }
-
-    public interface CustomHardcodedArgumentAttributeTestInterface
-    {
-        string FieldWithHardcodedValue([HardcodedValue] int value);
-    }
-
-    private class HardcodedValueAttribute : GraphQLAttribute
-    {
-        public override void Modify(ArgumentInformation argumentInformation)
-            => argumentInformation.SetDelegate(context => 85);
-    }
-
+    
     private class NoDefaultConstructorTestClass : NoDefaultConstructorTestInterface
     {
         public NoDefaultConstructorTestClass(bool value)

--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -268,7 +268,7 @@ public class AutoRegisteringObjectGraphTypeTests
     [InlineData(nameof(ArgumentTests.IdIntArg), "arg1", 123, null, 123)]
     [InlineData(nameof(ArgumentTests.TypedArg), "arg1", "123", null, 123)]
     [InlineData(nameof(ArgumentTests.MultipleArgs), "arg1", "hello", 123, "hello123")]
-    public async Task Argument_ResolverTests_WithNonNullString(string fieldName, string arg1Name, object? arg1Value, int? arg2Value, object? expected)
+    public async Task Argument_ResolverTests(string fieldName, string arg1Name, object? arg1Value, int? arg2Value, object? expected)
     {
         var graphType = new AutoRegisteringObjectGraphType<ArgumentTests>();
         var fieldType = graphType.Fields.Find(fieldName).ShouldNotBeNull();

--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -2,6 +2,7 @@
 
 using System.Collections;
 using System.ComponentModel;
+using System.Linq.Expressions;
 using System.Reflection;
 using GraphQL.DataLoader;
 using GraphQL.Execution;
@@ -485,6 +486,18 @@ public class AutoRegisteringObjectGraphTypeTests
         graphType.Fields.Find("Field4").ShouldNotBeNull();
         graphType.Fields.Find("Field5").ShouldNotBeNull();
         graphType.Fields.Count.ShouldBe(5);
+    }
+
+    [Fact]
+    public void CannotBuildWithoutMemberInstanceExpression()
+    {
+        Should.Throw<ArgumentNullException>(() => new NoMemberInstanceExpression<TestBasicClass>())
+            .ParamName.ShouldBe("instanceExpression");
+    }
+
+    public class NoMemberInstanceExpression<T> : AutoRegisteringObjectGraphType<T>
+    {
+        protected override LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo) => null!;
     }
 
     private class CustomHardcodedArgumentAttributeTestClass

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -659,7 +659,7 @@ namespace GraphQL.Execution
                 {
                     throw new InvalidOperationException(
                         $"Abstract type {abstractType.Name} must resolve to an Object type at " +
-                        $"runtime for field {node.Parent?.GraphType?.Name}.{node.Name} " +
+                        $"runtime for field {(node.IndexInParentNode.HasValue ? node.Parent?.Parent : node.Parent)?.GraphType?.Name}.{node.FieldDefinition.Name} " +
                         $"with value '{result}', received 'null'.");
                 }
 

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -613,7 +613,6 @@ namespace GraphQL.Execution
             var result = node.Result;
 
             IGraphType? fieldType = node.ResolvedType;
-            var objectType = fieldType as IObjectGraphType;
 
             if (fieldType is NonNullGraphType nonNullType)
             {
@@ -623,13 +622,15 @@ namespace GraphQL.Execution
                         + $" Field: {node.Name}, Type: {nonNullType}.");
                 }
 
-                objectType = nonNullType.ResolvedType as IObjectGraphType;
+                fieldType = nonNullType.ResolvedType;
             }
 
             if (result == null)
             {
                 return;
             }
+
+            var objectType = fieldType as IObjectGraphType;
 
             if (fieldType is IAbstractGraphType abstractType)
             {

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -72,14 +72,6 @@ public class AutoRegisteringInterfaceGraphType<TSourceType> : InterfaceGraphType
     protected virtual LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo)
         => throw new NotSupportedException();
 
-    private static readonly Expression<Func<IResolveFieldContext, TSourceType>> _sourceExpression
-        = context => (TSourceType)(context.Source ?? ThrowSourceNullException());
-
-    private static object ThrowSourceNullException()
-    {
-        throw new InvalidOperationException("IResolveFieldContext.Source is null; please use static methods when using an AutoRegisteringInterfaceGraphType as a root graph type or provide a root value.");
-    }
-
     private static readonly MethodInfo _getArgumentInformationInternalMethodInfo = typeof(AutoRegisteringInterfaceGraphType<TSourceType>).GetMethod(nameof(GetArgumentInformationInternal), BindingFlags.NonPublic | BindingFlags.Instance)!;
     private ArgumentInformation GetArgumentInformationInternal<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)
         => GetArgumentInformation<TParameterType>(fieldType, parameterInfo);

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -63,7 +63,8 @@ public class AutoRegisteringInterfaceGraphType<TSourceType> : InterfaceGraphType
             fieldType,
             BuildMemberInstanceExpression,
             getTypedArgumentInfoMethod,
-            ApplyArgumentAttributes);
+            ApplyArgumentAttributes,
+            true);
     }
 
     /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.BuildMemberInstanceExpression(MemberInfo)"/>

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -61,15 +61,16 @@ public class AutoRegisteringInterfaceGraphType<TSourceType> : InterfaceGraphType
         AutoRegisteringOutputHelper.BuildFieldType(
             memberInfo,
             fieldType,
-            BuildMemberInstanceExpression,
+            null,
             getTypedArgumentInfoMethod,
             ApplyArgumentAttributes,
             true);
     }
 
     /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.BuildMemberInstanceExpression(MemberInfo)"/>
+    [Obsolete("Interface graph types do not support field resolvers; use of this method is unnecessary.")]
     protected virtual LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo)
-        => _sourceExpression;
+        => throw new NotSupportedException();
 
     private static readonly Expression<Func<IResolveFieldContext, TSourceType>> _sourceExpression
         = context => (TSourceType)(context.Source ?? ThrowSourceNullException());

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -69,7 +69,7 @@ public class AutoRegisteringInterfaceGraphType<TSourceType> : InterfaceGraphType
     /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.BuildMemberInstanceExpression(MemberInfo)"/>
     [Obsolete("Interface graph types do not support field resolvers; use of this method is unnecessary.")]
     protected virtual LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo)
-        => throw new NotSupportedException();
+        => throw new NotSupportedException("Interface graph types do not support field resolvers");
 
     private static readonly MethodInfo _getArgumentInformationInternalMethodInfo = typeof(AutoRegisteringInterfaceGraphType<TSourceType>).GetMethod(nameof(GetArgumentInformationInternal), BindingFlags.NonPublic | BindingFlags.Instance)!;
     private ArgumentInformation GetArgumentInformationInternal<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -63,8 +63,7 @@ public class AutoRegisteringInterfaceGraphType<TSourceType> : InterfaceGraphType
             fieldType,
             null,
             getTypedArgumentInfoMethod,
-            ApplyArgumentAttributes,
-            true);
+            ApplyArgumentAttributes);
     }
 
     /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.BuildMemberInstanceExpression(MemberInfo)"/>

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -54,7 +54,7 @@ namespace GraphQL.Types
         protected virtual FieldType? CreateField(MemberInfo memberInfo)
             => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, BuildFieldType, false);
 
-        /// <inheritdoc cref="AutoRegisteringOutputHelper.BuildFieldType(MemberInfo, FieldType, Func{MemberInfo, LambdaExpression}, Func{Type, Func{FieldType, ParameterInfo, ArgumentInformation}}, Action{ParameterInfo, QueryArgument})"/>
+        /// <inheritdoc cref="AutoRegisteringOutputHelper.BuildFieldType(MemberInfo, FieldType, Func{MemberInfo, LambdaExpression}, Func{Type, Func{FieldType, ParameterInfo, ArgumentInformation}}, Action{ParameterInfo, QueryArgument}, bool)"/>
         protected void BuildFieldType(FieldType fieldType, MemberInfo memberInfo)
         {
             Func<Type, Func<FieldType, ParameterInfo, ArgumentInformation>> getTypedArgumentInfoMethod =
@@ -69,7 +69,8 @@ namespace GraphQL.Types
                 fieldType,
                 BuildMemberInstanceExpression,
                 getTypedArgumentInfoMethod,
-                ApplyArgumentAttributes);
+                ApplyArgumentAttributes,
+                false);
         }
 
         /// <summary>

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -54,7 +54,7 @@ namespace GraphQL.Types
         protected virtual FieldType? CreateField(MemberInfo memberInfo)
             => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, BuildFieldType, false);
 
-        /// <inheritdoc cref="AutoRegisteringOutputHelper.BuildFieldType(MemberInfo, FieldType, Func{MemberInfo, LambdaExpression}, Func{Type, Func{FieldType, ParameterInfo, ArgumentInformation}}, Action{ParameterInfo, QueryArgument}, bool)"/>
+        /// <inheritdoc cref="AutoRegisteringOutputHelper.BuildFieldType(MemberInfo, FieldType, Func{MemberInfo, LambdaExpression}, Func{Type, Func{FieldType, ParameterInfo, ArgumentInformation}}, Action{ParameterInfo, QueryArgument})"/>
         protected void BuildFieldType(FieldType fieldType, MemberInfo memberInfo)
         {
             Func<Type, Func<FieldType, ParameterInfo, ArgumentInformation>> getTypedArgumentInfoMethod =
@@ -69,8 +69,7 @@ namespace GraphQL.Types
                 fieldType,
                 BuildMemberInstanceExpression,
                 getTypedArgumentInfoMethod,
-                ApplyArgumentAttributes,
-                false);
+                ApplyArgumentAttributes);
         }
 
         /// <summary>

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -27,17 +27,20 @@ internal static class AutoRegisteringOutputHelper
     public static void BuildFieldType(
         MemberInfo memberInfo,
         FieldType fieldType,
-        Func<MemberInfo, LambdaExpression> BuildMemberInstanceExpression,
+        Func<MemberInfo, LambdaExpression>? BuildMemberInstanceExpression,
         Func<Type, Func<FieldType, ParameterInfo, ArgumentInformation>> getTypedArgumentInfoMethod,
         Action<ParameterInfo, QueryArgument> ApplyArgumentAttributes,
         bool isInterface)
     {
+        if (!isInterface && BuildMemberInstanceExpression == null)
+            throw new ArgumentNullException(nameof(BuildMemberInstanceExpression));
+
         if (memberInfo is PropertyInfo propertyInfo)
         {
             fieldType.Arguments = null;
             if (!isInterface)
             {
-                var resolver = new MemberResolver(propertyInfo, BuildMemberInstanceExpression(memberInfo));
+                var resolver = new MemberResolver(propertyInfo, BuildMemberInstanceExpression!(memberInfo));
                 fieldType.Resolver = resolver;
                 fieldType.StreamResolver = null;
             }
@@ -61,9 +64,9 @@ internal static class AutoRegisteringOutputHelper
                     queryArgument ?? throw new InvalidOperationException("Invalid response from ConstructQueryArgument: queryArgument and expression cannot both be null"));
                 expressions.Add(expression);
             }
-            var memberInstanceExpression = BuildMemberInstanceExpression(methodInfo);
             if (!isInterface)
             {
+                var memberInstanceExpression = BuildMemberInstanceExpression!(methodInfo);
                 if (IsObservable(methodInfo.ReturnType))
                 {
                     var resolver = new SourceStreamMethodResolver(methodInfo, memberInstanceExpression, expressions);
@@ -84,7 +87,7 @@ internal static class AutoRegisteringOutputHelper
             fieldType.Arguments = null;
             if (!isInterface)
             {
-                var resolver = new MemberResolver(fieldInfo, BuildMemberInstanceExpression(memberInfo));
+                var resolver = new MemberResolver(fieldInfo, BuildMemberInstanceExpression!(memberInfo));
                 fieldType.Resolver = resolver;
                 fieldType.StreamResolver = null;
             }

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Types;
 internal static class AutoRegisteringOutputHelper
 {
     private static readonly IFieldResolver _invalidFieldResolver = new FuncFieldResolver<object?>(_ => throw new InvalidOperationException("This field resolver should never be called. It is only used to prevent the default field resolver from being used."));
-    private static readonly ISourceStreamResolver _invalidStreamResolver = new SourceStreamResolver<object?>((Func<IResolveFieldContext, IObservable<object?>>)(_ => throw new InvalidOperationException("This source stream resolver should never be called. It is only used to prevent the default field resolver from being used.")));
+    private static readonly ISourceStreamResolver _invalidStreamResolver = new SourceStreamResolver<object?>((Func<IResolveFieldContext, IObservable<object?>>)(_ => throw new InvalidOperationException("This source stream resolver should never be called. It is only used to prevent the default source stream resolver from being used.")));
 
     /// <summary>
     /// Configures query arguments and a field resolver for the specified <see cref="FieldType"/>, overwriting

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -27,11 +27,11 @@ internal static class AutoRegisteringOutputHelper
     public static void BuildFieldType(
         MemberInfo memberInfo,
         FieldType fieldType,
-        Func<MemberInfo, LambdaExpression>? BuildMemberInstanceExpression,
+        Func<MemberInfo, LambdaExpression>? buildMemberInstanceExpressionFunc,
         Func<Type, Func<FieldType, ParameterInfo, ArgumentInformation>> getTypedArgumentInfoMethod,
-        Action<ParameterInfo, QueryArgument> ApplyArgumentAttributes)
+        Action<ParameterInfo, QueryArgument> applyArgumentAttributesFunc)
     {
-        // Note: If BuildMemberInstanceExpression is null, then it is assumed this is for
+        // Note: If buildMemberInstanceExpressionFunc is null, then it is assumed this is for
         // an interface graph type and the field resolver will be set to always throw an exception.
 
         if (fieldType == null)
@@ -40,9 +40,9 @@ internal static class AutoRegisteringOutputHelper
         if (memberInfo is PropertyInfo propertyInfo)
         {
             fieldType.Arguments = null;
-            if (BuildMemberInstanceExpression != null)
+            if (buildMemberInstanceExpressionFunc != null)
             {
-                var resolver = new MemberResolver(propertyInfo, BuildMemberInstanceExpression(memberInfo));
+                var resolver = new MemberResolver(propertyInfo, buildMemberInstanceExpressionFunc(memberInfo));
                 fieldType.Resolver = resolver;
                 fieldType.StreamResolver = null;
             }
@@ -58,7 +58,7 @@ internal static class AutoRegisteringOutputHelper
                 var (queryArgument, expression) = argumentInfo.ConstructQueryArgument();
                 if (queryArgument != null)
                 {
-                    ApplyArgumentAttributes(parameterInfo, queryArgument);
+                    applyArgumentAttributesFunc(parameterInfo, queryArgument);
                     queryArguments.Add(queryArgument);
                 }
                 expression ??= AutoRegisteringHelper.GetParameterExpression(
@@ -66,9 +66,9 @@ internal static class AutoRegisteringOutputHelper
                     queryArgument ?? throw new InvalidOperationException("Invalid response from ConstructQueryArgument: queryArgument and expression cannot both be null"));
                 expressions.Add(expression);
             }
-            if (BuildMemberInstanceExpression != null)
+            if (buildMemberInstanceExpressionFunc != null)
             {
-                var memberInstanceExpression = BuildMemberInstanceExpression(methodInfo);
+                var memberInstanceExpression = buildMemberInstanceExpressionFunc(methodInfo);
                 if (IsObservable(methodInfo.ReturnType))
                 {
                     var resolver = new SourceStreamMethodResolver(methodInfo, memberInstanceExpression, expressions);
@@ -87,9 +87,9 @@ internal static class AutoRegisteringOutputHelper
         else if (memberInfo is FieldInfo fieldInfo)
         {
             fieldType.Arguments = null;
-            if (BuildMemberInstanceExpression != null)
+            if (buildMemberInstanceExpressionFunc != null)
             {
-                var resolver = new MemberResolver(fieldInfo, BuildMemberInstanceExpression(memberInfo));
+                var resolver = new MemberResolver(fieldInfo, buildMemberInstanceExpressionFunc(memberInfo));
                 fieldType.Resolver = resolver;
                 fieldType.StreamResolver = null;
             }

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -102,7 +102,7 @@ internal static class AutoRegisteringOutputHelper
         {
             throw new ArgumentOutOfRangeException(nameof(memberInfo), "Member must be a field, property or method.");
         }
-        if (BuildMemberInstanceExpression == null)
+        if (buildMemberInstanceExpressionFunc == null)
         {
             fieldType.Resolver = _invalidFieldResolver;
             fieldType.StreamResolver = _invalidStreamResolver;

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using GraphQL.Resolvers;

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using GraphQL.Resolvers;
@@ -32,8 +33,10 @@ internal static class AutoRegisteringOutputHelper
         Action<ParameterInfo, QueryArgument> ApplyArgumentAttributes,
         bool isInterface)
     {
-        if (!isInterface && BuildMemberInstanceExpression == null)
-            throw new ArgumentNullException(nameof(BuildMemberInstanceExpression));
+        Debug.Assert(isInterface || BuildMemberInstanceExpression != null);
+
+        if (fieldType == null)
+            throw new ArgumentNullException(nameof(fieldType));
 
         if (memberInfo is PropertyInfo propertyInfo)
         {


### PR DESCRIPTION
Replaces #3414

This is a breaking change --- but (due to a bug) ONLY if the field that returns an interface type is not nullable.