### PR TITLE
Verify input source type constructors

### DIFF
--- a/docs2/site/docs/analyzers/.vscode/settings.json
+++ b/docs2/site/docs/analyzers/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "[markdown]": {
         "editor.rulers": [80],
-        "editor.wordWrap": "off"
+        "editor.wordWrap": "bounded"
     }
 }

--- a/docs2/site/docs/analyzers/GQL006_CanNotMatchInputFieldToTheSourceField.md
+++ b/docs2/site/docs/analyzers/GQL006_CanNotMatchInputFieldToTheSourceField.md
@@ -124,4 +124,5 @@ For more information, see
 
 ## Related rules
 
-[# GQL007: Can not set source field](/GQL007_CanNotSetSourceField)
+[GQL007: Can not set source field](/GQL007_CanNotSetSourceField)
+[GQL010: Can not resolve input source type constructor](/GQL010_CanNotResolveInputSourceTypeConstructor)

--- a/docs2/site/docs/analyzers/GQL007_CanNotSetSourceField.md
+++ b/docs2/site/docs/analyzers/GQL007_CanNotSetSourceField.md
@@ -130,3 +130,4 @@ For more information, see
 ## Related rules
 
 [GQL006: Can not match input field to the source field](/GQL006_CanNotMatchInputFieldToTheSourceField)
+[GQL010: Can not resolve input source type constructor](/GQL010_CanNotResolveInputSourceTypeConstructor)

--- a/docs2/site/docs/analyzers/GQL010_CanNotResolveInputSourceTypeConstructor.md
+++ b/docs2/site/docs/analyzers/GQL010_CanNotResolveInputSourceTypeConstructor.md
@@ -1,0 +1,145 @@
+# GQL010: Can not resolve input source type constructor
+
+|                        | Value  |
+| ---------------------- | ------ |
+| **Rule ID**            | GQL010 |
+| **Category**           | Usage  |
+| **Default severity**   | ERROR  |
+| **Enabled by default** | Yes    |
+| **Code fix provided**  | No     |
+
+## Cause
+
+This rule triggers when the type `TSourceType` used in the
+`InputObjectGraphType<TSourceType>` can't be constructed during the input
+parsing. If the type or one of its base types override the `ParseDictionary`
+method the validation is skipped.
+
+## Rule description
+
+The `TSourceType` should be a non-abstract `class`, `struct` or `record` and
+satisfy one of the following requirements:
+
+- Have an implicit default constructor
+- Have a public parameterless constructor
+- Have a singular public parameterized constructor
+- Have multiple public parameterized constructors and one and only one of them
+  is annotated with `GraphQLConstructorAttribute`
+
+## How to fix violations
+
+Follow the rules described in the [Rule description](#rule-description) section.
+
+## Example of a violation
+
+```c#
+// no public constructor
+public class MyInput1
+{
+    internal MyInput1(string name, int age)
+    {
+        Name = name;
+        Age = age;
+    }
+
+    public string Name { get; set; }
+    public int Age { get; set; }
+}
+
+// multiple public parametrized constructors
+public class MyInput2
+{
+    public MyInput2(string name)
+    {
+        Name = name;
+    }
+
+    public MyInput2(int age)
+    {
+        Age = age;
+    }
+
+    public string? Name { get; set; }
+    public int Age { get; set; }
+}
+```
+
+## Example of how to fix
+
+```c#
+// make the constructor public
+public class MyInput1
+{
+    public MyInput(string name, int age)
+    {
+        Name = name;
+        Age = age;
+    }
+
+    public string Name { get; set; }
+    public int Age { get; set; }
+}
+
+// annotate one of the constructors with a GraphQLConstructorAttribute
+public class MyInput2
+{
+    [GraphQLConstructor]
+    public MyInput2(string name)
+    {
+        Name = name;
+    }
+
+    public MyInput2(int age)
+    {
+        Age = age;
+    }
+
+    public string? Name { get; set; }
+    public int Age { get; set; }
+}
+```
+
+## Configure the analyzer
+
+If the `ParseDictionary` method of the analyzed type or any of its base types is
+overridden, the type analysis is skipped. However, you can manually force the
+analysis by specifying a comma-delimited list of full type names in the
+`.editorconfig` file using the
+`dotnet_diagnostic.input_graph_type_analyzer.force_types_analysis` configuration
+key.
+
+For instance, to enforce the analysis check for both
+`MyServer.BaseInputObjectGraphType` and `MyServer.BaseInputObjectGraphType2`,
+include the following configuration in your `.editorconfig` file:
+
+```ini
+dotnet_diagnostic.input_graph_type_analyzer.force_types_analysis = MyServer.BaseInputObjectGraphType,MyServer.BaseInputObjectGraphType2
+```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable GQL010
+// The code that's violating the rule is on this line.
+#pragma warning restore GQL010
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.cs]
+dotnet_diagnostic.GQL010.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).
+
+## Related rules
+
+[GQL006: Can not match input field to the source field](/GQL006_CanNotMatchInputFieldToTheSourceField)  
+[GQL007: Can not set source field](/GQL007_CanNotSetSourceField)

--- a/docs2/site/docs/analyzers/Overview.md
+++ b/docs2/site/docs/analyzers/Overview.md
@@ -58,8 +58,8 @@ that removes these incorrect usages.
 
 ### 4. InputGraphTypeAnalyzer
 
-The analyzer detects input graph type fields that can't be mapped to the source
-type during deserialization process.
+The analyzer verifies the input source type can be constructed and input graph
+type fields can be mapped to the source type during deserialization process.
 
 ### 5. FieldArgumentAnalyzer
 

