### PR TITLE
More AOT annotations

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <!--<ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors> does not work-->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2026;IL2055;IL2067;IL2070;IL2072;IL2075;IL2090;IL2091;IL2092;IL2095</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2026;IL2055;IL2062;IL2067;IL2070;IL2072;IL2075;IL2077;IL2087;IL2090;IL2091;IL2092;IL2095</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsPackable)' != 'true'">

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Builders
         /// </summary>
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
+        public static ConnectionBuilder<TSourceType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, TSourceType>()
             where TNodeType : IGraphType
             => ConnectionBuilder<TSourceType>.Create<TNodeType>();
 
@@ -27,7 +27,7 @@ namespace GraphQL.Builders
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
         /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
+        public static ConnectionBuilder<TSourceType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType, TSourceType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>();
@@ -39,7 +39,7 @@ namespace GraphQL.Builders
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
         /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
         /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
+        public static ConnectionBuilder<TSourceType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>
@@ -81,7 +81,7 @@ namespace GraphQL.Builders
         /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
         /// </summary>
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
+        public static ConnectionBuilder<TSourceType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType>(string name = "default")
             where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>(name);
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace GraphQL.Builders
         /// </summary>
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")
+        public static ConnectionBuilder<TSourceType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType>(string name = "default")
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
@@ -101,7 +101,7 @@ namespace GraphQL.Builders
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
         /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
+        public static ConnectionBuilder<TSourceType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType, TConnectionType>(string name = "default")
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -35,7 +35,7 @@ namespace GraphQL.Builders
         /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
         /// </summary>
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType>(string name = "default")
+        public static ConnectionBuilder<TSourceType, TReturnType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType>(string name = "default")
             where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>(name);
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace GraphQL.Builders
         /// </summary>
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType, TEdgeType>(string name = "default")
+        public static ConnectionBuilder<TSourceType, TReturnType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType>(string name = "default")
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
@@ -55,7 +55,7 @@ namespace GraphQL.Builders
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
         /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-        public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
+        public static ConnectionBuilder<TSourceType, TReturnType> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType, TConnectionType>(string name = "default")
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Builders
         /// <typeparam name="TReturnType">The type of the return value of the resolver.</typeparam>
         /// <param name="type">The graph type of the field.</param>
         [Obsolete("Please use FieldBuilder<TSourceType, TReturnType>.Create() method. This method will be removed in v8.")]
-        public static FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>(Type? type = null)
+        public static FieldBuilder<TSourceType, TReturnType> Create<TSourceType, TReturnType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null)
             => FieldBuilder<TSourceType, TReturnType>.Create(type);
 
         /// <inheritdoc cref="Create{TSourceType, TReturnType}(Type)"/>
