### PR TITLE
Rewrite the obsolete Name method on ConnectionBuilder

### DIFF
--- a/docs2/site/docs/analyzers/GQL001_DefineTheNameInFieldMethod.md
+++ b/docs2/site/docs/analyzers/GQL001_DefineTheNameInFieldMethod.md
@@ -1,4 +1,4 @@
-# GQL001: Define the name in `Field` method
+# GQL001: Define the name in `Field`, `Connection` or `ConnectionBuilder.Create` method
 
 |                        | Value   |
 | ---------------------- | ------- |
@@ -10,26 +10,32 @@
 
 ## Cause
 
-The `FieldBuilder` instance was created using the `Field` method overload that doesn't require a name argument, with the field name being supplied through the `Name` method.
+The `FieldBuilder` or `ConnectionBuilder` instance was created using the `Field`, `Connection` or `ConnectionBuilder.Create` method overload that doesn't require a name argument, with the name being supplied through the `Name` method.
 
 ## Rule description
 
-Field name should be provided in the `Field` method. The `Field` method overloads without name argument are obsolete and will be removed in future version.
+The name should be provided in the `Field`, `Connection` or `ConnectionBuilder.Create` method. Method overloads without the name argument are obsolete and will be removed in future version.
 
 ## How to fix violations
 
-Use the `Field` method overload that takes the name argument and remove the call to the `Name` method.
+Use the `Field`, `Connection` or `ConnectionBuilder.Create` method overload that takes the name argument and remove the call to the `Name` method.
 
 ## Example of a violation
 
 ```c#
 Field<StringGraphType>().Name("Name");
+Connection<StringGraphType>().Name("Name");
+ConnectionBuilder<string>.Create<StringGraphType>().Name("Name");
+ConnectionBuilder.Create<StringGraphType, string>().Name("Name");
 ```
 
 ## Example of how to fix
 
 ```c#
 Field<StringGraphType>("Name");
+Connection<StringGraphType>("Name");
+ConnectionBuilder<string>.Create<StringGraphType>("Name");
+ConnectionBuilder.Create<StringGraphType, string>("Name");
 ```
 
 ## Suppress a warning
