### PR TITLE
Configure trim analyzer only for .NET 6+ projects

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,7 +4,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/graphql-dotnet/graphql-dotnet/releases and https://graphql-dotnet.github.io/docs/migrations/migration7</PackageReleaseNotes>
     <Nullable>enable</Nullable>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</EnableTrimAnalyzer>
     <!--<EnableAotAnalyzer>true</EnableAotAnalyzer> PublishAot property enables it-->
     <!--<ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors> does not work-->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2026;IL2055;IL2067;IL2070;IL2072;IL2075;IL2090;IL2091;IL2092;IL2095</WarningsNotAsErrors>


### PR DESCRIPTION
See:
- https://github.com/dotnet/docs/blob/5423d3e2ca24642a82d32575ea1d17d18c3fd04f/docs/core/compatibility/sdk/8.0/trimming-unsupported-targetframework.md