@@ -175,7 +175,7 @@ namespace GraphQL.Builders
         /// <param name="name">The name of the argument.</param>
         /// <param name="description">The description of the argument.</param>
         /// <param name="configure">A delegate to further configure the argument.</param>
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure = null)
+        public virtual FieldBuilder<TSourceType, TReturnType> Argument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure = null)
             where TArgumentGraphType : IGraphType
             => Argument<TArgumentGraphType>(name, arg =>
             {
@@ -193,7 +193,7 @@ namespace GraphQL.Builders
         /// <param name="defaultValue">The default value of the argument.</param>
         /// <param name="configure">A delegate to further configure the argument.</param>
         [Obsolete("Please use Action<QueryArgument> parameter from other Argument() method overloads to set default value for parameter or use Arguments() method. This method will be removed in v8.")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string? description,
+        public virtual FieldBuilder<TSourceType, TReturnType> Argument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TArgumentGraphType, TArgumentType>(string name, string? description,
             TArgumentType? defaultValue = default, Action<QueryArgument>? configure = null)
             where TArgumentGraphType : IGraphType
             => Argument<TArgumentGraphType>(name, arg =>
@@ -208,7 +208,7 @@ namespace GraphQL.Builders
         /// </summary>
         /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
         /// <param name="name">The name of the argument.</param>
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name)
+        public virtual FieldBuilder<TSourceType, TReturnType> Argument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TArgumentGraphType>(string name)
             where TArgumentGraphType : IGraphType
             => Argument<TArgumentGraphType>(name, null);
 

--- a/src/GraphQL/Extensions/AssemblyExtensions.cs
+++ b/src/GraphQL/Extensions/AssemblyExtensions.cs
@@ -22,6 +22,7 @@ namespace GraphQL
         /// Skips classes where the source type is <see cref="object"/>, or where the class is marked with
         /// the <see cref="DoNotMapClrTypeAttribute"/>.
         /// </summary>
+        [RequiresUnreferencedCode("Types containing in the provided assembly might be removed")]
         public static List<(Type ClrType, Type GraphType)> GetClrTypeMappings(this Assembly assembly)
         {
             //create a list of type mappings

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -543,6 +543,7 @@ namespace GraphQL
         /// <see cref="InputObjectGraphType{TSourceType}"/>, <see cref="AutoRegisteringInputObjectGraphType{TSourceType}"/>, and
         /// <see cref="AutoRegisteringObjectGraphType{TSourceType}"/> as generic types.
         /// </summary>
+        [RequiresUnreferencedCode("Types containing in the provided assembly might be removed")]
         public static IGraphQLBuilder AddGraphTypes(this IGraphQLBuilder builder, Assembly assembly)
         {
             // Graph types are always created with the transient lifetime, since they are only instantiated once

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -38,7 +38,10 @@ namespace GraphQL
         /// In case of configuring field as Field(x => x.FName).Name("FirstName") source dictionary
         /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
         /// </param>
-        public static object ToObject(this IDictionary<string, object?> source, Type type, IGraphType? mappedType = null)
+        public static object ToObject(
+            this IDictionary<string, object?> source,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] Type type,
+            IGraphType? mappedType = null)
         {
             // Given Field(x => x.FName).Name("FirstName") and key == "FirstName" returns "FName"
             string GetPropertyName(string key, out FieldType? field)
@@ -205,7 +208,14 @@ namespace GraphQL
         /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
         /// </param>
         /// <remarks>There is special handling for strings, IEnumerable&lt;T&gt;, Nullable&lt;T&gt;, and Enum.</remarks>
-        public static object? GetPropertyValue(this object? propertyValue, Type fieldType, IGraphType? mappedType = null)
+        public static object? GetPropertyValue(
+            this object? propertyValue,
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)] Type fieldType,
+#else
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type fieldType,
+#endif
+            IGraphType? mappedType = null)
         {
             // Short-circuit conversion if the property value already of the right type
             if (propertyValue == null || fieldType == typeof(object) || fieldType.IsInstanceOfType(propertyValue))

--- a/src/GraphQL/Extensions/SchemaExtensions.cs
+++ b/src/GraphQL/Extensions/SchemaExtensions.cs
@@ -128,7 +128,7 @@ namespace GraphQL
         /// <param name="schema">The schema for which the mapping is registered.</param>
         /// <typeparam name="TClrType">The CLR property type from which to infer the GraphType.</typeparam>
         /// <param name="mode">Which registering mode to use - input only, output only or both.</param>
-        public static void AutoRegister<TClrType>(this ISchema schema, AutoRegisteringMode mode = AutoRegisteringMode.Both)
+        public static void AutoRegister<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] TClrType>(this ISchema schema, AutoRegisteringMode mode = AutoRegisteringMode.Both)
         {
             if (mode.HasFlag(AutoRegisteringMode.Output))
                 schema.RegisterTypeMapping<TClrType, AutoRegisteringObjectGraphType<TClrType>>();

--- a/src/GraphQL/IConfigureAutoSchema.cs
+++ b/src/GraphQL/IConfigureAutoSchema.cs
@@ -21,7 +21,7 @@ public interface IConfigureAutoSchema
     Type SchemaType { get; }
 }
 
-internal class ConfigureAutoSchema<TQueryClrType> : IConfigureAutoSchema
+internal class ConfigureAutoSchema<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] TQueryClrType> : IConfigureAutoSchema
 {
     public ConfigureAutoSchema(IGraphQLBuilder baseBuilder)
     {

--- a/src/GraphQL/Reflection/ReflectionHelper.cs
+++ b/src/GraphQL/Reflection/ReflectionHelper.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Reflection
         /// <param name="type">The type to check.</param>
         /// <param name="field">The desired field.</param>
         /// <param name="resolverType">defaults to Resolver</param>
-        public static IAccessor? ToAccessor(this Type? type, string field, ResolverType resolverType)
+        public static IAccessor? ToAccessor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] this Type? type, string field, ResolverType resolverType)
         {
             if (type == null)
                 return null;
@@ -41,7 +41,7 @@ namespace GraphQL.Reflection
         /// <param name="type">The type to check.</param>
         /// <param name="field">The desired field.</param>
         /// <param name="resolverType">Indicates if a resolver or stream resolver method is requested.</param>
-        public static MethodInfo? MethodForField(this Type type, string field, ResolverType resolverType)
+        public static MethodInfo? MethodForField([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] this Type type, string field, ResolverType resolverType)
         {
             var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
 
@@ -60,7 +60,7 @@ namespace GraphQL.Reflection
         /// </summary>
         /// <param name="type">The type to check.</param>
         /// <param name="field">The desired field.</param>
-        public static PropertyInfo? PropertyForField(this Type type, string field)
+        public static PropertyInfo? PropertyForField([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this Type type, string field)
         {
             var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -60,7 +60,9 @@ namespace GraphQL.Resolvers
         /// <param name="target"> The type from which you want to get the value. </param>
         /// <param name="name"> Property/method name. </param>
         /// <returns> Compiled field resolver. </returns>
-        private static IFieldResolver CreateResolver(Type target, string name)
+        private static IFieldResolver CreateResolver(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type target,
+            string name)
         {
             var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
             var source = Expression.MakeMemberAccess(param, _sourcePropertyInfo);

--- a/src/GraphQL/Types/AutoSchema.cs
+++ b/src/GraphQL/Types/AutoSchema.cs
@@ -5,9 +5,9 @@ namespace GraphQL.Types;
 /// <summary>
 /// A schema with a Query type that is initialized to an instance
 /// of <see cref="AutoRegisteringObjectGraphType{TSourceType}"/>
-/// with <typeparamref name="TQueryClrType"/> as the query clr type.
+/// with <typeparamref name="TQueryClrType"/> as the query CLR type.
 /// </summary>
-public class AutoSchema<TQueryClrType> : Schema
+public class AutoSchema<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] TQueryClrType> : Schema
 {
     /// <summary>
     /// Initializes a new instance from the specified service provider.

--- a/src/GraphQL/Types/Collections/AutoRegisteringGraphTypeMappingProvider.cs
+++ b/src/GraphQL/Types/Collections/AutoRegisteringGraphTypeMappingProvider.cs
@@ -35,7 +35,7 @@ public class AutoRegisteringGraphTypeMappingProvider : IGraphTypeMappingProvider
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AutoRegisteringObjectGraphType<>))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AutoRegisteringInterfaceGraphType<>))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(AutoRegisteringInputObjectGraphType<>))]
-    public virtual Type? GetGraphTypeFromClrType(Type clrType, bool isInputType, Type? preferredType)
+    public virtual Type? GetGraphTypeFromClrType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] Type clrType, bool isInputType, Type? preferredType)
     {
         if (preferredType != null)
             return preferredType;

--- a/src/GraphQL/Types/Collections/IGraphTypeMappingProvider.cs
+++ b/src/GraphQL/Types/Collections/IGraphTypeMappingProvider.cs
@@ -12,5 +12,5 @@ public interface IGraphTypeMappingProvider
     /// <param name="clrType">The CLR type to be mapped.</param>
     /// <param name="isInputType">Indicates whether the type is an input type.</param>
     /// <param name="preferredGraphType">The graph type that is suggested for this CLR type.</param>
-    Type? GetGraphTypeFromClrType(Type clrType, bool isInputType, Type? preferredGraphType);
+    Type? GetGraphTypeFromClrType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] Type clrType, bool isInputType, Type? preferredGraphType);
 }

