### PR TITLE
Add reflection caching to AutoRegisteringObjectGraphType

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -224,6 +224,7 @@ namespace GraphQL
         public static bool EnableReadDeprecationReasonFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromXmlDocumentation { get; set; }
+        public static bool EnableReflectionCaching { get; set; }
         public static bool TrackGraphTypeInitialization { get; set; }
         public static bool UseDeclaringTypeNames { get; set; }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -224,6 +224,7 @@ namespace GraphQL
         public static bool EnableReadDeprecationReasonFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromXmlDocumentation { get; set; }
+        public static bool EnableReflectionCaching { get; set; }
         public static bool TrackGraphTypeInitialization { get; set; }
         public static bool UseDeclaringTypeNames { get; set; }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -224,6 +224,7 @@ namespace GraphQL
         public static bool EnableReadDeprecationReasonFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromXmlDocumentation { get; set; }
+        public static bool EnableReflectionCaching { get; set; }
         public static bool TrackGraphTypeInitialization { get; set; }
         public static bool UseDeclaringTypeNames { get; set; }
     }

--- a/src/GraphQL.Tests/Types/AutoRegisteringInputObjectGraphTypeCachingTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInputObjectGraphTypeCachingTests.cs
@@ -1,0 +1,101 @@
+#nullable enable
+
+using System.ComponentModel;
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Types;
+
+[Collection("StaticTests")]
+public class AutoRegisteringInputObjectGraphTypeCachingTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CachingWorks(bool withCaching)
+    {
+        TestGraphType.Configured = false;
+        GlobalSwitches.EnableReflectionCaching = withCaching;
+        try
+        {
+            var graph1 = new TestGraphType();
+            Validate(graph1);
+
+            if (!withCaching)
+            {
+                Should.Throw<AlreadyConfiguredException>(() => new TestGraphType());
+                TestGraphType.Configured = false;
+            }
+            var graph2 = new TestGraphType();
+            Validate(graph2);
+
+            void Validate(TestGraphType graph)
+            {
+                graph.Name.ShouldBe("Class1");
+                graph.Description.ShouldBe("Desc1");
+                graph.DeprecationReason.ShouldBe("Dep1");
+                graph.Metadata.Count.ShouldBe(2); // deprecation directive and Test metadata
+                graph.GetMetadata<string>("Test").ShouldBe("Value");
+                graph.Fields.Count.ShouldBe(3);
+
+                var field = graph.GetField("Id").ShouldNotBeNull();
+                field.Name.ShouldBe("Id");
+                field.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
+                field.Description.ShouldBeNull();
+                field.DeprecationReason.ShouldBeNull();
+                field.Metadata.Count.ShouldBe(1); // original expression
+                field.Resolver.ShouldBeNull();
+
+                field = graph.GetField("Print").ShouldNotBeNull();
+                field.Name.ShouldBe("Print");
+                field.Type.ShouldBe(typeof(GraphQLClrInputTypeReference<string>));
+                field.Description.ShouldBe("Desc2");
+                field.DeprecationReason.ShouldBeNull();
+                field.Metadata.Count.ShouldBe(2); // original expression + Test2
+                field.GetMetadata<string>("Test2").ShouldBe("Value2");
+                field.Resolver.ShouldBeNull();
+
+                field = graph.GetField("Value").ShouldNotBeNull();
+                field.Name.ShouldBe("Value");
+                field.Type.ShouldBe(typeof(NonNullGraphType<GraphQLClrInputTypeReference<int>>));
+                field.Description.ShouldBeNull();
+                field.DeprecationReason.ShouldBe("Dep2");
+                field.Metadata.Count.ShouldBe(2); // deprecation directive + original expression
+                field.Resolver.ShouldBeNull();
+            }
+        }
+        finally
+        {
+            GlobalSwitches.EnableReflectionCaching = false;
+            TestGraphType.Configured = false;
+        }
+    }
+
+    private class TestGraphType : AutoRegisteringInputObjectGraphType<Class1>
+    {
+        public static bool Configured { get; set; }
+
+        protected override void ConfigureGraph()
+        {
+            base.ConfigureGraph();
+            if (Configured)
+                throw new AlreadyConfiguredException();
+            Configured = true;
+        }
+    }
+
+    private class AlreadyConfiguredException : Exception { }
+
+    [Metadata("Test", "Value")]
+    [Description("Desc1")]
+    [Obsolete("Dep1")]
+    private class Class1
+    {
+        [Id]
+        public int Id { get; set; }
+        [Metadata("Test2", "Value2")]
+        [Description("Desc2")]
+        public string? Print { get; set; }
+        [Obsolete("Dep2")]
+        public int Value { get; set; }
+    }
+}

