### PR TITLE
Fix Apollo Tracing path property

### DIFF
--- a/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
+++ b/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
@@ -22,7 +22,7 @@ namespace GraphQL.Instrumentation
                 { "typeName", context.ParentType.Name },
                 { "fieldName", name },
                 { "returnTypeName", context.FieldDefinition.ResolvedType!.ToString() },
-                { "path", context.Path },
+                { "path", context.ResponsePath },
             };
 
             using (context.Metrics.Subject("field", name, metadata))


### PR DESCRIPTION
The 'path' property should be the path within the response, meaning it should used aliased names.

See https://github.com/apollographql/apollo-tracing :

> This field should be a list of path segments starting at the root of the response and ending with the field associated with the error. Path segments that represent fields should be strings, and path segments that represent list indices should be 0‐indexed integers. If the error happens in an aliased field, the path to the error should use the aliased name, since it represents a path in the response, not in the query.