### PR TITLE
Fix document caching and add tests

### DIFF
--- a/src/GraphQL.Tests/Caching/MemoryCacheTests.cs
+++ b/src/GraphQL.Tests/Caching/MemoryCacheTests.cs
@@ -2,6 +2,9 @@
 
 using GraphQL.Caching;
 using GraphQLParser.AST;
+using Moq;
+using Moq.Protected;
+using Shouldly;
 
 namespace GraphQL.Tests.Caching;
 
@@ -39,5 +42,68 @@ public class MemoryCacheTests
         await Should.ThrowAsync<ArgumentNullException>(async () => await memoryCache.SetAsyncPublic(options, null!));
 
         (await memoryCache.GetAsyncPublic(options)).ShouldBe(doc);
+    }
+
+    [Theory]
+    // no query set
+    [InlineData(false, false, false, false, true, true, false)]
+    // doc already set
+    [InlineData(false, true, false, false, true, true, false)]
+    [InlineData(true, true, false, false, true, true, false)]
+    // typical path with cache miss
+    [InlineData(true, false, true, false, true, true, true)] // passed validation
+    [InlineData(true, false, true, false, false, true, false)] // failed validation
+    [InlineData(true, false, true, false, true, false, false)] // didn't set document (should not be possible)
+    [InlineData(true, false, true, false, false, false, false)] // failed parse
+    // typical path with cache hit; should never call SetAsync
+    [InlineData(true, false, true, true, true, true, false)]
+    [InlineData(true, false, true, true, false, true, false)]
+    [InlineData(true, false, true, true, true, false, false)]
+    [InlineData(true, false, true, true, false, false, false)]
+    public async Task ExecuteAsync(bool querySet, bool docSet, bool getCalled, bool getReturned, bool executed, bool exectuedSetDocument, bool setCalled)
+    {
+        var mockDocument = new GraphQLDocument();
+        var options = new ExecutionOptions
+        {
+            Query = querySet ? "Some Query" : null,
+            Document = docSet ? mockDocument : null,
+        };
+
+        var memoryDocumentCacheMock = new Mock<MemoryDocumentCache>() { CallBase = true };
+        memoryDocumentCacheMock.Protected()
+            .Setup<ValueTask<GraphQLDocument?>>("GetAsync", ItExpr.IsAny<ExecutionOptions>())
+            .Returns<ExecutionOptions>(opts =>
+            {
+                opts.ShouldBe(options);
+                if (getReturned)
+                    return new(mockDocument);
+                return default;
+            });
+
+        memoryDocumentCacheMock.Protected()
+            .Setup<ValueTask>("SetAsync", ItExpr.IsAny<ExecutionOptions>(), ItExpr.IsAny<GraphQLDocument>())
+            .Returns<ExecutionOptions, GraphQLDocument>((opts, doc) =>
+            {
+                opts.ShouldBe(options);
+                doc.ShouldBe(mockDocument);
+                return default;
+            });
+
+        var result = new ExecutionResult()
+        {
+            Executed = executed,
+            Document = exectuedSetDocument ? mockDocument : null,
+        };
+
+        var ret = await memoryDocumentCacheMock.Object.ExecuteAsync(options, (opts) =>
+        {
+            opts.ShouldBe(options);
+            return Task.FromResult(result);
+        });
+
+        ret.ShouldBe(result);
+
+        memoryDocumentCacheMock.Protected().Verify("GetAsync", getCalled ? Times.Once() : Times.Never(), ItExpr.IsAny<ExecutionOptions>());
+        memoryDocumentCacheMock.Protected().Verify("SetAsync", setCalled ? Times.Once() : Times.Never(), ItExpr.IsAny<ExecutionOptions>(), ItExpr.IsAny<GraphQLDocument>());
     }
 }

--- a/src/GraphQL.Tests/Caching/MemoryCacheTests.cs
+++ b/src/GraphQL.Tests/Caching/MemoryCacheTests.cs
@@ -4,7 +4,6 @@ using GraphQL.Caching;
 using GraphQLParser.AST;
 using Moq;
 using Moq.Protected;
-using Shouldly;
 
 namespace GraphQL.Tests.Caching;
 


### PR DESCRIPTION
MemoryDocumentCache was essentially useless, not passing on cached documents to the document executer, nor storing parsed documents and saving them in the cache.  Broke during 7.0 transition to `IConfigureExecution` in #3272 .  Added tests to ensure the cache's ExecuteAsync method works correctly in the future.