### PR TITLE
ObjectExtensions.ToObject requires mappedType

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -92,3 +92,7 @@ Specifically, this relates to the following methods:
 - `UseConfiguration<T>()` with the same `T` type
 
 This change was made to prevent duplicate registrations of the same service within the DI container.
+
+### 6. `ObjectExtensions.ToObject<T>` was removed.
+
+This was only used by internal tests.

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -93,6 +93,7 @@ Specifically, this relates to the following methods:
 
 This change was made to prevent duplicate registrations of the same service within the DI container.
 
-### 6. `ObjectExtensions.ToObject<T>` was removed.
+### 6. `ObjectExtensions.ToObject` changes
 
-This was only used by internal tests.
+- `ObjectExtensions.ToObject<T>` was removed; it was only used by internal tests.
+- `ObjectExtensions.ToObject` requires input object graph type for conversion.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -613,11 +613,9 @@ namespace GraphQL
     }
     public static class ObjectExtensions
     {
-        public static object? GetPropertyValue(this object? propertyValue, System.Type fieldType, GraphQL.Types.IGraphType? mappedType = null) { }
+        public static object? GetPropertyValue(this object? propertyValue, System.Type fieldType, GraphQL.Types.IGraphType mappedType) { }
         public static bool IsDefinedEnumValue(System.Type type, object? value) { }
-        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType? mappedType = null) { }
-        public static T ToObject<T>(this System.Collections.Generic.IDictionary<string, object?> source)
-            where T :  class { }
+        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType mappedType) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface)]
     public class OutputNameAttribute : GraphQL.GraphQLAttribute

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -613,11 +613,9 @@ namespace GraphQL
     }
     public static class ObjectExtensions
     {
-        public static object? GetPropertyValue(this object? propertyValue, System.Type fieldType, GraphQL.Types.IGraphType? mappedType = null) { }
+        public static object? GetPropertyValue(this object? propertyValue, System.Type fieldType, GraphQL.Types.IGraphType mappedType) { }
         public static bool IsDefinedEnumValue(System.Type type, object? value) { }
-        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType? mappedType = null) { }
-        public static T ToObject<T>(this System.Collections.Generic.IDictionary<string, object?> source)
-            where T :  class { }
+        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType mappedType) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface)]
     public class OutputNameAttribute : GraphQL.GraphQLAttribute

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -603,11 +603,9 @@ namespace GraphQL
     }
     public static class ObjectExtensions
     {
-        public static object? GetPropertyValue(this object? propertyValue, System.Type fieldType, GraphQL.Types.IGraphType? mappedType = null) { }
+        public static object? GetPropertyValue(this object? propertyValue, System.Type fieldType, GraphQL.Types.IGraphType mappedType) { }
         public static bool IsDefinedEnumValue(System.Type type, object? value) { }
-        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType? mappedType = null) { }
-        public static T ToObject<T>(this System.Collections.Generic.IDictionary<string, object?> source)
-            where T :  class { }
+        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType mappedType) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface)]
     public class OutputNameAttribute : GraphQL.GraphQLAttribute

--- a/src/GraphQL.Tests/Bugs/Bug1626.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1626.cs
@@ -1,4 +1,5 @@
 using GraphQL.Execution;
+using GraphQL.Types;
 
 namespace GraphQL.Tests.Bugs;
 
@@ -7,6 +8,11 @@ public class Bug1626
     [Fact]
     public void GetArgument_Should_Not_Throw_AmbiguousMatchException()
     {
+        var myChildGraphType = new InputObjectGraphType<MyChildDerivedType>();
+        myChildGraphType.Field(x => x.MyProperty).Type(new StringGraphType());
+        var myDerivedGraphType = new InputObjectGraphType<MyDerivedType>();
+        myDerivedGraphType.Field(x => x.MyChildProperty).Type(myChildGraphType);
+
         var context = new ResolveFieldContext
         {
             Arguments = new Dictionary<string, ArgumentValue>
@@ -18,7 +24,11 @@ public class Bug1626
                         ["MyProperty"] = "graphql"
                     }
                 }, ArgumentSource.Literal)
-            }
+            },
+            FieldDefinition = new FieldType
+            {
+                Arguments = new QueryArguments(new QueryArgument(myDerivedGraphType) { Name = "root" }),
+            },
         };
 
         var arg = context.GetArgument<MyDerivedType>("root");

--- a/src/GraphQL.Tests/Bugs/Bug256NullableEnumTests.cs
+++ b/src/GraphQL.Tests/Bugs/Bug256NullableEnumTests.cs
@@ -1,4 +1,5 @@
 using GraphQL.Execution;
+using GraphQL.Types;
 
 namespace GraphQL.Tests.Bugs;
 
