### PR TITLE
Add Microsoft.Bcl.AsyncInterfaces dependency for .NET Standard 2.0 projects

### DIFF
--- a/src/GraphQL.Tests/Types/AutoRegisteringObservableTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObservableTests.cs
@@ -1,6 +1,5 @@
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 #pragma warning disable CS8425 // Async-iterator member has one or more parameters of type 'CancellationToken' but none of them is decorated with the 'EnumeratorCancellation' attribute, so the cancellation token parameter from the generated 'IAsyncEnumerable<>.GetAsyncEnumerator' will be unconsumed
-#pragma warning disable IDE0005 // Using directive is unnecessary.
 
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
@@ -57,7 +56,6 @@ public class AutoRegisteringObservableTests
         e.Message.ShouldBe("initial error");
     }
 
-#if NET5_0_OR_GREATER
     [Theory]
     [InlineData(nameof(TestClass.AsyncStrings1))]
     [InlineData(nameof(TestClass.AsyncStrings2))]
@@ -214,7 +212,6 @@ public class AutoRegisteringObservableTests
         var returnedData = stream.Value.ToEnumerable().Select(result => new SystemTextJson.GraphQLSerializer().Serialize(result)).ToList();
         returnedData.ShouldHaveSingleItem().ShouldBeCrossPlatJson("""{"data":{"resolveFieldContextPassThrough":"1"}}""");
     }
-#endif
 
     public class TestClass
     {

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Nullability.Source" Version="2.1.0" PrivateAssets="all" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
   </ItemGroup>

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net5;net6</TargetFrameworks>
@@ -15,6 +15,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
   </ItemGroup>
 

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
   </ItemGroup>
 

--- a/src/GraphQL/Resolvers/ObservableFromAsyncEnumerable.cs
+++ b/src/GraphQL/Resolvers/ObservableFromAsyncEnumerable.cs
@@ -1,6 +1,3 @@
-#if !NETSTANDARD2_0
-// for .NET Standard 2.0, this requires the Microsoft.Bcl.AsyncInterfaces NuGet package
-
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using GraphQL.Execution;
@@ -141,5 +138,3 @@ internal sealed class ObservableFromAsyncEnumerable<T> : IObservable<object?>, I
         public IDictionary<string, object?> UserContext => _context.UserContext;
     }
 }
-
-#endif

--- a/src/GraphQL/Resolvers/SourceStreamMethodResolver.cs
+++ b/src/GraphQL/Resolvers/SourceStreamMethodResolver.cs
@@ -65,7 +65,6 @@ namespace GraphQL.Resolvers
                         taskBodyExpression = Expression.Call(_castFromTaskAsyncMethodInfo.MakeGenericMethod(innerType), bodyExpression);
                     }
                 }
-#if !NETSTANDARD2_0
                 // Task<IAsyncEnumerable<T>>
                 else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
                 {
@@ -74,7 +73,6 @@ namespace GraphQL.Resolvers
                     var func = method.CreateDelegate<Func<Expression, ParameterExpression, Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>>(null);
                     return func(bodyExpression, resolveFieldContextParameter);
                 }
-#endif
             }
             // ValueTask<T>
             else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(ValueTask<>))
@@ -89,7 +87,6 @@ namespace GraphQL.Resolvers
                         taskBodyExpression = Expression.Call(_castFromValueTaskAsyncMethodInfo.MakeGenericMethod(innerType), bodyExpression);
                     }
                 }
-#if !NETSTANDARD2_0
                 // ValueTask<IAsyncEnumerable<T>>
                 else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
                 {
@@ -98,7 +95,6 @@ namespace GraphQL.Resolvers
                     var func = method.CreateDelegate<Func<Expression, ParameterExpression, Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>>(null);
                     return func(bodyExpression, resolveFieldContextParameter);
                 }
-#endif
             }
             // IObservable<T>
             else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(IObservable<>))
@@ -113,7 +109,6 @@ namespace GraphQL.Resolvers
                         bodyExpression);
                 }
             }
-#if !NETSTANDARD2_0
             // IAsyncEnumerable<T>
             else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
             {
@@ -122,22 +117,16 @@ namespace GraphQL.Resolvers
                 var func = method.CreateDelegate<Func<Expression, ParameterExpression, Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>>(null);
                 return func(bodyExpression, resolveFieldContextParameter);
             }
