### PR TITLE
Analyzers/awaitable resolver analyzer

### DIFF
--- a/docs2/site/docs/analyzers/GQL009_UseAsyncResolver.md
+++ b/docs2/site/docs/analyzers/GQL009_UseAsyncResolver.md
@@ -1,0 +1,139 @@
+# GQL009: Use async resolver
+
+|                        | Value  |
+| ---------------------- | ------ |
+| **Rule ID**            | GQL009 |
+| **Category**           | Usage  |
+| **Default severity**   | Error  |
+| **Enabled by default** | Yes    |
+| **Code fix provided**  | Yes    |
+
+## Cause
+
+This rule triggers when the sync version of the `Resolve` or
+`ResolveScoped` methods is used with awaitable delegate.
+
+## Rule description
+
+`ResolveAsync` and `ResolveScopedAsync` methods should be used to
+register awaitable delegates. The most common awaitable types are
+`System.Threading.Tasks.Task` and `System.Threading.Tasks.ValueTask`,
+but any type that defines a valid `GetAwaiter()` method, which
+returns a valid awaiter with a `GetResult()` method is considered
+awaitable and is detected by the analyzer.  
+The rule is useful when `FieldBuilder` is defined without return type
+argument or the return type argument is defined as `object` or
+`dynamic` and compiler allows returning `Task<T>` and other
+awaitables from the delegate.
+
+## How to fix violations
+
+Replace the sync `Resolve` or `ResolveScoped` method with matching
+async version and await the delegate when needed.
+
+## Example of a violation
+
+```c#
+public class MyGraphType : ObjectGraphType<Person>
+{
+    public MyGraphType()
+    {
+        // 1. no return type defined
+        Field<StringGraphType>("Title")
+            .Resolve(ctx => Task.FromResult("developer"));
+
+        // 2. the method returns ValueTask<T>
+        Field<StringGraphType>("Title")
+            .Resolve(ctx => GetTitleAsync());
+
+        // 3. method group, return type defined in Field method
+        Field<StringGraphType, object>("Title")
+            .Resolve(ResolveTitleAsync);
+
+        // 4. field builder created with awaitable return type
+        Field<StringGraphType, Task<string>>("Title")
+            .ResolveScoped(ctx => Task.FromResult("developer"));
+
+        // 5. the method returns ValueTask<T>
+        Field<StringGraphType>("Title")
+            .ResolveScoped(ctx => GetTitleAsync());
+
+        // 6. object or dynamic is used as return type in Returns method
+        Field<StringGraphType>("Title").Returns<dynamic>()
+            .ResolveScoped(ctx => ResolveTitleAsync(ctx));
+    }
+
+    private ValueTask<string> GetTitleAsync() => ValueTask.FromResult("developer");
+
+    private Task<string> ResolveTitleAsync(IResolveFieldContext<Person> ctx) =>
+        Task.FromResult("developer");
+}
+```
+
+## Example of how to fix
+
+```c#
+public class MyGraphType : ObjectGraphType<Person>
+{
+    public MyGraphType()
+    {
+        // 1. no return type defined
+        //    await the delegate
+        Field<StringGraphType>("Title")
+            .ResolveAsync(async ctx => await Task.FromResult("developer"));
+
+        // 2. the method returns ValueTask<T>
+        //    await the delegate
+        Field<StringGraphType>("Title")
+            .ResolveAsync(async ctx => await GetTitleAsync());
+
+        // 3. method group, return type defined in Field method
+        //    await the delegate
+        Field<StringGraphType, object>("Title")
+            .ResolveAsync(async ctx => await ResolveTitleAsync(ctx));
+
+        // 4. field builder created with awaitable return type
+        //    unwrap the return type
+        Field<StringGraphType, string>("Title")
+            .ResolveScopedAsync(ctx => Task.FromResult("developer"));
+
+        // 5. the method returns ValueTask<T>
+        //    await the delegate and defined the return type
+        Field<StringGraphType, string>("Title")
+            .ResolveScopedAsync(async ctx => await GetTitleAsync());
+
+        // 6. object or dynamic is used as return type in Returns method
+        //    await the delegate and define the source type and return type
+        //    on the ResolveScopedAsync method
+        Field<StringGraphType>("Title").Returns<dynamic>()
+            .ResolveScopedAsync<Person, dynamic>(async ctx =>
+                await ResolveTitleAsync(ctx));
+    }
+
+    private ValueTask<string> GetTitleAsync() => ValueTask.FromResult("developer");
+
+    private Task<string> ResolveTitleAsync(IResolveFieldContext<Person> ctx) =>
+        Task.FromResult("developer");
+}
+```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable GQL009
+// The code that's violating the rule is on this line.
+#pragma warning restore GQL009
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.cs]
+dotnet_diagnostic.GQL009.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).
+
+## Related rules

--- a/docs2/site/docs/analyzers/Overview.md
+++ b/docs2/site/docs/analyzers/Overview.md
@@ -54,6 +54,12 @@ The analyzer detects input graph type fields that can't be mapped to the source 
 
 The analyzer detects an obsolete `Argument` method usage and offers a code fix to automatically replace it with with another `Argument` overload.
 
+### 6. AwaitableResolverAnalyzer
+
+The analyzer detects awaitable resolver delegates used in sync `Resolve` or
+`ResolveScoped` methods and provides a code fix to replace them with an
+appropriate async version.
+
 ## Configuration in .editorconfig
 
 Certain analyzers and code fixes offer configuration options that control when the rule is applied and how the automatic code fix executes code adjustments. Refer to the specific documentation page for each analyzer to understand the available configuration options and their application methods.

--- a/src/GraphQL.Analyzers.CodeFixes/AwaitableResolverCodeFixProvider.cs
+++ b/src/GraphQL.Analyzers.CodeFixes/AwaitableResolverCodeFixProvider.cs
@@ -36,7 +36,7 @@ public class AwaitableResolverCodeFixProvider : CodeFixProvider
                 continue;
             }
 
-            const string codeFixTitle = "Rewrite obsolete 'Argument' method";
+            const string codeFixTitle = "Replace with async method";
 
             context.RegisterCodeFix(
                 CodeAction.Create(
@@ -100,7 +100,7 @@ public class AwaitableResolverCodeFixProvider : CodeFixProvider
                 docEditor.ReplaceNode(lambda, newLambda);
                 break;
             }
-            // Resolve(MethodGroup)
+            // ResolveAsync(MethodGroup)
             case IdentifierNameSyntax methodGroupName:
             {
                 // Resolve(async context => await MethodGroup(context))
@@ -127,6 +127,7 @@ public class AwaitableResolverCodeFixProvider : CodeFixProvider
                 return document;
         }
 
+        // Resolve(...) => ResolveAsync(...)
         var newResolverNameSyntax = IdentifierName(resolverNameSyntax.Identifier.Text + ASYNC_SUFFIX);
         docEditor.ReplaceNode(resolverNameSyntax, newResolverNameSyntax);
 
@@ -149,7 +150,6 @@ public class AwaitableResolverCodeFixProvider : CodeFixProvider
         if (returnType.IsAwaitableNonDynamic(semanticModel!, root!.SpanStart))
         {
             // Field<T, Task<K>> or .Return<Task<K>>
-            // currently not supported
             return false;
         }
 
@@ -181,7 +181,7 @@ public class AwaitableResolverCodeFixProvider : CodeFixProvider
                 : returnStatement.WithExpression(
                     AwaitExpression(
                         Token(SyntaxKind.AwaitKeyword).WithTrailingTrivia(Space),
-                        returnStatement.Expression!));
+                        returnStatement.Expression));
         }
     }
 }

