### PR TITLE
Add ObjectExtensions.GetReflectionInformation

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -109,7 +109,7 @@ This change was made to prevent duplicate registrations of the same service with
   - Otherwise the public parameterless constructor is used if available.
   - Otherwise an exception is thrown during deserialization.
 - Only public properties are eligible candidates when matching a property.
-- Any init-only properties not provided in the dictionary are set to their default values.
+- Any init-only or required properties not provided in the dictionary are set to their default values.
 
 The changes above allow for matching behavior with source-generated or dynamically-compiled functions.
 

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -110,6 +110,7 @@ This change was made to prevent duplicate registrations of the same service with
   - Otherwise an exception is thrown during deserialization.
 - Only public properties are eligible candidates when matching a property.
 - Any init-only or required properties not provided in the dictionary are set to their default values.
+- Only public writable fields are eligible candidates when matching a field.
 
 The changes above allow for matching behavior with source-generated or dynamically-compiled functions.
 

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -103,10 +103,15 @@ This change was made to prevent duplicate registrations of the same service with
 - `ObjectExtensions.ToObject<T>` was removed; it was only used by internal tests.
 - `ObjectExtensions.ToObject` requires input object graph type for conversion.
 - Only public constructors are eligible candidates while selecting a constructor.
-- If only a single public constructor is available, it is used.
-- If a public constructor is marked with `[GraphQLConstructor]`, it is used.
-- Otherwise the public parameterless constructor is used if available.
-- Otherwise an exception is thrown during deserialization.
+- Constructor is selected based on the following rules:
+  - If only a single public constructor is available, it is used.
+  - If a public constructor is marked with `[GraphQLConstructor]`, it is used.
+  - Otherwise the public parameterless constructor is used if available.
+  - Otherwise an exception is thrown during deserialization.
+- Only public properties are eligible candidates when matching a property.
+- Any init-only properties not provided in the dictionary are set to their default values.
+
+The changes above allow for matching behavior with source-generated or dynamically-compiled functions.
 
 ### 7. `AutoRegisteringInputObjectGraphType` changes
 

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -620,7 +620,7 @@ namespace GraphQL
     {
         public static object? GetPropertyValue(this object? propertyValue, System.Type fieldType, GraphQL.Types.IGraphType mappedType) { }
         public static bool IsDefinedEnumValue(System.Type type, object? value) { }
-        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType mappedType) { }
+        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] System.Type type, GraphQL.Types.IGraphType mappedType) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface)]
     public class OutputNameAttribute : GraphQL.GraphQLAttribute

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -620,7 +620,7 @@ namespace GraphQL
     {
         public static object? GetPropertyValue(this object? propertyValue, System.Type fieldType, GraphQL.Types.IGraphType mappedType) { }
         public static bool IsDefinedEnumValue(System.Type type, object? value) { }
-        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IGraphType mappedType) { }
+        public static object ToObject(this System.Collections.Generic.IDictionary<string, object?> source, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] System.Type type, GraphQL.Types.IGraphType mappedType) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface)]
     public class OutputNameAttribute : GraphQL.GraphQLAttribute

--- a/src/GraphQL.Benchmarks/Benchmarks/ExecutionBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/ExecutionBenchmark.cs
@@ -2,7 +2,6 @@ using BenchmarkDotNet.Attributes;
 using GraphQL.Caching;
 using GraphQL.Execution;
 using GraphQL.StarWars;
