### PR TITLE
Fix data loader Then method

### DIFF
--- a/src/GraphQL.DataLoader.Tests/Types/QueryType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/QueryType.cs
@@ -79,10 +79,7 @@ public class QueryType : ObjectGraphType
                     users.GetUsersByIdAsync);
 
                 var ids = ctx.GetArgument<IEnumerable<int>>("ids");
-                // note: does not work properly without ToList, because LoadAsync would not have
-                // been called, so the ids would not have been queued for execution prior to the
-                // first call to GetResultAsync
-                var ret = ids.Select(id => loader.LoadAsync(id)).ToList();
+                var ret = ids.Select(id => loader.LoadAsync(id));
                 var ret2 = ret.Then(values => values.Where(x => x != null));
                 return ret2;
             });

--- a/src/GraphQL.DataLoader/Extensions/DataLoaderExtensions.cs
+++ b/src/GraphQL.DataLoader/Extensions/DataLoaderExtensions.cs
@@ -111,10 +111,6 @@ public static class DataLoaderExtensions
 
     /// <summary>
     /// Chains post-processing to a list of pending data loader operations.
-    /// <br/><br/>
-    /// Be sure the source list has been enumerated, for instance by calling
-    /// <see cref="Enumerable.ToList{TSource}(IEnumerable{TSource})">ToList</see>,
-    /// before calling this function.
     /// </summary>
     /// <typeparam name="T">The type of the return value of the data loaders.</typeparam>
     /// <typeparam name="TResult">The type of the result.</typeparam>

--- a/src/GraphQL.DataLoader/Extensions/DataLoaderExtensions.cs
+++ b/src/GraphQL.DataLoader/Extensions/DataLoaderExtensions.cs
@@ -123,6 +123,12 @@ public static class DataLoaderExtensions
     /// <returns>A pending data loader operation that can return a value once the data loaders and the chained delegate finish.</returns>
     public static IDataLoaderResult<TResult> Then<T, TResult>(this IEnumerable<IDataLoaderResult<T>> parents, Func<IEnumerable<T>, CancellationToken, Task<TResult>> chainedDelegate)
     {
+        // ensure that the source list has been enumerated; otherwise LoadAsync would not have
+        // been called, so the ids would not have been queued for execution prior to the
+        // first call to GetResultAsync
+        if (parents is not IList<IDataLoaderResult<T>>)
+            parents = parents.ToList();
+
         return new SimpleDataLoader<TResult>(async cancellationToken =>
         {
             List<T> list = parents is ICollection collection
@@ -139,6 +145,12 @@ public static class DataLoaderExtensions
     /// <inheritdoc cref="Then{T, TResult}(IEnumerable{IDataLoaderResult{T}}, Func{IEnumerable{T}, CancellationToken, Task{TResult}})"/>
     public static IDataLoaderResult<TResult> Then<T, TResult>(this IEnumerable<IDataLoaderResult<T>> parents, Func<IEnumerable<T>, Task<TResult>> chainedDelegate)
     {
+        // ensure that the source list has been enumerated; otherwise LoadAsync would not have
+        // been called, so the ids would not have been queued for execution prior to the
+        // first call to GetResultAsync
+        if (parents is not IList<IDataLoaderResult<T>>)
+            parents = parents.ToList();
+
         return new SimpleDataLoader<TResult>(async cancellationToken =>
         {
             List<T> list = parents is ICollection collection
@@ -155,6 +167,12 @@ public static class DataLoaderExtensions
     /// <inheritdoc cref="Then{T, TResult}(IEnumerable{IDataLoaderResult{T}}, Func{IEnumerable{T}, CancellationToken, Task{TResult}})"/>
     public static IDataLoaderResult<TResult> Then<T, TResult>(this IEnumerable<IDataLoaderResult<T>> parents, Func<IEnumerable<T>, TResult> chainedDelegate)
     {
+        // ensure that the source list has been enumerated; otherwise LoadAsync would not have
+        // been called, so the ids would not have been queued for execution prior to the
+        // first call to GetResultAsync
+        if (parents is not IList<IDataLoaderResult<T>>)
+            parents = parents.ToList();
+
         return new SimpleDataLoader<TResult>(async cancellationToken =>
         {
             List<T> list = parents is ICollection collection


### PR DESCRIPTION
Fixes poor design introduced in #3021.

The `Then` methods introduced in #3021 require that the input enumerable list has been iterated to work properly.  Although the xml comments describe this behavior, it is certainly not intuitive.  This was a bad design and should never have been a prerequisite for using these particular `Then` methods.  It's caused a 3-day outage in our servers due to this bad design.

This patch checks if the input list is an `IList` implementation (commonly an array or `List<T>`), indicating that the source list has been enumerated.  If it has not been, it does so via `ToList()`, which is correct and ** **required** ** for proper operation.

Note that another extension method already performs correct handling of lists, executing `LoadAsync` for each member and adding the resulting `IDataLoaderResult` instances to a list before passing it along to the remainder of the function:

```cs
public static IDataLoaderResult<T[]> LoadAsync<TKey, T>(this IDataLoader<TKey, T> dataLoader, IEnumerable<TKey> keys)
```

In my issue today, 100s of child nodes were supposed to be queued to load via a data loader, but instead were individually queued into a queue of 1 entry each, and each entry loaded from the database independently.  The amount of overhead for each data loader and database request, although small, was enough to max out the CPU on the server which generally is idle, without taxing the database itself too much.