--- a/src/GraphQL.Analyzers.CodeFixes/AwaitableResolverCodeFixProvider.cs
+++ b/src/GraphQL.Analyzers.CodeFixes/AwaitableResolverCodeFixProvider.cs
@@ -1,0 +1,187 @@
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis;
+using System.Composition;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace GraphQL.Analyzers;
+
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AwaitableResolverCodeFixProvider))]
+public class AwaitableResolverCodeFixProvider : CodeFixProvider
+{
+    public const string ASYNC_SUFFIX = "Async";
+    public const string CONTEXT_PARAMETER_NAME = "context";
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ImmutableArray.Create(AwaitableResolverAnalyzer.UseAsyncResolver.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var resolverNameSyntax = (SimpleNameSyntax)root!.FindNode(diagnosticSpan);
+
+            if (!await IsCodeFixSupportedAsync(context, resolverNameSyntax).ConfigureAwait(false))
+            {
+                continue;
+            }
+
+            const string codeFixTitle = "Rewrite obsolete 'Argument' method";
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: codeFixTitle,
+                    createChangedDocument: ct =>
+                        RewriteResolverMethodAsync(context.Document, resolverNameSyntax, ct),
+                    equivalenceKey: codeFixTitle),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> RewriteResolverMethodAsync(
+        Document document,
+        SimpleNameSyntax resolverNameSyntax,
+        CancellationToken cancellationToken)
+    {
+        var docEditor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var resolveInvocation = resolverNameSyntax.FindMethodInvocationExpression();
+        var resolver = resolveInvocation?.ArgumentList.Arguments.FirstOrDefault();
+        if (resolver == null)
+        {
+            return document;
+        }
+
+        switch (resolver.Expression)
+        {
+            // Resolve(ctx => AsyncMethod() or statement)
+            case SimpleLambdaExpressionSyntax { ExpressionBody: not null } lambda:
+            {
+                // Resolve(async ctx => await AsyncMethod() or statement)
+                var newLambda = lambda
+                    .WithAsyncKeyword(
+                        Token(SyntaxKind.AsyncKeyword).WithLeadingTrivia(Space))
+                    .WithExpressionBody(
+                        AwaitExpression(
+                            Token(SyntaxKind.AwaitKeyword).WithTrailingTrivia(Space),
+                            lambda.ExpressionBody));
+
+                docEditor.ReplaceNode(lambda, newLambda);
+
+                break;
+            }
+            // Resolve(ctx =>
+            // {
+            //     return AsyncMethod() or statement
+            // })
+            case SimpleLambdaExpressionSyntax { Block: not null } lambda:
+            {
+                var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+                var rewriter = new AwaitableStatementRewriter(semanticModel!, root!);
+                var newBlock = (BlockSyntax)rewriter.Visit(lambda.Block);
+
+                var newLambda = lambda
+                    .WithAsyncKeyword(
+                        Token(SyntaxKind.AsyncKeyword).WithLeadingTrivia(Space))
+                    .WithBlock(newBlock);
+
+                docEditor.ReplaceNode(lambda, newLambda);
+                break;
+            }
+            // Resolve(MethodGroup)
+            case IdentifierNameSyntax methodGroupName:
+            {
+                // Resolve(async context => await MethodGroup(context))
+                var newLambda = SyntaxFactory
+                    .SimpleLambdaExpression(
+                        Parameter(Identifier(CONTEXT_PARAMETER_NAME)))
+                    .WithAsyncKeyword(
+                        Token(SyntaxKind.AsyncKeyword).WithTrailingTrivia(Space))
+                    .WithExpressionBody(
+                        AwaitExpression(
+                                Token(SyntaxKind.AwaitKeyword).WithTrailingTrivia(Space),
+                                InvocationExpression(
+                                        IdentifierName(methodGroupName.Identifier))
+                                    .WithArgumentList(
+                                        ArgumentList(
+                                            SingletonSeparatedList(
+                                                Argument(
+                                                    IdentifierName(CONTEXT_PARAMETER_NAME)))))));
+
+                docEditor.ReplaceNode(methodGroupName, newLambda);
+                break;
+            }
+            default:
+                return document;
+        }
+
+        var newResolverNameSyntax = IdentifierName(resolverNameSyntax.Identifier.Text + ASYNC_SUFFIX);
+        docEditor.ReplaceNode(resolverNameSyntax, newResolverNameSyntax);
+
+        return docEditor.GetChangedDocument();
+    }
+
+    private static async Task<bool> IsCodeFixSupportedAsync(
+        CodeFixContext context,
+        SimpleNameSyntax resolverNameSyntax)
+    {
+        if (resolverNameSyntax.Identifier.Text == Constants.MethodNames.ResolveScoped)
+        {
+            // currently not supported
+            return false;
+        }
+
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        var returnType = resolverNameSyntax.GetFieldBuilderReturnTypeSymbol(semanticModel!);
+        if (returnType.IsAwaitableNonDynamic(semanticModel!, root!.SpanStart))
+        {
+            // Field<T, Task<K>> or .Return<Task<K>>
+            // currently not supported
+            return false;
+        }
+
+        return true;
+    }
+
+    private class AwaitableStatementRewriter : CSharpSyntaxRewriter
+    {
+        private readonly SemanticModel _semanticModel;
+        private readonly SyntaxNode _rootNode;
+
+        public AwaitableStatementRewriter(SemanticModel semanticModel, SyntaxNode rootNode)
+        {
+            _semanticModel = semanticModel;
+            _rootNode = rootNode;
+        }
+
+        public override SyntaxNode VisitReturnStatement(ReturnStatementSyntax returnStatement)
+        {
+            if (returnStatement.Expression == null)
+            {
+                return returnStatement;
+            }
+
+            var symbolInfo = _semanticModel.GetSymbolInfo(returnStatement.Expression);
+
+            return !symbolInfo.Symbol.IsAwaitableNonDynamic(_semanticModel, _rootNode.SpanStart)
+                ? returnStatement
+                : returnStatement.WithExpression(
+                    AwaitExpression(
+                        Token(SyntaxKind.AwaitKeyword).WithTrailingTrivia(Space),
+                        returnStatement.Expression!));
+        }
+    }
+}

