### PR TITLE
Add custom validation rule for denying introspection queries

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3408,6 +3408,10 @@ namespace GraphQL.Validation.Errors.Custom
     {
         public ComplexityError(string message) { }
     }
+    public class NoIntrospectionError : GraphQL.Validation.ValidationError
+    {
+        public NoIntrospectionError(GraphQLParser.ROM source, GraphQLParser.AST.ASTNode node) { }
+    }
 }
 namespace GraphQL.Validation.Rules
 {
@@ -3602,6 +3606,11 @@ namespace GraphQL.Validation.Rules.Custom
         [System.Obsolete("Please write a custom complexity analyzer as a validation rule. This constructor " +
             "will be removed in v8.")]
         public ComplexityValidationRule(GraphQL.Validation.Complexity.ComplexityConfiguration complexityConfiguration, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer) { }
+        public System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
+    }
+    public class NoIntrospectionValidationRule : GraphQL.Validation.IValidationRule
+    {
+        public NoIntrospectionValidationRule() { }
         public System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
     }
 }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3422,6 +3422,10 @@ namespace GraphQL.Validation.Errors.Custom
     {
         public ComplexityError(string message) { }
     }
+    public class NoIntrospectionError : GraphQL.Validation.ValidationError
+    {
+        public NoIntrospectionError(GraphQLParser.ROM source, GraphQLParser.AST.ASTNode node) { }
+    }
 }
 namespace GraphQL.Validation.Rules
 {
@@ -3616,6 +3620,11 @@ namespace GraphQL.Validation.Rules.Custom
         [System.Obsolete("Please write a custom complexity analyzer as a validation rule. This constructor " +
             "will be removed in v8.")]
         public ComplexityValidationRule(GraphQL.Validation.Complexity.ComplexityConfiguration complexityConfiguration, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer) { }
+        public System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
+    }
+    public class NoIntrospectionValidationRule : GraphQL.Validation.IValidationRule
+    {
+        public NoIntrospectionValidationRule() { }
         public System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
     }
 }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3353,6 +3353,10 @@ namespace GraphQL.Validation.Errors.Custom
     {
         public ComplexityError(string message) { }
     }
+    public class NoIntrospectionError : GraphQL.Validation.ValidationError
+    {
+        public NoIntrospectionError(GraphQLParser.ROM source, GraphQLParser.AST.ASTNode node) { }
+    }
 }
 namespace GraphQL.Validation.Rules
 {
@@ -3547,6 +3551,11 @@ namespace GraphQL.Validation.Rules.Custom
         [System.Obsolete("Please write a custom complexity analyzer as a validation rule. This constructor " +
             "will be removed in v8.")]
         public ComplexityValidationRule(GraphQL.Validation.Complexity.ComplexityConfiguration complexityConfiguration, GraphQL.Validation.Complexity.IComplexityAnalyzer complexityAnalyzer) { }
+        public System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
+    }
+    public class NoIntrospectionValidationRule : GraphQL.Validation.IValidationRule
+    {
+        public NoIntrospectionValidationRule() { }
         public System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
     }
 }

--- a/src/GraphQL.Tests/Validation/NoIntrospectionTests.cs
+++ b/src/GraphQL.Tests/Validation/NoIntrospectionTests.cs
@@ -1,0 +1,58 @@
+using GraphQL.Validation.Rules.Custom;
+
+namespace GraphQL.Tests.Validation;
+
+public class NoIntrospectionTests : ValidationTestBase<NoIntrospectionValidationRule, ValidationSchema>
+{
+    [Fact]
+    public void works()
+    {
+        ShouldPassRule("""
+            {
+              __typename
+              complicatedArgs {
+                __typename
+                complexArgField(complexArg: { requiredField: true, stringField: "aaaa" })
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void fails_type()
+    {
+        ShouldFailRule(_ =>
+        {
+            _.Query = """
+                {
+                  __type(name:"Query") {
+                    kind
+                  }
+                }
+                """;
+            _.Error(
+               message: "Introspection queries are not allowed.",
+               line: 2,
+               column: 3);
+        });
+    }
+
+    [Fact]
+    public void fails_schema()
+    {
+        ShouldFailRule(_ =>
+        {
+            _.Query = """
+                {
+                  __schema {
+                    description
+                  }
+                }
+                """;
+            _.Error(
+               message: "Introspection queries are not allowed.",
+               line: 2,
+               column: 3);
+        });
+    }
+}

--- a/src/GraphQL/Validation/Errors.Custom/NoIntrospectionError.cs
+++ b/src/GraphQL/Validation/Errors.Custom/NoIntrospectionError.cs
@@ -1,0 +1,19 @@
+using GraphQLParser;
+using GraphQLParser.AST;
+
+namespace GraphQL.Validation.Errors.Custom;
+
+/// <summary>
+/// Represents an error indiciating that introspection queries are not allowed.
+/// </summary>
+public class NoIntrospectionError : ValidationError
+{
+    /// <inheritdoc cref="NoIntrospectionError"/>
+    public NoIntrospectionError(ROM source, ASTNode node) : base(
+        source,
+        null,
+        "Introspection queries are not allowed.",
+        node)
+    {
+    }
+}

--- a/src/GraphQL/Validation/Rules.Custom/NoIntrospectionValidationRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/NoIntrospectionValidationRule.cs
@@ -1,0 +1,21 @@
+using GraphQL.Validation.Errors.Custom;
+using GraphQLParser.AST;
+
+namespace GraphQL.Validation.Rules.Custom;
+
+/// <summary>
+/// Analyzes the document for any introspection fields and reports an error if any are found.
+/// </summary>
+public class NoIntrospectionValidationRule : IValidationRule
+{
+    private static readonly MatchingNodeVisitor<GraphQLField> _visitor = new(
+        (field, context) =>
+        {
+            if (field.Name.Value == "__schema" || field.Name.Value == "__type")
+                context.ReportError(new NoIntrospectionError(context.Document.Source, field));
+        });
+
+    /// <inheritdoc/>
+    public ValueTask<INodeVisitor?> ValidateAsync(ValidationContext context)
+        => new(_visitor);
+}


### PR DESCRIPTION
This seems to be an often-asked question, so this PR adds a validation rule for denying introspection queries to the codebase.