### PR TITLE
Only root fields of subscriptions should set StreamResolver; only object output types should set Resolver

### DIFF
--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -603,7 +603,7 @@ in version 7.2+.
 
 Starting with version 7.4, the `StreamResolver` property should be set exclusively for root fields
 in subscriptions, while the `Resolver` property should only be assigned to object output types'
-fields. Fields within union types, interface types and input object types should not set these
+fields. Fields within interface types and input object types should not set these
 properties. This modification may lead to potential disruptions in your applications, as the
 schema may trigger an exception during initialization. To eliminate this exception, simply
 cease assigning these properties for the fields specified in the exception message.

--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -598,3 +598,10 @@ require them to resolve to GraphQL Object types. GraphQL.NET 7.2+ now enforces t
 Due to the above validation, resolvers defined on fields of interface types are never be used by
 GraphQL.NET. As such, resolvers are not generated for fields of `AutoRegisteringInterfaceGraphType`s
 in version 7.2+.
+
+### 18. `SchemaValidationVisitor` has more runtime checks
+
+From version 7.4 on, only root fields of subscriptions should set `StreamResolver` and only object
+output types should set `Resolver` properties. This change may be potentially breaking for your apps,
+because schema will throw exception during initialization. To get rid of that exception just stop
+setting these properties for fields mentioned in exception message.

--- a/docs2/site/docs/migrations/migration7.md
+++ b/docs2/site/docs/migrations/migration7.md
@@ -601,7 +601,9 @@ in version 7.2+.
 
 ### 18. `SchemaValidationVisitor` has more runtime checks
 
-From version 7.4 on, only root fields of subscriptions should set `StreamResolver` and only object
-output types should set `Resolver` properties. This change may be potentially breaking for your apps,
-because schema will throw exception during initialization. To get rid of that exception just stop
-setting these properties for fields mentioned in exception message.
+Starting with version 7.4, the `StreamResolver` property should be set exclusively for root fields
+in subscriptions, while the `Resolver` property should only be assigned to object output types'
+fields. Fields within union types, interface types and input object types should not set these
+properties. This modification may lead to potential disruptions in your applications, as the
+schema may trigger an exception during initialization. To eliminate this exception, simply
+cease assigning these properties for the fields specified in the exception message.

--- a/src/GraphQL.StarWars/Types/CharacterInterface.cs
+++ b/src/GraphQL.StarWars/Types/CharacterInterface.cs
@@ -10,12 +10,10 @@ public class CharacterInterface : InterfaceGraphType<StarWarsCharacter>
         Name = "Character";
 
         Field<NonNullGraphType<StringGraphType>>("id")
-            .Description("The id of the character.")
-            .Resolve(context => context.Source.Id);
+            .Description("The id of the character.");
 
         Field<StringGraphType>("name")
-            .Description("The name of the character.")
-            .Resolve(context => context.Source.Name);
+            .Description("The name of the character.");
 
         Field<ListGraphType<CharacterInterface>>("friends");
         Field<ConnectionType<CharacterInterface, EdgeType<CharacterInterface>>>("friendsConnection");

--- a/src/GraphQL.Tests/Bugs/Bug1889.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1889.cs
@@ -58,7 +58,7 @@ public class RGraphInterface : InterfaceGraphType<R>
     {
         Name = "RInterface";
 
-        Field<NonNullGraphType<StringGraphType>>("Value").Resolve(ctx => ctx.Source.Value);
+        Field<NonNullGraphType<StringGraphType>>("Value");
     }
 }
 
@@ -78,7 +78,7 @@ public class AGraphInterface : InterfaceGraphType<A>
     {
         Name = "AInterface";
 
-        Field<NonNullGraphType<RGraphInterface>>("R").Resolve(ctx => ctx.Source.methodUsedToGetRValue());
+        Field<NonNullGraphType<RGraphInterface>>("R");
     }
 }
 

--- a/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
+++ b/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
@@ -97,10 +97,26 @@ public class SchemaInitializationTests : SchemaInitializationTestBase
 
     // https://github.com/graphql-dotnet/graphql-dotnet/pull/3571
     [Fact]
