### PR TITLE
Fix formatting when the line before Field invocation contains whitespaces

### DIFF
--- a/src/GraphQL.Analyzers.CodeFixes/FieldBuilderCodeFixProvider.cs
+++ b/src/GraphQL.Analyzers.CodeFixes/FieldBuilderCodeFixProvider.cs
@@ -79,8 +79,8 @@ public class FieldBuilderCodeFixProvider : CodeFixProvider
         const int oneLevelIndentation = 4;
         int fieldInvocationIndentation = newFieldInvocationExpression
             .GetLeadingTrivia()
-            .Where(trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia))
-            .Sum(trivia => trivia.FullSpan.Length);
+            .LastOrDefault(trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+            .FullSpan.Length;
 
         var whitespaceTrivia = Whitespace(new string(' ', fieldInvocationIndentation + oneLevelIndentation));
         var newLineTrivia = EndOfLine(Environment.NewLine);

--- a/src/GraphQL.Analyzers.Tests/FieldBuilderAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/FieldBuilderAnalyzerTests.cs
@@ -455,6 +455,55 @@ public class FieldBuilderAnalyzerTests
     }
 
     [Fact]
+    public async Task EmptyLineWithWhiteSpacesBeforeField_ArgumentsFormattingPreservedAsync()
+    {
+        const string source = """
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : ObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    // next line contains whitespaces
+                    
+                    Field<StringGraphType>("name", "description", null,
+                        resolve: context => Resolve(
+                            "text"
+                        ));
+                }
+
+                public string Resolve(string s1) => s1;
+            }
+            """;
+
+        const string fix = """
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : ObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    // next line contains whitespaces
+                    
+                    Field<StringGraphType>("name").Description("description")
+                        .Resolve(context => Resolve(
+                            "text"
+                        ));
+                }
+
+                public string Resolve(string s1) => s1;
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(FieldBuilderAnalyzer.DoNotUseObsoleteFieldMethods).WithSpan(11, 9, 14, 15);
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fix).ConfigureAwait(false);
+    }
+
+    [Fact]
     public async Task ArgumentsFormattingPreserved_PreserveNewLines()
     {
         const string source = """


### PR DESCRIPTION
This PR fixes the second issue reported [here](https://github.com/graphql-dotnet/graphql-dotnet/pull/3720#issuecomment-1764981528)
![image](https://user-images.githubusercontent.com/6377684/275603655-527bc139-7540-4a01-afff-d3686a43a38c.png)

The fix for `);` on a separate line is more complicated, so I'll leave it as is.