@@ -54,4 +60,4 @@ For more information, see [How to suppress code analysis warnings](https://learn
 ## Related rules
 
 [GQL002: `Name` method invocation can be removed](/GQL002_NameMethodInvocationCanBeRemoved)  
-[GQL003: Different names defined by `Field` and `Name` methods](/GQL003_DifferentNamesDefinedByFieldAndNameMethods)
+[GQL003: Different names defined by `Field`, `Connection` or `ConnectionBuilder.Create` and `Name` methods](/GQL003_DifferentNamesDefinedByFieldAndNameMethods)

--- a/docs2/site/docs/analyzers/GQL002_NameMethodInvocationCanBeRemoved.md
+++ b/docs2/site/docs/analyzers/GQL002_NameMethodInvocationCanBeRemoved.md
@@ -10,11 +10,11 @@
 
 ## Cause
 
-The same name is provided in `Field` and `Name` methods.
+The same name is provided in `Field`, `Connection` or `ConnectionBuilder.Create` and `Name` methods.
 
 ## Rule description
 
-Field name should be provided in the `Field` method. The `Name` method call is unnecessary and can be removed.
+Field name should be provided in the `Field`, `Connection` or `ConnectionBuilder.Create` method. The `Name` method call is unnecessary and can be removed.
 
 ## How to fix violations
 
@@ -24,12 +24,18 @@ Remove the `Name` method call.
 
 ```c#
 Field<StringGraphType>("Name").Name("Name");
+Connection<StringGraphType>("Name").Name("Name");
+ConnectionBuilder<string>.Create<StringGraphType>("Name").Name("Name");
+ConnectionBuilder.Create<StringGraphType, string>("Name").Name("Name");
 ```
 
 ## Example of how to fix
 
 ```c#
 Field<StringGraphType>("Name");
+Connection<StringGraphType>("Name");
+ConnectionBuilder<string>.Create<StringGraphType>("Name");
+ConnectionBuilder.Create<StringGraphType, string>("Name");
 ```
 
 ## Suppress a warning
@@ -53,5 +59,5 @@ For more information, see [How to suppress code analysis warnings](https://learn
 
 ## Related rules
 
-[GQL001: Define the name in `Field` method](/GQL001_DefineTheNameInFieldMethod)  
-[GQL003: Different names defined by `Field` and `Name` methods](/GQL003_DifferentNamesDefinedByFieldAndNameMethods)
+[GQL001: Define the name in `Field`, `Connection` or `ConnectionBuilder.Create` method](/GQL001_DefineTheNameInFieldMethod)  
+[GQL003: Different names defined by `Field`, `Connection` or `ConnectionBuilder.Create` and `Name` methods](/GQL003_DifferentNamesDefinedByFieldAndNameMethods)

--- a/docs2/site/docs/analyzers/GQL003_DifferentNamesDefinedByFieldAndNameMethods.md
+++ b/docs2/site/docs/analyzers/GQL003_DifferentNamesDefinedByFieldAndNameMethods.md
@@ -1,4 +1,4 @@
-# GQL003: Different names defined by `Field` and `Name` methods
+# GQL003: Different names defined by `Field`, `Connection` or `ConnectionBuilder.Create` and `Name` methods
 
 |                        | Value   |
 | ---------------------- | ------- |
@@ -10,32 +10,41 @@
 
 ## Cause
 
-`Field` and `Name` methods define different field names.
+`Field`, `Connection` or `ConnectionBuilder.Create` and `Name` methods define different field names.
 
 ## Rule description
 
-Field name should be provided in the `Field` method. If you intend to use a different name, modify it within the `Field` method instead of using the `Name` method.
+Field name should be provided in the `Field`, `Connection` or `ConnectionBuilder.Create` method. If you intend to use a different name, modify it within the `Field`, `Connection` or `ConnectionBuilder.Create` method instead of using the `Name` method.
 
 ## How to fix violations
 
-Specify the preferred field name within the `Field` method and remove the use of the `Name` method.
+Specify the preferred field name within the `Field`, `Connection` or `ConnectionBuilder.Create` method and remove the use of the `Name` method.
 
 ## Example of a violation
 
 ```c#
 Field<StringGraphType>("Name1").Name("Name2");
+Connection<StringGraphType>("Name1").Name("Name2");
+ConnectionBuilder<string>.Create<StringGraphType>("Name1").Name("Name2");
+ConnectionBuilder.Create<StringGraphType, string>("Name1").Name("Name2");
 ```
 
 ## Example of how to fix
 
 ```c#
 Field<StringGraphType>("Name1");
+Connection<StringGraphType>("Name1");
+ConnectionBuilder<string>.Create<StringGraphType>("Name1");
+ConnectionBuilder.Create<StringGraphType, string>("Name1");
 ```
 
 or
 
 ```c#
 Field<StringGraphType>("Name2");
+Connection<StringGraphType>("Name2");
+ConnectionBuilder<string>.Create<StringGraphType>("Name2");
+ConnectionBuilder.Create<StringGraphType, string>("Name2");
 ```
 
 ## Suppress a warning
@@ -59,5 +68,5 @@ For more information, see [How to suppress code analysis warnings](https://learn
 
 ## Related rules
 
-[GQL001: Define the name in `Field` method](/GQL001_DefineTheNameInFieldMethod)  
+[GQL001: Define the name in `Field`, `Connection` or `ConnectionBuilder.Create` method](/GQL001_DefineTheNameInFieldMethod)  
 [GQL002: `Name` method invocation can be removed](/GQL002_NameMethodInvocationCanBeRemoved)

--- a/docs2/site/docs/analyzers/Overview.md
+++ b/docs2/site/docs/analyzers/Overview.md
@@ -26,18 +26,20 @@ Field("name").Description(...).Resolve(...)
 
 ### 2. FieldNameAnalyzer
 
-The `FieldNameAnalyzer` is designed to improve the field name definition method. It simplifies the way field names are assigned to enhance code consistency.
+The `FieldNameAnalyzer` detects the usage of the obsolete `Name` method on the field and connection builders and helps to rewrite the code to use builder creating methods that accept the name as an argument.
 
 Replace:
 
 ```csharp
-Field().Name("name")
+Field<TGraphType>().Name("name")
+Connection<TGraphType, TSourceType>().Name("name")
 ```
 
 With:
 
 ```csharp
-Field("name")
+Field<TGraphType>("name")
+Connection<TGraphType, TSourceType>("name")
 ```
 
 ### 3. ResolverAnalyzer

--- a/src/GraphQL.Analyzers.Tests/FieldNameAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/FieldNameAnalyzerTests.cs
@@ -19,7 +19,7 @@ public class FieldNameAnalyzerTests
     [Theory]
     [InlineData(Constants.MethodNames.Field)]
     [InlineData(Constants.MethodNames.Connection)]
-    public async Task FieldAndNameMethodsCalled_NotGraphQLBuilder_NoDiagnostics(string builderName)
+    public async Task FieldAndNameMethodsCalled_NotGraphQLBuilder_NoDiagnostics(string builder)
     {
         string source = $$"""
             namespace Sample.Server;
@@ -28,7 +28,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyType()
                 {
-                    {{builderName}}<string>().Name("Text");
+                    {{builder}}<string>().Name("Text");
                 }
 
                 private FieldBuilder<T> Field<T>()
@@ -66,7 +66,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Field)]
     [InlineData(Constants.MethodNames.Connection)]
     [InlineData(CONNECTION_BUILDER_CREATE)]
-    public async Task FieldWithoutName_NameMethodCallInTheMiddle_DefineTheNameInFieldMethod(string builderName)
+    public async Task FieldWithoutName_NameMethodCallInTheMiddle_DefineTheNameInFieldMethod(string builder)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -78,7 +78,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>().Name("Text").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>().Name("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -93,14 +93,14 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>("Text").Resolve(context => "Test");
                 }
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>().".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>().".Length + 1;
         int endColumn = startColumn + "Name(\"Text\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DefineTheNameInFieldMethod).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
@@ -110,7 +110,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Field)]
     [InlineData(Constants.MethodNames.Connection)]
     [InlineData(CONNECTION_BUILDER_CREATE)]
-    public async Task FieldWithoutName_NameMethodCallInTheEnd_DefineTheNameInFieldMethod(string builderName)
+    public async Task FieldWithoutName_NameMethodCallInTheEnd_DefineTheNameInFieldMethod(string builder)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -122,7 +122,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>().Description("description").Name("Text");
+                    {{builder}}<StringGraphType>().Description("description").Name("Text");
                 }
             }
             """;
@@ -137,14 +137,14 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Description("description");
+                    {{builder}}<StringGraphType>("Text").Description("description");
                 }
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>().Description(\"description\").".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>().Description(\"description\").".Length + 1;
         int endColumn = startColumn + "Name(\"Text\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DefineTheNameInFieldMethod).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
@@ -154,7 +154,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Field)]
     [InlineData(Constants.MethodNames.Connection)]
     [InlineData(CONNECTION_BUILDER_CREATE)]
-    public async Task FieldWithName_NoNameMethodCalled_NoDiagnostics(string builderName)
+    public async Task FieldWithName_NoNameMethodCalled_NoDiagnostics(string builder)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -166,7 +166,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -178,7 +178,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Field)]
     [InlineData(Constants.MethodNames.Connection)]
     [InlineData(CONNECTION_BUILDER_CREATE)]
-    public async Task FieldAndNameMethodsHaveSameValues_NameMethodInvocationCanBeRemoved(string builderName)
+    public async Task FieldAndNameMethodsHaveSameValues_NameMethodInvocationCanBeRemoved(string builder)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -190,7 +190,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Name("Text").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>("Text").Name("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -205,14 +205,14 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>("Text").Resolve(context => "Test");
                 }
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>(\"Text\").".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>(\"Text\").".Length + 1;
         int endColumn = startColumn + "Name(\"Text\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.NameMethodInvocationCanBeRemoved).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
@@ -223,7 +223,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Field, "nullable: false, name: \"Text\"")]
     [InlineData(Constants.MethodNames.Connection, "name: \"Text\"")]
     [InlineData(CONNECTION_BUILDER_CREATE, "name: \"Text\"")]
-    public async Task FieldAndNameMethodsHaveSameValues_NamedArguments_NameMethodInvocationCanBeRemoved(string builderName, string builderArgs)
+    public async Task FieldAndNameMethodsHaveSameValues_NamedArguments_NameMethodInvocationCanBeRemoved(string builder, string builderArgs)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -235,7 +235,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>({{builderArgs}}).Name("Text").Description("description");
+                    {{builder}}<StringGraphType>({{builderArgs}}).Name("Text").Description("description");
                 }
             }
             """;
@@ -250,14 +250,14 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>({{builderArgs}}).Description("description");
+                    {{builder}}<StringGraphType>({{builderArgs}}).Description("description");
                 }
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>({builderArgs}).".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>({builderArgs}).".Length + 1;
         int endColumn = startColumn + "Name(\"Text\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.NameMethodInvocationCanBeRemoved).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
@@ -267,7 +267,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Field)]
     [InlineData(Constants.MethodNames.Connection)]
     [InlineData(CONNECTION_BUILDER_CREATE)]
-    public async Task FieldAndNameMethodsHaveSameExpressions_NameMethodInvocationCanBeRemoved(string builderName)
+    public async Task FieldAndNameMethodsHaveSameExpressions_NameMethodInvocationCanBeRemoved(string builder)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -279,7 +279,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(GetName()).Name(GetName()).Resolve(context => "Test");
+                    {{builder}}<StringGraphType>(GetName()).Name(GetName()).Resolve(context => "Test");
                 }
 
                 private string GetName() => "Text";
@@ -296,16 +296,16 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(GetName()).Resolve(context => "Test");
+                    {{builder}}<StringGraphType>(GetName()).Resolve(context => "Test");
                 }
 
                 private string GetName() => "Text";
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>(GetName()).".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>(GetName()).".Length + 1;
         int endColumn = startColumn + "Name(GetName())".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.NameMethodInvocationCanBeRemoved).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
@@ -318,7 +318,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Connection, 1)]
     [InlineData(CONNECTION_BUILDER_CREATE, 0)]
     [InlineData(CONNECTION_BUILDER_CREATE, 1)]
-    public async Task FieldAndNameMethodsHaveDifferentNames_DifferentNamesDefinedByFieldAndNameMethods(string builderName, int codeActionIndex)
+    public async Task FieldAndNameMethodsHaveDifferentNames_DifferentNamesDefinedByFieldAndNameMethods(string builder, int codeActionIndex)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -330,7 +330,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text1").Name("Text2").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>("Text1").Name("Text2").Resolve(context => "Test");
                 }
             }
             """;
