### PR TITLE
Make SchemaPrinter more flexible

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2816,24 +2816,24 @@ namespace GraphQL.Utilities
         protected virtual bool IsDefinedType(string typeName) { }
         public bool IsSchemaOfCommonNames(GraphQL.Types.ISchema schema) { }
         public string Print() { }
-        public string PrintArgs(GraphQL.Types.FieldType field) { }
+        public virtual string PrintArgs(GraphQL.Types.FieldType field) { }
         public virtual string PrintComment(string? comment, string indentation = "", bool firstInBlock = true) { }
         public string PrintDeprecation(string? reason) { }
         public string PrintDescription(string? description, string indentation = "", bool firstInBlock = true) { }
         public string PrintDirective(GraphQL.Types.Directive directive) { }
-        public string PrintEnum(GraphQL.Types.EnumerationGraphType type) { }
+        public virtual string PrintEnum(GraphQL.Types.EnumerationGraphType type) { }
         public virtual string PrintFields(GraphQL.Types.IComplexGraphType type) { }
         public string PrintFilteredSchema(System.Func<string, bool> directiveFilter, System.Func<string, bool> typeFilter) { }
-        public string PrintInputObject(GraphQL.Types.IInputObjectGraphType type) { }
+        public virtual string PrintInputObject(GraphQL.Types.IInputObjectGraphType type) { }
         public string PrintInputValue(GraphQL.Types.FieldType field) { }
         public string PrintInputValue(GraphQL.Types.QueryArgument argument) { }
         public virtual string PrintInterface(GraphQL.Types.IInterfaceGraphType type) { }
         public string PrintIntrospectionSchema() { }
         public virtual string PrintObject(GraphQL.Types.IObjectGraphType type) { }
-        public string PrintScalar(GraphQL.Types.ScalarGraphType type) { }
+        public virtual string PrintScalar(GraphQL.Types.ScalarGraphType type) { }
         public string? PrintSchemaDefinition(GraphQL.Types.ISchema schema) { }
         public string PrintType(GraphQL.Types.IGraphType type) { }
-        public string PrintUnion(GraphQL.Types.UnionGraphType type) { }
+        public virtual string PrintUnion(GraphQL.Types.UnionGraphType type) { }
         protected static bool IsBuiltInDirective(string directiveName) { }
         protected static bool IsBuiltInScalar(string typeName) { }
         protected static bool IsIntrospectionType(string typeName) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2830,24 +2830,24 @@ namespace GraphQL.Utilities
         protected virtual bool IsDefinedType(string typeName) { }
         public bool IsSchemaOfCommonNames(GraphQL.Types.ISchema schema) { }
         public string Print() { }
-        public string PrintArgs(GraphQL.Types.FieldType field) { }
+        public virtual string PrintArgs(GraphQL.Types.FieldType field) { }
         public virtual string PrintComment(string? comment, string indentation = "", bool firstInBlock = true) { }
         public string PrintDeprecation(string? reason) { }
         public string PrintDescription(string? description, string indentation = "", bool firstInBlock = true) { }
         public string PrintDirective(GraphQL.Types.Directive directive) { }
-        public string PrintEnum(GraphQL.Types.EnumerationGraphType type) { }
+        public virtual string PrintEnum(GraphQL.Types.EnumerationGraphType type) { }
         public virtual string PrintFields(GraphQL.Types.IComplexGraphType type) { }
         public string PrintFilteredSchema(System.Func<string, bool> directiveFilter, System.Func<string, bool> typeFilter) { }
-        public string PrintInputObject(GraphQL.Types.IInputObjectGraphType type) { }
+        public virtual string PrintInputObject(GraphQL.Types.IInputObjectGraphType type) { }
         public string PrintInputValue(GraphQL.Types.FieldType field) { }
         public string PrintInputValue(GraphQL.Types.QueryArgument argument) { }
         public virtual string PrintInterface(GraphQL.Types.IInterfaceGraphType type) { }
         public string PrintIntrospectionSchema() { }
         public virtual string PrintObject(GraphQL.Types.IObjectGraphType type) { }
-        public string PrintScalar(GraphQL.Types.ScalarGraphType type) { }
+        public virtual string PrintScalar(GraphQL.Types.ScalarGraphType type) { }
         public string? PrintSchemaDefinition(GraphQL.Types.ISchema schema) { }
         public string PrintType(GraphQL.Types.IGraphType type) { }
