### PR TITLE
Add GetInputExtension method

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -711,6 +711,7 @@ namespace GraphQL
         public static object? GetArgument(this GraphQL.IResolveFieldContext context, System.Type argumentType, string name, object? defaultValue = null) { }
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
         public static GraphQL.Execution.DirectiveInfo? GetDirective(this GraphQL.IResolveFieldContext context, string name) { }
+        public static object? GetInputExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static object? GetOutputExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
         public static bool HasDirective(this GraphQL.IResolveFieldContext context, string name) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -711,6 +711,7 @@ namespace GraphQL
         public static object? GetArgument(this GraphQL.IResolveFieldContext context, System.Type argumentType, string name, object? defaultValue = null) { }
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
         public static GraphQL.Execution.DirectiveInfo? GetDirective(this GraphQL.IResolveFieldContext context, string name) { }
+        public static object? GetInputExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static object? GetOutputExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
         public static bool HasDirective(this GraphQL.IResolveFieldContext context, string name) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -701,6 +701,7 @@ namespace GraphQL
         public static object? GetArgument(this GraphQL.IResolveFieldContext context, System.Type argumentType, string name, object? defaultValue = null) { }
         public static TType GetArgument<TType>(this GraphQL.IResolveFieldContext context, string name, TType defaultValue = default) { }
         public static GraphQL.Execution.DirectiveInfo? GetDirective(this GraphQL.IResolveFieldContext context, string name) { }
+        public static object? GetInputExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static object? GetOutputExtension(this GraphQL.IResolveFieldContext context, string path) { }
         public static bool HasArgument(this GraphQL.IResolveFieldContext context, string name) { }
         public static bool HasDirective(this GraphQL.IResolveFieldContext context, string name) { }

--- a/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
+++ b/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
@@ -157,11 +157,14 @@ public class ResolveFieldContextTests
     {
         IResolveFieldContext context = null;
         Should.Throw<ArgumentNullException>(() => context.GetOutputExtension("e"));
+        Should.Throw<ArgumentNullException>(() => context.GetInputExtension("e"));
         Should.Throw<ArgumentNullException>(() => context.SetOutputExtension("e", 1));
 
         context = new ResolveFieldContext();
         context.GetOutputExtension("a").ShouldBe(null);
         context.GetOutputExtension("a.b.c.d").ShouldBe(null);
+        context.GetInputExtension("a").ShouldBe(null);
+        context.GetInputExtension("a.b.c.d").ShouldBe(null);
         Should.Throw<ArgumentException>(() => context.SetOutputExtension("e", 1));
     }
 
@@ -181,6 +184,28 @@ public class ResolveFieldContextTests
 
         _context.SetOutputExtension("a.b.c", "override");
         _context.GetOutputExtension("a.b.c.d").ShouldBe(null);
+    }
+
+    [Fact]
+    public void GetInputExtension_Should_Return_Value()
+    {
+        var context = new ResolveFieldContext
+        {
+            InputExtensions = new Dictionary<string, object>
+            {
+                ["a"] = 1,
+                ["b"] = new Dictionary<string, object>
+                {
+                    ["c"] = true
+                },
+                ["d"] = new object()
+            }
+        };
+        context.GetInputExtension("a").ShouldBe(1);
+        context.GetInputExtension("b.c").ShouldBe(true);
+        context.GetInputExtension("a.x").ShouldBe(null);
+        context.GetInputExtension("b.x").ShouldBe(null);
+        context.GetInputExtension("d").ShouldBeOfType<object>();
     }
 
     [Theory]

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -113,11 +113,8 @@ namespace GraphQL
                     throw new NoOperationError();
                 }
 
-                var operation = GetOperation(options.OperationName, document);
-                if (operation == null)
-                {
-                    throw new InvalidOperationError($"Query does not contain operation '{options.OperationName}'.");
-                }
+                var operation = GetOperation(options.OperationName, document)
+                    ?? throw new InvalidOperationError($"Query does not contain operation '{options.OperationName}'.");
                 metrics.SetOperationName(operation.Name);
 
                 IValidationResult validationResult;

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -92,8 +92,9 @@ namespace GraphQL
 
         /// <summary>
         /// A dictionary of extra information supplied with the GraphQL request.