@@ -15,7 +16,11 @@ public class Bug256NullableEnumTests
     {
         var ctx = new ResolveFieldContext
         {
-            Arguments = new Dictionary<string, ArgumentValue> { { "value", new ArgumentValue(EnumType.B, ArgumentSource.Literal) } }
+            Arguments = new Dictionary<string, ArgumentValue> { { "value", new ArgumentValue(EnumType.B, ArgumentSource.Literal) } },
+            FieldDefinition = new FieldType
+            {
+                Arguments = new QueryArguments(new QueryArgument(new EnumerationGraphType<EnumType>()) { Name = "value" }),
+            },
         };
 
         var result = ctx.GetArgument<EnumType?>("value");
@@ -27,7 +32,11 @@ public class Bug256NullableEnumTests
     {
         var ctx = new ResolveFieldContext
         {
-            Arguments = new Dictionary<string, ArgumentValue> { { "value", ArgumentValue.NullLiteral } }
+            Arguments = new Dictionary<string, ArgumentValue> { { "value", ArgumentValue.NullLiteral } },
+            FieldDefinition = new FieldType
+            {
+                Arguments = new QueryArguments(new QueryArgument(new EnumerationGraphType<EnumType>()) { Name = "value" }),
+            },
         };
 
         var result = ctx.GetArgument<EnumType?>("value");
@@ -39,7 +48,11 @@ public class Bug256NullableEnumTests
     {
         var ctx = new ResolveFieldContext
         {
-            Arguments = new Dictionary<string, ArgumentValue> { { "value", ArgumentValue.NullLiteral } }
+            Arguments = new Dictionary<string, ArgumentValue> { { "value", ArgumentValue.NullLiteral } },
+            FieldDefinition = new FieldType
+            {
+                Arguments = new QueryArguments(new QueryArgument(new EnumerationGraphType<EnumType>()) { Name = "value" }),
+            },
         };
 
         var result = ctx.GetArgument<EnumType>("value");
@@ -55,7 +68,11 @@ public class Bug256NullableEnumTests
     {
         var ctx = new ResolveFieldContext
         {
-            Arguments = new Dictionary<string, ArgumentValue> { { "value", new ArgumentValue(EnumType.B, ArgumentSource.Literal) } }
+            Arguments = new Dictionary<string, ArgumentValue> { { "value", new ArgumentValue(EnumType.B, ArgumentSource.Literal) } },
+            FieldDefinition = new FieldType
+            {
+                Arguments = new QueryArguments(new QueryArgument(new EnumerationGraphType<EnumType>()) { Name = "value" }),
+            },
         };
 
         var result = ctx.GetArgument<EnumType>("value");

--- a/src/GraphQL.Tests/Bugs/Bug947.cs
+++ b/src/GraphQL.Tests/Bugs/Bug947.cs
@@ -1,5 +1,7 @@
 using System.Numerics;
 using GraphQL.Execution;
+using GraphQL.Types;
+using GraphQL.Utilities.Federation;
 
 namespace GraphQL.Tests.Bugs;
 
@@ -8,6 +10,10 @@ public class Bug947
     [Fact]
     public void GetArgument_Should_Return_Properly_Converted_Values()
     {
+        var inputObjectGraphType = new InputObjectGraphType<SomeObject>();
+        inputObjectGraphType.Field(x => x.inner_int).Type(new IntGraphType());
+        inputObjectGraphType.Field(x => x.inner_string).Type(new StringGraphType());
+
         var context = new ResolveFieldContext
         {
             Arguments = new Dictionary<string, ArgumentValue>
@@ -21,7 +27,17 @@ public class Bug947
                                 { "inner_string", "ok" }
                             }, ArgumentSource.Literal)
                 }
-            }
+            },
+            FieldDefinition = new FieldType
+            {
+                Arguments = new QueryArguments
+                {
+                    new QueryArgument(new IntGraphType()) { Name = "int" },
+                    new QueryArgument(new StringGraphType()) { Name = "string" },
+                    new QueryArgument(new AnyScalarGraphType()) { Name = "vector" },
+                    new QueryArgument(inputObjectGraphType) { Name = "object" },
+                },
+            },
         };
 
         // int arg

--- a/src/GraphQL.Tests/Bugs/Bug956.cs
+++ b/src/GraphQL.Tests/Bugs/Bug956.cs
@@ -25,9 +25,6 @@ public sealed class Bug956QueryType : ObjectGraphType
                 string asString = ctx.GetArgument<string>("base64");
                 asString.ShouldBe("R3JhcGhRTCE="); // GraphQL!
 
-                var asList = ctx.GetArgument<List<byte>>("base64");
-                asList.Count.ShouldBe(12);
-
                 byte[] asBinary = ctx.GetArgument<byte[]>("base64");
                 Encoding.UTF8.GetString(asBinary).ShouldBe("GraphQL!");
 

