### PR TITLE
Improve Federation Support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,42 +1,54 @@
 {
-   "version": "0.2.0",
-   "configurations": [
-        {
-            "name": ".NET Core Launch (web)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/src/GraphQL.Harness/bin/Debug/netcoreapp2.2/GraphQL.Harness.dll",
-            "args": [],
-            "cwd": "${workspaceRoot}/src/GraphQL.Harness",
-            "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart",
-            "launchBrowser": {
-                "enabled": true,
-                "args": "${auto-detect-url}",
-                "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                },
-                "osx": {
-                    "command": "open"
-                },
-                "linux": {
-                    "command": "xdg-open"
-                }
-            },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceRoot}/Views"
-            }
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (web)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceRoot}/src/GraphQL.Harness/bin/Debug/netcoreapp2.2/GraphQL.Harness.dll",
+      "args": [],
+      "cwd": "${workspaceRoot}/src/GraphQL.Harness",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart",
+      "launchBrowser": {
+        "enabled": true,
+        "args": "${auto-detect-url}",
+        "windows": {
+          "command": "cmd.exe",
+          "args": "/C start ${auto-detect-url}"
         },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
+        "osx": {
+          "command": "open"
+        },
+        "linux": {
+          "command": "xdg-open"
         }
-    ]
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceRoot}/Views"
+      }
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    },
+    {
+      "name": "Federation: Schema First",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "schema-first-build",
+      "program": "${workspaceFolder}/src/GraphQL.Federation.SchemaFirst/bin/Debug/net7.0/GraphQL.Federation.SchemaFirst.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,21 +1,31 @@
 {
-    "version": "2.0.0",
-    "command": "dotnet",
-    "args": [],
-    "tasks": [
-        {
-            "label": "build",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "build",
-                "${workspaceRoot}/src/GraphQL.Harness/GraphQL.Harness.csproj"
-            ],
-            "problemMatcher": "$msCompile",
-            "group": {
-                "_id": "build",
-                "isDefault": false
-            }
-        }
-    ]
+  "version": "2.0.0",
+  "command": "dotnet",
+  "args": [],
+  "tasks": [
+    {
+      "label": "build",
+      "type": "shell",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceRoot}/src/GraphQL.Harness/GraphQL.Harness.csproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "_id": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "schema-first-build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/src/GraphQL.Federation.SchemaFirst/GraphQL.Federation.SchemaFirst.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
 }

--- a/src/GraphQL.Federation.SchemaFirst.Sample1/Program.cs
+++ b/src/GraphQL.Federation.SchemaFirst.Sample1/Program.cs
@@ -3,6 +3,7 @@ using GraphQL.Federation.SchemaFirst.Sample1.Schema;
 using GraphQL.Transport;
 using GraphQL.Types;
 using GraphQL.Utilities.Federation;
+using GraphQL.Utilities.Federation.Extensions;
 
 namespace GraphQL.Federation.SchemaFirst.Sample1;
 

--- a/src/GraphQL.Federation.SchemaFirst.Sample2/Program.cs
+++ b/src/GraphQL.Federation.SchemaFirst.Sample2/Program.cs
@@ -3,6 +3,7 @@ using GraphQL.Federation.SchemaFirst.Sample2.Schema;
 using GraphQL.Transport;
 using GraphQL.Types;
 using GraphQL.Utilities.Federation;
+using GraphQL.Utilities.Federation.Extensions;
 
 namespace GraphQL.Federation.SchemaFirst.Sample2;
 

--- a/src/GraphQL.Federation.SchemaFirst/Data.cs
+++ b/src/GraphQL.Federation.SchemaFirst/Data.cs
@@ -1,0 +1,63 @@
+namespace GraphQL.Federation.SchemaFirst;
+
+using GraphQL;
+
+public record CaseStudy(string CaseNumber, string? Description);
+public record DeprecatedProduct(string Sku, string Package, string? Reason, User? CreatedBy);
+public record Product(string Id, string? Sku, string? Package, ProductVariation? Variation, ProductDimension? Dimensions, User? CreatedBy, string? Notes, List<ProductResearch> research);
+public record ProductDimension(string? Size, float? Weight, string? Unit);
+public record ProductResearch(CaseStudy Study, string? Outcome);
+public record ProductVariation(string Id);
+public record User(string Email, string Name, int? TotalProductsCreated = 1337)
+{
+    public int? LengthOfEmployment { get; set; }
+
+    [GraphQLMetadata("yearsOfEmployment")]
+    public int YearsOfEmployment()
+    {
+        if (LengthOfEmployment == null)
+        {
+            throw new InvalidOperationException("yearsOfEmployment should never be null - it should be populated by _entities query");
+        }
+
+        return (int)LengthOfEmployment;
+    }
+
+    [GraphQLMetadata("averageProductsCreatedPerYear")]
+    public int? AverageProductsCreatedPerYear()
+    {
+        if (TotalProductsCreated != null && LengthOfEmployment != null)
+        {
+            return Convert.ToInt32((TotalProductsCreated * 1.0) / LengthOfEmployment);
+        }
+        return null;
+    }
+};
+
+public static class Data
+{
+    public static ProductDimension Dimension = new ProductDimension("small", 1, "kg");
+    public static IReadOnlyList<ProductResearch> ProductResearches = new List<ProductResearch>
+    {
+        new ProductResearch(new CaseStudy("1234", "Federation Study"), null),
+        new ProductResearch(new CaseStudy("1235", "Studio Study"), null)
+    };
+
+    public static User CreatedBy = new User("support@apollographql.com", "Jane Smith");
+    public static IReadOnlyList<User> Users = new List<User>
+    {
+        CreatedBy
+    };
+
+    private static DeprecatedProduct deprecatedProduct = new DeprecatedProduct("apollo-federation-v1", "@apollo/federation-v1", "Migrate to Federation V2", null);
+    public static IReadOnlyList<DeprecatedProduct> DeprecatedProducts = new List<DeprecatedProduct>
+    {
+        deprecatedProduct
+    };
+    public static IReadOnlyList<Product> Products = new List<Product>
+    {
+        new Product("apollo-federation", "federation", "@apollo/federation", new ProductVariation("OSS"), Dimension, CreatedBy, null, new List<ProductResearch> { ProductResearches[0] }),
+        new Product("apollo-studio", "sku", "", new ProductVariation("platform"), Dimension, CreatedBy, null, new List<ProductResearch> { ProductResearches[1] } )
+    };
+
+}

--- a/src/GraphQL.Federation.SchemaFirst/GraphQL.Federation.SchemaFirst.csproj
+++ b/src/GraphQL.Federation.SchemaFirst/GraphQL.Federation.SchemaFirst.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="schema.graphql" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GraphQL.MicrosoftDI\GraphQL.MicrosoftDI.csproj" />
+    <ProjectReference Include="..\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GraphQL.Federation.SchemaFirst/Program.cs
+++ b/src/GraphQL.Federation.SchemaFirst/Program.cs
@@ -1,0 +1,123 @@
+using System.Reflection;
+using GraphQL;
+using GraphQL.Transport;
+using GraphQL.Types;
+using GraphQL.Utilities.Federation;
+using GraphQL.Utilities.Federation.Types;
+using GraphQL.Utilities.Federation.Extensions;
+using GraphQL.Utilities.Federation.Visitors;
+
+using GraphQL.Federation.SchemaFirst.Schema;
+
+namespace GraphQL.Federation.SchemaFirst;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        // Configure services
+        var builder = WebApplication.CreateBuilder(args);
+        builder.Services.AddCors(options =>
+            options.AddDefaultPolicy(builder =>
+                builder.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod())
+        );
+
+        // Add GraphQL builder.Services and configure options
+        builder.Services
+            .AddSingleton<Query>()
+            .AddSingleton<AnyScalarGraphType>()
+            .AddSingleton<FieldSetScalarGraphType>()
+            .AddSingleton<ServiceGraphType>()
+            .AddSingleton<FederationLinkNodeVisitor>()
+            .AddSingleton<ISchema>(provider =>
+            {
+                var schemaString = File.ReadAllText("src/GraphQL.Federation.SchemaFirst/schema.graphql");
+                return FederatedSchema.For(schemaString, schemaBuilder =>
+                {
+                    schemaBuilder.ServiceProvider = provider;
+                    schemaBuilder.Types.Include<Query>();
+                    // reference resolvers
+                    schemaBuilder.Types.For(nameof(Product))
+                        .ResolveReferenceAsync<Product?>(ctx =>
+                        {
+                            var productId = ctx.Arguments.GetValueOrDefault("id")?.ToString();
+                            if (!string.IsNullOrEmpty(productId))
+                            {
+                                return Task.FromResult<Product?>(Data.Products.FirstOrDefault(p => p.Id == productId));
+                            }
+
+                            return Task.FromResult<Product?>(null);
+                        });
+                    schemaBuilder.Types.For(nameof(DeprecatedProduct))
+                        .ResolveReferenceAsync<DeprecatedProduct?>(ctx =>
+                        {
+                            var sku = ctx.Arguments["sku"]?.ToString();
+                            var pkg = ctx.Arguments["package"]?.ToString();
+                            if (!string.IsNullOrEmpty(sku) && !string.IsNullOrEmpty(pkg))
+                            {
+                                return Task.FromResult(Data.DeprecatedProducts.FirstOrDefault(p => p.Sku == sku && p.Package == pkg));
+                            }
+
+                            return Task.FromResult<DeprecatedProduct?>(null);
+                        });
+                    schemaBuilder.Types.For(nameof(User))
+                        .ResolveReferenceAsync<User?>(ctx =>
+                        {
+                            var email = ctx.Arguments["email"]?.ToString();
+                            if (!string.IsNullOrEmpty(email))
+                            {
+                                var user = Data.Users.FirstOrDefault(u => u.Email == email);
+                                if (user != null)
+                                {
+                                    string? totalProductsCreated = ctx.Arguments.GetValueOrDefault("totalProductsCreated")?.ToString();
+                                    if (totalProductsCreated != null)
+                                    {
+                                        user = user with { TotalProductsCreated = int.Parse(totalProductsCreated) };
+                                    }
+
+                                    string? yearsOfEmployment = ctx.Arguments.GetValueOrDefault("yearsOfEmployment")?.ToString();
+                                    if (yearsOfEmployment != null)
+                                    {
+                                        user.LengthOfEmployment = int.Parse(yearsOfEmployment);
+                                    }
+                                }
+                                return Task.FromResult(user);
+                            }
+
+                            return Task.FromResult<User?>(null);
+                        });
+                    schemaBuilder.Types.For(nameof(ProductResearch))
+                        .ResolveReferenceAsync<ProductResearch?>(ctx =>
+                        {
+                            var study = ctx.Arguments.GetValueOrDefault("study");
+                            if (study is Dictionary<string, object>)
+                            {
+                                var caseNumber = ((Dictionary<string, object>)study).GetValueOrDefault("caseNumber")?.ToString();
+                                return Task.FromResult(Data.ProductResearches.FirstOrDefault(r => r.Study.CaseNumber == caseNumber));
+                            }
+
+                            return Task.FromResult<ProductResearch?>(null);
+                        });
+                });
+            })
+            .AddGraphQL(graphqlBuilder =>
+            {
+
+                graphqlBuilder.UseApolloTracing();
+                graphqlBuilder.AddSystemTextJson();
+                graphqlBuilder.AddErrorInfoProvider(action =>
+                {
+                    action.ExposeExceptionDetails = true;
+                });
+            });
+
+        var app = builder.Build();
+
+        app.UseCors();
+        app.UseRouting();
+        app.UseGraphQL("/");
+        app.UseGraphQLPlayground("/playground");
+
+        await app.RunAsync().ConfigureAwait(false);
+    }
+}