--- a/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeCachingTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeCachingTests.cs
@@ -1,0 +1,108 @@
+#nullable enable
+
+using System.ComponentModel;
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Types;
+
+[Collection("StaticTests")]
+public class AutoRegisteringInterfaceGraphTypeCachingTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CachingWorks(bool withCaching)
+    {
+        TestGraphType.Configured = false;
+        GlobalSwitches.EnableReflectionCaching = withCaching;
+        try
+        {
+            var graph1 = new TestGraphType();
+            Validate(graph1);
+
+            if (!withCaching)
+            {
+                Should.Throw<AlreadyConfiguredException>(() => new TestGraphType());
+                TestGraphType.Configured = false;
+            }
+            var graph2 = new TestGraphType();
+            Validate(graph2);
+
+            void Validate(TestGraphType graph)
+            {
+                graph.Name.ShouldBe("Class1");
+                graph.Description.ShouldBe("Desc1");
+                graph.DeprecationReason.ShouldBe("Dep1");
+                graph.Metadata.Count.ShouldBe(2); // deprecation directive and Test metadata
+                graph.GetMetadata<string>("Test").ShouldBe("Value");
+                graph.Fields.Count.ShouldBe(3);
+
+                var field = graph.GetField("Id").ShouldNotBeNull();
+                field.Name.ShouldBe("Id");
+                field.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
+                field.Description.ShouldBeNull();
+                field.DeprecationReason.ShouldBeNull();
+                field.Metadata.Count.ShouldBe(0);
+                field.Resolver.ShouldBeNull();
+
+                field = graph.GetField("Print").ShouldNotBeNull();
+                field.Name.ShouldBe("Print");
+                field.Type.ShouldBe(typeof(GraphQLClrOutputTypeReference<string>));
+                field.Description.ShouldBe("Desc2");
+                field.DeprecationReason.ShouldBeNull();
+                field.Metadata.Count.ShouldBe(1);
+                field.GetMetadata<string>("Test2").ShouldBe("Value2");
+                field.Arguments.ShouldNotBeNull().Count.ShouldBe(1);
+                var arg = field.Arguments[0];
+                arg.Name.ShouldBe("id");
+                arg.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
+                arg.Description.ShouldBe("IdDesc");
+                arg.DeprecationReason.ShouldBeNull();
+                arg.Metadata.Count.ShouldBe(0);
+                field.Resolver.ShouldBeNull();
+
+                field = graph.GetField("Value").ShouldNotBeNull();
+                field.Name.ShouldBe("Value");
+                field.Type.ShouldBe(typeof(NonNullGraphType<GraphQLClrOutputTypeReference<int>>));
+                field.Description.ShouldBeNull();
+                field.DeprecationReason.ShouldBe("Dep2");
+                field.Metadata.Count.ShouldBe(1); // deprecation directive
+                field.Resolver.ShouldBeNull();
+            }
+        }
+        finally
+        {
+            GlobalSwitches.EnableReflectionCaching = false;
+            TestGraphType.Configured = false;
+        }
+    }
+
+    private class TestGraphType : AutoRegisteringInterfaceGraphType<Class1>
+    {
+        public static bool Configured { get; set; }
+
+        protected override void ConfigureGraph()
+        {
+            base.ConfigureGraph();
+            if (Configured)
+                throw new AlreadyConfiguredException();
+            Configured = true;
+        }
+    }
+
+    private class AlreadyConfiguredException : Exception { }
+
+    [Metadata("Test", "Value")]
+    [Description("Desc1")]
+    [Obsolete("Dep1")]
+    private class Class1
+    {
+        [Id]
+        public int Id { get; set; } = 5;
+        [Metadata("Test2", "Value2")]
+        [Description("Desc2")]
+        public string? Print([Id, Description("IdDesc")] int id) => id.ToString();
+        [Obsolete("Dep2")]
+        public int Value => 3;
+    }
+}

