### PR TITLE
Fix UnhandledError when resolving top-level subscription field

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,6 +5,7 @@
     <PackageReleaseNotes>See https://github.com/graphql-dotnet/graphql-dotnet/releases and https://graphql-dotnet.github.io/docs/migrations/migration7</PackageReleaseNotes>
     <Nullable>enable</Nullable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <!--<EnableAotAnalyzer>true</EnableAotAnalyzer> PublishAot property enables it-->
     <!--<ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors> does not work-->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2026;IL2055;IL2067;IL2070;IL2072;IL2075;IL2090;IL2091;IL2092;IL2095</WarningsNotAsErrors>
   </PropertyGroup>

--- a/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using GraphQL.Instrumentation;
 
 namespace GraphQL.Tests.Subscription;
 
@@ -52,8 +53,10 @@ public class SubscriptionTests
         data["messageGetAll"].ShouldNotBeNull();
     }
 
-    [Fact]
-    public async Task SubscribeToContent()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SubscribeToContent(bool useMiddleware)
     {
         /* Given */
         var addedMessage = new Message
@@ -69,7 +72,12 @@ public class SubscriptionTests
 
         var chat = new Chat();
         var schema = new ChatSchema(chat);
-
+        if (useMiddleware)
+        {
+            // see
+            var my = new NoopMiddleware();
+            schema.FieldMiddleware.Use(next => context => my.ResolveAsync(context, next));
+        }
         /* When */
         var result = await ExecuteSubscribeAsync(new ExecutionOptions
         {
@@ -84,6 +92,8 @@ public class SubscriptionTests
         var message = await stream.FirstOrDefaultAsync();
 
         message.ShouldNotBeNull();
+        var errors = message.Errors;
+        errors.ShouldBeNull();
         var data = message.Data.ToDict();
         data.ShouldNotBeNull();
         data["newMessageContent"].ShouldNotBeNull();
@@ -261,5 +271,10 @@ public class SubscriptionTests
         var error = await Should.ThrowAsync<ExecutionError>(async () => await stream.FirstOrDefaultAsync()).ConfigureAwait(false);
         error.InnerException.Message.ShouldBe("test");
         error.Path.ShouldBe(new[] { "messageAdded" });
+    }
+
+    private class NoopMiddleware : IFieldMiddleware
+    {
+        public ValueTask<object> ResolveAsync(IResolveFieldContext context, FieldMiddlewareDelegate next) => next(context);
     }
 }

--- a/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionTests.cs
@@ -74,7 +74,7 @@ public class SubscriptionTests
         var schema = new ChatSchema(chat);
         if (useMiddleware)
         {
-            // see
+            // see https://github.com/graphql-dotnet/graphql-dotnet/pull/3568
             var my = new NoopMiddleware();
             schema.FieldMiddleware.Use(next => context => my.ResolveAsync(context, next));
         }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -278,9 +278,8 @@ namespace GraphQL.Execution
                             {
                                 // parentType argument for GetFieldDefinition may be null in case of union field, in that case
                                 // GetFieldDefinition will not throw only if field is __typename
-                                var fieldType = GetFieldDefinition(context.Schema, (specificType as IComplexGraphType)!, field);
-                                if (fieldType == null)
-                                    throw new InvalidOperationException($"Schema is not configured correctly to fetch field '{field.Name}' from type '{specificType.Name}'.");
+                                var fieldType = GetFieldDefinition(context.Schema, (specificType as IComplexGraphType)!, field)
+                                    ?? throw new InvalidOperationException($"Schema is not configured correctly to fetch field '{field.Name}' from type '{specificType.Name}'.");
 
                                 Add(fields, field, fieldType);
                             }

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -477,7 +477,7 @@ namespace GraphQL.Types
                 {
                     foreach (var field in complex.Fields.List)
                     {
-                        var inner = field.Resolver ?? (complex == schema?.Subscription ? SourceFieldResolver.Instance : NameFieldResolver.Instance);
+                        var inner = field.Resolver ?? (ReferenceEquals(complex, schema?.Subscription) ? SourceFieldResolver.Instance : NameFieldResolver.Instance);
 
                         var fieldMiddlewareDelegate = transform(inner.ResolveAsync);
 

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -441,17 +441,12 @@ namespace GraphQL.Types
         /// </summary>
         public void ApplyMiddleware(IFieldMiddlewareBuilder fieldMiddlewareBuilder)
         {
-            ApplyMiddleware(fieldMiddlewareBuilder, null);
-        }
-
-        internal void ApplyMiddleware(IFieldMiddlewareBuilder fieldMiddlewareBuilder, ISchema? schema)
-        {
             var transform = (fieldMiddlewareBuilder ?? throw new ArgumentNullException(nameof(fieldMiddlewareBuilder))).Build();
 
             // allocation free optimization if no middlewares are defined
             if (transform != null)
             {
-                ApplyMiddleware(transform, schema);
+                ApplyMiddleware(transform);
             }
         }
 
@@ -463,11 +458,6 @@ namespace GraphQL.Types
         /// </summary>
         public void ApplyMiddleware(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform)
         {
-            ApplyMiddleware(transform, null);
-        }
-
-        private void ApplyMiddleware(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform, ISchema? schema)
-        {
             if (transform == null)
                 throw new ArgumentNullException(nameof(transform));
 
@@ -477,7 +467,7 @@ namespace GraphQL.Types
                 {
                     foreach (var field in complex.Fields.List)
                     {
-                        var inner = field.Resolver ?? (ReferenceEquals(complex, schema?.Subscription) ? SourceFieldResolver.Instance : NameFieldResolver.Instance);
+                        var inner = field.Resolver ?? (field.StreamResolver == null ? NameFieldResolver.Instance : SourceFieldResolver.Instance);
 
                         var fieldMiddlewareDelegate = transform(inner.ResolveAsync);
 

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -451,7 +451,7 @@ namespace GraphQL.Types
             {
                 // At this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete.
                 // However, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock.
-                _allTypes.ApplyMiddleware(FieldMiddleware);
+                _allTypes.ApplyMiddleware(FieldMiddleware, this);
 
                 foreach (var visitor in GetVisitors())
                     visitor.Run(this);

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -451,7 +451,7 @@ namespace GraphQL.Types
             {
                 // At this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete.
                 // However, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock.
-                _allTypes.ApplyMiddleware(FieldMiddleware, this);
+                _allTypes.ApplyMiddleware(FieldMiddleware);
 
                 foreach (var visitor in GetVisitors())
                     visitor.Run(this);


### PR DESCRIPTION
Also see #3213

Yesterday one of our team members found a bug when using field middleware and calling subscription.

Before fix:
```
    Shouldly.ShouldAssertException : errors
        should be null but was
    [GraphQL.Execution.UnhandledError: Error trying to resolve field 'newMessageContent'.
     ---> System.InvalidOperationException: Expected to find property or method 'newMessageContent' on type 'String' but it does not exist.
       at GraphQL.Resolvers.NameFieldResolver.CreateResolver(Type target, String name) in C:\_GITHUB_\graphql-dotnet\src\GraphQL\Resolvers\NameFieldResolver.cs:line 83
       at GraphQL.Resolvers.NameFieldResolver.<>c.<Resolve>b__6_0(ValueTuple`2 t) in C:\_GITHUB_\graphql-dotnet\src\GraphQL\Resolvers\NameFieldResolver.cs:line 38
       at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
       at GraphQL.Resolvers.NameFieldResolver.Resolve(IResolveFieldContext context, String name) in C:\_GITHUB_\graphql-dotnet\src\GraphQL\Resolvers\NameFieldResolver.cs:line 38
       at GraphQL.Resolvers.NameFieldResolver.ResolveAsync(IResolveFieldContext context) in C:\_GITHUB_\graphql-dotnet\src\GraphQL\Resolvers\NameFieldResolver.cs:line 28
       at GraphQL.Tests.Subscription.SubscriptionTests.MyMiddleware.ResolveAsync(IResolveFieldContext context, FieldMiddlewareDelegate next) in C:\_GITHUB_\graphql-dotnet\src\GraphQL.Tests\Subscription\SubscriptionTests.cs:line 58
       at GraphQL.Tests.Subscription.SubscriptionTests.<>c__DisplayClass3_1.<SubscribeToContent>b__1(IResolveFieldContext context) in C:\_GITHUB_\graphql-dotnet\src\GraphQL.Tests\Subscription\SubscriptionTests.cs:line 84
       at GraphQL.Resolvers.FuncFieldResolver`1.ResolveAsync(IResolveFieldContext context) in C:\_GITHUB_\graphql-dotnet\src\GraphQL\Resolvers\FuncFieldResolver.cs:line 40
       at GraphQL.Execution.ExecutionStrategy.ExecuteNodeAsync(ExecutionContext context, ExecutionNode node) in C:\_GITHUB_\graphql-dotnet\src\GraphQL\Execution\ExecutionStrategy.cs:line 477
       --- End of inner exception stack trace ---]
```

`ApplyMiddleware` method sets `NameFieldResolver.Instance` for all fields, even for subscriptions. I have no ideas why we haven't found it before.

@Shane32 I need your help. I do not like current implementation. The main problem is `complex == schema?.Subscription` comparison. `SchemaTypes` has no reference to schema but in fact only `Schema` calls all methods on `SchemaTypes`, so I just added two methods and delegated work to them. I would like to change design - either adding reference to `Schema` or in some other way.