@@ -345,7 +345,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text1").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>("Text1").Resolve(context => "Test");
                 }
             }
             """;
@@ -360,14 +360,14 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text2").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>("Text2").Resolve(context => "Test");
                 }
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>(\"Text1\").".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>(\"Text1\").".Length + 1;
         int endColumn = startColumn + "Name(\"Text2\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         string[] fixes = new[] { fix0, fix1 };
 
@@ -389,7 +389,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Connection, 1)]
     [InlineData(CONNECTION_BUILDER_CREATE, 0)]
     [InlineData(CONNECTION_BUILDER_CREATE, 1)]
-    public async Task FieldAndNameMethodsHaveDifferentNames_DifferentNamesDefinedByFieldAndNameMethods_CorrectlyFormatted(string builderName, int codeActionIndex)
+    public async Task FieldAndNameMethodsHaveDifferentNames_DifferentNamesDefinedByFieldAndNameMethods_CorrectlyFormatted(string builder, int codeActionIndex)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -401,7 +401,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text1").Name("Text2")
+                    {{builder}}<StringGraphType>("Text1").Name("Text2")
                         .Resolve(context => "Test");
                 }
             }
@@ -417,7 +417,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text1")
+                    {{builder}}<StringGraphType>("Text1")
                         .Resolve(context => "Test");
                 }
             }
@@ -433,15 +433,15 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text2")
+                    {{builder}}<StringGraphType>("Text2")
                         .Resolve(context => "Test");
                 }
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>(\"Text1\").".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>(\"Text1\").".Length + 1;
         int endColumn = startColumn + "Name(\"Text2\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         string[] fixes = new[] { fix0, fix1 };
 
@@ -463,7 +463,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Connection, 1)]
     [InlineData(CONNECTION_BUILDER_CREATE, 0)]
     [InlineData(CONNECTION_BUILDER_CREATE, 1)]
-    public async Task FieldAndNameMethodsHaveDifferentNames_DifferentNamesDefinedByFieldAndNameMethods_CorrectlyFormatted2(string builderName, int codeActionIndex)
+    public async Task FieldAndNameMethodsHaveDifferentNames_DifferentNamesDefinedByFieldAndNameMethods_CorrectlyFormatted2(string builder, int codeActionIndex)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -475,7 +475,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text1").Description("description")
+                    {{builder}}<StringGraphType>("Text1").Description("description")
                         .Name("Text2");
                 }
             }
@@ -491,7 +491,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text1").Description("description");
+                    {{builder}}<StringGraphType>("Text1").Description("description");
                 }
             }
             """;
