### PR TITLE
Fix ParseInt for large integers

### DIFF
--- a/src/GraphQL/Extensions/GraphQLExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLExtensions.cs
@@ -572,12 +572,6 @@ namespace GraphQL
                 return longResult;
             }
 
-            // If the value doesn't fit in an long, revert to using decimal...
-            if (Decimal.TryParse(v.Value, out decimal decimalResult))
-            {
-                return decimalResult;
-            }
-
             // If the value doesn't fit in an decimal, revert to using BigInteger...
             if (BigInt.TryParse(v.Value, out var bigIntegerResult))
             {


### PR DESCRIPTION
It should not parse into `decimal` because that is a floating-point type and could lose precision for large numbers.  `BigInteger` should be used for large integers.

This method is generally only used for schema printing, I think, and so should not effect typical use cases.