--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeCachingTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeCachingTests.cs
@@ -1,0 +1,118 @@
+#nullable enable
+
+using System.ComponentModel;
+using GraphQL.Execution;
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Types;
+
+[Collection("StaticTests")]
+public class AutoRegisteringObjectGraphTypeCachingTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CachingWorks(bool withCaching)
+    {
+        TestGraphType.Configured = false;
+        GlobalSwitches.EnableReflectionCaching = withCaching;
+        try
+        {
+            var graph1 = new TestGraphType();
+            await ValidateAsync(graph1).ConfigureAwait(false);
+
+            if (!withCaching)
+            {
+                Should.Throw<AlreadyConfiguredException>(() => new TestGraphType());
+                TestGraphType.Configured = false;
+            }
+            var graph2 = new TestGraphType();
+            await ValidateAsync(graph2).ConfigureAwait(false);
+
+            async Task ValidateAsync(TestGraphType graph)
+            {
+                graph.Name.ShouldBe("Class1");
+                graph.Description.ShouldBe("Desc1");
+                graph.DeprecationReason.ShouldBe("Dep1");
+                graph.Metadata.Count.ShouldBe(2); // deprecation directive and Test metadata
+                graph.GetMetadata<string>("Test").ShouldBe("Value");
+                graph.Fields.Count.ShouldBe(3);
+
+                var field = graph.GetField("Id").ShouldNotBeNull();
+                field.Name.ShouldBe("Id");
+                field.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
+                field.Description.ShouldBeNull();
+                field.DeprecationReason.ShouldBeNull();
+                field.Metadata.Count.ShouldBe(0);
+                var ret = await field.Resolver.ShouldNotBeNull().ResolveAsync(new ResolveFieldContext { Source = new Class1() }).ConfigureAwait(false);
+                ret.ShouldBeOfType<int>().ShouldBe(5);
+
+                field = graph.GetField("Print").ShouldNotBeNull();
+                field.Name.ShouldBe("Print");
+                field.Type.ShouldBe(typeof(GraphQLClrOutputTypeReference<string>));
+                field.Description.ShouldBe("Desc2");
+                field.DeprecationReason.ShouldBeNull();
+                field.Metadata.Count.ShouldBe(1);
+                field.GetMetadata<string>("Test2").ShouldBe("Value2");
+                field.Arguments.ShouldNotBeNull().Count.ShouldBe(1);
+                var arg = field.Arguments[0];
+                arg.Name.ShouldBe("id");
+                arg.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
+                arg.Description.ShouldBe("IdDesc");
+                arg.DeprecationReason.ShouldBeNull();
+                arg.Metadata.Count.ShouldBe(0);
+                var resolveContext = new ResolveFieldContext
+                {
+                    Source = new Class1(),
+                    Arguments = new Dictionary<string, ArgumentValue> { { "id", new(10, ArgumentSource.Literal) } },
+                };
+                var printRet = await field.Resolver.ShouldNotBeNull().ResolveAsync(resolveContext).ConfigureAwait(false);
+                printRet.ShouldBeOfType<string>().ShouldBe("10");
+
+                field = graph.GetField("Value").ShouldNotBeNull();
+                field.Name.ShouldBe("Value");
+                field.Type.ShouldBe(typeof(NonNullGraphType<GraphQLClrOutputTypeReference<int>>));
+                field.Description.ShouldBeNull();
+                field.DeprecationReason.ShouldBe("Dep2");
+                field.Metadata.Count.ShouldBe(1); // deprecation directive
+
+                var valueRet = await field.Resolver.ShouldNotBeNull().ResolveAsync(new ResolveFieldContext { Source = new Class1() }).ConfigureAwait(false);
+                valueRet.ShouldBeOfType<int>().ShouldBe(3);
+            }
+        }
+        finally
+        {
+            GlobalSwitches.EnableReflectionCaching = false;
+            TestGraphType.Configured = false;
+        }
+    }
+
+    private class TestGraphType : AutoRegisteringObjectGraphType<Class1>
+    {
+        public static bool Configured { get; set; }
+
+        protected override void ConfigureGraph()
+        {
+            base.ConfigureGraph();
+            if (Configured)
+                throw new AlreadyConfiguredException();
+            Configured = true;
+        }
+    }
+
+    private class AlreadyConfiguredException : Exception { }
+
+    [Metadata("Test", "Value")]
+    [Description("Desc1")]
+    [Obsolete("Dep1")]
+    private class Class1
+    {
+        [Id]
+        public int Id { get; set; } = 5;
+        [Metadata("Test2", "Value2")]
+        [Description("Desc2")]
+        public string? Print([Id, Description("IdDesc")] int id) => id.ToString();
+        [Obsolete("Dep2")]
+        public int Value => 3;
+    }
+}

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -182,7 +182,7 @@ public static class GraphQLBuilderExtensions // TODO: split
         // Also register the service as ISchema if not already registered.
         builder.Services.TryRegisterAsBoth<ISchema, TSchema>(serviceLifetime);
 