@@ -506,14 +506,14 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text2").Description("description");
+                    {{builder}}<StringGraphType>("Text2").Description("description");
                 }
             }
             """;
 
         int startColumn = $"            .".Length + 1;
         int endColumn = startColumn + "Name(\"Text2\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         string[] fixes = new[] { fix0, fix1 };
 
@@ -535,7 +535,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Connection, 1)]
     [InlineData(CONNECTION_BUILDER_CREATE, 0)]
     [InlineData(CONNECTION_BUILDER_CREATE, 1)]
-    public async Task FieldAndNameMethodsHaveDifferentNames_FieldUsesNamedArguments_DifferentNamesDefinedByFieldAndNameMethods(string builderName, int codeActionIndex)
+    public async Task FieldAndNameMethodsHaveDifferentNames_FieldUsesNamedArguments_DifferentNamesDefinedByFieldAndNameMethods(string builder, int codeActionIndex)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -547,7 +547,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(name: "Text1").Name("Text2").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>(name: "Text1").Name("Text2").Resolve(context => "Test");
                 }
             }
             """;
@@ -562,7 +562,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(name: "Text1").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>(name: "Text1").Resolve(context => "Test");
                 }
             }
             """;
@@ -577,14 +577,14 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(name: "Text2").Resolve(context => "Test");
+                    {{builder}}<StringGraphType>(name: "Text2").Resolve(context => "Test");
                 }
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>(name: \"Text1\").".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>(name: \"Text1\").".Length + 1;
         int endColumn = startColumn + "Name(\"Text2\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         string[] fixes = new[] { fix0, fix1 };
 
@@ -663,7 +663,7 @@ public class FieldNameAnalyzerTests
     [Theory]
     [InlineData(Constants.MethodNames.Field)]
     [InlineData(Constants.MethodNames.Connection)]
-    public async Task FieldCalledOnVariableWithoutName_DefineTheNameInFieldMethod(string builderName)
+    public async Task FieldCalledOnVariableWithoutName_DefineTheNameInFieldMethod(string builder)
     {
         string source = $$"""
             using GraphQL.Types;
@@ -674,7 +674,7 @@ public class FieldNameAnalyzerTests
             {
                 public void Register(ObjectGraphType graphType)
                 {
-                    graphType.{{builderName}}<StringGraphType>().Name("Text").Resolve(context => "Tests");
+                    graphType.{{builder}}<StringGraphType>().Name("Text").Resolve(context => "Tests");
                 }
             }
             """;
@@ -688,14 +688,14 @@ public class FieldNameAnalyzerTests
             {
                 public void Register(ObjectGraphType graphType)
                 {
-                    graphType.{{builderName}}<StringGraphType>("Text").Resolve(context => "Tests");
+                    graphType.{{builder}}<StringGraphType>("Text").Resolve(context => "Tests");
                 }
             }
             """;
 
-        int startColumn = $"        graphType.{builderName}<StringGraphType>().".Length + 1;
+        int startColumn = $"        graphType.{builder}<StringGraphType>().".Length + 1;
         int endColumn = startColumn + "Name(\"Text\")".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DefineTheNameInFieldMethod).WithSpan(9, startColumn, 9, endColumn).WithArguments(methodName);
         await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
