### PR TITLE
Deprecate Name method

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -935,6 +935,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
+        [System.Obsolete("Please configure the filed name by providing the name as an argument to the \'Fiel" +
+            "d\' method.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.IResolveFieldContext<TSourceType>, TReturnType?> resolve) { }
@@ -1896,8 +1898,12 @@ namespace GraphQL.Types
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
+        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type, string name) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -817,12 +817,24 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
@@ -848,6 +860,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name, string argumentName, object? argumentValue) { }
+        [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
+            "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> PageSize(int pageSize) { }
         public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
@@ -881,6 +895,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
+        [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
+            "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -946,7 +962,11 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -1889,21 +1909,33 @@ namespace GraphQL.Types
         protected ComplexGraphType() { }
         public GraphQL.Types.TypeFields Fields { get; }
         public virtual GraphQL.Types.FieldType AddField(GraphQL.Types.FieldType fieldType) { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
-        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
-        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
-        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type, string name) { }
-        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, GraphQL.Types.IGraphType type) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -868,12 +868,24 @@ namespace GraphQL.Builders
         public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -951,7 +951,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
-        [System.Obsolete("Please configure the filed name by providing the name as an argument to the \'Fiel" +
+        [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
             "d\' method.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -935,6 +935,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
+        [System.Obsolete("Please configure the filed name by providing the name as an argument to the \'Fiel" +
+            "d\' method.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.IResolveFieldContext<TSourceType>, TReturnType?> resolve) { }
@@ -1896,8 +1898,12 @@ namespace GraphQL.Types
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
+        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type, string name) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -817,12 +817,24 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
@@ -848,6 +860,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name, string argumentName, object? argumentValue) { }
+        [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
+            "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> PageSize(int pageSize) { }
         public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
@@ -881,6 +895,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
+        [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
+            "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -946,7 +962,11 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -1889,21 +1909,33 @@ namespace GraphQL.Types
         protected ComplexGraphType() { }
         public GraphQL.Types.TypeFields Fields { get; }
         public virtual GraphQL.Types.FieldType AddField(GraphQL.Types.FieldType fieldType) { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
-        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
-        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
-        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type, string name) { }
-        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, GraphQL.Types.IGraphType type) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -868,12 +868,24 @@ namespace GraphQL.Builders
         public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -951,7 +951,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
-        [System.Obsolete("Please configure the filed name by providing the name as an argument to the \'Fiel" +
+        [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
             "d\' method.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -917,6 +917,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
+        [System.Obsolete("Please configure the filed name by providing the name as an argument to the \'Fiel" +
+            "d\' method.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.IResolveFieldContext<TSourceType>, TReturnType?> resolve) { }
@@ -1848,8 +1850,12 @@ namespace GraphQL.Types
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
+        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(System.Type type) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type, string name) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(System.Type type, string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -799,12 +799,24 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
@@ -830,6 +842,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Directive(string name, string argumentName, object? argumentValue) { }
+        [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
+            "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> PageSize(int pageSize) { }
         public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
@@ -863,6 +877,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
+        [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
+            "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -928,7 +944,11 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<System.IObservable<TReturnType?>>> sourceStreamResolver) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, System.Type? type = null) { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -1841,21 +1861,33 @@ namespace GraphQL.Types
         protected ComplexGraphType() { }
         public GraphQL.Types.TypeFields Fields { get; }
         public virtual GraphQL.Types.FieldType AddField(GraphQL.Types.FieldType fieldType) { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
-        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
+        public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
-        [System.Obsolete("Use the overload that accepts the \'name\' argument")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(System.Type type) { }
-        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type, string name) { }
-        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(System.Type type, string name) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, GraphQL.Types.IGraphType type) { }
+        protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -850,12 +850,24 @@ namespace GraphQL.Builders
         public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
+            where TNodeType : GraphQL.Types.IGraphType
+            where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
+            where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -933,7 +933,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
-        [System.Obsolete("Please configure the filed name by providing the name as an argument to the \'Fiel" +
+        [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
             "d\' method.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }

--- a/src/GraphQL.DataLoader.Tests/Types/OrderItemType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/OrderItemType.cs
@@ -14,8 +14,7 @@ public class OrderItemType : ObjectGraphType<OrderItem>
         Field(x => x.Quantity);
         Field(x => x.UnitPrice);
 
-        Field<ProductType, Product>()
-            .Name("Product")
+        Field<ProductType, Product>("Product")
             .ResolveAsync(ctx =>
             {
                 var loader = accessor.Context.GetOrAddBatchLoader<int, Product>("GetProductById",

--- a/src/GraphQL.DataLoader.Tests/Types/QueryType.cs
+++ b/src/GraphQL.DataLoader.Tests/Types/QueryType.cs
@@ -32,8 +32,7 @@ public class QueryType : ObjectGraphType
                 return loader.LoadAsync();
             });
 
-        Field<OrderType, Order>()
-            .Name("Order")
+        Field<OrderType, Order>("Order")
             .Description("Get Order by ID")
             .Argument<NonNullGraphType<IntGraphType>>("orderId", "")
             .ResolveAsync(ctx =>
@@ -44,8 +43,7 @@ public class QueryType : ObjectGraphType
                 return loader.LoadAsync(ctx.GetArgument<int>("orderId"));
             });
 
-        Field<ListGraphType<OrderType>, IEnumerable<Order>>()
-            .Name("Orders")
+        Field<ListGraphType<OrderType>, IEnumerable<Order>>("Orders")
             .Description("Get all Orders")
             .ResolveAsync(_ =>
             {
@@ -55,8 +53,7 @@ public class QueryType : ObjectGraphType
                 return loader.LoadAsync();
             });
 
-        Field<NonNullGraphType<ListGraphType<UserType>>, IEnumerable<IDataLoaderResult<User>>>()
-            .Name("SpecifiedUsers")
+        Field<NonNullGraphType<ListGraphType<UserType>>, IEnumerable<IDataLoaderResult<User>>>("SpecifiedUsers")
             .Description("Get Users by ID")
             .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>>("ids")
             .Resolve(ctx =>
@@ -69,8 +66,7 @@ public class QueryType : ObjectGraphType
                 return ret;
             });
 
-        Field<NonNullGraphType<ListGraphType<UserType>>, IDataLoaderResult<IEnumerable<User>>>()
-            .Name("SpecifiedUsersWithThen")
+        Field<NonNullGraphType<ListGraphType<UserType>>, IDataLoaderResult<IEnumerable<User>>>("SpecifiedUsersWithThen")
             .Description("Get Users by ID skipping null matches")
             .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>>("ids")
             .Resolve(ctx =>

--- a/src/GraphQL.MicrosoftDI.Tests/ConnectionBuilderExtensionTests.cs
+++ b/src/GraphQL.MicrosoftDI.Tests/ConnectionBuilderExtensionTests.cs
@@ -35,7 +35,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope0()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -49,7 +49,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope0Alt()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder.ResolveScoped(_ => "hello");
         field.Resolver.ResolveAsync(_scopedContext).Result.ShouldBe("hello");
@@ -60,7 +60,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope1()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -75,7 +75,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope2()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -91,7 +91,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope3()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -108,7 +108,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope4()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -126,7 +126,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope5()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -145,7 +145,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope2Alt()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -160,7 +160,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope3Alt()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -175,7 +175,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope4Alt()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -190,7 +190,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope5Alt()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -205,7 +205,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope0()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -218,7 +218,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope1()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -232,7 +232,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope2()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -247,7 +247,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope3()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -263,7 +263,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope4()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -280,7 +280,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope5()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -298,7 +298,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope0Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -312,7 +312,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope0AsyncAlt()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder.ResolveScopedAsync(_ => Task.FromResult<object>("hello"));
         field.Resolver.ResolveAsync(_scopedContext).ShouldBeTask("hello");
@@ -323,7 +323,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope1Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -338,7 +338,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope2Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -354,7 +354,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope3Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -371,7 +371,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope4Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -389,7 +389,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithScope5Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -408,7 +408,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope0Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -421,7 +421,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope1Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -435,7 +435,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope2Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -450,7 +450,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope3Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -466,7 +466,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope4Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()
@@ -483,7 +483,7 @@ public class ConnectionBuilderExtensionTests : ScopedContextBase
     public void WithoutScope5Async()
     {
         var graph = new ObjectGraphType();
-        var builder = graph.Connection<StringGraphType>();
+        var builder = graph.Connection<StringGraphType>("connection");
         var field = builder.FieldType;
         builder
             .Resolve()

--- a/src/GraphQL.StarWars/Types/DroidType.cs
+++ b/src/GraphQL.StarWars/Types/DroidType.cs
@@ -15,8 +15,7 @@ public class DroidType : ObjectGraphType<Droid>
 
         Field<ListGraphType<CharacterInterface>>("friends").Resolve(context => data.GetFriends(context.Source));
 
-        Connection<CharacterInterface>()
-            .Name("friendsConnection")
+        Connection<CharacterInterface>("friendsConnection")
             .Description("A list of a character's friends.")
             .Bidirectional()
             .Resolve(context => context.GetPagedResults<Droid, StarWarsCharacter>(data, context.Source.Friends));

--- a/src/GraphQL.StarWars/Types/HumanType.cs
+++ b/src/GraphQL.StarWars/Types/HumanType.cs
@@ -20,8 +20,7 @@ public class HumanType : ObjectGraphType<Human>
         Field<ListGraphType<CharacterInterface>>("friends")
             .Resolve(context => data.GetFriends(context.Source));
 
-        Connection<CharacterInterface>()
-            .Name("friendsConnection")
+        Connection<CharacterInterface>("friendsConnection")
             .Description("A list of a character's friends.")
             .Bidirectional()
             .Resolve(context => context.GetPagedResults<Human, StarWarsCharacter>(data, context.Source.Friends));

--- a/src/GraphQL.Tests/AuthorizationTests.cs
+++ b/src/GraphQL.Tests/AuthorizationTests.cs
@@ -78,8 +78,7 @@ public class AuthorizationTests
     public void ConnectionBuilder()
     {
         var graph = new ObjectGraphType();
-        graph.Connection<StringGraphType>()
-            .Name("Field")
+        graph.Connection<StringGraphType>("Field")
             .AuthorizeWithPolicy("Policy1")
             .AuthorizeWithPolicy("Policy2")
             .AuthorizeWithPolicy("Policy2")

--- a/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/ConnectionBuilderTests.cs
@@ -23,12 +23,12 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
         // race condition with does_not_throw_with_filtering_nameconverter test
         try
         {
-            exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Connection<ObjectGraphType>().Name(fieldName));
+            exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Connection<ObjectGraphType>(fieldName));
         }
         catch (ShouldAssertException)
         {
             System.Threading.Thread.Sleep(100); // wait a bit and retry
-            exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Connection<ObjectGraphType>().Name(fieldName));
+            exception = Should.Throw<ArgumentOutOfRangeException>(() => type.Connection<ObjectGraphType>(fieldName));
         }
 
         exception.Message.ShouldStartWith("A field name can not be null or empty.");
@@ -138,8 +138,7 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
     {
         var type = new ObjectGraphType();
 
-        type.Connection<ObjectGraphType>()
-            .Name("testConnection")
+        type.Connection<ObjectGraphType>("testConnection")
             .Resolve(_ =>
                 new Connection<Child>
                 {
@@ -212,8 +211,7 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
                 },
             },
         };
-        type.Connection<ObjectGraphType>()
-            .Name("testConnection")
+        type.Connection<ObjectGraphType>("testConnection")
             .ResolveAsync(_ => Task.FromResult<object>(connection));
 
         var field = type.Fields.Single();
@@ -266,8 +264,7 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
                 },
             },
         };
-        type.Connection<ChildType, ParentChildrenEdgeType>()
-            .Name("testConnection")
+        type.Connection<ChildType, ParentChildrenEdgeType>("testConnection")
             .ResolveAsync(_ => Task.FromResult<object>(connection));
 
         var field = type.Fields.Single();
@@ -343,8 +340,7 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
             },
             ConnectionField1 = ConnectionField1Value
         };
-        type.Connection<ChildType, ParentChildrenEdgeType, ParentChildrenConnectionType>()
-            .Name("testConnection")
+        type.Connection<ChildType, ParentChildrenEdgeType, ParentChildrenConnectionType>("testConnection")
             .ResolveAsync(_ => Task.FromResult<object>(connection));
 
         var field = type.Fields.Single();
@@ -397,8 +393,7 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
     public void bidirectional_called_twice_creates_proper_arguments()
     {
         var graph = new ObjectGraphType();
-        graph.Connection<ChildType>()
-            .Name("connection")
+        graph.Connection<ChildType>("connection")
             .Description("RandomDescription")
             .Bidirectional()
             .Bidirectional();
@@ -411,8 +406,7 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
     public async Task should_use_pagesize()
     {
         var graph = new ObjectGraphType();
-        graph.Connection<ChildType>()
-            .Name("connection")
+        graph.Connection<ChildType>("connection")
             .PageSize(10)
             .Resolve(context => context.First);
         (await graph.Fields.Find("connection").Resolver.ResolveAsync(new ResolveFieldContext()).ConfigureAwait(false)).ShouldBe(10);
@@ -422,8 +416,7 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
     public async Task should_use_pagesize_async()
     {
         var graph = new ObjectGraphType();
-        graph.Connection<ChildType>()
-            .Name("connection")
+        graph.Connection<ChildType>("connection")
             .PageSize(10)
             .ResolveAsync(context => Task.FromResult<object>(context.First));
         (await graph.Fields.Find("connection").Resolver.ResolveAsync(new ResolveFieldContext()).ConfigureAwait(false)).ShouldBe(10);
@@ -471,13 +464,11 @@ public class ConnectionBuilderTests : QueryTestBase<ConnectionBuilderTests.TestS
         {
             Name = "Parent";
 
-            Connection<ChildType>()
-                .Name("connection1")
+            Connection<ChildType>("connection1")
                 .DeprecationReason("Deprecated")
                 .Resolve(context => context.Source.Connection1);
 
-            Connection<ChildType>()
-                .Name("connection2")
+            Connection<ChildType>("connection2")
                 .Description("RandomDescription")
                 .Bidirectional()
                 .Resolve(context => context.Source.Connection2);

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -179,8 +179,7 @@ public class ComplexGraphTypeTests
     public void allows_custom_name()
     {
         var type = new ComplexType<Droid>();
-        _ = type.Field(d => d.Name)
-            .Name("droid");
+        _ = type.Field("droid", d => d.Name);
 
         type.Fields.Last().Name.ShouldBe("droid");
     }

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -16,9 +16,22 @@ namespace GraphQL.Builders
         /// </summary>
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : IGraphType
             => ConnectionBuilder<TSourceType>.Create<TNodeType>();
+
+        /// <summary>
+        /// Returns a builder for new connection field for the specified node type.
+        /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
+        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
+        /// </summary>
+        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+        /// <param name="name">The name of the connection.</param>
+        public static ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
+            where TNodeType : IGraphType
+            => ConnectionBuilder<TSourceType>.Create<TNodeType>(name);
 
         /// <summary>
         /// Returns a builder for new connection field for the specified node and edge type.
@@ -27,10 +40,24 @@ namespace GraphQL.Builders
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
         /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>();
+
+        /// <summary>
+        /// Returns a builder for new connection field for the specified node and edge type.
+        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
+        /// </summary>
+        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+        /// <param name="name">The name of the connection.</param>
+        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
+            where TNodeType : IGraphType
+            where TEdgeType : EdgeType<TNodeType>
+            => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>(name);
 
         /// <summary>
         /// Returns a builder for new connection field for the specified node, edge and connection type.
@@ -39,11 +66,26 @@ namespace GraphQL.Builders
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
         /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
         /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>
             => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType, TConnectionType>();
+
+        /// <summary>
+        /// Returns a builder for new connection field for the specified node, edge and connection type.
+        /// </summary>
+        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+        /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
+        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+        /// <param name="name">The name of the connection.</param>
+        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>(string name)
+            where TNodeType : IGraphType
+            where TEdgeType : EdgeType<TNodeType>
+            where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+            => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType, TConnectionType>(name);
     }
 
     /// <summary>
@@ -144,6 +186,7 @@ namespace GraphQL.Builders
         }
 
         /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Name(string)"/>
+        [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method.")]
         public virtual ConnectionBuilder<TSourceType> Name(string name)
         {
             FieldType.Name = name;

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -123,7 +123,18 @@ namespace GraphQL.Builders
         /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
         /// </summary>
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType>(string name = "default")
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static ConnectionBuilder<TSourceType> Create<TNodeType>()
+            where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>();
+
+        /// <summary>
+        /// Returns a builder for new connection field for the specified node type.
+        /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
+        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
+        /// </summary>
+        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+        /// <param name="name">The name of the connection.</param>
+        public static ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
             where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>(name);
 
         /// <summary>
@@ -132,7 +143,20 @@ namespace GraphQL.Builders
         /// </summary>
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name = "default")
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
+            where TNodeType : IGraphType
+            where TEdgeType : EdgeType<TNodeType>
+            => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>();
+
+        /// <summary>
+        /// Returns a builder for new connection field for the specified node and edge type.
+        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
+        /// </summary>
+        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+        /// <param name="name">The name of the connection.</param>
+        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
@@ -143,7 +167,21 @@ namespace GraphQL.Builders
         /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
         /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
         /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
+            where TNodeType : IGraphType
+            where TEdgeType : EdgeType<TNodeType>
+            where TConnectionType : ConnectionType<TNodeType, TEdgeType> =>
+            Create<TNodeType, TEdgeType, TConnectionType>("default");
+
+        /// <summary>
+        /// Returns a builder for new connection field for the specified node, edge and connection type.
+        /// </summary>
+        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+        /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
+        /// <param name="name">The name of the connection.</param>
+        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name)
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -98,6 +98,7 @@ namespace GraphQL.Builders
         }
 
         /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Name(string)"/>
+        [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method.")]
         public virtual ConnectionBuilder<TSourceType, TReturnType> Name(string name)
         {
             FieldType.Name = name;

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -52,6 +52,7 @@ namespace GraphQL.Builders
         /// </summary>
         /// <param name="type">The graph type of the field.</param>
         /// <param name="name">The name of the field.</param>
+        [Obsolete("Please use the overload that accepts the name as the first argument.")]
         public static FieldBuilder<TSourceType, TReturnType> Create(IGraphType type, string name = "default")
         {
             var fieldType = new FieldType
@@ -62,8 +63,35 @@ namespace GraphQL.Builders
             return new FieldBuilder<TSourceType, TReturnType>(fieldType);
         }
 
+        /// <summary>
+        /// Returns a builder for a new field.
+        /// </summary>
+        /// <param name="name">The name of the field.</param>
+        /// <param name="type">The graph type of the field.</param>
+        public static FieldBuilder<TSourceType, TReturnType> Create(string name, IGraphType type)
+        {
+            var fieldType = new FieldType
+            {
+                Name = name,
+                ResolvedType = type,
+            };
+            return new FieldBuilder<TSourceType, TReturnType>(fieldType);
+        }
+
         /// <inheritdoc cref="Create(IGraphType, string)"/>
+        [Obsolete("Please use the overload that accepts the name as the first argument.")]
         public static FieldBuilder<TSourceType, TReturnType> Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null, string name = "default")
+        {
+            var fieldType = new FieldType
+            {
+                Name = name,
+                Type = type,
+            };
+            return new FieldBuilder<TSourceType, TReturnType>(fieldType);
+        }
+
+        /// <inheritdoc cref="Create(string, IGraphType)"/>
+        public static FieldBuilder<TSourceType, TReturnType> Create(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null)
         {
             var fieldType = new FieldType
             {

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -86,6 +86,7 @@ namespace GraphQL.Builders
         /// <summary>
         /// Sets the name of the field.
         /// </summary>
+        [Obsolete("Please configure the filed name by providing the name as an argument to the 'Field' method.")]
         public virtual FieldBuilder<TSourceType, TReturnType> Name(string name)
         {
             FieldType.Name = name;

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -114,7 +114,7 @@ namespace GraphQL.Builders
         /// <summary>
         /// Sets the name of the field.
         /// </summary>
-        [Obsolete("Please configure the filed name by providing the name as an argument to the 'Field' method.")]
+        [Obsolete("Please configure the field name by providing the name as an argument to the 'Field' method.")]
         public virtual FieldBuilder<TSourceType, TReturnType> Name(string name)
         {
             FieldType.Name = name;

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -431,7 +431,6 @@ namespace GraphQL.Types
             return builder;
         }
 
-
         /// <inheritdoc cref="Field{TGraphType, TReturnType}(string)"/>
         [Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
         public virtual FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>()

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -108,6 +108,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Creates a field builder used by Field() methods.
         /// </summary>
+        [Obsolete("Use the overload that accepts the 'name' argument")]
         protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             return FieldBuilder<TSourceType, TReturnType>.Create(type);
@@ -116,9 +117,26 @@ namespace GraphQL.Types
         /// <summary>
         /// Creates a field builder used by Field() methods.
         /// </summary>
+        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, string name)
+        {
+            return FieldBuilder<TSourceType, TReturnType>.Create(type, name);
+        }
+
+        /// <summary>
+        /// Creates a field builder used by Field() methods.
+        /// </summary>
+        [Obsolete("Use the overload that accepts the 'name' argument")]
         protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(IGraphType type)
         {
             return FieldBuilder<TSourceType, TReturnType>.Create(type);
+        }
+
+        /// <summary>
+        /// Creates a field builder used by Field() methods.
+        /// </summary>
+        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(IGraphType type, string name)
+        {
+            return FieldBuilder<TSourceType, TReturnType>.Create(type, name);
         }
 
         /// <summary>
@@ -408,10 +426,11 @@ namespace GraphQL.Types
         public virtual FieldBuilder<TSourceType, TReturnType> Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType, TReturnType>(string name)
             where TGraphType : IGraphType
         {
-            var builder = CreateBuilder<TReturnType>(typeof(TGraphType)).Name(name);
+            var builder = CreateBuilder<TReturnType>(typeof(TGraphType), name);
             AddField(builder.FieldType);
             return builder;
         }
+
 
         /// <inheritdoc cref="Field{TGraphType, TReturnType}(string)"/>
         [Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
@@ -450,8 +469,7 @@ namespace GraphQL.Types
                 throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from type '{typeof(TReturnType).Name}'. " + exp.Message, exp);
             }
 
-            var builder = CreateBuilder<TReturnType>(type)
-                .Name(name);
+            var builder = CreateBuilder<TReturnType>(type, name);
 
             AddField(builder.FieldType);
             return builder;
@@ -464,7 +482,7 @@ namespace GraphQL.Types
         /// <param name="name">The name of the field.</param>
         public virtual FieldBuilder<TSourceType, object> Field(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
-            var builder = CreateBuilder<object>(type).Name(name);
+            var builder = CreateBuilder<object>(type, name);
             AddField(builder.FieldType);
             return builder;
         }
@@ -476,7 +494,7 @@ namespace GraphQL.Types
         /// <param name="name">The name of the field.</param>
         public virtual FieldBuilder<TSourceType, object> Field(string name, IGraphType type)
         {
-            var builder = CreateBuilder<object>(type).Name(name);
+            var builder = CreateBuilder<object>(type, name);
             AddField(builder.FieldType);
             return builder;
         }
@@ -508,8 +526,7 @@ namespace GraphQL.Types
                 throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from expression '{expression}'. " + exp.Message, exp);
             }
 
-            var builder = CreateBuilder<TProperty>(type)
-                .Name(name)
+            var builder = CreateBuilder<TProperty>(type, name)
                 .Description(expression.DescriptionOf())
                 .DeprecationReason(expression.DeprecationReasonOf())
                 .DefaultValue(expression.DefaultValueOf());

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -108,7 +108,7 @@ namespace GraphQL.Types
         /// <summary>
         /// Creates a field builder used by Field() methods.
         /// </summary>
-        [Obsolete("Use the overload that accepts the 'name' argument")]
+        [Obsolete("Please use the overload that accepts the name as the first argument.")]
         protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             return FieldBuilder<TSourceType, TReturnType>.Create(type);
@@ -117,15 +117,15 @@ namespace GraphQL.Types
         /// <summary>
         /// Creates a field builder used by Field() methods.
         /// </summary>
-        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, string name)
+        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
-            return FieldBuilder<TSourceType, TReturnType>.Create(type, name);
+            return FieldBuilder<TSourceType, TReturnType>.Create(name, type);
         }
 
         /// <summary>
         /// Creates a field builder used by Field() methods.
         /// </summary>
-        [Obsolete("Use the overload that accepts the 'name' argument")]
+        [Obsolete("Please use the overload that accepts the name as the first argument.")]
         protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(IGraphType type)
         {
             return FieldBuilder<TSourceType, TReturnType>.Create(type);
@@ -134,9 +134,9 @@ namespace GraphQL.Types
         /// <summary>
         /// Creates a field builder used by Field() methods.
         /// </summary>
-        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(IGraphType type, string name)
+        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, IGraphType type)
         {
-            return FieldBuilder<TSourceType, TReturnType>.Create(type, name);
+            return FieldBuilder<TSourceType, TReturnType>.Create(name, type);
         }
 
         /// <summary>
@@ -426,7 +426,7 @@ namespace GraphQL.Types
         public virtual FieldBuilder<TSourceType, TReturnType> Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType, TReturnType>(string name)
             where TGraphType : IGraphType
         {
-            var builder = CreateBuilder<TReturnType>(typeof(TGraphType), name);
+            var builder = CreateBuilder<TReturnType>(name, typeof(TGraphType));
             AddField(builder.FieldType);
             return builder;
         }
@@ -469,7 +469,7 @@ namespace GraphQL.Types
                 throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from type '{typeof(TReturnType).Name}'. " + exp.Message, exp);
             }
 
-            var builder = CreateBuilder<TReturnType>(type, name);
+            var builder = CreateBuilder<TReturnType>(name, type);
 
             AddField(builder.FieldType);
             return builder;
@@ -482,7 +482,7 @@ namespace GraphQL.Types
         /// <param name="name">The name of the field.</param>
         public virtual FieldBuilder<TSourceType, object> Field(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
-            var builder = CreateBuilder<object>(type, name);
+            var builder = CreateBuilder<object>(name, type);
             AddField(builder.FieldType);
             return builder;
         }
@@ -494,7 +494,7 @@ namespace GraphQL.Types
         /// <param name="name">The name of the field.</param>
         public virtual FieldBuilder<TSourceType, object> Field(string name, IGraphType type)
         {
-            var builder = CreateBuilder<object>(type, name);
+            var builder = CreateBuilder<object>(name, type);
             AddField(builder.FieldType);
             return builder;
         }
@@ -526,7 +526,7 @@ namespace GraphQL.Types
                 throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from expression '{expression}'. " + exp.Message, exp);
             }
 
-            var builder = CreateBuilder<TProperty>(type, name)
+            var builder = CreateBuilder<TProperty>(name, type)
                 .Description(expression.DescriptionOf())
                 .DeprecationReason(expression.DeprecationReasonOf())
                 .DefaultValue(expression.DefaultValueOf());
@@ -574,6 +574,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType}(string)"/>
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public ConnectionBuilder<TSourceType> Connection<TNodeType>()
             where TNodeType : IGraphType
         {
@@ -582,7 +583,17 @@ namespace GraphQL.Types
             return builder;
         }
 
+        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType}(string)"/>
+        public ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
+            where TNodeType : IGraphType
+        {
+            var builder = ConnectionBuilder.Create<TNodeType, TSourceType>(name);
+            AddField(builder.FieldType);
+            return builder;
+        }
+
         /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType}(string)"/>
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
@@ -592,13 +603,35 @@ namespace GraphQL.Types
             return builder;
         }
 
+        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType}(string)"/>
+        public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
+            where TNodeType : IGraphType
+            where TEdgeType : EdgeType<TNodeType>
+        {
+            var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TSourceType>(name);
+            AddField(builder.FieldType);
+            return builder;
+        }
+
         /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType, TConnectionType}(string)"/>
+        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
         public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : IGraphType
             where TEdgeType : EdgeType<TNodeType>
             where TConnectionType : ConnectionType<TNodeType, TEdgeType>
         {
             var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TConnectionType, TSourceType>();
+            AddField(builder.FieldType);
+            return builder;
+        }
+
+        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType, TConnectionType}(string)"/>
+        public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>(string name)
+            where TNodeType : IGraphType
+            where TEdgeType : EdgeType<TNodeType>
+            where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+        {
+            var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TConnectionType, TSourceType>(name);
             AddField(builder.FieldType);
             return builder;
         }


### PR DESCRIPTION
Closes #3712 
A couple of questions.
1. There are the following [methods](https://github.com/graphql-dotnet/graphql-dotnet/blob/c2cc6671bf5eea6977f8865d436e2cbbe0659ca8/src/GraphQL/Builders/FieldBuilder.cs#L55)
```c#
public static FieldBuilder<TSourceType, TReturnType> Create(IGraphType type, string name = "default")
public static FieldBuilder<TSourceType, TReturnType> Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null, string name = "default")
```
After deprecating the `Name` the `"default"` value should be removed, but it will be a breaking change. Should I open an additional issue to do that in v8/9/whatever? Or should I deprecate it too and create an overload with the `name` as a first argument?
```c#
public static FieldBuilder<TSourceType, TReturnType> Create(string name, IGraphType type)
```
The second option will be more consistent with the `Field(string name, IGraphType type)` and `Field(string name, Type type)` methods.
2. [ConnectionBuilder](https://github.com/graphql-dotnet/graphql-dotnet/blob/c2cc6671bf5eea6977f8865d436e2cbbe0659ca8/src/GraphQL/Builders/ConnectionBuilder_Typed.cs) is not consistent with the `FieldBuilder`. Should it also be reworked to require `name` as a mandatory argument? If the answer is yes, it also needs an analyzer with the code fix.