### PR TITLE
Set FieldType.Resolver properly when calling a field builder's ResolveStream methods

### DIFF
--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -319,6 +319,7 @@ namespace GraphQL.Builders
         public virtual FieldBuilder<TSourceType, TReturnType> ResolveStream(Func<IResolveFieldContext<TSourceType>, IObservable<TReturnType?>> sourceStreamResolver)
         {
             FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(sourceStreamResolver);
+            FieldType.Resolver ??= SourceFieldResolver.Instance;
             return this;
         }
 
@@ -328,6 +329,7 @@ namespace GraphQL.Builders
         public virtual FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(Func<IResolveFieldContext<TSourceType>, Task<IObservable<TReturnType?>>> sourceStreamResolver)
         {
             FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(context => new ValueTask<IObservable<TReturnType?>>(sourceStreamResolver(context)));
+            FieldType.Resolver ??= SourceFieldResolver.Instance;
             return this;
         }
 


### PR DESCRIPTION
See:
- #3568 

I'd consider this a bug with the design of the new field builder methods.