### PR TITLE
AutoRegisteringInputObjectGraphType includes certain read-only properties

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -93,7 +93,7 @@ Specifically, this relates to the following methods:
 
 This change was made to prevent duplicate registrations of the same service within the DI container.
 
-### 6. `ObjectExtensions.ToObject` changes
+### 6. `ObjectExtensions.ToObject` changes (impacts `InputObjectGraphType`)
 
 - `ObjectExtensions.ToObject<T>` was removed; it was only used by internal tests.
 - `ObjectExtensions.ToObject` requires input object graph type for conversion.
@@ -102,3 +102,11 @@ This change was made to prevent duplicate registrations of the same service with
 - If a public constructor is marked with `[GraphQLConstructor]`, it is used.
 - Otherwise the public parameterless constructor is used if available.
 - Otherwise an exception is thrown during deserialization.
+
+### 7. `AutoRegisteringInputObjectGraphType` changes
+
+- See above changes to `ObjectExtensions.ToObject` for deserialization notes.
+- Registers read-only properties when the property name matches the name of a parameter in the
+  chosen constructor. Comparison is case-insensitive, matching `ToObject` behavior.
+  Does not register constructor parameters that are not read-only properties.
+  Any attributes such as `[Id]` must be applied to the property, not the constructor parameter.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1844,7 +1844,7 @@ namespace GraphQL.Types
         public static GraphQL.Resolvers.IFieldResolver BuildFieldResolver(System.Reflection.MemberInfo memberInfo, System.Type? sourceType, GraphQL.Types.FieldType? fieldType, System.Linq.Expressions.LambdaExpression instanceExpression) { }
         public static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver(System.Reflection.MethodInfo methodInfo, System.Type? sourceType, GraphQL.Types.FieldType? fieldType, System.Linq.Expressions.LambdaExpression instanceExpression) { }
     }
-    public class AutoRegisteringInputObjectGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TSourceType> : GraphQL.Types.InputObjectGraphType<TSourceType>
+    public class AutoRegisteringInputObjectGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TSourceType> : GraphQL.Types.InputObjectGraphType<TSourceType>
     {
         public AutoRegisteringInputObjectGraphType() { }
         public AutoRegisteringInputObjectGraphType(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[]? excludedProperties) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1844,7 +1844,7 @@ namespace GraphQL.Types
         public static GraphQL.Resolvers.IFieldResolver BuildFieldResolver(System.Reflection.MemberInfo memberInfo, System.Type? sourceType, GraphQL.Types.FieldType? fieldType, System.Linq.Expressions.LambdaExpression instanceExpression) { }
         public static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver(System.Reflection.MethodInfo methodInfo, System.Type? sourceType, GraphQL.Types.FieldType? fieldType, System.Linq.Expressions.LambdaExpression instanceExpression) { }
     }
-    public class AutoRegisteringInputObjectGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TSourceType> : GraphQL.Types.InputObjectGraphType<TSourceType>
+    public class AutoRegisteringInputObjectGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TSourceType> : GraphQL.Types.InputObjectGraphType<TSourceType>
     {
         public AutoRegisteringInputObjectGraphType() { }
         public AutoRegisteringInputObjectGraphType(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[]? excludedProperties) { }

--- a/src/GraphQL.Tests/Execution/InputConversionTestsBase.cs
+++ b/src/GraphQL.Tests/Execution/InputConversionTestsBase.cs
@@ -1,5 +1,6 @@
 namespace GraphQL.Tests.Execution;
 
+[Collection("StaticTests")] // due to tests with ValueConverter
 public abstract class InputConversionTestsBase
 {
     #region Input Types

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -179,7 +179,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "analyzers", "analyzers", "{
 		..\docs2\site\docs\analyzers\GQL007_CanNotSetSourceField.md = ..\docs2\site\docs\analyzers\GQL007_CanNotSetSourceField.md
 		..\docs2\site\docs\analyzers\GQL008_DoNotUseObsoleteArgumentMethod.md = ..\docs2\site\docs\analyzers\GQL008_DoNotUseObsoleteArgumentMethod.md
 		..\docs2\site\docs\analyzers\GQL009_UseAsyncResolver.md = ..\docs2\site\docs\analyzers\GQL009_UseAsyncResolver.md
-		..\docs2\site\docs\analyzers\GQL010_CanNotResolveInputSourceTypeConstructor.md = ..\docs2\site\docs\analyzers\GQL010_CanNotResolveInputSourceTypeConstructor.md
 		..\docs2\site\docs\analyzers\Overview.md = ..\docs2\site\docs\analyzers\Overview.md
 	EndProjectSection
 EndProject

--- a/src/GraphQL.sln
+++ b/src/GraphQL.sln
@@ -179,6 +179,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "analyzers", "analyzers", "{
 		..\docs2\site\docs\analyzers\GQL007_CanNotSetSourceField.md = ..\docs2\site\docs\analyzers\GQL007_CanNotSetSourceField.md
 		..\docs2\site\docs\analyzers\GQL008_DoNotUseObsoleteArgumentMethod.md = ..\docs2\site\docs\analyzers\GQL008_DoNotUseObsoleteArgumentMethod.md
 		..\docs2\site\docs\analyzers\GQL009_UseAsyncResolver.md = ..\docs2\site\docs\analyzers\GQL009_UseAsyncResolver.md
+		..\docs2\site\docs\analyzers\GQL010_CanNotResolveInputSourceTypeConstructor.md = ..\docs2\site\docs\analyzers\GQL010_CanNotResolveInputSourceTypeConstructor.md
 		..\docs2\site\docs\analyzers\Overview.md = ..\docs2\site\docs\analyzers\Overview.md
 	EndProjectSection
 EndProject

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -104,15 +104,7 @@ namespace GraphQL
             //   2. a constructor marked with GraphQLConstructorAttribute
             //   3. the parameterless constructor
             //   otherwise, throw
-            var ctor = _types.GetOrAdd(type, t =>
-            {
-                var allConstructors = t.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
-                return allConstructors.Length == 1
-                    ? allConstructors[0]
-                    : Array.Find(allConstructors, x => x.GetCustomAttribute<GraphQLConstructorAttribute>() != null)
-                        ?? Array.Find(allConstructors, x => x.GetParameters().Length == 0)
-                        ?? throw new InvalidOperationException($"Multiple constructors available for type '{t.GetFriendlyName()}'; please indicate preferred constructor to use via GraphQLConstructorAttribute.");
-            });
+            var ctor = _types.GetOrAdd(type, AutoRegisteringHelper.GetConstructor);
 
             ConstructorInfo? targetCtor = null;
             ParameterInfo[]? ctorParameters = null;

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -309,16 +309,59 @@ namespace GraphQL.Types
         /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
         /// parameterless constructor, or the only public contructor, or returns <see langword="null"/> otherwise.
         /// </summary>
-        internal static ConstructorInfo? GetConstructor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSourceType>()
+        internal static ConstructorInfo? GetConstructorOrDefault<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSourceType>()
+            => GetConstructorOrDefault(typeof(TSourceType));
+
+        /// <summary>
+        /// Identifies the constructor to use when constructing instances of <paramref name="sourceType"/>.
+        /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
+        /// parameterless constructor, or the only public contructor, or returns <see langword="null"/> otherwise.
+        /// </summary>
+        internal static ConstructorInfo? GetConstructorOrDefault([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type sourceType)
         {
-            var constructors = typeof(TSourceType).GetConstructors();
-            return constructors.Length switch
+            var constructors = sourceType.GetConstructors();
+            // if there are no public constructors, return null
+            if (constructors == null || constructors.Length == 0)
+                return null;
+            // if there is only one public constructor, return it
+            if (constructors.Length == 1)
+                return constructors[0];
+            // if there are multiple public constructors, return the one marked with GraphQLConstructorAttribute, or the parameterless constructor, or null
+            ConstructorInfo? match = null;
+            ConstructorInfo? parameterless = null;
+            foreach (var constructor in constructors)
             {
-                0 => null,
-                1 => constructors[0],
-                _ => Array.Find(constructors, c => c.GetCustomAttribute<GraphQLConstructorAttribute>() != null)
-                    ?? Array.Find(constructors, c => c.GetParameters().Length == 0),
-            };
+                if (constructor.GetCustomAttribute<GraphQLConstructorAttribute>() != null)
+                {
+                    if (match != null)
+                        throw new InvalidOperationException($"Multiple constructors marked with {nameof(GraphQLConstructorAttribute)} found on type '{sourceType.GetFriendlyName()}'.");
+                    match = constructor;
+                }
+                if (constructor.GetParameters().Length == 0)
+                {
+                    parameterless = constructor;
+                }
+            }
+            return match ?? parameterless;
+        }
+
+        /// <summary>
+        /// Identifies the constructor to use when constructing instances of <paramref name="sourceType"/>.
+        /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
+        /// parameterless constructor, or the only public contructor, or throws an exception otherwise.
+        /// </summary>
+        internal static ConstructorInfo GetConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type sourceType)
+        {
+            var ret = GetConstructorOrDefault(sourceType);
+            // if there are no valid constructors, throw the proper exception
+            if (ret == null)
+            {
+                if (sourceType.GetConstructors().Length == 0)
+                    throw new InvalidOperationException($"No public constructors found on type '{sourceType.GetFriendlyName()}'.");
+                else
+                    throw new InvalidOperationException($"Type '{sourceType.GetFriendlyName()}' must have a public parameterless constructor, a single constructor, or a public constructor marked with " + nameof(GraphQLConstructorAttribute) + ".");
+            }
+            return ret;
         }
     }
 }

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -303,5 +303,22 @@ namespace GraphQL.Types
             typeInformation.ApplyAttributes();
             return typeInformation;
         }
