### PR TITLE
Fix GQL009 code fix formatting

### DIFF
--- a/src/GraphQL.Analyzers.CodeFixes/AwaitableResolverCodeFixProvider.cs
+++ b/src/GraphQL.Analyzers.CodeFixes/AwaitableResolverCodeFixProvider.cs
@@ -71,11 +71,12 @@ public class AwaitableResolverCodeFixProvider : CodeFixProvider
                 // Resolve(async ctx => await AsyncMethod() or statement)
                 var newLambda = lambda
                     .WithAsyncKeyword(
-                        Token(SyntaxKind.AsyncKeyword).WithLeadingTrivia(Space))
+                        Token(SyntaxKind.AsyncKeyword).WithLeadingTrivia(lambda.GetLeadingTrivia()))
                     .WithExpressionBody(
                         AwaitExpression(
-                            Token(SyntaxKind.AwaitKeyword).WithTrailingTrivia(Space),
-                            lambda.ExpressionBody));
+                                Token(SyntaxKind.AwaitKeyword),
+                                lambda.ExpressionBody)
+                            .WithLeadingTrivia(lambda.ExpressionBody.GetLeadingTrivia()));
 
                 docEditor.ReplaceNode(lambda, newLambda);
 

--- a/src/GraphQL.Analyzers.Tests/AwaitableResolverAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/AwaitableResolverAnalyzerTests.cs
@@ -485,4 +485,102 @@ public class AwaitableResolverAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(source, expected, expectedFix);
     }
+
+    [Fact]
+    public async Task SyncResolve_AwaitableLambdaResolver_GQL009_FormatPreserved()
+    {
+        const string source =
+            """
+            using System;
+            using System.Threading.Tasks;
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : ObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    Field<StringGraphType>("Test")
+                        .Resolve(
+                            ctx => Task.FromResult("text")
+                        );
+                }
+            }
+
+            """;
+
+        const string fix =
+            """
+            using System;
+            using System.Threading.Tasks;
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : ObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    Field<StringGraphType>("Test")
+                        .ResolveAsync(
+                            async ctx => await Task.FromResult("text")
+                        );
+                }
+            }
+
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithSpan(12, 14, 12, 21).WithArguments(Constants.MethodNames.ResolveAsync);
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
+    }
+
+    [Fact]
+    public async Task SyncResolve_AwaitableLambdaResolver_GQL009_FormatPreserved2()
+    {
+        const string source =
+            """
+            using System;
+            using System.Threading.Tasks;
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : ObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    Field<StringGraphType>("Test")
+                        .Resolve(ctx =>
+                            Task.FromResult("text")
+                    );
+                }
+            }
+
+            """;
+
+        const string fix =
+            """
+            using System;
+            using System.Threading.Tasks;
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : ObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    Field<StringGraphType>("Test")
+                        .ResolveAsync(async ctx =>
+                            await Task.FromResult("text")
+                    );
+                }
+            }
+
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithSpan(12, 14, 12, 21).WithArguments(Constants.MethodNames.ResolveAsync);
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
+    }
 }


### PR DESCRIPTION
The formatting was broken when lambda's parameter or body was on a different line.