-#endif
 
             if (taskBodyExpression == null)
             {
-                throw new InvalidOperationException("Method must return a IObservable<T> or Task<IObservable<T>> where T is a reference type" +
-#if !NETSTANDARD2_0
-                    ", or a IAsyncEnumerable<T> or Task<IAsyncEnumerable<T>>" +
-#endif
-                    ".");
+                throw new InvalidOperationException("Method must return a IObservable<T> or Task<IObservable<T>> where T is a reference type, or a IAsyncEnumerable<T> or Task<IAsyncEnumerable<T>>.");
             }
 
             var lambda = Expression.Lambda<Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>(taskBodyExpression, resolveFieldContextParameter);
             return lambda.Compile();
         }
 
-#if !NETSTANDARD2_0
         private static readonly MethodInfo _convertFromAsyncEnumerableMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(ConvertFromAsyncEnumerable), BindingFlags.Static | BindingFlags.NonPublic)!;
         private static Func<IResolveFieldContext, ValueTask<IObservable<object?>>> ConvertFromAsyncEnumerable<T>(Expression body, ParameterExpression resolveFieldContextParameter)
         {
@@ -161,7 +150,6 @@ namespace GraphQL.Resolvers
             var func = lambda.Compile();
             return ObservableFromAsyncEnumerable<T>.Create(func);
         }
-#endif
 
         private static readonly MethodInfo _castFromValueTaskAsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromValueTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
         private static async ValueTask<IObservable<object?>> CastFromValueTaskAsync<T>(ValueTask<IObservable<T>> task) where T : class

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -109,28 +109,18 @@ internal static class AutoRegisteringOutputHelper
         }
     }
 
-#if !NETSTANDARD2_0
     /// <summary>
     /// Determines if the type is an <see cref="IObservable{T}"/> or task that returns an <see cref="IObservable{T}"/>.
     /// Also checks for <see cref="IAsyncEnumerable{T}"/> and task that returns an <see cref="IAsyncEnumerable{T}"/>.
     /// </summary>
-#else
-    /// <summary>
-    /// Determines if the type is an <see cref="IObservable{T}"/> or task that returns an <see cref="IObservable{T}"/>.
-    /// </summary>
-#endif
     private static bool IsObservableOrAsyncEnumerable(Type type)
     {
         if (!type.IsGenericType)
             return false;
 
         var g = type.GetGenericTypeDefinition();
-        if (g == typeof(IObservable<>))
+        if (g == typeof(IObservable<>) || g == typeof(IAsyncEnumerable<>))
             return true;
-#if !NETSTANDARD2_0
-        if (g == typeof(IAsyncEnumerable<>))
-            return true;
-#endif
         if (g == typeof(Task<>) || g == typeof(ValueTask<>))
             return IsObservableOrAsyncEnumerable(type.GetGenericArguments()[0]);
         return false;

--- a/src/GraphQL/Types/TypeInformation.cs
+++ b/src/GraphQL/Types/TypeInformation.cs
@@ -207,9 +207,7 @@ namespace GraphQL.Types
                     {
                         var genericType = type.Type.GetGenericTypeDefinition();
                         if (genericType == typeof(Task<>) || genericType == typeof(ValueTask<>)
-#if !NETSTANDARD2_0
                             || genericType == typeof(IAsyncEnumerable<>)
-#endif
                             || genericType == typeof(IDataLoaderResult<>) || genericType == typeof(IObservable<>))
                         {
                             //unwrap type


### PR DESCRIPTION
Enables IAsyncEnumerable subscription support for .NET Standard 2.0 projects for use with #3456 .

This PR targets #3456 currently.  If #3456 is merged then it will be updated to target master (7.3) or develop (8.0).

Besides the additional dependency, there are no breaking changes within this PR.

We can likely choose any version for the new `Microsoft.Bcl.AsyncInterfaces` dependency, as we only require the basic interface definitions.  We can also choose to remove the `System.Threading.Tasks.Extensions` dependency, as it is indirectly referenced by the `Microsoft.Bcl.AsyncInterfaces` dependency.  I left it in, just as Microsoft did with the `Microsoft.Extensions.DependencyInjection.Abstractions` 7.0.0 nuget package