--- a/src/GraphQL.Analyzers.CodeFixes/AwaitableResolverCodeFixProvider.cs
+++ b/src/GraphQL.Analyzers.CodeFixes/AwaitableResolverCodeFixProvider.cs
@@ -1,10 +1,10 @@
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis;
-using System.Composition;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Composition;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/GraphQL.Analyzers.CodeFixes/FieldArgumentCodeFixProvider.cs
+++ b/src/GraphQL.Analyzers.CodeFixes/FieldArgumentCodeFixProvider.cs
@@ -135,15 +135,14 @@ public class FieldArgumentCodeFixProvider : CodeFixProvider
 
         SimpleLambdaExpressionSyntax ConvertBodyConfigureLambdaToBlockLambda(SimpleLambdaExpressionSyntax lambda)
         {
-            var whitespace = Whitespace(" ");
             var block = SyntaxFactory
                 .Block(
                     ExpressionStatement(lambda.ExpressionBody!.WithoutTrailingTrivia())
-                        .WithLeadingTrivia(whitespace),
+                        .WithLeadingTrivia(Space),
                     ExpressionStatement(
                             CreateDefaultValuePropertyAssignment(lambda.Parameter.ToString(), defaultValueArg.Expression))
-                        .WithLeadingTrivia(whitespace)
-                        .WithTrailingTrivia(whitespace))
+                        .WithLeadingTrivia(Space)
+                        .WithTrailingTrivia(Space))
                 .WithLeadingTrivia(lambda.ExpressionBody!.GetLeadingTrivia());
 
             return SimpleLambdaExpression(lambda.Parameter, block)

