### PR TITLE
Graph types cannot be used as CLR types

### DIFF
--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -518,11 +518,11 @@ public class ComplexGraphTypeTests
         type.Fields.Find("field3").ShouldNotBeNull().Type.ShouldBe(typeof(GraphQLClrOutputTypeReference<int>));
 
         var e1 = Should.Throw<ArgumentException>(() => type.Field<int?>("field4"));
-        e1.Message.ShouldBe("The GraphQL type for field 'TestObject.field4' could not be derived implicitly from type 'Nullable`1'.");
+        e1.Message.ShouldStartWith("The GraphQL type for field 'TestObject.field4' could not be derived implicitly from type 'Nullable`1'. Explicitly nullable type: Nullable<Int32> cannot be coerced to a non nullable GraphQL type.");
         e1.InnerException.ShouldNotBeNull().Message.ShouldStartWith("Explicitly nullable type: Nullable<Int32> cannot be coerced to a non nullable GraphQL type.");
 
         var e2 = Should.Throw<ArgumentException>(() => type.Field<int?>("field5", false));
-        e2.Message.ShouldBe("The GraphQL type for field 'TestObject.field5' could not be derived implicitly from type 'Nullable`1'.");
+        e2.Message.ShouldStartWith("The GraphQL type for field 'TestObject.field5' could not be derived implicitly from type 'Nullable`1'. Explicitly nullable type: Nullable<Int32> cannot be coerced to a non nullable GraphQL type.");
         e2.InnerException.ShouldNotBeNull().Message.ShouldStartWith("Explicitly nullable type: Nullable<Int32> cannot be coerced to a non nullable GraphQL type.");
 
         type.Field<int?>("field6", true).Resolve(_ => 3);

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -239,7 +239,7 @@ namespace GraphQL.Builders
             }
             catch (ArgumentOutOfRangeException exp)
             {
-                throw new ArgumentException($"The GraphQL type for argument '{FieldType.Name}.{name}' could not be derived implicitly from type '{typeof(TArgumentClrType).Name}'.", exp);
+                throw new ArgumentException($"The GraphQL type for argument '{FieldType.Name}.{name}' could not be derived implicitly from type '{typeof(TArgumentClrType).Name}'. " + exp.Message, exp);
             }
 
             return Argument(type, name, configure);

--- a/src/GraphQL/Extensions/TypeExtensions.cs
+++ b/src/GraphQL/Extensions/TypeExtensions.cs
@@ -104,6 +104,11 @@ namespace GraphQL
         /// <remarks>This can handle arrays, lists and other collections implementing IEnumerable.</remarks>
         public static Type GetGraphTypeFromType(this Type type, bool isNullable = false, TypeMappingMode mode = TypeMappingMode.UseBuiltInScalarMappings)
         {
+            if (typeof(IGraphType).IsAssignableFrom(type))
+            {
+                throw new ArgumentOutOfRangeException(nameof(type), $"The graph type '{type.GetFriendlyName()}' cannot be used as a CLR type.");
+            }
+
             while (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDataLoaderResult<>))
             {
                 type = type.GetGenericArguments()[0];

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -447,7 +447,7 @@ namespace GraphQL.Types
             }
             catch (ArgumentOutOfRangeException exp)
             {
-                throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from type '{typeof(TReturnType).Name}'.", exp);
+                throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from type '{typeof(TReturnType).Name}'. " + exp.Message, exp);
             }
 
             var builder = CreateBuilder<TReturnType>(type)
@@ -505,7 +505,7 @@ namespace GraphQL.Types
             }
             catch (ArgumentOutOfRangeException exp)
             {
-                throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from expression '{expression}'.", exp);
+                throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from expression '{expression}'. " + exp.Message, exp);
             }
 
             var builder = CreateBuilder<TProperty>(type)


### PR DESCRIPTION
Prevents using graph types as CLR types for `GetGraphTypeFromType` and indirectly `FieldBuilder` and `ArgumentBuilder`

Fixes:
- #3507

Replaces:
- #3509 

This change will cause an exception to be thrown at the exact line of code in error, rather than during schema validation.