+
+        /// <summary>
+        /// Identifies the constructor to use when constructing instances of <typeparamref name="TSourceType"/>.
+        /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
+        /// parameterless constructor, or the only public contructor, or returns <see langword="null"/> otherwise.
+        /// </summary>
+        internal static ConstructorInfo? GetConstructor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSourceType>()
+        {
+            var constructors = typeof(TSourceType).GetConstructors();
+            return constructors.Length switch
+            {
+                0 => null,
+                1 => constructors[0],
+                _ => Array.Find(constructors, c => c.GetCustomAttribute<GraphQLConstructorAttribute>() != null)
+                    ?? Array.Find(constructors, c => c.GetParameters().Length == 0),
+            };
+        }
     }
 }

--- a/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
@@ -103,10 +103,12 @@ namespace GraphQL.Types
         {
             // determine which constructor will be used to create the object, or null if unknown (perhaps due to overriding ParseDictionary)
             var constructor = AutoRegisteringHelper.GetConstructorOrDefault<TSourceType>();
+            // get constructor's parameters
+            var constructorParameters = constructor?.GetParameters();
             // get constructor's parameter names
-            var parameters = constructor?.GetParameters().Select(x => x.Name).ToArray();
+            var parameters = constructorParameters == null || constructorParameters.Length == 0 ? null : constructorParameters.Select(x => x.Name).ToArray();
             // define PropertyInfo predicate based on whether the constructor has any parameters
-            Func<PropertyInfo, bool> predicate = parameters == null || parameters.Length == 0
+            Func<PropertyInfo, bool> predicate = parameters == null
                 // any writable property
                 ? static x => x.SetMethod?.IsPublic ?? false
                 // any writable property, or any read-only property that has a constructor parameter

--- a/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
@@ -102,7 +102,7 @@ namespace GraphQL.Types
         protected virtual IEnumerable<MemberInfo> GetRegisteredMembers()
         {
             // determine which constructor will be used to create the object, or null if unknown (perhaps due to overriding ParseDictionary)
-            var constructor = AutoRegisteringHelper.GetConstructor<TSourceType>();
+            var constructor = AutoRegisteringHelper.GetConstructorOrDefault<TSourceType>();
             // get constructor's parameter names
             var parameters = constructor?.GetParameters().Select(x => x.Name).ToArray();
             // define PropertyInfo predicate based on whether the constructor has any parameters

--- a/src/GraphQL/Types/TypeInformation.cs
+++ b/src/GraphQL/Types/TypeInformation.cs
@@ -122,7 +122,10 @@ namespace GraphQL.Types
         public TypeInformation(PropertyInfo propertyInfo, bool isInput)
             : this(propertyInfo, isInput, propertyInfo.PropertyType, false, false, false, null)
         {
-            var typeTree = Interpret(new NullabilityInfoContext().Create(propertyInfo), isInput);
+            // for the purposes of processing the nullability information, if the property is
+            // read-only, read the nullability information as if it were an output type (so read the getter)
+            var treatAsInput = isInput && propertyInfo.CanWrite;
+            var typeTree = Interpret(new NullabilityInfoContext().Create(propertyInfo), treatAsInput);
 
             ProcessTypeTree(typeTree, isInput);
         }


### PR DESCRIPTION
AutoRegisteringInputObjectGraphType includes read-only properties when the property name matches a parameter in the chosen constructor.