### PR TITLE
Add schema validation visitor for AOT scenarios

### DIFF
--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -19,6 +19,7 @@ namespace GraphQL
         /// <typeparam name="T">The type to create.</typeparam>
         /// <param name="source">The source of values.</param>
         /// <returns>T.</returns>
+        [RequiresUnreferencedCode("The type of the object to be converted to must be statically discoverable.")]
         public static T ToObject<T>(this IDictionary<string, object?> source)
             where T : class
             => (T)ToObject(source, typeof(T));
@@ -38,6 +39,7 @@ namespace GraphQL
         /// In case of configuring field as Field(x => x.FName).Name("FirstName") source dictionary
         /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
         /// </param>
+        [RequiresUnreferencedCode("The type of the object to be converted to must be statically discoverable.")]
         public static object ToObject(this IDictionary<string, object?> source, Type type, IGraphType? mappedType = null)
         {
             // Given Field(x => x.FName).Name("FirstName") and key == "FirstName" returns "FName"
@@ -205,6 +207,7 @@ namespace GraphQL
         /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
         /// </param>
         /// <remarks>There is special handling for strings, IEnumerable&lt;T&gt;, Nullable&lt;T&gt;, and Enum.</remarks>
+        [RequiresUnreferencedCode("The type of the object to be converted to must be statically discoverable.")]
         public static object? GetPropertyValue(this object? propertyValue, Type fieldType, IGraphType? mappedType = null)
         {
             // Short-circuit conversion if the property value already of the right type

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using GraphQL.Conversion;
 using GraphQL.Utilities;
 
@@ -83,4 +84,14 @@ public static class GlobalSwitches
     /// The collection is not thread-safe; instances should be added prior to schema initialization.
     /// </summary>
     public static ICollection<GraphQLAttribute> GlobalAttributes { get; } = new List<GraphQLAttribute>();
+
+    /// <summary>
+    /// Gets a value that determines whether the runtime supports dynamic code.
+    /// </summary>
+    internal static bool IsDynamicCodeSupported
+#if NETSTANDARD2_0
+        => true;
+#else
+        => RuntimeFeature.IsDynamicCodeSupported;
+#endif
 }

--- a/src/GraphQL/Types/Composite/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/InputObjectGraphType.cs
@@ -46,6 +46,8 @@ namespace GraphQL.Types
         /// much like a field resolver does for output objects. For example, you can set some 'computed'
         /// properties for your input object which were not passed in the GraphQL request.
         /// </summary>
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+            Justification = "Field expressions are required and ensure that properties can be statically identified.")]
         public virtual object ParseDictionary(IDictionary<string, object?> value)
         {
             if (value == null)

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -488,6 +488,8 @@ namespace GraphQL.Types
             CoerceInputTypeDefaultValues();
             SchemaValidationVisitor.Instance.Run(this);
             AppliedDirectivesValidationVisitor.Instance.Run(this);
+            if (!GlobalSwitches.IsDynamicCodeSupported)
+                AotValidationVisitor.Instance.Run(this);
         }
 
         /// <summary>

--- a/src/GraphQL/Utilities/Visitors/AotValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/AotValidationVisitor.cs
@@ -1,0 +1,39 @@
+using GraphQL.Resolvers;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Validates the schema meets limitations as required by the official specification. Also looks for
+/// default values within arguments and inputs fields which are stored in AST nodes
+/// and coerces them to their internally represented values.
+/// </summary>
+public class AotValidationVisitor : BaseSchemaNodeVisitor
+{
+    /// <summary>
+    /// Returns a static instance of the <see cref="AotValidationVisitor"/> class.
+    /// </summary>
+    public static AotValidationVisitor Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
+    {
+        if (type is IInputObjectGraphType)
+        {
+            // validate that an expression has been tied to the field
+            if (field.GetMetadata<string?>(ComplexGraphType<string>.ORIGINAL_EXPRESSION_PROPERTY_NAME) == null)
+            {
+                throw new InvalidOperationException("All fields on input objects must be defined with an expression in scenarios when dynamic compilation is not supported by the runtime. " +
+                    $"Please fix {type.Name}.{field.Name}.");
+            }
+        }
+        else if (type is not IInterfaceGraphType)
+        {
+            if (field.Resolver == null || field.Resolver is NameFieldResolver)
+            {
+                throw new InvalidOperationException("NameFieldResolver is not supported in scenarios when dynamic compilation is not supported by the runtime. " +
+                    $"Please fix {type.Name}.{field.Name}.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is the approach taken by MS for .NET 8 in some scenarios.

Note that `RuntimeFeature.IsDynamicCodeSupported` returns `true` while debugging.

In this PR, attempting to run the AOT sample produces this error when running the compiled app:

```
Sample of AOT compilation of a GraphQL query

Executing request: { hero { id name } }

Unhandled Exception: System.InvalidOperationException: NameFieldResolver is not supported in scenarios when dynamic compilation is not supported by the runtime. Please fix CharacterInterfaceConnection.totalCount.
   at GraphQL.Utilities.AotValidationVisitor.VisitObjectFieldDefinition(FieldType, IObjectGraphType, ISchema) + 0x348
   at GraphQL.SchemaExtensions.Run(ISchemaNodeVisitor, ISchema) + 0x861
   at GraphQL.Types.Schema.Validate() + 0x9c
   at GraphQL.Types.Schema.CreateAndInitializeSchemaTypes() + 0x16f
   at GraphQL.Types.Schema.Initialize() + 0x13e
```

This is correct.  In fact, disabling the visitor and attempting to access the property referenced by the above error produces this runtime error:

```
Sample of AOT compilation of a GraphQL query

Executing request: { hero { id name friendsConnection { totalCount } } }

Unhandled Exception: System.InvalidOperationException: Expected to find property or method 'totalCount' on type 'Connection`1' but it does not exist.
   at GraphQL.Resolvers.NameFieldResolver.CreateResolver(Type, String) + 0x2a0
   at GraphQL.Resolvers.NameFieldResolver.<>c.<Resolve>b__6_0(ValueTuple`2 t) + 0x2d
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey, Func`2) + 0x1c8
   at GraphQL.Resolvers.NameFieldResolver.Resolve(IResolveFieldContext, String) + 0x1d3
   at GraphQL.Resolvers.NameFieldResolver.ResolveAsync(IResolveFieldContext context) + 0x61
```

So we can see that the schema validation visitor added in this PR is doing its job correctly by identifying incorrectly configured fields within the schema.