--- a/src/GraphQL.Federation.SchemaFirst/Properties/launchSettings.json
+++ b/src/GraphQL.Federation.SchemaFirst/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "GraphQL.Federation.Sample1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:56847;http://localhost:56848"
+    }
+  }
+}

--- a/src/GraphQL.Federation.SchemaFirst/Schema/Category.cs
+++ b/src/GraphQL.Federation.SchemaFirst/Schema/Category.cs
@@ -1,0 +1,7 @@
+namespace GraphQL.Federation.SchemaFirst.Schema;
+
+public class Category
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+}

--- a/src/GraphQL.Federation.SchemaFirst/Schema/Query.cs
+++ b/src/GraphQL.Federation.SchemaFirst/Schema/Query.cs
@@ -1,0 +1,19 @@
+using GraphQL;
+
+namespace GraphQL.Federation.SchemaFirst.Schema;
+
+[GraphQLMetadata("Query")]
+public class Query
+{
+    [GraphQLMetadata("product")]
+    public Task<Product?> GetProductById(string Id)
+    {
+        return Task.FromResult(Data.Products.FirstOrDefault(p => p.Id == Id));
+    }
+
+    [GraphQLMetadata("deprecatedProduct", DeprecationReason = "Use product query instead")]
+    public Task<DeprecatedProduct?> GetDeprecatedProductBySkuAndPackage(string Sku, string Package)
+    {
+        return Task.FromResult(Data.DeprecatedProducts.FirstOrDefault(p => p.Sku == Sku && p.Package == Package));
+    }
+}

--- a/src/GraphQL.Federation.SchemaFirst/appsettings.json
+++ b/src/GraphQL.Federation.SchemaFirst/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://localhost:5000"
+      }
+    }
+  }
+}

--- a/src/GraphQL.Federation.SchemaFirst/docker-compose.yaml
+++ b/src/GraphQL.Federation.SchemaFirst/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  products:
+    build: src/GraphQL.Federation.SchemaFirst
+    ports:
+      - 5000:5000

--- a/src/GraphQL.Federation.SchemaFirst/schema.graphql
+++ b/src/GraphQL.Federation.SchemaFirst/schema.graphql
@@ -1,0 +1,58 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.2"
+    import: ["@key", "@provides", "@requires", "@external"]
+  )
+
+type Product @key(fields: "id") {
+  id: ID!
+  sku: String
+  package: String
+  variation: ProductVariation
+  dimensions: ProductDimension
+  createdBy: User @provides(fields: "totalProductsCreated")
+  notes: String
+  research: [ProductResearch!]!
+}
+
+type DeprecatedProduct @key(fields: "sku package") {
+  sku: String!
+  package: String!
+  reason: String
+  createdBy: User
+}
+
+type ProductVariation {
+  id: ID!
+}
+
+type ProductResearch @key(fields: "study { caseNumber }") {
+  study: CaseStudy!
+  outcome: String
+}
+
+type CaseStudy {
+  caseNumber: ID!
+  description: String
+}
+
+type ProductDimension {
+  size: String
+  weight: Float
+  unit: String
+}
+
+extend type Query {
+  product(id: ID!): Product
+  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct
+    @deprecated(reason: "Use product query instead")
+}
+
+extend type User @key(fields: "email") {
+  averageProductsCreatedPerYear: Int
+    @requires(fields: "totalProductsCreated yearsOfEmployment")
+  email: ID! @external
+  name: String
+  totalProductsCreated: Int @external
+  yearsOfEmployment: Int! @external
+}