-#if !DEBUG
+#if !DEBUG // otherwise any scoped service test would change the global switches
         if (serviceLifetime != ServiceLifetime.Singleton)
         {
             GlobalSwitches.EnableReflectionCaching = true;
@@ -230,7 +230,7 @@ public static class GraphQLBuilderExtensions // TODO: split
         // Also register the service as ISchema if not already registered.
         builder.Services.TryRegisterAsBoth<ISchema, TSchema>(schemaFactory, serviceLifetime);
 
-#if !DEBUG
+#if !DEBUG // otherwise any scoped service test would change the global switches
         if (serviceLifetime != ServiceLifetime.Singleton)
         {
             GlobalSwitches.EnableReflectionCaching = true;

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -239,7 +239,7 @@ public static class GraphQLBuilderExtensions // TODO: split
 
         return builder;
     }
-#endregion
+    #endregion
 
     #region - AddGraphTypeMappingProvider -
     /// <summary>
@@ -1211,5 +1211,5 @@ public static class GraphQLBuilderExtensions // TODO: split
         return builder;
     }
 #endif
-#endregion
+    #endregion
 }

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -159,7 +159,7 @@ public static class GraphQLBuilderExtensions // TODO: split
     /// <summary>
     /// Registers <typeparamref name="TSchema"/> within the dependency injection framework. <see cref="ISchema"/> is also
     /// registered if it is not already registered within the dependency injection framework. Singleton and scoped
-    /// lifetimes are supported.
+    /// lifetimes are supported. For scoped lifetimes, enables <see cref="GlobalSwitches.EnableReflectionCaching"/>.
     /// </summary>
     /// <remarks>
     /// Schemas that implement <see cref="IDisposable"/> of a transient lifetime are not supported, as this will cause a
@@ -181,6 +181,11 @@ public static class GraphQLBuilderExtensions // TODO: split
         // Register the service with the DI provider as TSchema, overwriting any existing registration
         // Also register the service as ISchema if not already registered.
         builder.Services.TryRegisterAsBoth<ISchema, TSchema>(serviceLifetime);
+
+        if (serviceLifetime != ServiceLifetime.Singleton)
+        {
+            GlobalSwitches.EnableReflectionCaching = true;
+        }
 
         return builder;
     }
@@ -222,6 +227,11 @@ public static class GraphQLBuilderExtensions // TODO: split
         // Register the service with the DI provider as TSchema, overwriting any existing registration
         // Also register the service as ISchema if not already registered.
         builder.Services.TryRegisterAsBoth<ISchema, TSchema>(schemaFactory, serviceLifetime);
+
+        if (serviceLifetime != ServiceLifetime.Singleton)
+        {
+            GlobalSwitches.EnableReflectionCaching = true;
+        }
 
         return builder;
     }

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -182,10 +182,12 @@ public static class GraphQLBuilderExtensions // TODO: split
         // Also register the service as ISchema if not already registered.
         builder.Services.TryRegisterAsBoth<ISchema, TSchema>(serviceLifetime);
 
+#if !DEBUG
         if (serviceLifetime != ServiceLifetime.Singleton)
         {
             GlobalSwitches.EnableReflectionCaching = true;
         }
+#endif
 
         return builder;
     }