--- a/src/GraphQL.Analyzers.Tests/AwaitableResolverAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/AwaitableResolverAnalyzerTests.cs
@@ -1,0 +1,294 @@
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = GraphQL.Analyzers.Tests.VerifiersExtensions.CSharpAnalyzerVerifier<
+    GraphQL.Analyzers.AwaitableResolverAnalyzer>;
+
+namespace GraphQL.Analyzers.Tests;
+
+public class AwaitableResolverAnalyzerTests
+{
+    private const string CUSTOM_AWAITABLE_SOURCE =
+        """
+        public class CustomAwaitable
+        {
+            public static CustomAwaitable<TResult> FromResult<TResult>(TResult result) => throw new NotImplementedException();
+        }
+
+        public class CustomAwaitable<TResult>
+        {
+            public static CustomAwaitable<TResult> FromResult(TResult result) => throw new NotImplementedException();
+            public CustomAwaiter<TResult> GetAwaiter() => throw new NotImplementedException();
+        }
+
+        public class CustomAwaiter<TResult> : System.Runtime.CompilerServices.INotifyCompletion
+        {
+            public void OnCompleted(Action continuation) => throw new NotImplementedException();
+            public bool IsCompleted => throw new NotImplementedException();
+            public TResult GetResult() => throw new NotImplementedException();
+        }
+        """;
+
+    [Fact]
+    public async Task Sanity_NoDiagnostics()
+    {
+        const string source = "";
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Theory]
+    [InlineData("ResolveAsync", "Task", "dynamic")]
+    [InlineData("ResolveAsync", "Task", "object")]
+    [InlineData("ResolveAsync", "Task", "System.Object")]
+    [InlineData("ResolveAsync", "Task", "string")]
+    [InlineData("ResolveAsync", "ValueTask", "dynamic")]
+    [InlineData("ResolveAsync", "ValueTask", "object")]
+    [InlineData("ResolveAsync", "ValueTask", "System.Object")]
+    [InlineData("ResolveAsync", "ValueTask", "string")]
+    [InlineData("ResolveAsync", "CustomAwaitable", "dynamic")]
+    [InlineData("ResolveAsync", "CustomAwaitable", "object")]
+    [InlineData("ResolveAsync", "CustomAwaitable", "System.Object")]
+    [InlineData("ResolveAsync", "CustomAwaitable", "string")]
+    [InlineData("ResolveScopedAsync<object, dynamic>", "Task", "dynamic")]
+    [InlineData("ResolveScopedAsync<object, object>", "Task", "object")]
+    [InlineData("ResolveScopedAsync<object, System.Object>", "Task", "System.Object")]
+    [InlineData("ResolveScopedAsync<object, string>", "Task", "string")]
+    [InlineData("ResolveScopedAsync<object, dynamic>", "ValueTask", "dynamic")]
+    [InlineData("ResolveScopedAsync<object, object>", "ValueTask", "object")]
+    [InlineData("ResolveScopedAsync<object, System.Object>", "ValueTask", "System.Object")]
+    [InlineData("ResolveScopedAsync<object, string>", "ValueTask", "string")]
+    [InlineData("ResolveScopedAsync<object, dynamic>", "CustomAwaitable", "dynamic")]
+    [InlineData("ResolveScopedAsync<object, object>", "CustomAwaitable", "object")]
+    [InlineData("ResolveScopedAsync<object, System.Object>", "CustomAwaitable", "System.Object")]
+    [InlineData("ResolveScopedAsync<object, string>", "CustomAwaitable", "string")]
+    public async Task AsyncResolve_NoDiagnostics(string resolveMethod, string awaitableType, string returnType)
+    {
+        string source =
+            $$"""
+              using System;
+              using System.Threading.Tasks;
+              using GraphQL.MicrosoftDI;
+              using GraphQL.Types;
+
+              namespace Sample.Server;
+
+              public class MyGraphType : ObjectGraphType
+              {
+                  public MyGraphType()
+                  {
+                      Field<StringGraphType, {{returnType}}>("Test")
+                          .{{resolveMethod}}(async ctx => await {{awaitableType}}.FromResult("text"));
+                  }
+              }
+
+              {{CUSTOM_AWAITABLE_SOURCE}}
+              """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Theory]
+    // Resolve - no return type
+    [InlineData("Resolve", "Field<StringGraphType>(\"Test\")")]
+    // Resolve - no return type defined by Field method
+    [InlineData("Resolve", "Field<StringGraphType, string>(\"Test\")")]
+    [InlineData("Resolve", "Field<StringGraphType, dynamic>(\"Test\")")]
+    [InlineData("Resolve", "Field<StringGraphType, object>(\"Test\")")]
+    [InlineData("Resolve", "Field<StringGraphType, System.Object>(\"Test\")")]
+    // Resolve - no return type defined by Returns method
+    [InlineData("Resolve", "Field<StringGraphType>(\"Test\").Returns<string>()")]
+    [InlineData("Resolve", "Field<StringGraphType>(\"Test\").Returns<dynamic>()")]
+    [InlineData("Resolve", "Field<StringGraphType>(\"Test\").Returns<object>()")]
+    [InlineData("Resolve", "Field<StringGraphType>(\"Test\").Returns<System.Object>()")]
+    // ResolveScoped - no return type
+    [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\")")]
+    // ResolveScoped - no return type defined by Field method
+    [InlineData("ResolveScoped", "Field<StringGraphType, string>(\"Test\")")]
+    [InlineData("ResolveScoped", "Field<StringGraphType, dynamic>(\"Test\")")]
+    [InlineData("ResolveScoped", "Field<StringGraphType, object>(\"Test\")")]
+    [InlineData("ResolveScoped", "Field<StringGraphType, System.Object>(\"Test\")")]
+    // ResolveScoped - no return type defined by Returns method
+    [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\").Returns<string>()")]
+    [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\").Returns<dynamic>()")]
+    [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\").Returns<object>()")]
+    [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\").Returns<System.Object>()")]
+    public async Task SyncResolve_NotAwaitableResolver_NoDiagnostics(string resolveMethod, string fieldDefinition)
+    {
+        string source =
+            $$"""
+              using GraphQL.MicrosoftDI;
+              using GraphQL.Types;
+
+              namespace Sample.Server;
+
+              public class MyGraphType : ObjectGraphType
+              {
+                  public MyGraphType()
+                  {
+                      {{fieldDefinition}}
+                          .{{resolveMethod}}(ctx => "text");
+                  }
+              }
+              """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Theory]
+    [InlineData("Resolve", "Task", "dynamic")]
+    [InlineData("Resolve", "Task", "object")]
+    [InlineData("Resolve", "Task", "System.Object")]
+    [InlineData("Resolve", "Task", "Task<string>")]
+    [InlineData("Resolve", "ValueTask", "dynamic")]
+    [InlineData("Resolve", "ValueTask", "object")]
+    [InlineData("Resolve", "ValueTask", "System.Object")]
+    [InlineData("Resolve", "ValueTask", "ValueTask<string>")]
+    [InlineData("Resolve", "CustomAwaitable", "dynamic")]
+    [InlineData("Resolve", "CustomAwaitable", "object")]
+    [InlineData("Resolve", "CustomAwaitable", "System.Object")]
+    [InlineData("Resolve", "CustomAwaitable", "CustomAwaitable<string>")]
+    [InlineData("ResolveScoped", "Task", "dynamic")]
+    [InlineData("ResolveScoped", "Task", "object")]
+    [InlineData("ResolveScoped", "Task", "System.Object")]
+    [InlineData("ResolveScoped", "Task", "Task<string>")]
+    [InlineData("ResolveScoped", "ValueTask", "dynamic")]
+    [InlineData("ResolveScoped", "ValueTask", "object")]
+    [InlineData("ResolveScoped", "ValueTask", "System.Object")]
+    [InlineData("ResolveScoped", "ValueTask", "ValueTask<string>")]
+    [InlineData("ResolveScoped", "CustomAwaitable", "dynamic")]
+    [InlineData("ResolveScoped", "CustomAwaitable", "object")]
+    [InlineData("ResolveScoped", "CustomAwaitable", "System.Object")]
+    [InlineData("ResolveScoped", "CustomAwaitable", "CustomAwaitable<string>")]
+    public async Task SyncResolve_AwaitableResolver_GQL009(string resolveMethod, string awaitableType, string returnType)
+    {
+        string source =
+            $$"""
+              using System;
+              using System.Threading.Tasks;
+              using GraphQL.MicrosoftDI;
+              using GraphQL.Types;
+
+              namespace Sample.Server;
+
+              public class MyGraphType : ObjectGraphType
+              {
+                  public MyGraphType()
+                  {
+                      Field<StringGraphType, {{returnType}}>("Test")
+                          .{{resolveMethod}}(ctx => {{awaitableType}}.FromResult("text"));
+                  }
+              }
+
+              {{CUSTOM_AWAITABLE_SOURCE}}
+              """;
+
+        const int startCol = 14;
+        int endCol = startCol + resolveMethod.Length;
+
+        var expected = VerifyCS.Diagnostic().WithSpan(13, startCol, 13, endCol).WithArguments(resolveMethod + "Async");
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Theory]
+    [InlineData("ctx => \"text\"", false)]
+    [InlineData("ctx => Resolve(ctx)", false)]
+    [InlineData("ctx => Task.FromResult(\"text\")", true)]
+    [InlineData("ctx => ResolveAsync(ctx)", true)]
+    public async Task SyncResolve_AwaitableLambdaResolver_GQL009(string resolver, bool report)
+    {
+        string source =
+            $$"""
+              using System;
+              using System.Threading.Tasks;
+              using GraphQL;
+              using GraphQL.Types;
+
+              namespace Sample.Server;
+
+              public class MyGraphType : ObjectGraphType
+              {
+                  public MyGraphType()
+                  {
+                      Field<StringGraphType>("Test").Resolve({{resolver}});
+                  }
+
+                  private string Resolve(IResolveFieldContext<object> ctx) => throw new NotImplementedException();
+                  private Task<string> ResolveAsync(IResolveFieldContext<object> ctx) => throw new NotImplementedException();
+              }
+              """;
+
+        var expected = report
+            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments("ResolveAsync") }
+            : DiagnosticResult.EmptyDiagnosticResults;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Theory]
+    [InlineData("\"text\"", false)]
+    [InlineData("Resolve(ctx)", false)]
+    [InlineData("Task.FromResult(\"text\")", true)]
+    [InlineData("ResolveAsync(ctx)", true)]
+    public async Task SyncResolve_AwaitableBlockResolver_GQL009(string resolver, bool report)
+    {
+        string source =
+            $$"""
+              using System;
+              using System.Threading.Tasks;
+              using GraphQL;
+              using GraphQL.Types;
+
+              namespace Sample.Server;
+
+              public class MyGraphType : ObjectGraphType
+              {
+                  public MyGraphType()
+                  {
+                      Field<StringGraphType>("Test").Resolve(ctx =>
+                      {
+                          return {{resolver}};
+                      });
+                  }
+
+                  private string Resolve(IResolveFieldContext<object> ctx) => throw new NotImplementedException();
+                  private Task<string> ResolveAsync(IResolveFieldContext<object> ctx) => throw new NotImplementedException();
+              }
+              """;
+
+        var expected = report
+            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments("ResolveAsync") }
+            : DiagnosticResult.EmptyDiagnosticResults;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+    [Theory]
+    [InlineData("Resolve", false)]
+    [InlineData("ResolveAsync", true)]
+    public async Task SyncResolve_AwaitableMethodGroupResolver_GQL009(string resolver, bool report)
+    {
+        string source =
+            $$"""
+              using System;
+              using System.Threading.Tasks;
+              using GraphQL;
+              using GraphQL.Types;
+
+              namespace Sample.Server;
+
+              public class MyGraphType : ObjectGraphType
+              {
+                  public MyGraphType()
+                  {
+                      Field<StringGraphType>("Test").Resolve({{resolver}});
+                  }
+
+                  private string Resolve(IResolveFieldContext<object> ctx) => throw new NotImplementedException();
+                  private Task<string> ResolveAsync(IResolveFieldContext<object> ctx) => throw new NotImplementedException();
+              }
+              """;
+
+        var expected = report
+            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments("ResolveAsync") }
+            : DiagnosticResult.EmptyDiagnosticResults;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+}

