### PR TITLE
SchemaTypes cleanup

### DIFF
--- a/docs2/site/docs/getting-started/custom-scalars.md
+++ b/docs2/site/docs/getting-started/custom-scalars.md
@@ -684,6 +684,12 @@ public class MySchema : Schema
 }
 ```
 
+Alternatively, you may register the type within your DI engine.
+
+```csharp
+services.AddSingleton<BooleanGraphType, MyBooleanGraphType>();
+```
+
 For schema-first schemas, register it immediately after calling `Schema.For` to create the schema.
 Immediately after calling `Schema.For` the schema is not yet initialized, therefore allowing registration of types.
 

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -26,6 +26,18 @@ Both interfaces extend `IProvideMetadata` with read/write access to the metadata
 Be sure not to write metadata during the execution of a query, as the same graph/field type instance may be used for
 multiple queries and you would run into concurrency issues.
 
+### 2. Built-in scalars may be overridden via DI registrations
+
+For GraphQL.NET built-in scalars (such as `IntGraphType` or `GuidGraphType`), a dervied class may be registered
+within the DI engine to facilitate replacement of the graph type throughout the schema versus calling `RegisterType`.
+
+```csharp
+services.AddSingleton<BooleanGraphType, MyBooleanGraphType>();
+```
+
+See https://graphql-dotnet.github.io/docs/getting-started/custom-scalars/#3-register-the-custom-scalar-within-your-schema
+for more details.
+
 ## Breaking Changes
 
 ### 1. Query type is required

--- a/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
+++ b/src/GraphQL.Tests/Types/Collections/SchemaTypesTests.cs
@@ -116,4 +116,75 @@ To view additional trace enable GlobalSwitches.TrackGraphTypeInitialization swit
             Should.Throw<InvalidOperationException>(() => Initialize(schema, serviceProvider, null));
         }
     }
+
+    [Fact]
+    public void can_initialize_built_in_types()
+    {
+        // create a service provider which returns null for all requested services
+        var mockServiceProvider = Mock.Of<IServiceProvider>(MockBehavior.Loose);
+
+        // create a schema for the built-in types
+        var queryType = new ObjectGraphType();
+        queryType.Field<StringGraphType>("string");
+        queryType.Field<IntGraphType>("int");
+        queryType.Field<IdGraphType>("id");
+        queryType.Field<BooleanGraphType>("boolean");
+        queryType.Field<FloatGraphType>("float");
+        var schema = new Schema(mockServiceProvider)
+        {
+            Query = queryType
+        };
+
+        // attempt to initialize the schema
+        schema.Initialize();
+    }
+
+    [Fact]
+    public void can_initialize_built_in_custom_types()
+    {
+        // create a service provider which returns null for all requested services
+        var mockServiceProvider = Mock.Of<IServiceProvider>(MockBehavior.Loose);
+
+        // create a schema for the built-in types
+        var queryType = new ObjectGraphType();
+
+        // date/time types
+        queryType.Field<DateTimeGraphType>("datetime");
+        queryType.Field<DateTimeOffsetGraphType>("datetimeoffset");
+        queryType.Field<DateGraphType>("date");
+        queryType.Field<TimeSpanSecondsGraphType>("timespanseconds");
+        queryType.Field<TimeSpanMillisecondsGraphType>("timespanmilliseconds");
+#if NET6_0_OR_GREATER
+        queryType.Field<DateOnlyGraphType>("dateonly");
+        queryType.Field<TimeOnlyGraphType>("timeonly");
+#endif
+
+        // floating-point types
+        queryType.Field<DecimalGraphType>("decimal");
+#if NET5_0_OR_GREATER
+        queryType.Field<HalfGraphType>("half");
+#endif
+
+        // integer types
+        queryType.Field<BigIntGraphType>("bigint");
+        queryType.Field<UIntGraphType>("uint");
+        queryType.Field<LongGraphType>("long");
+        queryType.Field<ULongGraphType>("ulong");
+        queryType.Field<ShortGraphType>("short");
+        queryType.Field<UShortGraphType>("ushort");
+        queryType.Field<ByteGraphType>("byte");
+        queryType.Field<SByteGraphType>("sbyte");
+
+        // other types
+        queryType.Field<UriGraphType>("uri");
+        queryType.Field<GuidGraphType>("guid");
+
+        var schema = new Schema(mockServiceProvider)
+        {
+            Query = queryType
+        };
+
+        // attempt to initialize the schema
+        schema.Initialize();
+    }
 }


### PR DESCRIPTION
Set up SchemaTypes so that built-in scalars are pulled from DI (if registered within the DI engine), allowing to override built-in scalars via the DI engine.  This compliments the existing technique available to override built-in scalars.

See: https://graphql-dotnet.github.io/docs/getting-started/custom-scalars/#3-register-the-custom-scalar-within-your-schema

For service providers that follow spec (return `null` if the requested service is not registered), there should be no changes.  For service providers that use `Activator.CreateInstance` there should be no changes.  Only if a custom DI engine was written to throw an exception for a service that was requested but not registered would there be a difference.  So this is a v8 change just in case.