@@ -228,14 +230,16 @@ public static class GraphQLBuilderExtensions // TODO: split
         // Also register the service as ISchema if not already registered.
         builder.Services.TryRegisterAsBoth<ISchema, TSchema>(schemaFactory, serviceLifetime);
 
+#if !DEBUG
         if (serviceLifetime != ServiceLifetime.Singleton)
         {
             GlobalSwitches.EnableReflectionCaching = true;
         }
+#endif
 
         return builder;
     }
-    #endregion
+#endregion
 
     #region - AddGraphTypeMappingProvider -
     /// <summary>
@@ -1207,5 +1211,5 @@ public static class GraphQLBuilderExtensions // TODO: split
         return builder;
     }
 #endif
-    #endregion
+#endregion
 }

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -90,6 +90,9 @@ public static class GlobalSwitches
     /// <br/><br/>
     /// By default disabled. <see cref="GraphQLBuilderExtensions.AddSchema{TSchema}(DI.IGraphQLBuilder, DI.ServiceLifetime)">AddSchema</see> sets
     /// this value to <see langword="true"/> when <see cref="DI.ServiceLifetime.Scoped"/> is specified.
+    /// <br/><br/>
+    /// Note that with reflection caching enabled, if there are two different classes derived from <see cref="Types.AutoRegisteringObjectGraphType{TSourceType}">AutoRegisteringObjectGraphType</see>
+    /// that have the same TSourceType, one instance will incorrectly pull cached information stored by the other instance.
     /// </summary>
     public static bool EnableReflectionCaching { get; set; }
 }

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -83,4 +83,13 @@ public static class GlobalSwitches
     /// The collection is not thread-safe; instances should be added prior to schema initialization.
     /// </summary>
     public static ICollection<GraphQLAttribute> GlobalAttributes { get; } = new List<GraphQLAttribute>();
+
+    /// <summary>
+    /// Enables caching of reflection metadata and resolvers from <see cref="Types.AutoRegisteringObjectGraphType{TSourceType}">AutoRegisteringObjectGraphType</see>;
+    /// useful for scoped schemas.
+    /// <br/><br/>
+    /// By default disabled. <see cref="GraphQLBuilderExtensions.AddSchema{TSchema}(DI.IGraphQLBuilder, DI.ServiceLifetime)">AddSchema</see> sets
+    /// this value to <see langword="true"/> when <see cref="DI.ServiceLifetime.Scoped"/> is specified.
+    /// </summary>
+    public static bool EnableReflectionCaching { get; set; }
 }

--- a/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
@@ -5,6 +6,11 @@ using System.Reflection;
 
 namespace GraphQL.Types
 {
+    internal static class AutoRegisteringInputObjectGraphType
+    {
+        public static ConcurrentDictionary<Type, IInputObjectGraphType> ReflectionCache { get; } = new();
+    }
+
     /// <summary>
     /// Allows you to automatically register the necessary fields for the specified input type.
     /// Supports <see cref="DescriptionAttribute"/>, <see cref="ObsoleteAttribute"/>, <see cref="DefaultValueAttribute"/> and <see cref="RequiredAttribute"/>.
@@ -17,6 +23,10 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Creates a GraphQL type from <typeparamref name="TSourceType"/>.
+        /// <br/><br/>
+        /// When <see cref="GlobalSwitches.EnableReflectionCaching"/> is enabled (typically for scoped schemas),
+        /// be sure to place any custom initialization code within <see cref="ConfigureGraph"/> or <see cref="ProvideFields"/>
+        /// so that the instance will be cached with the customizations.
         /// </summary>
         public AutoRegisteringInputObjectGraphType() : this(null) { }
 
@@ -25,13 +35,42 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="excludedProperties">Expressions for excluding fields, for example 'o => o.Age'.</param>
         public AutoRegisteringInputObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
+            : this(
+                GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringInputObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry)
+                    ? (AutoRegisteringInputObjectGraphType<TSourceType>?)cacheEntry
+                    : null,
+                excludedProperties,
+                GlobalSwitches.EnableReflectionCaching)
         {
+        }
+
+        internal AutoRegisteringInputObjectGraphType(AutoRegisteringInputObjectGraphType<TSourceType>? cloneFrom, Expression<Func<TSourceType, object?>>[]? excludedProperties, bool cache)
+            : base(cloneFrom)
+        {
+            // if copying a cached instance, just return the instance
+            if (cloneFrom != null)
+                return;
+
             _excludedProperties = excludedProperties;
             Name = typeof(TSourceType).GraphQLName();
             ConfigureGraph();
             foreach (var fieldType in ProvideFields())
             {
                 _ = AddField(fieldType);
+            }
+
+            // cache the instance if reflection caching is enabled
+            if (cache && excludedProperties == null)
+            {
+                foreach (var f in Fields.List)
+                {
+                    if (f.ResolvedType != null)
+                        cache = false;
+                }
+
+                // cache the constructed object
+                if (cache)
+                    AutoRegisteringInputObjectGraphType.ReflectionCache[typeof(TSourceType)] = new AutoRegisteringInputObjectGraphType<TSourceType>(this, null, false);
             }
         }
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -30,7 +30,12 @@ namespace GraphQL.Types
         /// </summary>
         /// <param name="excludedProperties">Expressions for excluding fields, for example 'o => o.Age'.</param>
         public AutoRegisteringObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