--- a/src/GraphQL.Analyzers.Tests/AwaitableResolverAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/AwaitableResolverAnalyzerTests.cs
@@ -16,7 +16,6 @@ public class AwaitableResolverAnalyzerTests
 
         public class CustomAwaitable<TResult>
         {
-            public static CustomAwaitable<TResult> FromResult(TResult result) => throw new NotImplementedException();
             public CustomAwaiter<TResult> GetAwaiter() => throw new NotImplementedException();
         }
 
@@ -89,24 +88,24 @@ public class AwaitableResolverAnalyzerTests
     [Theory]
     // Resolve - no return type
     [InlineData("Resolve", "Field<StringGraphType>(\"Test\")")]
-    // Resolve - no return type defined by Field method
+    // Resolve - return type defined by Field method
     [InlineData("Resolve", "Field<StringGraphType, string>(\"Test\")")]
     [InlineData("Resolve", "Field<StringGraphType, dynamic>(\"Test\")")]
     [InlineData("Resolve", "Field<StringGraphType, object>(\"Test\")")]
     [InlineData("Resolve", "Field<StringGraphType, System.Object>(\"Test\")")]
-    // Resolve - no return type defined by Returns method
+    // Resolve - return type defined by Returns method
     [InlineData("Resolve", "Field<StringGraphType>(\"Test\").Returns<string>()")]
     [InlineData("Resolve", "Field<StringGraphType>(\"Test\").Returns<dynamic>()")]
     [InlineData("Resolve", "Field<StringGraphType>(\"Test\").Returns<object>()")]
     [InlineData("Resolve", "Field<StringGraphType>(\"Test\").Returns<System.Object>()")]
     // ResolveScoped - no return type
     [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\")")]
-    // ResolveScoped - no return type defined by Field method
+    // ResolveScoped - return type defined by Field method
     [InlineData("ResolveScoped", "Field<StringGraphType, string>(\"Test\")")]
     [InlineData("ResolveScoped", "Field<StringGraphType, dynamic>(\"Test\")")]
     [InlineData("ResolveScoped", "Field<StringGraphType, object>(\"Test\")")]
     [InlineData("ResolveScoped", "Field<StringGraphType, System.Object>(\"Test\")")]
-    // ResolveScoped - no return type defined by Returns method
+    // ResolveScoped - return type defined by Returns method
     [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\").Returns<string>()")]
     [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\").Returns<dynamic>()")]
     [InlineData("ResolveScoped", "Field<StringGraphType>(\"Test\").Returns<object>()")]

--- a/src/GraphQL.Analyzers.Tests/AwaitableResolverAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/AwaitableResolverAnalyzerTests.cs
@@ -187,7 +187,7 @@ public class AwaitableResolverAnalyzerTests
               {{CUSTOM_AWAITABLE_SOURCE}}
               """;
 
-        var expected = VerifyCS.Diagnostic().WithSpan(13, 14, 13, 21).WithArguments("ResolveAsync");
+        var expected = VerifyCS.Diagnostic().WithSpan(13, 14, 13, 21).WithArguments(Constants.MethodNames.ResolveAsync);
         await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
     }
 
@@ -218,7 +218,7 @@ public class AwaitableResolverAnalyzerTests
               {{CUSTOM_AWAITABLE_SOURCE}}
               """;
 
-        var expected = VerifyCS.Diagnostic().WithSpan(13, 14, 13, 21).WithArguments("ResolveAsync");
+        var expected = VerifyCS.Diagnostic().WithSpan(13, 14, 13, 21).WithArguments(Constants.MethodNames.ResolveAsync);
         await VerifyCS.VerifyCodeFixAsync(source, expected, source);
     }
 
@@ -257,7 +257,7 @@ public class AwaitableResolverAnalyzerTests
               {{CUSTOM_AWAITABLE_SOURCE}}
               """;
 
-        var expected = VerifyCS.Diagnostic().WithSpan(13, 14, 13, 27).WithArguments("ResolveScopedAsync");
+        var expected = VerifyCS.Diagnostic().WithSpan(13, 14, 13, 27).WithArguments(Constants.MethodNames.ResolveScopedAsync);
         await VerifyCS.VerifyCodeFixAsync(source, expected, source);
     }
 
@@ -290,7 +290,7 @@ public class AwaitableResolverAnalyzerTests
               {{CUSTOM_AWAITABLE_SOURCE}}
               """;
 
-        var expected = VerifyCS.Diagnostic().WithSpan(13, 14, 13, 27).WithArguments("ResolveScopedAsync");
+        var expected = VerifyCS.Diagnostic().WithSpan(13, 14, 13, 27).WithArguments(Constants.MethodNames.ResolveScopedAsync);
         await VerifyCS.VerifyCodeFixAsync(source, expected, source);
     }
 
@@ -348,7 +348,7 @@ public class AwaitableResolverAnalyzerTests
               """;
 
         var expected = report
-            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments("ResolveAsync") }
+            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments(Constants.MethodNames.ResolveAsync) }
             : DiagnosticResult.EmptyDiagnosticResults;
 
         string expectedFix = report ? fix : source;
@@ -422,7 +422,7 @@ public class AwaitableResolverAnalyzerTests
               """;
 
         var expected = report
-            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments("ResolveAsync") }
+            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments(Constants.MethodNames.ResolveAsync) }
             : DiagnosticResult.EmptyDiagnosticResults;
 
         string expectedFix = report ? fix : source;
