### PR TITLE
Ensure only public properties are registered in AutoRegisteringObjectGraphType

### DIFF
--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -711,7 +711,7 @@ public class AutoRegisteringObjectGraphTypeTests
     {
         public int Field1 { get; set; } = 1;
         public int Field2 => 2;
-        public int Field3 { set { } }
+        public int Field3 { private get => 123; set { } }
         public int Field4() => 4;
         public int Field5 = 5;
         [Name("Field6AltName")]

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -139,7 +139,7 @@ internal static class AutoRegisteringOutputHelper
 
             var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
             var properties = AutoRegisteringHelper.ExcludeProperties(
-                types.SelectMany(type => type.GetProperties(flags)).Where(x => x.CanRead),
+                types.SelectMany(type => type.GetProperties(flags)).Where(x => x.GetMethod?.IsPublic ?? false),
                 excludedProperties);
             var methods = types.SelectMany(type => type.GetMethods(flags))
                 .Where(x =>
@@ -153,7 +153,7 @@ internal static class AutoRegisteringOutputHelper
         {
             var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
             var properties = AutoRegisteringHelper.ExcludeProperties(
-                typeof(TSourceType).GetProperties(flags).Where(x => x.CanRead),
+                typeof(TSourceType).GetProperties(flags).Where(x => x.GetMethod?.IsPublic ?? false),
                 excludedProperties);
             var methods = typeof(TSourceType).GetMethods(flags)
                 .Where(x =>


### PR DESCRIPTION
Aligns with changed behavior in #3782 .  This could be considered both a bug fix and a breaking change.  Only public properties were intended to be registered, but a public properties having a private getter was incorrectly registered also.  This change fixes that so only public properties with a public getter will be registered.