-            : this(GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry) ? (AutoRegisteringObjectGraphType<TSourceType>?)cacheEntry : null, excludedProperties, true)
+            : this(
+                  GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry)
+                    ? (AutoRegisteringObjectGraphType<TSourceType>?)cacheEntry
+                    : null,
+                  excludedProperties,
+                  GlobalSwitches.EnableReflectionCaching)
         {
         }
 
@@ -50,8 +55,7 @@ namespace GraphQL.Types
             }
 
             // cache the instance if reflection caching is enabled
-            if (GlobalSwitches.EnableReflectionCaching &&
-                excludedProperties == null &&
+            if (excludedProperties == null &&
                 cache &&
                 ResolvedInterfaces.Count == 0)
             {

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -42,6 +42,8 @@ namespace GraphQL.Types
             {
                 // set default props (see constructors for ObjectGraphType, ComplexGraphType, and GraphType)
                 SetName(GetDefaultName(), validate: GetType().Assembly != typeof(GraphType).Assembly);
+                if (typeof(IGraphType).IsAssignableFrom(typeof(TSourceType)) && GetType() != typeof(Introspection.__Type))
+                    throw new InvalidOperationException($"Cannot use graph type '{typeof(TSourceType).Name}' as a model for graph type '{GetType().Name}'. Please use a model rather than a graph type for {nameof(TSourceType)}.");
                 Description ??= typeof(TSourceType).Description();
                 DeprecationReason ??= typeof(TSourceType).ObsoleteMessage();
                 if (typeof(TSourceType) != typeof(object))

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -22,6 +22,11 @@ namespace GraphQL.Types
 
         /// <summary>
         /// Creates a GraphQL type from <typeparamref name="TSourceType"/>.
+        /// <br/><br/>
+        /// When <see cref="GlobalSwitches.EnableReflectionCaching"/> is enabled (typically for scoped schemas),
+        /// be sure to place any custom initialization code within <see cref="ConfigureGraph"/> or <see cref="ProvideFields"/>
+        /// so that the instance will be cached with the customizations. Also note that <see cref="ObjectGraphType{TSourceType}.Interfaces"/>
+        /// will reference a shared instance of <see cref="Interfaces"/> when restored from the cache and must not be modified further.
         /// </summary>
         public AutoRegisteringObjectGraphType() : this(null) { }
 
@@ -55,8 +60,8 @@ namespace GraphQL.Types
             }
 
             // cache the instance if reflection caching is enabled
-            if (excludedProperties == null &&
-                cache &&
+            if (cache &&
+                excludedProperties == null &&
                 ResolvedInterfaces.Count == 0)
             {
                 foreach (var f in Fields.List)

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -36,11 +36,11 @@ namespace GraphQL.Types
         /// <param name="excludedProperties">Expressions for excluding fields, for example 'o => o.Age'.</param>
         public AutoRegisteringObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
             : this(
-                  GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry)
+                GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry)
                     ? (AutoRegisteringObjectGraphType<TSourceType>?)cacheEntry
                     : null,
-                  excludedProperties,
-                  GlobalSwitches.EnableReflectionCaching)
+                excludedProperties,
+                GlobalSwitches.EnableReflectionCaching)
         {
         }
 

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -49,6 +49,8 @@ namespace GraphQL.Types
                     Type = f.Type,
                 };
                 f.CopyMetadataTo(field);