-using GraphQL.StarWars.Types;
 using GraphQL.Types;
 using GraphQL.Validation;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,15 +22,10 @@ public class ExecutionBenchmark : IBenchmark
     {
         var services = new ServiceCollection();
 
+        services.AddGraphQL(b => b
+            .AddSchema<StarWarsSchema>()
+            .AddGraphTypes(typeof(StarWarsQuery).Assembly));
         services.AddSingleton<StarWarsData>();
-        services.AddSingleton<StarWarsQuery>();
-        services.AddSingleton<StarWarsMutation>();
-        services.AddSingleton<HumanType>();
-        services.AddSingleton<HumanInputType>();
-        services.AddSingleton<DroidType>();
-        services.AddSingleton<CharacterInterface>();
-        services.AddSingleton<EpisodeEnum>();
-        services.AddSingleton<ISchema, StarWarsSchema>();
 
         _provider = services.BuildServiceProvider();
         _schema = _provider.GetRequiredService<ISchema>();

--- a/src/GraphQL.Benchmarks/Benchmarks/ToObjectBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/ToObjectBenchmark.cs
@@ -9,10 +9,10 @@ namespace GraphQL.Benchmarks;
 [MemoryDiagnoser]
 public class ToObjectBenchmark : IBenchmark
 {
-    private IGraphType _personType = null!;
-    private IGraphType _companyType = null!;
-    private IGraphType _employeeType = null!;
-    private IGraphType _salaryType = null!;
+    private IInputObjectGraphType _personType = null!;
+    private IInputObjectGraphType _companyType = null!;
+    private IInputObjectGraphType _employeeType = null!;
+    private IInputObjectGraphType _salaryType = null!;
     private Dictionary<string, object?> _personData = null!;
     private readonly Dictionary<string, object?> _noData = [];
     private Dictionary<string, object?> _companyData = null!;
@@ -29,10 +29,10 @@ public class ToObjectBenchmark : IBenchmark
         var provider = services.BuildServiceProvider();
         var schema = provider.GetRequiredService<ISchema>();
         schema.Initialize();
-        _personType = schema.AllTypes[nameof(Person)]!;
-        _companyType = schema.AllTypes[nameof(Company)]!;
-        _employeeType = schema.AllTypes[nameof(Employee)]!;
-        _salaryType = schema.AllTypes[nameof(SalaryInfo)]!;
+        _personType = (IInputObjectGraphType)schema.AllTypes[nameof(Person)]!;
+        _companyType = (IInputObjectGraphType)schema.AllTypes[nameof(Company)]!;
+        _employeeType = (IInputObjectGraphType)schema.AllTypes[nameof(Employee)]!;
+        _salaryType = (IInputObjectGraphType)schema.AllTypes[nameof(SalaryInfo)]!;
         _personData = new Dictionary<string, object?>()
         {
             { "name", "John Doe" },
@@ -91,49 +91,49 @@ public class ToObjectBenchmark : IBenchmark
     [Benchmark]
     public void Person_Populated()
     {
-        ObjectExtensions.ToObject(_personData, typeof(Person), _personType);
+        _ = (Person)_personType.ParseDictionary(_personData);
     }
 
     [Benchmark]
     public void Person_Undefined()
     {
-        ObjectExtensions.ToObject(_noData, typeof(Person), _personType);
+        _ = (Person)_personType.ParseDictionary(_noData);
     }
 
     [Benchmark]
     public void Company_Populated()
     {
-        ObjectExtensions.ToObject(_companyData, typeof(Company), _companyType);
+        _ = (Company)_companyType.ParseDictionary(_companyData);
     }
 
     [Benchmark]
     public void Company_Undefined()
     {
-        ObjectExtensions.ToObject(_noData, typeof(Company), _companyType);
+        _ = (Company)_companyType.ParseDictionary(_noData);
     }
 
     [Benchmark]
     public void Employee_Populated()
     {
-        ObjectExtensions.ToObject(_employeeData, typeof(Employee), _employeeType);
+        _ = (Employee)_employeeType.ParseDictionary(_employeeData);
     }
 
     [Benchmark]
     public void Employee_Undefined()
     {
-        ObjectExtensions.ToObject(_noData, typeof(Employee), _employeeType);
+        _ = (Employee)_employeeType.ParseDictionary(_noData);
     }
 
     [Benchmark]
     public void Salary_Populated()
     {
-        ObjectExtensions.ToObject(_salaryData, typeof(SalaryInfo), _salaryType);
+        _ = (SalaryInfo)_salaryType.ParseDictionary(_salaryData);
     }
 
     [Benchmark]
     public void Salary_Undefined()
     {
-        ObjectExtensions.ToObject(_noData, typeof(SalaryInfo), _salaryType);
+        _ = (SalaryInfo)_salaryType.ParseDictionary(_noData);
     }
 
     void IBenchmark.RunProfiler() => Person_Populated();

--- a/src/GraphQL.Benchmarks/Benchmarks/ToObjectBenchmark.cs
+++ b/src/GraphQL.Benchmarks/Benchmarks/ToObjectBenchmark.cs
@@ -1,0 +1,196 @@
+#nullable enable
+
+using BenchmarkDotNet.Attributes;
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Benchmarks;
+
+[MemoryDiagnoser]
+public class ToObjectBenchmark : IBenchmark
+{
+    private IGraphType _personType = null!;
+    private IGraphType _companyType = null!;
+    private IGraphType _employeeType = null!;
+    private IGraphType _salaryType = null!;
+    private Dictionary<string, object?> _personData = null!;
+    private readonly Dictionary<string, object?> _noData = [];
+    private Dictionary<string, object?> _companyData = null!;
+    private Dictionary<string, object?> _employeeData = null!;
+    private Dictionary<string, object?> _salaryData = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddAutoSchema<Query>());
+
+        var provider = services.BuildServiceProvider();
+        var schema = provider.GetRequiredService<ISchema>();
+        schema.Initialize();
+        _personType = schema.AllTypes[nameof(Person)]!;
+        _companyType = schema.AllTypes[nameof(Company)]!;
+        _employeeType = schema.AllTypes[nameof(Employee)]!;
+        _salaryType = schema.AllTypes[nameof(SalaryInfo)]!;
+        _personData = new Dictionary<string, object?>()
+        {
+            { "name", "John Doe" },
+            { "age", 123 }
+        };
+
+        _companyData = new Dictionary<string, object?>()
+        {
+            { "name", "John Doe" },
+            { "emailAddress", "johndoe@example.dummy" },
+            { "phoneNumber", "123-456-7890" },
+            { "website", new Uri("https://github.com/graphql-dotnet/graphql-dotnet") },
+            { "employees", new List<object?>()
+                {
+                    new Employee()
+                    {
+                        FirstName = null!,
+                        LastName = null!,
+                        SalaryHistory = null!,
+                    },
+                    new Employee()
+                    {
+                        FirstName = null!,
+                        LastName = null!,
+                        SalaryHistory = null!,
+                    },
+                }
+            },
+            { "addresses", new object?[] { } }
+        };
+
+        _employeeData = new Dictionary<string, object?>
+        {
+            { "firstName", "John" },
+            { "lastName", "Doe" },
+            { "emailAddress", "john.doe@example.com" },
+            { "salaryHistory", new object[] {} },
+            { "address1", "123 Main St" },
+            { "address2", "Apt 4" },
+            { "city", "Anytown" },
+            { "state", "Anystate" },
+            { "zipCode", "12345" },
+            { "phoneNumber", "123-456-7890" }
+        };
+
+        _salaryData = new Dictionary<string, object?>
+        {
+            { "income", 50000.0 },
+            { "salary", 45000.0 },
+            { "bonus", 5000.0 },
+            { "benefits", 7000.0 },
+            { "taxes", 10000.0 }
+        };
+    }
+
+    [Benchmark]
+    public void Person_Populated()
+    {
+        ObjectExtensions.ToObject(_personData, typeof(Person), _personType);
+    }
+
+    [Benchmark]
+    public void Person_Undefined()
+    {
+        ObjectExtensions.ToObject(_noData, typeof(Person), _personType);
+    }
+
+    [Benchmark]
+    public void Company_Populated()
+    {
+        ObjectExtensions.ToObject(_companyData, typeof(Company), _companyType);
+    }
+
+    [Benchmark]
+    public void Company_Undefined()
+    {
+        ObjectExtensions.ToObject(_noData, typeof(Company), _companyType);
+    }
+
+    [Benchmark]
+    public void Employee_Populated()
+    {
+        ObjectExtensions.ToObject(_employeeData, typeof(Employee), _employeeType);
+    }
+
+    [Benchmark]
+    public void Employee_Undefined()
+    {
+        ObjectExtensions.ToObject(_noData, typeof(Employee), _employeeType);
+    }
+
+    [Benchmark]
+    public void Salary_Populated()
+    {
+        ObjectExtensions.ToObject(_salaryData, typeof(SalaryInfo), _salaryType);
+    }
+
+    [Benchmark]
+    public void Salary_Undefined()
+    {
+        ObjectExtensions.ToObject(_noData, typeof(SalaryInfo), _salaryType);
+    }
+
+    void IBenchmark.RunProfiler() => Person_Populated();
+
+    public class Query
+    {
+        public virtual string TestClass1(Person arg) => "ok";
+        public virtual string TestClass2(Company arg) => "ok";
+    }
+
+    public class Person
+    {
+        public string? Name { get; set; }
+        public int? Age { get; set; }
+    }
+
+    public class Employee : Address
+    {
+        public required string FirstName { get; set; }
+        public required string LastName { get; set; }
+        public string? EmailAddress { get; set; }
+        public required SalaryInfo[] SalaryHistory { get; set; }
+    }
+
+    // sample class with a lot of value-type fields
+    public class SalaryInfo
+    {
+        public double Income { get; set; }
+        public double Salary { get; set; }
+        public double Bonus { get; set; }
+        public double Benefits { get; set; }
+        public double Taxes { get; set; }
+    }
+
+    // sample class with a lot of class-type fields
+    public class Address
+    {
+        public string? Address1 { get; set; }
+        public string? Address2 { get; set; }
+        public string? City { get; set; }
+        public string? State { get; set; }
+        public string? ZipCode { get; set; }
+        public string? PhoneNumber { get; set; }
+    }
+
+    public class CompanyAddress : Address
+    {
+        public required string Description { get; set; }
+    }
+
+    public class Company
+    {
+        public required string Name { get; set; }
+        public required List<Employee> Employees { get; set; }
+        public required List<CompanyAddress> Addresses { get; set; }
+        public required string EmailAddress { get; set; }
+        public required string PhoneNumber { get; set; }
+        public Uri? Website { get; set; }
+    }
+}

--- a/src/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
+++ b/src/GraphQL.Benchmarks/GraphQL.Benchmarks.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\GraphQL.MicrosoftDI\GraphQL.MicrosoftDI.csproj" />
     <ProjectReference Include="..\GraphQL.NewtonsoftJson\GraphQL.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\GraphQL.StarWars\GraphQL.StarWars.csproj" />
     <ProjectReference Include="..\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />

--- a/src/GraphQL.Benchmarks/Properties/launchSettings.json
+++ b/src/GraphQL.Benchmarks/Properties/launchSettings.json
@@ -10,6 +10,10 @@
     "DetailedBenchmarks": {
       "commandName": "Project",
       "commandLineArgs": "DetailedBenchmark"
+    },
+    "ToObjectBenchmarks": {
+      "commandName": "Project",
+      "commandLineArgs": "ToObjectBenchmark"
     }
   }
 }