-    public void Deprecate_Required_Arguments_And_Input_Fields_Produce_Friendly_Error()
+    public void Deprecate_Required_Arguments_And_Input_Fields_Should_Produce_Friendly_Error()
     {
         ShouldThrow<Issue3571Schema1, InvalidOperationException>("The required argument 'flag' of field 'MyQuery.str' has no default value so `@deprecated` directive must not be applied to this argument. To deprecate a required argument, it must first be made optional by either changing the type to nullable or adding a default value.");
         ShouldThrow<Issue3571Schema2, InvalidOperationException>("The required input field 'age' of an Input Object 'PersonInput' has no default value so `@deprecated` directive must not be applied to this input field. To deprecate an input field, it must first be made optional by either changing the type to nullable or adding a default value.");
+    }
+
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/2994
+    [Fact]
+    public void StreamResolver_On_Wrong_Fields_Should_Produce_Friendly_Error()
+    {
+        ShouldThrow<SchemaWithFieldStreamResolver1, InvalidOperationException>("The field 'str' of an Object type 'MyQuery' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+        ShouldThrow<SchemaWithFieldStreamResolver2, InvalidOperationException>("The field 'id' of an Interface type 'My' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+        ShouldThrow<SchemaWithFieldStreamResolver3, InvalidOperationException>("The field 'name' of an Input Object type 'PersonInput' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+    }
+
+    // https://github.com/graphql-dotnet/graphql-dotnet/issues/1176
+    [Fact]
+    public void Resolver_On_InputField_Should_Produce_Friendly_Error()
+    {
+        ShouldThrow<SchemaWithInputFieldResolver, InvalidOperationException>("The field 'name' of an Input Object type 'PersonInput' must not have Resolver set. You should set Resolver only for output types.");
     }
 }
 
@@ -448,6 +464,96 @@ public class Issue3571Schema2 : Schema
         {
             Field(x => x.Name);
             Field(x => x.Age).DeprecationReason("Use some other input field.");
+        }
+    }
+
+    private class Person
+    {
+        public string Name { get; set; }
+
+        public int Age { get; set; }
+    }
+}
+
+public class SchemaWithFieldStreamResolver1 : Schema
+{
+    public SchemaWithFieldStreamResolver1()
+    {
+        var type = new ObjectGraphType { Name = "MyQuery" };
+        type.Field<StringGraphType>("str")
+            .ResolveStream(_ => new Subscription.SampleObservable<string>())
+            .Resolve(_ => "abc");
+        Query = type;
+    }
+}
+
+public class SchemaWithFieldStreamResolver2 : Schema
+{
+    public SchemaWithFieldStreamResolver2()
+    {
+        var type = new ObjectGraphType { Name = "MyQuery" };
+        type.Field<MyInterface>("hero").Resolve(_ => null);
+        Query = type;
+    }
+
+    private class MyInterface : InterfaceGraphType
+    {
+        public MyInterface()
+        {
+            Name = "My";
+
+            Field<StringGraphType>("id")
+                .ResolveStream(_ => new Subscription.SampleObservable<string>())
+                .Resolve(_ => "abc");
+        }
+    }
+}
+
+public class SchemaWithFieldStreamResolver3 : Schema
+{
+    public SchemaWithFieldStreamResolver3()
+    {
+        var type = new ObjectGraphType { Name = "MyQuery" };
+        type.Field<StringGraphType>("str")
+            .Argument<PersonInput>("person")
+            .Resolve(_ => "abc");
+        Query = type;
+    }
+
+    private class PersonInput : InputObjectGraphType<Person>
+    {
+        public PersonInput()
+        {
+            Field(x => x.Name).ResolveStream(_ => new Subscription.SampleObservable<string>());
+            Field(x => x.Age);
+        }
+    }
+
+    private class Person
+    {
+        public string Name { get; set; }
+
+        public int Age { get; set; }
+    }
+}
+
+public class SchemaWithInputFieldResolver : Schema
+{
+    public SchemaWithInputFieldResolver()
+    {
+        var type = new ObjectGraphType { Name = "MyQuery" };
+        type.Field<StringGraphType>("str")
+            .Argument<PersonInput>("person")
+            .Resolve(_ => "abc");
+        Query = type;
+    }
+
+    private class PersonInput : InputObjectGraphType<Person>
+    {
+        public PersonInput()
+        {
+            Field(x => x.Name).Resolve(_ => "abc");
+            Field(x => x.Age);
         }
     }
 

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -469,9 +469,9 @@ namespace GraphQL.Types
 
             foreach (var item in Dictionary)
             {
-                if (item.Value is IComplexGraphType complex && item.Value is not IInputObjectGraphType)
+                if (item.Value is IObjectGraphType obj)
                 {
-                    foreach (var field in complex.Fields.List)
+                    foreach (var field in obj.Fields.List)
                     {
                         var inner = field.Resolver ?? (field.StreamResolver == null ? NameFieldResolver.Instance : SourceFieldResolver.Instance);
 

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -469,7 +469,7 @@ namespace GraphQL.Types
 
             foreach (var item in Dictionary)
             {
-                if (item.Value is IComplexGraphType complex)
+                if (item.Value is IComplexGraphType complex && item.Value is not IInputObjectGraphType)
                 {
                     foreach (var field in complex.Fields.List)
                     {

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -9,7 +9,6 @@ namespace GraphQL.Types;
 /// </summary>
 internal static class AutoRegisteringOutputHelper
 {
-    private static readonly IFieldResolver _invalidFieldResolver = new FuncFieldResolver<object?>(_ => throw new InvalidOperationException("This field resolver should never be called. It is only used to prevent the default field resolver from being used."));
     /// <summary>
     /// Configures query arguments and a field resolver for the specified <see cref="FieldType"/>, overwriting
     /// any existing configuration within <see cref="FieldType.Arguments"/>, <see cref="FieldType.Resolver"/>

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Types;
 internal static class AutoRegisteringOutputHelper
 {
     private static readonly IFieldResolver _invalidFieldResolver = new FuncFieldResolver<object?>(_ => throw new InvalidOperationException("This field resolver should never be called. It is only used to prevent the default field resolver from being used."));
-    private static readonly ISourceStreamResolver _invalidStreamResolver = new SourceStreamResolver<object?>((Func<IResolveFieldContext, IObservable<object?>>)(_ => throw new InvalidOperationException("This source stream resolver should never be called. It is only used to prevent the default source stream resolver from being used.")));
+    //private static readonly ISourceStreamResolver _invalidStreamResolver = new SourceStreamResolver<object?>((Func<IResolveFieldContext, IObservable<object?>>)(_ => throw new InvalidOperationException("This source stream resolver should never be called. It is only used to prevent the default source stream resolver from being used.")));
 
     /// <summary>
     /// Configures query arguments and a field resolver for the specified <see cref="FieldType"/>, overwriting
@@ -105,7 +105,7 @@ internal static class AutoRegisteringOutputHelper
         if (buildMemberInstanceExpressionFunc == null)
         {
             fieldType.Resolver = _invalidFieldResolver;
-            fieldType.StreamResolver = _invalidStreamResolver;
+            // fieldType.StreamResolver = _invalidStreamResolver; // Do not set it; SchemaValidationVisitor has all needed checks
         }
     }
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -104,7 +104,8 @@ internal static class AutoRegisteringOutputHelper
         }
         if (buildMemberInstanceExpressionFunc == null)
         {
-            fieldType.Resolver = _invalidFieldResolver;
+            // interface types do not set resolvers
+            fieldType.Resolver = null;
             // fieldType.StreamResolver = _invalidStreamResolver; // Do not set it; SchemaValidationVisitor has all needed checks
         }
     }

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -106,7 +106,7 @@ internal static class AutoRegisteringOutputHelper
         {
             // interface types do not set resolvers
             fieldType.Resolver = null;
-            // fieldType.StreamResolver = _invalidStreamResolver; // Do not set it; SchemaValidationVisitor has all needed checks
+            fieldType.StreamResolver = null;
         }
     }
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -10,8 +10,6 @@ namespace GraphQL.Types;
 internal static class AutoRegisteringOutputHelper
 {
     private static readonly IFieldResolver _invalidFieldResolver = new FuncFieldResolver<object?>(_ => throw new InvalidOperationException("This field resolver should never be called. It is only used to prevent the default field resolver from being used."));
-    //private static readonly ISourceStreamResolver _invalidStreamResolver = new SourceStreamResolver<object?>((Func<IResolveFieldContext, IObservable<object?>>)(_ => throw new InvalidOperationException("This source stream resolver should never be called. It is only used to prevent the default source stream resolver from being used.")));
-
     /// <summary>
     /// Configures query arguments and a field resolver for the specified <see cref="FieldType"/>, overwriting
     /// any existing configuration within <see cref="FieldType.Arguments"/>, <see cref="FieldType.Resolver"/>

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -514,7 +514,7 @@ namespace GraphQL.Types
                 .DeprecationReason(expression.DeprecationReasonOf())
                 .DefaultValue(expression.DefaultValueOf());
 
-            if (this is not IInputObjectGraphType)
+            if (this is IObjectGraphType)
                 builder.Resolve(new ExpressionFieldResolver<TSourceType, TProperty>(expression));
 
             if (expression.Body is MemberExpression expr)

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -510,10 +510,12 @@ namespace GraphQL.Types
 
             var builder = CreateBuilder<TProperty>(type)
                 .Name(name)
-                .Resolve(new ExpressionFieldResolver<TSourceType, TProperty>(expression))
                 .Description(expression.DescriptionOf())
                 .DeprecationReason(expression.DeprecationReasonOf())
                 .DefaultValue(expression.DefaultValueOf());
+
+            if (this is not IInputObjectGraphType)
+                builder.Resolve(new ExpressionFieldResolver<TSourceType, TProperty>(expression));
 
             if (expression.Body is MemberExpression expr)
             {

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -77,7 +77,7 @@ namespace GraphQL.Types
         public IFieldResolver? Resolver { get; set; }
 
         /// <summary>
-        /// Gets or sets a subscription resolver for the field. Only applicable to subscription fields.
+        /// Gets or sets a subscription resolver for the field. Only applicable to the root fields of subscription.
         /// </summary>
         public ISourceStreamResolver? StreamResolver { get; set; }
     }

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -63,6 +63,9 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must be an output type.");
 
             ValidateFieldArgumentsUniqueness(field, type);
+
+            if (field.StreamResolver != null && type != schema.Subscription)
+                throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
         }
 
         /// <inheritdoc/>
@@ -129,6 +132,9 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must be an output type.");
 
             ValidateFieldArgumentsUniqueness(field, type);
+
+            if (field.StreamResolver != null && type != schema.Subscription)
+                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
         }
 
         /// <inheritdoc/>
@@ -210,6 +216,12 @@ namespace GraphQL.Utilities
             // 2.4
             if (field.ResolvedType is NonNullGraphType && field.DefaultValue is null && field.DeprecationReason is not null)
                 throw new InvalidOperationException($"The required input field '{field.Name}' of an Input Object '{type.Name}' has no default value so `@deprecated` directive must not be applied to this input field. To deprecate an input field, it must first be made optional by either changing the type to nullable or adding a default value.");
+
+            if (field.StreamResolver != null)
+                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+
+            if (field.Resolver != null)
+                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have Resolver set. You should set Resolver only for output types.");
         }
 
         #endregion

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -135,6 +135,9 @@ namespace GraphQL.Utilities
 
             if (field.StreamResolver != null && type != schema.Subscription)
                 throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+
+            if (field.Resolver != null)
+                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have Resolver set. Each interface is translated to a concrete type during request execution. You should set Resolver only for fields of object output types.");
         }
 
         /// <inheritdoc/>
@@ -221,7 +224,7 @@ namespace GraphQL.Utilities
                 throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
 
             if (field.Resolver != null)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have Resolver set. You should set Resolver only for output types.");
+                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have Resolver set. You should set Resolver only for fields of object output types.");
         }
 
         #endregion


### PR DESCRIPTION
fixes #2994
also fixes #1176

@Shane32 I suggest to consider this as a "fix" for #1176. I do not believe that we will split `FieldType` for inputs and outputs or redesign API in some other way. At least I'm sure that it will be opened for years without any progress. Schema validation allows to find all invalid usages during initialization, i.e. early thought in runtime, not at compile time, so I think this is a good compromise and we do not need to break the whole design.