-        /// This is reserved for implementors to extend the protocol however they see fit, and
-        /// hence there are no additional restrictions on its contents.
+        /// This is reserved for implementors to extend the protocol however they see fit,
+        /// and hence there are no additional restrictions on its contents. Also you may use
+        /// <see cref="ResolveFieldContextExtensions.GetInputExtension(IResolveFieldContext, string)">GetInputExtension</see> method.
         /// </summary>
         IReadOnlyDictionary<string, object?> InputExtensions { get; }
 

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -100,8 +100,8 @@ namespace GraphQL
         /// <summary>
         /// The response map may also contain an entry with key extensions. This entry is reserved for implementors to extend the
         /// protocol however they see fit, and hence there are no additional restrictions on its contents. This dictionary is shared
-        /// by all running resolvers and is not thread safe. Also you may use <see cref="ResolveFieldContextExtensions.GetOutputExtension(IResolveFieldContext, string)">GetExtension</see>
-        /// and <see cref="ResolveFieldContextExtensions.SetOutputExtension(IResolveFieldContext, string, object)">SetExtension</see>
+        /// by all running resolvers and is not thread safe. Also you may use <see cref="ResolveFieldContextExtensions.GetOutputExtension(IResolveFieldContext, string)">GetOutputExtension</see>
+        /// and <see cref="ResolveFieldContextExtensions.SetOutputExtension(IResolveFieldContext, string, object)">SetOutputExtension</see>
         /// methods.
         /// </summary>
         IDictionary<string, object?> OutputExtensions { get; }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -121,7 +121,7 @@ namespace GraphQL
             // Actually context.InputExtensions is of type GraphQL.Inputs : ReadOnlyDictionary<string, object?> and
             // ReadOnlyDictionary<string, object?> implements IDictionary<string, object?> so this cast should never
             // return null for majority of cases.
-            return GetByPath(context.InputExtensions as IDictionary<string, object?>, path, true);
+            return GetByPath(context.InputExtensions as IDictionary<string, object?>, path, false);
         }
 
         /// <summary>

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -118,10 +118,7 @@ namespace GraphQL
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            // Actually context.InputExtensions is of type GraphQL.Inputs : ReadOnlyDictionary<string, object?> and
-            // ReadOnlyDictionary<string, object?> implements IDictionary<string, object?> so this cast should never
-            // return null for majority of cases.
-            return GetByPath(context.InputExtensions as IDictionary<string, object?>, path, false);
+            return GetByPath(context.InputExtensions, path, false);
         }
 
         /// <summary>
@@ -135,10 +132,12 @@ namespace GraphQL
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            return GetByPath(context.OutputExtensions, path, true);
+            // Actually Dictionary<TKey, TValue> (as a widely used class) implements IReadOnlyDictionary<TKey, TValue>
+            // so this cast should never hurt for majority of cases.
+            return GetByPath(context.OutputExtensions as IReadOnlyDictionary<string, object?>, path, true);
         }
 
-        private static object? GetByPath(IDictionary<string, object?>? dictionary, string path, bool useLock)
+        private static object? GetByPath(IReadOnlyDictionary<string, object?>? dictionary, string path, bool useLock)
         {
             object? Get()
             {
@@ -150,7 +149,7 @@ namespace GraphQL
 
                     for (int i = 0; i < keys.Length - 1; ++i)
                     {
-                        if (values.TryGetValue(keys[i], out object? v) && v is IDictionary<string, object?> d)
+                        if (values.TryGetValue(keys[i], out object? v) && v is IReadOnlyDictionary<string, object?> d)
                             values = d;
                         else
                             return null;


### PR DESCRIPTION
Why does `IResolveFieldContext.InputExtensions` has `IReadOnlyDictionary<string, object?>` type instead of `Inputs`? Because of this I have to cast extensions
```
 // actually context.InputExtensions is of type GraphQL.Inputs
                if (context.InputExtensions is not IDictionary<string, object?> values || values.Count == 0)
                    return null;
```