@@ -799,7 +799,7 @@ public class FieldNameAnalyzerTests
     [InlineData(Constants.MethodNames.Field)]
     [InlineData(Constants.MethodNames.Connection)]
     [InlineData(CONNECTION_BUILDER_CREATE)]
-    public async Task FieldWithoutName_NameMethodCalled_NameOverloadUnknown_DefineTheNameInFieldMethod(string builderName)
+    public async Task FieldWithoutName_NameMethodCalled_NameOverloadUnknown_DefineTheNameInFieldMethod(string builder)
     {
         string source = $$"""
             using GraphQL.Builders;
@@ -811,7 +811,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>().Name();
+                    {{builder}}<StringGraphType>().Name();
                 }
             }
             """;
@@ -826,14 +826,14 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>();
+                    {{builder}}<StringGraphType>();
                 }
             }
             """;
 
-        int startColumn = $"        {builderName}<StringGraphType>().".Length + 1;
+        int startColumn = $"        {builder}<StringGraphType>().".Length + 1;
         int endColumn = startColumn + "Name()".Length;
-        string methodName = GetMethodName(builderName);
+        string methodName = GetMethodName(builder);
 
         var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DefineTheNameInFieldMethod).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         var test = new VerifyCS.Test

--- a/src/GraphQL.Analyzers.Tests/FieldNameAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/FieldNameAnalyzerTests.cs
@@ -78,7 +78,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>().Name("Text").Description("description");
+                    {{builderName}}<StringGraphType>().Name("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -93,7 +93,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Description("description");
+                    {{builderName}}<StringGraphType>("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -166,7 +166,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Description("description");
+                    {{builderName}}<StringGraphType>("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -190,7 +190,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Name("Text").Description("description");
+                    {{builderName}}<StringGraphType>("Text").Name("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -205,7 +205,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text").Description("description");
+                    {{builderName}}<StringGraphType>("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -279,7 +279,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(GetName()).Name(GetName()).Description("description");
+                    {{builderName}}<StringGraphType>(GetName()).Name(GetName()).Resolve(context => "Test");
                 }
 
                 private string GetName() => "Text";
@@ -296,7 +296,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(GetName()).Description("description");
+                    {{builderName}}<StringGraphType>(GetName()).Resolve(context => "Test");
                 }
 
                 private string GetName() => "Text";
@@ -330,7 +330,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text1").Name("Text2").Description("description");
+                    {{builderName}}<StringGraphType>("Text1").Name("Text2").Resolve(context => "Test");
                 }
             }
             """;
@@ -345,7 +345,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text1").Description("description");
+                    {{builderName}}<StringGraphType>("Text1").Resolve(context => "Test");
                 }
             }
             """;
@@ -360,7 +360,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>("Text2").Description("description");
+                    {{builderName}}<StringGraphType>("Text2").Resolve(context => "Test");
                 }
             }
             """;
@@ -402,7 +402,7 @@ public class FieldNameAnalyzerTests
                 public MyGraphType()
                 {
                     {{builderName}}<StringGraphType>("Text1").Name("Text2")
-                        .Description("description");
+                        .Resolve(context => "Test");
                 }
             }
             """;
@@ -418,7 +418,7 @@ public class FieldNameAnalyzerTests
                 public MyGraphType()
                 {
                     {{builderName}}<StringGraphType>("Text1")
-                        .Description("description");
+                        .Resolve(context => "Test");
                 }
             }
             """;
@@ -434,7 +434,7 @@ public class FieldNameAnalyzerTests
                 public MyGraphType()
                 {
                     {{builderName}}<StringGraphType>("Text2")
-                        .Description("description");
+                        .Resolve(context => "Test");
                 }
             }
             """;
@@ -547,7 +547,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(name: "Text1").Name("Text2").Description("description");
+                    {{builderName}}<StringGraphType>(name: "Text1").Name("Text2").Resolve(context => "Test");
                 }
             }
             """;
@@ -562,7 +562,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(name: "Text1").Description("description");
+                    {{builderName}}<StringGraphType>(name: "Text1").Resolve(context => "Test");
                 }
             }
             """;
@@ -577,7 +577,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    {{builderName}}<StringGraphType>(name: "Text2").Description("description");
+                    {{builderName}}<StringGraphType>(name: "Text2").Resolve(context => "Test");
                 }
             }
             """;
@@ -613,7 +613,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    Field<string>(name: "Text1", nullable: true).Name("Text2").Description("description");
+                    Field<string>(name: "Text1", nullable: true).Name("Text2").Resolve(context => "Test");
                 }
             }
             """;
@@ -627,7 +627,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    Field<string>(name: "Text1", nullable: true).Description("description");
+                    Field<string>(name: "Text1", nullable: true).Resolve(context => "Test");
                 }
             }
             """;
@@ -641,7 +641,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    Field<string>(name: "Text2", nullable: true).Description("description");
+                    Field<string>(name: "Text2", nullable: true).Resolve(context => "Test");
                 }
             }
             """;
@@ -859,7 +859,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    ConnectionBuilder.Create<StringGraphType, string>().Name("Text").Description("description");
+                    ConnectionBuilder.Create<StringGraphType, string>().Name("Text").Resolve(context => "Test");
                 }
             }
             """;
