### PR TITLE
Ignore InputObjectGraphType analysis if type overrides ParseDictionary

### DIFF
--- a/docs2/site/docs/analyzers/GQL006_CanNotMatchInputFieldToTheSourceField.md
+++ b/docs2/site/docs/analyzers/GQL006_CanNotMatchInputFieldToTheSourceField.md
@@ -10,7 +10,10 @@
 
 ## Cause
 
-This rule triggers when a field defined on a type deriving from `InputObjectGraphType<TSourceType>` cannot be mapped to the `TSourceType` type.
+This rule triggers when a field defined on a type deriving from
+`InputObjectGraphType<TSourceType>` cannot be mapped to the `TSourceType` type.
+If the type or one of its base types override the `ParseDictionary` method the
+validation is skipped.
 
 ## Rule description
 
@@ -75,6 +78,23 @@ public class MySourceType
 }
 ```
 
+## Configure the analyzer
+
+If the `ParseDictionary` method of the analyzed type or any of its base types
+is overridden, the type analysis is skipped. However, you can manually force
+the analysis by specifying a comma-delimited list of full type names in the
+`.editorconfig` file using the
+`dotnet_diagnostic.input_graph_type_analyzer.force_types_analysis`
+configuration key.
+
+For instance, to enforce the analysis check for both
+`MyServer.BaseInputObjectGraphType` and `MyServer.BaseInputObjectGraphType2`,
+include the following configuration in your `.editorconfig` file:
+
+```ini
+dotnet_diagnostic.input_graph_type_analyzer.force_types_analysis = MyServer.BaseInputObjectGraphType,MyServer.BaseInputObjectGraphType2
+```
+
 ## Suppress a warning
 
 If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
@@ -95,3 +115,5 @@ dotnet_diagnostic.GQL006.severity = none
 For more information, see [How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).
 
 ## Related rules
+
+[# GQL007: Can not set source field](/GQL007_CanNotSetSourceField)

--- a/docs2/site/docs/analyzers/GQL007_CanNotSetSourceField.md
+++ b/docs2/site/docs/analyzers/GQL007_CanNotSetSourceField.md
@@ -10,7 +10,10 @@
 
 ## Cause
 
-This rule triggers when a field defined on a type deriving from `InputObjectGraphType<TSourceType>` has a matching field or property on the `TSourceType` type but it's not not settable.
+This rule triggers when a field defined on a type deriving from
+`InputObjectGraphType<TSourceType>` has a matching field or property on the
+`TSourceType` type but it's not not settable. If the type or one of its base
+types override the `ParseDictionary` method the validation is skipped.
 
 ## Rule description
 
@@ -79,6 +82,23 @@ public class MySourceType
     public string Title;
     public string Age;
 }
+```
+
+## Configure the analyzer
+
+If the `ParseDictionary` method of the analyzed type or any of its base types
+is overridden, the type analysis is skipped. However, you can manually force
+the analysis by specifying a comma-delimited list of full type names in the
+`.editorconfig` file using the
+`dotnet_diagnostic.input_graph_type_analyzer.force_types_analysis`
+configuration key.
+
+For instance, to enforce the analysis check for both
+`MyServer.BaseInputObjectGraphType` and `MyServer.BaseInputObjectGraphType2`,
+include the following configuration in your `.editorconfig` file:
+
+```ini
+dotnet_diagnostic.input_graph_type_analyzer.force_types_analysis = MyServer.BaseInputObjectGraphType,MyServer.BaseInputObjectGraphType2
 ```
 
 ## Suppress a warning

--- a/src/GraphQL.Analyzers/Constants.cs
+++ b/src/GraphQL.Analyzers/Constants.cs
@@ -33,6 +33,7 @@ public static class Constants
         public const string FieldSubscribe = "FieldSubscribe";
         public const string FieldSubscribeAsync = "FieldSubscribeAsync";
         public const string Name = "Name";
+        public const string ParseDictionary = "ParseDictionary";
         public const string Resolve = "Resolve";
         public const string ResolveAsync = "ResolveAsync";
         public const string ResolveDelegate = "ResolveDelegate";

--- a/src/GraphQL.Analyzers/Extensions.cs
+++ b/src/GraphQL.Analyzers/Extensions.cs
@@ -95,6 +95,12 @@ public static class Extensions
         return defaultValue;
     }
 