--- a/src/GraphQL/Utilities/Federation/Attributes/ExternalAttribute.cs
+++ b/src/GraphQL/Utilities/Federation/Attributes/ExternalAttribute.cs
@@ -1,0 +1,20 @@
+using GraphQL.Utilities.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Attributes
+{
+    /// <summary>
+    /// Adds "@external" directive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+    public class ExternalAttribute : GraphQLAttribute
+    {
+        /// <inheritdoc/>
+        public override void Modify(FieldType fieldType, bool isInputType)
+        {
+            if (isInputType)
+                throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+            fieldType.External();
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Attributes/InaccessibleAttribute.cs
+++ b/src/GraphQL/Utilities/Federation/Attributes/InaccessibleAttribute.cs
@@ -1,0 +1,26 @@
+using GraphQL.Utilities.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Attributes
+{
+    /// <summary>
+    /// Adds "@inaccessible" directive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+    public class InaccessibleAttribute : GraphQLAttribute
+    {
+        /// <inheritdoc/>
+        public override void Modify(IGraphType graphType)
+        {
+            graphType.Inaccessible();
+        }
+
+        /// <inheritdoc/>
+        public override void Modify(FieldType fieldType, bool isInputType)
+        {
+            if (isInputType)
+                throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+            fieldType.Inaccessible();
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Attributes/KeyAttribute.cs
+++ b/src/GraphQL/Utilities/Federation/Attributes/KeyAttribute.cs
@@ -1,0 +1,38 @@
+using GraphQL.Utilities.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Attributes
+{
+    /// <summary>
+    /// Adds "@key" directive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class KeyAttribute : GraphQLAttribute
+    {
+        private readonly string _fields;
+
+        /// <summary> Resolvable. </summary>
+        public bool Resolvable { get; set; } = true;
+
+
+        /// <summary> .ctor </summary>
+        public KeyAttribute(string fields)
+        {
+            if (string.IsNullOrEmpty(fields))
+                throw new ArgumentNullException(nameof(fields));
+            _fields = fields;
+        }
+        /// <summary> .ctor </summary>
+        public KeyAttribute(params string[] fields)
+            : this(string.Join(" ", fields.Select(x => x.ToCamelCase())))
+        { }
+
+        /// <inheritdoc/>
+        public override void Modify(IGraphType graphType)
+        {
+            if (graphType is not IObjectGraphType objectGraphType)
+                throw new ArgumentOutOfRangeException(nameof(graphType), graphType, "Only ObjectGraphType is supported.");
+            objectGraphType.Key(_fields, Resolvable);
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Attributes/OverrideAttribute.cs
+++ b/src/GraphQL/Utilities/Federation/Attributes/OverrideAttribute.cs
@@ -1,0 +1,29 @@
+using GraphQL.Utilities.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Attributes
+{
+    /// <summary>
+    /// Adds "@override" directive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+    public class OverrideAttribute : GraphQLAttribute
+    {
+        /// <summary> .ctor </summary>
+        public string From { get; }
+
+        /// <summary> .ctor </summary>
+        public OverrideAttribute(string from)
+        {
+            From = from;
+        }
+
+        /// <inheritdoc/>
+        public override void Modify(FieldType fieldType, bool isInputType)
+        {
+            if (isInputType)
+                throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+            fieldType.Override(From);
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Attributes/ProvidesAttribute.cs
+++ b/src/GraphQL/Utilities/Federation/Attributes/ProvidesAttribute.cs
@@ -1,0 +1,32 @@
+using GraphQL.Utilities.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Attributes
+{
+    /// <summary>
+    /// Adds "@provides" directive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+    public class ProvidesAttribute : GraphQLAttribute
+    {
+        private readonly string _fields;
+
+        /// <summary> .ctor </summary>
+        public ProvidesAttribute(string fields)
+        {
+            _fields = fields;
+        }
+        /// <summary> .ctor </summary>
+        public ProvidesAttribute(params string[] fields)
+            : this(string.Join(" ", fields.Select(x => x.ToCamelCase())))
+        { }
+
+        /// <inheritdoc/>
+        public override void Modify(FieldType fieldType, bool isInputType)
+        {
+            if (isInputType)
+                throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+            fieldType.Provides(_fields);
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Attributes/RequiresAttribute.cs
+++ b/src/GraphQL/Utilities/Federation/Attributes/RequiresAttribute.cs
@@ -1,0 +1,34 @@
+using GraphQL.Utilities.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Attributes
+{
+    /// <summary>
+    /// Adds "@requires" directive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+    public class RequiresAttribute : GraphQLAttribute
+    {
+        private readonly string _fields;
+
+        /// <summary> .ctor </summary>
+        public RequiresAttribute(string fields)
+        {
+            if (string.IsNullOrEmpty(fields))
+                throw new ArgumentNullException(nameof(fields));
+            _fields = fields;
+        }
+        /// <summary> .ctor </summary>
+        public RequiresAttribute(params string[] fields)
+            : this(string.Join(" ", fields.Select(x => x.ToCamelCase())))
+        { }
+
+        /// <inheritdoc/>
+        public override void Modify(FieldType fieldType, bool isInputType)
+        {
+            if (isInputType)
+                throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+            fieldType.Requires(_fields);
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Attributes/ShareableAttribute.cs
+++ b/src/GraphQL/Utilities/Federation/Attributes/ShareableAttribute.cs
@@ -1,0 +1,26 @@
+using GraphQL.Utilities.Federation.Extensions;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Attributes
+{
+    /// <summary>
+    /// Adds "@shareable" directive.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+    public class ShareableAttribute : GraphQLAttribute
+    {
+        /// <inheritdoc/>
+        public override void Modify(IGraphType graphType)
+        {
+            graphType.Shareable();
+        }
+
+        /// <inheritdoc/>
+        public override void Modify(FieldType fieldType, bool isInputType)
+        {
+            if (isInputType)
+                throw new ArgumentOutOfRangeException(nameof(isInputType), isInputType, "Input types are not supported.");
+            fieldType.Shareable();
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Enums/FederationDirectiveEnum.cs
+++ b/src/GraphQL/Utilities/Federation/Enums/FederationDirectiveEnum.cs
@@ -1,0 +1,42 @@
+namespace GraphQL.Utilities.Federation.Enums
+{
+    /// <summary>
+    /// Enumeration of all Federation directives.
+    /// </summary>
+    [Flags]
+    public enum FederationDirectiveEnum
+    {
+        /// <summary>
+        /// No directives defined
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// @key directive.
+        /// </summary>
+        Key = 1,
+        /// <summary>
+        /// @shareable directive.
+        /// </summary>
+        Shareable = 2,
+        /// <summary>
+        /// @inaccessible directive.
+        /// </summary>
+        Inaccessible = 4,
+        /// <summary>
+        /// @override directive.
+        /// </summary>
+        Override = 8,
+        /// <summary>
+        /// @external directive.
+        /// </summary>
+        External = 16,
+        /// <summary>
+        /// @provides directive.
+        /// </summary>
+        Provides = 32,
+        /// <summary>
+        /// @requires directive.
+        /// </summary>
+        Requires = 64
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Enums/FederationVersions.cs
+++ b/src/GraphQL/Utilities/Federation/Enums/FederationVersions.cs
@@ -1,0 +1,20 @@
+namespace GraphQL.Utilities.Federation.Enums
+{
+    /// <summary>
+    /// This controls the Federation Version used to build the schema
+    /// For version 2.x, this changes the value in the @link directive
+    /// </summary>
+    enum FederationVersion
+    {
+        V1 = 1,
+        V20 = 21
+        // V2_1 = 2.1
+
+        // "2.0",
+        // "2.1",
+        // "2.2",
+        // "2.3",
+        // "2.4",
+        // "2.5"
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Extensions/FederationFieldExtensions.cs
+++ b/src/GraphQL/Utilities/Federation/Extensions/FederationFieldExtensions.cs
@@ -1,0 +1,124 @@
+using GraphQL.Builders;
+using GraphQL.Types;
+using GraphQLParser.AST;
+using static GraphQL.Utilities.Federation.FederationHelper;
+
+namespace GraphQL.Utilities.Federation.Extensions
+{
+    /// <summary>
+    /// Federation extensions for Fields.
+    /// </summary>
+    public static class FederationFieldExtensions
+    {
+        /// <summary>
+        /// Adds "@shareable" directive.
+        /// </summary>
+        public static FieldBuilder<TSourceType, TReturnType> Shareable<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder)
+        { fieldBuilder.FieldType.Shareable(); return fieldBuilder; }
+
+        /// <summary>
+        /// Adds "@inaccessible" directive.
+        /// </summary>
+        public static FieldBuilder<TSourceType, TReturnType> Inaccessible<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder)
+        { fieldBuilder.FieldType.Inaccessible(); return fieldBuilder; }
+
+        /// <summary>
+        /// Adds "@override" directive.
+        /// </summary>
+        public static FieldBuilder<TSourceType, TReturnType> Override<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string from)
+        { fieldBuilder.FieldType.Override(from); return fieldBuilder; }
+
+        /// <summary>
+        /// Adds "@external" directive.
+        /// </summary>
+        public static FieldBuilder<TSourceType, TReturnType> External<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder)
+        { fieldBuilder.FieldType.External(); return fieldBuilder; }
+
+        /// <summary>
+        /// Adds "@provides" directive.
+        /// </summary>
+        public static FieldBuilder<TSourceType, TReturnType> Provides<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields)
+        { fieldBuilder.FieldType.Provides(fields); return fieldBuilder; }
+
+        /// <summary>
+        /// Adds "@requires" directive.
+        /// </summary>
+        public static FieldBuilder<TSourceType, TReturnType> Requires<TSourceType, TReturnType>(this FieldBuilder<TSourceType, TReturnType> fieldBuilder, string fields)
+        { fieldBuilder.FieldType.Requires(fields); return fieldBuilder; }
+
+        /// <summary>
+        /// Adds "@shareable" directive.
+        /// </summary>
+        public static void Shareable(this FieldType fieldType)
+        {
+            var astMetadata = fieldType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(SHAREABLE_DIRECTIVE));
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+
+        /// <summary>
+        /// Adds "@inaccessible" directive.
+        /// </summary>
+        public static void Inaccessible(this FieldType fieldType)
+        {
+            var astMetadata = fieldType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(INACCESSIBLE_DIRECTIVE));
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+
+        /// <summary>
+        /// Adds "@override" directive.
+        /// </summary>
+        public static void Override(this FieldType fieldType, string from)
+        {
+            var astMetadata = fieldType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(OVERRIDE_DIRECTIVE));
+            directive.AddFromArgument(from);
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+
+        /// <summary>
+        /// Adds "@external" directive.
+        /// </summary>
+        public static void External(this FieldType fieldType)
+        {
+            var astMetadata = fieldType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(EXTERNAL_DIRECTIVE));
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+
+        /// <summary>
+        /// Adds "@provides" directive.
+        /// </summary>
+        public static void Provides(this FieldType fieldType, string[] fields) =>
+            fieldType.Provides(string.Join(" ", fields.Select(x => x.ToCamelCase())));
+
+        /// <summary>
+        /// Adds "@provides" directive.
+        /// </summary>
+        public static void Provides(this FieldType fieldType, string fields)
+        {
+            var astMetadata = fieldType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(PROVIDES_DIRECTIVE));
+            directive.AddFieldsArgument(fields.ToCamelCase());
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+
+        /// <summary>
+        /// Adds "@requires" directive.
+        /// </summary>
+        public static void Requires(this FieldType fieldType, string[] fields) =>
+            fieldType.Requires(string.Join(" ", fields.Select(x => x.ToCamelCase())));
+
+        /// <summary>
+        /// Adds "@requires" directive.
+        /// </summary>
+        public static void Requires(this FieldType fieldType, string fields)
+        {
+            var astMetadata = fieldType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(REQUIRES_DIRECTIVE));
+            directive.AddFieldsArgument(fields.ToCamelCase());
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Extensions/FederationGraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Utilities/Federation/Extensions/FederationGraphQLBuilderExtensions.cs
@@ -1,0 +1,50 @@
+using GraphQL.DI;
+using GraphQL.Utilities.Federation.Enums;
+using GraphQL.Utilities.Federation.Types;
+using GraphQL.Utilities.Federation.Visitors;
+using GraphQL.Utilities;
+
+namespace GraphQL.Utilities.Federation.Extensions
+{
+    /// <summary>
+    /// Federation extensions for <see cref="IGraphQLBuilder"/>.
+    /// </summary>
+    public static class FederationGraphQLBuilderExtensions
+    {
+        /// <summary>
+        /// Registers Federation types, directives and, optionally, Query fields.
+        /// </summary>
+        /// <param name="builder"> <see cref="IGraphQLBuilder"/> instance. </param>
+        /// <param name="import"> Flags enum used to specify which Federation directives are used by subgraph. </param>
+        /// <param name="federationVersion">The version of federation to use to build the schema</param>
+        /// <param name="addFields"> Pass false to skip adding Federation fields to Query (true by default). </param>
+        public static IGraphQLBuilder AddFederation(
+            this IGraphQLBuilder builder,
+            FederationDirectiveEnum import,
+            string federationVersion = "2.2",
+            bool addFields = true)
+        {
+            builder.Services
+                .Register(new ServiceGraphType())
+                .Register<AnyScalarGraphType>(ServiceLifetime.Singleton)
+                .Register<EntityType>(ServiceLifetime.Singleton)
+                .Register<NeverType>(ServiceLifetime.Singleton)
+                .Register<FederationEntitiesSchemaNodeVisitor>(ServiceLifetime.Singleton)
+                .Register<FederationQuerySchemaNodeVisitor>(ServiceLifetime.Singleton);
+            return builder
+                .ConfigureSchema((schema, services) =>
+                {
+                    schema.BuildLinkExtension(import, federationVersion);
+                    schema.RegisterType<ServiceGraphType>();
+                    schema.RegisterType<AnyScalarGraphType>();
+                    schema.RegisterType<EntityType>();
+                    schema.RegisterType<NeverType>();
+                    schema.RegisterVisitor<FederationEntitiesSchemaNodeVisitor>();
+                    if (addFields)
+                    {
+                        schema.RegisterVisitor<FederationQuerySchemaNodeVisitor>();
+                    }
+                });
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Extensions/FederationGraphTypeExtensions.cs
+++ b/src/GraphQL/Utilities/Federation/Extensions/FederationGraphTypeExtensions.cs
@@ -1,0 +1,126 @@
+using GraphQL.Builders;
+using GraphQL.DataLoader;
+using GraphQL.Utilities.Federation;
+using GraphQL.Utilities.Federation.Types;
+using GraphQL.Utilities.Federation.Visitors;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using GraphQLParser.AST;
+using static GraphQL.Utilities.Federation.FederationHelper;
+
+namespace GraphQL.Utilities.Federation.Extensions
+{
+    /// <summary>
+    /// Federation extensions for Graph Types.
+    /// </summary>
+    public static partial class FederationGraphTypeExtensions
+    {
+        /// <summary>
+        /// Adds "_service" field. Intended to use on Query in conjunction with .AddFederation(..., addFields = false).
+        /// </summary>
+        public static FieldBuilder<T, object> AddServices<T>(this ComplexGraphType<T> graphType) =>
+            graphType.Field<NonNullGraphType<ServiceGraphType>>("_service")
+                .Resolve(context => new { });
+
+        /// <summary>
+        /// Adds "_entities" field. Intended to use on Query in conjunction with .AddFederation(..., addFields = false).
+        /// </summary>
+        public static FieldBuilder<T, object> AddEntities<T>(this ComplexGraphType<T> graphType)
+        {
+            return graphType.Field<NonNullGraphType<ListGraphType<EntityType>>>("_entities")
+                .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<Utilities.Federation.Types.AnyScalarGraphType>>>>("representations")
+                .Resolve(FederationQuerySchemaNodeVisitor.ResolveEntities);
+        }
+
+        /// <summary>
+        /// Adds "@key" directive.
+        /// </summary>
+        public static void Key(this IObjectGraphType graphType, string[] fields, bool resolvable = true) =>
+            graphType.Key(string.Join(" ", fields.Select(x => x.ToCamelCase())), resolvable);
+
+        /// <summary>
+        /// Adds "@key" directive.
+        /// </summary>
+        public static void Key(this IObjectGraphType graphType, string fields, bool resolvable = true)
+        {
+            var astMetadata = graphType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(KEY_DIRECTIVE));
+            directive.AddFieldsArgument(fields.ToCamelCase());
+            directive.AddResolvableArgument(resolvable);
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+
+        /// <summary>
+        /// Adds "@shareable" directive.
+        /// </summary>
+        public static void Shareable(this IGraphType graphType)
+        {
+            if (graphType.IsInputType())
+                throw new ArgumentOutOfRangeException(nameof(graphType), graphType, "Input types are not supported.");
+            var astMetadata = graphType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(SHAREABLE_DIRECTIVE));
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+
+        /// <summary>
+        /// Adds "@inaccessible" directive.
+        /// </summary>
+        public static void Inaccessible(this IGraphType graphType)
+        {
+            if (graphType.IsInputType())
+                throw new ArgumentOutOfRangeException(nameof(graphType), graphType, "Input types are not supported.");
+            var astMetadata = graphType.BuildAstMetadata();
+            var directive = new GraphQLDirective(new GraphQLName(INACCESSIBLE_DIRECTIVE));
+            astMetadata!.Directives!.Items.Add(directive);
+        }
+
+
+        /// <summary>
+        /// Specifies reference resolver for the type.
+        /// </summary>
+        public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, FuncFederatedResolver<TSourceType> resolver) =>
+            graphType.Metadata[RESOLVER_METADATA] = resolver;
+
+        // /// <summary>
+        // /// Specifies reference resolver for the type.
+        // /// </summary>
+        // public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, Func<FuncFederatedResolver, TSourceType> resolver) =>
+        //     graphType.Metadata[RESOLVER_METADATA] = new FuncFederatedResolver<TSourceType>((context) => resolver(context));
+
+        // /// <summary>
+        // /// Specifies reference resolver for the type.
+        // /// </summary>
+        // public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, Func<FuncFederatedResolver<TSourceType>, Task<TSourceType?>> resolver) =>
+        //     graphType.Metadata[RESOLVER_METADATA] = new FuncFederatedResolver<TSourceType>((context) => resolver(context));
+
+        // /// <summary>
+        // /// Specifies reference resolver for the type.
+        // /// </summary>
+        // public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, Func<FuncFederatedResolver, IDataLoaderResult<TSourceType>> resolver) =>
+        //     graphType.Metadata[RESOLVER_METADATA] = new FuncFederatedResolver<TSourceType>((context) => resolver(context));
+
+        /// <summary>
+        /// Specifies reference resolver for the type.
+        /// </summary>
+        public static void ResolveReference<TSourceType>(this TypeConfig typeConfig, FuncFederatedResolver<TSourceType> resolver) =>
+            typeConfig.Metadata[RESOLVER_METADATA] = resolver;
+
+        // /// <summary>
+        // /// Specifies reference resolver for the type.
+        // /// </summary>
+        // public static void ResolveReference<TSourceType>(this TypeConfig typeConfig, Func<FederatedResolveContext, TSourceType> resolver) =>
+        //     typeConfig.Metadata[RESOLVER_METADATA] = new FuncFederatedResolver<TSourceType>((context) => resolver(context));
+
+        // /// <summary>
+        // /// Specifies reference resolver for the type.
+        // /// </summary>
+        // public static void ResolveReference<TSourceType>(this TypeConfig typeConfig, Func<FederatedResolveContext<TSourceType>, Task<TSourceType?>> resolver) =>
+        //     typeConfig.Metadata[RESOLVER_METADATA] = new FuncFederatedResolver<TSourceType>((context) => resolver(context));
+
+        // /// <summary>
+        // /// Specifies reference resolver for the type.
+        // /// </summary>
+        // public static void ResolveReference<TSourceType>(this TypeConfig typeConfig, Func<IResolveFieldContext, IDataLoaderResult<TSourceType>> resolver) =>
+        //     typeConfig.Metadata[RESOLVER_METADATA] = new FuncFederatedResolver<TSourceType>((context) => resolver(context));
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Extensions/TypeConfigExtensions.cs
+++ b/src/GraphQL/Utilities/Federation/Extensions/TypeConfigExtensions.cs
@@ -1,6 +1,6 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation.Extensions
 {
     public static class TypeConfigExtensions
     {

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -1,96 +1,71 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 using GraphQL.Types;
+using GraphQL.Utilities;
 using GraphQLParser.AST;
+using GraphQLParser.Visitors;
+using static GraphQL.Utilities.Federation.FederationHelper;
 
 namespace GraphQL.Utilities.Federation
 {
     //todo: [Obsolete("Please use the schema.Print() extension method instead. This class will be removed in v9.")]
     public class FederatedSchemaPrinter : SchemaPrinter //TODO:should be completely rewritten
     {
-        private readonly List<string> _federatedDirectives = new()
+        private static readonly HashSet<string> _federatedDirectives = new()
         {
-            "external",
-            "provides",
-            "requires",
-            "key",
-            "extends"
+            KEY_DIRECTIVE,
+            SHAREABLE_DIRECTIVE,
+            INACCESSIBLE_DIRECTIVE,
+            OVERRIDE_DIRECTIVE,
+            EXTERNAL_DIRECTIVE,
+            PROVIDES_DIRECTIVE,
+            REQUIRES_DIRECTIVE,
         };
 
-        private readonly List<string> _federatedTypes = new()
+        private static readonly HashSet<string> _federatedTypes = new()
         {
             "_Service",
             "_Entity",
-            "_Any"
+            "_Any",
+            "_Never",
         };
+        private static readonly SDLPrinter _sdlPrinter = new();
 
         public FederatedSchemaPrinter(ISchema schema, SchemaPrinterOptions? options = null)
             : base(schema, options)
         {
         }
 
-        public string PrintFederatedDirectives(IGraphType type)
+        public string PrintFederatedSchema()
         {
-            Schema?.Initialize();
+            var result = PrintFilteredSchema(
+                directiveName => !IsBuiltInDirective(directiveName) && !IsFederatedDirective(directiveName),
+                typeName => !IsFederatedType(typeName) && IsDefinedType(typeName));
 
-            return type.IsInputObjectType() ? "" : PrintFederatedDirectivesFromAst(type);
-        }
-
-        public string PrintFederatedDirectivesFromAst(IProvideMetadata type)
-        {
-            Schema?.Initialize();
-
-            var astDirectives = type.GetAstType<IHasDirectivesNode>()?.Directives ?? type.GetExtensionDirectives<GraphQLDirective>();
-            if (astDirectives == null)
-                return "";
-
-            var dirs = string.Join(
-                " ",
-                astDirectives
-                    .Where(x => IsFederatedDirective((string)x.Name)) //TODO:alloc
-                    .Select(PrintAstDirective)
-            );
-
-            return string.IsNullOrWhiteSpace(dirs) ? "" : $" {dirs}";
-        }
-
-        public string PrintAstDirective(GraphQLDirective directive)
-        {
-            Schema?.Initialize();
-
-            return directive.Print();
+            var linkSchemaExtension = Schema.GetMetadata<ASTNode>(LINK_SCHEMA_EXTENSION_METADATA);
+            return $"{result}{Environment.NewLine}{Environment.NewLine}{PrintAstNode(linkSchemaExtension)}";
         }
 
         public override string PrintObject(IObjectGraphType type)
         {
             Schema?.Initialize();
 
-            var isExtension = type!.IsExtensionType();
-
-            var interfaces = type!.ResolvedInterfaces.List.Select(x => x.Name).ToList();
-            var delimiter = " & ";
+            var interfaces = type.ResolvedInterfaces.Select(x => x.Name).ToList();
+            var delimiter = Options.OldImplementsSyntax ? ", " : " & ";
             var implementedInterfaces = interfaces.Count > 0
-                ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
+                ? $" implements {string.Join(delimiter, interfaces)}"
                 : "";
 
-            var federatedDirectives = PrintFederatedDirectives(type);
+            var federatedDirectives = type.IsInputObjectType()
+                ? string.Empty
+                : PrintFederatedDirectives(type);
 
-            var extended = isExtension ? "extend " : "";
-
-            if (type.Fields.Any(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name)))
-                return FormatDescription(type.Description) + "{1}type {2}{3}{4} {{{0}{5}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, implementedInterfaces, federatedDirectives, PrintFields(type));
+            if (type.Fields.Count > 0)
+                return $"{FormatDescription(type.Description)}type {type.Name}{implementedInterfaces}{federatedDirectives} {{{Environment.NewLine}{PrintFields(type)}{Environment.NewLine}}}";
             else
-                return FormatDescription(type.Description) + "{0}type {1}{2}{3}".ToFormat(extended, type.Name, implementedInterfaces, federatedDirectives);
-        }
-
-        public override string PrintInterface(IInterfaceGraphType type)
-        {
-            Schema?.Initialize();
-
-            var isExtension = type.IsExtensionType();
-            var extended = isExtension ? "extend " : "";
-
-            return FormatDescription(type.Description) + "{1}interface {2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, PrintFields(type));
+            {
+                return $"{FormatDescription(type.Description)}type {type.Name}{implementedInterfaces}{federatedDirectives}";
+            }
         }
 
         public override string PrintFields(IComplexGraphType type)
@@ -99,38 +74,146 @@ namespace GraphQL.Utilities.Federation
 
             var fields = type?.Fields
                 .Where(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name))
-                .Select(x =>
-                new
+                .Select(x => new
                 {
                     x.Name,
                     Type = x.ResolvedType,
                     Args = PrintArgs(x),
                     Description = FormatDescription(x.Description, "  "),
                     Deprecation = Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : string.Empty,
-                    FederatedDirectives = PrintFederatedDirectivesFromAst(x)
+                    FederatedDirectives = PrintFederatedDirectives(x)
                 }).ToList();
 
-            return fields == null ? "" : string.Join(Environment.NewLine, fields.Select(
-                f => "{3}  {0}{1}: {2}{4}{5}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation, f.FederatedDirectives)));
+            return fields == null
+                ? string.Empty
+                : string.Join(Environment.NewLine, fields.Select(f => $"{f.Description}  {f.Name}{f.Args}: {f.Type}{f.Deprecation}{f.FederatedDirectives}"));
         }
 
-        public string PrintFederatedSchema()
+
+        private string PrintFederatedDirectives(IProvideMetadata type)
         {
-            Schema?.Initialize();
-
-            return PrintFilteredSchema(
-                directiveName => !IsBuiltInDirective(directiveName) && !IsFederatedDirective(directiveName),
-                typeName => !IsFederatedType(typeName) && IsDefinedType(typeName));
+            var directives = type.GetMetadata<IHasDirectivesNode>(AST_METAFIELD)?.Directives;
+            if (directives == null)
+                return string.Empty;
+            var result = string.Join(" ", directives
+                .Where(x => IsFederatedDirective(x.Name.StringValue))
+                .Select(PrintAstNode));
+            return string.IsNullOrWhiteSpace(result) ? string.Empty : $" {result}";
         }
 
-        public bool IsFederatedDirective(string directiveName)
+        private static string PrintAstNode(ASTNode node)
         {
-            return _federatedDirectives.Contains(directiveName);
+            using var writer = new StringWriter();
+            _sdlPrinter.PrintAsync(node, writer).AsTask().GetAwaiter().GetResult();
+            return writer.ToString();
         }
 
-        public bool IsFederatedType(string typeName)
-        {
-            return _federatedTypes.Contains(typeName);
-        }
+        private bool IsFederatedDirective(string directiveName) => _federatedDirectives.Contains(directiveName);
+
+        private bool IsFederatedType(string typeName) => _federatedTypes.Contains(typeName);
+
+        // public string PrintFederatedDirectives(IGraphType type)
+        // {
+        //     Schema?.Initialize();
+
+        //     return type.IsInputObjectType() ? "" : PrintFederatedDirectivesFromAst(type);
+        // }
+
+        // public string PrintFederatedDirectivesFromAst(IProvideMetadata type)
+        // {
+        //     Schema?.Initialize();
+
+        //     var astDirectives = type.GetAstType<IHasDirectivesNode>()?.Directives ?? type.GetExtensionDirectives<GraphQLDirective>();
+        //     if (astDirectives == null)
+        //         return "";
+
+        //     var dirs = string.Join(
+        //         " ",
+        //         astDirectives
+        //             .Where(x => IsFederatedDirective((string)x.Name)) //TODO:alloc
+        //             .Select(PrintAstDirective)
+        //     );
+
+        //     return string.IsNullOrWhiteSpace(dirs) ? "" : $" {dirs}";
+        // }
+
+        // public string PrintAstDirective(GraphQLDirective directive)
+        // {
+        //     Schema?.Initialize();
+
+        //     return directive.Print();
+        // }
+
+        // public override string PrintObject(IObjectGraphType type)
+        // {
+        //     Schema?.Initialize();
+
+        //     var isExtension = type!.IsExtensionType();
+
+        //     var interfaces = type!.ResolvedInterfaces.List.Select(x => x.Name).ToList();
+        //     var delimiter = " & ";
+        //     var implementedInterfaces = interfaces.Count > 0
+        //         ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
+        //         : "";
+
+        //     var federatedDirectives = PrintFederatedDirectives(type);
+
+        //     var extended = isExtension ? "extend " : "";
+
+        //     if (type.Fields.Any(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name)))
+        //         return FormatDescription(type.Description) + "{1}type {2}{3}{4} {{{0}{5}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, implementedInterfaces, federatedDirectives, PrintFields(type));
+        //     else
+        //         return FormatDescription(type.Description) + "{0}type {1}{2}{3}".ToFormat(extended, type.Name, implementedInterfaces, federatedDirectives);
+        // }
+
+        // public override string PrintInterface(IInterfaceGraphType type)
+        // {
+        //     Schema?.Initialize();
+
+        //     var isExtension = type.IsExtensionType();
+        //     var extended = isExtension ? "extend " : "";
+
+        //     return FormatDescription(type.Description) + "{1}interface {2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, PrintFields(type));
+        // }
+
+        // public override string PrintFields(IComplexGraphType type)
+        // {
+        //     Schema?.Initialize();
+
+        //     var fields = type?.Fields
+        //         .Where(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name))
+        //         .Select(x =>
+        //         new
+        //         {
+        //             x.Name,
+        //             Type = x.ResolvedType,
+        //             Args = PrintArgs(x),
+        //             Description = FormatDescription(x.Description, "  "),
+        //             Deprecation = Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : string.Empty,
+        //             FederatedDirectives = PrintFederatedDirectivesFromAst(x)
+        //         }).ToList();
+
+        //     return fields == null ? "" : string.Join(Environment.NewLine, fields.Select(
+        //         f => "{3}  {0}{1}: {2}{4}{5}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation, f.FederatedDirectives)));
+        // }
+
+        // public string PrintFederatedSchema()
+        // {
+        //     Schema?.Initialize();
+
+        //     return PrintFilteredSchema(
+        //         directiveName => !IsBuiltInDirective(directiveName) && !IsFederatedDirective(directiveName),
+        //         typeName => !IsFederatedType(typeName) && IsDefinedType(typeName));
+        // }
+
+        // public bool IsFederatedDirective(string directiveName)
+        // {
+        //     return _federatedDirectives.Contains(directiveName);
+        // }
+
+        // public bool IsFederatedType(string typeName)
+        // {
+        //     return _federatedTypes.Contains(typeName);
+        // }
     }
 }

--- a/src/GraphQL/Utilities/Federation/FederationHelper.cs
+++ b/src/GraphQL/Utilities/Federation/FederationHelper.cs
@@ -78,10 +78,10 @@ namespace GraphQL.Utilities.Federation
         {
             var linkSchemaExtension = new GraphQLSchemaExtension
             {
-                Directives = new GraphQLDirectives([
+                Directives = new GraphQLDirectives(new List<GraphQLDirective> {
                     new GraphQLDirective(new GraphQLName("link"))
                     {
-                        Arguments = new GraphQLArguments([
+                        Arguments = new GraphQLArguments(new List<GraphQLArgument> {
                             new GraphQLArgument(new GraphQLName("url"), new GraphQLStringValue("https://specs.apollo.dev/federation/v" + federationVersion)),
                             new GraphQLArgument(new GraphQLName("import"), new GraphQLListValue()
                             {
@@ -92,9 +92,9 @@ namespace GraphQL.Utilities.Federation
                                                     .Cast<GraphQLValue>()
                                                     .ToList()
                             }),
-                        ])
+                        })
                     }
-                ])
+                })
             };
             schema.Metadata[LINK_SCHEMA_EXTENSION_METADATA] = linkSchemaExtension;
         }
@@ -103,7 +103,7 @@ namespace GraphQL.Utilities.Federation
         {
             var astMetadata = type.GetMetadata<IHasDirectivesNode>(AST_METAFIELD, () => new GraphQLObjectTypeDefinition(new GraphQLName(AST_METAFIELD))
             {
-                Directives = new GraphQLDirectives([])
+                Directives = new GraphQLDirectives(new List<GraphQLDirective>())
             });
             type.Metadata[AST_METAFIELD] = astMetadata;
             return astMetadata;
@@ -111,19 +111,19 @@ namespace GraphQL.Utilities.Federation
 
         public static void AddFieldsArgument(this GraphQLDirective directive, string fields)
         {
-            ((directive.Arguments ??= new GraphQLArguments([])).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(FIELDS_ARGUMENT), new GraphQLStringValue(fields)));
+            ((directive.Arguments ??= new GraphQLArguments(new List<GraphQLArgument>())).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(FIELDS_ARGUMENT), new GraphQLStringValue(fields)));
         }
 
         public static void AddFromArgument(this GraphQLDirective directive, string from)
         {
-            ((directive.Arguments ??= new GraphQLArguments([])).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(FROM_ARGUMENT), new GraphQLStringValue(from)));
+            ((directive.Arguments ??= new GraphQLArguments(new List<GraphQLArgument>())).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(FROM_ARGUMENT), new GraphQLStringValue(from)));
         }
 
         public static void AddResolvableArgument(this GraphQLDirective directive, bool resolvable)
         {
             if (!resolvable)
             {
-                ((directive.Arguments ??= new GraphQLArguments([])).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(RESOLVABLE_ARGUMENT), new GraphQLFalseBooleanValue()));
+                ((directive.Arguments ??= new GraphQLArguments(new List<GraphQLArgument>())).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(RESOLVABLE_ARGUMENT), new GraphQLFalseBooleanValue()));
             }
         }
     }

--- a/src/GraphQL/Utilities/Federation/FederationHelper.cs
+++ b/src/GraphQL/Utilities/Federation/FederationHelper.cs
@@ -1,0 +1,130 @@
+using GraphQL.Utilities.Federation.Enums;
+using GraphQL.Types;
+using GraphQLParser.AST;
+
+namespace GraphQL.Utilities.Federation
+{
+    internal static class FederationHelper
+    {
+        public const string AST_METAFIELD = "__AST_MetaField__";
+        public const string RESOLVER_METADATA = "__FedResolver__";
+        public const string LINK_SCHEMA_EXTENSION_METADATA = "__FedLinkSchemaExtension__";
+
+        public const string KEY_DIRECTIVE = "key";
+        public const string SHAREABLE_DIRECTIVE = "shareable";
+        public const string INACCESSIBLE_DIRECTIVE = "inaccessible";
+        public const string OVERRIDE_DIRECTIVE = "override";
+        public const string EXTERNAL_DIRECTIVE = "external";
+        public const string PROVIDES_DIRECTIVE = "provides";
+        public const string REQUIRES_DIRECTIVE = "requires";
+        public const string FIELDS_ARGUMENT = "fields";
+        public const string FROM_ARGUMENT = "from";
+        public const string RESOLVABLE_ARGUMENT = "resolvable";
+
+        public const string FEDERATED_V1_SDL = @"
+            scalar _Any
+            # scalar FieldSet
+
+            # a union of all types that use the @key directive
+            # union _Entity
+
+            #type _Service {
+            #    sdl: String
+            #}
+
+            #extend type Query {
+            #    _entities(representations: [_Any!]!): [_Entity]!
+            #    _service: _Service!
+            #}
+
+            directive @external on FIELD_DEFINITION
+            directive @requires(fields: String!) on FIELD_DEFINITION
+            directive @provides(fields: String!) on FIELD_DEFINITION
+            directive @key(fields: String!) on OBJECT | INTERFACE
+
+            # this is an optional directive
+            directive @extends on OBJECT | INTERFACE
+        ";
+        public const string FEDERATED_V2_SDL = @"
+            scalar _Any
+            scalar FieldSet
+            directive @external on FIELD_DEFINITION | OBJECT
+            directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+            directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+            directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+            directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+            directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+            directive @override(from: String!) on FIELD_DEFINITION
+            # directive @composeDirective(name: String!) repeatable on SCHEMA
+            # directive @interfaceObject on OBJECT
+            # directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+            # directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+            # directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+            # directive @extends on OBJECT | INTERFACE
+        ";
+
+        public static readonly Dictionary<FederationDirectiveEnum, string> FederationDirectiveEnumMap = new()
+        {
+            [FederationDirectiveEnum.Key] = $"@{KEY_DIRECTIVE}",
+            [FederationDirectiveEnum.Shareable] = $"@{SHAREABLE_DIRECTIVE}",
+            [FederationDirectiveEnum.Inaccessible] = $"@{INACCESSIBLE_DIRECTIVE}",
+            [FederationDirectiveEnum.Override] = $"@{OVERRIDE_DIRECTIVE}",
+            [FederationDirectiveEnum.External] = $"@{EXTERNAL_DIRECTIVE}",
+            [FederationDirectiveEnum.Provides] = $"@{PROVIDES_DIRECTIVE}",
+            [FederationDirectiveEnum.Requires] = $"@{REQUIRES_DIRECTIVE}",
+        };
+
+        internal static void BuildLinkExtension(this ISchema schema, FederationDirectiveEnum import, string federationVersion = "2.5")
+        {
+            var linkSchemaExtension = new GraphQLSchemaExtension
+            {
+                Directives = new GraphQLDirectives([
+                    new GraphQLDirective(new GraphQLName("link"))
+                    {
+                        Arguments = new GraphQLArguments([
+                            new GraphQLArgument(new GraphQLName("url"), new GraphQLStringValue("https://specs.apollo.dev/federation/v" + federationVersion)),
+                            new GraphQLArgument(new GraphQLName("import"), new GraphQLListValue()
+                            {
+                                Values = Enum.GetValues(typeof(FederationDirectiveEnum))
+                                                    .Cast<FederationDirectiveEnum>()
+                                                    .Where(x => import.HasFlag(x) && x != FederationDirectiveEnum.None)
+                                                    .Select(x => new GraphQLStringValue(FederationDirectiveEnumMap[x]))
+                                                    .Cast<GraphQLValue>()
+                                                    .ToList()
+                            }),
+                        ])
+                    }
+                ])
+            };
+            schema.Metadata[LINK_SCHEMA_EXTENSION_METADATA] = linkSchemaExtension;
+        }
+
+        public static IHasDirectivesNode BuildAstMetadata(this IProvideMetadata type)
+        {
+            var astMetadata = type.GetMetadata<IHasDirectivesNode>(AST_METAFIELD, () => new GraphQLObjectTypeDefinition(new GraphQLName(AST_METAFIELD))
+            {
+                Directives = new GraphQLDirectives([])
+            });
+            type.Metadata[AST_METAFIELD] = astMetadata;
+            return astMetadata;
+        }
+
+        public static void AddFieldsArgument(this GraphQLDirective directive, string fields)
+        {
+            ((directive.Arguments ??= new GraphQLArguments([])).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(FIELDS_ARGUMENT), new GraphQLStringValue(fields)));
+        }
+
+        public static void AddFromArgument(this GraphQLDirective directive, string from)
+        {
+            ((directive.Arguments ??= new GraphQLArguments([])).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(FROM_ARGUMENT), new GraphQLStringValue(from)));
+        }
+
+        public static void AddResolvableArgument(this GraphQLDirective directive, bool resolvable)
+        {
+            if (!resolvable)
+            {
+                ((directive.Arguments ??= new GraphQLArguments([])).Items ??= new()).Add(new GraphQLArgument(new GraphQLName(RESOLVABLE_ARGUMENT), new GraphQLFalseBooleanValue()));
+            }
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Types/AnyScalarGraphType.cs
+++ b/src/GraphQL/Utilities/Federation/Types/AnyScalarGraphType.cs
@@ -1,0 +1,37 @@
+using GraphQL.Types;
+using GraphQLParser.AST;
+
+namespace GraphQL.Utilities.Federation.Types
+{
+    /// <summary>
+    /// Represents a type unknown within this portion of the federated schema.
+    /// </summary>
+    public class AnyScalarGraphType : ScalarGraphType
+    {
+        /// <summary>
+        /// Initializes a new instance of this class.
+        /// </summary>
+        public AnyScalarGraphType()
+        {
+            Name = "_Any";
+        }
+
+        /// <inheritdoc/>
+        public override object? ParseLiteral(GraphQLValue value) => value.ParseAnyLiteral();
+
+        /// <inheritdoc/>
+        public override object? ParseValue(object? value) => value;
+
+        /// <inheritdoc/>
+        public override bool CanParseLiteral(GraphQLValue value) => true;
+
+        /// <inheritdoc/>
+        public override bool CanParseValue(object? value) => true;
+
+        /// <inheritdoc/>
+        public override bool IsValidDefault(object value) => true;
+
+        /// <inheritdoc/>
+        public override GraphQLValue ToAST(object? value) => ThrowASTConversionError(value);
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Types/EntityType.cs
+++ b/src/GraphQL/Utilities/Federation/Types/EntityType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Types
+{
+    internal class EntityType : UnionGraphType
+    {
+        public EntityType()
+        {
+            Name = "_Entity";
+            Type<NeverType>();
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Types/FieldSetScalarGraphType.cs
+++ b/src/GraphQL/Utilities/Federation/Types/FieldSetScalarGraphType.cs
@@ -1,19 +1,19 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation.Types
 {
     /// <summary>
     /// Represents a type unknown within this portion of the federated schema.
     /// </summary>
-    public class AnyScalarGraphType : ScalarGraphType
+    public class FieldSetScalarGraphType : ScalarGraphType
     {
         /// <summary>
         /// Initializes a new instance of this class.
         /// </summary>
-        public AnyScalarGraphType()
+        public FieldSetScalarGraphType()
         {
-            Name = "_Any";
+            Name = "FieldSet";
         }
 
         /// <inheritdoc/>
@@ -31,7 +31,7 @@ namespace GraphQL.Utilities.Federation
         /// <inheritdoc/>
         public override bool IsValidDefault(object value) => true;
 
-        /// <inheritdoc/>
-        public override GraphQLValue ToAST(object? value) => ThrowASTConversionError(value);
+        // /// <inheritdoc/>
+        // public override GraphQLValue ToAST(object? value) => ThrowASTConversionError(value);
     }
 }

--- a/src/GraphQL/Utilities/Federation/Types/NeverType.cs
+++ b/src/GraphQL/Utilities/Federation/Types/NeverType.cs
@@ -1,0 +1,14 @@
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Federation.Types
+{
+    internal class NeverType : ObjectGraphType
+    {
+        public NeverType()
+        {
+            Name = "_Never";
+            IsTypeOf = _ => false;
+            Field<NeverType>("_never");
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Types/ServiceGraphType.cs
+++ b/src/GraphQL/Utilities/Federation/Types/ServiceGraphType.cs
@@ -2,7 +2,7 @@
 
 using GraphQL.Types;
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation.Types
 {
     public class ServiceGraphType : ObjectGraphType
     {

--- a/src/GraphQL/Utilities/Federation/Visitors/FederationEntitiesSchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Federation/Visitors/FederationEntitiesSchemaNodeVisitor.cs
@@ -1,0 +1,31 @@
+using GraphQL.Utilities.Federation.Types;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using GraphQLParser.AST;
+using static GraphQL.Utilities.Federation.FederationHelper;
+
+namespace GraphQL.Utilities.Federation.Visitors
+{
+    internal class FederationEntitiesSchemaNodeVisitor : BaseSchemaNodeVisitor
+    {
+        private readonly EntityType _entityType;
+
+
+        public FederationEntitiesSchemaNodeVisitor(EntityType entityType)
+        {
+            _entityType = entityType;
+        }
+
+
+        public override void VisitObject(IObjectGraphType type, ISchema schema)
+        {
+            var astMetafield = type.GetMetadata<IHasDirectivesNode>(AST_METAFIELD);
+            if (astMetafield?.Directives?.Items?.Any(x =>
+                x.Name == KEY_DIRECTIVE
+                && !x.Arguments!.Any(y => y.Name == RESOLVABLE_ARGUMENT && y.Value is GraphQLFalseBooleanValue)) == true)
+            {
+                _entityType.AddPossibleType(type);
+            }
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Visitors/FederationLinkNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Federation/Visitors/FederationLinkNodeVisitor.cs
@@ -1,0 +1,42 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+using GraphQL.Utilities.Federation.Types;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using static GraphQL.Utilities.Federation.FederationHelper;
+using GraphQLParser.AST;
+using GraphQL.Utilities.Federation.Enums;
+
+namespace GraphQL.Utilities.Federation.Visitors
+{
+    public class FederationLinkNodeVisitor : BaseSchemaNodeVisitor
+    {
+        public override void VisitSchema(ISchema schema)
+        {
+            FederationDirectiveEnum fedDirectives = getFedDirectives(schema);
+            if (fedDirectives != FederationDirectiveEnum.None)
+                schema.BuildLinkExtension(fedDirectives, "2.5");
+        }
+
+        private FederationDirectiveEnum getFedDirectives(ISchema schema)
+        {
+            FederationDirectiveEnum fedDirectives = FederationDirectiveEnum.None;
+            var directives = schema.Directives;
+            if (directives != null)
+            {
+                foreach (Directive directive in directives)
+                {
+                    string d = $"@{directive.Name}";
+                    if (directive != null && FederationDirectiveEnumMap.ContainsValue(d))
+                    {
+                        var directiveEnum = FederationDirectiveEnumMap.FirstOrDefault(x => x.Value == d).Key;
+                        if (!fedDirectives.HasFlag(directiveEnum))
+                            fedDirectives |= directiveEnum;
+                    }
+                }
+            }
+
+            return fedDirectives;
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Federation/Visitors/FederationQuerySchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Federation/Visitors/FederationQuerySchemaNodeVisitor.cs
@@ -1,0 +1,68 @@
+using GraphQL.Utilities.Federation.Types;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using static GraphQL.Utilities.Federation.FederationHelper;
+
+namespace GraphQL.Utilities.Federation.Visitors
+{
+    internal class FederationQuerySchemaNodeVisitor : BaseSchemaNodeVisitor
+    {
+        private readonly ServiceGraphType _serviceType;
+        private readonly EntityType _entityType;
+
+
+        public FederationQuerySchemaNodeVisitor(ServiceGraphType serviceType, EntityType entityType)
+        {
+            _serviceType = serviceType;
+            _entityType = entityType;
+        }
+
+        public override void VisitObject(IObjectGraphType type, ISchema schema)
+        {
+            if (type == schema.Query)
+            {
+                type.AddField(new FieldType
+                {
+                    Name = "_service",
+                    ResolvedType = new NonNullGraphType(_serviceType),
+                    Resolver = new FuncFieldResolver<object>(context => new { })
+                });
+
+                var representationsType = new NonNullGraphType(new ListGraphType(new NonNullGraphType(new AnyScalarGraphType())));
+                type.AddField(new FieldType
+                {
+                    Name = "_entities",
+                    ResolvedType = new NonNullGraphType(new ListGraphType(_entityType)),
+                    Arguments = new QueryArguments(
+                        new QueryArgument(representationsType) { Name = "representations" }
+                    ),
+                    Resolver = new FuncFieldResolver<object>(ResolveEntities)
+                });
+            }
+        }
+
+        // BUG: Authorization only works at a field level. Authorization at GraphType level doesn't work.
+        //      i.e. _entities(representations: [{ __typename: "MyType", id: 1 }]) { myField }
+        //      will only check authorization for "myField" but not for "MyType".
+        public static object ResolveEntities(IResolveFieldContext context)
+        {
+            var repMaps = context.GetArgument<List<Dictionary<string, object?>>>("representations");
+            var results = new List<object?>();
+            foreach (var repMap in repMaps)
+            {
+                var typeName = repMap["__typename"]?.ToString();
+                var graphTypeInstance = context.Schema.AllTypes[typeName]!;
+                var resolver = graphTypeInstance.GetMetadata<FuncFederatedResolver<object>>(RESOLVER_METADATA);
+                if (resolver == null)
+                {
+                    throw new NotImplementedException($"ResolveReference() was not provided for {graphTypeInstance.Name}.");
+                }
+
+                var result = resolver.Resolve(new FederatedResolveContext { ParentFieldContext = context, Arguments = repMap });
+                results.Add(result);
+            }
+            return results;
+        }
+    }
+}


### PR DESCRIPTION
This PR is a combination of PR #3144, but keeping the code contained in GraphQL.Utilities.Federation. 

This PR also adds:
- Add `@link` statement for schema first when using Fed 2
- Add subgraph compatibility project for Schema first to test with Apollo subgraph action 
  - With this test passing, we could remove the GraphQL.Federation.SchemaFirst.Sample1/2 projects along with the action that composes/downloads router etc.

Things to complete still:
- [ ] Incorporate tests from #3144 into GraphQL.Tests
- [ ] Previous `testfederation` action passing (Needed this PR to get action to run, couldn't get it running locally with `act`
- [ ] Incorporate official Apollo testing with [federation subgraph compatibility action](https://github.com/marketplace/actions/apollo-federation-subgraph-compatibility) for newly added schema first project
- [ ] Add code-first example for testing with Apollo GitHub action
- [ ] XML documentation
- [ ] Add documentation to official docs for Federation patterns (code first and schema first, both Fed 1 and 2)