--- a/src/GraphQL/Types/Collections/ManualGraphTypeMappingProvider.cs
+++ b/src/GraphQL/Types/Collections/ManualGraphTypeMappingProvider.cs
@@ -15,6 +15,6 @@ internal class ManualGraphTypeMappingProvider : IGraphTypeMappingProvider
         _isOutputType = graphType.IsOutputType();
     }
 
-    public Type? GetGraphTypeFromClrType(Type clrType, bool isInputType, Type? preferredGraphType)
+    public Type? GetGraphTypeFromClrType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] Type clrType, bool isInputType, Type? preferredGraphType)
         => clrType == _clrType && (isInputType && _isInputType || !isInputType && _isOutputType) ? _graphType : preferredGraphType;
 }

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -220,7 +220,7 @@ namespace GraphQL.Types
             _introspectionTypes = CreateIntrospectionTypes(schema.Features.AppliedDirectives, schema.Features.RepeatableDirectives);
 
             _context = new TypeCollectionContext(
-               type => BuildGraphQLType(type, t => _builtInScalars.TryGetValue(t, out var graphType) ? graphType : _introspectionTypes.TryGetValue(t, out graphType) ? graphType : (IGraphType)Activator.CreateInstance(t)!),
+               type => BuildGraphQLType(type, ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] t) => _builtInScalars.TryGetValue(t, out var graphType) ? graphType : _introspectionTypes.TryGetValue(t, out graphType) ? graphType : (IGraphType)Activator.CreateInstance(t)!),
                (name, type, ctx) =>
                {
                    SetGraphType(name, type);
@@ -394,7 +394,9 @@ namespace GraphQL.Types
         /// </summary>
         public int Count => Dictionary.Count;
 
-        private IGraphType BuildGraphQLType(Type type, IGraphType resolvedType)
+        private IGraphType BuildGraphQLType(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type,
+            IGraphType resolvedType)
             => BuildGraphQLType(type, _ => resolvedType);
 
         /// <summary>
@@ -405,10 +407,12 @@ namespace GraphQL.Types
         /// <see cref="IProvideResolvedType.ResolvedType"/> property is set to a new instance of
         /// the base (wrapped) type.
         /// </summary>
-        protected internal virtual IGraphType BuildGraphQLType(Type type, Func<Type, IGraphType> resolve)
+        protected internal virtual IGraphType BuildGraphQLType(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type,
+            Func<Type, IGraphType> resolve)
         {
             var local = resolve;
-            local ??= t => (IGraphType)Activator.CreateInstance(t)!;
+            local ??= ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] t) => (IGraphType)Activator.CreateInstance(t)!;
             resolve = t => FindGraphType(t) ?? local(t);
 
             if (type.IsGenericType)

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -133,7 +133,11 @@ internal static class AutoRegisteringOutputHelper
     /// that do not return <see langword="void"/> or <see cref="Task"/>
     /// including properties and methods declared on inherited classes.
     /// </summary>
