### PR TITLE
quickfix/issue-3472-object-expressions

### DIFF
--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -51,7 +51,7 @@ namespace GraphQL.Types
                 }
             }
 
-            name = name.Replace('`', '_');
+            name = name.Replace('`', '_').Replace('@', '_');
             if (name.EndsWith(nameof(GraphType), StringComparison.InvariantCulture))
                 name = name.Substring(0, name.Length - nameof(GraphType).Length);
 

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -51,7 +51,8 @@ namespace GraphQL.Types
                 }
             }
 
-            name = name.Replace('`', '_').Replace('@', '_');
+            name = name.Replace('`', '_')
+                       .Replace('@', '_'); // https://github.com/graphql-dotnet/graphql-dotnet/issues/3472
             if (name.EndsWith(nameof(GraphType), StringComparison.InvariantCulture))
                 name = name.Substring(0, name.Length - nameof(GraphType).Length);
 


### PR DESCRIPTION
Remove `@` symbols from the default name in order to support F# Object Expressions