@@ -874,7 +874,7 @@ public class FieldNameAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    ConnectionBuilder.Create<StringGraphType, string>("Text").Description("description");
+                    ConnectionBuilder.Create<StringGraphType, string>("Text").Resolve(context => "Test");
                 }
             }
             """;

--- a/src/GraphQL.Analyzers.Tests/FieldNameAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/FieldNameAnalyzerTests.cs
@@ -371,7 +371,7 @@ public class FieldNameAnalyzerTests
 
         string[] fixes = new[] { fix0, fix1 };
 
-        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName, methodName);
+        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         var test = new VerifyCS.Test
         {
             TestCode = source,
@@ -445,7 +445,7 @@ public class FieldNameAnalyzerTests
 
         string[] fixes = new[] { fix0, fix1 };
 
-        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName, methodName);
+        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         var test = new VerifyCS.Test
         {
             TestCode = source,
@@ -517,7 +517,7 @@ public class FieldNameAnalyzerTests
 
         string[] fixes = new[] { fix0, fix1 };
 
-        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(11, startColumn, 11, endColumn).WithArguments(methodName, methodName);
+        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(11, startColumn, 11, endColumn).WithArguments(methodName);
         var test = new VerifyCS.Test
         {
             TestCode = source,
@@ -588,7 +588,7 @@ public class FieldNameAnalyzerTests
 
         string[] fixes = new[] { fix0, fix1 };
 
-        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName, methodName);
+        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(10, startColumn, 10, endColumn).WithArguments(methodName);
         var test = new VerifyCS.Test
         {
             TestCode = source,
@@ -649,7 +649,7 @@ public class FieldNameAnalyzerTests
         string[] fixes = new[] { fix0, fix1 };
         string methodName = Constants.MethodNames.Field;
 
-        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(9, 54, 9, 67).WithArguments(methodName, methodName);
+        var expected = VerifyCS.Diagnostic(FieldNameAnalyzer.DifferentNamesDefinedByFieldAndNameMethods).WithSpan(9, 54, 9, 67).WithArguments(methodName);
         var test = new VerifyCS.Test
         {
             TestCode = source,

--- a/src/GraphQL.Analyzers/Constants.cs
+++ b/src/GraphQL.Analyzers/Constants.cs
@@ -20,6 +20,8 @@ public static class Constants
     public static class MethodNames
     {
         public const string Arguments = "Arguments";
+        public const string Connection = "Connection";
+        public const string Create = "Create";
         public const string DeprecationReason = "DeprecationReason";
         public const string Description = "Description";
         public const string Field = "Field";
@@ -39,6 +41,7 @@ public static class Constants
 
     public static class Properties
     {
+        public const string BuilderMethodName = "BuilderMethodName";
         public const string IsAsync = "IsAsync";
         public const string IsDelegate = "IsDelegate";
     }

--- a/src/GraphQL.Analyzers/Extensions.cs
+++ b/src/GraphQL.Analyzers/Extensions.cs
@@ -8,20 +8,20 @@ namespace GraphQL.Analyzers;
 
 public static class Extensions
 {
-    public static InvocationExpressionSyntax? FindFieldInvocationExpression(this ExpressionSyntax expression)
+    public static InvocationExpressionSyntax? FindMethodInvocationExpression(this ExpressionSyntax expression, string methodName)
     {
-        var fieldNameSyntax = expression.FindFieldSimpleNameSyntax();
-        return fieldNameSyntax?.FindFieldInvocationExpression();
+        var simpleNameSyntax = expression.FindSimpleNameSyntax(methodName);
+        return simpleNameSyntax?.FindMethodInvocationExpression();
     }
 
-    public static SimpleNameSyntax? FindFieldSimpleNameSyntax(this ExpressionSyntax expression)
+    public static SimpleNameSyntax? FindSimpleNameSyntax(this ExpressionSyntax expression, string builderName)
     {
         return expression.DescendantNodes()
             .OfType<SimpleNameSyntax>()
-            .FirstOrDefault(simpleNameSyntax => simpleNameSyntax.Identifier.Text == Constants.MethodNames.Field);
+            .FirstOrDefault(simpleNameSyntax => simpleNameSyntax.Identifier.Text == builderName);
     }
 
-    public static InvocationExpressionSyntax? FindFieldInvocationExpression(this SimpleNameSyntax fieldSimpleName)
+    public static InvocationExpressionSyntax? FindMethodInvocationExpression(this SimpleNameSyntax fieldSimpleName)
     {
         return fieldSimpleName.Parent switch
         {

--- a/src/GraphQL.Analyzers/FieldBuilderAnalyzer.cs
+++ b/src/GraphQL.Analyzers/FieldBuilderAnalyzer.cs
@@ -86,7 +86,7 @@ public class FieldBuilderAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var fieldInvocation = genericNameSyntax.FindFieldInvocationExpression()!;
+        var fieldInvocation = genericNameSyntax.FindMethodInvocationExpression()!;
 
         ReportFieldTypeDiagnostic(
             context,

--- a/src/GraphQL.Analyzers/FieldNameAnalyzer.cs
+++ b/src/GraphQL.Analyzers/FieldNameAnalyzer.cs
@@ -36,7 +36,7 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor DifferentNamesDefinedByFieldAndNameMethods = new(
         id: DiagnosticIds.DIFFERENT_NAMES_DEFINED_BY_FIELD_AND_NAME_METHODS,
         title: "Different names defined by 'Field', 'Connection' or 'ConnectionBuilder.Create' and 'Name' methods",
-        messageFormat: "The name should be provided via '{0}' method. Different names defined by '{1}' and 'Name' methods.",
+        messageFormat: "The name should be provided via '{0}' method. Different names defined by '{0}' and 'Name' methods.",
         category: DiagnosticCategories.USAGE,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -79,7 +79,7 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
         // Field().Name("xxx")
         if (!builderMethodInvocation.ArgumentList.Arguments.Any())
         {
-            ReportNameDiagnostic(context, nameMemberAccessExpression, DefineTheNameInFieldMethod, builderName, builderName);
+            ReportNameDiagnostic(context, nameMemberAccessExpression, DefineTheNameInFieldMethod, builderName);
             return;
         }
 
@@ -87,7 +87,7 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
         var fieldName = builderMethodInvocation.GetMethodArgument(Constants.ArgumentNames.Name, context.SemanticModel);
         if (fieldName == null)
         {
-            ReportNameDiagnostic(context, nameMemberAccessExpression, DefineTheNameInFieldMethod, builderName, builderName);
+            ReportNameDiagnostic(context, nameMemberAccessExpression, DefineTheNameInFieldMethod, builderName);
             return;
         }
 
@@ -96,12 +96,12 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
         if (fieldName.Expression.IsEquivalentTo(nameName.Expression))
         {
             // Field("xxx").Name("xxx")
-            ReportNameDiagnostic(context, nameMemberAccessExpression, NameMethodInvocationCanBeRemoved, builderName, builderName);
+            ReportNameDiagnostic(context, nameMemberAccessExpression, NameMethodInvocationCanBeRemoved, builderName);
         }
         else
         {
             // Field("xxx").Name("yyy")
-            ReportNameDiagnostic(context, nameMemberAccessExpression, DifferentNamesDefinedByFieldAndNameMethods, builderName, builderName, builderName);
+            ReportNameDiagnostic(context, nameMemberAccessExpression, DifferentNamesDefinedByFieldAndNameMethods, builderName);
         }
     }
 
@@ -140,8 +140,7 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
         SyntaxNodeAnalysisContext context,
         MemberAccessExpressionSyntax nameMemberAccessExpression,
         DiagnosticDescriptor diagnosticDescriptor,
-        string builderMethodName,
-        params object[] messageArgs)
+        string builderMethodName)
     {
         var props = new Dictionary<string, string?>
         {
@@ -153,7 +152,7 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
             diagnosticDescriptor,
             location,
             props,
-            messageArgs);
+            messageArgs: builderMethodName);
         context.ReportDiagnostic(diagnostic);
     }
 }

--- a/src/GraphQL.Analyzers/FieldNameAnalyzer.cs
+++ b/src/GraphQL.Analyzers/FieldNameAnalyzer.cs
@@ -13,8 +13,8 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
     // Fixed:     Field<T>("xxx")        or Field<T>("xxx", x => x.Prop)
     public static readonly DiagnosticDescriptor DefineTheNameInFieldMethod = new(
         id: DiagnosticIds.DEFINE_THE_NAME_IN_FIELD_METHOD,
-        title: "Define the name in 'Field' method",
-        messageFormat: "Field name should be provided via 'Field' method",
+        title: "Define the name in 'Field', 'Connection' or 'ConnectionBuilder.Create' method",
+        messageFormat: "The name should be provided via '{0}' method",
         category: DiagnosticCategories.USAGE,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -25,7 +25,7 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor NameMethodInvocationCanBeRemoved = new(
         id: DiagnosticIds.NAME_METHOD_INVOCATION_CAN_BE_REMOVED,
         title: "'Name' method invocation can be removed",
-        messageFormat: "Field name should be provided via 'Field' method. 'Name' method invocation can be removed.",
+        messageFormat: "The name should be provided via '{0}' method. 'Name' method invocation can be removed.",
         category: DiagnosticCategories.USAGE,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -35,8 +35,8 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
     // Fixed:     Field<T>("xxx") or Field<T>("yyy")
     public static readonly DiagnosticDescriptor DifferentNamesDefinedByFieldAndNameMethods = new(
         id: DiagnosticIds.DIFFERENT_NAMES_DEFINED_BY_FIELD_AND_NAME_METHODS,
-        title: "Different names defined by 'Field' and 'Name' methods",
-        messageFormat: "Field name should be provided via 'Field' method. Different names defined by 'Field' and 'Name' methods.",
+        title: "Different names defined by 'Field', 'Connection' or 'ConnectionBuilder.Create' and 'Name' methods",
+        messageFormat: "The name should be provided via '{0}' method. Different names defined by '{1}' and 'Name' methods.",
         category: DiagnosticCategories.USAGE,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -68,24 +68,26 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var fieldInvocation = nameMemberAccessExpression.FindFieldInvocationExpression();
-        if (fieldInvocation == null)
+        if (!TryGetBuilderInvocation(
+                nameMemberAccessExpression,
+                out string? builderName,
+                out var builderMethodInvocation))
         {
             return;
         }
 
         // Field().Name("xxx")
-        if (!fieldInvocation.ArgumentList.Arguments.Any())
+        if (!builderMethodInvocation.ArgumentList.Arguments.Any())
         {
-            ReportNameDiagnostic(context, nameMemberAccessExpression, DefineTheNameInFieldMethod);
+            ReportNameDiagnostic(context, nameMemberAccessExpression, DefineTheNameInFieldMethod, builderName, builderName);
             return;
         }
 
         // Field(x => x.CompanyName).Name("xxx")
-        var fieldName = fieldInvocation.GetMethodArgument(Constants.ArgumentNames.Name, context.SemanticModel);
+        var fieldName = builderMethodInvocation.GetMethodArgument(Constants.ArgumentNames.Name, context.SemanticModel);
         if (fieldName == null)
         {
-            ReportNameDiagnostic(context, nameMemberAccessExpression, DefineTheNameInFieldMethod);
+            ReportNameDiagnostic(context, nameMemberAccessExpression, DefineTheNameInFieldMethod, builderName, builderName);
             return;
         }
 
@@ -94,24 +96,64 @@ public class FieldNameAnalyzer : DiagnosticAnalyzer
         if (fieldName.Expression.IsEquivalentTo(nameName.Expression))
         {
             // Field("xxx").Name("xxx")
-            ReportNameDiagnostic(context, nameMemberAccessExpression, NameMethodInvocationCanBeRemoved);
+            ReportNameDiagnostic(context, nameMemberAccessExpression, NameMethodInvocationCanBeRemoved, builderName, builderName);
         }
         else
         {
             // Field("xxx").Name("yyy")
-            ReportNameDiagnostic(context, nameMemberAccessExpression, DifferentNamesDefinedByFieldAndNameMethods);
+            ReportNameDiagnostic(context, nameMemberAccessExpression, DifferentNamesDefinedByFieldAndNameMethods, builderName, builderName, builderName);
         }
     }
 
-    private void ReportNameDiagnostic(
+    private static bool TryGetBuilderInvocation(
+        MemberAccessExpressionSyntax nameMemberAccessExpression,
+        [NotNullWhen(true)] out string? builderName,
+        [NotNullWhen(true)] out InvocationExpressionSyntax? builderMethodInvocation)
+    {
+        builderName = Constants.MethodNames.Field;
+        builderMethodInvocation = nameMemberAccessExpression.FindMethodInvocationExpression(builderName);
+        if (builderMethodInvocation != null)
+        {
+            return true;
+        }
+
+        builderName = Constants.MethodNames.Connection;
+        builderMethodInvocation = nameMemberAccessExpression.FindMethodInvocationExpression(builderName);
+        if (builderMethodInvocation != null)
+        {
+            return true;
+        }
+
+        builderName = Constants.MethodNames.Create;
+        builderMethodInvocation = nameMemberAccessExpression.FindMethodInvocationExpression(builderName);
+        if (builderMethodInvocation != null)
+        {
+            return true;
+        }
+
+        builderName = null;
+        builderMethodInvocation = null;
+        return false;
+    }
+
+    private static void ReportNameDiagnostic(
         SyntaxNodeAnalysisContext context,
         MemberAccessExpressionSyntax nameMemberAccessExpression,
-        DiagnosticDescriptor diagnosticDescriptor)
+        DiagnosticDescriptor diagnosticDescriptor,
+        string builderMethodName,
+        params object[] messageArgs)
     {
+        var props = new Dictionary<string, string?>
+        {
+            [Constants.Properties.BuilderMethodName] = builderMethodName
+        }.ToImmutableDictionary();
+
         var location = nameMemberAccessExpression.GetMethodInvocationLocation();
         var diagnostic = Diagnostic.Create(
             diagnosticDescriptor,
-            location);
+            location,
+            props,
+            messageArgs);
         context.ReportDiagnostic(diagnostic);
     }
 }

--- a/src/GraphQL.Analyzers/ResolverAnalyzer.cs
+++ b/src/GraphQL.Analyzers/ResolverAnalyzer.cs
@@ -62,7 +62,7 @@ public class ResolverAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var fieldInvocationExpression = resolveMemberAccessExpression.FindFieldInvocationExpression();
+        var fieldInvocationExpression = resolveMemberAccessExpression.FindMethodInvocationExpression(Constants.MethodNames.Field);
 
         // without Field() invocation we know nothing about the source type
         // where FieldBuilder was created


### PR DESCRIPTION
The `FieldNameAnalyzer` was extended to support `ConnectionBuilder.Name` in addition to `FieldBuilder.Name`.
The `ComplexGraphType.Connection` and `ConnectionBuilder<TSourceType>.Create` methods were tested on all the use cases the `ComplexGraphType.Field` was tested. The `ConnectionBuilder.Create` (non-generic builder class) has a single test but it should work the same way the `ConnectionBuilder<TSourceType>.Create` works.