### PR TITLE
Fix issue with inherited record equals method being added to output

### DIFF
--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -436,6 +436,16 @@ public class AutoRegisteringObjectGraphTypeTests
     }
 
     [Fact]
+    public void TestInheritedRecordNoExtraFields()
+    {
+        var graphType = new AutoRegisteringObjectGraphType<TestInheritedRecord>();
+        graphType.Fields.Find("Id").ShouldNotBeNull();
+        graphType.Fields.Find("Name").ShouldNotBeNull();
+        graphType.Fields.Find("Description").ShouldNotBeNull();
+        graphType.Fields.Count.ShouldBe(3);
+    }
+
+    [Fact]
     public void TestBasicRecordStructNoExtraFields()
     {
         var graphType = new AutoRegisteringObjectGraphType<TestBasicRecordStruct>();
@@ -741,6 +751,14 @@ public class AutoRegisteringObjectGraphTypeTests
     }
 
     private record TestBasicRecord(int Id, string Name);
+    private record TestInheritedRecord : TestBasicRecord
+    {
+        public string Description { get; init; }
+        public TestInheritedRecord(int Id, string Name, string Description) : base(Id, Name)
+        {
+            this.Description = Description;
+        }
+    }
 
     private record struct TestBasicRecordStruct(int Id, string Name);
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -165,11 +165,21 @@ internal static class AutoRegisteringOutputHelper
                     x.ReturnType != typeof(Task) &&                          // exclude methods which do not return a value
                     x.GetBaseDefinition().DeclaringType != typeof(object) && // exclude methods inherited from object (e.g. GetHashCode)
                                                                              // exclude methods generated for record types: bool Equals(TSourceType)
-                    !(x.Name == "Equals" && !x.IsStatic && x.GetParameters().Length == 1 && x.GetParameters()[0].ParameterType == typeof(TSourceType) && x.ReturnType == typeof(bool)) &&
+                    !IsRecordEqualsMethod<TSourceType>(x) &&
                     x.Name != "<Clone>$");                                   // exclude methods generated for record types
             return properties.Concat<MemberInfo>(methods);
         }
     }
+
+    private static bool IsRecordEqualsMethod<TSourceType>(MethodInfo method) =>
+        method.Name == "Equals"
+        && !method.IsStatic
+        && method.GetParameters().Length == 1
+        && IsTypeSourceOrAncestor(typeof(TSourceType), method.GetParameters()[0].ParameterType)
+        && method.ReturnType == typeof(bool);
+
+    private static bool IsTypeSourceOrAncestor(Type sourceType, Type type) =>
+        sourceType == type || sourceType.BaseType != typeof(object) && sourceType.BaseType is not null && IsTypeSourceOrAncestor(sourceType.BaseType, type);
 
     /// <summary>
     /// Analyzes a method parameter and returns an instance of <see cref="ArgumentInformation"/>


### PR DESCRIPTION
Fix issue with inherited record equals method being added to output.

When auto-registering a record that inherits another record the inherited record's equals method was added to the output graph type.

This additionally created unwanted input graph types of the base record.