### PR TITLE
Downgrade Microsoft.CodeAnalysis packages to v3.11.0 to support older compilers

### DIFF
--- a/src/GraphQL.Analyzers.CodeFixes/GraphQL.Analyzers.CodeFixes.csproj
+++ b/src/GraphQL.Analyzers.CodeFixes/GraphQL.Analyzers.CodeFixes.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Must verify that analzyers are recognized by VS after upgrading, as 4.7.0 was not working with VS 2022 -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
+    <!-- https://github.com/graphql-dotnet/graphql-dotnet/issues/3829 -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Analyzers/GraphQL.Analyzers.csproj
+++ b/src/GraphQL.Analyzers/GraphQL.Analyzers.csproj
@@ -15,8 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <!-- Must verify that analzyers are recognized by VS after upgrading, as 4.7.0 was not working with VS 2022 -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <!-- https://github.com/graphql-dotnet/graphql-dotnet/issues/3829 -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #3829.

Note, in the test project I still use v4.6.0 to allow the use of newer language features such as file-scoped namespaces in the analyzed source.