-        public string PrintUnion(GraphQL.Types.UnionGraphType type) { }
+        public virtual string PrintUnion(GraphQL.Types.UnionGraphType type) { }
         protected static bool IsBuiltInDirective(string directiveName) { }
         protected static bool IsBuiltInScalar(string typeName) { }
         protected static bool IsIntrospectionType(string typeName) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2761,24 +2761,24 @@ namespace GraphQL.Utilities
         protected virtual bool IsDefinedType(string typeName) { }
         public bool IsSchemaOfCommonNames(GraphQL.Types.ISchema schema) { }
         public string Print() { }
-        public string PrintArgs(GraphQL.Types.FieldType field) { }
+        public virtual string PrintArgs(GraphQL.Types.FieldType field) { }
         public virtual string PrintComment(string? comment, string indentation = "", bool firstInBlock = true) { }
         public string PrintDeprecation(string? reason) { }
         public string PrintDescription(string? description, string indentation = "", bool firstInBlock = true) { }
         public string PrintDirective(GraphQL.Types.Directive directive) { }
-        public string PrintEnum(GraphQL.Types.EnumerationGraphType type) { }
+        public virtual string PrintEnum(GraphQL.Types.EnumerationGraphType type) { }
         public virtual string PrintFields(GraphQL.Types.IComplexGraphType type) { }
         public string PrintFilteredSchema(System.Func<string, bool> directiveFilter, System.Func<string, bool> typeFilter) { }
-        public string PrintInputObject(GraphQL.Types.IInputObjectGraphType type) { }
+        public virtual string PrintInputObject(GraphQL.Types.IInputObjectGraphType type) { }
         public string PrintInputValue(GraphQL.Types.FieldType field) { }
         public string PrintInputValue(GraphQL.Types.QueryArgument argument) { }
         public virtual string PrintInterface(GraphQL.Types.IInterfaceGraphType type) { }
         public string PrintIntrospectionSchema() { }
         public virtual string PrintObject(GraphQL.Types.IObjectGraphType type) { }
-        public string PrintScalar(GraphQL.Types.ScalarGraphType type) { }
+        public virtual string PrintScalar(GraphQL.Types.ScalarGraphType type) { }
         public string? PrintSchemaDefinition(GraphQL.Types.ISchema schema) { }
         public string PrintType(GraphQL.Types.IGraphType type) { }
-        public string PrintUnion(GraphQL.Types.UnionGraphType type) { }
+        public virtual string PrintUnion(GraphQL.Types.UnionGraphType type) { }
         protected static bool IsBuiltInDirective(string directiveName) { }
         protected static bool IsBuiltInScalar(string typeName) { }
         protected static bool IsIntrospectionType(string typeName) { }

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -200,7 +200,7 @@ namespace GraphQL.Utilities
             };
         }
 
-        public string PrintScalar(ScalarGraphType type)
+        public virtual string PrintScalar(ScalarGraphType type)
         {
             Schema?.Initialize();
 
@@ -230,7 +230,7 @@ namespace GraphQL.Utilities
             return FormatDescription(type.Description) + "interface {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, PrintFields(type));
         }
 
-        public string PrintUnion(UnionGraphType type)
+        public virtual string PrintUnion(UnionGraphType type)
         {
             Schema?.Initialize();
 
@@ -238,7 +238,7 @@ namespace GraphQL.Utilities
             return FormatDescription(type.Description) + "union {0} = {1}".ToFormat(type.Name, possibleTypes);
         }
 
-        public string PrintEnum(EnumerationGraphType type)
+        public virtual string PrintEnum(EnumerationGraphType type)
         {
             Schema?.Initialize();
 
@@ -246,7 +246,7 @@ namespace GraphQL.Utilities
             return FormatDescription(type.Description) + "enum {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, values);
         }
 
-        public string PrintInputObject(IInputObjectGraphType type)
+        public virtual string PrintInputObject(IInputObjectGraphType type)
         {
             Schema?.Initialize();
 

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -276,7 +276,7 @@ namespace GraphQL.Utilities
                     f => "{3}  {0}{1}: {2}{4}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation)));
         }
 
-        public string PrintArgs(FieldType field)
+        public virtual string PrintArgs(FieldType field)
         {
             Schema?.Initialize();
 


### PR DESCRIPTION
Allow more methods to be overrided. 

This is do to enable custom implementations of the SchemaPrinter the support custom print implementations for Scalars, InputObjects, Unions, Arguments and Enumerations. 

   