### PR TITLE
Fix FieldBuilderCodeFixProvider formatting and try preserve code comments

### DIFF
--- a/src/GraphQL.Analyzers.CodeFixes/FieldBuilderCodeFixProvider.cs
+++ b/src/GraphQL.Analyzers.CodeFixes/FieldBuilderCodeFixProvider.cs
@@ -123,9 +123,14 @@ public class FieldBuilderCodeFixProvider : CodeFixProvider
 
             if (invocationName != null)
             {
-                var leadingTrivia = reformat || newLine
-                    ? TriviaList(newLineTrivia, whitespaceTrivia)
-                    : TriviaList(whitespaceTrivia);
+                var argLeadingTrivia = arg.GetLeadingTrivia();
+                var leadingTrivia = reformat
+                    ? argLeadingTrivia.Any()
+                        ? TriviaList(newLineTrivia).AddRange(argLeadingTrivia)
+                        : TriviaList(newLineTrivia, whitespaceTrivia)
+                    : newLine
+                        ? TriviaList(newLineTrivia).AddRange(argLeadingTrivia)
+                        : TriviaList(whitespaceTrivia);
 
                 newFieldInvocationExpression = CreateInvocationExpression(
                     newFieldInvocationExpression,
@@ -140,6 +145,10 @@ public class FieldBuilderCodeFixProvider : CodeFixProvider
         }
 
         docEditor.ReplaceNode(fieldInvocationExpression, newFieldInvocationExpression);
+
+        var x = await docEditor.GetChangedDocument().GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var xx = x.ToString();
+
         return docEditor.GetChangedDocument();
     }
 

--- a/src/GraphQL.Analyzers.CodeFixes/FieldBuilderCodeFixProvider.cs
+++ b/src/GraphQL.Analyzers.CodeFixes/FieldBuilderCodeFixProvider.cs
@@ -130,7 +130,10 @@ public class FieldBuilderCodeFixProvider : CodeFixProvider
                 newFieldInvocationExpression = CreateInvocationExpression(
                     newFieldInvocationExpression,
                     invocationName,
-                    arg.Expression,
+                    arg.Expression
+                        .WithTrailingTrivia(
+                            arg.Expression.GetTrailingTrivia()
+                                .Where(t => !t.IsKind(SyntaxKind.EndOfLineTrivia))),
                     leadingTrivia,
                     skipNulls);
             }

--- a/src/GraphQL.Analyzers.Tests/FieldBuilderAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/FieldBuilderAnalyzerTests.cs
@@ -341,21 +341,22 @@ public class FieldBuilderAnalyzerTests
                 public MyGraphType()
                 {
                     Field<StringGraphType>(
-                        "name",
-                        // arg comment
+                        "name" /* a */, // b
+                        // c
                         arguments: new QueryArguments(
                             new QueryArgument<StringGraphType> { Name = "argName1" },
                             new QueryArgument<StringGraphType> { Name = "argName2" }
                         ),
-                        // description comment
+                        // d
                         description: "desc"
-                    );
+                    ); // e
                 }
             }
             """;
 
-        // NOTE: empty lines before the comment shouldn't appear,
-        // but I have no idea where they come from...
+        // NOTE: line break before 'Description' shouldn't appear,
+        // but I have no idea where it comes from...
+        // At least comments are preserved
         const string fix =
             """
             using GraphQL.Types;
@@ -366,16 +367,16 @@ public class FieldBuilderAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    Field<StringGraphType>("name")
-
-                        // arg comment
+                    Field<StringGraphType>("name" /* a */)
+                        // b
+                        // c
                         .Arguments(new QueryArguments(
                             new QueryArgument<StringGraphType> { Name = "argName1" },
                             new QueryArgument<StringGraphType> { Name = "argName2" }
                         ))
 
-                        // description comment
-                        .Description("desc");
+                        // d
+                        .Description("desc"); // e
                 }
             }
             """;
@@ -792,7 +793,7 @@ public class FieldBuilderAnalyzerTests
     }
 
     [Fact]
-    public async Task ReformatOptionIsTrue_SourceReformatted2()
+    public async Task ReformatOptionIsTrue_SourceReformatted_CommentsPreserved()
     {
         const string source =
             """
@@ -804,13 +805,35 @@ public class FieldBuilderAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    Field<StringGraphType>("name", "description",
-                        // comment
-                        deprecationReason: "reason",
-                        resolve: context => "text");
+                    Field<StringGraphType>("name" /* a */, /* b */ "description",
+                        // c
+                        deprecationReason: "reason", // d
+                        resolve: context => "text"); // e
                 }
             }
             """;
+
+        // NOTE: this is the expected output, but I can't get rid of these line breaks.
+        // At least the comments are preserved
+        /*const string fix =
+            """
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : ObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    Field<StringGraphType>("name" /* a #1#)
+                        /* b #1#
+                        .Description("description")
+                        // c
+                        .DeprecationReason("reason") // d
+                        .Resolve(context => "text"); // e
+                }
+            }
+            """;*/
 
         const string fix =
             """
@@ -822,12 +845,14 @@ public class FieldBuilderAnalyzerTests
             {
                 public MyGraphType()
                 {
-                    Field<StringGraphType>("name")
+                    Field<StringGraphType>("name" /* a */)
+                        /* b */
                         .Description("description")
 
-                        // comment
+                        // c
                         .DeprecationReason("reason")
-                        .Resolve(context => "text");
+                        // d
+                        .Resolve(context => "text"); // e
                 }
             }
             """;

--- a/src/GraphQL.Analyzers.Tests/FieldBuilderAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/FieldBuilderAnalyzerTests.cs
@@ -281,6 +281,53 @@ public class FieldBuilderAnalyzerTests
     }
 
     [Fact]
+    public async Task ArgumentsListMultilineFormatted_FormattingPreserved2()
+    {
+        const string source =
+            """
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : InputObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    Field<StringGraphType>(
+                        "name",
+                        arguments: new QueryArguments(
+                            new QueryArgument<StringGraphType> { Name = "argName1" },
+                            new QueryArgument<StringGraphType> { Name = "argName2" }
+                        )
+                    );
+                }
+            }
+            """;
+
+        const string fix =
+            """
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            public class MyGraphType : InputObjectGraphType
+            {
+                public MyGraphType()
+                {
+                    Field<StringGraphType>("name")
+                        .Arguments(new QueryArguments(
+                            new QueryArgument<StringGraphType> { Name = "argName1" },
+                            new QueryArgument<StringGraphType> { Name = "argName2" }
+                        ));
+                }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(FieldBuilderAnalyzer.DoNotUseObsoleteFieldMethods).WithSpan(9, 9, 15, 10);
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fix);
+    }
+
+    [Fact]
     public async Task NonGenericFieldMethod_FixProvided()
     {
         const string source =


### PR DESCRIPTION
This fixes the line break after the last argument mentioned [here](https://github.com/graphql-dotnet/graphql-dotnet/pull/3824#issuecomment-1856104581).

Additionally, it tries to keep the code comments during the rewrite. There are still a few cases when the comment can be lost. For example, in the following code, the comments `// a` and `/* b */` will be lost:
```c#
Field<StringGraphType>(
    // a
    /* b /* "name" /* c */, // d
    ...
```

I hope folks will forgive me for a little work to restore them manually 🙄

Also, it sometimes adds a line break before the comments that shouldn't appear. I checked the altered code returned from the `docEditor.GetChangedDocument();`, and it looks correct but breaks somewhere deep in Roslyn infra.