### PR TITLE
Make IDataLoaderContextAccessor.Context non-null

### DIFF
--- a/src/GraphQL.ApiTests/GraphQL.DataLoader.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.DataLoader.approved.txt
@@ -38,7 +38,7 @@ namespace GraphQL.DataLoader
     public class DataLoaderContextAccessor : GraphQL.DataLoader.IDataLoaderContextAccessor
     {
         public DataLoaderContextAccessor() { }
-        public GraphQL.DataLoader.DataLoaderContext? Context { get; set; }
+        public GraphQL.DataLoader.DataLoaderContext Context { get; set; }
     }
     public static class DataLoaderContextExtensions
     {
@@ -108,7 +108,7 @@ namespace GraphQL.DataLoader
     }
     public interface IDataLoaderContextAccessor
     {
-        GraphQL.DataLoader.DataLoaderContext? Context { get; set; }
+        GraphQL.DataLoader.DataLoaderContext Context { get; set; }
     }
     public interface IDataLoader<T>
     {

--- a/src/GraphQL.DataLoader/DataLoaderContextAccessor.cs
+++ b/src/GraphQL.DataLoader/DataLoaderContextAccessor.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace GraphQL.DataLoader;
 
 /// <inheritdoc cref="IDataLoaderContextAccessor"/>
@@ -9,7 +11,11 @@ public class DataLoaderContextAccessor : IDataLoaderContextAccessor
     [AllowNull]
     public DataLoaderContext Context
     {
-        get => _current.Value!;
+        get
+        {
+            Debug.Assert(_current.Value != null, "DataLoaderContext is null. Ensure that DataLoaderDocumentListener is registered in the IoC container");
+            return _current.Value!;
+        }
         set => _current.Value = value;
     }
 }

--- a/src/GraphQL.DataLoader/DataLoaderContextAccessor.cs
+++ b/src/GraphQL.DataLoader/DataLoaderContextAccessor.cs
@@ -6,9 +6,10 @@ public class DataLoaderContextAccessor : IDataLoaderContextAccessor
     private static readonly AsyncLocal<DataLoaderContext?> _current = new();
 
     /// <inheritdoc/>
-    public DataLoaderContext? Context
+    [AllowNull]
+    public DataLoaderContext Context
     {
-        get => _current.Value;
+        get => _current.Value!;
         set => _current.Value = value;
     }
 }

--- a/src/GraphQL.DataLoader/DataLoaderContextAccessor.cs
+++ b/src/GraphQL.DataLoader/DataLoaderContextAccessor.cs
@@ -15,5 +15,5 @@ public class DataLoaderContextAccessor : IDataLoaderContextAccessor
 
     [DoesNotReturn]
     private DataLoaderContext ThrowMissingContext()
-        => throw new InvalidOperationException("DataLoaderContext is null. Ensure that DataLoaderDocumentListener is registered in the IoC container");
+        => throw new InvalidOperationException("DataLoaderContext is null. Ensure that you have called IGraphQLBuilder.AddDataLoader() or otherwise have added an instance of DataLoaderDocumentListener to ExecutionOptions.Listeners.");
 }

--- a/src/GraphQL.DataLoader/DataLoaderContextAccessor.cs
+++ b/src/GraphQL.DataLoader/DataLoaderContextAccessor.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace GraphQL.DataLoader;
 
 /// <inheritdoc cref="IDataLoaderContextAccessor"/>
@@ -11,11 +9,11 @@ public class DataLoaderContextAccessor : IDataLoaderContextAccessor
     [AllowNull]
     public DataLoaderContext Context
     {
-        get
-        {
-            Debug.Assert(_current.Value != null, "DataLoaderContext is null. Ensure that DataLoaderDocumentListener is registered in the IoC container");
-            return _current.Value!;
-        }
+        get => _current.Value ?? ThrowMissingContext();
         set => _current.Value = value;
     }
+
+    [DoesNotReturn]
+    private DataLoaderContext ThrowMissingContext()
+        => throw new InvalidOperationException("DataLoaderContext is null. Ensure that DataLoaderDocumentListener is registered in the IoC container");
 }

--- a/src/GraphQL.DataLoader/DataLoaderDocumentListener.cs
+++ b/src/GraphQL.DataLoader/DataLoaderDocumentListener.cs
@@ -26,7 +26,7 @@ public class DataLoaderDocumentListener : IDocumentExecutionListener
     /// <inheritdoc/>
     public Task BeforeExecutionAsync(IExecutionContext context)
     {
-        _accessor.Context ??= new();
+        _accessor.Context = new();
 
         return Task.CompletedTask;
     }

--- a/src/GraphQL.DataLoader/IDataLoaderContextAccessor.cs
+++ b/src/GraphQL.DataLoader/IDataLoaderContextAccessor.cs
@@ -8,5 +8,6 @@ public interface IDataLoaderContextAccessor
     /// <summary>
     /// The current <seealso cref="DataLoaderContext"/>
     /// </summary>
-    DataLoaderContext? Context { get; set; }
+    [AllowNull]
+    DataLoaderContext Context { get; set; }
 }


### PR DESCRIPTION
As discussed in #3777, this PR changes the null annotations for `IDataLoaderContextAccessor.Context` to be non-null. This supports the nullability contract when the property is used correctly (e.g., inside of a document execution) and when the `DataLoaderDocumentListener` is registered