--- a/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
@@ -205,7 +205,10 @@ public class FieldBuilderTests
     {
         var objectType = new ObjectGraphType();
         objectType.Field<StringGraphType>("_")
-            .Argument<IntGraphType>("skip", "desc1", arg => arg.DefaultValue = 1)
+            .Argument<IntGraphType>("skip", "desc1", arg => {
+                arg.DefaultValue = 1;
+                arg.ResolvedType = new IntGraphType();
+            })
             .Resolve(context =>
             {
                 context.GetArgument<int?>("skip").ShouldBe(1);
@@ -250,7 +253,7 @@ public class FieldBuilderTests
     {
         var objectType = new ObjectGraphType();
         objectType.Field<StringGraphType>("_")
-            .Argument<IntGraphType, int?>("skip", "desc1")
+            .Argument<IntGraphType>("skip", c => c.ResolvedType = new IntGraphType())
             .Resolve(context =>
             {
                 context.GetArgument<int?>("skip").ShouldBe(null);
@@ -293,7 +296,7 @@ public class FieldBuilderTests
     {
         var objectType = new ObjectGraphType();
         objectType.Field<StringGraphType>("_")
-            .Argument<EpisodeEnum, Episodes>("episode", "episodes")
+            .Argument<EpisodeEnum>("episode", configure => configure.ResolvedType = new EpisodeEnum())
             .Resolve(context =>
             {
                 context.GetArgument<Episodes>("episode").ShouldBe(Episodes.JEDI);
@@ -336,7 +339,7 @@ public class FieldBuilderTests
     {
         var objectType = new ObjectGraphType();
         objectType.Field<StringGraphType>("_")
-            .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>>("episodes", "episodes")
+            .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>>("episodes", c => c.ResolvedType = new NonNullGraphType(new ListGraphType(new NonNullGraphType(new StringGraphType()))))
             .Resolve(context =>
             {
                 context.GetArgument<IEnumerable<string>>("episodes").ShouldBe(new List<string> { "JEDI", "EMPIRE" });
@@ -359,7 +362,7 @@ public class FieldBuilderTests
     {
         var objectType = new ObjectGraphType();
         objectType.Field<StringGraphType>("_")
-            .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>>("episodes", "episodes")
+            .Argument<NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>>("episodes", c => c.ResolvedType = new NonNullGraphType(new ListGraphType(new NonNullGraphType(new StringGraphType()))))
             .Resolve(context =>
             {
                 context.GetArgument<Collection<string>>("episodes").ShouldBe(new Collection<string> { "JEDI", "EMPIRE" });
@@ -382,7 +385,11 @@ public class FieldBuilderTests
     {
         var objectType = new ObjectGraphType();
         objectType.Field<StringGraphType>("_")
-            .Argument<StringGraphType>("arg1", "desc1", arg => arg.DefaultValue = "default")
+            .Argument<StringGraphType>("arg1", "desc1", arg =>
+            {
+                arg.DefaultValue = "default";
+                arg.ResolvedType = new StringGraphType();
+            })
             .Resolve(context =>
             {
                 context.GetArgument("arg1", "default2").ShouldBe("arg1value");

--- a/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
+++ b/src/GraphQL.Tests/Builders/FieldBuilderTests.cs
@@ -205,7 +205,8 @@ public class FieldBuilderTests
     {
         var objectType = new ObjectGraphType();
         objectType.Field<StringGraphType>("_")
-            .Argument<IntGraphType>("skip", "desc1", arg => {
+            .Argument<IntGraphType>("skip", "desc1", arg =>
+            {
                 arg.DefaultValue = 1;
                 arg.ResolvedType = new IntGraphType();
             })

--- a/src/GraphQL.Tests/Execution/InputConversionTestsBase.cs
+++ b/src/GraphQL.Tests/Execution/InputConversionTestsBase.cs
@@ -332,28 +332,28 @@ public abstract class InputConversionTestsBase
     [Fact]
     public void can_convert_json_to_input_object_with_custom_converter()
     {
-        const string json = """{ "name1": "tom", "age1": 10 }""";
+        const string json = """{ "name": "tom", "age": 10 }""";
 
         var inputs = VariablesToInputs(json);
 
         // before custom converter
         var person1 = inputs.ToObject<Person>();
-        person1.Name.ShouldBeNull();
-        person1.Age.ShouldBe(0);
+        person1.Name.ShouldBe("tom");
+        person1.Age.ShouldBe(10);
 
-        ValueConverter.Register(v => new Person { Name = (string)v["name1"], Age = (int)v["age1"] });
+        ValueConverter.Register(v => new Person { Name = (string)v["name"] + "sample", Age = (int)v["age"] + 2 });
 
         // after registering custom converter
         var person2 = inputs.ToObject<Person>();
-        person2.Name.ShouldBe("tom");
-        person2.Age.ShouldBe(10);
+        person2.Name.ShouldBe("tomsample");
+        person2.Age.ShouldBe(12);
 
         // after unregistering custom converter
         ValueConverter.Register<Person>(null);
 
         var person3 = inputs.ToObject<Person>();
-        person3.Name.ShouldBeNull();
-        person3.Age.ShouldBe(0);
+        person3.Name.ShouldBe("tom");
+        person3.Age.ShouldBe(10);
     }
 
     protected abstract Inputs VariablesToInputs(string variables);

--- a/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
+++ b/src/GraphQL.Tests/Execution/ResolveFieldContextTests.cs
@@ -11,11 +11,24 @@ public class ResolveFieldContextTests
 
     public ResolveFieldContextTests()
     {
+        var fieldDef = new FieldType()
+        {
+            Arguments = new QueryArguments
+            {
+                new QueryArgument(new IntGraphType()) { Name = "int" },
+                new QueryArgument(new LongGraphType()) { Name = "long" },
+                new QueryArgument(new FloatGraphType()) { Name = "float" },
+                new QueryArgument(new StringGraphType()) { Name = "string" },
+                new QueryArgument(new ListGraphType(new StringGraphType())) { Name = "stringlist" },
+                new QueryArgument(new EnumerationGraphType<SomeEnum>()) { Name = "enum" },
+            },
+        };
         _context = new ResolveFieldContext
         {
             Arguments = new Dictionary<string, ArgumentValue>(),
             Errors = new ExecutionErrors(),
             OutputExtensions = new Dictionary<string, object>(),
+            FieldDefinition = fieldDef,
         };
     }
 
@@ -23,8 +36,8 @@ public class ResolveFieldContextTests
     public void argument_converts_int_to_long()
     {
         const int val = 1;
-        _context.Arguments["a"] = new ArgumentValue(val, ArgumentSource.Literal);
-        long result = _context.GetArgument<long>("a");
+        _context.Arguments["int"] = new ArgumentValue(val, ArgumentSource.Literal);
+        long result = _context.GetArgument<long>("int");
         result.ShouldBe(1);
     }
 
@@ -32,8 +45,8 @@ public class ResolveFieldContextTests
     public void argument_converts_long_to_int()
     {
         const long val = 1;
-        _context.Arguments["a"] = new ArgumentValue(val, ArgumentSource.Literal);
-        int result = _context.GetArgument<int>("a");
+        _context.Arguments["long"] = new ArgumentValue(val, ArgumentSource.Literal);
+        int result = _context.GetArgument<int>("long");
         result.ShouldBe(1);
     }
 
@@ -41,16 +54,16 @@ public class ResolveFieldContextTests
     public void long_to_int_should_throw_for_out_of_range()
     {
         const long val = 89429901947254093;
-        _context.Arguments["a"] = new ArgumentValue(val, ArgumentSource.Literal);
-        Should.Throw<OverflowException>(() => _context.GetArgument<int>("a"));
+        _context.Arguments["long"] = new ArgumentValue(val, ArgumentSource.Literal);
+        Should.Throw<OverflowException>(() => _context.GetArgument<int>("long"));
     }
 
     [Fact]
     public void argument_returns_boxed_string_uncast()
     {
         const string val = "one";
-        _context.Arguments["a"] = new ArgumentValue(val, ArgumentSource.Literal);
-        object result = _context.GetArgument<object>("a");
+        _context.Arguments["string"] = new ArgumentValue(val, ArgumentSource.Literal);
+        object result = _context.GetArgument<object>("string");
         result.ShouldBe("one");
     }
 
@@ -58,8 +71,8 @@ public class ResolveFieldContextTests
     public void argument_returns_long()
     {
         const long val = 1000000000000001;
-        _context.Arguments["a"] = new ArgumentValue(val, ArgumentSource.Literal);
-        long result = _context.GetArgument<long>("a");
+        _context.Arguments["long"] = new ArgumentValue(val, ArgumentSource.Literal);
+        long result = _context.GetArgument<long>("long");
         result.ShouldBe(1000000000000001);
     }
 
@@ -67,8 +80,8 @@ public class ResolveFieldContextTests
     public void argument_returns_enum()
     {
         const SomeEnum val = SomeEnum.Two;
-        _context.Arguments["a"] = new ArgumentValue(val, ArgumentSource.Literal);
-        var result = _context.GetArgument<SomeEnum>("a");
+        _context.Arguments["enum"] = new ArgumentValue(val, ArgumentSource.Literal);
+        var result = _context.GetArgument<SomeEnum>("enum");
         result.ShouldBe(SomeEnum.Two);
     }
 
@@ -76,8 +89,8 @@ public class ResolveFieldContextTests
     public void argument_returns_enum_from_string()
     {
         const string val = "two";
-        _context.Arguments["a"] = new ArgumentValue(val, ArgumentSource.Literal);
-        var result = _context.GetArgument<SomeEnum>("a");
+        _context.Arguments["enum"] = new ArgumentValue(val, ArgumentSource.Literal);
+        var result = _context.GetArgument<SomeEnum>("enum");
         result.ShouldBe(SomeEnum.Two);
     }
 
@@ -85,21 +98,21 @@ public class ResolveFieldContextTests
     public void argument_returns_enum_from_number()
     {
         const int val = 1;
-        _context.Arguments["a"] = new ArgumentValue(val, ArgumentSource.Literal);
-        var result = _context.GetArgument<SomeEnum>("a");
+        _context.Arguments["enum"] = new ArgumentValue(val, ArgumentSource.Literal);
+        var result = _context.GetArgument<SomeEnum>("enum");
         result.ShouldBe(SomeEnum.Two);
     }
 
     [Fact]
     public void argument_returns_default_when_missing()
     {
-        _context.GetArgument<string>("wat").ShouldBeNull();
+        _context.GetArgument<string>("string").ShouldBeNull();
     }
 
     [Fact]
     public void argument_returns_provided_default_when_missing()
     {
-        _context.GetArgument("wat", "foo").ShouldBe("foo");
+        _context.GetArgument("string", "foo").ShouldBe("foo");
     }
 
     [Fact]
@@ -107,9 +120,9 @@ public class ResolveFieldContextTests
     {
         _context.Arguments = new Dictionary<string, ArgumentValue>
         {
-            { "a", new ArgumentValue(new string[] { "one", "two"}, ArgumentSource.Literal) }
+            { "stringlist", new ArgumentValue(new string[] { "one", "two"}, ArgumentSource.Literal) }
         };
-        var result = _context.GetArgument<List<string>>("a");
+        var result = _context.GetArgument<List<string>>("stringlist");
         result.ShouldNotBeNull();
         result.Count.ShouldBe(2);
         result[0].ShouldBe("one");

--- a/src/GraphQL.Tests/NameFieldResolverTests.cs
+++ b/src/GraphQL.Tests/NameFieldResolverTests.cs
@@ -1,5 +1,6 @@
 using GraphQL.Execution;
 using GraphQL.Resolvers;
+using GraphQL.Types;
 using GraphQLParser.AST;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -40,7 +41,14 @@ public class NameFieldResolverTests
             new ResolveFieldContext
             {
                 Source = person,
-                FieldDefinition = new GraphQL.Types.FieldType { Name = name },
+                FieldDefinition = new FieldType
+                {
+                    Name = name,
+                    Arguments = new QueryArguments
+                    {
+                        new QueryArgument(new StringGraphType()) { Name = "prefix" },
+                    },
+                },
                 FieldAst = new GraphQLField(name == null ? default : new GraphQLName(name)),
                 Arguments = new Dictionary<string, ArgumentValue>()
                 {

--- a/src/GraphQL.Tests/ObjectExtensions.cs
+++ b/src/GraphQL.Tests/ObjectExtensions.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Tests;
+
+internal static class ObjectExtensions
+{
+    public static T? ToObject<T>(this IDictionary<string, object?> data)
+    {
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddAutoSchema<QueryT<T>>());
+        var provider = services.BuildServiceProvider();
+        var schema = provider.GetRequiredService<ISchema>();
+        schema.Initialize();
+        var type = schema.Query.Fields.Find("test")!.Arguments!.Single().ResolvedType!;
+        return (T?)data.ToObject(typeof(T), type);
+    }
+
+    private class QueryT<T>
+    {
+        public virtual string? Test(T value) => null;
+    }
+}

--- a/src/GraphQL.Tests/ObjectExtensions.cs
+++ b/src/GraphQL.Tests/ObjectExtensions.cs
@@ -12,7 +12,7 @@ internal static class ObjectExtensions
         var services = new ServiceCollection();
         services.AddGraphQL(b => b
             .AddAutoSchema<QueryT<T>>());
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var schema = provider.GetRequiredService<ISchema>();
         schema.Initialize();
         var type = schema.Query.Fields.Find("test")!.Arguments!.Single().ResolvedType!;

--- a/src/GraphQL.Tests/ObjectExtensionsTest.cs
+++ b/src/GraphQL.Tests/ObjectExtensionsTest.cs
@@ -1,3 +1,5 @@
+using GraphQL.Types;
+
 namespace GraphQL.Tests;
 
 [Collection("StaticTests")]
@@ -70,7 +72,7 @@ public class ObjectExtensionsTests
         double[] doubles = new[] { 1.00, 2.01, 3.14 };
 
         // Act
-        object actual = doubles.GetPropertyValue(typeof(double[]));
+        object actual = doubles.GetPropertyValue(typeof(double[]), new ListGraphType(new NonNullGraphType(new FloatGraphType())));
 
         // Assert
         actual.ShouldBe(doubles);
@@ -83,7 +85,7 @@ public class ObjectExtensionsTests
         var doubles = new List<double> { 1.00, 2.01, 3.14 };
 
         // Act
-        object actual = doubles.GetPropertyValue(typeof(double[]));
+        object actual = doubles.GetPropertyValue(typeof(double[]), new ListGraphType(new NonNullGraphType(new FloatGraphType())));
 
         // Assert
         actual.ShouldBe(doubles);
@@ -96,7 +98,7 @@ public class ObjectExtensionsTests
         var doubles = new List<double?> { 1.00, 2.01, 3.14, null };
 
         // Act
-        object actual = doubles.GetPropertyValue(typeof(double?[]));
+        object actual = doubles.GetPropertyValue(typeof(double?[]), new ListGraphType(new FloatGraphType()));
 
         // Assert
         actual.ShouldBe(doubles);
@@ -109,7 +111,7 @@ public class ObjectExtensionsTests
         double?[] doubles = new double?[] { 1.00, 2.01, 3.14 };
 
         // Act
-        object actual = doubles.GetPropertyValue(typeof(double?[]));
+        object actual = doubles.GetPropertyValue(typeof(double?[]), new ListGraphType(new FloatGraphType()));
 
         // Assert
         actual.ShouldBe(doubles);
@@ -122,7 +124,7 @@ public class ObjectExtensionsTests
         var doubles = new List<double> { 1.00, 2.01, 3.14 };
 
         // Act
-        object actual = doubles.GetPropertyValue(typeof(List<double>));
+        object actual = doubles.GetPropertyValue(typeof(List<double>), new ListGraphType(new NonNullGraphType(new FloatGraphType())));
 
         // Assert
         actual.ShouldBe(doubles);
@@ -135,7 +137,7 @@ public class ObjectExtensionsTests
         var doubles = new List<double[]> { new[] { 1.00, 2.01, 3.14 }, new[] { 3.25, 2.21, 1.10 } };
 
         // Act
-        object actual = doubles.GetPropertyValue(typeof(List<double[]>));
+        object actual = doubles.GetPropertyValue(typeof(List<double[]>), new ListGraphType(new ListGraphType(new NonNullGraphType(new FloatGraphType()))));
 
         // Assert
         actual.ShouldBe(doubles);
@@ -148,7 +150,7 @@ public class ObjectExtensionsTests
         double[][] doubles = new[] { new[] { 1.00, 2.01, 3.14 }, new[] { 3.25, 2.21, 1.10 } };
 
         // Act
-        object actual = doubles.GetPropertyValue(typeof(double[][]));
+        object actual = doubles.GetPropertyValue(typeof(double[][]), new ListGraphType(new ListGraphType(new NonNullGraphType(new FloatGraphType()))));
 
         // Assert
         actual.ShouldBe(doubles);
@@ -161,7 +163,7 @@ public class ObjectExtensionsTests
         var doubles = new List<double[]> { new[] { 1.00, 2.01, 3.14 }, new[] { 3.25, 2.21, 1.10 } };
 
         // Act
-        object actual = doubles.GetPropertyValue(typeof(double[][]));
+        object actual = doubles.GetPropertyValue(typeof(double[][]), new ListGraphType(new ListGraphType(new NonNullGraphType(new FloatGraphType()))));
 
         // Assert
         actual.ShouldBe(doubles);
@@ -174,7 +176,7 @@ public class ObjectExtensionsTests
         string[] strings = new[] { "foo", "bar", "new" };
 
         // Act
-        object actual = strings.GetPropertyValue(typeof(string[]));
+        object actual = strings.GetPropertyValue(typeof(string[]), new ListGraphType(new NonNullGraphType(new StringGraphType())));
 
         // Assert
         actual.ShouldBe(strings);
@@ -187,7 +189,7 @@ public class ObjectExtensionsTests
         var strings = new List<string> { "foo", "bar", "new" };
 
         // Act
-        object actual = strings.GetPropertyValue(typeof(string[]));
+        object actual = strings.GetPropertyValue(typeof(string[]), new ListGraphType(new NonNullGraphType(new StringGraphType())));
 
         // Assert
         actual.ShouldBe(strings);
@@ -200,7 +202,7 @@ public class ObjectExtensionsTests
         var strings = new List<string> { "foo", "bar", "new" };
 
         // Act
-        object actual = strings.GetPropertyValue(typeof(List<string>));
+        object actual = strings.GetPropertyValue(typeof(List<string>), new ListGraphType(new NonNullGraphType(new StringGraphType())));
 
         // Assert
         actual.ShouldBe(strings);
@@ -213,7 +215,7 @@ public class ObjectExtensionsTests
         var strings = new List<string[]> { new[] { "foo", "bar", "boo" }, new[] { "new", "year", "eve" } };
 
         // Act
-        object actual = strings.GetPropertyValue(typeof(List<string[]>));
+        object actual = strings.GetPropertyValue(typeof(List<string[]>), new ListGraphType(new NonNullGraphType(new StringGraphType())));
 
         // Assert
         actual.ShouldBe(strings);
@@ -226,7 +228,7 @@ public class ObjectExtensionsTests
         string[][] strings = new[] { new[] { "foo", "bar", "boo" }, new[] { "new", "year", "eve" } };
 
         // Act
-        object actual = strings.GetPropertyValue(typeof(string[][]));
+        object actual = strings.GetPropertyValue(typeof(string[][]), new ListGraphType(new ListGraphType(new NonNullGraphType(new StringGraphType()))));
 
         // Assert
         actual.ShouldBe(strings);
@@ -239,7 +241,7 @@ public class ObjectExtensionsTests
         var strings = new List<string[]> { new[] { "foo", "bar", "boo" }, new[] { "new", "year", "eve" } };
 
         // Act
-        object actual = strings.GetPropertyValue(typeof(string[][]));
+        object actual = strings.GetPropertyValue(typeof(string[][]), new ListGraphType(new ListGraphType(new NonNullGraphType(new StringGraphType()))));
 
         // Assert
         actual.ShouldBe(strings);
@@ -252,7 +254,7 @@ public class ObjectExtensionsTests
         var strings = new List<List<string>> { new List<string> { "foo", "bar", "boo" }, new List<string> { "new", "year", "eve" } };
 
         // Act
-        object actual = strings.GetPropertyValue(typeof(string[][]));
+        object actual = strings.GetPropertyValue(typeof(string[][]), new ListGraphType(new ListGraphType(new NonNullGraphType(new StringGraphType()))));
 
         // Assert
         actual.ShouldBe(strings);

--- a/src/GraphQL.Tests/Types/AutoRegisteringInputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInputObjectGraphTypeTests.cs
@@ -184,10 +184,10 @@ public class AutoRegisteringInputObjectGraphTypeTests
     [InlineData(nameof(FieldTests.NotNullEnumerableNotNullIntField), typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<int>>>>))]
     [InlineData(nameof(FieldTests.NullableEnumerableNullableIntField), typeof(ListGraphType<GraphQLClrInputTypeReference<int>>))]
     [InlineData(nameof(FieldTests.NullableEnumerableNotNullIntField), typeof(ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<int>>>))]
-    [InlineData(nameof(FieldTests.NotNullArrayNullableTupleField), typeof(NonNullGraphType<ListGraphType<GraphQLClrInputTypeReference<Tuple<int, string>>>>))]
-    [InlineData(nameof(FieldTests.NotNullArrayNotNullTupleField), typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<Tuple<int, string>>>>>))]
-    [InlineData(nameof(FieldTests.NullableArrayNullableTupleField), typeof(ListGraphType<GraphQLClrInputTypeReference<Tuple<int, string>>>))]
-    [InlineData(nameof(FieldTests.NullableArrayNotNullTupleField), typeof(ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<Tuple<int, string>>>>))]
+    [InlineData(nameof(FieldTests.NotNullArrayNullableTupleField), typeof(NonNullGraphType<ListGraphType<GraphQLClrInputTypeReference<InputTuple<int, string>>>>))]
+    [InlineData(nameof(FieldTests.NotNullArrayNotNullTupleField), typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<InputTuple<int, string>>>>>))]
+    [InlineData(nameof(FieldTests.NullableArrayNullableTupleField), typeof(ListGraphType<GraphQLClrInputTypeReference<InputTuple<int, string>>>))]
+    [InlineData(nameof(FieldTests.NullableArrayNotNullTupleField), typeof(ListGraphType<NonNullGraphType<GraphQLClrInputTypeReference<InputTuple<int, string>>>>))]
     [InlineData(nameof(FieldTests.IdField), typeof(NonNullGraphType<IdGraphType>))]
     [InlineData(nameof(FieldTests.NullableIdField), typeof(IdGraphType))]
     [InlineData(nameof(FieldTests.EnumerableField), typeof(NonNullGraphType<ListGraphType<GraphQLClrInputTypeReference<object>>>))]
@@ -195,7 +195,7 @@ public class AutoRegisteringInputObjectGraphTypeTests
     [InlineData(nameof(FieldTests.NullableEnumerableField), typeof(ListGraphType<GraphQLClrInputTypeReference<object>>))]
     [InlineData(nameof(FieldTests.NullableCollectionField), typeof(ListGraphType<GraphQLClrInputTypeReference<object>>))]
     [InlineData(nameof(FieldTests.ListOfListOfIntsField), typeof(ListGraphType<ListGraphType<GraphQLClrInputTypeReference<int>>>))]
-    public void Field_DectectsProperType(string fieldName, Type expectedGraphType)
+    public void Field_DetectsProperType(string fieldName, Type expectedGraphType)
     {
         var graphType = new AutoRegisteringInputObjectGraphType<FieldTests>();
         var fieldType = graphType.Fields.Find(fieldName).ShouldNotBeNull();

--- a/src/GraphQL.Tests/Types/AutoRegisteringInputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInputObjectGraphTypeTests.cs
@@ -264,11 +264,14 @@ public class AutoRegisteringInputObjectGraphTypeTests
             { "field6AltName", 16 },
         };
         var graph = new TestFieldSupport<TestClass>();
+
+        // initialize schema
         var queryType = new ObjectGraphType();
         queryType.Field<StringGraphType>("test");
         var schema = new Schema() { Query = queryType };
         schema.RegisterType(graph);
         schema.Initialize();
+
         var actual = graph.ParseDictionary(dic).ShouldBeOfType<TestClass>();
         actual.Field1.ShouldBe(11);
         actual.Field3Value.ShouldBe(13);

--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeCachingTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeCachingTests.cs
@@ -41,15 +41,21 @@ public class AutoRegisteringObjectGraphTypeCachingTests
                 var field = graph.GetField("Id").ShouldNotBeNull();
                 field.Name.ShouldBe("Id");
                 field.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
+                field.ResolvedType = new NonNullGraphType(new IdGraphType()); // simulate initialization
                 field.Description.ShouldBeNull();
                 field.DeprecationReason.ShouldBeNull();
                 field.Metadata.Count.ShouldBe(0);
-                var ret = await field.Resolver.ShouldNotBeNull().ResolveAsync(new ResolveFieldContext { Source = new Class1() });
+                var ret = await field.Resolver.ShouldNotBeNull().ResolveAsync(new ResolveFieldContext
+                {
+                    Source = new Class1(),
+                    FieldDefinition = field,
+                });
                 ret.ShouldBeOfType<int>().ShouldBe(5);
 
                 field = graph.GetField("Print").ShouldNotBeNull();
                 field.Name.ShouldBe("Print");
                 field.Type.ShouldBe(typeof(GraphQLClrOutputTypeReference<string>));
+                field.ResolvedType = new StringGraphType(); // simulate initialization
                 field.Description.ShouldBe("Desc2");
                 field.DeprecationReason.ShouldBeNull();
                 field.Metadata.Count.ShouldBe(1);
@@ -58,6 +64,7 @@ public class AutoRegisteringObjectGraphTypeCachingTests
                 var arg = field.Arguments[0];
                 arg.Name.ShouldBe("id");
                 arg.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
+                arg.ResolvedType = new NonNullGraphType(new IdGraphType()); // simulate initialization
                 arg.Description.ShouldBe("IdDesc");
                 arg.DeprecationReason.ShouldBeNull();
                 arg.Metadata.Count.ShouldBe(0);
@@ -65,6 +72,7 @@ public class AutoRegisteringObjectGraphTypeCachingTests
                 {
                     Source = new Class1(),
                     Arguments = new Dictionary<string, ArgumentValue> { { "id", new(10, ArgumentSource.Literal) } },
+                    FieldDefinition = field,
                 };
                 var printRet = await field.Resolver.ShouldNotBeNull().ResolveAsync(resolveContext);
                 printRet.ShouldBeOfType<string>().ShouldBe("10");

--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -276,6 +276,17 @@ public class AutoRegisteringObjectGraphTypeTests
     {
         var graphType = new AutoRegisteringObjectGraphType<ArgumentTests>();
         var fieldType = graphType.Fields.Find(fieldName).ShouldNotBeNull();
+
+        // initialize schema
+        var services = new ServiceCollection();
+        services
+            .AddSingleton("testService")
+            .AddGraphQL(b => b
+                .AddAutoSchema<Class1>()
+                .ConfigureSchema(b => b.RegisterType(graphType)));
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ISchema>().Initialize();
+
         using var cts = new CancellationTokenSource();
         cts.Cancel();
         var context = new ResolveFieldContext
@@ -283,6 +294,8 @@ public class AutoRegisteringObjectGraphTypeTests
             Arguments = new Dictionary<string, ArgumentValue>(),
             CancellationToken = cts.Token,
             Source = new ArgumentTests(),
+            FieldDefinition = fieldType,
+            RequestServices = provider,
         };
         if (arg1Name != null)
         {
@@ -292,10 +305,6 @@ public class AutoRegisteringObjectGraphTypeTests
         {
             context.Arguments.Add("arg2", new ArgumentValue(arg2Value, ArgumentSource.Variable));
         }
-        var serviceCollection = new ServiceCollection();
-        serviceCollection.AddSingleton<string>("testService");
-        using var provider = serviceCollection.BuildServiceProvider();
-        context.RequestServices = provider;
         fieldType.Resolver.ShouldNotBeNull();
         (await fieldType.Resolver!.ResolveAsync(context)).ShouldBe(expected);
     }
@@ -473,6 +482,14 @@ public class AutoRegisteringObjectGraphTypeTests
         var graphType = new TestFieldSupport<TestStructModel>();
         graphType.Name.ShouldBe("Test");
         graphType.Fields.Count.ShouldBe(3);
+
+        // initialize graph type
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddAutoSchema<Class1>()
+            .ConfigureSchema(s => s.RegisterType(graphType)));
+        services.BuildServiceProvider().GetRequiredService<ISchema>().Initialize();
+
         var context = new ResolveFieldContext
         {
             Source = new TestStructModel(),
@@ -480,11 +497,19 @@ public class AutoRegisteringObjectGraphTypeTests
             {
                 { "prefix", new ArgumentValue("test", ArgumentSource.Literal) },
             },
+            FieldDefinition = graphType.Fields.Find("id")!,
         };
-        (await graphType.Fields.Find("Id").ShouldNotBeNull().Resolver!.ResolveAsync(context)).ShouldBe(1);
-        graphType.Fields.Find("Id")!.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
-        (await graphType.Fields.Find("Name").ShouldNotBeNull().Resolver!.ResolveAsync(context)).ShouldBe("Example");
-        (await graphType.Fields.Find("IdAndName").ShouldNotBeNull().Resolver!.ResolveAsync(context)).ShouldBe("testExample1");
+        (await graphType.Fields.Find("id").ShouldNotBeNull().Resolver!.ResolveAsync(context)).ShouldBe(1);
+        graphType.Fields.Find("id")!.Type.ShouldBe(typeof(NonNullGraphType<IdGraphType>));
+        context.FieldDefinition = graphType.Fields.Find("name")!;
+        (await graphType.Fields.Find("name").ShouldNotBeNull().Resolver!.ResolveAsync(context)).ShouldBe("Example");
+        context.FieldDefinition = graphType.Fields.Find("idAndName")!;
+        (await graphType.Fields.Find("idAndName").ShouldNotBeNull().Resolver!.ResolveAsync(context)).ShouldBe("testExample1");
+    }
+
+    public class Class1
+    {
+        public string? Test { get; set; }
     }
 
     [Fact]

--- a/src/GraphQL/Execution/DirectiveInfo.cs
+++ b/src/GraphQL/Execution/DirectiveInfo.cs
@@ -57,6 +57,9 @@ namespace GraphQL.Execution
                 return false;
             }
 
+            var resolvedType = Directive.Arguments?.Find(name)?.ResolvedType
+                ?? throw new InvalidOperationException($"Could not obtain graph type instance for argument '{name}'");
+
             if (arg.Value is IDictionary<string, object?> inputObject)
             {
                 if (argumentType == typeof(object))
@@ -65,11 +68,11 @@ namespace GraphQL.Execution
                     return true;
                 }
 
-                result = inputObject.ToObject(argumentType, Directive.Arguments?.Find(name)?.ResolvedType);
+                result = inputObject.ToObject(argumentType, resolvedType);
                 return true;
             }
 
-            result = arg.Value.GetPropertyValue(argumentType, Directive.Arguments?.Find(name)?.ResolvedType);
+            result = arg.Value.GetPropertyValue(argumentType, resolvedType);
             return true;
         }
     }

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -130,7 +130,7 @@ namespace GraphQL
                 if (fieldName is not null)
                 {
                     var fieldType = inputGraphType.Fields.Find(fieldName)?.ResolvedType
-                        ?? throw new InvalidOperationException($"Could not find resolved type for field '{fieldName}' of type '{inputGraphType}'.");
+                        ?? throw new InvalidOperationException($"Could not find ResolvedType for field '{fieldName}' of type '{inputGraphType}'.");
                     object? arg = GetPropertyValue(values[i], ctorParameters[i].ParameterType, fieldType);
                     ctorArguments[i] = arg;
                 }

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -130,7 +130,7 @@ namespace GraphQL
                 if (fieldName is not null)
                 {
                     var fieldType = inputGraphType.Fields.Find(fieldName)?.ResolvedType
-                        ?? throw new InvalidOperationException($"Could not find ResolvedType for field '{fieldName}' of type '{inputGraphType}'.");
+                        ?? throw new InvalidOperationException($"Could not get ResolvedType for field '{fieldName}' of type '{inputGraphType}'.");
                     object? arg = GetPropertyValue(values[i], ctorParameters[i].ParameterType, fieldType);
                     ctorArguments[i] = arg;
                 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -66,6 +66,9 @@ namespace GraphQL
                 return false;
             }
 
+            var resolvedType = context.FieldDefinition?.Arguments?.Find(argumentName)?.ResolvedType
+                ?? throw new InvalidOperationException($"Could not obtain graph type instance for argument '{name}'");
+
             if (arg.Value is IDictionary<string, object?> inputObject)
             {
                 if (argumentType == typeof(object))
@@ -74,11 +77,11 @@ namespace GraphQL
                     return true;
                 }
 
-                result = inputObject.ToObject(argumentType, context.FieldDefinition?.Arguments?.Find(argumentName)?.ResolvedType);
+                result = inputObject.ToObject(argumentType, resolvedType);
                 return true;
             }
 
-            result = arg.Value.GetPropertyValue(argumentType, context.FieldDefinition?.Arguments?.Find(argumentName)?.ResolvedType);
+            result = arg.Value.GetPropertyValue(argumentType, resolvedType);
             return true;
         }
 


### PR DESCRIPTION
Prior to making any planned changes to `ToObject`, I think it is necessary to require a reference to the input object graph type.  This will simplify the design and changes to `ToObject` in subsequent PRs.