+                if (f.ResolvedType != null)
+                    throw new InvalidOperationException("Cannot clone field when ResolvedType is set.");
 
                 if (f.Arguments?.List != null && f.Arguments.List.Count > 0)
                 {

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -24,6 +24,13 @@ namespace GraphQL.Types
             DeprecationReason ??= typeof(TSourceType).ObsoleteMessage();
         }
 
+        internal ComplexGraphType(string? name, bool validate, string? description, string? deprecationReason)
+            : base(name, validate)
+        {
+            Description = description;
+            DeprecationReason = deprecationReason;
+        }
+
         /// <inheritdoc/>
         public TypeFields Fields { get; } = new();
 

--- a/src/GraphQL/Types/Composite/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/InputObjectGraphType.cs
@@ -39,6 +39,20 @@ namespace GraphQL.Types
     public class InputObjectGraphType<TSourceType> : ComplexGraphType<TSourceType>, IInputObjectGraphType
     {
         /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        public InputObjectGraphType()
+            : this(null)
+        {
+        }
+
+        internal InputObjectGraphType(InputObjectGraphType<TSourceType>? cloneFrom)
+            : base(cloneFrom)
+        {
+            // if (cloneFrom == null) { /* initialization logic */ }
+        }
+
+        /// <summary>
         /// Converts a supplied dictionary of keys and values to an object.
         /// The default implementation uses <see cref="ObjectExtensions.ToObject"/> to convert the
         /// supplied field values into an object of type <typeparamref name="TSourceType"/>.

--- a/src/GraphQL/Types/Composite/InterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/InterfaceGraphType.cs
@@ -10,6 +10,27 @@ namespace GraphQL.Types
     /// <inheritdoc cref="InterfaceGraphType"/>
     public class InterfaceGraphType<TSource> : ComplexGraphType<TSource>, IInterfaceGraphType
     {
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        public InterfaceGraphType()
+            : this(null)
+        {
+        }
+
+        internal InterfaceGraphType(InterfaceGraphType<TSource>? copyFrom)
+            : base(copyFrom)
+        {
+            if (copyFrom != null)
+            {
+                if (copyFrom.PossibleTypes.Count != 0)
+                    throw new InvalidOperationException("Cannot clone interface containing possible types.");
+                if (copyFrom.ResolveType != null)
+                    throw new InvalidOperationException("Cannot clone interface with configured ResolveType property.");
+            }
+            // else { /* initialization logic */ }
+        }
+
         /// <inheritdoc/>
         public PossibleTypes PossibleTypes { get; } = new PossibleTypes();
 

--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -32,6 +32,12 @@ namespace GraphQL.Types
                 IsTypeOf = instance => instance is TSourceType;
         }
 
+        internal ObjectGraphType(string? name, bool validate, string? description, string? deprecationReason, Func<object, bool>? isTypeOf)
+            : base(name, validate, description, deprecationReason)
+        {
+            IsTypeOf = isTypeOf;
+        }
+
         /// <inheritdoc/>
         public void AddResolvedInterface(IInterfaceGraphType graphType)
         {
@@ -66,5 +72,14 @@ namespace GraphQL.Types
     /// </summary>
     public class ObjectGraphType : ObjectGraphType<object?>
     {
+        /// <inheritdoc cref="ObjectGraphType{TSourceType}.ObjectGraphType()"/>
+        public ObjectGraphType()
+        {
+        }
+
+        internal ObjectGraphType(string? name, bool validate, string? description, string? deprecationReason, Func<object, bool>? isTypeOf)
+            : base(name, validate, description, deprecationReason, isTypeOf)
+        {
+        }
     }
 }

--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -43,6 +43,8 @@ namespace GraphQL.Types
             }
             IsTypeOf = cloneFrom.IsTypeOf;
             Interfaces = cloneFrom.Interfaces;
+            if (cloneFrom.ResolvedInterfaces.Count > 0)
+                throw new InvalidOperationException("Cannot clone ObjectGraphType when ResolvedInterfaces contains items.");
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -27,15 +27,22 @@ namespace GraphQL.Types
 
         /// <inheritdoc/>
         public ObjectGraphType()
