### PR TITLE
Fix of eternal loop in ComplexityAnalyzer in case of fragment cycles

### DIFF
--- a/src/GraphQL.Tests/Complexity/ComplexityTestBase.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityTestBase.cs
@@ -18,12 +18,14 @@ public class ComplexityTestBase
 
     protected ComplexityResult AnalyzeComplexity(string query) => Analyzer.Analyze(DocumentBuilder.Build(query), 2.0d, 250);
 
-    public async Task<ExecutionResult> Execute(ComplexityConfiguration complexityConfig, string query) =>
+    public async Task<ExecutionResult> Execute(ComplexityConfiguration complexityConfig, string query, bool onlyComplexityRule = false) =>
         await StarWarsTestBase.Executer.ExecuteAsync(options =>
         {
             options.Schema = CreateSchema();
             options.Query = query;
-            options.ValidationRules = GraphQL.Validation.DocumentValidator.CoreRules.Append(new ComplexityValidationRule(complexityConfig));
+            options.ValidationRules = onlyComplexityRule
+                ? new[] { new ComplexityValidationRule(complexityConfig) }
+                : GraphQL.Validation.DocumentValidator.CoreRules.Append(new ComplexityValidationRule(complexityConfig));
         }).ConfigureAwait(false);
 
     //ISSUE: manually created test instance with ServiceProvider

--- a/src/GraphQL.Tests/Complexity/ComplexityValidationTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityValidationTests.cs
@@ -1,3 +1,5 @@
+using GraphQL.Execution;
+using GraphQL.Validation;
 using GraphQL.Validation.Complexity;
 using GraphQL.Validation.Errors;
 using GraphQL.Validation.Errors.Custom;
@@ -170,6 +172,6 @@ public class ComplexityValidationTest : ComplexityTestBase
 
         res.Result.Errors.ShouldNotBe(null);
         res.Result.Errors.Count.ShouldBe(1);
-        res.Result.Errors[0].ShouldBeOfType<NoFragmentCyclesError>().Message.ShouldBe("Cannot spread fragment 'RecursiveFragment' within itself.");
+        res.Result.Errors[0].ShouldBeOfType<ValidationError>().Message.ShouldBe("It looks like document has fragment cycle. Please make sure you are using standard validation rules especially NoFragmentCycles one.");
     }
 }

--- a/src/GraphQL.Tests/Complexity/ComplexityValidationTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityValidationTests.cs
@@ -1,9 +1,6 @@
-using GraphQL.Execution;
 using GraphQL.Validation;
 using GraphQL.Validation.Complexity;
-using GraphQL.Validation.Errors;
 using GraphQL.Validation.Errors.Custom;
-using GraphQL.Validation.Rules;
 
 namespace GraphQL.Tests.Complexity;
 

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalyzer.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalyzer.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using GraphQL.Types;
-using GraphQL.Validation.Errors;
 using GraphQL.Validation.Errors.Custom;
 using GraphQLParser;
 using GraphQLParser.AST;

--- a/src/GraphQL/Validation/Errors/NoFragmentCyclesError.cs
+++ b/src/GraphQL/Validation/Errors/NoFragmentCyclesError.cs
@@ -8,11 +8,6 @@ namespace GraphQL.Validation.Errors
     {
         internal const string NUMBER = "5.5.2.2";
 
-        internal NoFragmentCyclesError(GraphQLDocument document, string fragName, params ASTNode[] nodes)
-            : base(document.Source, NUMBER, CycleErrorMessage(fragName, Array.Empty<string>()), nodes)
-        {
-        }
-
         /// <summary>
         /// Initializes a new instance with the specified properties.
         /// </summary>

--- a/src/GraphQL/Validation/Errors/NoFragmentCyclesError.cs
+++ b/src/GraphQL/Validation/Errors/NoFragmentCyclesError.cs
@@ -8,6 +8,11 @@ namespace GraphQL.Validation.Errors
     {
         internal const string NUMBER = "5.5.2.2";
 
+        internal NoFragmentCyclesError(GraphQLDocument document, string fragName, params ASTNode[] nodes)
+            : base(document.Source, NUMBER, CycleErrorMessage(fragName, Array.Empty<string>()), nodes)
+        {
+        }
+
         /// <summary>
         /// Initializes a new instance with the specified properties.
         /// </summary>


### PR DESCRIPTION
Fixes #3527.

There are 2 bugs in fact.
1. `ComplexityValidationRule` should run after all other standard rules. Before fix it was actually run (syncronously) **before** those rules that return non-null visitor. Note that @arguit wrote test with absolutely wrong schema, not StarWars.
2. `ComplexityValidationRule` indeed hangs in infinite while loop.

I successfully fixed the first. Also I added fast check to eliminate all possible problems with complexity analysis. Then I decided to fix the second. I "fixed" it but tests failed. It turned out that the code I added in `ComplexityAnalyzer.cs` is not enough. It was a naive approach. In fact, `NoFragmentCycles` rule should always be run if we use complexity analysis. First I thought to "force-inject" it into list of validation rules but then I changed my mind. It seems that it will be better to rollback changes in `ComplexityAnalyzer.cs` at all and go on with fix1. It is unlikely that someone uses complexity analysis when turning off the standard rules. Fix1 should solve #3527 so I believe fix2 is not needed. 

[UPDATED] I changed check to simple counter with limit of 2000.