### PR TITLE
Consume analyzers by the sample project

### DIFF
--- a/src/GraphQL.StarWars/GraphQL.StarWars.csproj
+++ b/src/GraphQL.StarWars/GraphQL.StarWars.csproj
@@ -10,4 +10,13 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\GraphQL.Analyzers\GraphQL.Analyzers.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer" />
+    <ProjectReference Include="..\GraphQL.Analyzers.CodeFixes\GraphQL.Analyzers.CodeFixes.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Enable analyzers in the `GraphQL.StarWars` to see them live without the need to create the nuget package.