+    public static string? GetStringOption(this AnalyzerOptions analyzerOptions, string name, SyntaxTree tree, string? defaultValue = default)
+    {
+        var config = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(tree);
+        return config.TryGetValue(name, out string? configValue) ? configValue : defaultValue;
+    }
+
     public static Location GetMethodInvocationLocation(this MemberAccessExpressionSyntax memberAccessExpressionSyntax)
     {
         var methodNameLocation = memberAccessExpressionSyntax.Name.GetLocation();

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.cs
@@ -237,7 +237,7 @@ public class InputGraphTypeAnalyzer : DiagnosticAnalyzer
         }
 
         var genericInputObjectGraphType = context.Compilation.GetTypeByMetadataName("GraphQL.Types.InputObjectGraphType`1");
-        var methodSymbol = genericInputObjectGraphType?.GetMembers(Constants.MethodNames.ParseDictionary)
+        var parseDictionaryBaseMethod = genericInputObjectGraphType?.GetMembers(Constants.MethodNames.ParseDictionary)
             .OfType<IMethodSymbol>()
             .Single(); // analyzers are not supposed to throw exceptions but we expect this to fail in tests if the base type changes
 
@@ -258,7 +258,7 @@ public class InputGraphTypeAnalyzer : DiagnosticAnalyzer
             bool overridesParseDictionary = sourceTypeSymbol
                 .GetMembers("ParseDictionary")
                 .OfType<IMethodSymbol>()
-                .Any(m => SymbolEqualityComparer.Default.Equals(m.OverriddenMethod?.OriginalDefinition, methodSymbol));
+                .Any(m => SymbolEqualityComparer.Default.Equals(m.OverriddenMethod?.OriginalDefinition, parseDictionaryBaseMethod));
 
             if (overridesParseDictionary && forceTypesAnalysis?.Contains($"{sourceTypeSymbol.ContainingNamespace}.{sourceTypeSymbol.Name}") != true)
             {

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.cs
@@ -30,6 +30,8 @@ public class InputGraphTypeAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: HelpLinks.CAN_NOT_SET_SOURCE_FIELD);
 
+    public static string ForceTypesAnalysisOption => "dotnet_diagnostic.input_graph_type_analyzer.force_types_analysis";
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(CanNotMatchInputFieldToTheSourceField, CanNotSetSourceField);
 
@@ -235,10 +237,15 @@ public class InputGraphTypeAnalyzer : DiagnosticAnalyzer
         }
 
         var genericInputObjectGraphType = context.Compilation.GetTypeByMetadataName("GraphQL.Types.InputObjectGraphType`1");
-        if (genericInputObjectGraphType == null)
-        {
-            return null;
-        }
+        var methodSymbol = genericInputObjectGraphType?.GetMembers(Constants.MethodNames.ParseDictionary)
+            .OfType<IMethodSymbol>()
+            .Single(); // analyzers are not supposed to throw exceptions but we expect this to fail in tests if the base type changes
+
+        string? forceTypesAnalysisOption = context.Options.GetStringOption(ForceTypesAnalysisOption, context.Node.SyntaxTree);
+        var forceTypesAnalysis = forceTypesAnalysisOption
+            ?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(t => t.Trim())
+            .ToList();
 
         var sourceTypeSymbol = typeSymbol;
         while (sourceTypeSymbol != null)
@@ -246,6 +253,16 @@ public class InputGraphTypeAnalyzer : DiagnosticAnalyzer
             if (SymbolEqualityComparer.Default.Equals(sourceTypeSymbol.OriginalDefinition, genericInputObjectGraphType))
             {
                 return sourceTypeSymbol.TypeArguments.Single(); // <TSourceType>
+            }
+
+            bool overridesParseDictionary = sourceTypeSymbol
+                .GetMembers("ParseDictionary")
+                .OfType<IMethodSymbol>()
+                .Any(m => SymbolEqualityComparer.Default.Equals(m.OverriddenMethod?.OriginalDefinition, methodSymbol));
+
+            if (overridesParseDictionary && forceTypesAnalysis?.Contains($"{sourceTypeSymbol.ContainingNamespace}.{sourceTypeSymbol.Name}") != true)
+            {
+                return null;
             }
 
             sourceTypeSymbol = sourceTypeSymbol.BaseType;


### PR DESCRIPTION
Fixes #3775 

It appears that it's possible to get overridden methods based on the semantic model without the source code. So the limitation `when the source code of one of the base types is not available` was removed.