--- a/src/GraphQL.Analyzers.Tests/InputGraphTypeAnalyzerTests.Constructors.cs
+++ b/src/GraphQL.Analyzers.Tests/InputGraphTypeAnalyzerTests.Constructors.cs
@@ -1,0 +1,261 @@
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = GraphQL.Analyzers.Tests.VerifiersExtensions.CSharpAnalyzerVerifier<
+    GraphQL.Analyzers.InputGraphTypeAnalyzer>;
+
+namespace GraphQL.Analyzers.Tests;
+
+public partial class InputGraphTypeAnalyzerTests
+{
+    [Theory]
+    [InlineData(null, false)] // implicit default constructor
+    [InlineData("public MySource() { }", false)]
+    [InlineData("private MySource() { }", true)]
+    [InlineData("internal MySource() { }", true)]
+    [InlineData("public MySource(string name) { }", false)]
+    [InlineData("private MySource(string name) { }", true)]
+    [InlineData("internal MySource(string name) { }", true)]
+    public async Task SingleConstructor_GQL010_WhenNonPublic(string constructor, bool report)
+    {
+        string source =
+            $$"""
+              using GraphQL.Types;
+              using System.Collections.Generic;
+
+              namespace Sample.Server;
+
+              public class CustomInputObjectGraphType : InputObjectGraphType<MySource>
+              {
+                  public CustomInputObjectGraphType()
+                  {
+                      Field<StringGraphType>("Name");
+                  }
+              }
+
+              public class MySource
+              {
+                  {{constructor}}
+                  public string Name { get; set; }
+              }
+              """;
+
+        var expected = report
+            ? new[]
+            {
+                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+                    .WithSpan(6, 64, 6, 72).WithArguments("MySource")
+            }
+            : DiagnosticResult.EmptyDiagnosticResults;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task DefaultAndNonDefaultConstructor_NoDiagnostics()
+    {
+        const string source =
+            """
+              using GraphQL.Types;
+              using System.Collections.Generic;
+
+              namespace Sample.Server;
+
+              public class CustomInputObjectGraphType : InputObjectGraphType<MySource>
+              {
+                  public CustomInputObjectGraphType()
+                  {
+                      Field<StringGraphType>("Name");
+                  }
+              }
+
+              public class MySource
+              {
+                  public MySource() { }
+                  public MySource(string name) { }
+                  public string Name { get; set; }
+              }
+              """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task TwoNonDefaultConstructors_GQL010()
+    {
+        const string source =
+            """
+            using GraphQL.Types;
+            using System.Collections.Generic;
+
+            namespace Sample.Server;
+
+            public class CustomInputObjectGraphType : InputObjectGraphType<MySource>
+            {
+                public CustomInputObjectGraphType()
+                {
+                    Field<StringGraphType>("Name");
+                }
+            }
+
+            public class MySource
+            {
+                public MySource(int num) { }
+                public MySource(string name) { }
+                public string Name { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+            .WithSpan(6, 64, 6, 72).WithArguments("MySource");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Theory]
+    [InlineData(null, null, true)]
+    [InlineData("[GraphQLConstructor]", null, false)]
+    [InlineData(null, "[GraphQLConstructor]", false)]
+    [InlineData("[GraphQLConstructor]", "[GraphQLConstructor]", true)]
+    [InlineData("[Another]", "[GraphQLConstructor]", false)]
+    [InlineData("[Another]", "[Another]", true)]
+    public async Task TwoNonDefaultConstructors_WithAttribute_GQL010_WhenNotSingleGraphQLConstructorAttribute(string attribute1, string attribute2, bool report)
+    {
+        string source =
+            $$"""
+              using System;
+              using GraphQL;
+              using GraphQL.Types;
+              using System.Collections.Generic;
+
+              namespace Sample.Server;
+
+              public class CustomInputObjectGraphType : InputObjectGraphType<MySource>
+              {
+                  public CustomInputObjectGraphType()
+                  {
+                      Field<StringGraphType>("Name");
+                  }
+              }
+
+              public class MySource
+              {
+                  {{attribute1}}
+                  public MySource(int num) { }
+                  {{attribute2}}
+                  public MySource(string name) { }
+                  public string Name { get; set; }
+              }
+
+              [AttributeUsage(AttributeTargets.Constructor)]
+              public class AnotherAttribute : Attribute { }
+              """;
+
+        var expected = report
+            ? new[]
+            {
+                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+                    .WithSpan(8, 64, 8, 72).WithArguments("MySource")
+            }
+            : DiagnosticResult.EmptyDiagnosticResults;
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task DefaultConstructor_SourceTypeIsAbstract_GQL010()
+    {
+        const string source =
+            """
+            using GraphQL;
+            using GraphQL.Types;
+            using System.Collections.Generic;
+
+            namespace Sample.Server;
+
+            public class CustomInputObjectGraphType : InputObjectGraphType<MySource>
+            {
+                public CustomInputObjectGraphType()
+                {
+                    Field<StringGraphType>("Name");
+                }
+            }
+
+            public abstract class MySource
+            {
+                public string Name { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+            .WithSpan(7, 64, 7, 72).WithArguments("MySource");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task TwoNonDefaultConstructors_SourceTypeIsOpenGeneric_NoDiagnostics()
+    {
+        const string source =
+            """
+            using GraphQL;
+            using GraphQL.Types;
+            using System.Collections.Generic;
+
+            namespace Sample.Server;
+
+            public class CustomInputObjectGraphType<TSource> : InputObjectGraphType<TSource>
+                where TSource : MySource
+            {
+                public CustomInputObjectGraphType()
+                {
+                    Field<StringGraphType>("Name");
+                }
+            }
+
+            public class MySource
+            {
+                public MySource(int num) { }
+                public MySource(string name) { }
+                public string Name { get; set; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task TwoNonDefaultConstructors_SourceTypeDefinedByTheBaseClass_GQL010_OnBaseOnly()
+    {
+        const string source =
+            """
+            using GraphQL;
+            using GraphQL.Types;
+            using System.Collections.Generic;
+
+            namespace Sample.Server;
+
+            public class CustomInputObjectGraphType : BaseInputObjectGraphType
+            {
+                public CustomInputObjectGraphType()
+                {
+                    Field<StringGraphType>("Name");
+                }
+            }
+
+            public class BaseInputObjectGraphType : InputObjectGraphType<MySource>
+            {
+            }
+
+            public class MySource
+            {
+                public MySource(int num) { }
+                public MySource(string name) { }
+                public string Name { get; set; }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+            .WithSpan(15, 62, 15, 70).WithArguments("MySource");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+}

--- a/src/GraphQL.Analyzers.Tests/InputGraphTypeAnalyzerTests.Constructors.cs
+++ b/src/GraphQL.Analyzers.Tests/InputGraphTypeAnalyzerTests.Constructors.cs
@@ -41,7 +41,7 @@ public partial class InputGraphTypeAnalyzerTests
         var expected = report
             ? new[]
             {
-                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputSourceTypeConstructor)
                     .WithSpan(6, 64, 6, 72).WithArguments("MySource")
             }
             : DiagnosticResult.EmptyDiagnosticResults;
@@ -104,7 +104,7 @@ public partial class InputGraphTypeAnalyzerTests
             }
             """;
 
-        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputSourceTypeConstructor)
             .WithSpan(6, 64, 6, 72).WithArguments("MySource");
 
         await VerifyCS.VerifyAnalyzerAsync(source, expected);
@@ -152,7 +152,7 @@ public partial class InputGraphTypeAnalyzerTests
         var expected = report
             ? new[]
             {
-                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputSourceTypeConstructor)
                     .WithSpan(8, 64, 8, 72).WithArguments("MySource")
             }
             : DiagnosticResult.EmptyDiagnosticResults;
@@ -185,7 +185,7 @@ public partial class InputGraphTypeAnalyzerTests
             }
             """;
 
-        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputSourceTypeConstructor)
             .WithSpan(7, 64, 7, 72).WithArguments("MySource");
 
         await VerifyCS.VerifyAnalyzerAsync(source, expected);
@@ -253,7 +253,7 @@ public partial class InputGraphTypeAnalyzerTests
             }
             """;
 
-        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+        var expected = VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputSourceTypeConstructor)
             .WithSpan(15, 62, 15, 70).WithArguments("MySource");
 
         await VerifyCS.VerifyAnalyzerAsync(source, expected);

--- a/src/GraphQL.Analyzers.Tests/InputGraphTypeAnalyzerTests.Fields.cs
+++ b/src/GraphQL.Analyzers.Tests/InputGraphTypeAnalyzerTests.Fields.cs
@@ -150,7 +150,7 @@ public partial class InputGraphTypeAnalyzerTests
             ? DiagnosticResult.EmptyDiagnosticResults
             : new[]
             {
-                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputSourceTypeConstructor)
                     .WithSpan(5, 54, 5, 66).WithArguments("MySourceType"),
                 VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotMatchInputFieldToTheSourceField)
                     .WithSpan(9, 32, 9, 43).WithArguments("FirstName", "MySourceType")

--- a/src/GraphQL.Analyzers.Tests/InputGraphTypeAnalyzerTests.Fields.cs
+++ b/src/GraphQL.Analyzers.Tests/InputGraphTypeAnalyzerTests.Fields.cs
@@ -4,7 +4,7 @@ using VerifyCS = GraphQL.Analyzers.Tests.VerifiersExtensions.CSharpAnalyzerVerif
 
 namespace GraphQL.Analyzers.Tests;
 
-public class InputGraphTypeAnalyzerTests
+public partial class InputGraphTypeAnalyzerTests
 {
     [Fact]
     public async Task Sanity_NoDiagnostics()
@@ -150,6 +150,8 @@ public class InputGraphTypeAnalyzerTests
             ? DiagnosticResult.EmptyDiagnosticResults
             : new[]
             {
+                VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotResolveInputObjectConstructor)
+                    .WithSpan(5, 54, 5, 66).WithArguments("MySourceType"),
                 VerifyCS.Diagnostic(InputGraphTypeAnalyzer.CanNotMatchInputFieldToTheSourceField)
                     .WithSpan(9, 32, 9, 43).WithArguments("FirstName", "MySourceType")
             };

--- a/src/GraphQL.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/GraphQL.Analyzers/AnalyzerReleases.Unshipped.md
@@ -14,4 +14,4 @@ GQL006 | Usage | Warning | InputGraphTypeAnalyzer, [Documentation](https://graph
 GQL007 | Usage | Warning | InputGraphTypeAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL007_CanNotSetSourceField)
 GQL008 | Usage | Warning | FieldArgumentAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL008_DoNotUseObsoleteArgumentMethod)
 GQL009 | Usage | Error | AwaitableResolverAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL009_UseAsyncResolver)
-GQL010 | Usage | Error | InputGraphTypeAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL010_CanNotResolveInputObjectConstructor)
+GQL010 | Usage | Error | InputGraphTypeAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL010_CanNotResolveInputSourceTypeConstructor)

--- a/src/GraphQL.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/GraphQL.Analyzers/AnalyzerReleases.Unshipped.md
@@ -14,3 +14,4 @@ GQL006 | Usage | Warning | InputGraphTypeAnalyzer, [Documentation](https://graph
 GQL007 | Usage | Warning | InputGraphTypeAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL007_CanNotSetSourceField)
 GQL008 | Usage | Warning | FieldArgumentAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL008_DoNotUseObsoleteArgumentMethod)
 GQL009 | Usage | Error | AwaitableResolverAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL009_UseAsyncResolver)
+GQL010 | Usage | Error | InputGraphTypeAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/GQL010_CanNotResolveInputObjectConstructor)

--- a/src/GraphQL.Analyzers/Helpers/Constants.cs
+++ b/src/GraphQL.Analyzers/Helpers/Constants.cs
@@ -61,6 +61,7 @@ public static class Constants
     public static class Types
     {
         public const string FieldType = "FieldType";
+        public const string GraphQLConstructorAttribute = "GraphQLConstructorAttribute";
     }
 
     public static class Interfaces

--- a/src/GraphQL.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/GraphQL.Analyzers/Helpers/DiagnosticIds.cs
@@ -11,4 +11,5 @@ public static class DiagnosticIds
     public const string CAN_NOT_SET_SOURCE_FIELD = "GQL007";
     public const string DO_NOT_USE_OBSOLETE_ARGUMENT_METHOD = "GQL008";
     public const string USE_ASYNC_RESOLVER = "GQL009";
+    public const string CAN_NOT_RESOLVE_INPUT_OBJECT_CONSTRUCTOR = "GQL010";
 }

--- a/src/GraphQL.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/GraphQL.Analyzers/Helpers/DiagnosticIds.cs
@@ -11,5 +11,5 @@ public static class DiagnosticIds
     public const string CAN_NOT_SET_SOURCE_FIELD = "GQL007";
     public const string DO_NOT_USE_OBSOLETE_ARGUMENT_METHOD = "GQL008";
     public const string USE_ASYNC_RESOLVER = "GQL009";
-    public const string CAN_NOT_RESOLVE_INPUT_OBJECT_CONSTRUCTOR = "GQL010";
+    public const string CAN_NOT_RESOLVE_INPUT_SOURCE_TYPE_CONSTRUCTOR = "GQL010";
 }

--- a/src/GraphQL.Analyzers/Helpers/HelpLinks.cs
+++ b/src/GraphQL.Analyzers/Helpers/HelpLinks.cs
@@ -12,5 +12,5 @@ public static class HelpLinks
     public const string CAN_NOT_SET_SOURCE_FIELD = $"{DOCS_URL}/GQL007_CanNotSetSourceField";
     public const string DO_NOT_USE_OBSOLETE_ARGUMENT_METHOD = $"{DOCS_URL}/GQL008_DoNotUseObsoleteArgumentMethod";
     public const string USE_ASYNC_RESOLVER = $"{DOCS_URL}/GQL009_UseAsyncResolver";
-    public const string CAN_NOT_RESOLVE_INPUT_OBJECT_CONSTRUCTOR = $"{DOCS_URL}/GQL010_CanNotResolveInputObjectConstructor";
+    public const string CAN_NOT_RESOLVE_INPUT_SOURCE_TYPE_CONSTRUCTOR = $"{DOCS_URL}/GQL010_CanNotResolveInputObjectConstructor";
 }

--- a/src/GraphQL.Analyzers/Helpers/HelpLinks.cs
+++ b/src/GraphQL.Analyzers/Helpers/HelpLinks.cs
@@ -12,5 +12,5 @@ public static class HelpLinks
     public const string CAN_NOT_SET_SOURCE_FIELD = $"{DOCS_URL}/GQL007_CanNotSetSourceField";
     public const string DO_NOT_USE_OBSOLETE_ARGUMENT_METHOD = $"{DOCS_URL}/GQL008_DoNotUseObsoleteArgumentMethod";
     public const string USE_ASYNC_RESOLVER = $"{DOCS_URL}/GQL009_UseAsyncResolver";
-    public const string CAN_NOT_RESOLVE_INPUT_SOURCE_TYPE_CONSTRUCTOR = $"{DOCS_URL}/GQL010_CanNotResolveInputObjectConstructor";
+    public const string CAN_NOT_RESOLVE_INPUT_SOURCE_TYPE_CONSTRUCTOR = $"{DOCS_URL}/GQL010_CanNotResolveInputSourceTypeConstructor";
 }

--- a/src/GraphQL.Analyzers/Helpers/HelpLinks.cs
+++ b/src/GraphQL.Analyzers/Helpers/HelpLinks.cs
@@ -12,4 +12,5 @@ public static class HelpLinks
     public const string CAN_NOT_SET_SOURCE_FIELD = $"{DOCS_URL}/GQL007_CanNotSetSourceField";
     public const string DO_NOT_USE_OBSOLETE_ARGUMENT_METHOD = $"{DOCS_URL}/GQL008_DoNotUseObsoleteArgumentMethod";
     public const string USE_ASYNC_RESOLVER = $"{DOCS_URL}/GQL009_UseAsyncResolver";
+    public const string CAN_NOT_RESOLVE_INPUT_OBJECT_CONSTRUCTOR = $"{DOCS_URL}/GQL010_CanNotResolveInputObjectConstructor";
 }

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Constructors.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Constructors.cs
@@ -1,7 +1,7 @@
 using GraphQL.Analyzers.Helpers;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis;
 
 namespace GraphQL.Analyzers;
 

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Constructors.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Constructors.cs
@@ -7,16 +7,16 @@ namespace GraphQL.Analyzers;
 
 public partial class InputGraphTypeAnalyzer
 {
-    public static readonly DiagnosticDescriptor CanNotResolveInputObjectConstructor = new(
-        id: DiagnosticIds.CAN_NOT_RESOLVE_INPUT_OBJECT_CONSTRUCTOR,
-        title: "Can not resolve input object constructor",
-        messageFormat: "The source input type '{0}' must be a non-abstract, have a parameterless constructor, or " +
+    public static readonly DiagnosticDescriptor CanNotResolveInputSourceTypeConstructor = new(
+        id: DiagnosticIds.CAN_NOT_RESOLVE_INPUT_SOURCE_TYPE_CONSTRUCTOR,
+        title: "Can not resolve input source type constructor",
+        messageFormat: "The input source type '{0}' must be a non-abstract, have a parameterless constructor, or " +
                        "a singular parameterized constructor, or a parameterized constructor annotated with " +
                        $"'{Constants.Types.GraphQLConstructorAttribute}'",
         category: DiagnosticCategories.USAGE,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        helpLinkUri: HelpLinks.CAN_NOT_RESOLVE_INPUT_OBJECT_CONSTRUCTOR);
+        helpLinkUri: HelpLinks.CAN_NOT_RESOLVE_INPUT_SOURCE_TYPE_CONSTRUCTOR);
 
     private static void AnalyzeSourceTypeConstructors(
         SyntaxNodeAnalysisContext context,
@@ -80,7 +80,7 @@ public partial class InputGraphTypeAnalyzer
             if (location != null)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
-                    CanNotResolveInputObjectConstructor,
+                    CanNotResolveInputSourceTypeConstructor,
                     location,
                     (sourceTypeSymbol as INamedTypeSymbol)?.Name));
             }

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Constructors.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Constructors.cs
@@ -1,0 +1,109 @@
+using GraphQL.Analyzers.Helpers;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis;
+
+namespace GraphQL.Analyzers;
+
+public partial class InputGraphTypeAnalyzer
+{
+    public static readonly DiagnosticDescriptor CanNotResolveInputObjectConstructor = new(
+        id: DiagnosticIds.CAN_NOT_RESOLVE_INPUT_OBJECT_CONSTRUCTOR,
+        title: "Can not resolve input object constructor",
+        messageFormat: "The source input type '{0}' must be a non-abstract, have a parameterless constructor, or " +
+                       "a singular parameterized constructor, or a parameterized constructor annotated with " +
+                       $"'{Constants.Types.GraphQLConstructorAttribute}'",
+        category: DiagnosticCategories.USAGE,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: HelpLinks.CAN_NOT_RESOLVE_INPUT_OBJECT_CONSTRUCTOR);
+
+    private static void AnalyzeSourceTypeConstructors(
+        SyntaxNodeAnalysisContext context,
+        BaseTypeDeclarationSyntax inputObjectDeclarationSyntax,
+        ITypeSymbol sourceTypeSymbol)
+    {
+        // MyInput<SourceType> : InputObjectGraphType<SourceType>
+        if (sourceTypeSymbol is ITypeParameterSymbol)
+        {
+            return;
+        }
+
+        if (sourceTypeSymbol.IsAbstract)
+        {
+            ReportConstructorDiagnostic();
+            return;
+        }
+
+        var constructors = sourceTypeSymbol
+            .GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(method => method is
+            {
+                MethodKind: MethodKind.Constructor,
+                DeclaredAccessibility: Accessibility.Public
+            })
+            .ToList();
+
+        // no public constructor
+        if (constructors.Count == 0)
+        {
+            ReportConstructorDiagnostic();
+            return;
+        }
+
+        // single public or implicit default constructor
+        if (constructors.Count == 1)
+        {
+            return;
+        }
+
+        // explicit default constructor
+        if (constructors.Any(ctor => ctor.Parameters.Length == 0))
+        {
+            return;
+        }
+
+        // one constructor with [GraphQLConstructor] attribute
+        if (constructors.Count(HasGraphQLAttribute) == 1)
+        {
+            return;
+        }
+
+        // no default constructors and (no [GraphQLConstructor] attribute, or multiple [GraphQLConstructor] attributes)
+        ReportConstructorDiagnostic();
+        return;
+
+        void ReportConstructorDiagnostic()
+        {
+            var location = FindSourceSymbolUsageLocation();
+            if (location != null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    CanNotResolveInputObjectConstructor,
+                    location,
+                    (sourceTypeSymbol as INamedTypeSymbol)?.Name));
+            }
+        }
+
+        // the location of the 'SourceType' in InputObjectGraphType<SourceType>
+        Location? FindSourceSymbolUsageLocation() =>
+            inputObjectDeclarationSyntax.BaseList
+                ?.Types
+                .Select(baseTypeSyntax => baseTypeSyntax.Type)
+                .OfType<GenericNameSyntax>()
+                .SelectMany(generic => generic.TypeArgumentList.Arguments)
+                .FirstOrDefault(arg =>
+                {
+                    var argType = context.SemanticModel.GetTypeInfo(arg).Type;
+                    return argType != null && SymbolEqualityComparer.Default.Equals(argType, sourceTypeSymbol);
+                })
+                ?.GetLocation();
+    }
+
+    private static bool HasGraphQLAttribute(IMethodSymbol constructor) =>
+        constructor
+            .GetAttributes()
+            .Any(attr => attr.AttributeClass?.Name == Constants.Types.GraphQLConstructorAttribute &&
+                         attr.AttributeClass.IsGraphQLSymbol());
+}

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Fields.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Fields.cs
@@ -1,0 +1,259 @@
+using GraphQL.Analyzers.Helpers;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis;
+
+namespace GraphQL.Analyzers;
+
+public partial class InputGraphTypeAnalyzer
+{
+    public static readonly DiagnosticDescriptor CanNotMatchInputFieldToTheSourceField = new(
+        id: DiagnosticIds.CAN_NOT_MATCH_INPUT_FIELD_TO_THE_SOURCE_FIELD,
+        title: "Can not match input field to the source field",
+        messageFormat: "No property, field or constructor parameter " +
+                       "called '{0}' was found on the source type(s) {1}. " +
+                       "This field will be ignored during the input deserialization.",
+        category: DiagnosticCategories.USAGE,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: HelpLinks.CAN_NOT_MATCH_INPUT_FIELD_TO_THE_SOURCE_FIELD);
+
+    public static readonly DiagnosticDescriptor CanNotSetSourceField = new(
+        id: DiagnosticIds.CAN_NOT_SET_SOURCE_FIELD,
+        title: "Can not set source field",
+        messageFormat: "The field '{0}' can't be mapped to the {1} '{2}' of the type '{3}' because it's {4}. " +
+                       "This field will be ignored during the input deserialization.",
+        category: DiagnosticCategories.USAGE,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: HelpLinks.CAN_NOT_SET_SOURCE_FIELD);
+
+    private static void AnalyzeInputGraphTypeFields(
+        SyntaxNodeAnalysisContext context,
+        BaseTypeDeclarationSyntax inputObjectDeclarationSyntax,
+        ITypeSymbol sourceTypeSymbol)
+    {
+        var allowedSymbols = (sourceTypeSymbol is ITypeParameterSymbol parameterSymbol
+                ? GetAllowedFieldNames(parameterSymbol.ConstraintTypes)
+                : GetAllowedFieldNames(sourceTypeSymbol))
+            .GroupBy(symbol => symbol.Name, StringComparer.InvariantCultureIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.ToList(),
+                StringComparer.InvariantCultureIgnoreCase);
+
+        foreach (var fieldInvocationExpression in GetDeclaredFields(inputObjectDeclarationSyntax))
+        {
+            var nameArg = fieldInvocationExpression
+                .GetMethodArgument(Constants.ArgumentNames.Name, context.SemanticModel)
+                ?.Expression;
+
+            string? fieldName = null;
+            switch (nameArg)
+            {
+                case LiteralExpressionSyntax literal:
+                    fieldName = literal.Token.ValueText;
+                    break;
+                case IdentifierNameSyntax: // ConstField
+                case MemberAccessExpressionSyntax: // ConstClass.ConstField
+                    var nameSymbol = context.SemanticModel.GetSymbolInfo(nameArg).Symbol;
+                    if (nameSymbol is IFieldSymbol { IsConst: true, ConstantValue: string } constSymbol)
+                    {
+                        fieldName = (string)constSymbol.ConstantValue!;
+                    }
+                    break;
+            }
+
+            var expressionArg = fieldInvocationExpression
+                .GetMethodArgument(Constants.ArgumentNames.Expression, context.SemanticModel)
+                ?.Expression;
+
+            // don't analyze name for Field("FirstName", source => source.Name), only the accessibility
+            if (expressionArg is SimpleLambdaExpressionSyntax { Body: MemberAccessExpressionSyntax mem })
+            {
+                var expressionSymbol = context.SemanticModel.GetSymbolInfo(mem);
+                if (expressionSymbol.Symbol != null)
+                {
+                    var symbols = new List<ISymbol> { expressionSymbol.Symbol };
+                    AnalyzeAccessibility(
+                        context,
+                        nameArg ?? mem,
+                        fieldName ?? expressionSymbol.Symbol.Name,
+                        symbols);
+                }
+                continue;
+            }
+
+            if (nameArg != null && fieldName != null)
+            {
+                AnalyzeFieldName(context, nameArg, fieldName, allowedSymbols, sourceTypeSymbol);
+            }
+        }
+    }
+
+    private static IEnumerable<ISymbol> GetAllowedFieldNames(IEnumerable<ITypeSymbol> sourceTypeSymbols) =>
+        sourceTypeSymbols.SelectMany(GetAllowedFieldNames);
+
+    private static IEnumerable<ISymbol> GetAllowedFieldNames(ITypeSymbol sourceTypeSymbol)
+    {
+        // consider ctor params on the type itself but not base classes
+        IEnumerable<ISymbol> symbols = sourceTypeSymbol
+            .GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(method => method is
+            {
+                MethodKind: MethodKind.Constructor,
+                DeclaredAccessibility: Accessibility.Public
+            })
+            .SelectMany(ctor => ctor.Parameters);
+
+        var nullableSourceTypeSymbol = sourceTypeSymbol;
+        while (nullableSourceTypeSymbol != null)
+        {
+            var fieldsOrProperties = nullableSourceTypeSymbol
+                .GetMembers()
+                .Where(symbol => !symbol.IsImplicitlyDeclared && symbol is IPropertySymbol or IFieldSymbol);
+
+            symbols = symbols.Concat(fieldsOrProperties);
+            nullableSourceTypeSymbol = nullableSourceTypeSymbol.BaseType;
+        }
+
+        return symbols;
+    }
+
+    private static IEnumerable<InvocationExpressionSyntax> GetDeclaredFields(BaseTypeDeclarationSyntax classDeclaration)
+    {
+        return classDeclaration
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(IsFieldInvocation);
+
+        static bool IsFieldInvocation(InvocationExpressionSyntax exp)
+        {
+            return exp.Expression switch
+            {
+                // Field
+                SimpleNameSyntax nameSyntax =>
+                    IsField(nameSyntax),
+                // this.Field
+                MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax } expressionSyntax =>
+                    IsField(expressionSyntax.Name),
+                _ => false
+            };
+        }
+
+        static bool IsField(SimpleNameSyntax simpleNameSyntax) =>
+            simpleNameSyntax.Identifier.Text == Constants.MethodNames.Field;
+    }
+
+    private static void AnalyzeFieldName(
+        SyntaxNodeAnalysisContext context,
+        ExpressionSyntax nameExpression,
+        string fieldName,
+        IDictionary<string, List<ISymbol>> allowedSymbols,
+        ISymbol sourceTypeSymbol)
+    {
+        if (allowedSymbols.TryGetValue(fieldName, out var symbols))
+        {
+            AnalyzeAccessibility(context, nameExpression, fieldName, symbols);
+            return;
+        }
+
+        string names = sourceTypeSymbol.Name;
+
+        if (sourceTypeSymbol is ITypeParameterSymbol p && p.ConstraintTypes.Any())
+        {
+            names = string.Join(" or ", p.ConstraintTypes.Select(t => t.Name));
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                CanNotMatchInputFieldToTheSourceField,
+                nameExpression.GetLocation(),
+                fieldName,
+                names));
+    }
+
+    private static void AnalyzeAccessibility(
+        SyntaxNodeAnalysisContext context,
+        ExpressionSyntax nameExpression,
+        string fieldName,
+        List<ISymbol> symbols)
+    {
+        var diagnostics = symbols.ConvertAll(CheckSymbol);
+
+        // at least one field can be set
+        if (diagnostics.Any(diagnostic => diagnostic == null))
+        {
+            return;
+        }
+
+        foreach (var diagnostic in diagnostics)
+        {
+            context.ReportDiagnostic(diagnostic!);
+        }
+
+        Diagnostic? CheckSymbol(ISymbol symbol)
+        {
+            List<string>? reasons = null;
+            string? symbolType = null;
+
+            if (symbol.DeclaredAccessibility != Accessibility.Public)
+            {
+                (reasons ??= new List<string>()).Add("not 'public'");
+            }
+
+            if (symbol.IsStatic)
+            {
+                (reasons ??= new List<string>()).Add("'static'");
+            }
+
+            switch (symbol)
+            {
+                case IParameterSymbol:
+                    return null;
+                case IPropertySymbol property:
+                {
+                    symbolType = "property";
+                    if (property.SetMethod is not { DeclaredAccessibility: Accessibility.Public })
+                    {
+                        (reasons ??= new List<string>()).Add("doesn't have a public setter");
+                    }
+                    break;
+                }
+                case IFieldSymbol field:
+                {
+                    symbolType = "field";
+                    if (field.IsConst)
+                    {
+                        _ = reasons!.Remove("'static'");
+                        reasons.Add("'const'");
+                    }
+                    else if (field.IsReadOnly)
+                    {
+                        (reasons ??= new List<string>()).Add("'readonly'");
+                    }
+                    break;
+                }
+            }
+
+            if (reasons == null)
+            {
+                return null;
+            }
+
+            string reason = reasons.Count == 1
+                ? reasons[0]
+                : string.Join(", ", reasons.Take(reasons.Count - 1)) + $" and {reasons.Last()}";
+
+            return Diagnostic.Create(
+                CanNotSetSourceField,
+                nameExpression.GetLocation(),
+                fieldName,
+                symbolType,
+                symbol.Name,
+                symbol.ContainingType.Name,
+                reason);
+        }
+    }
+}

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Fields.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.Fields.cs
@@ -1,7 +1,7 @@
 using GraphQL.Analyzers.Helpers;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis;
 
 namespace GraphQL.Analyzers;
 

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.cs
@@ -8,33 +8,15 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace GraphQL.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class InputGraphTypeAnalyzer : DiagnosticAnalyzer
+public partial class InputGraphTypeAnalyzer : DiagnosticAnalyzer
 {
-    public static readonly DiagnosticDescriptor CanNotMatchInputFieldToTheSourceField = new(
-        id: DiagnosticIds.CAN_NOT_MATCH_INPUT_FIELD_TO_THE_SOURCE_FIELD,
-        title: "Can not match input field to the source field",
-        messageFormat: "No property, field or constructor parameter " +
-                       "called '{0}' was found on the source type(s) {1}. " +
-                       "This field will be ignored during the input deserialization.",
-        category: DiagnosticCategories.USAGE,
-        defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
-        helpLinkUri: HelpLinks.CAN_NOT_MATCH_INPUT_FIELD_TO_THE_SOURCE_FIELD);
-
-    public static readonly DiagnosticDescriptor CanNotSetSourceField = new(
-        id: DiagnosticIds.CAN_NOT_SET_SOURCE_FIELD,
-        title: "Can not set source field",
-        messageFormat: "The field '{0}' can't be mapped to the {1} '{2}' of the type '{3}' because it's {4}. " +
-                       "This field will be ignored during the input deserialization.",
-        category: DiagnosticCategories.USAGE,
-        defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
-        helpLinkUri: HelpLinks.CAN_NOT_SET_SOURCE_FIELD);
-
     public static string ForceTypesAnalysisOption => "dotnet_diagnostic.input_graph_type_analyzer.force_types_analysis";
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(CanNotMatchInputFieldToTheSourceField, CanNotSetSourceField);
+        ImmutableArray.Create(
+            CanNotMatchInputFieldToTheSourceField,
+            CanNotSetSourceField,
+            CanNotResolveInputObjectConstructor);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -52,173 +34,8 @@ public class InputGraphTypeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var allowedSymbols = (sourceTypeSymbol is ITypeParameterSymbol parameterSymbol
-                ? GetAllowedFieldNames(parameterSymbol.ConstraintTypes)
-                : GetAllowedFieldNames(sourceTypeSymbol))
-            .GroupBy(symbol => symbol.Name, StringComparer.InvariantCultureIgnoreCase)
-            .ToDictionary(
-                group => group.Key,
-                group => group.ToList(),
-                StringComparer.InvariantCultureIgnoreCase);
-
-        foreach (var fieldInvocationExpression in GetDeclaredFields(classDeclaration))
-        {
-            var nameArg = fieldInvocationExpression
-                .GetMethodArgument(Constants.ArgumentNames.Name, context.SemanticModel)
-                ?.Expression;
-
-            string? fieldName = null;
-            switch (nameArg)
-            {
-                case LiteralExpressionSyntax literal:
-                    fieldName = literal.Token.ValueText;
-                    break;
-                case IdentifierNameSyntax: // ConstField
-                case MemberAccessExpressionSyntax: // ConstClass.ConstField
-                    var nameSymbol = context.SemanticModel.GetSymbolInfo(nameArg).Symbol;
-                    if (nameSymbol is IFieldSymbol { IsConst: true, ConstantValue: string } constSymbol)
-                    {
-                        fieldName = (string)constSymbol.ConstantValue!;
-                    }
-                    break;
-            }
-
-            var expressionArg = fieldInvocationExpression
-                .GetMethodArgument(Constants.ArgumentNames.Expression, context.SemanticModel)
-                ?.Expression;
-
-            // don't analyze name for Field("FirstName", source => source.Name), only the accessibility
-            if (expressionArg is SimpleLambdaExpressionSyntax { Body: MemberAccessExpressionSyntax mem })
-            {
-                var expressionSymbol = context.SemanticModel.GetSymbolInfo(mem);
-                if (expressionSymbol.Symbol != null)
-                {
-                    var symbols = new List<ISymbol> { expressionSymbol.Symbol };
-                    AnalyzeAccessibility(
-                        context,
-                        nameArg ?? mem,
-                        fieldName ?? expressionSymbol.Symbol.Name,
-                        symbols);
-                }
-                continue;
-            }
-
-            if (nameArg != null && fieldName != null)
-            {
-                AnalyzeFieldName(context, nameArg, fieldName, allowedSymbols, sourceTypeSymbol);
-            }
-        }
-    }
-
-    private static void AnalyzeFieldName(
-        SyntaxNodeAnalysisContext context,
-        ExpressionSyntax nameExpression,
-        string fieldName,
-        IDictionary<string, List<ISymbol>> allowedSymbols,
-        ISymbol sourceTypeSymbol)
-    {
-        if (allowedSymbols.TryGetValue(fieldName, out var symbols))
-        {
-            AnalyzeAccessibility(context, nameExpression, fieldName, symbols);
-            return;
-        }
-
-        string names = sourceTypeSymbol.Name;
-
-        if (sourceTypeSymbol is ITypeParameterSymbol p && p.ConstraintTypes.Any())
-        {
-            names = string.Join(" or ", p.ConstraintTypes.Select(t => t.Name));
-        }
-
-        context.ReportDiagnostic(
-            Diagnostic.Create(
-                CanNotMatchInputFieldToTheSourceField,
-                nameExpression.GetLocation(),
-                fieldName,
-                names));
-    }
-
-    private static void AnalyzeAccessibility(
-        SyntaxNodeAnalysisContext context,
-        ExpressionSyntax nameExpression,
-        string fieldName,
-        List<ISymbol> symbols)
-    {
-        var diagnostics = symbols.ConvertAll(CheckSymbol);
-
-        // at least one field can be set
-        if (diagnostics.Any(diagnostic => diagnostic == null))
-        {
-            return;
-        }
-
-        foreach (var diagnostic in diagnostics)
-        {
-            context.ReportDiagnostic(diagnostic!);
-        }
-
-        Diagnostic? CheckSymbol(ISymbol symbol)
-        {
-            List<string>? reasons = null;
-            string? symbolType = null;
-
-            if (symbol.DeclaredAccessibility != Accessibility.Public)
-            {
-                (reasons ??= new List<string>()).Add("not 'public'");
-            }
-
-            if (symbol.IsStatic)
-            {
-                (reasons ??= new List<string>()).Add("'static'");
-            }
-
-            switch (symbol)
-            {
-                case IParameterSymbol:
-                    return null;
-                case IPropertySymbol property:
-                {
-                    symbolType = "property";
-                    if (property.SetMethod is not { DeclaredAccessibility: Accessibility.Public })
-                    {
-                        (reasons ??= new List<string>()).Add("doesn't have a public setter");
-                    }
-                    break;
-                }
-                case IFieldSymbol field:
-                {
-                    symbolType = "field";
-                    if (field.IsConst)
-                    {
-                        _ = reasons!.Remove("'static'");
-                        reasons.Add("'const'");
-                    }
-                    else if (field.IsReadOnly)
-                    {
-                        (reasons ??= new List<string>()).Add("'readonly'");
-                    }
-                    break;
-                }
-            }
-
-            if (reasons == null)
-            {
-                return null;
-            }
-
-            string reason = reasons.Count == 1
-                ? reasons[0]
-                : string.Join(", ", reasons.Take(reasons.Count - 1)) + $" and {reasons.Last()}";
-
-            return Diagnostic.Create(
-                CanNotSetSourceField,
-                nameExpression.GetLocation(),
-                fieldName,
-                symbolType,
-                symbol.Name,
-                symbol.ContainingType.Name,
-                reason);
-        }
+        AnalyzeSourceTypeConstructors(context, classDeclaration, sourceTypeSymbol);
+        AnalyzeInputGraphTypeFields(context, classDeclaration, sourceTypeSymbol);
     }
 
     private static ITypeSymbol? GetSourceTypeSymbol(
@@ -270,60 +87,5 @@ public class InputGraphTypeAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
-    }
-
-    private static IEnumerable<ISymbol> GetAllowedFieldNames(IEnumerable<ITypeSymbol> sourceTypeSymbols) =>
-        sourceTypeSymbols.SelectMany(GetAllowedFieldNames);
-
-    private static IEnumerable<ISymbol> GetAllowedFieldNames(ITypeSymbol sourceTypeSymbol)
-    {
-        // consider ctor params on the type itself but not base classes
-        IEnumerable<ISymbol> symbols = sourceTypeSymbol
-            .GetMembers()
-            .OfType<IMethodSymbol>()
-            .Where(method => method is
-            {
-                MethodKind: MethodKind.Constructor,
-                DeclaredAccessibility: Accessibility.Public
-            })
-            .SelectMany(ctor => ctor.Parameters);
-
-        var nullableSourceTypeSymbol = sourceTypeSymbol;
-        while (nullableSourceTypeSymbol != null)
-        {
-            var fieldsOrProperties = nullableSourceTypeSymbol
-                .GetMembers()
-                .Where(symbol => !symbol.IsImplicitlyDeclared && symbol is IPropertySymbol or IFieldSymbol);
-
-            symbols = symbols.Concat(fieldsOrProperties);
-            nullableSourceTypeSymbol = nullableSourceTypeSymbol.BaseType;
-        }
-
-        return symbols;
-    }
-
-    private static IEnumerable<InvocationExpressionSyntax> GetDeclaredFields(ClassDeclarationSyntax classDeclaration)
-    {
-        return classDeclaration
-            .DescendantNodes()
-            .OfType<InvocationExpressionSyntax>()
-            .Where(IsFieldInvocation);
-
-        static bool IsFieldInvocation(InvocationExpressionSyntax exp)
-        {
-            return exp.Expression switch
-            {
-                // Field
-                SimpleNameSyntax nameSyntax =>
-                    IsField(nameSyntax),
-                // this.Field
-                MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax } expressionSyntax =>
-                    IsField(expressionSyntax.Name),
-                _ => false
-            };
-        }
-
-        static bool IsField(SimpleNameSyntax simpleNameSyntax) =>
-            simpleNameSyntax.Identifier.Text == Constants.MethodNames.Field;
     }
 }

--- a/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.cs
+++ b/src/GraphQL.Analyzers/InputGraphTypeAnalyzer.cs
@@ -16,7 +16,7 @@ public partial class InputGraphTypeAnalyzer : DiagnosticAnalyzer
         ImmutableArray.Create(
             CanNotMatchInputFieldToTheSourceField,
             CanNotSetSourceField,
-            CanNotResolveInputObjectConstructor);
+            CanNotResolveInputSourceTypeConstructor);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/src/GraphQL.ApiTests/BomTests.cs
+++ b/src/GraphQL.ApiTests/BomTests.cs
@@ -12,8 +12,9 @@ public class BomTests
 
         var gitRoot = new DirectoryInfo(GetPath()).Parent!.Parent!.Parent!;
         // Protection from situations when this test is copied to another repo or the folder structure changed, etc.
-        if (!File.Exists(Path.Combine(gitRoot.FullName, "src", "GraphQL.sln")))
-            throw new InvalidOperationException("Unable to find repository root");
+        var slnFile = Path.Combine(gitRoot.FullName, "src", "GraphQL.sln");
+        if (!File.Exists(slnFile))
+            throw new InvalidOperationException($"Unable to find repository root - '{slnFile}' missing.");
 
         byte[] buffer = new byte[3];
         int counter = 0;

--- a/src/GraphQL.ApiTests/BomTests.cs
+++ b/src/GraphQL.ApiTests/BomTests.cs
@@ -10,11 +10,12 @@ public class BomTests
     {
         string GetPath([CallerFilePath] string path = "") => path; // <GIT_ROOT>\src\GraphQL.ApiTests\BomTests.cs
 
-        var gitRoot = new DirectoryInfo(GetPath()).Parent!.Parent!.Parent!;
+        var callerFilePath = GetPath();
+        var gitRoot = new DirectoryInfo(callerFilePath).Parent!.Parent!.Parent!;
         // Protection from situations when this test is copied to another repo or the folder structure changed, etc.
         var slnFile = Path.Combine(gitRoot.FullName, "src", "GraphQL.sln");
         if (!File.Exists(slnFile))
-            throw new InvalidOperationException($"Unable to find repository root - '{slnFile}' missing.");
+            throw new InvalidOperationException($"Unable to find repository root - '{slnFile}' missing; caller file path '{callerFilePath}'.");
 
         byte[] buffer = new byte[3];
         int counter = 0;

--- a/src/GraphQL.ApiTests/BomTests.cs
+++ b/src/GraphQL.ApiTests/BomTests.cs
@@ -11,7 +11,7 @@ public class BomTests
         string GetPath([CallerFilePath] string path = "") => path; // <GIT_ROOT>\src\GraphQL.ApiTests\BomTests.cs
 
         var callerFilePath = GetPath();
-        var gitRoot = new DirectoryInfo(callerFilePath).Parent!.Parent!.Parent!;
+        var gitRoot = new FileInfo(callerFilePath).Directory!.Parent!.Parent!;
         // Protection from situations when this test is copied to another repo or the folder structure changed, etc.
         var slnFile = Path.Combine(gitRoot.FullName, "src", "GraphQL.sln");
         if (!File.Exists(slnFile))

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -179,6 +179,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "analyzers", "analyzers", "{
 		..\docs2\site\docs\analyzers\GQL007_CanNotSetSourceField.md = ..\docs2\site\docs\analyzers\GQL007_CanNotSetSourceField.md
 		..\docs2\site\docs\analyzers\GQL008_DoNotUseObsoleteArgumentMethod.md = ..\docs2\site\docs\analyzers\GQL008_DoNotUseObsoleteArgumentMethod.md
 		..\docs2\site\docs\analyzers\GQL009_UseAsyncResolver.md = ..\docs2\site\docs\analyzers\GQL009_UseAsyncResolver.md
+		..\docs2\site\docs\analyzers\GQL010_CanNotResolveInputSourceTypeConstructor.md = ..\docs2\site\docs\analyzers\GQL010_CanNotResolveInputSourceTypeConstructor.md
 		..\docs2\site\docs\analyzers\Overview.md = ..\docs2\site\docs\analyzers\Overview.md
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Closes #3774.

Notes:
- I made the `InputGraphTypeAnalyzerTests` partial and moved the fields validation into `.Fields` and constructor validation into `.Constructors`. Nothing changed in the fields validation logic.
- the analyzer diagnostic is reported also on `abstract` source types.
- the analyzer is skipped on an open generic source type
```c#
 public class CustomInputObjectGraphType<TSource> : InputObjectGraphType<TSource>
     where TSource : MySource
```
- the diagnostic also reported when multiple public constructors annotated with `[GraphQLConstructor]`
- there are no tests but I tested manually that everything works also with structs, records, and records with primary constructors