--- a/src/GraphQL.Tests/Bugs/Bug947.cs
+++ b/src/GraphQL.Tests/Bugs/Bug947.cs
@@ -63,9 +63,7 @@ public class Bug947
         Should.Throw<InvalidOperationException>(() => context.GetArgument<string>("object"));
         Should.Throw<InvalidOperationException>(() => context.GetArgument<DateTime>("object"));
 
-        var otherObject = context.GetArgument<SomeOtherObject>("object");
-        otherObject.unknown.ShouldBe(0);
-        otherObject.unknown2.ShouldBeNull();
+        Should.Throw<InvalidOperationException>(() => context.GetArgument<SomeOtherObject>("object"));
     }
 }
 

--- a/src/GraphQL.Tests/Bugs/Issue1285.cs
+++ b/src/GraphQL.Tests/Bugs/Issue1285.cs
@@ -10,7 +10,7 @@ public class Issue1285 : QueryTestBase<Issue1285Schema>
     {
         const string query = """
         query {
-          getsome(input: { readOnlyProp: 7, privateSetProp: 3, valueProp: null, ints: null, ints2: [1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0], intsList: null, intsList2: [1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0] })
+          getsome(input: { readOnlyProp: 7, valueProp: null, ints: null, ints2: [1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0], intsList: null, intsList2: [1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0] })
         }
         """;
         const string expected = """
@@ -50,7 +50,6 @@ public class Issue1285Query : ObjectGraphType
 
                 arg.ValueProp.ShouldBe(0);
                 arg.ReadOnlyProp.ShouldBe(7);
-                arg.PrivateSetProp.ShouldBe(3);
 
                 return arg.Ints;
             });
@@ -75,8 +74,6 @@ public class ArrayInput
     public int ValueProp { get; set; }
 
     public int ReadOnlyProp { get; }
-
-    public int PrivateSetProp { get; private set; }
 }
 
 public class ArrayInputType : InputObjectGraphType<ArrayInput>
@@ -89,6 +86,5 @@ public class ArrayInputType : InputObjectGraphType<ArrayInput>
         Field(o => o.IntsList2, nullable: true);
         Field(o => o.ValueProp, nullable: true);
         Field(o => o.ReadOnlyProp, nullable: true);
-        Field(o => o.PrivateSetProp, nullable: true);
     }
 }

--- a/src/GraphQL.Tests/Execution/AbstractInputTests.cs
+++ b/src/GraphQL.Tests/Execution/AbstractInputTests.cs
@@ -14,7 +14,7 @@ public class AbstractInputTests : QueryTestBase<AbstractInputSchema>
             """;
         var res = AssertQueryWithErrors(query, null, expectedErrorCount: 1, executed: false);
         res.Errors[0].Code.ShouldBe("INVALID_LITERAL");
-        res.Errors[0].Message.ShouldBe("""Invalid literal for argument 'input' of field 'run'. Type 'GraphQL.Tests.Bugs.MyInputClassBase' is abstract and can not be used to construct objects from dictionary values. Please register a conversion within the ValueConverter or for input graph types override ParseDictionary method.""");
+        res.Errors[0].Message.ShouldBe("""Invalid literal for argument 'input' of field 'run'. No public constructors found on type 'MyInputClassBase'.""");
     }
 }
 

