### PR TITLE
Include license in package

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2021 Joseph T. McBride, Ivan Maximov, Shane Krueger, et al. All rights reserved.
+Copyright (c) 2015-2023 Joseph T. McBride, Ivan Maximov, Shane Krueger, et al. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,7 @@
     <VersionPrefix>7.4.1-preview</VersionPrefix>
     <NextVersion>8.0.0</NextVersion>
     <LangVersion>latest</LangVersion>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,6 @@
     <VersionPrefix>7.4.1-preview</VersionPrefix>
     <NextVersion>8.0.0</NextVersion>
     <LangVersion>latest</LangVersion>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -21,6 +21,7 @@
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="..\..\assets\logo.64x64.png" Pack="true" PackagePath="\" Visible="false" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" Visible="false" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <InternalsVisibleTo Condition="'$(SignAssembly)' == 'true'" Include="$(MSBuildProjectName).Tests, $(_FriendAssembliesPublicKey)"/>
     <InternalsVisibleTo Condition="'$(SignAssembly)' != 'true'" Include="$(MSBuildProjectName).Tests"/>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup Condition="'$(IsPackable)' == 'true'">
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/graphql-dotnet/graphql-dotnet/releases and https://graphql-dotnet.github.io/docs/migrations/migration7</PackageReleaseNotes>
     <Nullable>enable</Nullable>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup Condition="'$(IsPackable)' == 'true'">
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/graphql-dotnet/graphql-dotnet/releases and https://graphql-dotnet.github.io/docs/migrations/migration7</PackageReleaseNotes>
     <Nullable>enable</Nullable>

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.1;netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <Description>GraphQL for .NET</Description>
     <Authors>Joe McBride</Authors>
-    <Copyright>Copyright (c) 2015-2021 Joseph T. McBride, Ivan Maximov, Shane Krueger, et al. All rights reserved.</Copyright>
+    <Copyright>Copyright (c) 2015-2023 Joseph T. McBride, Ivan Maximov, Shane Krueger, et al. All rights reserved.</Copyright>
     <PackageTags>GraphQL;json;api</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
Hopefully then the license should appear in Visual Studio, similar to MS packages:

![image](https://user-images.githubusercontent.com/6377684/235752964-0f63a1de-d0d6-41a5-adb0-fa5b276ef4ff.png)

Right now it looks like this:

![image](https://user-images.githubusercontent.com/6377684/235753112-70743838-8c99-4cb0-9857-4975647595a4.png)
