### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4 (#3711)"

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -80,7 +80,7 @@ jobs:
           publish/GraphQL.AotCompilationSample.TypeFirst
       - name: Upload coverage to codecov
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: 'src/.coverage/**/coverage.opencover.xml'
 


### PR DESCRIPTION
This reverts commit 9c2971d370924345051e081d76a702346ec32b97.

Note: `codecov/codecov-action@v4` was removed and replaced with a beta tag.