--- a/src/GraphQL.Tests/ObjectExtensionsTest.cs
+++ b/src/GraphQL.Tests/ObjectExtensionsTest.cs
@@ -387,4 +387,36 @@ public class ObjectExtensionsTests
         public required int Month { get; set; } = -2;
         public int Year { get; set; } = -3;
     }
+
+    [Fact]
+    public void toobject_cannot_initialize_readonly_field()
+    {
+        var queryObject = new ObjectGraphType() { Name = "Query" };
+        queryObject.Field<StringGraphType>("dummy");
+        var schema = new Schema()
+        {
+            Query = queryObject
+        };
+        var inputType = new MyInput8Type();
+        schema.RegisterType(inputType);
+        schema.Initialize();
+
+        Should.Throw<InvalidOperationException>(() => inputType.ParseDictionary("{}".ToInputs()))
+            .Message.ShouldBe("Field named 'Age' on CLR type 'MyInput8' is defined as a read-only field. Please add a constructor parameter with the same name to initialize this field.");
+    }
+
+    private class MyInput8Type : InputObjectGraphType<MyInput8>
+    {
+        public MyInput8Type()
+        {
+            Field(x => x.Name);
+            Field(x => x.Age);
+        }
+    }
+
+    private class MyInput8
+    {
+        public required string Name { get; set; } = "abc";
+        public readonly int Age = -1;
+    }
 }

--- a/src/GraphQL.Tests/ObjectExtensionsTest.cs
+++ b/src/GraphQL.Tests/ObjectExtensionsTest.cs
@@ -364,4 +364,27 @@ public class ObjectExtensionsTests
         public int Month { get; init; } = -2;
         public int Year { get; set; } = -3;
     }
+
+    [Fact]
+    public void toobject_initializes_required_props()
+    {
+        var inputs = """{ "company": "test", "month": 5 }""".ToInputs();
+        var person = inputs.ToObject<MyInput7>();
+        person.Name.ShouldBe(null);
+        person.Company.ShouldBe("test");
+        person.Description.ShouldBe("def");
+        person.Age.ShouldBe(0);
+        person.Month.ShouldBe(5);
+        person.Year.ShouldBe(-3);
+    }
+
+    private class MyInput7
+    {
+        public required string Name { get; set; } = "abc";
+        public required string Company { get; set; } = "ghi";
+        public string Description { get; set; } = "def";
+        public required int Age { get; set; } = -1;
+        public required int Month { get; set; } = -2;
+        public int Year { get; set; } = -3;
+    }
 }

--- a/src/GraphQL.Tests/ObjectExtensionsTest.cs
+++ b/src/GraphQL.Tests/ObjectExtensionsTest.cs
@@ -328,4 +328,40 @@ public class ObjectExtensionsTests
         [GraphQLConstructor]
         public MyInput4(string name) { Name = name; }
     }