@@ -478,7 +478,7 @@ public class AwaitableResolverAnalyzerTests
               """;
 
         var expected = report
-            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments("ResolveAsync") }
+            ? new[] { VerifyCS.Diagnostic().WithSpan(12, 40, 12, 47).WithArguments(Constants.MethodNames.ResolveAsync) }
             : DiagnosticResult.EmptyDiagnosticResults;
 
         string expectedFix = report ? fix : source;

--- a/src/GraphQL.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/GraphQL.Analyzers/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,4 @@ GQL005 | Usage | Error | ResolverAnalyzer, [Documentation](https://graphql-dotne
 GQL006 | Usage | Warning | InputGraphTypeAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL006_CanNotMatchInputFieldToTheSourceField)
 GQL007 | Usage | Warning | InputGraphTypeAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL007_CanNotSetSourceField)
 GQL008 | Usage | Warning | FieldArgumentAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL008_DoNotUseObsoleteArgumentMethod)
+GQL009 | Usage | Error | AwaitableResolverAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL009_UseAsyncResolver)

--- a/src/GraphQL.Analyzers/AwaitableResolverAnalyzer.cs
+++ b/src/GraphQL.Analyzers/AwaitableResolverAnalyzer.cs
@@ -1,0 +1,187 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace GraphQL.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AwaitableResolverAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor UseAsyncResolver = new(
+        id: DiagnosticIds.USE_ASYNC_RESOLVER,
+        title: "Use async resolver",
+        messageFormat: "Use '{0}' to register awaitable resolver",
+        category: DiagnosticCategories.USAGE,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: HelpLinks.USE_ASYNC_RESOLVER);
+
+    private static readonly Dictionary<string, string> _supportedMethodsMap = new()
+    {
+        [Constants.MethodNames.Resolve] = Constants.MethodNames.ResolveAsync,
+        [Constants.MethodNames.ResolveScoped] = Constants.MethodNames.ResolveScopedAsync
+    };
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(UseAsyncResolver);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
+    }
+
+    private void AnalyzeMemberAccessExpression(SyntaxNodeAnalysisContext context)
+    {
+        var resolveMemberAccessExpression = (MemberAccessExpressionSyntax)context.Node;
+        string methodName = resolveMemberAccessExpression.Name.Identifier.Text;
+
+        if (!_supportedMethodsMap.ContainsKey(methodName))
+        {
+            return;
+        }
+
+        if (!resolveMemberAccessExpression.IsGraphQLSymbol(context))
+        {
+            return;
+        }
+
+        var returnType = GetReturnTypeSymbol(context, resolveMemberAccessExpression);
+        if (returnType == null)
+        {
+            return;
+        }
+
+        // Field<T, Task<K>> or .Return<Task<K>>
+        if (returnType.IsAwaitableNonDynamic(context.SemanticModel, context.Node.SpanStart))
+        {
+            ReportDiagnostic(context, resolveMemberAccessExpression, methodName);
+            return;
+        }
+
+        // not object and not dynamic
+        if (returnType is ITypeSymbol { SpecialType: not SpecialType.System_Object, Kind: not SymbolKind.DynamicType })
+        {
+            return;
+        }
+
+        var invocation = resolveMemberAccessExpression.FindMethodInvocationExpression(methodName);
+        var resolver = invocation?.ArgumentList.Arguments.FirstOrDefault();
+        if (resolver == null)
+        {
+            return;
+        }
+
+        switch (resolver.Expression)
+        {
+            // Resolve(ctx => AsyncMethod() or statement)
+            case SimpleLambdaExpressionSyntax { ExpressionBody: not null } lambda:
+            {
+                var expressionStatementSymbolInfo = context.SemanticModel.GetSymbolInfo(lambda.ExpressionBody);
+                if (expressionStatementSymbolInfo.Symbol.IsAwaitableNonDynamic(context.SemanticModel, context.Node.SpanStart))
+                {
+                    ReportDiagnostic(context, resolveMemberAccessExpression, methodName);
+                }
+
+                break;
+            }
+            // Resolve(ctx =>
+            // {
+            //     return AsyncMethod() or statement
+            // })
+            case SimpleLambdaExpressionSyntax { Block: not null } lambda:
+            {
+                bool hasAwaitableStatements = lambda.Block.Statements
+                    .OfType<ReturnStatementSyntax>()
+                    .Where(returnStatement => returnStatement.Expression != null)
+                    .Any(returnStatement =>
+                    {
+                        var symbolInfo = context.SemanticModel.GetSymbolInfo(returnStatement.Expression!);
+                        return symbolInfo.Symbol.IsAwaitableNonDynamic(context.SemanticModel, context.Node.SpanStart);
+                    });
+
+                if (hasAwaitableStatements)
+                {
+                    ReportDiagnostic(context, resolveMemberAccessExpression, methodName);
+                }
+
+                break;
+            }
+            // Resolve(MethodGroup)
+            case IdentifierNameSyntax methodGroupName:
+            {
+                var symbolInfo = context.SemanticModel.GetSymbolInfo(methodGroupName);
+                if (symbolInfo.Symbol.IsAwaitableNonDynamic(context.SemanticModel, context.Node.SpanStart))
+                {
+                    ReportDiagnostic(context, resolveMemberAccessExpression, methodName);
+                }
+
+                break;
+            }
+        }
+    }
+
+    private static ISymbol? GetReturnTypeSymbol(
+        SyntaxNodeAnalysisContext context,
+        ExpressionSyntax expression)
+    {
+        var resolveMethodInfo = context.SemanticModel.GetSymbolInfo(expression);
+        if (resolveMethodInfo.Symbol is IMethodSymbol { ReturnType: INamedTypeSymbol { MetadataName: "FieldBuilder`2" } namedType })
+        {
+            return namedType.TypeArguments[1];
+        }
+
+        return null;
+    }
+
+    private static void ReportDiagnostic(
+        SyntaxNodeAnalysisContext context,
+        MemberAccessExpressionSyntax resolveMemberAccessExpression,
+        string syncResolverName)
+    {
+        var location = resolveMemberAccessExpression.FindSimpleNameSyntax(syncResolverName)!.GetLocation();
+        var diagnostic = Diagnostic.Create(UseAsyncResolver, location, _supportedMethodsMap[syncResolverName]);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    // TODO: remove
+    private static ISymbol? GetReturnTypeSymbol2(
+        SyntaxNodeAnalysisContext context,
+        ExpressionSyntax expression)
+    {
+        // Returns<TReturnType>
+        var returnsGenericName = expression.FindGenericNameSyntax(Constants.MethodNames.Returns);
+        if (returnsGenericName != null)
+        {
+            if (returnsGenericName.TypeArgumentList.Arguments.Count != 1)
+            {
+                return null;
+            }
+
+            var returnType = returnsGenericName.TypeArgumentList.Arguments[0];
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(returnType);
+            return symbolInfo.Symbol;
+        }
+
+        // Field<TSourceType, TReturnType>
+        var fieldGenericName = expression.FindGenericNameSyntax(Constants.MethodNames.Field);
+        if (fieldGenericName == null)
+        {
+            return null;
+        }
+
+        if (fieldGenericName.TypeArgumentList.Arguments.Count == 2)
+        {
+            var returnType = fieldGenericName.TypeArgumentList.Arguments[1];
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(returnType);
+            return symbolInfo.Symbol;
+        }
+
+        return context.Compilation.GetSpecialType(SpecialType.System_Object);
+    }
+}

--- a/src/GraphQL.Analyzers/Constants.cs
+++ b/src/GraphQL.Analyzers/Constants.cs
@@ -40,6 +40,7 @@ public static class Constants
         public const string ResolveScopedAsync = "ResolveScopedAsync";
         public const string ResolveStream = "ResolveStream";
         public const string ResolveStreamAsync = "ResolveStreamAsync";
+        public const string Returns = "Returns";
     }
 
     public static class ObjectProperties

--- a/src/GraphQL.Analyzers/DiagnosticIds.cs
+++ b/src/GraphQL.Analyzers/DiagnosticIds.cs
@@ -10,4 +10,5 @@ public static class DiagnosticIds
     public const string CAN_NOT_MATCH_INPUT_FIELD_TO_THE_SOURCE_FIELD = "GQL006";
     public const string CAN_NOT_SET_SOURCE_FIELD = "GQL007";
     public const string DO_NOT_USE_OBSOLETE_ARGUMENT_METHOD = "GQL008";
+    public const string USE_ASYNC_RESOLVER = "GQL009";
 }

--- a/src/GraphQL.Analyzers/Extensions.cs
+++ b/src/GraphQL.Analyzers/Extensions.cs
@@ -123,9 +123,11 @@ public static class Extensions
     }
 
     /// <summary>
-    /// If the <paramref name="symbol"/> is a method symbol, returns <see langword="true"/> if the method's return type is "awaitable", but not if it's <see langword="dynamic"/>.
+    /// If the <paramref name="symbol"/> is a method symbol, returns <see langword="true"/> if the method's return type is "awaitable",
+    /// but not if it's <see langword="dynamic"/>.
     /// If the <paramref name="symbol"/> is a type symbol, returns <see langword="true"/> if that type is "awaitable".
-    /// An "awaitable" is any type that exposes a GetAwaiter method which returns a valid "awaiter". This GetAwaiter method may be an instance method or an extension method.
+    /// An "awaitable" is any type that exposes a GetAwaiter method which returns a valid "awaiter".
+    /// This GetAwaiter method may be an instance method or an extension method.
     /// </summary>
     /// https://github.com/dotnet/roslyn/blob/342787a7e6906de95080654e28e8db5dd9116b9a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs#L577
     public static bool IsAwaitableNonDynamic([NotNullWhen(true)] this ISymbol? symbol, SemanticModel semanticModel, int position)

--- a/src/GraphQL.Analyzers/Extensions.cs
+++ b/src/GraphQL.Analyzers/Extensions.cs
@@ -109,6 +109,19 @@ public static class Extensions
     public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
         => new(source, comparer);
 
+    public static ISymbol? GetFieldBuilderReturnTypeSymbol(
+        this ExpressionSyntax expression,
+        SemanticModel semanticModel)
+    {
+        var resolveMethodInfo = semanticModel.GetSymbolInfo(expression);
+        if (resolveMethodInfo.Symbol is IMethodSymbol { ReturnType: INamedTypeSymbol { MetadataName: "FieldBuilder`2" } namedType })
+        {
+            return namedType.TypeArguments[1];
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// If the <paramref name="symbol"/> is a method symbol, returns <see langword="true"/> if the method's return type is "awaitable", but not if it's <see langword="dynamic"/>.
     /// If the <paramref name="symbol"/> is a type symbol, returns <see langword="true"/> if that type is "awaitable".

--- a/src/GraphQL.Analyzers/Extensions.cs
+++ b/src/GraphQL.Analyzers/Extensions.cs
@@ -14,19 +14,30 @@ public static class Extensions
         return simpleNameSyntax?.FindMethodInvocationExpression();
     }
 
-    public static SimpleNameSyntax? FindSimpleNameSyntax(this ExpressionSyntax expression, string builderName)
+    public static SimpleNameSyntax? FindSimpleNameSyntax(this ExpressionSyntax expression, string name)
     {
-        return expression.DescendantNodes()
-            .OfType<SimpleNameSyntax>()
-            .FirstOrDefault(simpleNameSyntax => simpleNameSyntax.Identifier.Text == builderName);
+        return expression.FindNameSyntax<SimpleNameSyntax>(name);
     }
 
-    public static InvocationExpressionSyntax? FindMethodInvocationExpression(this SimpleNameSyntax fieldSimpleName)
+    public static GenericNameSyntax? FindGenericNameSyntax(this ExpressionSyntax expression, string name)
     {
-        return fieldSimpleName.Parent switch
+        return expression.FindNameSyntax<GenericNameSyntax>(name);
+    }
+
+    public static TNameSyntax? FindNameSyntax<TNameSyntax>(this ExpressionSyntax expression, string name)
+        where TNameSyntax : SimpleNameSyntax
+    {
+        return expression.DescendantNodes()
+            .OfType<TNameSyntax>()
+            .FirstOrDefault(simpleNameSyntax => simpleNameSyntax.Identifier.Text == name);
+    }
+
+    public static InvocationExpressionSyntax? FindMethodInvocationExpression(this SimpleNameSyntax methodSimpleName)
+    {
+        return methodSimpleName.Parent switch
         {
-            InvocationExpressionSyntax findFieldInvocation => findFieldInvocation,
-            MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax findFieldInvocation } => findFieldInvocation,
+            InvocationExpressionSyntax invocation => invocation,
+            MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax invocation } => invocation,
             _ => null
         };
     }
@@ -97,6 +108,78 @@ public static class Extensions
 
     public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
         => new(source, comparer);
+
+    /// <summary>
+    /// If the <paramref name="symbol"/> is a method symbol, returns <see langword="true"/> if the method's return type is "awaitable", but not if it's <see langword="dynamic"/>.
+    /// If the <paramref name="symbol"/> is a type symbol, returns <see langword="true"/> if that type is "awaitable".
+    /// An "awaitable" is any type that exposes a GetAwaiter method which returns a valid "awaiter". This GetAwaiter method may be an instance method or an extension method.
+    /// </summary>
+    /// https://github.com/dotnet/roslyn/blob/342787a7e6906de95080654e28e8db5dd9116b9a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs#L577
+    public static bool IsAwaitableNonDynamic([NotNullWhen(true)] this ISymbol? symbol, SemanticModel semanticModel, int position)
+    {
+        var methodSymbol = symbol as IMethodSymbol;
+        ITypeSymbol? typeSymbol = null;
+
+        if (methodSymbol == null)
+        {
+            typeSymbol = symbol as ITypeSymbol;
+            if (typeSymbol == null)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (methodSymbol.ReturnType == null)
+            {
+                return false;
+            }
+        }
+
+        // otherwise: needs valid GetAwaiter
+        var potentialGetAwaiters = semanticModel.LookupSymbols(
+            position,
+            container: typeSymbol ?? methodSymbol!.ReturnType.OriginalDefinition,
+            name: WellKnownMemberNames.GetAwaiter,
+            includeReducedExtensionMethods: true);
+
+        var getAwaiters = potentialGetAwaiters.OfType<IMethodSymbol>().Where(x => !x.Parameters.Any());
+        return getAwaiters.Any(VerifyGetAwaiter);
+    }
+
+    public static bool IsValidGetAwaiter(this IMethodSymbol symbol)
+        => symbol.Name == WellKnownMemberNames.GetAwaiter &&
+        VerifyGetAwaiter(symbol);
+
+    private static bool VerifyGetAwaiter(IMethodSymbol getAwaiter)
+    {
+        var returnType = getAwaiter.ReturnType;
+        if (returnType == null)
+        {
+            return false;
+        }
+
+        // bool IsCompleted { get }
+        if (!returnType.GetMembers().OfType<IPropertySymbol>().Any(p => p.Name == WellKnownMemberNames.IsCompleted && p.Type.SpecialType == SpecialType.System_Boolean && p.GetMethod != null))
+        {
+            return false;
+        }
+
+        var methods = returnType.GetMembers().OfType<IMethodSymbol>();
+
+        // NOTE: (vladres) The current version of C# Spec, §7.7.7.3 'Runtime evaluation of await expressions', requires that
+        // NOTE: the interface method INotifyCompletion.OnCompleted or ICriticalNotifyCompletion.UnsafeOnCompleted is invoked
+        // NOTE: (rather than any OnCompleted method conforming to a certain pattern).
+        // NOTE: Should this code be updated to match the spec?
+
+        // void OnCompleted(Action) 
+        // Actions are delegates, so we'll just check for delegates.
+        if (!methods.Any(x => x.Name == WellKnownMemberNames.OnCompleted && x.ReturnsVoid && x.Parameters is [{ Type.TypeKind: TypeKind.Delegate }]))
+            return false;
+
+        // void GetResult() || T GetResult()
+        return methods.Any(m => m.Name == WellKnownMemberNames.GetResult && !m.Parameters.Any());
+    }
 
     private static ArgumentSyntax? GetArgument(
         string argumentName,

--- a/src/GraphQL.Analyzers/HelpLinks.cs
+++ b/src/GraphQL.Analyzers/HelpLinks.cs
@@ -11,4 +11,5 @@ public static class HelpLinks
     public const string CAN_NOT_MATCH_INPUT_FIELD_TO_THE_SOURCE_FIELD = $"{DOCS_URL}/GQL006_CanNotMatchInputFieldToTheSourceField";
     public const string CAN_NOT_SET_SOURCE_FIELD = $"{DOCS_URL}/GQL007_CanNotSetSourceField";
     public const string DO_NOT_USE_OBSOLETE_ARGUMENT_METHOD = $"{DOCS_URL}/GQL008_DoNotUseObsoleteArgumentMethod";
+    public const string USE_ASYNC_RESOLVER = $"{DOCS_URL}/GQL009_UseAsyncResolver";
 }

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -177,6 +177,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "analyzers", "analyzers", "{
 		..\docs2\site\docs\analyzers\GQL006_CanNotMatchInputFieldToTheSourceField.md = ..\docs2\site\docs\analyzers\GQL006_CanNotMatchInputFieldToTheSourceField.md
 		..\docs2\site\docs\analyzers\GQL007_CanNotSetSourceField.md = ..\docs2\site\docs\analyzers\GQL007_CanNotSetSourceField.md
 		..\docs2\site\docs\analyzers\GQL008_DoNotUseObsoleteArgumentMethod.md = ..\docs2\site\docs\analyzers\GQL008_DoNotUseObsoleteArgumentMethod.md
+		..\docs2\site\docs\analyzers\GQL009_UseAsyncResolver.md = ..\docs2\site\docs\analyzers\GQL009_UseAsyncResolver.md
 		..\docs2\site\docs\analyzers\Overview.md = ..\docs2\site\docs\analyzers\Overview.md
 	EndProjectSection
 EndProject

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -35,12 +35,12 @@ namespace GraphQL
         /// <param name="mappedType">
         /// GraphType for matching dictionary keys with <paramref name="type"/> property names.
         /// GraphType contains information about this matching in Metadata property.
-        /// In case of configuring field as Field(x => x.FName).Name("FirstName") source dictionary
+        /// In case of configuring field as Field("FirstName", x => x.FName) source dictionary
         /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
         /// </param>
         public static object ToObject(this IDictionary<string, object?> source, Type type, IGraphType? mappedType = null)
         {
-            // Given Field(x => x.FName).Name("FirstName") and key == "FirstName" returns "FName"
+            // Given Field("FirstName", x => x.FName) and key == "FirstName" returns "FName"
             string GetPropertyName(string key, out FieldType? field)
             {
                 var complexType = mappedType?.GetNamedType() as IComplexGraphType;
@@ -201,7 +201,7 @@ namespace GraphQL
         /// <param name="mappedType">
         /// GraphType for matching dictionary keys with <paramref name="fieldType"/> property names.
         /// GraphType contains information about this matching in Metadata property.
-        /// In case of configuring field as Field(x => x.FName).Name("FirstName") source dictionary
+        /// In case of configuring field as Field("FirstName", x => x.FName) source dictionary
         /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
         /// </param>
         /// <remarks>There is special handling for strings, IEnumerable&lt;T&gt;, Nullable&lt;T&gt;, and Enum.</remarks>

--- a/src/GraphQL/Types/Composite/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/InputObjectGraphType.cs
@@ -128,7 +128,7 @@ namespace GraphQL.Types
             if (value == null)
                 return null;
 
-            // Given Field(x => x.FName).Name("FirstName") and key == "FirstName" returns "FName"
+            // Given Field("FirstName", x => x.FName) and key == "FirstName" returns "FName"
             string propertyName = field.GetMetadata(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME, field.Name) ?? field.Name;
             PropertyInfo? propertyInfo;
             try


### PR DESCRIPTION
Detect the awaitable delegates in sync resolve methods and provide a code fix.

```c#
// before
Field<StringGraphType>("Title").Resolve(ctx => GetTitleAsync());

// after
Field<StringGraphType>("Title").ResolveAsync(async ctx => await GetTitleAsync());
```

Note that there are some not supported scenarios. Some can be fixed later, others are edge cases that will just make the code much more complicated.

For example, I can detect and fix cases like this
```c#
Field<StringGraphType>("Test").Resolve(ctx =>
{
    if (condition)
        return GetAsync();
    else
        return GetAnotherAsync();
});
```

But I decided not to support trinary operators for now because there can be multiple nested levels
```c#
Field<StringGraphType>("Test").Resolve(ctx =>
{
    return condition
        ? GetAsync();
        : anotherCondition
            ? GetAnotherAsync()
            : null;
});
```

Also, I detect and warn about awaitable return types like this
```c#
Field<StringGraphType, Task<string>>("Title")
    .Resolve(ctx => Task.FromResult("developer"));
```

But I don't provide a code fix because of the complexity of implementing it and because I believe people don't write such a code.

I also don't currently provide an automatic code fix for `ResolveScoped` because of the complexity. For example:
```C#
//before
Field<StringGraphType>("Title").ResolveScoped(ctx => GetTitleAsync());

// after
Field<StringGraphType, string>("Title").ResolveScopedAsync(async ctx => await GetTitleAsync());
```
Awaiting is not enough. Need also to define the return type. But I hope to fill this gap in the future.

And the most complex scenario:
```c#
// before
Field<StringGraphType>("Title", object).ResolveScoped(ctx => ResolveTitleAsync(ctx));

// after
Field<StringGraphType>("Title", object).ResolveScopedAsync<Person, object>(async ctx =>await ResolveTitleAsync(ctx));
```
Need to define the source and the result types on the `ResolveScopedAsync`. But again, I don't believe people set an `object` or `dynamic` explicitly as the return type.