### PR TITLE
CI fix for .NET SDK 7.0.200

### DIFF
--- a/.github/workflows/build-artifacts-code.yml
+++ b/.github/workflows/build-artifacts-code.yml
@@ -54,7 +54,8 @@ jobs:
         run: dotnet build --no-restore -c Release -p:VersionSuffix=$GITHUB_RUN_NUMBER
       - name: Pack solution [Release]
         working-directory: src
-        run: dotnet pack --no-restore --no-build -c Release -p:VersionSuffix=$GITHUB_RUN_NUMBER -o out
+        run: dotnet pack --no-restore --no-build -c Release -p:VersionSuffix=$GITHUB_RUN_NUMBER -p:PackageOutputPath=out
+        # See: https://github.com/dotnet/sdk/issues/30624#issuecomment-1432118204
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish-code.yml
+++ b/.github/workflows/publish-code.yml
@@ -61,7 +61,8 @@ jobs:
         run: dotnet build --no-restore -c Release -p:Version=$version
       - name: Pack solution [Release]
         working-directory: src
-        run: dotnet pack --no-restore --no-build -c Release -p:Version=$version -o out
+        run: dotnet pack --no-restore --no-build -c Release -p:Version=$version -p:PackageOutputPath=out
+        # See: https://github.com/dotnet/sdk/issues/30624#issuecomment-1432118204
       - name: Upload Nuget packages as workflow artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
See:
- https://github.com/dotnet/sdk/issues/15607
- https://github.com/dotnet/sdk/issues/30624
- https://github.com/dotnet/sdk/issues/30625
- https://github.com/dotnet/sdk/issues/30624#issuecomment-1432118204

The new error will be downgraded to a warning in the release next month.  Until then we can explicitly specify the output folder as shown in this PR.  Note that the `-o` option will not produce an error for `dotnet pack` at all after the release next month.