+
+    [Fact]
+    public void toobject_sets_initonly_props()
+    {
+        var inputs = """{ "name": "tom" }""".ToInputs();
+        var person = inputs.ToObject<MyInput5>();
+        person.Name.ShouldBe("tom");
+    }
+
+    private class MyInput5
+    {
+        public string Name { get; init; }
+    }
+
+    [Fact]
+    public void toobject_initializes_initonly_props()
+    {
+        var inputs = """{ "company": "test", "month": 5 }""".ToInputs();
+        var person = inputs.ToObject<MyInput6>();
+        person.Name.ShouldBe(null);
+        person.Company.ShouldBe("test");
+        person.Description.ShouldBe("def");
+        person.Age.ShouldBe(0);
+        person.Month.ShouldBe(5);
+        person.Year.ShouldBe(-3);
+    }
+
+    private class MyInput6
+    {
+        public string Name { get; init; } = "abc";
+        public string Company { get; init; } = "ghi";
+        public string Description { get; set; } = "def";
+        public int Age { get; init; } = -1;
+        public int Month { get; init; } = -2;
+        public int Year { get; set; } = -3;
+    }
 }

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -65,7 +65,9 @@ namespace GraphQL
             object obj;
             try
             {
-                obj = reflectionInfo.Constructor.Invoke(ctorArguments);
+                obj = reflectionInfo.CtorFields.Length == 0
+                    ? Activator.CreateInstance(type)!
+                    : reflectionInfo.Constructor.Invoke(ctorArguments);
             }
             catch (TargetInvocationException ex)
             {

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -231,9 +231,9 @@ namespace GraphQL
                 if (propertyInfo?.SetMethod?.IsPublic ?? false)
                 {
                     var isExternalInit = propertyInfo.SetMethod.ReturnParameter.GetRequiredCustomModifiers()
-                        .Any(type => type == typeof(IsExternalInit));
+                        .Any(type => type.FullName == typeof(IsExternalInit).FullName);
 
-                    var isRequired = Attribute.IsDefined(propertyInfo, typeof(RequiredMemberAttribute));
+                    var isRequired = propertyInfo.CustomAttributes.Any(x => x.AttributeType.FullName == typeof(RequiredMemberAttribute).FullName);
 
                     return (propertyInfo, isExternalInit, isRequired);
                 }
@@ -255,7 +255,7 @@ namespace GraphQL
 
                 if (fieldInfo != null)
                 {
-                    var isRequired = Attribute.IsDefined(fieldInfo, typeof(RequiredMemberAttribute));
+                    var isRequired = fieldInfo.CustomAttributes.Any(x => x.AttributeType.FullName == typeof(RequiredMemberAttribute).FullName);
 
                     return (fieldInfo, false, isRequired);
                 }

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using GraphQL.Types;
@@ -11,10 +10,6 @@ namespace GraphQL
     /// </summary>
     public static class ObjectExtensions
     {
-        private static readonly ConcurrentDictionary<Type, ConstructorInfo> _types = new();
-
-        private static readonly List<object?> _emptyValues = new();
-
         /// <summary>
         /// Creates a new instance of the indicated type, populating it with the dictionary.
         /// Can use any constructor of the indicated type, provided that there are keys in the
@@ -28,66 +23,16 @@ namespace GraphQL
         /// In case of configuring field as Field("FirstName", x => x.FName) source dictionary
         /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
         /// </param>
-        public static object ToObject(this IDictionary<string, object?> source, Type type, IGraphType mappedType)
+        public static object ToObject(
+            this IDictionary<string, object?> source,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+            Type type,
+            IGraphType mappedType)
         {
             var inputGraphType = (mappedType is NonNullGraphType nonNullGraphType
                 ? nonNullGraphType.ResolvedType as IInputObjectGraphType
                 : mappedType as IInputObjectGraphType)
                 ?? throw new InvalidOperationException($"Graph type supplied is not an input object graph type.");
-
-            // Given Field("FirstName", x => x.FName) and key == "FirstName" returns "FName"
-            string GetPropertyName(string key, out FieldType field)
-            {
-                // type may not contain mapping information
-                field = inputGraphType.GetField(key)
-                    ?? throw new InvalidOperationException($"Could not find field '{key}' on type '{inputGraphType}'.");
-                return field.GetMetadata(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME, key) ?? key;
-            }
-
-            // Returns values (from source or defaults) that match constructor signature + used keys from source
-            (List<object?>?, List<string?>?) GetValuesAndUsedKeys(ParameterInfo[] parameters)
-            {
-                // parameterless constructors are the most common use case
-                if (parameters.Length == 0)
-                    return (_emptyValues, null);
-
-                // otherwise we have to iterate over the parameters - worse performance but this is rather rare case
-                List<object?>? values = null;
-                List<string?>? keys = null;
-
-                if (parameters.All(p =>
-                {
-                    // Source values take precedence
-                    if (source.Any(keyValue =>
-                    {
-                        bool matched = string.Equals(GetPropertyName(keyValue.Key, out var _), p.Name, StringComparison.InvariantCultureIgnoreCase);
-                        if (matched)
-                        {
-                            (values ??= new()).Add(keyValue.Value);
-                            (keys ??= new()).Add(keyValue.Key);
-                        }
-                        return matched;
-                    }))
-                    {
-                        return true;
-                    }
-
-                    // Then check for default values if any
-                    if (p.HasDefaultValue)
-                    {
-                        (values ??= new()).Add(p.DefaultValue);
-                        (keys ??= new()).Add(null);
-                        return true;
-                    }
-
-                    return false;
-                }))
-                {
-                    return (values, keys);
-                }
-
-                return (null, null);
-            }
 
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -96,54 +41,26 @@ namespace GraphQL
             if (ValueConverter.TryConvertTo(source, type, out object? result, typeof(IDictionary<string, object>)))
                 return result!;
 
-            if (type.IsAbstract)
-                throw new InvalidOperationException($"Type '{type}' is abstract and can not be used to construct objects from dictionary values. Please register a conversion within the ValueConverter or for input graph types override ParseDictionary method.");
+            var reflectionInfo = GetReflectionInformation(type, inputGraphType);
 
-            // attempt to use:
-            //   1. the only constructor
-            //   2. a constructor marked with GraphQLConstructorAttribute
-            //   3. the parameterless constructor
-            //   otherwise, throw
-            var ctor = _types.GetOrAdd(type, AutoRegisteringHelper.GetConstructor);
+            // build the constructor arguments
+            object?[] ctorArguments = reflectionInfo.CtorFields.Length == 0
+                ? Array.Empty<object>()
+                : new object[reflectionInfo.CtorFields.Length];
 
-            ConstructorInfo? targetCtor = null;
-            ParameterInfo[]? ctorParameters = null;
-            List<object?>? values = null;
-            List<string?>? usedKeys = null;
-
-            var parameters = ctor.GetParameters();
-            (values, usedKeys) = GetValuesAndUsedKeys(parameters);
-            if (values != null)
+            for (int i = 0; i < reflectionInfo.CtorFields.Length; ++i)
             {
-                targetCtor = ctor;
-                ctorParameters = parameters;
+                var ctorField = reflectionInfo.CtorFields[i];
+                ctorArguments[i] = ctorField.Key != null
+                    ? GetPropertyValue(source.TryGetValue(ctorField.Key, out var value) ? value : null, ctorField.ParameterInfo.ParameterType, ctorField.GraphType!)
+                    : ctorField.ParameterInfo.DefaultValue;
             }
 
-            if (targetCtor == null || ctorParameters == null || values == null)
-                throw new ArgumentException($"Type '{type}' does not contain a constructor that could be used for current input arguments.", nameof(type));
-
-            object?[] ctorArguments = ctorParameters.Length == 0 ? Array.Empty<object>() : new object[ctorParameters.Length];
-
-            for (int i = 0; i < ctorParameters.Length; ++i)
-            {
-                var fieldName = usedKeys![i];
-                if (fieldName is not null)
-                {
-                    var fieldType = inputGraphType.Fields.Find(fieldName)?.ResolvedType
-                        ?? throw new InvalidOperationException($"Could not get ResolvedType for field '{fieldName}' of type '{inputGraphType}'.");
-                    object? arg = GetPropertyValue(values[i], ctorParameters[i].ParameterType, fieldType);
-                    ctorArguments[i] = arg;
-                }
-                else
-                {
-                    ctorArguments[i] = values[i]; // default constructor argument
-                }
-            }
-
+            // construct the object
             object obj;
             try
             {
-                obj = targetCtor.Invoke(ctorArguments);
+                obj = reflectionInfo.Constructor.Invoke(ctorArguments);
             }
             catch (TargetInvocationException ex)
             {
@@ -151,52 +68,171 @@ namespace GraphQL
                 return ""; // never executed, necessary only for intellisense
             }
 
-            foreach (var item in source)
+            // populate the remaining fields
+            foreach (var field in reflectionInfo.MemberFields)
             {
-                // these parameters have already been used in the constructor, no need to set property
-                if (usedKeys?.Any(k => k == item.Key) == true)
-                    continue;
-
-                string propertyName = GetPropertyName(item.Key, out var field);
-                PropertyInfo? propertyInfo = null;
-
-                try
+                if (source.TryGetValue(field.Key, out var value))
                 {
-                    propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-                }
-                catch (AmbiguousMatchException)
-                {
-                    propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-                }
-
-                if (propertyInfo != null && propertyInfo.CanWrite)
-                {
-                    object? value = GetPropertyValue(item.Value, propertyInfo.PropertyType, field.ResolvedType
-                        ?? throw new InvalidOperationException($"Could not get ResolvedType for field '{field.Name}' of type '{inputGraphType}'."));
-                    propertyInfo.SetValue(obj, value, null); //issue: this works even if propertyInfo is ValueType and value is null
-                }
-                else
-                {
-                    FieldInfo? fieldInfo;
-
-                    try
+                    if (field.Member is PropertyInfo propertyInfo)
                     {
-                        fieldInfo = type.GetField(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                        var coercedValue = GetPropertyValue(value, propertyInfo.PropertyType, field.GraphType);
+                        propertyInfo.SetValue(obj, coercedValue); //issue: this works even if propertyInfo is ValueType and value is null
                     }
-                    catch (AmbiguousMatchException)
+                    else if (field.Member is FieldInfo fieldInfo)
                     {
-                        fieldInfo = type.GetField(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                        var coercedValue = GetPropertyValue(value, fieldInfo.FieldType, field.GraphType);
+                        fieldInfo.SetValue(obj, coercedValue);
                     }
-
-                    if (fieldInfo != null)
-                    {
-                        object? value = GetPropertyValue(item.Value, fieldInfo.FieldType, field.ResolvedType!);
-                        fieldInfo.SetValue(obj, value);
-                    }
+                }
+                else if (field.InitOnly)
+                {
+                    // initialize all unspecified init-only properties
+                    var propertyInfo = (PropertyInfo)field.Member;
+                    propertyInfo.SetValue(obj, null);
                 }
             }
 
             return obj;
+        }
+
+        private struct ReflectionInfo
+        {
+            public ConstructorInfo Constructor;
+            public (string? Key, ParameterInfo ParameterInfo, IGraphType? GraphType)[] CtorFields;
+            public (string Key, MemberInfo Member, bool InitOnly, IGraphType GraphType)[] MemberFields;
+        }
+
+        /// <summary>
+        /// Gets reflection information based on the specified CLR type and graph type.
+        /// </summary>
+        private static ReflectionInfo GetReflectionInformation(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+            Type clrType,
+            IInputObjectGraphType graphType)
+        {
+            // gather for each field: dictionary key, clr property name, and graph type
+            var fields = new (string Key, string? MemberName, IGraphType ResolvedType)[graphType.Fields.Count];
+            for (var i = 0; i < graphType.Fields.Count; i++)
+            {
+                var fieldType = graphType.Fields.List[i];
+                // get clr property name (also used for matching on field name or constructor parameter name)
+                var fieldName = fieldType.GetMetadata<string>(InputObjectGraphType.ORIGINAL_EXPRESSION_PROPERTY_NAME) ?? fieldType.Name;
+                // get graph type
+                var resolvedType = fieldType.ResolvedType
+                    ?? throw new InvalidOperationException($"Field '{fieldType.Name}' of graph type '{graphType.Name}' does not have the ResolvedType property set.");
+                // add to list
+                fields[i] = (fieldType.Name, fieldName, resolvedType);
+            }
+            // validate that no two different fields use the same member
+            var memberNames = new HashSet<string>(fields.Select(x => x.MemberName!));
+            if (memberNames.Count != fields.Length)
+                throw new InvalidOperationException($"Two fields within graph type '{graphType.Name}' were mapped to the same member.");
+            // find best constructor to use, with preference to the constructor with the most parameters
+            var bestConstructor = AutoRegisteringHelper.GetConstructor(clrType);
+            // pull out parameters that are applicable for that constructor
+            var ctorParameters = bestConstructor.GetParameters();
+            var memberCount = fields.Length;
+            var ctorFields = ctorParameters.Length > 0
+                ? new (string? Key, ParameterInfo Parameter, IGraphType? GraphType)[ctorParameters.Length]
+                : Array.Empty<(string? Key, ParameterInfo Parameter, IGraphType? GraphType)>();
+            for (var i = 0; i < ctorParameters.Length; i++)
+            {
+                var ctorParam = ctorParameters[i];
+                // look for a field that matches the constructor parameter name
+                var index = Array.FindIndex<(string, string? MemberName, IGraphType)>(fields, 0, fields.Length, x => string.Equals(x.MemberName, ctorParam.Name, StringComparison.OrdinalIgnoreCase));
+                if (index == -1)
+                {
+                    if (ctorParam.IsOptional)
+                        ctorFields[i] = (null, ctorParam, null);
+                    else
+                        throw new InvalidOperationException($"Cannot find field named '{ctorParam.Name}' on graph type '{graphType.Name}' to fulfill constructor parameter for type '{clrType.GetFriendlyName()}'.");
+                }
+                else
+                {
+                    // add to list, and mark to be removed from fields
+                    var value = fields[index];
+                    ctorFields[i] = (value.Key, ctorParam, value.ResolvedType);
+                    value.MemberName = null;
+                    fields[index] = value;
+                    memberCount--;
+                }
+            }
+
+            // find other members
+            var members = memberCount > 0
+                ? new (string Key, MemberInfo Member, bool InitOnly, IGraphType ResolvedType)[memberCount]
+                : Array.Empty<(string Key, MemberInfo Member, bool InitOnly, IGraphType ResolvedType)>();
+            var memberIndex = 0;
+            for (var i = 0; i < fields.Length; i++)
+            {
+                var field = fields[i];
+                // skip fields handled by constructor
+                if (field.MemberName == null)
+                    continue;
+                // look for match on type
+                var (member, initOnly) = FindMatchingMember(clrType, field.MemberName);
+                members[memberIndex++] = (field.Key, member, initOnly, field.ResolvedType);
+            }
+
+            return new ReflectionInfo
+            {
+                Constructor = bestConstructor,
+                CtorFields = ctorFields,
+                MemberFields = members,
+            };
+
+            static (MemberInfo, bool) FindMatchingMember(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+                Type type,
+                string propertyName)
+            {
+                PropertyInfo? propertyInfo = null;
+
+                // note: analzyer raises false IL2070 warning due to BindingFlags.IgnoreCase being present
+
+                try
+                {
+#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                    propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                }
+                catch (AmbiguousMatchException)
+                {
+#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                    propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                }
+
+                if (propertyInfo?.SetMethod?.IsPublic ?? false)
+                {
+                    var isExternalInit = propertyInfo.SetMethod.ReturnParameter.GetRequiredCustomModifiers()
+                        .Any(type => type.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+
+                    return (propertyInfo, isExternalInit);
+                }
+
+                FieldInfo? fieldInfo;
+
+                try
+                {
+#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                    fieldInfo = type.GetField(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                }
+                catch (AmbiguousMatchException)
+                {
+#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                    fieldInfo = type.GetField(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                }
+
+                if (fieldInfo?.IsPublic ?? false)
+                {
+                    return (fieldInfo, false);
+                }
+
+                throw new InvalidOperationException($"Cannot find member named '{propertyName}' on CLR type '{type.GetFriendlyName()}'.");
+            }
         }
 
         /// <summary>

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -133,15 +133,19 @@ namespace GraphQL
                 // add to list
                 fields[i] = (fieldType.Name, fieldName, resolvedType);
             }
+
             // find best constructor to use, with preference to the constructor with the most parameters
             var (bestConstructor, ctorParameters) = _types.GetOrAdd(
                 clrType,
                 static clrType =>
                 {
+#pragma warning disable IL2067 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
                     var constructor = AutoRegisteringHelper.GetConstructor(clrType);
+#pragma warning restore IL2067 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
                     var parameters = constructor.GetParameters();
                     return (constructor, parameters);
                 });
+
             // pull out parameters that are applicable for that constructor
             var memberCount = fields.Length;
             var ctorFields = ctorParameters.Length > 0
@@ -240,7 +244,7 @@ namespace GraphQL
 #pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
                 }
 
-                if (fieldInfo?.IsPublic ?? false)
+                if (fieldInfo != null)
                 {
                     return (fieldInfo, false);
                 }

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -283,6 +283,9 @@ namespace GraphQL
 
                 if (fieldInfo != null)
                 {
+                    if (fieldInfo.IsInitOnly)
+                        throw new InvalidOperationException($"Field named '{propertyName}' on CLR type '{type.GetFriendlyName()}' is defined as a read-only field. Please add a constructor parameter with the same name to initialize this field.");
+
                     var isRequired = fieldInfo.CustomAttributes.Any(x => x.AttributeType.FullName == typeof(RequiredMemberAttribute).FullName);
 
                     return (fieldInfo, false, isRequired);

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -157,7 +157,7 @@ namespace GraphQL
                 fields[i] = (fieldType.Name, fieldName, resolvedType);
             }
 
-            // find best constructor to use, with preference to the constructor with the most parameters
+            // find best constructor to use
             var (bestConstructor, ctorParameters) = _types.GetOrAdd(
                 clrType,
                 static clrType =>

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -12,7 +12,7 @@ namespace GraphQL
     public static class ObjectExtensions
     {
         private static readonly ConcurrentDictionary<Type, (ConstructorInfo, ParameterInfo[])> _types = new();
-        private static readonly ConcurrentDictionary<(Type, string), (MemberInfo, bool)> _members = new();
+        private static readonly ConcurrentDictionary<(Type Type, string PropertyName), (MemberInfo MemberInfo, bool IsInitOnly)> _members = new();
 
         /// <summary>
         /// Creates a new instance of the indicated type, populating it with the dictionary.
@@ -88,7 +88,7 @@ namespace GraphQL
                         fieldInfo.SetValue(obj, coercedValue);
                     }
                 }
-                else if (field.InitOnly)
+                else if (field.IsInitOnly)
                 {
                     // initialize all unspecified init-only properties
                     var propertyInfo = (PropertyInfo)field.Member;
@@ -103,7 +103,7 @@ namespace GraphQL
         {
             public ConstructorInfo Constructor;
             public (string? Key, ParameterInfo ParameterInfo, IGraphType? GraphType)[] CtorFields;
-            public (string Key, MemberInfo Member, bool InitOnly, IGraphType GraphType)[] MemberFields;
+            public (string Key, MemberInfo Member, bool IsInitOnly, IGraphType GraphType)[] MemberFields;
         }
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace GraphQL
                     continue;
                 // look for match on type
 #pragma warning disable IL2077 // 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'FindMatchingMember(Type, String)'. The field '(System.Type, System.String).Item1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-                var (member, initOnly) = _members.GetOrAdd((clrType, field.MemberName), static info => FindMatchingMember(info.Item1, info.Item2));
+                var (member, initOnly) = _members.GetOrAdd((clrType, field.MemberName), static info => FindMatchingMember(info.Type, info.PropertyName));
 #pragma warning restore IL2077 // 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'FindMatchingMember(Type, String)'. The field '(System.Type, System.String).Item1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
                 members[memberIndex++] = (field.Key, member, initOnly, field.ResolvedType);
             }

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -11,7 +11,7 @@ namespace GraphQL
     /// </summary>
     public static class ObjectExtensions
     {
-        private static readonly ConcurrentDictionary<Type, (ConstructorInfo, ParameterInfo[])> _types = new();
+        private static readonly ConcurrentDictionary<Type, (ConstructorInfo Constructor, ParameterInfo[] ConstructorParameters)> _types = new();
         private static readonly ConcurrentDictionary<(Type Type, string PropertyName), (MemberInfo MemberInfo, bool IsInitOnly)> _members = new();
 
         /// <summary>

--- a/src/GraphQL/Types/Composite/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/InputObjectGraphType.cs
@@ -70,7 +70,9 @@ namespace GraphQL.Types
                 return value;
 
             // for InputObjectGraphType<TSourceType>, convert to TSourceType via ToObject.
+#pragma warning disable IL2087 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
             return value.ToObject(typeof(TSourceType), this);
+#pragma warning restore IL2087 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This PR makes `ToObject` use a separate function to pull reflection information to determine 'how' to construct the object.  This makes `ToObject` itself much simpler.

There are a couple implementation changes, but otherwise is functionally identical:
- Private setters for public properties are not supported
- Writing to read-only fields is not supported
- Init-only setters are always initialized to their default value if not specified

This allows for:
- Caching of reflection information independent of `ToObject` operation (separate PR)
- Re-use of reflection information for dynamically-compiled `ToObject` implementations (separate PR)
- 100% compatible with a source-generated `ToObject` implementation

Also todo in separate PR:
- Clean up logic in `ObjectExtensions.GetPropertyValue`

Note:
- Does not set init-only properties first, as would occur with a source-generated implementation
- We could set ALL undefined properties to their default values, not just init-only ones, making reflection, source-generated and dynamically-compiled versions simpler.