-    public static IEnumerable<MemberInfo> GetRegisteredMembers<TSourceType>(Expression<Func<TSourceType, object?>>[]? excludedProperties)
+#if NET6_0_OR_GREATER
+    public static IEnumerable<MemberInfo> GetRegisteredMembers<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.Interfaces)] TSourceType>(Expression<Func<TSourceType, object?>>[]? excludedProperties)
+#else
+    public static IEnumerable<MemberInfo> GetRegisteredMembers<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] TSourceType>(Expression<Func<TSourceType, object?>>[]? excludedProperties)
+#endif
     {
         if (typeof(TSourceType).IsInterface)
         {

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -415,13 +415,13 @@ namespace GraphQL.Types
 
         /// <inheritdoc cref="Field{TGraphType, TReturnType}(string)"/>
         [Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>()
+        public virtual FieldBuilder<TSourceType, TReturnType> Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType, TReturnType>()
             where TGraphType : IGraphType
             => Field<TGraphType, TReturnType>("default");
 
         /// <inheritdoc cref="Field{TGraphType}(string)"/>
         [Obsolete("Please call Field<TGraphType>(string name) instead.")]
-        public virtual FieldBuilder<TSourceType, object> Field<TGraphType>()
+        public virtual FieldBuilder<TSourceType, object> Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>()
             where TGraphType : IGraphType
             => Field<TGraphType, object>("default");
 
@@ -430,7 +430,7 @@ namespace GraphQL.Types
         /// </summary>
         /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
         /// <param name="name">The name of the field.</param>
-        public virtual FieldBuilder<TSourceType, object> Field<TGraphType>(string name)
+        public virtual FieldBuilder<TSourceType, object> Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(string name)
             where TGraphType : IGraphType
             => Field<TGraphType, object>(name);
 
@@ -555,7 +555,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType}(string)"/>
-        public ConnectionBuilder<TSourceType> Connection<TNodeType>()
+        public ConnectionBuilder<TSourceType> Connection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType>()
             where TNodeType : IGraphType
         {
             var builder = ConnectionBuilder.Create<TNodeType, TSourceType>();
@@ -564,7 +564,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType}(string)"/>
-        public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
+        public ConnectionBuilder<TSourceType> Connection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
         {
@@ -574,7 +574,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType, TConnectionType}(string)"/>
-        public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
+        public ConnectionBuilder<TSourceType> Connection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType, TConnectionType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>

--- a/src/GraphQL/Types/Composite/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/InputObjectGraphType.cs
@@ -36,7 +36,7 @@ namespace GraphQL.Types
     }
 
     /// <inheritdoc cref="IInputObjectGraphType"/>
-    public class InputObjectGraphType<TSourceType> : ComplexGraphType<TSourceType>, IInputObjectGraphType
+    public class InputObjectGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] TSourceType> : ComplexGraphType<TSourceType>, IInputObjectGraphType
     {
         /// <summary>
         /// Converts a supplied dictionary of keys and values to an object.

--- a/src/GraphQL/Types/Relay/ConnectionType.cs
+++ b/src/GraphQL/Types/Relay/ConnectionType.cs
@@ -51,7 +51,7 @@ namespace GraphQL.Types.Relay
     /// the node graph type. The edge graph type used is <see cref="EdgeType{TNodeType}"/>.
     /// </summary>
     /// <typeparam name="TNodeType">The graph type of the result data set's data type.</typeparam>
-    public class ConnectionType<TNodeType> : ConnectionType<TNodeType, EdgeType<TNodeType>>
+    public class ConnectionType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType> : ConnectionType<TNodeType, EdgeType<TNodeType>>
         where TNodeType : IGraphType
     {
     }

--- a/src/GraphQL/Types/Scalars/Enumeration/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/Enumeration/EnumerationGraphType.cs
@@ -118,10 +118,17 @@ public class EnumerationGraphType : ScalarGraphType
 /// Also it can get descriptions for enum fields from the XML comments.
 /// </summary>
 /// <typeparam name="TEnum"> The enum to take values from. </typeparam>
-public class EnumerationGraphType<TEnum> : EnumerationGraphType
+public class EnumerationGraphType<[DynamicallyAccessedMembers(GET_ALL_MEMBERS)] TEnum> : EnumerationGraphType
     where TEnum : Enum
 {
     private static readonly EnumCaseAttribute? _caseAttr = typeof(TEnum).GetCustomAttribute<EnumCaseAttribute>();
+
+    private const DynamicallyAccessedMemberTypes GET_ALL_MEMBERS = DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields |
+           DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods |
+           DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents |
+           DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties |
+           DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors |
+           DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EnumerationGraphType"/> class.

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -303,7 +303,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             return type;
         }
 
-        private void InitializeField(FieldConfig config, Type? parentType)
+        private void InitializeField(FieldConfig config, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] Type? parentType)
         {
             config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);
 
@@ -324,7 +324,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
             }
         }
 
-        private void InitializeSubscriptionField(FieldConfig config, Type? parentType)
+        private void InitializeSubscriptionField(FieldConfig config, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] Type? parentType)
         {
             config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);
             config.StreamResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.StreamResolver);


### PR DESCRIPTION
I tried to follow AOT annotations guidelines and I have a bad feeling about this all.

Problems:
1. It is very toxic for code - even worse then async/await "infection" or NRT annotations.
2. I do not understand why we should manually write annotations - the analyzer already knows what is missing in specific cases and demands to put it into code. It looks strange. I hope that in NET8 this will be fixed and it will not be necessary to manually do the work. Though it may be the same story as for NRT - analizer knows but it's a developer responsibility to say the last word.
3. I do not understant what to do in 50% of cases when `Type` comes from some calculated variable.
4. It seems to me that we "excessive" demand trimmer to preserve some type's parts in methods with branch logic (for example, type.GetProperties() in the first branch and type.GetMethods() in the second).

I'm skeptical about such code annotation.