### PR TITLE
ConnectionBuilder.Resolve* return builder instance

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.MicrosoftDI.approved.txt
@@ -3,8 +3,8 @@ namespace GraphQL.MicrosoftDI
     public class ConnectionResolverBuilder<TSourceType, TReturnType>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1> WithService<T1>() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithServices<T1, T2>() { }
@@ -15,40 +15,40 @@ namespace GraphQL.MicrosoftDI
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithService<T2>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3> WithService<T3>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4> WithService<T4>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5> WithService<T5>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5> WithScope() { }
     }
     public class GraphQLBuilder : GraphQL.DI.GraphQLBuilderBase, GraphQL.DI.IServiceRegister, Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Collections.Generic.ICollection<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IEnumerable<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IList<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.IEnumerable
@@ -121,10 +121,10 @@ namespace GraphQL.MicrosoftDI
     {
         public static GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, object> Resolve<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder) { }
         public static GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType> Resolve<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder) { }
-        public static void ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public static void ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public static void ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
-        public static void ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
     }
     public static class ScopedFieldBuilderExtensions
     {

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -863,8 +863,8 @@ namespace GraphQL.Builders
             "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> PageSize(int pageSize) { }
-        public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
-        public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
@@ -910,8 +910,8 @@ namespace GraphQL.Builders
             "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
-        public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType>(string name = "default")
             where TNodeType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -863,8 +863,8 @@ namespace GraphQL.Builders
             "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> PageSize(int pageSize) { }
-        public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
-        public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
@@ -910,8 +910,8 @@ namespace GraphQL.Builders
             "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
-        public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType>(string name = "default")
             where TNodeType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -845,8 +845,8 @@ namespace GraphQL.Builders
             "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> PageSize(int pageSize) { }
-        public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
-        public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, object?> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
@@ -892,8 +892,8 @@ namespace GraphQL.Builders
             "\'Connection\' method.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
-        public virtual void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public virtual void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType>(string name = "default")
             where TNodeType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/netstandard20/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20/GraphQL.MicrosoftDI.approved.txt
@@ -3,8 +3,8 @@ namespace GraphQL.MicrosoftDI
     public class ConnectionResolverBuilder<TSourceType, TReturnType>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1> WithService<T1>() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithServices<T1, T2>() { }
@@ -15,40 +15,40 @@ namespace GraphQL.MicrosoftDI
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithService<T2>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3> WithService<T3>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4> WithService<T4>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4> WithScope() { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5> WithService<T5>() { }
     }
     public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5>
     {
         public ConnectionResolverBuilder(GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped) { }
-        public void Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType?> resolver) { }
-        public void ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType?> resolver) { }
+        public GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5> WithScope() { }
     }
     public class GraphQLBuilder : GraphQL.DI.GraphQLBuilderBase, GraphQL.DI.IServiceRegister, Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Collections.Generic.ICollection<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IEnumerable<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IList<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.IEnumerable
@@ -121,10 +121,10 @@ namespace GraphQL.MicrosoftDI
     {
         public static GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, object> Resolve<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder) { }
         public static GraphQL.MicrosoftDI.ConnectionResolverBuilder<TSourceType, TReturnType> Resolve<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder) { }
-        public static void ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public static void ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
-        public static void ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
-        public static void ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveScoped<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> ResolveScopedAsync<TSourceType, TReturnType>(this GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> builder, System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
     }
     public static class ScopedFieldBuilderExtensions
     {

--- a/src/GraphQL.MicrosoftDI/ConnectionResolverBuilder.cs
+++ b/src/GraphQL.MicrosoftDI/ConnectionResolverBuilder.cs
@@ -1,7 +1,6 @@
 #pragma warning disable IDE0039 // Use local function
 
 using GraphQL.Builders;
-using GraphQL.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.MicrosoftDI;
@@ -59,21 +58,15 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType>
     /// <summary>
     /// Specifies the delegate to execute when the field is being resolved.
     /// </summary>
-    public void Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
     {
-        if (_scoped)
-            _builder.ResolveScoped(resolver);
-        else
-            _builder.Resolve(resolver);
+        return _scoped ? _builder.ResolveScoped(resolver) : _builder.Resolve(resolver);
     }
 
     /// <inheritdoc cref="Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-    public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
     {
-        if (_scoped)
-            _builder.ResolveScopedAsync(resolver);
-        else
-            _builder.ResolveAsync(resolver);
+        return _scoped ? _builder.ResolveScopedAsync(resolver) : _builder.ResolveAsync(resolver);
     }
 }
 