+            : this(null)
         {
-            if (typeof(TSourceType) != typeof(object))
-                IsTypeOf = instance => instance is TSourceType;
         }
 
-        internal ObjectGraphType(string? name, bool validate, string? description, string? deprecationReason, Func<object, bool>? isTypeOf)
-            : base(name, validate, description, deprecationReason)
+        internal ObjectGraphType(ObjectGraphType<TSourceType>? cloneFrom)
+            : base(cloneFrom)
         {
-            IsTypeOf = isTypeOf;
+            if (cloneFrom == null)
+            {
+                if (typeof(TSourceType) != typeof(object))
+                    IsTypeOf = instance => instance is TSourceType;
+                Interfaces = new Interfaces();
+                return;
+            }
+            IsTypeOf = cloneFrom.IsTypeOf;
+            Interfaces = cloneFrom.Interfaces;
         }
 
         /// <inheritdoc/>
@@ -49,7 +56,7 @@ namespace GraphQL.Types
         }
 
         /// <inheritdoc/>
-        public Interfaces Interfaces { get; } = new Interfaces();
+        public Interfaces Interfaces { get; }
 
         /// <inheritdoc/>
         public ResolvedInterfaces ResolvedInterfaces { get; } = new ResolvedInterfaces();
@@ -72,14 +79,5 @@ namespace GraphQL.Types
     /// </summary>
     public class ObjectGraphType : ObjectGraphType<object?>
     {
-        /// <inheritdoc cref="ObjectGraphType{TSourceType}.ObjectGraphType()"/>
-        public ObjectGraphType()
-        {
-        }
-
-        internal ObjectGraphType(string? name, bool validate, string? description, string? deprecationReason, Func<object, bool>? isTypeOf)
-            : base(name, validate, description, deprecationReason, isTypeOf)
-        {
-        }
     }
 }

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -47,7 +47,7 @@ namespace GraphQL.Types
 
         private bool IsTypeModifier => this is ListGraphType || this is NonNullGraphType; // lgtm [cs/type-test-of-this]
 
-        internal string GetDefaultName()
+        private string GetDefaultName()
         {
             var type = GetType();
 

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -13,24 +13,28 @@ namespace GraphQL.Types
         /// <summary>
         /// Initializes a new instance of the graph type.
         /// </summary>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         protected GraphType()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+            : this(null)
         {
-            if (!IsTypeModifier) // specification requires name must be null for these types
-            {
-                // GraphType must always have a valid name so set it to default name in constructor
-                // and skip validation only for well-known types including introspection.
-                // This name can be always changed later to any valid value.
-                SetName(GetDefaultName(), validate: GetType().Assembly != typeof(GraphType).Assembly);
-            }
         }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal GraphType(string? name, bool validate)
+        internal GraphType(GraphType? cloneFrom)
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
-            SetName(name!, validate);
+            if (cloneFrom == null)
+            {
+                if (!IsTypeModifier) // specification requires name must be null for these types
+                {
+                    // GraphType must always have a valid name so set it to default name in constructor
+                    // and skip validation only for well-known types including introspection.
+                    // This name can be always changed later to any valid value.
+                    SetName(GetDefaultName(), validate: GetType().Assembly != typeof(GraphType).Assembly);
+                }
+                return;
+            }
+            _name = cloneFrom._name;
+            cloneFrom.CopyMetadataTo(this);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -26,6 +26,13 @@ namespace GraphQL.Types
             }
         }
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        internal GraphType(string? name, bool validate)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+            SetName(name!, validate);
+        }
+
         /// <inheritdoc/>
         public virtual void Initialize(ISchema schema)
         {
@@ -36,7 +43,7 @@ namespace GraphQL.Types
 
         private bool IsTypeModifier => this is ListGraphType || this is NonNullGraphType; // lgtm [cs/type-test-of-this]
 
-        private string GetDefaultName()
+        internal string GetDefaultName()
         {
             var type = GetType();
 


### PR DESCRIPTION
This likely would drastically reduce initialization time for scoped schemas that use `AutoRegisteringObjectGraphType` and `AutoRegisteringInputObjectGraphType`.