@@ -85,7 +78,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1>
     private readonly ConnectionBuilder<TSourceType, TReturnType> _builder;
     private bool _scoped;
 
-    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ConnectionResolverBuilder(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
+    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
     public ConnectionResolverBuilder(ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped)
     {
         _builder = builder;
@@ -104,31 +97,25 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1>
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-    public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, TReturnType?> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, TReturnType?> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver2 =
             context => resolver(
                 context,
                 context.RequestServices.GetRequiredService<T1>());
 
-        if (_scoped)
-            _builder.ResolveScoped(resolver2);
-        else
-            _builder.Resolve(resolver2);
+        return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-    public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, Task<TReturnType?>> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, Task<TReturnType?>> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver2 =
             context => resolver(
                 context,
                 context.RequestServices.GetRequiredService<T1>());
 
-        if (_scoped)
-            _builder.ResolveScopedAsync(resolver2);
-        else
-            _builder.ResolveAsync(resolver2);
+        return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 }
 
@@ -140,7 +127,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2>
     private readonly ConnectionBuilder<TSourceType, TReturnType> _builder;
     private bool _scoped;
 
-    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ConnectionResolverBuilder(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
+    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
     public ConnectionResolverBuilder(ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped)
     {
         _builder = builder;
@@ -159,7 +146,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2>
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-    public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, TReturnType?> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, TReturnType?> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver2 =
             context => resolver(
@@ -167,14 +154,11 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2>
                 context.RequestServices.GetRequiredService<T1>(),
                 context.RequestServices.GetRequiredService<T2>());
 
-        if (_scoped)
-            _builder.ResolveScoped(resolver2);
-        else
-            _builder.Resolve(resolver2);
+        return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-    public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, Task<TReturnType?>> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, Task<TReturnType?>> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver2 =
             context => resolver(
@@ -182,10 +166,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2>
                 context.RequestServices.GetRequiredService<T1>(),
                 context.RequestServices.GetRequiredService<T2>());
 
-        if (_scoped)
-            _builder.ResolveScopedAsync(resolver2);
-        else
-            _builder.ResolveAsync(resolver2);
+        return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 }
 
@@ -197,7 +178,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
     private readonly ConnectionBuilder<TSourceType, TReturnType> _builder;
     private bool _scoped;
 
-    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ConnectionResolverBuilder(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
+    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
     public ConnectionResolverBuilder(ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped)
     {
         _builder = builder;
@@ -216,7 +197,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-    public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType?> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, TReturnType?> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver2 =
             context => resolver(
@@ -225,14 +206,11 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
                 context.RequestServices.GetRequiredService<T2>(),
                 context.RequestServices.GetRequiredService<T3>());
 
-        if (_scoped)
-            _builder.ResolveScoped(resolver2);
-        else
-            _builder.Resolve(resolver2);
+        return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-    public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, Task<TReturnType?>> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, Task<TReturnType?>> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver2 =
             context => resolver(
@@ -241,10 +219,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
                 context.RequestServices.GetRequiredService<T2>(),
                 context.RequestServices.GetRequiredService<T3>());
 
-        if (_scoped)
-            _builder.ResolveScopedAsync(resolver2);
-        else
-            _builder.ResolveAsync(resolver2);
+        return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 }
 
@@ -256,7 +231,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
     private readonly ConnectionBuilder<TSourceType, TReturnType> _builder;
     private bool _scoped;
 
-    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ConnectionResolverBuilder(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
+    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
     public ConnectionResolverBuilder(ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped)
     {
         _builder = builder;
@@ -275,7 +250,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-    public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType?> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, TReturnType?> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver2 =
             context => resolver(
@@ -285,14 +260,11 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
                 context.RequestServices.GetRequiredService<T3>(),
                 context.RequestServices.GetRequiredService<T4>());
 
-        if (_scoped)
-            _builder.ResolveScoped(resolver2);
-        else
-            _builder.Resolve(resolver2);
+        return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-    public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, Task<TReturnType?>> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, Task<TReturnType?>> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver2 =
             context => resolver(
@@ -302,10 +274,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
                 context.RequestServices.GetRequiredService<T3>(),
                 context.RequestServices.GetRequiredService<T4>());
 
-        if (_scoped)
-            _builder.ResolveScopedAsync(resolver2);
-        else
-            _builder.ResolveAsync(resolver2);
+        return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 }
 
@@ -317,7 +286,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4,
     private readonly ConnectionBuilder<TSourceType, TReturnType> _builder;
     private bool _scoped;
 
-    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ConnectionResolverBuilder(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
+    /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}(ConnectionBuilder{TSourceType, TReturnType}, bool)"/>
     public ConnectionResolverBuilder(ConnectionBuilder<TSourceType, TReturnType> builder, bool scoped)
     {
         _builder = builder;
@@ -332,7 +301,7 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4,
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-    public void Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType?> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, TReturnType?> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver2 =
             context => resolver(
@@ -343,14 +312,11 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4,
                 context.RequestServices.GetRequiredService<T4>(),
                 context.RequestServices.GetRequiredService<T5>());
 
-        if (_scoped)
-            _builder.ResolveScoped(resolver2);
-        else
-            _builder.Resolve(resolver2);
+        return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
     /// <inheritdoc cref="ConnectionResolverBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-    public void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, Task<TReturnType?>> resolver)
+    public ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, T1, T2, T3, T4, T5, Task<TReturnType?>> resolver)
     {
         Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver2 =
             context => resolver(
@@ -361,9 +327,6 @@ public class ConnectionResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4,
                 context.RequestServices.GetRequiredService<T4>(),
                 context.RequestServices.GetRequiredService<T5>());
 
-        if (_scoped)
-            _builder.ResolveScopedAsync(resolver2);
-        else
-            _builder.ResolveAsync(resolver2);
+        return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 }

--- a/src/GraphQL.MicrosoftDI/ScopedConnectionBuilderExtensions.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedConnectionBuilderExtensions.cs
@@ -14,11 +14,11 @@ public static class ScopedConnectionBuilderExtensions
     /// <see cref="ConnectionBuilder{TSourceType, TReturnType}.PageSize(int?)">PageSize</see> and/or
     /// <see cref="ConnectionBuilder{TSourceType, TReturnType}.Bidirectional">Bidirectional</see> have been called.
     /// </summary>
-    public static void ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
+    public static ConnectionBuilder<TSourceType> ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
     {
         if (resolver == null)
             throw new ArgumentNullException(nameof(resolver));
-        builder.Resolve(context =>
+        return builder.Resolve(context =>
         {
             using var scope = context.RequestServicesOrThrow().CreateScope();
             return resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider));
@@ -26,11 +26,11 @@ public static class ScopedConnectionBuilderExtensions
     }
 
     /// <inheritdoc cref="ResolveScoped{TSourceType, TReturnType}(ConnectionBuilder{TSourceType}, Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-    public static void ResolveScopedAsync<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
+    public static ConnectionBuilder<TSourceType> ResolveScopedAsync<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType> builder, Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
     {
         if (resolver == null)
             throw new ArgumentNullException(nameof(resolver));
-        builder.ResolveAsync(async context =>
+        return builder.ResolveAsync(async context =>
         {
             using var scope = context.RequestServicesOrThrow().CreateScope();
             return await resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider)).ConfigureAwait(false);
@@ -46,11 +46,11 @@ public static class ScopedConnectionBuilderExtensions
         => new(builder.Returns<object>(), false);
 
     /// <inheritdoc cref="ResolveScoped{TSourceType, TReturnType}(ConnectionBuilder{TSourceType}, Func{IResolveConnectionContext{TSourceType}, TReturnType})"/>
-    public static void ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType, TReturnType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
+    public static ConnectionBuilder<TSourceType, TReturnType> ResolveScoped<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType, TReturnType> builder, Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
     {
         if (resolver == null)
             throw new ArgumentNullException(nameof(resolver));
-        builder.Resolve(context =>
+        return builder.Resolve(context =>
         {
             using var scope = context.RequestServicesOrThrow().CreateScope();
             return resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider));
@@ -58,11 +58,11 @@ public static class ScopedConnectionBuilderExtensions
     }
 
     /// <inheritdoc cref="ResolveScopedAsync{TSourceType, TReturnType}(ConnectionBuilder{TSourceType}, Func{IResolveConnectionContext{TSourceType}, Task{TReturnType}})"/>
-    public static void ResolveScopedAsync<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType, TReturnType> builder, Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
+    public static ConnectionBuilder<TSourceType, TReturnType> ResolveScopedAsync<TSourceType, TReturnType>(this ConnectionBuilder<TSourceType, TReturnType> builder, Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
     {
         if (resolver == null)
             throw new ArgumentNullException(nameof(resolver));
-        builder.ResolveAsync(async context =>
+        return builder.ResolveAsync(async context =>
         {
             using var scope = context.RequestServicesOrThrow().CreateScope();
             return await resolver(new ScopedResolveConnectionContextAdapter<TSourceType>(context, scope.ServiceProvider)).ConfigureAwait(false);

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -405,7 +405,7 @@ namespace GraphQL.Builders
         /// <summary>
         /// Sets the resolver method for the connection field.
         /// </summary>
-        public virtual void Resolve(Func<IResolveConnectionContext<TSourceType>, object?> resolver)
+        public virtual ConnectionBuilder<TSourceType> Resolve(Func<IResolveConnectionContext<TSourceType>, object?> resolver)
         {
             var isUnidirectional = !IsBidirectional;
             var pageSize = PageSizeFromMetadata;
@@ -415,12 +415,14 @@ namespace GraphQL.Builders
                 CheckForErrors(connectionContext);
                 return resolver(connectionContext);
             });
+
+            return this;
         }
 
         /// <summary>
         /// Sets the resolver method for the connection field.
         /// </summary>
-        public virtual void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<object?>> resolver)
+        public virtual ConnectionBuilder<TSourceType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<object?>> resolver)
         {
             var isUnidirectional = !IsBidirectional;
             var pageSize = PageSizeFromMetadata;
@@ -430,6 +432,8 @@ namespace GraphQL.Builders
                 CheckForErrors(connectionContext);
                 return new ValueTask<object?>(resolver(connectionContext));
             });
+
+            return this;
         }
 
         private static void CheckForErrors(IResolveConnectionContext<TSourceType> context)

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -237,7 +237,7 @@ namespace GraphQL.Builders
         /// Sets the resolver method for the connection field. This method must be called after
         /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
         /// </summary>
-        public virtual void Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
+        public virtual ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
         {
             var isUnidirectional = !IsBidirectional;
             var pageSize = PageSizeFromMetadata;
@@ -247,13 +247,15 @@ namespace GraphQL.Builders
                 CheckForErrors(connectionContext);
                 return resolver(connectionContext);
             });
+
+            return this;
         }
 
         /// <summary>
         /// Sets the resolver method for the connection field. This method must be called after
         /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
         /// </summary>
-        public virtual void ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
+        public virtual ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
         {
             var isUnidirectional = !IsBidirectional;
             var pageSize = PageSizeFromMetadata;
@@ -263,6 +265,8 @@ namespace GraphQL.Builders
                 CheckForErrors(connectionContext);
                 return new ValueTask<TReturnType?>(resolver(connectionContext));
             });
+
+            return this;
         }
 
         private static void CheckForErrors(IResolveConnectionContext<TSourceType> context)


### PR DESCRIPTION
As discussed [here](https://github.com/graphql-dotnet/graphql-dotnet/pull/3747#discussion_r1367714889) made `ConnectionBuilder` and `FieldBuilder` api more consistent