### PR TITLE
Change solution to use file-scoped namespaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -194,7 +194,7 @@ csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
 
 # C# formatting settings - Namespace options
-csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_namespace_declarations = file_scoped:error
 
 ########## name all private fields using camelCase with underscore prefix ##########
 # https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions?view=vs-2019

--- a/src/GraphQL/Attributes/DoNotMapClrTypeAttribute.cs
+++ b/src/GraphQL/Attributes/DoNotMapClrTypeAttribute.cs
@@ -1,14 +1,13 @@
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Indicates that <see cref="SchemaExtensions.RegisterTypeMappings(Types.ISchema)"/> and
+/// <see cref="GraphQLBuilderExtensions.AddClrTypeMappings(DI.IGraphQLBuilder)"/>
+/// should skip this class when scanning an assembly for CLR type mappings.
+/// This attribute can be placed either on the graph type or the CLR type that comprises
+/// the mapping.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class DoNotMapClrTypeAttribute : Attribute
 {
-    /// <summary>
-    /// Indicates that <see cref="SchemaExtensions.RegisterTypeMappings(Types.ISchema)"/> and
-    /// <see cref="GraphQLBuilderExtensions.AddClrTypeMappings(DI.IGraphQLBuilder)"/>
-    /// should skip this class when scanning an assembly for CLR type mappings.
-    /// This attribute can be placed either on the graph type or the CLR type that comprises
-    /// the mapping.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public sealed class DoNotMapClrTypeAttribute : Attribute
-    {
-    }
 }

--- a/src/GraphQL/Attributes/DoNotRegisterAttribute.cs
+++ b/src/GraphQL/Attributes/DoNotRegisterAttribute.cs
@@ -1,13 +1,12 @@
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Indicates that <see cref="GraphQLBuilderExtensions.AddGraphTypes(DI.IGraphQLBuilder, System.Reflection.Assembly)"/>
+/// should skip this class when scanning an assembly for classes that implement <see cref="IGraphType"/>
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class DoNotRegisterAttribute : Attribute
 {
-    /// <summary>
-    /// Indicates that <see cref="GraphQLBuilderExtensions.AddGraphTypes(DI.IGraphQLBuilder, System.Reflection.Assembly)"/>
-    /// should skip this class when scanning an assembly for classes that implement <see cref="IGraphType"/>
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public sealed class DoNotRegisterAttribute : Attribute
-    {
-    }
 }

--- a/src/GraphQL/Attributes/FromServicesAttribute.cs
+++ b/src/GraphQL/Attributes/FromServicesAttribute.cs
@@ -1,24 +1,23 @@
 using GraphQL.Types;
 using GraphQL.Utilities;
 
-namespace GraphQL
-{
-    /// <summary>
-    /// Specifies that the method argument should be pulled from <see cref="IResolveFieldContext.RequestServices"/>.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter)]
-    public class FromServicesAttribute : GraphQLAttribute
-    {
-        /* This is a typed copy of the below code, but does not work in AOT compilation scenarios.
-         * However, this is the recommended pattern for user-defined attributes.
-         * 
-        /// <inheritdoc/>
-        public override void Modify<TParameterType>(ArgumentInformation argumentInformation)
-            => argumentInformation.SetDelegate(context => context.RequestServicesOrThrow().GetRequiredService<TParameterType>());
-        */
+namespace GraphQL;
 
-        /// <inheritdoc/>
-        public override void Modify(ArgumentInformation argumentInformation)
-            => argumentInformation.SetDelegateWithCast(context => context.RequestServicesOrThrow().GetRequiredService(argumentInformation.ParameterInfo.ParameterType));
-    }
+/// <summary>
+/// Specifies that the method argument should be pulled from <see cref="IResolveFieldContext.RequestServices"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class FromServicesAttribute : GraphQLAttribute
+{
+    /* This is a typed copy of the below code, but does not work in AOT compilation scenarios.
+     * However, this is the recommended pattern for user-defined attributes.
+     * 
+    /// <inheritdoc/>
+    public override void Modify<TParameterType>(ArgumentInformation argumentInformation)
+        => argumentInformation.SetDelegate(context => context.RequestServicesOrThrow().GetRequiredService<TParameterType>());
+    */
+
+    /// <inheritdoc/>
+    public override void Modify(ArgumentInformation argumentInformation)
+        => argumentInformation.SetDelegateWithCast(context => context.RequestServicesOrThrow().GetRequiredService(argumentInformation.ParameterInfo.ParameterType));
 }

--- a/src/GraphQL/Attributes/FromSourceAttribute.cs
+++ b/src/GraphQL/Attributes/FromSourceAttribute.cs
@@ -1,19 +1,18 @@
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Specifies that the method argument should be pulled from <see cref="IResolveFieldContext.Source"/>,
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class FromSourceAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Specifies that the method argument should be pulled from <see cref="IResolveFieldContext.Source"/>,
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter)]
-    public class FromSourceAttribute : GraphQLAttribute
+    /// <inheritdoc/>
+    public override void Modify(ArgumentInformation argumentInformation)
     {
-        /// <inheritdoc/>
-        public override void Modify(ArgumentInformation argumentInformation)
-        {
-            if (argumentInformation.SourceType != null && !argumentInformation.ParameterInfo.ParameterType.IsAssignableFrom(argumentInformation.SourceType))
-                throw new InvalidOperationException($"Source parameter type '{argumentInformation.ParameterInfo.ParameterType.Name}' does not match source type of '{argumentInformation.SourceType.Name}'.");
-            argumentInformation.SetDelegateWithCast(context => context.Source);
-        }
+        if (argumentInformation.SourceType != null && !argumentInformation.ParameterInfo.ParameterType.IsAssignableFrom(argumentInformation.SourceType))
+            throw new InvalidOperationException($"Source parameter type '{argumentInformation.ParameterInfo.ParameterType.Name}' does not match source type of '{argumentInformation.SourceType.Name}'.");
+        argumentInformation.SetDelegateWithCast(context => context.Source);
     }
 }

--- a/src/GraphQL/Attributes/FromUserContextAttribute.cs
+++ b/src/GraphQL/Attributes/FromUserContextAttribute.cs
@@ -1,18 +1,17 @@
 using GraphQL.Execution;
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Specifies that the method argument should be pulled from <see cref="IResolveFieldContext"/>.<see cref="IProvideUserContext.UserContext">UserContext</see>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class FromUserContextAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Specifies that the method argument should be pulled from <see cref="IResolveFieldContext"/>.<see cref="IProvideUserContext.UserContext">UserContext</see>.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter)]
-    public class FromUserContextAttribute : GraphQLAttribute
+    /// <inheritdoc/>
+    public override void Modify(ArgumentInformation argumentInformation)
     {
-        /// <inheritdoc/>
-        public override void Modify(ArgumentInformation argumentInformation)
-        {
-            argumentInformation.SetDelegateWithCast(context => context.UserContext);
-        }
+        argumentInformation.SetDelegateWithCast(context => context.UserContext);
     }
 }

--- a/src/GraphQL/Attributes/GraphQLAttribute.cs
+++ b/src/GraphQL/Attributes/GraphQLAttribute.cs
@@ -3,104 +3,103 @@ using System.Reflection;
 using GraphQL.Types;
 using GraphQL.Utilities;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Allows additional configuration to be applied to a type, field or query argument definition.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true)]
+public abstract class GraphQLAttribute : Attribute
 {
     /// <summary>
-    /// Allows additional configuration to be applied to a type, field or query argument definition.
+    /// Updates the properties of the specified <see cref="TypeConfig"/> as necessary.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class GraphQLAttribute : Attribute
+    public virtual void Modify(TypeConfig type)
     {
-        /// <summary>
-        /// Updates the properties of the specified <see cref="TypeConfig"/> as necessary.
-        /// </summary>
-        public virtual void Modify(TypeConfig type)
-        {
-        }
-
-        /// <summary>
-        /// Updates the properties of the specified <see cref="FieldConfig"/> as necessary.
-        /// </summary>
-        public virtual void Modify(FieldConfig field)
-        {
-        }
-
-        /// <summary>
-        /// Updates the properties of the specified <see cref="IGraphType"/> as necessary.
-        /// </summary>
-        public virtual void Modify(IGraphType graphType)
-        {
-        }
-
-        /// <summary>
-        /// Updates the properties of the specified <see cref="EnumValueDefinition"/> as necessary.
-        /// </summary>
-        public virtual void Modify(EnumValueDefinition enumValueDefinition)
-        {
-        }
-
-        /// <summary>
-        /// Updates the properties of the specified <see cref="FieldType"/> as necessary.
-        /// </summary>
-        /// <param name="fieldType">The <see cref="FieldType"/> to update.</param>
-        /// <param name="isInputType">Indicates if the graph type containing this field is an input type.</param>
-        public virtual void Modify(FieldType fieldType, bool isInputType)
-        {
-        }
-
-        /// <summary>
-        /// Updates the properties of the specified <see cref="TypeInformation"/> as necessary.
-        /// </summary>
-        public virtual void Modify(TypeInformation typeInformation)
-        {
-        }
-
-        private static readonly MethodInfo _modifyMethod = typeof(GraphQLAttribute)
-            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
-            .Where(x => x.Name == nameof(GraphQLAttribute.Modify) && x.IsGenericMethod)
-            .Single();
-        private static readonly ConcurrentDictionary<Type, MethodInfo> _typedModifyMethods = new();
-
-        /// <summary>
-        /// Updates the properties of the specified <see cref="ArgumentInformation"/> as necessary.
-        /// </summary>
-        public virtual void Modify(ArgumentInformation argumentInformation)
-        {
-            var typedMethod = _typedModifyMethods.GetOrAdd(
-                argumentInformation.ParameterInfo.ParameterType,
-                type => _modifyMethod.MakeGenericMethod(type));
-            var func = (Action<ArgumentInformation>)typedMethod.CreateDelegate(typeof(Action<ArgumentInformation>), this);
-            func(argumentInformation);
-        }
-
-        /// <summary>
-        /// Updates the properties of the specified <see cref="ArgumentInformation"/> as necessary.
-        /// <typeparamref name="TParameterType"/> represents the return type of the parameter.
-        /// </summary>
-        public virtual void Modify<TParameterType>(ArgumentInformation argumentInformation)
-        {
-        }
-
-        /// <summary>
-        /// Updates the properties of the specified <see cref="QueryArgument"/> as necessary.
-        /// </summary>
-        public virtual void Modify(QueryArgument queryArgument)
-        {
-        }
-
-        /// <summary>
-        /// Determines if a specified member should be included during automatic generation
-        /// of a graph type from a CLR type.
-        /// <br/><br/>
-        /// When called for enumeration values, <paramref name="isInputType"/> is <see langword="null"/>.
-        /// </summary>
-        public virtual bool ShouldInclude(MemberInfo memberInfo, bool? isInputType) => true;
-
-        /// <summary>
-        /// Determines the order in which GraphQL attributes are applied to the graph type, field type, or parameter definition.
-        /// Attributes with the lowest <see cref="Priority"/> value are applied first.
-        /// The default priority is 1.
-        /// </summary>
-        public virtual float Priority => 1.0f;
     }
+
+    /// <summary>
+    /// Updates the properties of the specified <see cref="FieldConfig"/> as necessary.
+    /// </summary>
+    public virtual void Modify(FieldConfig field)
+    {
+    }
+
+    /// <summary>
+    /// Updates the properties of the specified <see cref="IGraphType"/> as necessary.
+    /// </summary>
+    public virtual void Modify(IGraphType graphType)
+    {
+    }
+
+    /// <summary>
+    /// Updates the properties of the specified <see cref="EnumValueDefinition"/> as necessary.
+    /// </summary>
+    public virtual void Modify(EnumValueDefinition enumValueDefinition)
+    {
+    }
+
+    /// <summary>
+    /// Updates the properties of the specified <see cref="FieldType"/> as necessary.
+    /// </summary>
+    /// <param name="fieldType">The <see cref="FieldType"/> to update.</param>
+    /// <param name="isInputType">Indicates if the graph type containing this field is an input type.</param>
+    public virtual void Modify(FieldType fieldType, bool isInputType)
+    {
+    }
+
+    /// <summary>
+    /// Updates the properties of the specified <see cref="TypeInformation"/> as necessary.
+    /// </summary>
+    public virtual void Modify(TypeInformation typeInformation)
+    {
+    }
+
+    private static readonly MethodInfo _modifyMethod = typeof(GraphQLAttribute)
+        .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+        .Where(x => x.Name == nameof(GraphQLAttribute.Modify) && x.IsGenericMethod)
+        .Single();
+    private static readonly ConcurrentDictionary<Type, MethodInfo> _typedModifyMethods = new();
+
+    /// <summary>
+    /// Updates the properties of the specified <see cref="ArgumentInformation"/> as necessary.
+    /// </summary>
+    public virtual void Modify(ArgumentInformation argumentInformation)
+    {
+        var typedMethod = _typedModifyMethods.GetOrAdd(
+            argumentInformation.ParameterInfo.ParameterType,
+            type => _modifyMethod.MakeGenericMethod(type));
+        var func = (Action<ArgumentInformation>)typedMethod.CreateDelegate(typeof(Action<ArgumentInformation>), this);
+        func(argumentInformation);
+    }
+
+    /// <summary>
+    /// Updates the properties of the specified <see cref="ArgumentInformation"/> as necessary.
+    /// <typeparamref name="TParameterType"/> represents the return type of the parameter.
+    /// </summary>
+    public virtual void Modify<TParameterType>(ArgumentInformation argumentInformation)
+    {
+    }
+
+    /// <summary>
+    /// Updates the properties of the specified <see cref="QueryArgument"/> as necessary.
+    /// </summary>
+    public virtual void Modify(QueryArgument queryArgument)
+    {
+    }
+
+    /// <summary>
+    /// Determines if a specified member should be included during automatic generation
+    /// of a graph type from a CLR type.
+    /// <br/><br/>
+    /// When called for enumeration values, <paramref name="isInputType"/> is <see langword="null"/>.
+    /// </summary>
+    public virtual bool ShouldInclude(MemberInfo memberInfo, bool? isInputType) => true;
+
+    /// <summary>
+    /// Determines the order in which GraphQL attributes are applied to the graph type, field type, or parameter definition.
+    /// Attributes with the lowest <see cref="Priority"/> value are applied first.
+    /// The default priority is 1.
+    /// </summary>
+    public virtual float Priority => 1.0f;
 }

--- a/src/GraphQL/Attributes/GraphQLMetadataAttribute.cs
+++ b/src/GraphQL/Attributes/GraphQLMetadataAttribute.cs
@@ -1,168 +1,167 @@
 using GraphQL.Types;
 using GraphQL.Utilities;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Attribute for specifying additional information when matching a CLR type to a corresponding GraphType.
+/// </summary>
+[AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public sealed class GraphQLMetadataAttribute : GraphQLAttribute
+{
+    private Type? _mappedToInput;
+    private Type? _mappedToOutput;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    public GraphQLMetadataAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified GraphType name.
+    /// </summary>
+    /// <param name="name"></param>
+    public GraphQLMetadataAttribute(string name)
+    {
+        Name = name;
+    }
+
+    /// <summary>
+    /// GraphType name.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// GraphType description.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Deprecation reason of the field or GraphType.
+    /// </summary>
+    public string? DeprecationReason { get; set; }
+
+    /// <summary>
+    /// Indicates if the marked method represents a field resolver or a subscription event stream resolver.
+    /// </summary>
+    public ResolverType ResolverType { get; set; }
+
+    /// <summary>
+    /// Indicates the CLR type that this graph type represents.
+    /// </summary>
+    public Type? IsTypeOf { get; set; }
+
+    /// <summary>
+    /// Indicates which GraphType input type this CLR type is mapped to (if used in input context).
+    /// </summary>
+    [Obsolete("Please use the [InputType] attribute instead of this property.")]
+    public Type? InputType
+    {
+        get => _mappedToInput;
+        set
+        {
+            if (value != null && !value.IsInputType())
+                throw new ArgumentException(nameof(InputType), $"'{value}' should be of input type");
+
+            _mappedToInput = value;
+        }
+    }
+
+    /// <summary>
+    /// Indicates which GraphType output type this CLR type is mapped to (if used in output context).
+    /// </summary>
+    [Obsolete("Please use the [OutputType] attribute instead of this property.")]
+    public Type? OutputType
+    {
+        get => _mappedToOutput;
+        set
+        {
+            if (value != null && !value.IsOutputType())
+                throw new ArgumentException(nameof(OutputType), $"'{value}' should be of output type");
+
+            _mappedToOutput = value;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(TypeConfig type)
+    {
+        type.Description = Description;
+        type.DeprecationReason = DeprecationReason;
+
+        if (IsTypeOf != null)
+            type.IsTypeOfFunc = t => IsTypeOf.IsAssignableFrom(t.GetType());
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldConfig field)
+    {
+        field.Description = Description;
+        field.DeprecationReason = DeprecationReason;
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(EnumValueDefinition enumValueDefinition)
+    {
+        if (Name != null)
+            enumValueDefinition.Name = Name;
+
+        if (Description != null)
+            enumValueDefinition.Description = Description == "" ? null : Description;
+
+        if (DeprecationReason != null)
+            enumValueDefinition.DeprecationReason = DeprecationReason == "" ? null : DeprecationReason;
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType)
+    {
+        if (Name != null)
+            graphType.Name = Name;
+
+        if (Description != null)
+            graphType.Description = Description == "" ? null : Description;
+
+        if (DeprecationReason != null)
+            graphType.DeprecationReason = DeprecationReason == "" ? null : DeprecationReason;
+
+        if (graphType is IObjectGraphType objectGraphType && IsTypeOf != null)
+            objectGraphType.IsTypeOf = obj => IsTypeOf.IsAssignableFrom(obj.GetType());
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (Name != null)
+            fieldType.Name = Name;
+
+        if (Description != null)
+            fieldType.Description = Description == "" ? null : Description;
+
+        if (DeprecationReason != null)
+            fieldType.DeprecationReason = DeprecationReason == "" ? null : DeprecationReason;
+
+        if (isInputType && _mappedToInput != null)
+            fieldType.Type = _mappedToInput;
+
+        if (!isInputType && _mappedToOutput != null)
+            fieldType.Type = _mappedToOutput;
+    }
+}
+
+/// <summary>
+/// Indicates if the specified method is a field resolver or event stream resolver.
+/// </summary>
+public enum ResolverType
 {
     /// <summary>
-    /// Attribute for specifying additional information when matching a CLR type to a corresponding GraphType.
+    /// Indicates the specified method is a field resolver
     /// </summary>
-    [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
-    public sealed class GraphQLMetadataAttribute : GraphQLAttribute
-    {
-        private Type? _mappedToInput;
-        private Type? _mappedToOutput;
-
-        /// <summary>
-        /// Initializes a new instance.
-        /// </summary>
-        public GraphQLMetadataAttribute()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified GraphType name.
-        /// </summary>
-        /// <param name="name"></param>
-        public GraphQLMetadataAttribute(string name)
-        {
-            Name = name;
-        }
-
-        /// <summary>
-        /// GraphType name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// GraphType description.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Deprecation reason of the field or GraphType.
-        /// </summary>
-        public string? DeprecationReason { get; set; }
-
-        /// <summary>
-        /// Indicates if the marked method represents a field resolver or a subscription event stream resolver.
-        /// </summary>
-        public ResolverType ResolverType { get; set; }
-
-        /// <summary>
-        /// Indicates the CLR type that this graph type represents.
-        /// </summary>
-        public Type? IsTypeOf { get; set; }
-
-        /// <summary>
-        /// Indicates which GraphType input type this CLR type is mapped to (if used in input context).
-        /// </summary>
-        [Obsolete("Please use the [InputType] attribute instead of this property.")]
-        public Type? InputType
-        {
-            get => _mappedToInput;
-            set
-            {
-                if (value != null && !value.IsInputType())
-                    throw new ArgumentException(nameof(InputType), $"'{value}' should be of input type");
-
-                _mappedToInput = value;
-            }
-        }
-
-        /// <summary>
-        /// Indicates which GraphType output type this CLR type is mapped to (if used in output context).
-        /// </summary>
-        [Obsolete("Please use the [OutputType] attribute instead of this property.")]
-        public Type? OutputType
-        {
-            get => _mappedToOutput;
-            set
-            {
-                if (value != null && !value.IsOutputType())
-                    throw new ArgumentException(nameof(OutputType), $"'{value}' should be of output type");
-
-                _mappedToOutput = value;
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(TypeConfig type)
-        {
-            type.Description = Description;
-            type.DeprecationReason = DeprecationReason;
-
-            if (IsTypeOf != null)
-                type.IsTypeOfFunc = t => IsTypeOf.IsAssignableFrom(t.GetType());
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(FieldConfig field)
-        {
-            field.Description = Description;
-            field.DeprecationReason = DeprecationReason;
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(EnumValueDefinition enumValueDefinition)
-        {
-            if (Name != null)
-                enumValueDefinition.Name = Name;
-
-            if (Description != null)
-                enumValueDefinition.Description = Description == "" ? null : Description;
-
-            if (DeprecationReason != null)
-                enumValueDefinition.DeprecationReason = DeprecationReason == "" ? null : DeprecationReason;
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(IGraphType graphType)
-        {
-            if (Name != null)
-                graphType.Name = Name;
-
-            if (Description != null)
-                graphType.Description = Description == "" ? null : Description;
-
-            if (DeprecationReason != null)
-                graphType.DeprecationReason = DeprecationReason == "" ? null : DeprecationReason;
-
-            if (graphType is IObjectGraphType objectGraphType && IsTypeOf != null)
-                objectGraphType.IsTypeOf = obj => IsTypeOf.IsAssignableFrom(obj.GetType());
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(FieldType fieldType, bool isInputType)
-        {
-            if (Name != null)
-                fieldType.Name = Name;
-
-            if (Description != null)
-                fieldType.Description = Description == "" ? null : Description;
-
-            if (DeprecationReason != null)
-                fieldType.DeprecationReason = DeprecationReason == "" ? null : DeprecationReason;
-
-            if (isInputType && _mappedToInput != null)
-                fieldType.Type = _mappedToInput;
-
-            if (!isInputType && _mappedToOutput != null)
-                fieldType.Type = _mappedToOutput;
-        }
-    }
-
+    Resolver,
     /// <summary>
-    /// Indicates if the specified method is a field resolver or event stream resolver.
+    /// Indicates the specified method is an source stream resolver
     /// </summary>
-    public enum ResolverType
-    {
-        /// <summary>
-        /// Indicates the specified method is a field resolver
-        /// </summary>
-        Resolver,
-        /// <summary>
-        /// Indicates the specified method is an source stream resolver
-        /// </summary>
-        StreamResolver
-    }
+    StreamResolver
 }

--- a/src/GraphQL/Attributes/IdAttribute.cs
+++ b/src/GraphQL/Attributes/IdAttribute.cs
@@ -1,15 +1,14 @@
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Specifies that a property will be mapped to <see cref="IdGraphType"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class IdAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Specifies that a property will be mapped to <see cref="IdGraphType"/>.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Parameter)]
-    public class IdAttribute : GraphQLAttribute
-    {
-        /// <inheritdoc/>
-        public override void Modify(TypeInformation typeInformation)
-            => typeInformation.GraphType = typeof(IdGraphType);
-    }
+    /// <inheritdoc/>
+    public override void Modify(TypeInformation typeInformation)
+        => typeInformation.GraphType = typeof(IdGraphType);
 }

--- a/src/GraphQL/Attributes/IgnoreAttribute.cs
+++ b/src/GraphQL/Attributes/IgnoreAttribute.cs
@@ -1,14 +1,13 @@
 using System.Reflection;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Does not add the marked property to the auto-registered GraphQL type as a field.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class IgnoreAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Does not add the marked property to the auto-registered GraphQL type as a field.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
-    public class IgnoreAttribute : GraphQLAttribute
-    {
-        /// <inheritdoc/>
-        public override bool ShouldInclude(MemberInfo memberInfo, bool? isInputType) => false;
-    }
+    /// <inheritdoc/>
+    public override bool ShouldInclude(MemberInfo memberInfo, bool? isInputType) => false;
 }

--- a/src/GraphQL/Attributes/InputNameAttribute.cs
+++ b/src/GraphQL/Attributes/InputNameAttribute.cs
@@ -1,50 +1,49 @@
 using GraphQL.Conversion;
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Specifies a GraphQL type name for a CLR class when used as an input type.
+/// Note that the specified name will be translated by the schema's <see cref="INameConverter"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class InputNameAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Specifies a GraphQL type name for a CLR class when used as an input type.
-    /// Note that the specified name will be translated by the schema's <see cref="INameConverter"/>.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
-    public class InputNameAttribute : GraphQLAttribute
+    private string _name;
+
+    /// <inheritdoc cref="NameAttribute"/>
+    public InputNameAttribute(string name)
     {
-        private string _name;
-
-        /// <inheritdoc cref="NameAttribute"/>
-        public InputNameAttribute(string name)
-        {
-            _name = name ?? throw new ArgumentNullException(nameof(name));
-        }
-
-        /// <summary>
-        /// Returns the GraphQL name of the associated graph type or field.
-        /// </summary>
-        public string Name
-        {
-            get => _name;
-            set => _name = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(IGraphType graphType)
-        {
-            if (graphType is IInputObjectGraphType)
-            {
-                graphType.Name = Name;
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(FieldType fieldType, bool isInputType)
-        {
-            if (isInputType)
-                fieldType.Name = Name;
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(QueryArgument queryArgument)
-            => queryArgument.Name = Name;
+        _name = name ?? throw new ArgumentNullException(nameof(name));
     }
+
+    /// <summary>
+    /// Returns the GraphQL name of the associated graph type or field.
+    /// </summary>
+    public string Name
+    {
+        get => _name;
+        set => _name = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType)
+    {
+        if (graphType is IInputObjectGraphType)
+        {
+            graphType.Name = Name;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+            fieldType.Name = Name;
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(QueryArgument queryArgument)
+        => queryArgument.Name = Name;
 }

--- a/src/GraphQL/Attributes/InputTypeAttribute.cs
+++ b/src/GraphQL/Attributes/InputTypeAttribute.cs
@@ -1,61 +1,60 @@
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Specifies an input graph type mapping for the CLR class or property marked with this attribute.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class InputTypeAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Specifies an input graph type mapping for the CLR class or property marked with this attribute.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
-    public class InputTypeAttribute : GraphQLAttribute
+    private Type _inputType = null!;
+
+    /// <inheritdoc cref="InputTypeAttribute"/>
+    public InputTypeAttribute(Type graphType)
     {
-        private Type _inputType = null!;
-
-        /// <inheritdoc cref="InputTypeAttribute"/>
-        public InputTypeAttribute(Type graphType)
-        {
-            InputType = graphType;
-        }
-
-        /// <inheritdoc cref="InputTypeAttribute"/>
-        public Type InputType
-        {
-            get => _inputType;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (!value.IsInputType())
-                    throw new ArgumentException(nameof(InputType), $"'{value}' should be an input type");
-
-                _inputType = value;
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(FieldType fieldType, bool isInputType)
-        {
-            if (isInputType)
-            {
-                fieldType.Type = _inputType;
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(QueryArgument queryArgument)
-        {
-            queryArgument.Type = _inputType;
-        }
+        InputType = graphType;
     }
 
     /// <inheritdoc cref="InputTypeAttribute"/>
-    public class InputTypeAttribute<TGraphType> : InputTypeAttribute
-        where TGraphType : IGraphType
+    public Type InputType
     {
-        /// <inheritdoc cref="InputTypeAttribute"/>
-        public InputTypeAttribute()
-            : base(typeof(TGraphType))
+        get => _inputType;
+        set
         {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            if (!value.IsInputType())
+                throw new ArgumentException(nameof(InputType), $"'{value}' should be an input type");
+
+            _inputType = value;
         }
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+        {
+            fieldType.Type = _inputType;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(QueryArgument queryArgument)
+    {
+        queryArgument.Type = _inputType;
+    }
+}
+
+/// <inheritdoc cref="InputTypeAttribute"/>
+public class InputTypeAttribute<TGraphType> : InputTypeAttribute
+    where TGraphType : IGraphType
+{
+    /// <inheritdoc cref="InputTypeAttribute"/>
+    public InputTypeAttribute()
+        : base(typeof(TGraphType))
+    {
     }
 }

--- a/src/GraphQL/Attributes/MetadataAttribute.cs
+++ b/src/GraphQL/Attributes/MetadataAttribute.cs
@@ -1,47 +1,46 @@
 using GraphQL.Types;
 using GraphQL.Utilities;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Marks a class (graph type) or property (field) with additional metadata.
+/// </summary>
+[AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true)]
+public class MetadataAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Marks a class (graph type) or property (field) with additional metadata.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true)]
-    public class MetadataAttribute : GraphQLAttribute
+    /// <inheritdoc cref="MetadataAttribute"/>
+    public MetadataAttribute(string key, object? value)
     {
-        /// <inheritdoc cref="MetadataAttribute"/>
-        public MetadataAttribute(string key, object? value)
-        {
-            Key = key;
-            Value = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the metadata key.
-        /// </summary>
-        public string Key { get; set; }
-
-        /// <summary>
-        /// Gets or sets the metadata value.
-        /// </summary>
-        public object? Value { get; set; }
-
-        /// <inheritdoc/>
-        public override void Modify(TypeConfig type) => type.WithMetadata(Key, Value);
-
-        /// <inheritdoc/>
-        public override void Modify(FieldConfig field) => field.WithMetadata(Key, Value);
-
-        /// <inheritdoc/>
-        public override void Modify(EnumValueDefinition enumValueDefinition) => enumValueDefinition.WithMetadata(Key, Value);
-
-        /// <inheritdoc/>
-        public override void Modify(IGraphType graphType) => graphType.WithMetadata(Key, Value);
-
-        /// <inheritdoc/>
-        public override void Modify(FieldType fieldType, bool isInputType) => fieldType.WithMetadata(Key, Value);
-
-        /// <inheritdoc/>
-        public override void Modify(QueryArgument queryArgument) => queryArgument.WithMetadata(Key, Value);
+        Key = key;
+        Value = value;
     }
+
+    /// <summary>
+    /// Gets or sets the metadata key.
+    /// </summary>
+    public string Key { get; set; }
+
+    /// <summary>
+    /// Gets or sets the metadata value.
+    /// </summary>
+    public object? Value { get; set; }
+
+    /// <inheritdoc/>
+    public override void Modify(TypeConfig type) => type.WithMetadata(Key, Value);
+
+    /// <inheritdoc/>
+    public override void Modify(FieldConfig field) => field.WithMetadata(Key, Value);
+
+    /// <inheritdoc/>
+    public override void Modify(EnumValueDefinition enumValueDefinition) => enumValueDefinition.WithMetadata(Key, Value);
+
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType) => graphType.WithMetadata(Key, Value);
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType) => fieldType.WithMetadata(Key, Value);
+
+    /// <inheritdoc/>
+    public override void Modify(QueryArgument queryArgument) => queryArgument.WithMetadata(Key, Value);
 }

--- a/src/GraphQL/Attributes/NameAttribute.cs
+++ b/src/GraphQL/Attributes/NameAttribute.cs
@@ -1,46 +1,45 @@
 using GraphQL.Conversion;
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Specifies a GraphQL type name for a CLR class, or a field name for a property.
+/// Note that the specified name will be translated by the schema's <see cref="INameConverter"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class NameAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Specifies a GraphQL type name for a CLR class, or a field name for a property.
-    /// Note that the specified name will be translated by the schema's <see cref="INameConverter"/>.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Parameter)]
-    public class NameAttribute : GraphQLAttribute
+    private string _name;
+
+    /// <inheritdoc cref="NameAttribute"/>
+    public NameAttribute(string name)
     {
-        private string _name;
-
-        /// <inheritdoc cref="NameAttribute"/>
-        public NameAttribute(string name)
-        {
-            _name = name ?? throw new ArgumentNullException(nameof(name));
-        }
-
-        /// <summary>
-        /// Returns the GraphQL name of the associated graph type or field.
-        /// </summary>
-        public string Name
-        {
-            get => _name;
-            set => _name = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(EnumValueDefinition enumValueDefinition)
-            => enumValueDefinition.Name = Name;
-
-        /// <inheritdoc/>
-        public override void Modify(IGraphType graphType)
-            => graphType.Name = Name;
-
-        /// <inheritdoc/>
-        public override void Modify(FieldType fieldType, bool isInputType)
-            => fieldType.Name = Name;
-
-        /// <inheritdoc/>
-        public override void Modify(QueryArgument queryArgument)
-            => queryArgument.Name = Name;
+        _name = name ?? throw new ArgumentNullException(nameof(name));
     }
+
+    /// <summary>
+    /// Returns the GraphQL name of the associated graph type or field.
+    /// </summary>
+    public string Name
+    {
+        get => _name;
+        set => _name = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(EnumValueDefinition enumValueDefinition)
+        => enumValueDefinition.Name = Name;
+
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType)
+        => graphType.Name = Name;
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+        => fieldType.Name = Name;
+
+    /// <inheritdoc/>
+    public override void Modify(QueryArgument queryArgument)
+        => queryArgument.Name = Name;
 }

--- a/src/GraphQL/Attributes/OutputNameAttribute.cs
+++ b/src/GraphQL/Attributes/OutputNameAttribute.cs
@@ -1,46 +1,45 @@
 using GraphQL.Conversion;
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Specifies a GraphQL type name for a CLR class when used as an output type.
+/// Note that the specified name will be translated by the schema's <see cref="INameConverter"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class OutputNameAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Specifies a GraphQL type name for a CLR class when used as an output type.
-    /// Note that the specified name will be translated by the schema's <see cref="INameConverter"/>.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
-    public class OutputNameAttribute : GraphQLAttribute
+    private string _name;
+
+    /// <inheritdoc cref="NameAttribute"/>
+    public OutputNameAttribute(string name)
     {
-        private string _name;
+        _name = name ?? throw new ArgumentNullException(nameof(name));
+    }
 
-        /// <inheritdoc cref="NameAttribute"/>
-        public OutputNameAttribute(string name)
-        {
-            _name = name ?? throw new ArgumentNullException(nameof(name));
-        }
+    /// <summary>
+    /// Returns the GraphQL name of the associated graph type or field.
+    /// </summary>
+    public string Name
+    {
+        get => _name;
+        set => _name = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
-        /// <summary>
-        /// Returns the GraphQL name of the associated graph type or field.
-        /// </summary>
-        public string Name
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType)
+    {
+        if (graphType is not IInputObjectGraphType)
         {
-            get => _name;
-            set => _name = value ?? throw new ArgumentNullException(nameof(value));
+            graphType.Name = Name;
         }
+    }
 
-        /// <inheritdoc/>
-        public override void Modify(IGraphType graphType)
-        {
-            if (graphType is not IInputObjectGraphType)
-            {
-                graphType.Name = Name;
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(FieldType fieldType, bool isInputType)
-        {
-            if (!isInputType)
-                fieldType.Name = Name;
-        }
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (!isInputType)
+            fieldType.Name = Name;
     }
 }

--- a/src/GraphQL/Attributes/OutputTypeAttribute.cs
+++ b/src/GraphQL/Attributes/OutputTypeAttribute.cs
@@ -1,55 +1,54 @@
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Specifies an output graph type mapping for the CLR class or property marked with this attribute.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
+public class OutputTypeAttribute : GraphQLAttribute
 {
-    /// <summary>
-    /// Specifies an output graph type mapping for the CLR class or property marked with this attribute.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field)]
-    public class OutputTypeAttribute : GraphQLAttribute
+    private Type _outputType = null!;
+
+    /// <inheritdoc cref="OutputTypeAttribute"/>
+    public OutputTypeAttribute(Type graphType)
     {
-        private Type _outputType = null!;
-
-        /// <inheritdoc cref="OutputTypeAttribute"/>
-        public OutputTypeAttribute(Type graphType)
-        {
-            OutputType = graphType;
-        }
-
-        /// <inheritdoc cref="OutputTypeAttribute"/>
-        public Type OutputType
-        {
-            get => _outputType;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (!value.IsOutputType())
-                    throw new ArgumentException(nameof(OutputType), $"'{value}' should be an output type");
-
-                _outputType = value;
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Modify(FieldType fieldType, bool isInputType)
-        {
-            if (!isInputType)
-            {
-                fieldType.Type = _outputType;
-            }
-        }
+        OutputType = graphType;
     }
 
     /// <inheritdoc cref="OutputTypeAttribute"/>
-    public class OutputTypeAttribute<TGraphType> : OutputTypeAttribute
-        where TGraphType : IGraphType
+    public Type OutputType
     {
-        /// <inheritdoc cref="OutputTypeAttribute"/>
-        public OutputTypeAttribute()
-            : base(typeof(TGraphType))
+        get => _outputType;
+        set
         {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            if (!value.IsOutputType())
+                throw new ArgumentException(nameof(OutputType), $"'{value}' should be an output type");
+
+            _outputType = value;
         }
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (!isInputType)
+        {
+            fieldType.Type = _outputType;
+        }
+    }
+}
+
+/// <inheritdoc cref="OutputTypeAttribute"/>
+public class OutputTypeAttribute<TGraphType> : OutputTypeAttribute
+    where TGraphType : IGraphType
+{
+    /// <inheritdoc cref="OutputTypeAttribute"/>
+    public OutputTypeAttribute()
+        : base(typeof(TGraphType))
+    {
     }
 }

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -2,466 +2,465 @@ using GraphQL.Types;
 using GraphQL.Types.Relay;
 using GraphQL.Types.Relay.DataObjects;
 
-namespace GraphQL.Builders
+namespace GraphQL.Builders;
+
+/// <summary>
+/// Static methods to create connection field builders.
+/// </summary>
+public static class ConnectionBuilder
 {
     /// <summary>
-    /// Static methods to create connection field builders.
+    /// Returns a builder for new connection field for the specified node type.
+    /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
     /// </summary>
-    public static class ConnectionBuilder
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, [NotAGraphType] TSourceType>()
+        where TNodeType : IGraphType
+        => ConnectionBuilder<TSourceType>.Create<TNodeType>();
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node type.
+    /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+    /// <param name="name">The name of the connection.</param>
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, [NotAGraphType] TSourceType>(string name)
+        where TNodeType : IGraphType
+        => ConnectionBuilder<TSourceType>.Create<TNodeType>(name);
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node and edge type.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, [NotAGraphType] TSourceType>()
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>();
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node and edge type.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+    /// <param name="name">The name of the connection.</param>
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, [NotAGraphType] TSourceType>(string name)
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>(name);
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node, edge and connection type.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
+    /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, [NotAGraphType] TSourceType>()
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+        => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType, TConnectionType>();
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node, edge and connection type.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
+    /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+    /// <param name="name">The name of the connection.</param>
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, [NotAGraphType] TSourceType>(string name)
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+        => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType, TConnectionType>(name);
+}
+
+/// <summary>
+/// Builds a connection field for graphs that have the specified source type.
+/// </summary>
+// TODO: Remove in v5
+public class ConnectionBuilder<[NotAGraphType] TSourceType> : IMetadataWriter
+{
+    internal const string PAGE_SIZE_METADATA_KEY = "__ConnectionBuilder_PageSize";
+
+    private bool IsBidirectional => FieldType.Arguments?.Find("before")?.Type == typeof(StringGraphType) && FieldType.Arguments.Find("last")?.Type == typeof(IntGraphType);
+
+    private int? PageSizeFromMetadata
     {
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node type.
-        /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, [NotAGraphType] TSourceType>()
-            where TNodeType : IGraphType
-            => ConnectionBuilder<TSourceType>.Create<TNodeType>();
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node type.
-        /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        /// <param name="name">The name of the connection.</param>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, [NotAGraphType] TSourceType>(string name)
-            where TNodeType : IGraphType
-            => ConnectionBuilder<TSourceType>.Create<TNodeType>(name);
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node and edge type.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, [NotAGraphType] TSourceType>()
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>();
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node and edge type.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        /// <param name="name">The name of the connection.</param>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, [NotAGraphType] TSourceType>(string name)
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType>(name);
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node, edge and connection type.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, [NotAGraphType] TSourceType>()
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            where TConnectionType : ConnectionType<TNodeType, TEdgeType>
-            => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType, TConnectionType>();
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node, edge and connection type.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-        /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-        /// <param name="name">The name of the connection.</param>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, [NotAGraphType] TSourceType>(string name)
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            where TConnectionType : ConnectionType<TNodeType, TEdgeType>
-            => ConnectionBuilder<TSourceType>.Create<TNodeType, TEdgeType, TConnectionType>(name);
+        get => FieldType.GetMetadata<int?>(PAGE_SIZE_METADATA_KEY);
+        set => FieldType.WithMetadata(PAGE_SIZE_METADATA_KEY, value);
     }
 
     /// <summary>
-    /// Builds a connection field for graphs that have the specified source type.
+    /// Returns the generated field.
     /// </summary>
-    // TODO: Remove in v5
-    public class ConnectionBuilder<[NotAGraphType] TSourceType> : IMetadataWriter
+    public FieldType FieldType { get; protected set; }
+
+    /// <summary>
+    /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
+    /// </summary>
+    protected ConnectionBuilder(FieldType fieldType)
     {
-        internal const string PAGE_SIZE_METADATA_KEY = "__ConnectionBuilder_PageSize";
-
-        private bool IsBidirectional => FieldType.Arguments?.Find("before")?.Type == typeof(StringGraphType) && FieldType.Arguments.Find("last")?.Type == typeof(IntGraphType);
-
-        private int? PageSizeFromMetadata
-        {
-            get => FieldType.GetMetadata<int?>(PAGE_SIZE_METADATA_KEY);
-            set => FieldType.WithMetadata(PAGE_SIZE_METADATA_KEY, value);
-        }
-
-        /// <summary>
-        /// Returns the generated field.
-        /// </summary>
-        public FieldType FieldType { get; protected set; }
-
-        /// <summary>
-        /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
-        /// </summary>
-        protected ConnectionBuilder(FieldType fieldType)
-        {
-            FieldType = fieldType;
-        }
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node type.
-        /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public static ConnectionBuilder<TSourceType> Create<TNodeType>()
-            where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>();
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node type.
-        /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <param name="name">The name of the connection.</param>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
-            where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>(name);
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node and edge type.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>();
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node and edge type.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        /// <param name="name">The name of the connection.</param>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node, edge and connection type.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            where TConnectionType : ConnectionType<TNodeType, TEdgeType> =>
-            Create<TNodeType, TEdgeType, TConnectionType>("default");
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node, edge and connection type.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-        /// <param name="name">The name of the connection.</param>
-        public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name)
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            where TConnectionType : ConnectionType<TNodeType, TEdgeType>
-        {
-            var fieldType = new FieldType
-            {
-                Name = name,
-                Type = typeof(TConnectionType),
-                Arguments = new QueryArguments(),
-            };
-            fieldType.Arguments.Add(new QueryArgument(typeof(StringGraphType))
-            {
-                Name = "after",
-                Description = "Only return edges after the specified cursor.",
-            });
-            fieldType.Arguments.Add(new QueryArgument(typeof(IntGraphType))
-            {
-                Name = "first",
-                Description = "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
-            });
-            return new ConnectionBuilder<TSourceType>(fieldType);
-        }
-
-        /// <summary>
-        /// Configure the connection to be bi-directional.
-        /// </summary>
-        public ConnectionBuilder<TSourceType> Bidirectional()
-        {
-            if (IsBidirectional)
-            {
-                return this;
-            }
-
-            Argument<StringGraphType, string>("before",
-                "Only return edges prior to the specified cursor.");
-            Argument<IntGraphType, int?>("last",
-                "Specifies the maximum number of edges to return, starting prior to the cursor specified by 'before', or the last number of edges if 'before' is not specified.");
-
-            return this;
-        }
-
-        /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Name(string)"/>
-        [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method.")]
-        public virtual ConnectionBuilder<TSourceType> Name(string name)
-        {
-            FieldType.Name = name;
-            return this;
-        }
-
-        /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Description(string)"/>
-        public virtual ConnectionBuilder<TSourceType> Description(string? description)
-        {
-            FieldType.Description = description;
-            return this;
-        }
-
-        /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.DeprecationReason(string)"/>
-        public virtual ConnectionBuilder<TSourceType> DeprecationReason(string? deprecationReason)
-        {
-            FieldType.DeprecationReason = deprecationReason;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the default page size.
-        /// </summary>
-        public virtual ConnectionBuilder<TSourceType> PageSize(int pageSize)
-        {
-            PageSizeFromMetadata = pageSize;
-            return this;
-        }
-
-        /// <summary>
-        /// Clears the default page size, so all records are returned by default.
-        /// </summary>
-        public virtual ConnectionBuilder<TSourceType> ReturnAll()
-        {
-            PageSizeFromMetadata = null;
-            return this;
-        }
-
-        /// <summary>
-        /// Adds an argument to the connection field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, Action<QueryArgument>? configure = null)
-            where TArgumentGraphType : IGraphType
-        {
-            var arg = new QueryArgument(typeof(TArgumentGraphType))
-            {
-                Name = name,
-            };
-            configure?.Invoke(arg);
-            FieldType.Arguments!.Add(arg);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds an argument to the connection field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="description">The description of the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, string? description)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, arg => arg.Description = description);
-
-        /// <summary>
-        /// Adds an argument to the connection field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="description">The description of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, arg =>
-            {
-                arg.Description = description;
-                configure?.Invoke(arg);
-            });
-
-        /// <summary>
-        /// Adds an argument to the connection field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <typeparam name="TArgumentType">The type of the argument value.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="description">The description of the argument.</param>
-        /// <param name="defaultValue">The default value of the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
-            [AllowNull] TArgumentType defaultValue = default!)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, arg =>
-            {
-                arg.Description = description;
-                arg.DefaultValue = defaultValue;
-            });
-
-        /// <summary>
-        /// Adds an argument to the connection field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <typeparam name="TArgumentType">The type of the argument value.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="description">The description of the argument.</param>
-        /// <param name="defaultValue">The default value of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
-            [AllowNull] TArgumentType defaultValue, Action<QueryArgument>? configure)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, arg =>
-            {
-                arg.Description = description;
-                arg.DefaultValue = defaultValue;
-                configure?.Invoke(arg);
-            });
-
-        /// <summary>
-        /// Runs a configuration delegate for the connection field.
-        /// </summary>
-        public virtual ConnectionBuilder<TSourceType> Configure(Action<FieldType> configure)
-        {
-            configure(FieldType);
-            return this;
-        }
-
-        /// <summary>
-        /// Apply directive to connection field without specifying arguments. If the directive
-        /// declaration has arguments, then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        public virtual ConnectionBuilder<TSourceType> Directive(string name)
-        {
-            FieldType.ApplyDirective(name);
-            return this;
-        }
-
-        /// <summary>
-        /// Apply directive to connection field specifying one argument. If the directive
-        /// declaration has other arguments, then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        /// <param name="argumentName">Argument name.</param>
-        /// <param name="argumentValue">Argument value.</param>
-        public virtual ConnectionBuilder<TSourceType> Directive(string name, string argumentName, object? argumentValue)
-        {
-            FieldType.ApplyDirective(name, argumentName, argumentValue);
-            return this;
-        }
-
-        /// <summary>
-        /// Apply directive to connection field specifying configuration delegate.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        /// <param name="configure">Configuration delegate.</param>
-        public virtual ConnectionBuilder<TSourceType> Directive(string name, Action<AppliedDirective> configure)
-        {
-            FieldType.ApplyDirective(name, configure);
-            return this;
-        }
-
-        /// <summary>
-        /// Specifies the return data type of the connection resolver. Typically this would be <see cref="Connection{TNode}"/>
-        /// or <see cref="Connection{TNode, TEdge}"/>, but it can be any type that returns the proper fields for the
-        /// connection graph type.
-        /// <br/><br/>
-        /// For instance, to specify a return type for a Widget you might write:
-        /// <br/><br/>
-        /// <code>
-        /// .Returns&lt;Connection&lt;Widget&gt;&gt;()
-        /// </code>
-        /// </summary>
-        public virtual ConnectionBuilder<TSourceType, TNewReturnType> Returns<[NotAGraphType] TNewReturnType>()
-        {
-            return new ConnectionBuilder<TSourceType, TNewReturnType>(FieldType);
-        }
-
-        /// <summary>
-        /// Sets the resolver method for the connection field.
-        /// </summary>
-        [AllowedOn<IObjectGraphType>]
-        public virtual ConnectionBuilder<TSourceType> Resolve(Func<IResolveConnectionContext<TSourceType>, object?> resolver)
-        {
-            var isUnidirectional = !IsBidirectional;
-            var pageSize = PageSizeFromMetadata;
-            FieldType.Resolver = new Resolvers.FuncFieldResolver<object>(context =>
-            {
-                var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
-                CheckForErrors(connectionContext);
-                return resolver(connectionContext);
-            });
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the resolver method for the connection field.
-        /// </summary>
-        [AllowedOn<IObjectGraphType>]
-        public virtual ConnectionBuilder<TSourceType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<object?>> resolver)
-        {
-            var isUnidirectional = !IsBidirectional;
-            var pageSize = PageSizeFromMetadata;
-            FieldType.Resolver = new Resolvers.FuncFieldResolver<object>(context =>
-            {
-                var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
-                CheckForErrors(connectionContext);
-                return new ValueTask<object?>(resolver(connectionContext));
-            });
-
-            return this;
-        }
-
-        private static void CheckForErrors(IResolveConnectionContext<TSourceType> context)
-        {
-            if (context.First.HasValue && context.Last.HasValue)
-            {
-                throw new ArgumentException("Cannot specify both `first` and `last`.");
-            }
-            if (context.IsUnidirectional && context.Last.HasValue)
-            {
-                throw new ArgumentException("Cannot use `last` with unidirectional connections.");
-            }
-        }
-
-        // Allows metadata builder extension methods to read/write to the underlying field type without unnecessarily
-        // exposing metadata methods directly on the field builder; users can always use the FieldType property
-        // to access the underlying metadata directly.
-        Dictionary<string, object?> IProvideMetadata.Metadata => FieldType.Metadata;
-        IMetadataReader IMetadataWriter.MetadataReader => FieldType;
-        TType IProvideMetadata.GetMetadata<TType>(string key, TType defaultValue) => FieldType.GetMetadata(key, defaultValue);
-        TType IProvideMetadata.GetMetadata<TType>(string key, Func<TType> defaultValueFactory) => FieldType.GetMetadata(key, defaultValueFactory);
-        bool IProvideMetadata.HasMetadata(string key) => FieldType.HasMetadata(key);
+        FieldType = fieldType;
     }
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node type.
+    /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public static ConnectionBuilder<TSourceType> Create<TNodeType>()
+        where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>();
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node type.
+    /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <param name="name">The name of the connection.</param>
+    public static ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
+        where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>(name);
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node and edge type.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>();
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node and edge type.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    /// <param name="name">The name of the connection.</param>
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node, edge and connection type.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        where TConnectionType : ConnectionType<TNodeType, TEdgeType> =>
+        Create<TNodeType, TEdgeType, TConnectionType>("default");
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node, edge and connection type.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
+    /// <param name="name">The name of the connection.</param>
+    public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>(string name)
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+    {
+        var fieldType = new FieldType
+        {
+            Name = name,
+            Type = typeof(TConnectionType),
+            Arguments = new QueryArguments(),
+        };
+        fieldType.Arguments.Add(new QueryArgument(typeof(StringGraphType))
+        {
+            Name = "after",
+            Description = "Only return edges after the specified cursor.",
+        });
+        fieldType.Arguments.Add(new QueryArgument(typeof(IntGraphType))
+        {
+            Name = "first",
+            Description = "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
+        });
+        return new ConnectionBuilder<TSourceType>(fieldType);
+    }
+
+    /// <summary>
+    /// Configure the connection to be bi-directional.
+    /// </summary>
+    public ConnectionBuilder<TSourceType> Bidirectional()
+    {
+        if (IsBidirectional)
+        {
+            return this;
+        }
+
+        Argument<StringGraphType, string>("before",
+            "Only return edges prior to the specified cursor.");
+        Argument<IntGraphType, int?>("last",
+            "Specifies the maximum number of edges to return, starting prior to the cursor specified by 'before', or the last number of edges if 'before' is not specified.");
+
+        return this;
+    }
+
+    /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Name(string)"/>
+    [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method.")]
+    public virtual ConnectionBuilder<TSourceType> Name(string name)
+    {
+        FieldType.Name = name;
+        return this;
+    }
+
+    /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Description(string)"/>
+    public virtual ConnectionBuilder<TSourceType> Description(string? description)
+    {
+        FieldType.Description = description;
+        return this;
+    }
+
+    /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.DeprecationReason(string)"/>
+    public virtual ConnectionBuilder<TSourceType> DeprecationReason(string? deprecationReason)
+    {
+        FieldType.DeprecationReason = deprecationReason;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the default page size.
+    /// </summary>
+    public virtual ConnectionBuilder<TSourceType> PageSize(int pageSize)
+    {
+        PageSizeFromMetadata = pageSize;
+        return this;
+    }
+
+    /// <summary>
+    /// Clears the default page size, so all records are returned by default.
+    /// </summary>
+    public virtual ConnectionBuilder<TSourceType> ReturnAll()
+    {
+        PageSizeFromMetadata = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an argument to the connection field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, Action<QueryArgument>? configure = null)
+        where TArgumentGraphType : IGraphType
+    {
+        var arg = new QueryArgument(typeof(TArgumentGraphType))
+        {
+            Name = name,
+        };
+        configure?.Invoke(arg);
+        FieldType.Arguments!.Add(arg);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an argument to the connection field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="description">The description of the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, string? description)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, arg => arg.Description = description);
+
+    /// <summary>
+    /// Adds an argument to the connection field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="description">The description of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, arg =>
+        {
+            arg.Description = description;
+            configure?.Invoke(arg);
+        });
+
+    /// <summary>
+    /// Adds an argument to the connection field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <typeparam name="TArgumentType">The type of the argument value.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="description">The description of the argument.</param>
+    /// <param name="defaultValue">The default value of the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
+        [AllowNull] TArgumentType defaultValue = default!)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, arg =>
+        {
+            arg.Description = description;
+            arg.DefaultValue = defaultValue;
+        });
+
+    /// <summary>
+    /// Adds an argument to the connection field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <typeparam name="TArgumentType">The type of the argument value.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="description">The description of the argument.</param>
+    /// <param name="defaultValue">The default value of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual ConnectionBuilder<TSourceType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
+        [AllowNull] TArgumentType defaultValue, Action<QueryArgument>? configure)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, arg =>
+        {
+            arg.Description = description;
+            arg.DefaultValue = defaultValue;
+            configure?.Invoke(arg);
+        });
+
+    /// <summary>
+    /// Runs a configuration delegate for the connection field.
+    /// </summary>
+    public virtual ConnectionBuilder<TSourceType> Configure(Action<FieldType> configure)
+    {
+        configure(FieldType);
+        return this;
+    }
+
+    /// <summary>
+    /// Apply directive to connection field without specifying arguments. If the directive
+    /// declaration has arguments, then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    public virtual ConnectionBuilder<TSourceType> Directive(string name)
+    {
+        FieldType.ApplyDirective(name);
+        return this;
+    }
+
+    /// <summary>
+    /// Apply directive to connection field specifying one argument. If the directive
+    /// declaration has other arguments, then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    /// <param name="argumentName">Argument name.</param>
+    /// <param name="argumentValue">Argument value.</param>
+    public virtual ConnectionBuilder<TSourceType> Directive(string name, string argumentName, object? argumentValue)
+    {
+        FieldType.ApplyDirective(name, argumentName, argumentValue);
+        return this;
+    }
+
+    /// <summary>
+    /// Apply directive to connection field specifying configuration delegate.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    /// <param name="configure">Configuration delegate.</param>
+    public virtual ConnectionBuilder<TSourceType> Directive(string name, Action<AppliedDirective> configure)
+    {
+        FieldType.ApplyDirective(name, configure);
+        return this;
+    }
+
+    /// <summary>
+    /// Specifies the return data type of the connection resolver. Typically this would be <see cref="Connection{TNode}"/>
+    /// or <see cref="Connection{TNode, TEdge}"/>, but it can be any type that returns the proper fields for the
+    /// connection graph type.
+    /// <br/><br/>
+    /// For instance, to specify a return type for a Widget you might write:
+    /// <br/><br/>
+    /// <code>
+    /// .Returns&lt;Connection&lt;Widget&gt;&gt;()
+    /// </code>
+    /// </summary>
+    public virtual ConnectionBuilder<TSourceType, TNewReturnType> Returns<[NotAGraphType] TNewReturnType>()
+    {
+        return new ConnectionBuilder<TSourceType, TNewReturnType>(FieldType);
+    }
+
+    /// <summary>
+    /// Sets the resolver method for the connection field.
+    /// </summary>
+    [AllowedOn<IObjectGraphType>]
+    public virtual ConnectionBuilder<TSourceType> Resolve(Func<IResolveConnectionContext<TSourceType>, object?> resolver)
+    {
+        var isUnidirectional = !IsBidirectional;
+        var pageSize = PageSizeFromMetadata;
+        FieldType.Resolver = new Resolvers.FuncFieldResolver<object>(context =>
+        {
+            var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
+            CheckForErrors(connectionContext);
+            return resolver(connectionContext);
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the resolver method for the connection field.
+    /// </summary>
+    [AllowedOn<IObjectGraphType>]
+    public virtual ConnectionBuilder<TSourceType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<object?>> resolver)
+    {
+        var isUnidirectional = !IsBidirectional;
+        var pageSize = PageSizeFromMetadata;
+        FieldType.Resolver = new Resolvers.FuncFieldResolver<object>(context =>
+        {
+            var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
+            CheckForErrors(connectionContext);
+            return new ValueTask<object?>(resolver(connectionContext));
+        });
+
+        return this;
+    }
+
+    private static void CheckForErrors(IResolveConnectionContext<TSourceType> context)
+    {
+        if (context.First.HasValue && context.Last.HasValue)
+        {
+            throw new ArgumentException("Cannot specify both `first` and `last`.");
+        }
+        if (context.IsUnidirectional && context.Last.HasValue)
+        {
+            throw new ArgumentException("Cannot use `last` with unidirectional connections.");
+        }
+    }
+
+    // Allows metadata builder extension methods to read/write to the underlying field type without unnecessarily
+    // exposing metadata methods directly on the field builder; users can always use the FieldType property
+    // to access the underlying metadata directly.
+    Dictionary<string, object?> IProvideMetadata.Metadata => FieldType.Metadata;
+    IMetadataReader IMetadataWriter.MetadataReader => FieldType;
+    TType IProvideMetadata.GetMetadata<TType>(string key, TType defaultValue) => FieldType.GetMetadata(key, defaultValue);
+    TType IProvideMetadata.GetMetadata<TType>(string key, Func<TType> defaultValueFactory) => FieldType.GetMetadata(key, defaultValueFactory);
+    bool IProvideMetadata.HasMetadata(string key) => FieldType.HasMetadata(key);
 }

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -1,298 +1,297 @@
 using GraphQL.Types;
 using GraphQL.Types.Relay;
 
-namespace GraphQL.Builders
+namespace GraphQL.Builders;
+
+/// <summary>
+/// Builds a connection field for graphs that have the specified source and return type.
+/// </summary>
+public class ConnectionBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnType> : IMetadataWriter
 {
-    /// <summary>
-    /// Builds a connection field for graphs that have the specified source and return type.
-    /// </summary>
-    public class ConnectionBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnType> : IMetadataWriter
+    private bool IsBidirectional => FieldType.Arguments?.Find("before")?.Type == typeof(StringGraphType) && FieldType.Arguments.Find("last")?.Type == typeof(IntGraphType);
+
+    private int? PageSizeFromMetadata
     {
-        private bool IsBidirectional => FieldType.Arguments?.Find("before")?.Type == typeof(StringGraphType) && FieldType.Arguments.Find("last")?.Type == typeof(IntGraphType);
-
-        private int? PageSizeFromMetadata
-        {
-            get => FieldType.GetMetadata<int?>(ConnectionBuilder<TSourceType>.PAGE_SIZE_METADATA_KEY);
-            set => FieldType.WithMetadata(ConnectionBuilder<TSourceType>.PAGE_SIZE_METADATA_KEY, value);
-        }
-
-        /// <summary>
-        /// Returns the generated field.
-        /// </summary>
-        public FieldType FieldType { get; protected set; }
-
-        /// <summary>
-        /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
-        /// </summary>
-        protected internal ConnectionBuilder(FieldType fieldType)
-        {
-            FieldType = fieldType;
-        }
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node type.
-        /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType>(string name = "default")
-            where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>(name);
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node and edge type.
-        /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType, TEdgeType>(string name = "default")
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
-
-        /// <summary>
-        /// Returns a builder for new connection field for the specified node, edge and connection type.
-        /// </summary>
-        /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-        /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-        /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-        public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            where TConnectionType : ConnectionType<TNodeType, TEdgeType>
-        {
-            var fieldType = new FieldType
-            {
-                Name = name,
-                Type = typeof(TConnectionType),
-                Arguments = new QueryArguments(
-                    new QueryArgument<StringGraphType>
-                    {
-                        Name = "after",
-                        Description = "Only return edges after the specified cursor.",
-                    },
-                    new QueryArgument<IntGraphType>
-                    {
-                        Name = "first",
-                        Description = "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
-                    }
-                ),
-            };
-
-            return new ConnectionBuilder<TSourceType, TReturnType>(fieldType);
-        }
-
-        /// <summary>
-        /// Configure the connection to be bi-directional.
-        /// </summary>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Bidirectional()
-        {
-            if (IsBidirectional)
-                return this;
-
-            Argument<StringGraphType, string>("before",
-                "Only return edges prior to the specified cursor.");
-            Argument<IntGraphType, int?>("last",
-                "Specifies the maximum number of edges to return, starting prior to the cursor specified by 'before', or the last number of edges if 'before' is not specified.");
-
-            return this;
-        }
-
-        /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Name(string)"/>
-        [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method.")]
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Name(string name)
-        {
-            FieldType.Name = name;
-            return this;
-        }
-
-        /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Description(string)"/>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Description(string? description)
-        {
-            FieldType.Description = description;
-            return this;
-        }
-
-        /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.DeprecationReason(string)"/>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason)
-        {
-            FieldType.DeprecationReason = deprecationReason;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the default page size or clears (if null) the default page size, so all records are returned by default.
-        /// </summary>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize)
-        {
-            PageSizeFromMetadata = pageSize;
-            return this;
-        }
-
-        /// <summary>
-        /// Adds an argument to the connection field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, Action<QueryArgument>? configure = null)
-            where TArgumentGraphType : IGraphType
-        {
-            var arg = new QueryArgument(typeof(TArgumentGraphType))
-            {
-                Name = name,
-            };
-            configure?.Invoke(arg);
-            FieldType.Arguments!.Add(arg);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds an argument to the connection field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="description">The description of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure = null)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, arg =>
-            {
-                arg.Description = description;
-                configure?.Invoke(arg);
-            });
-
-        /// <summary>
-        /// Adds an argument to the connection field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <typeparam name="TArgumentType">The type of the argument value.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="description">The description of the argument.</param>
-        /// <param name="defaultValue">The default value of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
-            [AllowNull] TArgumentType defaultValue = default!, Action<QueryArgument>? configure = null)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, arg =>
-            {
-                arg.Description = description;
-                arg.DefaultValue = defaultValue;
-                configure?.Invoke(arg);
-            });
-
-        /// <summary>
-        /// Runs a configuration delegate for the connection field.
-        /// </summary>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Configure(Action<FieldType> configure)
-        {
-            configure(FieldType);
-            return this;
-        }
-
-        /// <summary>
-        /// Apply directive to connection field without specifying arguments. If the directive
-        /// declaration has arguments, then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Directive(string name)
-        {
-            FieldType.ApplyDirective(name);
-            return this;
-        }
-
-        /// <summary>
-        /// Apply directive to connection field specifying one argument. If the directive
-        /// declaration has other arguments, then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        /// <param name="argumentName">Argument name.</param>
-        /// <param name="argumentValue">Argument value.</param>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue)
-        {
-            FieldType.ApplyDirective(name, argumentName, argumentValue);
-            return this;
-        }
-
-        /// <summary>
-        /// Apply directive to connection field specifying configuration delegate.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        /// <param name="configure">Configuration delegate.</param>
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Directive(string name, Action<AppliedDirective> configure)
-        {
-            FieldType.ApplyDirective(name, configure);
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the return type of the field.
-        /// </summary>
-        /// <typeparam name="TNewReturnType">The type of the return value of the resolver.</typeparam>
-        public virtual ConnectionBuilder<TSourceType, TNewReturnType> Returns<[NotAGraphType] TNewReturnType>()
-        {
-            return new ConnectionBuilder<TSourceType, TNewReturnType>(FieldType);
-        }
-
-        /// <summary>
-        /// Sets the resolver method for the connection field. This method must be called after
-        /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
-        /// </summary>
-        [AllowedOn<IObjectGraphType>]
-        public virtual ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
-        {
-            var isUnidirectional = !IsBidirectional;
-            var pageSize = PageSizeFromMetadata;
-            FieldType.Resolver = new Resolvers.FuncFieldResolver<TReturnType>(context =>
-            {
-                var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
-                CheckForErrors(connectionContext);
-                return resolver(connectionContext);
-            });
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the resolver method for the connection field. This method must be called after
-        /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
-        /// </summary>
-        [AllowedOn<IObjectGraphType>]
-        public virtual ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
-        {
-            var isUnidirectional = !IsBidirectional;
-            var pageSize = PageSizeFromMetadata;
-            FieldType.Resolver = new Resolvers.FuncFieldResolver<TReturnType>(context =>
-            {
-                var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
-                CheckForErrors(connectionContext);
-                return new ValueTask<TReturnType?>(resolver(connectionContext));
-            });
-
-            return this;
-        }
-
-        private static void CheckForErrors(IResolveConnectionContext<TSourceType> context)
-        {
-            if (context.First.HasValue && context.Last.HasValue)
-            {
-                throw new ArgumentException("Cannot specify both `first` and `last`.");
-            }
-            if (context.IsUnidirectional && context.Last.HasValue)
-            {
-                throw new ArgumentException("Cannot use `last` with unidirectional connections.");
-            }
-        }
-
-        // Allows metadata builder extension methods to read/write to the underlying field type without unnecessarily
-        // exposing metadata methods directly on the field builder; users can always use the FieldType property
-        // to access the underlying metadata directly.
-        Dictionary<string, object?> IProvideMetadata.Metadata => FieldType.Metadata;
-        IMetadataReader IMetadataWriter.MetadataReader => FieldType;
-        TType IProvideMetadata.GetMetadata<TType>(string key, TType defaultValue) => FieldType.GetMetadata(key, defaultValue);
-        TType IProvideMetadata.GetMetadata<TType>(string key, Func<TType> defaultValueFactory) => FieldType.GetMetadata(key, defaultValueFactory);
-        bool IProvideMetadata.HasMetadata(string key) => FieldType.HasMetadata(key);
+        get => FieldType.GetMetadata<int?>(ConnectionBuilder<TSourceType>.PAGE_SIZE_METADATA_KEY);
+        set => FieldType.WithMetadata(ConnectionBuilder<TSourceType>.PAGE_SIZE_METADATA_KEY, value);
     }
+
+    /// <summary>
+    /// Returns the generated field.
+    /// </summary>
+    public FieldType FieldType { get; protected set; }
+
+    /// <summary>
+    /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
+    /// </summary>
+    protected internal ConnectionBuilder(FieldType fieldType)
+    {
+        FieldType = fieldType;
+    }
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node type.
+    /// The edge type is <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType>(string name = "default")
+        where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>(name);
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node and edge type.
+    /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType, TEdgeType>(string name = "default")
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        => Create<TNodeType, TEdgeType, ConnectionType<TNodeType, TEdgeType>>(name);
+
+    /// <summary>
+    /// Returns a builder for new connection field for the specified node, edge and connection type.
+    /// </summary>
+    /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
+    /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
+    /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
+    public static ConnectionBuilder<TSourceType, TReturnType> Create<TNodeType, TEdgeType, TConnectionType>(string name = "default")
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+    {
+        var fieldType = new FieldType
+        {
+            Name = name,
+            Type = typeof(TConnectionType),
+            Arguments = new QueryArguments(
+                new QueryArgument<StringGraphType>
+                {
+                    Name = "after",
+                    Description = "Only return edges after the specified cursor.",
+                },
+                new QueryArgument<IntGraphType>
+                {
+                    Name = "first",
+                    Description = "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
+                }
+            ),
+        };
+
+        return new ConnectionBuilder<TSourceType, TReturnType>(fieldType);
+    }
+
+    /// <summary>
+    /// Configure the connection to be bi-directional.
+    /// </summary>
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Bidirectional()
+    {
+        if (IsBidirectional)
+            return this;
+
+        Argument<StringGraphType, string>("before",
+            "Only return edges prior to the specified cursor.");
+        Argument<IntGraphType, int?>("last",
+            "Specifies the maximum number of edges to return, starting prior to the cursor specified by 'before', or the last number of edges if 'before' is not specified.");
+
+        return this;
+    }
+
+    /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Name(string)"/>
+    [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method.")]
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Name(string name)
+    {
+        FieldType.Name = name;
+        return this;
+    }
+
+    /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Description(string)"/>
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Description(string? description)
+    {
+        FieldType.Description = description;
+        return this;
+    }
+
+    /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.DeprecationReason(string)"/>
+    public virtual ConnectionBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason)
+    {
+        FieldType.DeprecationReason = deprecationReason;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the default page size or clears (if null) the default page size, so all records are returned by default.
+    /// </summary>
+    public virtual ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize)
+    {
+        PageSizeFromMetadata = pageSize;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an argument to the connection field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, Action<QueryArgument>? configure = null)
+        where TArgumentGraphType : IGraphType
+    {
+        var arg = new QueryArgument(typeof(TArgumentGraphType))
+        {
+            Name = name,
+        };
+        configure?.Invoke(arg);
+        FieldType.Arguments!.Add(arg);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an argument to the connection field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="description">The description of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure = null)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, arg =>
+        {
+            arg.Description = description;
+            configure?.Invoke(arg);
+        });
+
+    /// <summary>
+    /// Adds an argument to the connection field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <typeparam name="TArgumentType">The type of the argument value.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="description">The description of the argument.</param>
+    /// <param name="defaultValue">The default value of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
+        [AllowNull] TArgumentType defaultValue = default!, Action<QueryArgument>? configure = null)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, arg =>
+        {
+            arg.Description = description;
+            arg.DefaultValue = defaultValue;
+            configure?.Invoke(arg);
+        });
+
+    /// <summary>
+    /// Runs a configuration delegate for the connection field.
+    /// </summary>
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Configure(Action<FieldType> configure)
+    {
+        configure(FieldType);
+        return this;
+    }
+
+    /// <summary>
+    /// Apply directive to connection field without specifying arguments. If the directive
+    /// declaration has arguments, then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Directive(string name)
+    {
+        FieldType.ApplyDirective(name);
+        return this;
+    }
+
+    /// <summary>
+    /// Apply directive to connection field specifying one argument. If the directive
+    /// declaration has other arguments, then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    /// <param name="argumentName">Argument name.</param>
+    /// <param name="argumentValue">Argument value.</param>
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue)
+    {
+        FieldType.ApplyDirective(name, argumentName, argumentValue);
+        return this;
+    }
+
+    /// <summary>
+    /// Apply directive to connection field specifying configuration delegate.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    /// <param name="configure">Configuration delegate.</param>
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Directive(string name, Action<AppliedDirective> configure)
+    {
+        FieldType.ApplyDirective(name, configure);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the return type of the field.
+    /// </summary>
+    /// <typeparam name="TNewReturnType">The type of the return value of the resolver.</typeparam>
+    public virtual ConnectionBuilder<TSourceType, TNewReturnType> Returns<[NotAGraphType] TNewReturnType>()
+    {
+        return new ConnectionBuilder<TSourceType, TNewReturnType>(FieldType);
+    }
+
+    /// <summary>
+    /// Sets the resolver method for the connection field. This method must be called after
+    /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
+    /// </summary>
+    [AllowedOn<IObjectGraphType>]
+    public virtual ConnectionBuilder<TSourceType, TReturnType> Resolve(Func<IResolveConnectionContext<TSourceType>, TReturnType?> resolver)
+    {
+        var isUnidirectional = !IsBidirectional;
+        var pageSize = PageSizeFromMetadata;
+        FieldType.Resolver = new Resolvers.FuncFieldResolver<TReturnType>(context =>
+        {
+            var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
+            CheckForErrors(connectionContext);
+            return resolver(connectionContext);
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the resolver method for the connection field. This method must be called after
+    /// <see cref="PageSize(int?)"/> and/or <see cref="Bidirectional"/> have been called.
+    /// </summary>
+    [AllowedOn<IObjectGraphType>]
+    public virtual ConnectionBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveConnectionContext<TSourceType>, Task<TReturnType?>> resolver)
+    {
+        var isUnidirectional = !IsBidirectional;
+        var pageSize = PageSizeFromMetadata;
+        FieldType.Resolver = new Resolvers.FuncFieldResolver<TReturnType>(context =>
+        {
+            var connectionContext = new ResolveConnectionContext<TSourceType>(context, isUnidirectional, pageSize);
+            CheckForErrors(connectionContext);
+            return new ValueTask<TReturnType?>(resolver(connectionContext));
+        });
+
+        return this;
+    }
+
+    private static void CheckForErrors(IResolveConnectionContext<TSourceType> context)
+    {
+        if (context.First.HasValue && context.Last.HasValue)
+        {
+            throw new ArgumentException("Cannot specify both `first` and `last`.");
+        }
+        if (context.IsUnidirectional && context.Last.HasValue)
+        {
+            throw new ArgumentException("Cannot use `last` with unidirectional connections.");
+        }
+    }
+
+    // Allows metadata builder extension methods to read/write to the underlying field type without unnecessarily
+    // exposing metadata methods directly on the field builder; users can always use the FieldType property
+    // to access the underlying metadata directly.
+    Dictionary<string, object?> IProvideMetadata.Metadata => FieldType.Metadata;
+    IMetadataReader IMetadataWriter.MetadataReader => FieldType;
+    TType IProvideMetadata.GetMetadata<TType>(string key, TType defaultValue) => FieldType.GetMetadata(key, defaultValue);
+    TType IProvideMetadata.GetMetadata<TType>(string key, Func<TType> defaultValueFactory) => FieldType.GetMetadata(key, defaultValueFactory);
+    bool IProvideMetadata.HasMetadata(string key) => FieldType.HasMetadata(key);
 }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -3,440 +3,439 @@ using GraphQL.Resolvers;
 using GraphQL.Types;
 using GraphQL.Validation.Rules.Custom;
 
-namespace GraphQL.Builders
+namespace GraphQL.Builders;
+
+/// <summary>
+/// Builds a field for a graph with a specified source type and return type.
+/// </summary>
+/// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
+/// <typeparam name="TReturnType">The type of the return value of the resolver.</typeparam>
+public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnType> : IMetadataWriter
 {
     /// <summary>
-    /// Builds a field for a graph with a specified source type and return type.
+    /// Returns the generated field.
     /// </summary>
-    /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-    /// <typeparam name="TReturnType">The type of the return value of the resolver.</typeparam>
-    public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnType> : IMetadataWriter
+    public FieldType FieldType { get; }
+
+    /// <summary>
+    /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
+    /// </summary>
+    protected FieldBuilder(FieldType fieldType)
     {
-        /// <summary>
-        /// Returns the generated field.
-        /// </summary>
-        public FieldType FieldType { get; }
-
-        /// <summary>
-        /// Initializes a new instance for the specified <see cref="Types.FieldType"/>.
-        /// </summary>
-        protected FieldBuilder(FieldType fieldType)
-        {
-            FieldType = fieldType;
-        }
-
-        /// <summary>
-        /// Returns a builder for a new field.
-        /// </summary>
-        /// <param name="type">The graph type of the field.</param>
-        /// <param name="name">The name of the field.</param>
-        [Obsolete("Please use the overload that accepts the name as the first argument.")]
-        public static FieldBuilder<TSourceType, TReturnType> Create(IGraphType type, string name = "default")
-        {
-            var fieldType = new FieldType
-            {
-                Name = name,
-                ResolvedType = type,
-            };
-            return new FieldBuilder<TSourceType, TReturnType>(fieldType);
-        }
-
-        /// <summary>
-        /// Returns a builder for a new field.
-        /// </summary>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="type">The graph type of the field.</param>
-        public static FieldBuilder<TSourceType, TReturnType> Create(string name, IGraphType type)
-        {
-            var fieldType = new FieldType
-            {
-                Name = name,
-                ResolvedType = type,
-            };
-            return new FieldBuilder<TSourceType, TReturnType>(fieldType);
-        }
-
-        /// <inheritdoc cref="Create(IGraphType, string)"/>
-        [Obsolete("Please use the overload that accepts the name as the first argument.")]
-        public static FieldBuilder<TSourceType, TReturnType> Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null, string name = "default")
-        {
-            var fieldType = new FieldType
-            {
-                Name = name,
-                Type = type,
-            };
-            return new FieldBuilder<TSourceType, TReturnType>(fieldType);
-        }
-
-        /// <inheritdoc cref="Create(string, IGraphType)"/>
-        public static FieldBuilder<TSourceType, TReturnType> Create(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null)
-        {
-            var fieldType = new FieldType
-            {
-                Name = name,
-                Type = type,
-            };
-            return new FieldBuilder<TSourceType, TReturnType>(fieldType);
-        }
-
-        /// <summary>
-        /// Sets the graph type of the field.
-        /// </summary>
-        /// <param name="type">The graph type of the field.</param>
-        public virtual FieldBuilder<TSourceType, TReturnType> Type(IGraphType type)
-        {
-            FieldType.ResolvedType = type;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the name of the field.
-        /// </summary>
-        [Obsolete("Please configure the field name by providing the name as an argument to the 'Field' method.")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Name(string name)
-        {
-            FieldType.Name = name;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the description of the field.
-        /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> Description(string? description)
-        {
-            FieldType.Description = description;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the deprecation reason of the field.
-        /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason)
-        {
-            FieldType.DeprecationReason = deprecationReason;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the default value of fields on input object graph types.
-        /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType? defaultValue = default)
-        {
-            FieldType.DefaultValue = defaultValue;
-            return this;
-        }
-
-        internal FieldBuilder<TSourceType, TReturnType> DefaultValue(object? defaultValue)
-        {
-            FieldType.DefaultValue = defaultValue;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the input coercion for the field, replacing any existing coercion function.
-        /// Runs before any validation defined via <see cref="Validate"/>.
-        /// Null values are not passed to this function.
-        /// Applies only to input fields.
-        /// </summary>
-        [AllowedOn<IInputObjectGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> ParseValue(Func<object, object> parseValue)
-        {
-            FieldType.Parser = parseValue;
-            return this;
-        }
-
-        /// <summary>
-        /// Adds validation to the field, appending it to any existing validation function.
-        /// Runs after any coercion defined via <see cref="ParseValue"/>.
-        /// Null values are not passed to this function.
-        /// Applies only to input fields.
-        /// </summary>
-        [AllowedOn<IInputObjectGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Validate(Action<object> validation)
-        {
-            FieldType.Validator += validation;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the resolver for the field.
-        /// </summary>
-        [AllowedOn<IObjectGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Resolve(IFieldResolver? resolver)
-        {
-            FieldType.Resolver = resolver;
-            return this;
-        }
-
-        /// <inheritdoc cref="Resolve(IFieldResolver)"/>
-        [AllowedOn<IObjectGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Resolve(Func<IResolveFieldContext<TSourceType>, TReturnType?> resolve)
-            => Resolve(new FuncFieldResolver<TSourceType, TReturnType>(resolve));
-
-        /// <inheritdoc cref="Resolve(IFieldResolver)"/>
-        [AllowedOn<IObjectGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveFieldContext<TSourceType>, Task<TReturnType?>> resolve)
-            => Resolve(new FuncFieldResolver<TSourceType, TReturnType>(context => new ValueTask<TReturnType?>(resolve(context))));
-
-        /// <inheritdoc cref="Resolve(IFieldResolver)"/>
-        [AllowedOn<IObjectGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> ResolveDelegate(Delegate? resolve)
-        {
-            IFieldResolver? resolver = null;
-
-            if (resolve != null)
-            {
-                // create an instance expression that points to the instance represented by the delegate
-                // for instance, if the delegate represents obj.MyMethod,
-                // then the lambda would be: _ => obj
-                var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
-                var body = Expression.Constant(resolve.Target, resolve.Method.DeclaringType!);
-                var lambda = Expression.Lambda(body, param);
-                resolver = AutoRegisteringHelper.BuildFieldResolver(resolve.Method, null, null, lambda);
-            }
-
-            return Resolve(resolver);
-        }
-
-        /// <summary>
-        /// Sets the return type of the field.
-        /// </summary>
-        /// <typeparam name="TNewReturnType">The type of the return value of the resolver.</typeparam>
-        public virtual FieldBuilder<TSourceType, TNewReturnType> Returns<[NotAGraphType] TNewReturnType>()
-            => new(FieldType);
-
-        /// <summary>
-        /// Adds an argument to the field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="description">The description of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure = null)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, arg =>
-            {
-                arg.Description = description;
-                configure?.Invoke(arg);
-            });
-
-        /// <summary>
-        /// Adds an argument to the field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <typeparam name="TArgumentType">The type of the argument value.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="description">The description of the argument.</param>
-        /// <param name="defaultValue">The default value of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [Obsolete("Please use Action<QueryArgument> parameter from other Argument() method overloads to set default value for parameter or use Arguments() method. This method will be removed in v8.")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
-            TArgumentType? defaultValue = default, Action<QueryArgument>? configure = null)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, arg =>
-            {
-                arg.Description = description;
-                arg.DefaultValue = defaultValue;
-                configure?.Invoke(arg);
-            });
-
-        /// <summary>
-        /// Adds an argument to the field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name)
-            where TArgumentGraphType : IGraphType
-            => Argument<TArgumentGraphType>(name, null);
-
-        /// <summary>
-        /// Adds an argument to the field.
-        /// </summary>
-        /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TArgumentGraphType>(string name, Action<QueryArgument>? configure = null)
-            where TArgumentGraphType : IGraphType
-            => Argument(typeof(TArgumentGraphType), name, configure);
-
-        /// <summary>
-        /// Adds an argument to the field.
-        /// </summary>
-        /// <typeparam name="TArgumentClrType">The clr type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="nullable">Indicates if the argument is optional or not.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<[NotAGraphType] TArgumentClrType>(string name, bool nullable = false, Action<QueryArgument>? configure = null)
-        {
-            Type type;
-
-            try
-            {
-                type = typeof(TArgumentClrType).GetGraphTypeFromType(nullable, TypeMappingMode.InputType);
-            }
-            catch (ArgumentOutOfRangeException exp)
-            {
-                throw new ArgumentException($"The GraphQL type for argument '{FieldType.Name}.{name}' could not be derived implicitly from type '{typeof(TArgumentClrType).Name}'. " + exp.Message, exp);
-            }
-
-            return Argument(type, name, configure);
-        }
-
-        /// <summary>
-        /// Adds an argument to the field.
-        /// </summary>
-        /// <typeparam name="TArgumentClrType">The clr type of the argument.</typeparam>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="nullable">Indicates if the argument is optional or not.</param>
-        /// <param name="description">The description of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument<[NotAGraphType] TArgumentClrType>(string name, bool nullable, string? description, Action<QueryArgument>? configure = null)
-            => Argument<TArgumentClrType>(name, nullable, b =>
-            {
-                b.Description = description;
-                configure?.Invoke(b);
-            });
-
-        /// <summary>
-        /// Adds an argument to the field.
-        /// </summary>
-        /// <param name="type">The graph type of the argument.</param>
-        /// <param name="name">The name of the argument.</param>
-        /// <param name="configure">A delegate to further configure the argument.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Argument([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, string name, Action<QueryArgument>? configure = null)
-        {
-            var arg = new QueryArgument(type)
-            {
-                Name = name,
-            };
-            configure?.Invoke(arg);
-            FieldType.Arguments ??= new();
-            FieldType.Arguments.Add(arg);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the specified collection of arguments to the field.
-        /// </summary>
-        /// <param name="arguments">Arguments to add.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Arguments(IEnumerable<QueryArgument> arguments)
-        {
-            if (arguments != null)
-            {
-                foreach (var arg in arguments)
-                {
-                    FieldType.Arguments ??= new();
-                    FieldType.Arguments.Add(arg);
-                }
-            }
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the specified collection of arguments to the field.
-        /// </summary>
-        /// <param name="arguments">Arguments to add.</param>
-        [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> Arguments(params QueryArgument[] arguments)
-        {
-            return Arguments((IEnumerable<QueryArgument>)arguments);
-        }
-
-        /// <summary>
-        /// Runs a configuration delegate for the field.
-        /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> Configure(Action<FieldType> configure)
-        {
-            configure(FieldType);
-            return this;
-        }
-
-        /// <summary>
-        /// Sets a source stream resolver for the field.
-        /// </summary>
-        [AllowedOn<IObjectGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> ResolveStream(Func<IResolveFieldContext<TSourceType>, IObservable<TReturnType?>> sourceStreamResolver)
-        {
-            FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(sourceStreamResolver);
-            FieldType.Resolver ??= SourceFieldResolver.Instance;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets a source stream resolver for the field.
-        /// </summary>
-        [AllowedOn<IObjectGraphType>]
-        public virtual FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(Func<IResolveFieldContext<TSourceType>, Task<IObservable<TReturnType?>>> sourceStreamResolver)
-        {
-            FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(context => new ValueTask<IObservable<TReturnType?>>(sourceStreamResolver(context)));
-            FieldType.Resolver ??= SourceFieldResolver.Instance;
-            return this;
-        }
-
-        /// <summary>
-        /// Apply directive to field without specifying arguments. If the directive declaration has arguments,
-        /// then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        [Obsolete("Please use the ApplyDirective method")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name)
-            => this.ApplyDirective(name);
-
-        /// <summary>
-        /// Apply directive to field specifying one argument. If the directive declaration has other arguments,
-        /// then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        /// <param name="argumentName">Argument name.</param>
-        /// <param name="argumentValue">Argument value.</param>
-        [Obsolete("Please use the ApplyDirective method")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue)
-            => this.ApplyDirective(name, argumentName, argumentValue);
-
-        /// <summary>
-        /// Apply directive specifying two arguments. If the directive declaration has other arguments,
-        /// then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        /// <param name="argument1Name">First argument name.</param>
-        /// <param name="argument1Value">First argument value.</param>
-        /// <param name="argument2Name">Second argument name.</param>
-        /// <param name="argument2Value">Second argument value.</param>
-        [Obsolete("Please use the ApplyDirective method")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value)
-            => this.ApplyDirective(name, argument1Name, argument1Value, argument2Name, argument2Value);
-
-        /// <summary>
-        /// Apply directive to field specifying configuration delegate.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        /// <param name="configure">Configuration delegate.</param>
-        [Obsolete("Please use the ApplyDirective method")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, Action<AppliedDirective> configure)
-            => this.ApplyDirective(name, configure);
-
-        /// <summary>
-        /// Specify field's complexity impact which will be taken into account by <see cref="ComplexityValidationRule"/>.
-        /// </summary>
-        /// <param name="impact">Field's complexity impact.</param>
-        [Obsolete("Please use the WithComplexityImpact method")]
-        public virtual FieldBuilder<TSourceType, TReturnType> ComplexityImpact(double impact)
-            => this.WithComplexityImpact(impact);
-
-        // Allows metadata builder extension methods to read/write to the underlying field type without unnecessarily
-        // exposing metadata methods directly on the field builder; users can always use the FieldType property
-        // to access the underlying metadata directly.
-        Dictionary<string, object?> IProvideMetadata.Metadata => FieldType.Metadata;
-        IMetadataReader IMetadataWriter.MetadataReader => FieldType;
-        TType IProvideMetadata.GetMetadata<TType>(string key, TType defaultValue) => FieldType.GetMetadata(key, defaultValue);
-        TType IProvideMetadata.GetMetadata<TType>(string key, Func<TType> defaultValueFactory) => FieldType.GetMetadata(key, defaultValueFactory);
-        bool IProvideMetadata.HasMetadata(string key) => FieldType.HasMetadata(key);
+        FieldType = fieldType;
     }
+
+    /// <summary>
+    /// Returns a builder for a new field.
+    /// </summary>
+    /// <param name="type">The graph type of the field.</param>
+    /// <param name="name">The name of the field.</param>
+    [Obsolete("Please use the overload that accepts the name as the first argument.")]
+    public static FieldBuilder<TSourceType, TReturnType> Create(IGraphType type, string name = "default")
+    {
+        var fieldType = new FieldType
+        {
+            Name = name,
+            ResolvedType = type,
+        };
+        return new FieldBuilder<TSourceType, TReturnType>(fieldType);
+    }
+
+    /// <summary>
+    /// Returns a builder for a new field.
+    /// </summary>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="type">The graph type of the field.</param>
+    public static FieldBuilder<TSourceType, TReturnType> Create(string name, IGraphType type)
+    {
+        var fieldType = new FieldType
+        {
+            Name = name,
+            ResolvedType = type,
+        };
+        return new FieldBuilder<TSourceType, TReturnType>(fieldType);
+    }
+
+    /// <inheritdoc cref="Create(IGraphType, string)"/>
+    [Obsolete("Please use the overload that accepts the name as the first argument.")]
+    public static FieldBuilder<TSourceType, TReturnType> Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null, string name = "default")
+    {
+        var fieldType = new FieldType
+        {
+            Name = name,
+            Type = type,
+        };
+        return new FieldBuilder<TSourceType, TReturnType>(fieldType);
+    }
+
+    /// <inheritdoc cref="Create(string, IGraphType)"/>
+    public static FieldBuilder<TSourceType, TReturnType> Create(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null)
+    {
+        var fieldType = new FieldType
+        {
+            Name = name,
+            Type = type,
+        };
+        return new FieldBuilder<TSourceType, TReturnType>(fieldType);
+    }
+
+    /// <summary>
+    /// Sets the graph type of the field.
+    /// </summary>
+    /// <param name="type">The graph type of the field.</param>
+    public virtual FieldBuilder<TSourceType, TReturnType> Type(IGraphType type)
+    {
+        FieldType.ResolvedType = type;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the name of the field.
+    /// </summary>
+    [Obsolete("Please configure the field name by providing the name as an argument to the 'Field' method.")]
+    public virtual FieldBuilder<TSourceType, TReturnType> Name(string name)
+    {
+        FieldType.Name = name;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the description of the field.
+    /// </summary>
+    public virtual FieldBuilder<TSourceType, TReturnType> Description(string? description)
+    {
+        FieldType.Description = description;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the deprecation reason of the field.
+    /// </summary>
+    public virtual FieldBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason)
+    {
+        FieldType.DeprecationReason = deprecationReason;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the default value of fields on input object graph types.
+    /// </summary>
+    public virtual FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType? defaultValue = default)
+    {
+        FieldType.DefaultValue = defaultValue;
+        return this;
+    }
+
+    internal FieldBuilder<TSourceType, TReturnType> DefaultValue(object? defaultValue)
+    {
+        FieldType.DefaultValue = defaultValue;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the input coercion for the field, replacing any existing coercion function.
+    /// Runs before any validation defined via <see cref="Validate"/>.
+    /// Null values are not passed to this function.
+    /// Applies only to input fields.
+    /// </summary>
+    [AllowedOn<IInputObjectGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> ParseValue(Func<object, object> parseValue)
+    {
+        FieldType.Parser = parseValue;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds validation to the field, appending it to any existing validation function.
+    /// Runs after any coercion defined via <see cref="ParseValue"/>.
+    /// Null values are not passed to this function.
+    /// Applies only to input fields.
+    /// </summary>
+    [AllowedOn<IInputObjectGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Validate(Action<object> validation)
+    {
+        FieldType.Validator += validation;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the resolver for the field.
+    /// </summary>
+    [AllowedOn<IObjectGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Resolve(IFieldResolver? resolver)
+    {
+        FieldType.Resolver = resolver;
+        return this;
+    }
+
+    /// <inheritdoc cref="Resolve(IFieldResolver)"/>
+    [AllowedOn<IObjectGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Resolve(Func<IResolveFieldContext<TSourceType>, TReturnType?> resolve)
+        => Resolve(new FuncFieldResolver<TSourceType, TReturnType>(resolve));
+
+    /// <inheritdoc cref="Resolve(IFieldResolver)"/>
+    [AllowedOn<IObjectGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> ResolveAsync(Func<IResolveFieldContext<TSourceType>, Task<TReturnType?>> resolve)
+        => Resolve(new FuncFieldResolver<TSourceType, TReturnType>(context => new ValueTask<TReturnType?>(resolve(context))));
+
+    /// <inheritdoc cref="Resolve(IFieldResolver)"/>
+    [AllowedOn<IObjectGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> ResolveDelegate(Delegate? resolve)
+    {
+        IFieldResolver? resolver = null;
+
+        if (resolve != null)
+        {
+            // create an instance expression that points to the instance represented by the delegate
+            // for instance, if the delegate represents obj.MyMethod,
+            // then the lambda would be: _ => obj
+            var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
+            var body = Expression.Constant(resolve.Target, resolve.Method.DeclaringType!);
+            var lambda = Expression.Lambda(body, param);
+            resolver = AutoRegisteringHelper.BuildFieldResolver(resolve.Method, null, null, lambda);
+        }
+
+        return Resolve(resolver);
+    }
+
+    /// <summary>
+    /// Sets the return type of the field.
+    /// </summary>
+    /// <typeparam name="TNewReturnType">The type of the return value of the resolver.</typeparam>
+    public virtual FieldBuilder<TSourceType, TNewReturnType> Returns<[NotAGraphType] TNewReturnType>()
+        => new(FieldType);
+
+    /// <summary>
+    /// Adds an argument to the field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="description">The description of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string? description, Action<QueryArgument>? configure = null)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, arg =>
+        {
+            arg.Description = description;
+            configure?.Invoke(arg);
+        });
+
+    /// <summary>
+    /// Adds an argument to the field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <typeparam name="TArgumentType">The type of the argument value.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="description">The description of the argument.</param>
+    /// <param name="defaultValue">The default value of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [Obsolete("Please use Action<QueryArgument> parameter from other Argument() method overloads to set default value for parameter or use Arguments() method. This method will be removed in v8.")]
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
+        TArgumentType? defaultValue = default, Action<QueryArgument>? configure = null)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, arg =>
+        {
+            arg.Description = description;
+            arg.DefaultValue = defaultValue;
+            configure?.Invoke(arg);
+        });
+
+    /// <summary>
+    /// Adds an argument to the field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name)
+        where TArgumentGraphType : IGraphType
+        => Argument<TArgumentGraphType>(name, null);
+
+    /// <summary>
+    /// Adds an argument to the field.
+    /// </summary>
+    /// <typeparam name="TArgumentGraphType">The graph type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TArgumentGraphType>(string name, Action<QueryArgument>? configure = null)
+        where TArgumentGraphType : IGraphType
+        => Argument(typeof(TArgumentGraphType), name, configure);
+
+    /// <summary>
+    /// Adds an argument to the field.
+    /// </summary>
+    /// <typeparam name="TArgumentClrType">The clr type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="nullable">Indicates if the argument is optional or not.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument<[NotAGraphType] TArgumentClrType>(string name, bool nullable = false, Action<QueryArgument>? configure = null)
+    {
+        Type type;
+
+        try
+        {
+            type = typeof(TArgumentClrType).GetGraphTypeFromType(nullable, TypeMappingMode.InputType);
+        }
+        catch (ArgumentOutOfRangeException exp)
+        {
+            throw new ArgumentException($"The GraphQL type for argument '{FieldType.Name}.{name}' could not be derived implicitly from type '{typeof(TArgumentClrType).Name}'. " + exp.Message, exp);
+        }
+
+        return Argument(type, name, configure);
+    }
+
+    /// <summary>
+    /// Adds an argument to the field.
+    /// </summary>
+    /// <typeparam name="TArgumentClrType">The clr type of the argument.</typeparam>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="nullable">Indicates if the argument is optional or not.</param>
+    /// <param name="description">The description of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument<[NotAGraphType] TArgumentClrType>(string name, bool nullable, string? description, Action<QueryArgument>? configure = null)
+        => Argument<TArgumentClrType>(name, nullable, b =>
+        {
+            b.Description = description;
+            configure?.Invoke(b);
+        });
+
+    /// <summary>
+    /// Adds an argument to the field.
+    /// </summary>
+    /// <param name="type">The graph type of the argument.</param>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, string name, Action<QueryArgument>? configure = null)
+    {
+        var arg = new QueryArgument(type)
+        {
+            Name = name,
+        };
+        configure?.Invoke(arg);
+        FieldType.Arguments ??= new();
+        FieldType.Arguments.Add(arg);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds the specified collection of arguments to the field.
+    /// </summary>
+    /// <param name="arguments">Arguments to add.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Arguments(IEnumerable<QueryArgument> arguments)
+    {
+        if (arguments != null)
+        {
+            foreach (var arg in arguments)
+            {
+                FieldType.Arguments ??= new();
+                FieldType.Arguments.Add(arg);
+            }
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Adds the specified collection of arguments to the field.
+    /// </summary>
+    /// <param name="arguments">Arguments to add.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Arguments(params QueryArgument[] arguments)
+    {
+        return Arguments((IEnumerable<QueryArgument>)arguments);
+    }
+
+    /// <summary>
+    /// Runs a configuration delegate for the field.
+    /// </summary>
+    public virtual FieldBuilder<TSourceType, TReturnType> Configure(Action<FieldType> configure)
+    {
+        configure(FieldType);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a source stream resolver for the field.
+    /// </summary>
+    [AllowedOn<IObjectGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> ResolveStream(Func<IResolveFieldContext<TSourceType>, IObservable<TReturnType?>> sourceStreamResolver)
+    {
+        FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(sourceStreamResolver);
+        FieldType.Resolver ??= SourceFieldResolver.Instance;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a source stream resolver for the field.
+    /// </summary>
+    [AllowedOn<IObjectGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> ResolveStreamAsync(Func<IResolveFieldContext<TSourceType>, Task<IObservable<TReturnType?>>> sourceStreamResolver)
+    {
+        FieldType.StreamResolver = new SourceStreamResolver<TSourceType, TReturnType>(context => new ValueTask<IObservable<TReturnType?>>(sourceStreamResolver(context)));
+        FieldType.Resolver ??= SourceFieldResolver.Instance;
+        return this;
+    }
+
+    /// <summary>
+    /// Apply directive to field without specifying arguments. If the directive declaration has arguments,
+    /// then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    [Obsolete("Please use the ApplyDirective method")]
+    public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name)
+        => this.ApplyDirective(name);
+
+    /// <summary>
+    /// Apply directive to field specifying one argument. If the directive declaration has other arguments,
+    /// then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    /// <param name="argumentName">Argument name.</param>
+    /// <param name="argumentValue">Argument value.</param>
+    [Obsolete("Please use the ApplyDirective method")]
+    public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue)
+        => this.ApplyDirective(name, argumentName, argumentValue);
+
+    /// <summary>
+    /// Apply directive specifying two arguments. If the directive declaration has other arguments,
+    /// then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    /// <param name="argument1Name">First argument name.</param>
+    /// <param name="argument1Value">First argument value.</param>
+    /// <param name="argument2Name">Second argument name.</param>
+    /// <param name="argument2Value">Second argument value.</param>
+    [Obsolete("Please use the ApplyDirective method")]
+    public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value)
+        => this.ApplyDirective(name, argument1Name, argument1Value, argument2Name, argument2Value);
+
+    /// <summary>
+    /// Apply directive to field specifying configuration delegate.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    /// <param name="configure">Configuration delegate.</param>
+    [Obsolete("Please use the ApplyDirective method")]
+    public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, Action<AppliedDirective> configure)
+        => this.ApplyDirective(name, configure);
+
+    /// <summary>
+    /// Specify field's complexity impact which will be taken into account by <see cref="ComplexityValidationRule"/>.
+    /// </summary>
+    /// <param name="impact">Field's complexity impact.</param>
+    [Obsolete("Please use the WithComplexityImpact method")]
+    public virtual FieldBuilder<TSourceType, TReturnType> ComplexityImpact(double impact)
+        => this.WithComplexityImpact(impact);
+
+    // Allows metadata builder extension methods to read/write to the underlying field type without unnecessarily
+    // exposing metadata methods directly on the field builder; users can always use the FieldType property
+    // to access the underlying metadata directly.
+    Dictionary<string, object?> IProvideMetadata.Metadata => FieldType.Metadata;
+    IMetadataReader IMetadataWriter.MetadataReader => FieldType;
+    TType IProvideMetadata.GetMetadata<TType>(string key, TType defaultValue) => FieldType.GetMetadata(key, defaultValue);
+    TType IProvideMetadata.GetMetadata<TType>(string key, Func<TType> defaultValueFactory) => FieldType.GetMetadata(key, defaultValueFactory);
+    bool IProvideMetadata.HasMetadata(string key) => FieldType.HasMetadata(key);
 }

--- a/src/GraphQL/Conversion/CamelCaseNameConverter.cs
+++ b/src/GraphQL/Conversion/CamelCaseNameConverter.cs
@@ -1,26 +1,25 @@
 using GraphQL.Types;
 
-namespace GraphQL.Conversion
+namespace GraphQL.Conversion;
+
+/// <summary>
+/// Camel case name converter; set as the default <see cref="INameConverter"/> within <see cref="Schema.NameConverter"/>.
+/// Always used by all introspection fields regardless of the selected <see cref="INameConverter"/>.
+/// </summary>
+public class CamelCaseNameConverter : INameConverter
 {
     /// <summary>
-    /// Camel case name converter; set as the default <see cref="INameConverter"/> within <see cref="Schema.NameConverter"/>.
-    /// Always used by all introspection fields regardless of the selected <see cref="INameConverter"/>.
+    /// Static instance of <see cref="CamelCaseNameConverter"/> that can be reused instead of creating new.
     /// </summary>
-    public class CamelCaseNameConverter : INameConverter
-    {
-        /// <summary>
-        /// Static instance of <see cref="CamelCaseNameConverter"/> that can be reused instead of creating new.
-        /// </summary>
-        public static readonly CamelCaseNameConverter Instance = new();
+    public static readonly CamelCaseNameConverter Instance = new();
 
-        /// <summary>
-        /// Returns the field name converted to camelCase.
-        /// </summary>
-        public string NameForField(string fieldName, IComplexGraphType parentGraphType) => fieldName.ToCamelCase();
+    /// <summary>
+    /// Returns the field name converted to camelCase.
+    /// </summary>
+    public string NameForField(string fieldName, IComplexGraphType parentGraphType) => fieldName.ToCamelCase();
 
-        /// <summary>
-        /// Returns the argument name converted to camelCase.
-        /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName.ToCamelCase();
-    }
+    /// <summary>
+    /// Returns the argument name converted to camelCase.
+    /// </summary>
+    public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName.ToCamelCase();
 }

--- a/src/GraphQL/Conversion/DefaultNameConverter.cs
+++ b/src/GraphQL/Conversion/DefaultNameConverter.cs
@@ -1,25 +1,24 @@
 using GraphQL.Types;
 
-namespace GraphQL.Conversion
+namespace GraphQL.Conversion;
+
+/// <summary>
+/// A name converter which does not modify the names passed to it.
+/// </summary>
+public class DefaultNameConverter : INameConverter
 {
     /// <summary>
-    /// A name converter which does not modify the names passed to it.
+    /// Static instance of <see cref="DefaultNameConverter"/> that can be reused instead of creating new.
     /// </summary>
-    public class DefaultNameConverter : INameConverter
-    {
-        /// <summary>
-        /// Static instance of <see cref="DefaultNameConverter"/> that can be reused instead of creating new.
-        /// </summary>
-        public static readonly DefaultNameConverter Instance = new();
+    public static readonly DefaultNameConverter Instance = new();
 
-        /// <summary>
-        /// Returns the field name without modification
-        /// </summary>
-        public string NameForField(string fieldName, IComplexGraphType parentGraphType) => fieldName;
+    /// <summary>
+    /// Returns the field name without modification
+    /// </summary>
+    public string NameForField(string fieldName, IComplexGraphType parentGraphType) => fieldName;
 
-        /// <summary>
-        /// Returns the argument name without modification
-        /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName;
-    }
+    /// <summary>
+    /// Returns the argument name without modification
+    /// </summary>
+    public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName;
 }

--- a/src/GraphQL/Conversion/INameConverter.cs
+++ b/src/GraphQL/Conversion/INameConverter.cs
@@ -1,25 +1,24 @@
 using GraphQL.Types;
 
-namespace GraphQL.Conversion
+namespace GraphQL.Conversion;
+
+/// <summary>
+/// Sanitizes graph field and argument names to a particular case convention, such as camelСase or PascalCase.<br/>
+/// <br/>
+/// Set <see cref="Schema.NameConverter"/> to an instance of a derived class to select a converter to use.
+/// The default converter is <see cref="CamelCaseNameConverter"/>.<br/>
+/// <br/>
+/// Introspection fields always use <see cref="CamelCaseNameConverter"/> regardless of the selected <see cref="INameConverter"/>.
+/// </summary>
+public interface INameConverter
 {
     /// <summary>
-    /// Sanitizes graph field and argument names to a particular case convention, such as camelСase or PascalCase.<br/>
-    /// <br/>
-    /// Set <see cref="Schema.NameConverter"/> to an instance of a derived class to select a converter to use.
-    /// The default converter is <see cref="CamelCaseNameConverter"/>.<br/>
-    /// <br/>
-    /// Introspection fields always use <see cref="CamelCaseNameConverter"/> regardless of the selected <see cref="INameConverter"/>.
+    /// Sanitizes a field name for a specified parent graph type; returns the updated field name
     /// </summary>
-    public interface INameConverter
-    {
-        /// <summary>
-        /// Sanitizes a field name for a specified parent graph type; returns the updated field name
-        /// </summary>
-        string NameForField(string fieldName, IComplexGraphType parentGraphType);
+    string NameForField(string fieldName, IComplexGraphType parentGraphType);
 
-        /// <summary>
-        /// Sanitizes an argument name for a specified parent graph type and field definition; returns the updated field name
-        /// </summary>
-        string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field);
-    }
+    /// <summary>
+    /// Sanitizes an argument name for a specified parent graph type and field definition; returns the updated field name
+    /// </summary>
+    string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field);
 }

--- a/src/GraphQL/Conversion/PascalCaseNameConverter.cs
+++ b/src/GraphQL/Conversion/PascalCaseNameConverter.cs
@@ -1,25 +1,24 @@
 using GraphQL.Types;
 
-namespace GraphQL.Conversion
+namespace GraphQL.Conversion;
+
+/// <summary>
+/// PascalCase name converter.
+/// </summary>
+public class PascalCaseNameConverter : INameConverter
 {
     /// <summary>
-    /// PascalCase name converter.
+    /// Static instance of <see cref="PascalCaseNameConverter"/> that can be reused instead of creating new.
     /// </summary>
-    public class PascalCaseNameConverter : INameConverter
-    {
-        /// <summary>
-        /// Static instance of <see cref="PascalCaseNameConverter"/> that can be reused instead of creating new.
-        /// </summary>
-        public static readonly PascalCaseNameConverter Instance = new();
+    public static readonly PascalCaseNameConverter Instance = new();
 
-        /// <summary>
-        /// Returns the field name converted to PascalCase.
-        /// </summary>
-        public string NameForField(string fieldName, IComplexGraphType parentGraphType) => fieldName.ToPascalCase();
+    /// <summary>
+    /// Returns the field name converted to PascalCase.
+    /// </summary>
+    public string NameForField(string fieldName, IComplexGraphType parentGraphType) => fieldName.ToPascalCase();
 
-        /// <summary>
-        /// Returns the argument name converted to PascalCase.
-        /// </summary>
-        public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName.ToPascalCase();
-    }
+    /// <summary>
+    /// Returns the argument name converted to PascalCase.
+    /// </summary>
+    public string NameForArgument(string argumentName, IComplexGraphType parentGraphType, FieldType field) => argumentName.ToPascalCase();
 }

--- a/src/GraphQL/Conversion/ValueConverter.cs
+++ b/src/GraphQL/Conversion/ValueConverter.cs
@@ -2,253 +2,252 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using System.Numerics;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// This class provides value conversions between objects of different types.
+/// Conversions are registered in a static thread safe dictionary and are used for all schemas in the application.
+/// <br/><br/>
+/// Each ScalarGraphType calls <see cref="ConvertTo(object, Type)">ConvertTo</see> method to return correct value
+/// type from its <see cref=" GraphQL.Types.ScalarGraphType.ParseValue(object)">ParseValue</see> method.
+/// Also conversions may be useful in advanced <see cref="ResolveFieldContextExtensions.GetArgument{TType}(IResolveFieldContext, string, TType)">GetArgument</see>
+/// use cases when deserialization from the values dictionary to the complex input argument is required.
+/// </summary>
+public static class ValueConverter
 {
+    private static readonly ConcurrentDictionary<Type, ConcurrentDictionary<Type, Func<object, object>>> _valueConversions = new();
+
     /// <summary>
-    /// This class provides value conversions between objects of different types.
-    /// Conversions are registered in a static thread safe dictionary and are used for all schemas in the application.
-    /// <br/><br/>
-    /// Each ScalarGraphType calls <see cref="ConvertTo(object, Type)">ConvertTo</see> method to return correct value
-    /// type from its <see cref=" GraphQL.Types.ScalarGraphType.ParseValue(object)">ParseValue</see> method.
-    /// Also conversions may be useful in advanced <see cref="ResolveFieldContextExtensions.GetArgument{TType}(IResolveFieldContext, string, TType)">GetArgument</see>
-    /// use cases when deserialization from the values dictionary to the complex input argument is required.
+    /// Register built-in conversions. This list is expected to grow over time.
     /// </summary>
-    public static class ValueConverter
+    static ValueConverter()
     {
-        private static readonly ConcurrentDictionary<Type, ConcurrentDictionary<Type, Func<object, object>>> _valueConversions = new();
-
-        /// <summary>
-        /// Register built-in conversions. This list is expected to grow over time.
-        /// </summary>
-        static ValueConverter()
-        {
-            Register<string, sbyte>(value => sbyte.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, byte>(value => byte.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, short>(value => short.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, ushort>(value => ushort.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, int>(value => int.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, uint>(value => uint.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, long>(value => long.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, ulong>(value => ulong.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, BigInteger>(value => BigInteger.Parse(value, NumberFormatInfo.InvariantInfo));
-            Register<string, float>(value => float.Parse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
-            Register<string, double>(value => double.Parse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
-            Register<string, decimal>(value => decimal.Parse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
+        Register<string, sbyte>(value => sbyte.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, byte>(value => byte.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, short>(value => short.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, ushort>(value => ushort.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, int>(value => int.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, uint>(value => uint.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, long>(value => long.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, ulong>(value => ulong.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, BigInteger>(value => BigInteger.Parse(value, NumberFormatInfo.InvariantInfo));
+        Register<string, float>(value => float.Parse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
+        Register<string, double>(value => double.Parse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
+        Register<string, decimal>(value => decimal.Parse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo));
 #if NET6_0_OR_GREATER
-            Register<string, DateOnly>(value => DateOnly.Parse(value, DateTimeFormatInfo.InvariantInfo));
-            Register<string, TimeOnly>(value => TimeOnly.Parse(value, DateTimeFormatInfo.InvariantInfo));
+        Register<string, DateOnly>(value => DateOnly.Parse(value, DateTimeFormatInfo.InvariantInfo));
+        Register<string, TimeOnly>(value => TimeOnly.Parse(value, DateTimeFormatInfo.InvariantInfo));
 #endif
-            Register<string, DateTime>(value => DateTimeOffset.Parse(value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal).UtcDateTime);
-            Register<string, DateTimeOffset>(value => DateTimeOffset.Parse(value, DateTimeFormatInfo.InvariantInfo));
-            Register(typeof(string), typeof(bool), value =>
-            {
-                string stringValue = (string)value;
-                if (string.CompareOrdinal(stringValue, "1") == 0)
-                    return BoolBox.True;
-                else if (string.CompareOrdinal(stringValue, "0") == 0)
-                    return BoolBox.False;
-
-                return Convert.ToBoolean(value, NumberFormatInfo.InvariantInfo).Boxed();
-            });
-            Register<string, Guid>(value => Guid.Parse(value));
-            Register<string, Uri>(value => new Uri(value));
-            Register<string, byte[]>(value => Convert.FromBase64String(value)); // such a built-in conversion for string->byte[] seems useful
-
-            Register<DateTime, DateTimeOffset>(value => value);
-            Register<DateTimeOffset, DateTime>(value => value.UtcDateTime);
-            Register<TimeSpan, long>(value => (long)value.TotalSeconds);
-
-            Register<int, sbyte>(value => checked((sbyte)value));
-            Register<int, byte>(value => checked((byte)value));
-            Register<int, short>(value => checked((short)value));
-            Register<int, ushort>(value => checked((ushort)value));
-            Register(typeof(int), typeof(bool), value => Convert.ToBoolean(value, NumberFormatInfo.InvariantInfo).Boxed());
-            Register<int, uint>(value => checked((uint)value));
-            Register<int, long>(value => value);
-            Register<int, ulong>(value => checked((ulong)value));
-            Register<int, BigInteger>(value => new BigInteger(value));
-            Register<int, double>(value => value);
-            Register<int, float>(value => value);
-            Register<int, decimal>(value => value);
-            Register<int, TimeSpan>(value => TimeSpan.FromSeconds(value));
-
-            Register<long, sbyte>(value => checked((sbyte)value));
-            Register<long, byte>(value => checked((byte)value));
-            Register<long, short>(value => checked((short)value));
-            Register<long, ushort>(value => checked((ushort)value));
-            Register<long, int>(value => checked((int)value));
-            Register<long, uint>(value => checked((uint)value));
-            Register<long, ulong>(value => checked((ulong)value));
-            Register<long, BigInteger>(value => new BigInteger(value));
-            Register<long, double>(value => value);
-            Register<long, float>(value => value);
-            Register<long, decimal>(value => value);
-            Register<long, TimeSpan>(value => TimeSpan.FromSeconds(value));
-
-            Register<BigInteger, sbyte>(value => checked((sbyte)value));
-            Register<BigInteger, byte>(value => checked((byte)value));
-            Register<BigInteger, decimal>(value => checked((decimal)value));
-            Register<BigInteger, double>(value => checked((double)value));
-            Register<BigInteger, short>(value => checked((short)value));
-            Register<BigInteger, long>(value => checked((long)value));
-            Register<BigInteger, sbyte>(value => checked((sbyte)value));
-            Register<BigInteger, ushort>(value => checked((ushort)value));
-            Register<BigInteger, uint>(value => checked((uint)value));
-            Register<BigInteger, ulong>(value => checked((ulong)value));
-            Register<BigInteger, int>(value => checked((int)value));
-            Register<BigInteger, float>(value => checked((float)value));
-
-            Register<uint, sbyte>(value => checked((sbyte)value));
-            Register<uint, byte>(value => checked((byte)value));
-            Register<uint, int>(value => checked((int)value));
-            Register<uint, long>(value => value);
-            Register<uint, ulong>(value => value);
-            Register<uint, short>(value => checked((short)value));
-            Register<uint, ushort>(value => checked((ushort)value));
-            Register<uint, BigInteger>(value => new BigInteger(value));
-
-            Register<ulong, BigInteger>(value => new BigInteger(value));
-
-            Register<byte, sbyte>(value => checked((sbyte)value));
-            Register<byte, int>(value => value);
-            Register<byte, long>(value => value);
-            Register<byte, ulong>(value => value);
-            Register<byte, short>(value => value);
-            Register<byte, ushort>(value => value);
-            Register<byte, BigInteger>(value => new BigInteger(value));
-
-            Register<sbyte, byte>(value => checked((byte)value));
-            Register<sbyte, int>(value => value);
-            Register<sbyte, long>(value => value);
-            Register<sbyte, ulong>(value => checked((ulong)value));
-            Register<sbyte, short>(value => value);
-            Register<sbyte, ushort>(value => checked((ushort)value));
-            Register<sbyte, BigInteger>(value => new BigInteger(value));
-
-            Register<float, double>(value => value);
-            Register<float, decimal>(value => checked((decimal)value));
-            Register<float, BigInteger>(value => new BigInteger(value));
-
-            Register<double, float>(value => checked((float)value));
-            Register<double, decimal>(value => checked((decimal)value));
-
-            Register<char, byte>(value => checked((byte)value));
-            Register<char, int>(value => value);
-
-            Register<decimal, double>(value => checked((double)value));
-        }
-
-        /// <summary>
-        /// <para>Returns an object of the specified type and whose value is equivalent to the specified object.</para>
-        /// <para>Throws a <see cref="InvalidOperationException"/> if there is no conversion registered; conversion functions may throw other exceptions</para>
-        /// </summary>
-        public static T? ConvertTo<T>(object? value)
+        Register<string, DateTime>(value => DateTimeOffset.Parse(value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal).UtcDateTime);
+        Register<string, DateTimeOffset>(value => DateTimeOffset.Parse(value, DateTimeFormatInfo.InvariantInfo));
+        Register(typeof(string), typeof(bool), value =>
         {
-            object? v = ConvertTo(value, typeof(T));
+            string stringValue = (string)value;
+            if (string.CompareOrdinal(stringValue, "1") == 0)
+                return BoolBox.True;
+            else if (string.CompareOrdinal(stringValue, "0") == 0)
+                return BoolBox.False;
 
-            return v == null ? default : (T)v;
-        }
+            return Convert.ToBoolean(value, NumberFormatInfo.InvariantInfo).Boxed();
+        });
+        Register<string, Guid>(value => Guid.Parse(value));
+        Register<string, Uri>(value => new Uri(value));
+        Register<string, byte[]>(value => Convert.FromBase64String(value)); // such a built-in conversion for string->byte[] seems useful
 
-        /// <summary>
-        /// <para>Returns an object of the specified type and whose value is equivalent to the specified object.</para>
-        /// <para>Throws a <see cref="InvalidOperationException"/> if there is no conversion registered; conversion functions may throw other exceptions</para>
-        /// </summary>
-        public static object? ConvertTo(object? value, Type targetType)
-        {
-            if (value == null)
-                return null;
+        Register<DateTime, DateTimeOffset>(value => value);
+        Register<DateTimeOffset, DateTime>(value => value.UtcDateTime);
+        Register<TimeSpan, long>(value => (long)value.TotalSeconds);
 
-            if (!TryConvertTo(value, targetType, out object? result))
-                throw new InvalidOperationException($"Could not find conversion from '{value.GetType().FullName}' to '{targetType.FullName}'");
+        Register<int, sbyte>(value => checked((sbyte)value));
+        Register<int, byte>(value => checked((byte)value));
+        Register<int, short>(value => checked((short)value));
+        Register<int, ushort>(value => checked((ushort)value));
+        Register(typeof(int), typeof(bool), value => Convert.ToBoolean(value, NumberFormatInfo.InvariantInfo).Boxed());
+        Register<int, uint>(value => checked((uint)value));
+        Register<int, long>(value => value);
+        Register<int, ulong>(value => checked((ulong)value));
+        Register<int, BigInteger>(value => new BigInteger(value));
+        Register<int, double>(value => value);
+        Register<int, float>(value => value);
+        Register<int, decimal>(value => value);
+        Register<int, TimeSpan>(value => TimeSpan.FromSeconds(value));
 
-            return result;
-        }
+        Register<long, sbyte>(value => checked((sbyte)value));
+        Register<long, byte>(value => checked((byte)value));
+        Register<long, short>(value => checked((short)value));
+        Register<long, ushort>(value => checked((ushort)value));
+        Register<long, int>(value => checked((int)value));
+        Register<long, uint>(value => checked((uint)value));
+        Register<long, ulong>(value => checked((ulong)value));
+        Register<long, BigInteger>(value => new BigInteger(value));
+        Register<long, double>(value => value);
+        Register<long, float>(value => value);
+        Register<long, decimal>(value => value);
+        Register<long, TimeSpan>(value => TimeSpan.FromSeconds(value));
 
-        /// <summary>
-        /// <para>
-        /// If a conversion delegate was registered, converts an object to the specified type and
-        /// returns <see langword="true"/>; returns <see langword="false"/> if no conversion delegate is registered.
-        /// </para>
-        /// <para>Conversion delegates may throw exceptions if the conversion was unsuccessful</para>
-        /// </summary>
-        internal static bool TryConvertTo(object? value, Type targetType, out object? result, Type? sourceType = null)
-        {
-            if (value == null || targetType.IsInstanceOfType(value))
-            {
-                result = value;
-                return true;
-            }
+        Register<BigInteger, sbyte>(value => checked((sbyte)value));
+        Register<BigInteger, byte>(value => checked((byte)value));
+        Register<BigInteger, decimal>(value => checked((decimal)value));
+        Register<BigInteger, double>(value => checked((double)value));
+        Register<BigInteger, short>(value => checked((short)value));
+        Register<BigInteger, long>(value => checked((long)value));
+        Register<BigInteger, sbyte>(value => checked((sbyte)value));
+        Register<BigInteger, ushort>(value => checked((ushort)value));
+        Register<BigInteger, uint>(value => checked((uint)value));
+        Register<BigInteger, ulong>(value => checked((ulong)value));
+        Register<BigInteger, int>(value => checked((int)value));
+        Register<BigInteger, float>(value => checked((float)value));
 
-            var conversion = GetConversion(sourceType ?? value.GetType(), targetType);
-            if (conversion == null)
-            {
-                result = null;
-                return false;
-            }
-            else
-            {
-                result = conversion(value);
-                return true;
-            }
-        }
+        Register<uint, sbyte>(value => checked((sbyte)value));
+        Register<uint, byte>(value => checked((byte)value));
+        Register<uint, int>(value => checked((int)value));
+        Register<uint, long>(value => value);
+        Register<uint, ulong>(value => value);
+        Register<uint, short>(value => checked((short)value));
+        Register<uint, ushort>(value => checked((ushort)value));
+        Register<uint, BigInteger>(value => new BigInteger(value));
 
-        /// <summary>
-        /// Returns the conversion delegate registered to convert objects of type <paramref name="valueType"/>
-        /// to type <paramref name="targetType"/>, if any.
-        /// </summary>
-        /// <param name="valueType">Type of original values.</param>
-        /// <param name="targetType">Converted value type.</param>
-        /// <returns>The conversion delegate if it is present, <see langword="null"/> otherwise.</returns>
-        public static Func<object, object>? GetConversion(Type valueType, Type targetType)
-        {
-            return _valueConversions.TryGetValue(valueType, out var conversions) && conversions.TryGetValue(targetType, out var conversion)
-                ? conversion
-                : null;
-        }
+        Register<ulong, BigInteger>(value => new BigInteger(value));
 
-        /// <summary>
-        /// Allows you to register your own conversion delegate from one type to another.
-        /// <br/><br/>
-        /// If the conversion from valueType to targetType is already registered, then it will be overwritten.
-        /// </summary>
-        /// <param name="valueType">Type of original value.</param>
-        /// <param name="targetType">Converted value type.</param>
-        /// <param name="conversion">Conversion delegate; <see langword="null"/> for unregister already registered conversion.</param>
-        public static void Register(Type valueType, Type targetType, Func<object, object>? conversion)
-        {
-            if (!_valueConversions.TryGetValue(valueType, out var conversions) &&
-                !_valueConversions.TryAdd(valueType, conversions = new ConcurrentDictionary<Type, Func<object, object>>()))
-                conversions = _valueConversions[valueType];
+        Register<byte, sbyte>(value => checked((sbyte)value));
+        Register<byte, int>(value => value);
+        Register<byte, long>(value => value);
+        Register<byte, ulong>(value => value);
+        Register<byte, short>(value => value);
+        Register<byte, ushort>(value => value);
+        Register<byte, BigInteger>(value => new BigInteger(value));
 
-            if (conversion == null)
-                conversions.TryRemove(targetType, out var _);
-            else
-                conversions[targetType] = conversion;
-        }
+        Register<sbyte, byte>(value => checked((byte)value));
+        Register<sbyte, int>(value => value);
+        Register<sbyte, long>(value => value);
+        Register<sbyte, ulong>(value => checked((ulong)value));
+        Register<sbyte, short>(value => value);
+        Register<sbyte, ushort>(value => checked((ushort)value));
+        Register<sbyte, BigInteger>(value => new BigInteger(value));
 
-        /// <summary>
-        /// Allows you to register your own conversion delegate from one type to another.
-        /// <br/><br/>
-        /// If the conversion from TSource to TTarget is already registered, then it will be overwritten.
-        /// </summary>
-        /// <typeparam name="TSource">Type of original value.</typeparam>
-        /// <typeparam name="TTarget">Converted value type.</typeparam>
-        /// <param name="conversion">Conversion delegate; <see langword="null"/> for unregister already registered conversion.</param>
-        public static void Register<TSource, TTarget>(Func<TSource, TTarget>? conversion)
-            => Register(typeof(TSource), typeof(TTarget), conversion == null ? null : v => conversion((TSource)v)!);
+        Register<float, double>(value => value);
+        Register<float, decimal>(value => checked((decimal)value));
+        Register<float, BigInteger>(value => new BigInteger(value));
 
-        /// <summary>
-        /// Allows you to register your own conversion delegate from dictionary to some complex object.
-        /// <br/><br/>
-        /// This method may be useful in advanced <see cref="ResolveFieldContextExtensions.GetArgument{TType}(IResolveFieldContext, string, TType)">GetArgument</see>
-        /// use cases when deserialization from the values dictionary to the complex input argument is required.
-        /// <br/><br/>
-        /// If the conversion from dictionary to TTarget is already registered, then it will be overwritten.
-        /// </summary>
-        /// <typeparam name="TTarget">Converted value type.</typeparam>
-        /// <param name="conversion">Conversion delegate; <see langword="null"/> for unregister already registered conversion.</param>
-        public static void Register<TTarget>(Func<IDictionary<string, object>, TTarget>? conversion)
-            where TTarget : class
-            => Register<IDictionary<string, object>, TTarget>(conversion);
+        Register<double, float>(value => checked((float)value));
+        Register<double, decimal>(value => checked((decimal)value));
+
+        Register<char, byte>(value => checked((byte)value));
+        Register<char, int>(value => value);
+
+        Register<decimal, double>(value => checked((double)value));
     }
+
+    /// <summary>
+    /// <para>Returns an object of the specified type and whose value is equivalent to the specified object.</para>
+    /// <para>Throws a <see cref="InvalidOperationException"/> if there is no conversion registered; conversion functions may throw other exceptions</para>
+    /// </summary>
+    public static T? ConvertTo<T>(object? value)
+    {
+        object? v = ConvertTo(value, typeof(T));
+
+        return v == null ? default : (T)v;
+    }
+
+    /// <summary>
+    /// <para>Returns an object of the specified type and whose value is equivalent to the specified object.</para>
+    /// <para>Throws a <see cref="InvalidOperationException"/> if there is no conversion registered; conversion functions may throw other exceptions</para>
+    /// </summary>
+    public static object? ConvertTo(object? value, Type targetType)
+    {
+        if (value == null)
+            return null;
+
+        if (!TryConvertTo(value, targetType, out object? result))
+            throw new InvalidOperationException($"Could not find conversion from '{value.GetType().FullName}' to '{targetType.FullName}'");
+
+        return result;
+    }
+
+    /// <summary>
+    /// <para>
+    /// If a conversion delegate was registered, converts an object to the specified type and
+    /// returns <see langword="true"/>; returns <see langword="false"/> if no conversion delegate is registered.
+    /// </para>
+    /// <para>Conversion delegates may throw exceptions if the conversion was unsuccessful</para>
+    /// </summary>
+    internal static bool TryConvertTo(object? value, Type targetType, out object? result, Type? sourceType = null)
+    {
+        if (value == null || targetType.IsInstanceOfType(value))
+        {
+            result = value;
+            return true;
+        }
+
+        var conversion = GetConversion(sourceType ?? value.GetType(), targetType);
+        if (conversion == null)
+        {
+            result = null;
+            return false;
+        }
+        else
+        {
+            result = conversion(value);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Returns the conversion delegate registered to convert objects of type <paramref name="valueType"/>
+    /// to type <paramref name="targetType"/>, if any.
+    /// </summary>
+    /// <param name="valueType">Type of original values.</param>
+    /// <param name="targetType">Converted value type.</param>
+    /// <returns>The conversion delegate if it is present, <see langword="null"/> otherwise.</returns>
+    public static Func<object, object>? GetConversion(Type valueType, Type targetType)
+    {
+        return _valueConversions.TryGetValue(valueType, out var conversions) && conversions.TryGetValue(targetType, out var conversion)
+            ? conversion
+            : null;
+    }
+
+    /// <summary>
+    /// Allows you to register your own conversion delegate from one type to another.
+    /// <br/><br/>
+    /// If the conversion from valueType to targetType is already registered, then it will be overwritten.
+    /// </summary>
+    /// <param name="valueType">Type of original value.</param>
+    /// <param name="targetType">Converted value type.</param>
+    /// <param name="conversion">Conversion delegate; <see langword="null"/> for unregister already registered conversion.</param>
+    public static void Register(Type valueType, Type targetType, Func<object, object>? conversion)
+    {
+        if (!_valueConversions.TryGetValue(valueType, out var conversions) &&
+            !_valueConversions.TryAdd(valueType, conversions = new ConcurrentDictionary<Type, Func<object, object>>()))
+            conversions = _valueConversions[valueType];
+
+        if (conversion == null)
+            conversions.TryRemove(targetType, out var _);
+        else
+            conversions[targetType] = conversion;
+    }
+
+    /// <summary>
+    /// Allows you to register your own conversion delegate from one type to another.
+    /// <br/><br/>
+    /// If the conversion from TSource to TTarget is already registered, then it will be overwritten.
+    /// </summary>
+    /// <typeparam name="TSource">Type of original value.</typeparam>
+    /// <typeparam name="TTarget">Converted value type.</typeparam>
+    /// <param name="conversion">Conversion delegate; <see langword="null"/> for unregister already registered conversion.</param>
+    public static void Register<TSource, TTarget>(Func<TSource, TTarget>? conversion)
+        => Register(typeof(TSource), typeof(TTarget), conversion == null ? null : v => conversion((TSource)v)!);
+
+    /// <summary>
+    /// Allows you to register your own conversion delegate from dictionary to some complex object.
+    /// <br/><br/>
+    /// This method may be useful in advanced <see cref="ResolveFieldContextExtensions.GetArgument{TType}(IResolveFieldContext, string, TType)">GetArgument</see>
+    /// use cases when deserialization from the values dictionary to the complex input argument is required.
+    /// <br/><br/>
+    /// If the conversion from dictionary to TTarget is already registered, then it will be overwritten.
+    /// </summary>
+    /// <typeparam name="TTarget">Converted value type.</typeparam>
+    /// <param name="conversion">Conversion delegate; <see langword="null"/> for unregister already registered conversion.</param>
+    public static void Register<TTarget>(Func<IDictionary<string, object>, TTarget>? conversion)
+        where TTarget : class
+        => Register<IDictionary<string, object>, TTarget>(conversion);
 }

--- a/src/GraphQL/DI/ConfigureExecutionOptions.cs
+++ b/src/GraphQL/DI/ConfigureExecutionOptions.cs
@@ -1,33 +1,32 @@
-namespace GraphQL.DI // TODO: think about namespaces!
+namespace GraphQL.DI; // TODO: think about namespaces!
+
+internal sealed class ConfigureExecutionOptions : IConfigureExecution
 {
-    internal sealed class ConfigureExecutionOptions : IConfigureExecution
+    private readonly Func<ExecutionOptions, Task> _action;
+
+    public ConfigureExecutionOptions(Func<ExecutionOptions, Task> action)
     {
-        private readonly Func<ExecutionOptions, Task> _action;
-
-        public ConfigureExecutionOptions(Func<ExecutionOptions, Task> action)
-        {
-            _action = action;
-        }
-
-        public ConfigureExecutionOptions(Action<ExecutionOptions> action)
-        {
-            _action = opt => { action(opt); return Task.CompletedTask; };
-        }
-
-        public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
-        {
-            var task = _action(options);
-            if (task.IsCompleted && task.Status == TaskStatus.RanToCompletion)
-                return next(options);
-            return Continuer(task, options, next);
-
-            static async Task<ExecutionResult> Continuer(Task task, ExecutionOptions options, ExecutionDelegate next)
-            {
-                await task.ConfigureAwait(false);
-                return await next(options).ConfigureAwait(false);
-            }
-        }
-
-        public float SortOrder => GraphQLBuilderExtensions.SORT_ORDER_OPTIONS;
+        _action = action;
     }
+
+    public ConfigureExecutionOptions(Action<ExecutionOptions> action)
+    {
+        _action = opt => { action(opt); return Task.CompletedTask; };
+    }
+
+    public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
+    {
+        var task = _action(options);
+        if (task.IsCompleted && task.Status == TaskStatus.RanToCompletion)
+            return next(options);
+        return Continuer(task, options, next);
+
+        static async Task<ExecutionResult> Continuer(Task task, ExecutionOptions options, ExecutionDelegate next)
+        {
+            await task.ConfigureAwait(false);
+            return await next(options).ConfigureAwait(false);
+        }
+    }
+
+    public float SortOrder => GraphQLBuilderExtensions.SORT_ORDER_OPTIONS;
 }

--- a/src/GraphQL/DI/DefaultServiceProvider.cs
+++ b/src/GraphQL/DI/DefaultServiceProvider.cs
@@ -1,36 +1,35 @@
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Activator.CreateInstance based service provider.
+/// </summary>
+/// <seealso cref="IServiceProvider" />
+public sealed class DefaultServiceProvider : IServiceProvider
 {
     /// <summary>
-    /// Activator.CreateInstance based service provider.
+    /// Gets an instance of the specified type. Returns <see langword="null"/> for interfaces.
+    /// Can not return <see langword="null"/> for classes but may throw exception.
     /// </summary>
-    /// <seealso cref="IServiceProvider" />
-    public sealed class DefaultServiceProvider : IServiceProvider
+    /// <param name="serviceType">Desired type</param>
+    /// <returns>An instance of <paramref name="serviceType"/>.</returns>
+    public object? GetService(Type serviceType)
     {
-        /// <summary>
-        /// Gets an instance of the specified type. Returns <see langword="null"/> for interfaces.
-        /// Can not return <see langword="null"/> for classes but may throw exception.
-        /// </summary>
-        /// <param name="serviceType">Desired type</param>
-        /// <returns>An instance of <paramref name="serviceType"/>.</returns>
-        public object? GetService(Type serviceType)
+        if (serviceType == null)
+            throw new ArgumentNullException(nameof(serviceType));
+
+        if (serviceType == typeof(IServiceProvider) || serviceType == typeof(DefaultServiceProvider))
+            return this;
+
+        if (serviceType.IsInterface || serviceType.IsAbstract || serviceType.IsGenericTypeDefinition)
+            return null;
+
+        try
         {
-            if (serviceType == null)
-                throw new ArgumentNullException(nameof(serviceType));
-
-            if (serviceType == typeof(IServiceProvider) || serviceType == typeof(DefaultServiceProvider))
-                return this;
-
-            if (serviceType.IsInterface || serviceType.IsAbstract || serviceType.IsGenericTypeDefinition)
-                return null;
-
-            try
-            {
-                return Activator.CreateInstance(serviceType);
-            }
-            catch (Exception exception)
-            {
-                throw new Exception($"Failed to call Activator.CreateInstance. Type: {serviceType.FullName}", exception);
-            }
+            return Activator.CreateInstance(serviceType);
+        }
+        catch (Exception exception)
+        {
+            throw new Exception($"Failed to call Activator.CreateInstance. Type: {serviceType.FullName}", exception);
         }
     }
 }

--- a/src/GraphQL/DI/FuncServiceProvider.cs
+++ b/src/GraphQL/DI/FuncServiceProvider.cs
@@ -1,27 +1,26 @@
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Func based service provider.
+/// </summary>
+/// <seealso cref="IServiceProvider" />
+/// <remarks>This is mainly used as an adapter for other service providers such as DI frameworks.</remarks>
+public sealed class FuncServiceProvider : IServiceProvider
 {
+    private readonly Func<Type, object?> _resolver;
+
     /// <summary>
-    /// Func based service provider.
+    /// Initializes a new instance of the <see cref="FuncServiceProvider"/> class.
     /// </summary>
-    /// <seealso cref="IServiceProvider" />
-    /// <remarks>This is mainly used as an adapter for other service providers such as DI frameworks.</remarks>
-    public sealed class FuncServiceProvider : IServiceProvider
+    /// <param name="resolver">The resolver function.</param>
+    public FuncServiceProvider(Func<Type, object?> resolver)
     {
-        private readonly Func<Type, object?> _resolver;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FuncServiceProvider"/> class.
-        /// </summary>
-        /// <param name="resolver">The resolver function.</param>
-        public FuncServiceProvider(Func<Type, object?> resolver)
-        {
-            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
-        }
-
-        /// <summary>
-        /// Gets an instance of the specified type. May return <see langword="null"/>. Also you can use GetRequiredService extension method.
-        /// </summary>
-        /// <param name="type">Desired type</param>
-        public object? GetService(Type type) => _resolver(type);
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
     }
+
+    /// <summary>
+    /// Gets an instance of the specified type. May return <see langword="null"/>. Also you can use GetRequiredService extension method.
+    /// </summary>
+    /// <param name="type">Desired type</param>
+    public object? GetService(Type type) => _resolver(type);
 }

--- a/src/GraphQL/DI/GraphQLBuilderBase.cs
+++ b/src/GraphQL/DI/GraphQLBuilderBase.cs
@@ -6,87 +6,86 @@ using GraphQL.Types;
 using GraphQL.Types.Relay;
 using GraphQL.Validation;
 
-namespace GraphQL.DI
+namespace GraphQL.DI;
+
+/// <summary>
+/// Base implementation of <see cref="IGraphQLBuilder"/>.
+/// </summary>
+public abstract class GraphQLBuilderBase : IGraphQLBuilder
 {
     /// <summary>
-    /// Base implementation of <see cref="IGraphQLBuilder"/>.
+    /// Register the default services required by GraphQL if they have not already been registered.
+    /// Includes graph types required for connection builders (GraphQL Relay) and generic graph types
+    /// such as <see cref="EnumerationGraphType{TEnum}"/> and <see cref="AutoRegisteringObjectGraphType{TSourceType}"/>.
+    /// <br/><br/>
+    /// Does not include <see cref="IGraphQLSerializer"/>, and the default <see cref="IDocumentExecuter"/>
+    /// implementation does not support subscriptions.
     /// </summary>
-    public abstract class GraphQLBuilderBase : IGraphQLBuilder
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ErrorInfoProviderOptions))] // TODO: this should be preserved by the call to Configure<ErrorInfoProviderOptions>(), but it is not
+    protected virtual void RegisterDefaultServices()
     {
-        /// <summary>
-        /// Register the default services required by GraphQL if they have not already been registered.
-        /// Includes graph types required for connection builders (GraphQL Relay) and generic graph types
-        /// such as <see cref="EnumerationGraphType{TEnum}"/> and <see cref="AutoRegisteringObjectGraphType{TSourceType}"/>.
-        /// <br/><br/>
-        /// Does not include <see cref="IGraphQLSerializer"/>, and the default <see cref="IDocumentExecuter"/>
-        /// implementation does not support subscriptions.
-        /// </summary>
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ErrorInfoProviderOptions))] // TODO: this should be preserved by the call to Configure<ErrorInfoProviderOptions>(), but it is not
-        protected virtual void RegisterDefaultServices()
+        // configure an error to be displayed when no IGraphQLSerializer is registered
+        Services.TryRegister<IGraphQLSerializer>(_ =>
         {
-            // configure an error to be displayed when no IGraphQLSerializer is registered
-            Services.TryRegister<IGraphQLSerializer>(_ =>
+            throw new InvalidOperationException(
+                "IGraphQLSerializer not set in DI container. " +
+                "Add a IGraphQLSerializer implementation, for example " +
+                "GraphQL.SystemTextJson.GraphQLSerializer or GraphQL.NewtonsoftJson.GraphQLSerializer. " +
+                "For more information, see: https://github.com/graphql-dotnet/graphql-dotnet/blob/master/README.md.");
+        }, ServiceLifetime.Transient);
+        // configure an error to be displayed when no IGraphQLTextSerializer is registered
+        Services.TryRegister<IGraphQLTextSerializer>(_ =>
+        {
+            throw new InvalidOperationException(
+                "IGraphQLTextSerializer not set in DI container. " +
+                "Add a IGraphQLTextSerializer implementation, for example " +
+                "GraphQL.SystemTextJson.GraphQLSerializer or GraphQL.NewtonsoftJson.GraphQLSerializer. " +
+                "For more information, see: https://github.com/graphql-dotnet/graphql-dotnet/blob/master/README.md.");
+        }, ServiceLifetime.Transient);
+
+        // configure service implementations to use the configured default services when not overridden by a user
+        Services.TryRegister<IDocumentExecuter, DocumentExecuter>(ServiceLifetime.Singleton);
+        Services.TryRegister(typeof(IDocumentExecuter<>), typeof(DocumentExecuter<>), ServiceLifetime.Singleton);
+        Services.TryRegister<IDocumentBuilder, GraphQLDocumentBuilder>(ServiceLifetime.Singleton);
+        Services.TryRegister<IDocumentValidator, DocumentValidator>(ServiceLifetime.Singleton);
+        Services.TryRegister<IErrorInfoProvider, ErrorInfoProvider>(ServiceLifetime.Singleton);
+        Services.TryRegister<IExecutionStrategySelector, DefaultExecutionStrategySelector>(ServiceLifetime.Singleton);
+
+        // configure relay graph types
+        Services.TryRegister(typeof(EdgeType<>), typeof(EdgeType<>), ServiceLifetime.Transient);
+        Services.TryRegister(typeof(ConnectionType<>), typeof(ConnectionType<>), ServiceLifetime.Transient);
+        Services.TryRegister(typeof(ConnectionType<,>), typeof(ConnectionType<,>), ServiceLifetime.Transient);
+        Services.TryRegister<PageInfoType>(ServiceLifetime.Transient);
+
+        // configure generic graph types
+        Services.TryRegister(typeof(EnumerationGraphType<>), typeof(EnumerationGraphType<>), ServiceLifetime.Transient);
+        Services.TryRegister(typeof(InputObjectGraphType<>), typeof(InputObjectGraphType<>), ServiceLifetime.Transient);
+        Services.TryRegister(typeof(AutoRegisteringInputObjectGraphType<>), typeof(AutoRegisteringInputObjectGraphType<>), ServiceLifetime.Transient);
+        Services.TryRegister(typeof(AutoRegisteringObjectGraphType<>), typeof(AutoRegisteringObjectGraphType<>), ServiceLifetime.Transient);
+        Services.TryRegister(typeof(AutoRegisteringInterfaceGraphType<>), typeof(AutoRegisteringInterfaceGraphType<>), ServiceLifetime.Transient);
+
+        // configure execution to use the default registered schema if none specified
+        this.ConfigureExecutionOptions(options =>
+        {
+            if (options.RequestServices != null && options.Schema == null)
             {
-                throw new InvalidOperationException(
-                    "IGraphQLSerializer not set in DI container. " +
-                    "Add a IGraphQLSerializer implementation, for example " +
-                    "GraphQL.SystemTextJson.GraphQLSerializer or GraphQL.NewtonsoftJson.GraphQLSerializer. " +
-                    "For more information, see: https://github.com/graphql-dotnet/graphql-dotnet/blob/master/README.md.");
-            }, ServiceLifetime.Transient);
-            // configure an error to be displayed when no IGraphQLTextSerializer is registered
-            Services.TryRegister<IGraphQLTextSerializer>(_ =>
-            {
-                throw new InvalidOperationException(
-                    "IGraphQLTextSerializer not set in DI container. " +
-                    "Add a IGraphQLTextSerializer implementation, for example " +
-                    "GraphQL.SystemTextJson.GraphQLSerializer or GraphQL.NewtonsoftJson.GraphQLSerializer. " +
-                    "For more information, see: https://github.com/graphql-dotnet/graphql-dotnet/blob/master/README.md.");
-            }, ServiceLifetime.Transient);
+                options.Schema = options.RequestServices.GetService(typeof(ISchema)) as ISchema;
+            }
+        });
 
-            // configure service implementations to use the configured default services when not overridden by a user
-            Services.TryRegister<IDocumentExecuter, DocumentExecuter>(ServiceLifetime.Singleton);
-            Services.TryRegister(typeof(IDocumentExecuter<>), typeof(DocumentExecuter<>), ServiceLifetime.Singleton);
-            Services.TryRegister<IDocumentBuilder, GraphQLDocumentBuilder>(ServiceLifetime.Singleton);
-            Services.TryRegister<IDocumentValidator, DocumentValidator>(ServiceLifetime.Singleton);
-            Services.TryRegister<IErrorInfoProvider, ErrorInfoProvider>(ServiceLifetime.Singleton);
-            Services.TryRegister<IExecutionStrategySelector, DefaultExecutionStrategySelector>(ServiceLifetime.Singleton);
-
-            // configure relay graph types
-            Services.TryRegister(typeof(EdgeType<>), typeof(EdgeType<>), ServiceLifetime.Transient);
-            Services.TryRegister(typeof(ConnectionType<>), typeof(ConnectionType<>), ServiceLifetime.Transient);
-            Services.TryRegister(typeof(ConnectionType<,>), typeof(ConnectionType<,>), ServiceLifetime.Transient);
-            Services.TryRegister<PageInfoType>(ServiceLifetime.Transient);
-
-            // configure generic graph types
-            Services.TryRegister(typeof(EnumerationGraphType<>), typeof(EnumerationGraphType<>), ServiceLifetime.Transient);
-            Services.TryRegister(typeof(InputObjectGraphType<>), typeof(InputObjectGraphType<>), ServiceLifetime.Transient);
-            Services.TryRegister(typeof(AutoRegisteringInputObjectGraphType<>), typeof(AutoRegisteringInputObjectGraphType<>), ServiceLifetime.Transient);
-            Services.TryRegister(typeof(AutoRegisteringObjectGraphType<>), typeof(AutoRegisteringObjectGraphType<>), ServiceLifetime.Transient);
-            Services.TryRegister(typeof(AutoRegisteringInterfaceGraphType<>), typeof(AutoRegisteringInterfaceGraphType<>), ServiceLifetime.Transient);
-
-            // configure execution to use the default registered schema if none specified
-            this.ConfigureExecutionOptions(options =>
-            {
-                if (options.RequestServices != null && options.Schema == null)
-                {
-                    options.Schema = options.RequestServices.GetService(typeof(ISchema)) as ISchema;
-                }
-            });
-
-            // configure mapping for IOptions<ErrorInfoProviderOptions>
-            Services.Configure<ErrorInfoProviderOptions>();
+        // configure mapping for IOptions<ErrorInfoProviderOptions>
+        Services.Configure<ErrorInfoProviderOptions>();
 
 #if NET5_0_OR_GREATER
-            if (OpenTelemetry.AutoInstrumentation.Initializer.Enabled)
-            {
-                // this will run prior to any other calls to UseTelemetry
-                // it will also cause telemetry to be called first in the pipeline
-                this.ConfigureExecution(GraphQLTelemetryProvider.AutoTelemetryProvider);
-            }
-#endif
+        if (OpenTelemetry.AutoInstrumentation.Initializer.Enabled)
+        {
+            // this will run prior to any other calls to UseTelemetry
+            // it will also cause telemetry to be called first in the pipeline
+            this.ConfigureExecution(GraphQLTelemetryProvider.AutoTelemetryProvider);
         }
-
-        /// <inheritdoc />
-        public abstract IServiceRegister Services { get; }
+#endif
     }
+
+    /// <inheritdoc />
+    public abstract IServiceRegister Services { get; }
 }

--- a/src/GraphQL/DI/IConfigureExecution.cs
+++ b/src/GraphQL/DI/IConfigureExecution.cs
@@ -1,52 +1,51 @@
-namespace GraphQL.DI
+namespace GraphQL.DI;
+
+/// <summary>
+/// Allows configuration of document execution, adding or replacing default behavior.
+/// This configuration generally happens in <see cref="IDocumentExecuter.ExecuteAsync" /> implementations.
+/// </summary>
+public interface IConfigureExecution
 {
     /// <summary>
-    /// Allows configuration of document execution, adding or replacing default behavior.
-    /// This configuration generally happens in <see cref="IDocumentExecuter.ExecuteAsync" /> implementations.
+    /// Called when the document begins executing, passing in a delegate to continue execution.
     /// </summary>
-    public interface IConfigureExecution
-    {
-        /// <summary>
-        /// Called when the document begins executing, passing in a delegate to continue execution.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="ExecutionOptions.RequestServices"/> can be used to resolve other services from the dependency injection framework.
-        /// </remarks>
-        Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next);
-
-        /// <summary>
-        /// Determines the order of the registered <see cref="IConfigureExecution"/> instances;
-        /// the lowest order executes first; instances with the same value execute in the same
-        /// order they were registered, assuming the dependency injection provider returns
-        /// instances in the order they were registered.
-        /// <para>
-        /// The default sort order of configurations are as follows:
-        /// </para>
-        /// <list type="bullet">
-        /// <item>100: Option configurations -- 'Add' calls such as <see cref="GraphQLBuilderExtensions.AddValidationRule{TValidationRule}(IGraphQLBuilder, bool, ServiceLifetime)">AddValidationRule</see>, and <see cref="GraphQLBuilderExtensions.ConfigureExecutionOptions(IGraphQLBuilder, Action{ExecutionOptions})">ConfigureExecutionOptions</see> calls</item>
-        /// <item>200: Execution configurations -- 'Use' calls such as <see cref="GraphQLBuilderExtensions.UseApolloTracing(IGraphQLBuilder, bool)">UseApolloTracing</see>, and <see cref="GraphQLBuilderExtensions.ConfigureExecution(IGraphQLBuilder, Func{ExecutionOptions, ExecutionDelegate, Task{ExecutionResult}})">ConfigureExecution</see> calls</item>
-        /// </list>
-        /// </summary>
-        float SortOrder { get; }
-    }
+    /// <remarks>
+    /// <see cref="ExecutionOptions.RequestServices"/> can be used to resolve other services from the dependency injection framework.
+    /// </remarks>
+    Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next);
 
     /// <summary>
-    /// A function that can process a GraphQL document.
+    /// Determines the order of the registered <see cref="IConfigureExecution"/> instances;
+    /// the lowest order executes first; instances with the same value execute in the same
+    /// order they were registered, assuming the dependency injection provider returns
+    /// instances in the order they were registered.
+    /// <para>
+    /// The default sort order of configurations are as follows:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>100: Option configurations -- 'Add' calls such as <see cref="GraphQLBuilderExtensions.AddValidationRule{TValidationRule}(IGraphQLBuilder, bool, ServiceLifetime)">AddValidationRule</see>, and <see cref="GraphQLBuilderExtensions.ConfigureExecutionOptions(IGraphQLBuilder, Action{ExecutionOptions})">ConfigureExecutionOptions</see> calls</item>
+    /// <item>200: Execution configurations -- 'Use' calls such as <see cref="GraphQLBuilderExtensions.UseApolloTracing(IGraphQLBuilder, bool)">UseApolloTracing</see>, and <see cref="GraphQLBuilderExtensions.ConfigureExecution(IGraphQLBuilder, Func{ExecutionOptions, ExecutionDelegate, Task{ExecutionResult}})">ConfigureExecution</see> calls</item>
+    /// </list>
     /// </summary>
-    public delegate Task<ExecutionResult> ExecutionDelegate(ExecutionOptions options);
+    float SortOrder { get; }
+}
 
-    internal class ConfigureExecution : IConfigureExecution
+/// <summary>
+/// A function that can process a GraphQL document.
+/// </summary>
+public delegate Task<ExecutionResult> ExecutionDelegate(ExecutionOptions options);
+
+internal class ConfigureExecution : IConfigureExecution
+{
+    private readonly Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> _action;
+
+    public ConfigureExecution(Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> action)
     {
-        private readonly Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> _action;
-
-        public ConfigureExecution(Func<ExecutionOptions, ExecutionDelegate, Task<ExecutionResult>> action)
-        {
-            _action = action;
-        }
-
-        public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
-            => _action(options, next);
-
-        public float SortOrder => GraphQLBuilderExtensions.SORT_ORDER_CONFIGURATION;
+        _action = action;
     }
+
+    public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
+        => _action(options, next);
+
+    public float SortOrder => GraphQLBuilderExtensions.SORT_ORDER_CONFIGURATION;
 }

--- a/src/GraphQL/DI/IConfigureSchema.cs
+++ b/src/GraphQL/DI/IConfigureSchema.cs
@@ -1,36 +1,35 @@
 using GraphQL.Types;
 
-namespace GraphQL.DI
+namespace GraphQL.DI;
+
+/// <summary>
+/// Allows configuration of a schema prior to the code in its constructor.
+/// <br/><br/>
+/// Typically executes during the <see cref="Schema"/> constructor,
+/// which executes prior to any descendant classes' constructors.
+/// </summary>
+public interface IConfigureSchema
 {
     /// <summary>
-    /// Allows configuration of a schema prior to the code in its constructor.
+    /// Configures a schema prior to the code in its constructor.
     /// <br/><br/>
-    /// Typically executes during the <see cref="Schema"/> constructor,
+    /// Specifically, typically executes during the <see cref="Schema"/> constructor,
     /// which executes prior to any descendant classes' constructors.
     /// </summary>
-    public interface IConfigureSchema
+    void Configure(ISchema schema, IServiceProvider serviceProvider);
+}
+
+internal sealed class ConfigureSchema : IConfigureSchema
+{
+    private readonly Action<ISchema, IServiceProvider> _action;
+
+    public ConfigureSchema(Action<ISchema, IServiceProvider> action)
     {
-        /// <summary>
-        /// Configures a schema prior to the code in its constructor.
-        /// <br/><br/>
-        /// Specifically, typically executes during the <see cref="Schema"/> constructor,
-        /// which executes prior to any descendant classes' constructors.
-        /// </summary>
-        void Configure(ISchema schema, IServiceProvider serviceProvider);
+        _action = action ?? throw new ArgumentNullException(nameof(action));
     }
 
-    internal sealed class ConfigureSchema : IConfigureSchema
+    public void Configure(ISchema schema, IServiceProvider serviceProvider)
     {
-        private readonly Action<ISchema, IServiceProvider> _action;
-
-        public ConfigureSchema(Action<ISchema, IServiceProvider> action)
-        {
-            _action = action ?? throw new ArgumentNullException(nameof(action));
-        }
-
-        public void Configure(ISchema schema, IServiceProvider serviceProvider)
-        {
-            _action(schema, serviceProvider);
-        }
+        _action(schema, serviceProvider);
     }
 }

--- a/src/GraphQL/DI/IGraphQLBuilder.cs
+++ b/src/GraphQL/DI/IGraphQLBuilder.cs
@@ -1,13 +1,12 @@
-namespace GraphQL.DI
+namespace GraphQL.DI;
+
+/// <summary>
+/// An interface for configuring GraphQL.NET services.
+/// </summary>
+public interface IGraphQLBuilder
 {
     /// <summary>
-    /// An interface for configuring GraphQL.NET services.
+    /// Provides an interface for registering services with the dependency injection provider.
     /// </summary>
-    public interface IGraphQLBuilder
-    {
-        /// <summary>
-        /// Provides an interface for registering services with the dependency injection provider.
-        /// </summary>
-        IServiceRegister Services { get; }
-    }
+    IServiceRegister Services { get; }
 }

--- a/src/GraphQL/DI/IServiceRegister.cs
+++ b/src/GraphQL/DI/IServiceRegister.cs
@@ -1,63 +1,62 @@
-namespace GraphQL.DI
+namespace GraphQL.DI;
+
+/// <summary>
+/// An interface for registering services with the dependency injection provider.
+/// </summary>
+public interface IServiceRegister
 {
     /// <summary>
-    /// An interface for registering services with the dependency injection provider.
+    /// Registers the service of type <paramref name="serviceType"/> with the dependency injection provider.
+    /// Optionally removes any existing implementation of the same service type.
+    /// When not replacing existing registrations, requesting the service type should return the most recent registration,
+    /// and requesting an <see cref="IEnumerable{T}"/> of the service type should return all of the registrations.
     /// </summary>
-    public interface IServiceRegister
-    {
-        /// <summary>
-        /// Registers the service of type <paramref name="serviceType"/> with the dependency injection provider.
-        /// Optionally removes any existing implementation of the same service type.
-        /// When not replacing existing registrations, requesting the service type should return the most recent registration,
-        /// and requesting an <see cref="IEnumerable{T}"/> of the service type should return all of the registrations.
-        /// </summary>
-        IServiceRegister Register(
-            Type serviceType,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
-            ServiceLifetime serviceLifetime,
-            bool replace = false);
+    IServiceRegister Register(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
+        ServiceLifetime serviceLifetime,
+        bool replace = false);
 
-        /// <inheritdoc cref="Register(Type, Type, ServiceLifetime, bool)"/>
-        IServiceRegister Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime, bool replace = false);
+    /// <inheritdoc cref="Register(Type, Type, ServiceLifetime, bool)"/>
+    IServiceRegister Register(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime, bool replace = false);
 
-        /// <inheritdoc cref="Register(Type, Type, ServiceLifetime, bool)"/>
-        IServiceRegister Register(Type serviceType, object implementationInstance, bool replace = false);
+    /// <inheritdoc cref="Register(Type, Type, ServiceLifetime, bool)"/>
+    IServiceRegister Register(Type serviceType, object implementationInstance, bool replace = false);
 
-        /// <summary>
-        /// Registers the service of type <paramref name="serviceType"/> with the dependency
-        /// injection provider if a service of the same type (and of the same implementation type
-        /// in case of <see cref="RegistrationCompareMode.ServiceTypeAndImplementationType"/>)
-        /// has not already been registered.
-        /// </summary>
-        IServiceRegister TryRegister(
-            Type serviceType,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
-            ServiceLifetime serviceLifetime,
-            RegistrationCompareMode mode = RegistrationCompareMode.ServiceType);
+    /// <summary>
+    /// Registers the service of type <paramref name="serviceType"/> with the dependency
+    /// injection provider if a service of the same type (and of the same implementation type
+    /// in case of <see cref="RegistrationCompareMode.ServiceTypeAndImplementationType"/>)
+    /// has not already been registered.
+    /// </summary>
+    IServiceRegister TryRegister(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
+        ServiceLifetime serviceLifetime,
+        RegistrationCompareMode mode = RegistrationCompareMode.ServiceType);
 
-        /// <summary>
-        /// Registers the service of type <paramref name="serviceType"/> with the dependency
-        /// injection provider if a service of the same type (and of the same implementation type
-        /// in case of <see cref="RegistrationCompareMode.ServiceTypeAndImplementationType"/>)
-        /// has not already been registered.
-        /// <br/><br/>
-        /// With <see cref="RegistrationCompareMode.ServiceTypeAndImplementationType"/>, it is required
-        /// that <paramref name="implementationFactory"/> is a strongly typed delegate with a return type
-        /// of a specific implementation type.
-        /// </summary>
-        IServiceRegister TryRegister(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime, RegistrationCompareMode mode = RegistrationCompareMode.ServiceType);
+    /// <summary>
+    /// Registers the service of type <paramref name="serviceType"/> with the dependency
+    /// injection provider if a service of the same type (and of the same implementation type
+    /// in case of <see cref="RegistrationCompareMode.ServiceTypeAndImplementationType"/>)
+    /// has not already been registered.
+    /// <br/><br/>
+    /// With <see cref="RegistrationCompareMode.ServiceTypeAndImplementationType"/>, it is required
+    /// that <paramref name="implementationFactory"/> is a strongly typed delegate with a return type
+    /// of a specific implementation type.
+    /// </summary>
+    IServiceRegister TryRegister(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime serviceLifetime, RegistrationCompareMode mode = RegistrationCompareMode.ServiceType);
 
-        /// <inheritdoc cref="TryRegister(Type, Type, ServiceLifetime, RegistrationCompareMode)"/>
-        IServiceRegister TryRegister(Type serviceType, object implementationInstance, RegistrationCompareMode mode = RegistrationCompareMode.ServiceType);
+    /// <inheritdoc cref="TryRegister(Type, Type, ServiceLifetime, RegistrationCompareMode)"/>
+    IServiceRegister TryRegister(Type serviceType, object implementationInstance, RegistrationCompareMode mode = RegistrationCompareMode.ServiceType);
 
-        /// <summary>
-        /// Configures an options class of type <typeparamref name="TOptions"/>. Each registration call to this method
-        /// will be applied to instance of <typeparamref name="TOptions"/> returned from the DI engine.
-        /// <br/><br/>
-        /// If <paramref name="action"/> is <see langword="null"/> then <typeparamref name="TOptions"/> is still configured and
-        /// will return a default instance (unless otherwise configured with a subsequent call to <see cref="Configure{TOptions}(Action{TOptions, IServiceProvider}?)">Configure</see>).
-        /// </summary>
-        IServiceRegister Configure<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(Action<TOptions, IServiceProvider>? action = null)
-            where TOptions : class, new();
-    }
+    /// <summary>
+    /// Configures an options class of type <typeparamref name="TOptions"/>. Each registration call to this method
+    /// will be applied to instance of <typeparamref name="TOptions"/> returned from the DI engine.
+    /// <br/><br/>
+    /// If <paramref name="action"/> is <see langword="null"/> then <typeparamref name="TOptions"/> is still configured and
+    /// will return a default instance (unless otherwise configured with a subsequent call to <see cref="Configure{TOptions}(Action{TOptions, IServiceProvider}?)">Configure</see>).
+    /// </summary>
+    IServiceRegister Configure<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(Action<TOptions, IServiceProvider>? action = null)
+        where TOptions : class, new();
 }

--- a/src/GraphQL/DI/RegistrationCompareMode.cs
+++ b/src/GraphQL/DI/RegistrationCompareMode.cs
@@ -1,22 +1,21 @@
-namespace GraphQL.DI
+namespace GraphQL.DI;
+
+/// <summary>
+/// Comparison mode used for <see cref="IServiceRegister.TryRegister(Type, Type, ServiceLifetime, RegistrationCompareMode)">IServiceRegister.TryRegister</see>
+/// methods.
+/// </summary>
+public enum RegistrationCompareMode
 {
     /// <summary>
-    /// Comparison mode used for <see cref="IServiceRegister.TryRegister(Type, Type, ServiceLifetime, RegistrationCompareMode)">IServiceRegister.TryRegister</see>
-    /// methods.
+    /// Registers the service with the dependency injection provider
+    /// if a service of the same service type has not already been registered.
     /// </summary>
-    public enum RegistrationCompareMode
-    {
-        /// <summary>
-        /// Registers the service with the dependency injection provider
-        /// if a service of the same service type has not already been registered.
-        /// </summary>
-        ServiceType,
+    ServiceType,
 
-        /// <summary>
-        /// Registers the service with the dependency injection provider
-        /// if a service of the same service type and same implementation type
-        /// has not already been registered.
-        /// </summary>
-        ServiceTypeAndImplementationType
-    }
+    /// <summary>
+    /// Registers the service with the dependency injection provider
+    /// if a service of the same service type and same implementation type
+    /// has not already been registered.
+    /// </summary>
+    ServiceTypeAndImplementationType
 }

--- a/src/GraphQL/DI/ServiceLifetime.cs
+++ b/src/GraphQL/DI/ServiceLifetime.cs
@@ -1,26 +1,25 @@
-namespace GraphQL.DI
+namespace GraphQL.DI;
+
+/// <summary>
+/// Specifies the lifetime of a service.
+/// </summary>
+public enum ServiceLifetime
 {
     /// <summary>
-    /// Specifies the lifetime of a service.
+    /// Specifies that a single instance of the service will be created.
     /// </summary>
-    public enum ServiceLifetime
-    {
-        /// <summary>
-        /// Specifies that a single instance of the service will be created.
-        /// </summary>
-        Singleton,
+    Singleton,
 
-        /// <summary>
-        /// Specifies that a new instance of the service will be created for each scope.
-        /// </summary>
-        /// <remarks>
-        /// In ASP.NET Core applications a scope is created around each server request.
-        /// </remarks>
-        Scoped,
+    /// <summary>
+    /// Specifies that a new instance of the service will be created for each scope.
+    /// </summary>
+    /// <remarks>
+    /// In ASP.NET Core applications a scope is created around each server request.
+    /// </remarks>
+    Scoped,
 
-        /// <summary>
-        /// Specifies that a new instance of the service will be created every time it is requested.
-        /// </summary>
-        Transient,
-    }
+    /// <summary>
+    /// Specifies that a new instance of the service will be created every time it is requested.
+    /// </summary>
+    Transient,
 }

--- a/src/GraphQL/DataLoader/IDataLoaderResult.cs
+++ b/src/GraphQL/DataLoader/IDataLoaderResult.cs
@@ -1,27 +1,26 @@
-namespace GraphQL.DataLoader
+namespace GraphQL.DataLoader;
+
+/// <summary>
+/// Represents a pending operation that can return a value
+/// </summary>
+/// <typeparam name="T">The type of value that is returned</typeparam>
+public interface IDataLoaderResult<[NotAGraphType] T> : IDataLoaderResult
 {
     /// <summary>
-    /// Represents a pending operation that can return a value
+    /// Asynchronously executes the loader if it has not yet been executed; then returns the result
     /// </summary>
-    /// <typeparam name="T">The type of value that is returned</typeparam>
-    public interface IDataLoaderResult<[NotAGraphType] T> : IDataLoaderResult
-    {
-        /// <summary>
-        /// Asynchronously executes the loader if it has not yet been executed; then returns the result
-        /// </summary>
-        /// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to pass to fetch delegate</param>
-        new Task<T> GetResultAsync(CancellationToken cancellationToken = default);
-    }
+    /// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to pass to fetch delegate</param>
+    new Task<T> GetResultAsync(CancellationToken cancellationToken = default);
+}
 
+/// <summary>
+/// Represents a pending operation that can return a value
+/// </summary>
+public interface IDataLoaderResult
+{
     /// <summary>
-    /// Represents a pending operation that can return a value
+    /// Asynchronously executes the loader if it has not yet been executed; then returns the result
     /// </summary>
-    public interface IDataLoaderResult
-    {
-        /// <summary>
-        /// Asynchronously executes the loader if it has not yet been executed; then returns the result
-        /// </summary>
-        /// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to pass to fetch delegate</param>
-        Task<object?> GetResultAsync(CancellationToken cancellationToken = default);
-    }
+    /// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to pass to fetch delegate</param>
+    Task<object?> GetResultAsync(CancellationToken cancellationToken = default);
 }

--- a/src/GraphQL/Execution/ArgumentValue.cs
+++ b/src/GraphQL/Execution/ArgumentValue.cs
@@ -1,63 +1,62 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents the value of an argument.
+/// </summary>
+public readonly struct ArgumentValue
 {
     /// <summary>
-    /// Represents the value of an argument.
+    /// Returns an instance of this struct containing a <see langword="null"/> value supplied as a literal.
     /// </summary>
-    public readonly struct ArgumentValue
+    public static ArgumentValue NullLiteral => new(null, ArgumentSource.Literal);
+
+    /// <summary>
+    /// Returns an instance of this struct containing a <see langword="null"/> value supplied as a variable.
+    /// </summary>
+    public static ArgumentValue NullVariable => new(null, ArgumentSource.Variable);
+
+    /// <summary>
+    /// Initializes a new instance with the specified values.
+    /// </summary>
+    public ArgumentValue(object? value, ArgumentSource source)
     {
-        /// <summary>
-        /// Returns an instance of this struct containing a <see langword="null"/> value supplied as a literal.
-        /// </summary>
-        public static ArgumentValue NullLiteral => new(null, ArgumentSource.Literal);
-
-        /// <summary>
-        /// Returns an instance of this struct containing a <see langword="null"/> value supplied as a variable.
-        /// </summary>
-        public static ArgumentValue NullVariable => new(null, ArgumentSource.Variable);
-
-        /// <summary>
-        /// Initializes a new instance with the specified values.
-        /// </summary>
-        public ArgumentValue(object? value, ArgumentSource source)
-        {
-            Value = value;
-            Source = source;
-        }
-
-        /// <summary>
-        /// Returns the value of the argument.
-        /// </summary>
-        public object? Value { get; }
-
-        /// <summary>
-        /// Returns a value indicating the source of the argument's value.
-        /// </summary>
-        public ArgumentSource Source { get; }
+        Value = value;
+        Source = source;
     }
 
     /// <summary>
-    /// The source of an argument's value.
+    /// Returns the value of the argument.
     /// </summary>
-    public enum ArgumentSource
-    {
-        /// <summary>
-        /// The field default value.
-        /// </summary>
-        FieldDefault,
+    public object? Value { get; }
 
-        /// <summary>
-        /// A literal value supplied for the argument.
-        /// </summary>
-        Literal,
+    /// <summary>
+    /// Returns a value indicating the source of the argument's value.
+    /// </summary>
+    public ArgumentSource Source { get; }
+}
 
-        /// <summary>
-        /// A variable referenced by the argument.
-        /// </summary>
-        Variable,
+/// <summary>
+/// The source of an argument's value.
+/// </summary>
+public enum ArgumentSource
+{
+    /// <summary>
+    /// The field default value.
+    /// </summary>
+    FieldDefault,
 
-        /// <summary>
-        /// A default value for a variable referenced by the argument.
-        /// </summary>
-        VariableDefault,
-    }
+    /// <summary>
+    /// A literal value supplied for the argument.
+    /// </summary>
+    Literal,
+
+    /// <summary>
+    /// A variable referenced by the argument.
+    /// </summary>
+    Variable,
+
+    /// <summary>
+    /// A default value for a variable referenced by the argument.
+    /// </summary>
+    VariableDefault,
 }

--- a/src/GraphQL/Execution/DefaultExecutionStrategySelector.cs
+++ b/src/GraphQL/Execution/DefaultExecutionStrategySelector.cs
@@ -1,50 +1,49 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <inheritdoc cref="IExecutionStrategySelector"/>
+public class DefaultExecutionStrategySelector : IExecutionStrategySelector
 {
-    /// <inheritdoc cref="IExecutionStrategySelector"/>
-    public class DefaultExecutionStrategySelector : IExecutionStrategySelector
+    private readonly ExecutionStrategyRegistration[] _registrations;
+
+    /// <summary>
+    /// Initializes an instance that only returns the default registrations;
+    /// <see cref="ParallelExecutionStrategy"/> for <see cref="OperationType.Query"/> and
+    /// <see cref="SerialExecutionStrategy"/> for <see cref="OperationType.Mutation"/>.
+    /// </summary>
+    public DefaultExecutionStrategySelector()
+        : this(Array.Empty<ExecutionStrategyRegistration>())
     {
-        private readonly ExecutionStrategyRegistration[] _registrations;
+    }
 
-        /// <summary>
-        /// Initializes an instance that only returns the default registrations;
-        /// <see cref="ParallelExecutionStrategy"/> for <see cref="OperationType.Query"/> and
-        /// <see cref="SerialExecutionStrategy"/> for <see cref="OperationType.Mutation"/>.
-        /// </summary>
-        public DefaultExecutionStrategySelector()
-            : this(Array.Empty<ExecutionStrategyRegistration>())
+    /// <summary>
+    /// Initializes a new instance with the specified registrations.
+    /// If no registration is specified for <see cref="OperationType.Query"/>, returns <see cref="ParallelExecutionStrategy"/>.
+    /// If no registration is specified for <see cref="OperationType.Mutation"/>, returns <see cref="SerialExecutionStrategy"/>.
+    /// </summary>
+    public DefaultExecutionStrategySelector(IEnumerable<ExecutionStrategyRegistration> registrations)
+    {
+        _registrations = (registrations ?? throw new ArgumentNullException(nameof(registrations))).ToArray();
+    }
+
+    /// <inheritdoc/>
+    public virtual IExecutionStrategy Select(ExecutionContext context)
+    {
+        var operationType = context.Operation.Operation;
+
+        foreach (var registration in _registrations)
         {
+            if (registration.Operation == operationType)
+                return registration.Strategy;
         }
-
-        /// <summary>
-        /// Initializes a new instance with the specified registrations.
-        /// If no registration is specified for <see cref="OperationType.Query"/>, returns <see cref="ParallelExecutionStrategy"/>.
-        /// If no registration is specified for <see cref="OperationType.Mutation"/>, returns <see cref="SerialExecutionStrategy"/>.
-        /// </summary>
-        public DefaultExecutionStrategySelector(IEnumerable<ExecutionStrategyRegistration> registrations)
+        // no matching registration, so return default implementation
+        return operationType switch
         {
-            _registrations = (registrations ?? throw new ArgumentNullException(nameof(registrations))).ToArray();
-        }
-
-        /// <inheritdoc/>
-        public virtual IExecutionStrategy Select(ExecutionContext context)
-        {
-            var operationType = context.Operation.Operation;
-
-            foreach (var registration in _registrations)
-            {
-                if (registration.Operation == operationType)
-                    return registration.Strategy;
-            }
-            // no matching registration, so return default implementation
-            return operationType switch
-            {
-                OperationType.Query => ParallelExecutionStrategy.Instance,
-                OperationType.Mutation => SerialExecutionStrategy.Instance,
-                OperationType.Subscription => SubscriptionExecutionStrategy.Instance,
-                _ => throw new InvalidOperationException($"Unexpected OperationType '{operationType}'.")
-            };
-        }
+            OperationType.Query => ParallelExecutionStrategy.Instance,
+            OperationType.Mutation => SerialExecutionStrategy.Instance,
+            OperationType.Subscription => SubscriptionExecutionStrategy.Instance,
+            _ => throw new InvalidOperationException($"Unexpected OperationType '{operationType}'.")
+        };
     }
 }

--- a/src/GraphQL/Execution/DirectiveInfo.cs
+++ b/src/GraphQL/Execution/DirectiveInfo.cs
@@ -1,79 +1,78 @@
 using GraphQL.Types;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents information about directive that has been provided in the GraphQL query request.
+/// </summary>
+public class DirectiveInfo
 {
     /// <summary>
-    /// Represents information about directive that has been provided in the GraphQL query request.
+    /// Creates an instance of <see cref="DirectiveInfo"/> with the specified
+    /// directive definition and directive arguments.
     /// </summary>
-    public class DirectiveInfo
+    public DirectiveInfo(Directive directive, IDictionary<string, ArgumentValue> arguments)
     {
-        /// <summary>
-        /// Creates an instance of <see cref="DirectiveInfo"/> with the specified
-        /// directive definition and directive arguments.
-        /// </summary>
-        public DirectiveInfo(Directive directive, IDictionary<string, ArgumentValue> arguments)
+        Directive = directive;
+        Arguments = arguments;
+    }
+
+    /// <summary>
+    /// Directive definition.
+    /// </summary>
+    public Directive Directive { get; }
+
+    /// <summary>
+    /// Dictionary of directive arguments.
+    /// </summary>
+    public IDictionary<string, ArgumentValue> Arguments { get; }
+
+    /// <summary>
+    /// Returns the value of the specified directive argument, or <paramref name="defaultValue"/> when
+    /// unspecified. Variable default values take precedence over the <paramref name="defaultValue"/> parameter.
+    /// </summary>
+    public TType GetArgument<TType>(string name, TType defaultValue = default!)
+    {
+        bool exists = TryGetArgument(typeof(TType), name, out object? result);
+        return exists
+            ? (TType)result!
+            : defaultValue;
+    }
+
+    /// <inheritdoc cref="GetArgument{TType}(string, TType)"/>
+    public object? GetArgument(Type argumentType, string name, object? defaultValue = null)
+    {
+        bool exists = TryGetArgument(argumentType, name, out object? result);
+        return exists
+            ? result
+            : defaultValue;
+    }
+
+    // initially copy-pasted from ResolveFieldContextExtensions.TryGetArgument and then modified
+    private bool TryGetArgument(Type argumentType, string name, out object? result)
+    {
+        if (Arguments == null || !Arguments.TryGetValue(name, out var arg))
         {
-            Directive = directive;
-            Arguments = arguments;
+            result = null;
+            return false;
         }
 
-        /// <summary>
-        /// Directive definition.
-        /// </summary>
-        public Directive Directive { get; }
+        var resolvedType = Directive.Arguments?.Find(name)?.ResolvedType
+            ?? throw new InvalidOperationException($"Could not obtain graph type instance for argument '{name}'");
 
-        /// <summary>
-        /// Dictionary of directive arguments.
-        /// </summary>
-        public IDictionary<string, ArgumentValue> Arguments { get; }
-
-        /// <summary>
-        /// Returns the value of the specified directive argument, or <paramref name="defaultValue"/> when
-        /// unspecified. Variable default values take precedence over the <paramref name="defaultValue"/> parameter.
-        /// </summary>
-        public TType GetArgument<TType>(string name, TType defaultValue = default!)
+        if (arg.Value is IDictionary<string, object?> inputObject)
         {
-            bool exists = TryGetArgument(typeof(TType), name, out object? result);
-            return exists
-                ? (TType)result!
-                : defaultValue;
-        }
-
-        /// <inheritdoc cref="GetArgument{TType}(string, TType)"/>
-        public object? GetArgument(Type argumentType, string name, object? defaultValue = null)
-        {
-            bool exists = TryGetArgument(argumentType, name, out object? result);
-            return exists
-                ? result
-                : defaultValue;
-        }
-
-        // initially copy-pasted from ResolveFieldContextExtensions.TryGetArgument and then modified
-        private bool TryGetArgument(Type argumentType, string name, out object? result)
-        {
-            if (Arguments == null || !Arguments.TryGetValue(name, out var arg))
+            if (argumentType == typeof(object))
             {
-                result = null;
-                return false;
-            }
-
-            var resolvedType = Directive.Arguments?.Find(name)?.ResolvedType
-                ?? throw new InvalidOperationException($"Could not obtain graph type instance for argument '{name}'");
-
-            if (arg.Value is IDictionary<string, object?> inputObject)
-            {
-                if (argumentType == typeof(object))
-                {
-                    result = arg.Value;
-                    return true;
-                }
-
-                result = inputObject.ToObject(argumentType, resolvedType);
+                result = arg.Value;
                 return true;
             }
 
-            result = arg.Value.GetPropertyValue(argumentType, resolvedType);
+            result = inputObject.ToObject(argumentType, resolvedType);
             return true;
         }
+
+        result = arg.Value.GetPropertyValue(argumentType, resolvedType);
+        return true;
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -7,319 +7,318 @@ using GraphQL.Validation;
 using GraphQLParser.AST;
 using ExecutionContext = GraphQL.Execution.ExecutionContext;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// <inheritdoc cref="IDocumentExecuter"/>
+/// <br/><br/>
+/// Default implementation for <see cref="IDocumentExecuter"/>.
+/// </summary>
+public class DocumentExecuter : IDocumentExecuter
 {
+    private readonly IDocumentBuilder _documentBuilder;
+    private readonly IDocumentValidator _documentValidator;
+    private readonly ExecutionDelegate _execution;
+    private readonly IExecutionStrategySelector _executionStrategySelector;
+
     /// <summary>
-    /// <inheritdoc cref="IDocumentExecuter"/>
-    /// <br/><br/>
-    /// Default implementation for <see cref="IDocumentExecuter"/>.
+    /// Initializes a new instance with default <see cref="IDocumentBuilder"/> and
+    /// <see cref="IDocumentValidator"/> instances, and without document caching.
     /// </summary>
-    public class DocumentExecuter : IDocumentExecuter
+    public DocumentExecuter()
+        : this(new GraphQLDocumentBuilder(), new DocumentValidator())
     {
-        private readonly IDocumentBuilder _documentBuilder;
-        private readonly IDocumentValidator _documentValidator;
-        private readonly ExecutionDelegate _execution;
-        private readonly IExecutionStrategySelector _executionStrategySelector;
-
-        /// <summary>
-        /// Initializes a new instance with default <see cref="IDocumentBuilder"/> and
-        /// <see cref="IDocumentValidator"/> instances, and without document caching.
-        /// </summary>
-        public DocumentExecuter()
-            : this(new GraphQLDocumentBuilder(), new DocumentValidator())
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance with specified <see cref="IDocumentBuilder"/> and
-        /// <see cref="IDocumentValidator"/>.
-        /// </summary>
-        public DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator)
-            : this(documentBuilder, documentValidator, new DefaultExecutionStrategySelector(), Array.Empty<IConfigureExecution>())
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified <see cref="IDocumentBuilder"/>,
-        /// <see cref="IDocumentValidator"/>, <see cref="IExecutionStrategySelector"/> and
-        /// a set of <see cref="IConfigureExecution"/> instances.
-        /// </summary>
-        public DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IExecutionStrategySelector executionStrategySelector, IEnumerable<IConfigureExecution> configurations)
-        {
-            _documentBuilder = documentBuilder ?? throw new ArgumentNullException(nameof(documentBuilder));
-            _documentValidator = documentValidator ?? throw new ArgumentNullException(nameof(documentValidator));
-            _executionStrategySelector = executionStrategySelector ?? throw new ArgumentNullException(nameof(executionStrategySelector));
-            _execution = BuildExecutionDelegate(configurations);
-        }
-
-        private ExecutionDelegate BuildExecutionDelegate(IEnumerable<IConfigureExecution> configurations)
-        {
-            ExecutionDelegate execution = CoreExecuteAsync;
-
-            // OrderBy here performs a stable sort; that is, if the sort order of two elements are equal,
-            // the order of the elements are preserved. The order is reversed since each execution wraps
-            // the prior configured executions. OrderByDescending is not used because that would result
-            // in a different sort order when there are two executions with equal sort orders.
-            foreach (var action in configurations.OrderBy(x => x.SortOrder).Reverse())
-            {
-                var nextExecution = execution;
-                execution = async options => await action.ExecuteAsync(options, nextExecution).ConfigureAwait(false);
-            }
-            return execution;
-        }
-
-        /// <inheritdoc/>
-        public virtual Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)
-        {
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
-
-            return _execution(options);
-        }
-
-        private async Task<ExecutionResult> CoreExecuteAsync(ExecutionOptions options)
-        {
-            if (options.Schema == null)
-                throw new InvalidOperationException("Cannot execute request if no schema is specified");
-            if (options.Query == null && options.Document == null)
-                return new ExecutionResult { Errors = new ExecutionErrors { new QueryMissingError() } };
-            options.CancellationToken.ThrowIfCancellationRequested();
-
-            var metrics = (options.EnableMetrics ? new Metrics() : Metrics.None).Start(options.OperationName);
-
-            ExecutionResult? result = null;
-            ExecutionContext? context = null;
-            bool executionOccurred = false;
-
-            try
-            {
-                if (!options.Schema.Initialized)
-                {
-                    using (metrics.Subject("schema", "Initializing schema"))
-                    {
-                        options.Schema.Initialize();
-                    }
-                }
-
-                var document = options.Document;
-                if (document == null)
-                {
-                    using (metrics.Subject("document", "Building document"))
-                        document = _documentBuilder.Build(options.Query!);
-                }
-
-                var operation = GetOperation(options.OperationName, document);
-                metrics.SetOperationName(operation.Name);
-
-                IValidationResult validationResult;
-                using (metrics.Subject("document", "Validating document"))
-                {
-                    validationResult = await _documentValidator.ValidateAsync(
-                        new ValidationOptions
-                        {
-                            Document = document,
-                            Rules = options.ValidationRules,
-                            Operation = operation,
-                            UserContext = options.UserContext,
-                            RequestServices = options.RequestServices,
-                            User = options.User,
-                            CancellationToken = options.CancellationToken,
-                            Schema = options.Schema,
-                            Metrics = metrics,
-                            Variables = options.Variables ?? Inputs.Empty,
-                            Extensions = options.Extensions ?? Inputs.Empty,
-                        }).ConfigureAwait(false);
-                }
-
-                context = BuildExecutionContext(options, document, operation, validationResult, metrics);
-
-                foreach (var listener in options.Listeners)
-                {
-                    await listener.AfterValidationAsync(context, validationResult) // TODO: remove ExecutionContext or make different type ?
-                        .ConfigureAwait(false);
-                }
-
-                if (!validationResult.IsValid || context.Errors.Count > 0)
-                {
-                    var errors = !validationResult.IsValid ? validationResult.Errors : context.Errors;
-                    if (!validationResult.IsValid && context.Errors.Count > 0)
-                        errors.AddRange(context.Errors);
-                    return new ExecutionResult
-                    {
-                        Errors = errors,
-                        Perf = metrics.Finish()
-                    };
-                }
-
-                executionOccurred = true;
-
-                using (metrics.Subject("execution", "Executing operation"))
-                {
-                    if (context.Listeners != null)
-                    {
-                        foreach (var listener in context.Listeners)
-                        {
-                            await listener.BeforeExecutionAsync(context)
-                                .ConfigureAwait(false);
-                        }
-                    }
-
-                    var task = (context.ExecutionStrategy ?? throw new InvalidOperationException("Execution strategy not specified")).ExecuteAsync(context)
-                        .ConfigureAwait(false);
-
-                    result = await task;
-
-                    if (context.Listeners != null)
-                    {
-                        foreach (var listener in context.Listeners)
-                        {
-                            await listener.AfterExecutionAsync(context)
-                                .ConfigureAwait(false);
-                        }
-                    }
-                }
-
-                result.AddErrors(context.Errors);
-            }
-            catch (OperationCanceledException) when (options.CancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (ExecutionError ex)
-            {
-                (result ??= new()).AddError(ex);
-            }
-            catch (Exception ex)
-            {
-                if (options.ThrowOnUnhandledException)
-                    throw;
-
-                UnhandledExceptionContext? exceptionContext = null;
-                if (options.UnhandledExceptionDelegate != null)
-                {
-                    exceptionContext = new UnhandledExceptionContext(context, null, ex);
-                    await options.UnhandledExceptionDelegate(exceptionContext).ConfigureAwait(false);
-                    ex = exceptionContext.Exception;
-                }
-
-                (result ??= new()).AddError(ex is ExecutionError executionError ? executionError : new UnhandledError(exceptionContext?.ErrorMessage ?? "Error executing document.", ex));
-            }
-            finally
-            {
-                result ??= new();
-                result.Perf = metrics.Finish();
-                if (executionOccurred)
-                    result.Executed = true;
-                context?.Dispose();
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Builds a <see cref="ExecutionContext"/> instance from the provided values.
-        /// </summary>
-        protected virtual ExecutionContext BuildExecutionContext(ExecutionOptions options, GraphQLDocument document, GraphQLOperationDefinition operation, IValidationResult validationResult, Metrics metrics)
-        {
-            var context = new ExecutionContext
-            {
-                Document = document,
-                Schema = options.Schema!,
-                RootValue = options.Root,
-                UserContext = options.UserContext,
-
-                Operation = operation,
-                Variables = validationResult.Variables ?? Variables.None,
-                ArgumentValues = validationResult.ArgumentValues,
-                DirectiveValues = validationResult.DirectiveValues,
-                Errors = new ExecutionErrors(),
-                InputExtensions = options.Extensions ?? Inputs.Empty,
-                OutputExtensions = new Dictionary<string, object?>(),
-                CancellationToken = options.CancellationToken,
-
-                Metrics = metrics,
-                Listeners = options.Listeners,
-                ThrowOnUnhandledException = options.ThrowOnUnhandledException,
-                UnhandledExceptionDelegate = options.UnhandledExceptionDelegate,
-                MaxParallelExecutionCount = options.MaxParallelExecutionCount,
-                RequestServices = options.RequestServices,
-                User = options.User,
-            };
-
-            context.ExecutionStrategy = SelectExecutionStrategy(context);
-
-            return context;
-        }
-
-        /// <summary>
-        /// Returns the selected <see cref="GraphQLOperationDefinition"/> given a specified <see cref="GraphQLDocument"/> and operation name.
-        /// <br/><br/>
-        /// Returns <see langword="null"/> if an operation cannot be found that matches the given criteria.
-        /// Returns the first operation from the document if no operation name was specified.
-        /// </summary>
-        /// <exception cref="InvalidOperationNameError">Thrown when the operation name is specified but no operation can be found with that name.</exception>
-        /// <exception cref="NoOperationNameError">Thrown when the document includes multiple operations, but no operation name was specified in the request.</exception>
-        /// <exception cref="NoOperationError">Thrown when the document does not include any operations.</exception>
-        protected virtual GraphQLOperationDefinition GetOperation(string? operationName, GraphQLDocument document)
-        {
-            if (operationName == null)
-            {
-                GraphQLOperationDefinition? match = null;
-                foreach (var def in document.Definitions)
-                {
-                    if (def is GraphQLOperationDefinition op)
-                    {
-                        if (match != null)
-                            throw new NoOperationNameError();
-                        match = op;
-                    }
-                }
-
-                return match ?? throw new NoOperationError();
-            }
-
-            foreach (var def in document.Definitions)
-            {
-                if (def is GraphQLOperationDefinition op && op.Name == operationName)
-                    return op;
-            }
-
-            throw new InvalidOperationNameError(operationName);
-        }
-
-        /// <summary>
-        /// Returns an instance of an <see cref="IExecutionStrategy"/> given specified execution parameters.
-        /// <br/><br/>
-        /// Typically the strategy is selected based on the type of operation.
-        /// <br/><br/>
-        /// By default, the selection is handled by the <see cref="IExecutionStrategySelector"/> implementation passed to the
-        /// constructor, which will select an execution strategy based on a set of <see cref="ExecutionStrategyRegistration"/>
-        /// instances passed to it.
-        /// <br/><br/>
-        /// For the <see cref="DefaultExecutionStrategySelector"/> without any registrations,
-        /// query operations will return a <see cref="ParallelExecutionStrategy"/> while mutation operations return a
-        /// <see cref="SerialExecutionStrategy"/>. Subscription operations return a <see cref="SubscriptionExecutionStrategy"/>.
-        /// </summary>
-        protected virtual IExecutionStrategy SelectExecutionStrategy(ExecutionContext context)
-            => _executionStrategySelector.Select(context);
     }
 
-    internal class DocumentExecuter<TSchema> : IDocumentExecuter<TSchema>
-        where TSchema : ISchema
+    /// <summary>
+    /// Initializes a new instance with specified <see cref="IDocumentBuilder"/> and
+    /// <see cref="IDocumentValidator"/>.
+    /// </summary>
+    public DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator)
+        : this(documentBuilder, documentValidator, new DefaultExecutionStrategySelector(), Array.Empty<IConfigureExecution>())
     {
-        private readonly IDocumentExecuter _documentExecuter;
-        public DocumentExecuter(IDocumentExecuter documentExecuter)
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified <see cref="IDocumentBuilder"/>,
+    /// <see cref="IDocumentValidator"/>, <see cref="IExecutionStrategySelector"/> and
+    /// a set of <see cref="IConfigureExecution"/> instances.
+    /// </summary>
+    public DocumentExecuter(IDocumentBuilder documentBuilder, IDocumentValidator documentValidator, IExecutionStrategySelector executionStrategySelector, IEnumerable<IConfigureExecution> configurations)
+    {
+        _documentBuilder = documentBuilder ?? throw new ArgumentNullException(nameof(documentBuilder));
+        _documentValidator = documentValidator ?? throw new ArgumentNullException(nameof(documentValidator));
+        _executionStrategySelector = executionStrategySelector ?? throw new ArgumentNullException(nameof(executionStrategySelector));
+        _execution = BuildExecutionDelegate(configurations);
+    }
+
+    private ExecutionDelegate BuildExecutionDelegate(IEnumerable<IConfigureExecution> configurations)
+    {
+        ExecutionDelegate execution = CoreExecuteAsync;
+
+        // OrderBy here performs a stable sort; that is, if the sort order of two elements are equal,
+        // the order of the elements are preserved. The order is reversed since each execution wraps
+        // the prior configured executions. OrderByDescending is not used because that would result
+        // in a different sort order when there are two executions with equal sort orders.
+        foreach (var action in configurations.OrderBy(x => x.SortOrder).Reverse())
         {
-            _documentExecuter = documentExecuter ?? throw new ArgumentNullException(nameof(documentExecuter));
+            var nextExecution = execution;
+            execution = async options => await action.ExecuteAsync(options, nextExecution).ConfigureAwait(false);
+        }
+        return execution;
+    }
+
+    /// <inheritdoc/>
+    public virtual Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)
+    {
+        if (options == null)
+            throw new ArgumentNullException(nameof(options));
+
+        return _execution(options);
+    }
+
+    private async Task<ExecutionResult> CoreExecuteAsync(ExecutionOptions options)
+    {
+        if (options.Schema == null)
+            throw new InvalidOperationException("Cannot execute request if no schema is specified");
+        if (options.Query == null && options.Document == null)
+            return new ExecutionResult { Errors = new ExecutionErrors { new QueryMissingError() } };
+        options.CancellationToken.ThrowIfCancellationRequested();
+
+        var metrics = (options.EnableMetrics ? new Metrics() : Metrics.None).Start(options.OperationName);
+
+        ExecutionResult? result = null;
+        ExecutionContext? context = null;
+        bool executionOccurred = false;
+
+        try
+        {
+            if (!options.Schema.Initialized)
+            {
+                using (metrics.Subject("schema", "Initializing schema"))
+                {
+                    options.Schema.Initialize();
+                }
+            }
+
+            var document = options.Document;
+            if (document == null)
+            {
+                using (metrics.Subject("document", "Building document"))
+                    document = _documentBuilder.Build(options.Query!);
+            }
+
+            var operation = GetOperation(options.OperationName, document);
+            metrics.SetOperationName(operation.Name);
+
+            IValidationResult validationResult;
+            using (metrics.Subject("document", "Validating document"))
+            {
+                validationResult = await _documentValidator.ValidateAsync(
+                    new ValidationOptions
+                    {
+                        Document = document,
+                        Rules = options.ValidationRules,
+                        Operation = operation,
+                        UserContext = options.UserContext,
+                        RequestServices = options.RequestServices,
+                        User = options.User,
+                        CancellationToken = options.CancellationToken,
+                        Schema = options.Schema,
+                        Metrics = metrics,
+                        Variables = options.Variables ?? Inputs.Empty,
+                        Extensions = options.Extensions ?? Inputs.Empty,
+                    }).ConfigureAwait(false);
+            }
+
+            context = BuildExecutionContext(options, document, operation, validationResult, metrics);
+
+            foreach (var listener in options.Listeners)
+            {
+                await listener.AfterValidationAsync(context, validationResult) // TODO: remove ExecutionContext or make different type ?
+                    .ConfigureAwait(false);
+            }
+
+            if (!validationResult.IsValid || context.Errors.Count > 0)
+            {
+                var errors = !validationResult.IsValid ? validationResult.Errors : context.Errors;
+                if (!validationResult.IsValid && context.Errors.Count > 0)
+                    errors.AddRange(context.Errors);
+                return new ExecutionResult
+                {
+                    Errors = errors,
+                    Perf = metrics.Finish()
+                };
+            }
+
+            executionOccurred = true;
+
+            using (metrics.Subject("execution", "Executing operation"))
+            {
+                if (context.Listeners != null)
+                {
+                    foreach (var listener in context.Listeners)
+                    {
+                        await listener.BeforeExecutionAsync(context)
+                            .ConfigureAwait(false);
+                    }
+                }
+
+                var task = (context.ExecutionStrategy ?? throw new InvalidOperationException("Execution strategy not specified")).ExecuteAsync(context)
+                    .ConfigureAwait(false);
+
+                result = await task;
+
+                if (context.Listeners != null)
+                {
+                    foreach (var listener in context.Listeners)
+                    {
+                        await listener.AfterExecutionAsync(context)
+                            .ConfigureAwait(false);
+                    }
+                }
+            }
+
+            result.AddErrors(context.Errors);
+        }
+        catch (OperationCanceledException) when (options.CancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (ExecutionError ex)
+        {
+            (result ??= new()).AddError(ex);
+        }
+        catch (Exception ex)
+        {
+            if (options.ThrowOnUnhandledException)
+                throw;
+
+            UnhandledExceptionContext? exceptionContext = null;
+            if (options.UnhandledExceptionDelegate != null)
+            {
+                exceptionContext = new UnhandledExceptionContext(context, null, ex);
+                await options.UnhandledExceptionDelegate(exceptionContext).ConfigureAwait(false);
+                ex = exceptionContext.Exception;
+            }
+
+            (result ??= new()).AddError(ex is ExecutionError executionError ? executionError : new UnhandledError(exceptionContext?.ErrorMessage ?? "Error executing document.", ex));
+        }
+        finally
+        {
+            result ??= new();
+            result.Perf = metrics.Finish();
+            if (executionOccurred)
+                result.Executed = true;
+            context?.Dispose();
         }
 
-        public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)
-        {
-            if (options.Schema != null)
-                throw new InvalidOperationException("ExecutionOptions.Schema must be null when calling this typed IDocumentExecuter<> implementation; it will be pulled from the dependency injection provider.");
+        return result;
+    }
 
-            options.Schema = options.RequestServicesOrThrow().GetRequiredService<TSchema>();
-            return _documentExecuter.ExecuteAsync(options);
+    /// <summary>
+    /// Builds a <see cref="ExecutionContext"/> instance from the provided values.
+    /// </summary>
+    protected virtual ExecutionContext BuildExecutionContext(ExecutionOptions options, GraphQLDocument document, GraphQLOperationDefinition operation, IValidationResult validationResult, Metrics metrics)
+    {
+        var context = new ExecutionContext
+        {
+            Document = document,
+            Schema = options.Schema!,
+            RootValue = options.Root,
+            UserContext = options.UserContext,
+
+            Operation = operation,
+            Variables = validationResult.Variables ?? Variables.None,
+            ArgumentValues = validationResult.ArgumentValues,
+            DirectiveValues = validationResult.DirectiveValues,
+            Errors = new ExecutionErrors(),
+            InputExtensions = options.Extensions ?? Inputs.Empty,
+            OutputExtensions = new Dictionary<string, object?>(),
+            CancellationToken = options.CancellationToken,
+
+            Metrics = metrics,
+            Listeners = options.Listeners,
+            ThrowOnUnhandledException = options.ThrowOnUnhandledException,
+            UnhandledExceptionDelegate = options.UnhandledExceptionDelegate,
+            MaxParallelExecutionCount = options.MaxParallelExecutionCount,
+            RequestServices = options.RequestServices,
+            User = options.User,
+        };
+
+        context.ExecutionStrategy = SelectExecutionStrategy(context);
+
+        return context;
+    }
+
+    /// <summary>
+    /// Returns the selected <see cref="GraphQLOperationDefinition"/> given a specified <see cref="GraphQLDocument"/> and operation name.
+    /// <br/><br/>
+    /// Returns <see langword="null"/> if an operation cannot be found that matches the given criteria.
+    /// Returns the first operation from the document if no operation name was specified.
+    /// </summary>
+    /// <exception cref="InvalidOperationNameError">Thrown when the operation name is specified but no operation can be found with that name.</exception>
+    /// <exception cref="NoOperationNameError">Thrown when the document includes multiple operations, but no operation name was specified in the request.</exception>
+    /// <exception cref="NoOperationError">Thrown when the document does not include any operations.</exception>
+    protected virtual GraphQLOperationDefinition GetOperation(string? operationName, GraphQLDocument document)
+    {
+        if (operationName == null)
+        {
+            GraphQLOperationDefinition? match = null;
+            foreach (var def in document.Definitions)
+            {
+                if (def is GraphQLOperationDefinition op)
+                {
+                    if (match != null)
+                        throw new NoOperationNameError();
+                    match = op;
+                }
+            }
+
+            return match ?? throw new NoOperationError();
         }
+
+        foreach (var def in document.Definitions)
+        {
+            if (def is GraphQLOperationDefinition op && op.Name == operationName)
+                return op;
+        }
+
+        throw new InvalidOperationNameError(operationName);
+    }
+
+    /// <summary>
+    /// Returns an instance of an <see cref="IExecutionStrategy"/> given specified execution parameters.
+    /// <br/><br/>
+    /// Typically the strategy is selected based on the type of operation.
+    /// <br/><br/>
+    /// By default, the selection is handled by the <see cref="IExecutionStrategySelector"/> implementation passed to the
+    /// constructor, which will select an execution strategy based on a set of <see cref="ExecutionStrategyRegistration"/>
+    /// instances passed to it.
+    /// <br/><br/>
+    /// For the <see cref="DefaultExecutionStrategySelector"/> without any registrations,
+    /// query operations will return a <see cref="ParallelExecutionStrategy"/> while mutation operations return a
+    /// <see cref="SerialExecutionStrategy"/>. Subscription operations return a <see cref="SubscriptionExecutionStrategy"/>.
+    /// </summary>
+    protected virtual IExecutionStrategy SelectExecutionStrategy(ExecutionContext context)
+        => _executionStrategySelector.Select(context);
+}
+
+internal class DocumentExecuter<TSchema> : IDocumentExecuter<TSchema>
+    where TSchema : ISchema
+{
+    private readonly IDocumentExecuter _documentExecuter;
+    public DocumentExecuter(IDocumentExecuter documentExecuter)
+    {
+        _documentExecuter = documentExecuter ?? throw new ArgumentNullException(nameof(documentExecuter));
+    }
+
+    public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options)
+    {
+        if (options.Schema != null)
+            throw new InvalidOperationException("ExecutionOptions.Schema must be null when calling this typed IDocumentExecuter<> implementation; it will be pulled from the dependency injection provider.");
+
+        options.Schema = options.RequestServicesOrThrow().GetRequiredService<TSchema>();
+        return _documentExecuter.ExecuteAsync(options);
     }
 }

--- a/src/GraphQL/Execution/DocumentExecutionListener.cs
+++ b/src/GraphQL/Execution/DocumentExecutionListener.cs
@@ -1,32 +1,31 @@
 using GraphQL.Validation;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Provides the ability to log query validation failures and monitor progress of a GraphQL request's execution.
+/// </summary>
+public interface IDocumentExecutionListener
 {
-    /// <summary>
-    /// Provides the ability to log query validation failures and monitor progress of a GraphQL request's execution.
-    /// </summary>
-    public interface IDocumentExecutionListener
-    {
-        /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
-        Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult);
+    /// <summary>Executes after document validation is complete. Can be used to log validation failures.</summary>
+    Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult);
 
-        /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
-        Task BeforeExecutionAsync(IExecutionContext context);
+    /// <summary>Executes after document validation passes, before calling <see cref="IExecutionStrategy.ExecuteAsync(ExecutionContext)"/>.</summary>
+    Task BeforeExecutionAsync(IExecutionContext context);
 
-        /// <summary>Executes after the <see cref="IExecutionStrategy"/> has completed executing the request</summary>
-        Task AfterExecutionAsync(IExecutionContext context);
-    }
+    /// <summary>Executes after the <see cref="IExecutionStrategy"/> has completed executing the request</summary>
+    Task AfterExecutionAsync(IExecutionContext context);
+}
 
-    /// <inheritdoc cref="IDocumentExecutionListener"/>
-    public abstract class DocumentExecutionListenerBase : IDocumentExecutionListener
-    {
-        /// <inheritdoc/>
-        public virtual Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult) => Task.CompletedTask;
+/// <inheritdoc cref="IDocumentExecutionListener"/>
+public abstract class DocumentExecutionListenerBase : IDocumentExecutionListener
+{
+    /// <inheritdoc/>
+    public virtual Task AfterValidationAsync(IExecutionContext context, IValidationResult validationResult) => Task.CompletedTask;
 
-        /// <inheritdoc/>
-        public virtual Task BeforeExecutionAsync(IExecutionContext context) => Task.CompletedTask;
+    /// <inheritdoc/>
+    public virtual Task BeforeExecutionAsync(IExecutionContext context) => Task.CompletedTask;
 
-        /// <inheritdoc/>
-        public virtual Task AfterExecutionAsync(IExecutionContext context) => Task.CompletedTask;
-    }
+    /// <inheritdoc/>
+    public virtual Task AfterExecutionAsync(IExecutionContext context) => Task.CompletedTask;
 }

--- a/src/GraphQL/Execution/ErrorInfo.cs
+++ b/src/GraphQL/Execution/ErrorInfo.cs
@@ -1,21 +1,20 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents the fields of a GraphQL error entry. See https://spec.graphql.org/October2021/#sec-Errors
+/// </summary>
+public struct ErrorInfo
 {
+    // The following descriptions are copied from https://spec.graphql.org/October2021/#sec-Errors
+
     /// <summary>
-    /// Represents the fields of a GraphQL error entry. See https://spec.graphql.org/October2021/#sec-Errors
+    /// A description of the error intended for the developer as a guide to understand and correct the error
     /// </summary>
-    public struct ErrorInfo
-    {
-        // The following descriptions are copied from https://spec.graphql.org/October2021/#sec-Errors
+    public string Message;
 
-        /// <summary>
-        /// A description of the error intended for the developer as a guide to understand and correct the error
-        /// </summary>
-        public string Message;
-
-        /// <summary>
-        /// This entry, if set, must have a map as its value. This entry is reserved for implementors to add additional
-        /// information to errors however they see fit, and there are no additional restrictions on its contents.
-        /// </summary>
-        public IDictionary<string, object?>? Extensions;
-    }
+    /// <summary>
+    /// This entry, if set, must have a map as its value. This entry is reserved for implementors to add additional
+    /// information to errors however they see fit, and there are no additional restrictions on its contents.
+    /// </summary>
+    public IDictionary<string, object?>? Extensions;
 }

--- a/src/GraphQL/Execution/ErrorInfoProvider.cs
+++ b/src/GraphQL/Execution/ErrorInfoProvider.cs
@@ -1,153 +1,152 @@
 using System.Collections.Concurrent;
 using GraphQL.Validation;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <inheritdoc cref="IErrorInfoProvider"/>
+public class ErrorInfoProvider : IErrorInfoProvider
 {
-    /// <inheritdoc cref="IErrorInfoProvider"/>
-    public class ErrorInfoProvider : IErrorInfoProvider
+    private static readonly ConcurrentDictionary<Type, string> _exceptionErrorCodes = new();
+
+    private readonly ErrorInfoProviderOptions _options;
+
+    /// <summary>
+    /// Initializes an <see cref="ErrorInfoProvider"/> with a default set of <see cref="ErrorInfoProviderOptions"/>.
+    /// </summary>
+    public ErrorInfoProvider()
+        : this(new ErrorInfoProviderOptions())
     {
-        private static readonly ConcurrentDictionary<Type, string> _exceptionErrorCodes = new();
+    }
 
-        private readonly ErrorInfoProviderOptions _options;
+    /// <summary>
+    /// Initializes an <see cref="ErrorInfoProvider"/> with a specified set of <see cref="ErrorInfoProviderOptions"/>.
+    /// </summary>
+    public ErrorInfoProvider(ErrorInfoProviderOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
 
-        /// <summary>
-        /// Initializes an <see cref="ErrorInfoProvider"/> with a default set of <see cref="ErrorInfoProviderOptions"/>.
-        /// </summary>
-        public ErrorInfoProvider()
-            : this(new ErrorInfoProviderOptions())
+    /// <summary>
+    /// Initializes an <see cref="ErrorInfoProvider"/> with a set of <see cref="ErrorInfoProviderOptions"/> filled out by the specified delegate.
+    /// </summary>
+    public ErrorInfoProvider(Action<ErrorInfoProviderOptions> optionsBuilder)
+    {
+        if (optionsBuilder == null)
+            throw new ArgumentNullException(nameof(optionsBuilder));
+        _options = new ErrorInfoProviderOptions();
+        optionsBuilder(_options);
+    }
+
+    /// <inheritdoc/>
+    public virtual ErrorInfo GetInfo(ExecutionError executionError)
+    {
+        if (executionError == null)
+            throw new ArgumentNullException(nameof(executionError));
+
+        IDictionary<string, object?>? extensions = null;
+
+        if (_options.ExposeExtensions)
         {
-        }
+            var code = _options.ExposeCode ? executionError.Code : null;
+            var codes = _options.ExposeCodes ? GetCodesForError(executionError).ToList() : null;
+            if (codes?.Count == 0)
+                codes = null;
+            var number = _options.ExposeCode && executionError is ValidationError validationError ? validationError.Number : null;
+            var data = _options.ExposeData && executionError.Data?.Count > 0 ? executionError.Data : null;
+            var details = _options.ExposeExceptionDetails && _options.ExposeExceptionDetailsMode == ExposeExceptionDetailsMode.Extensions
+                ? executionError.ToString()
+                : null;
+            var userExtensions = executionError.Extensions;
 
-        /// <summary>
-        /// Initializes an <see cref="ErrorInfoProvider"/> with a specified set of <see cref="ErrorInfoProviderOptions"/>.
-        /// </summary>
-        public ErrorInfoProvider(ErrorInfoProviderOptions options)
-        {
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-        }
-
-        /// <summary>
-        /// Initializes an <see cref="ErrorInfoProvider"/> with a set of <see cref="ErrorInfoProviderOptions"/> filled out by the specified delegate.
-        /// </summary>
-        public ErrorInfoProvider(Action<ErrorInfoProviderOptions> optionsBuilder)
-        {
-            if (optionsBuilder == null)
-                throw new ArgumentNullException(nameof(optionsBuilder));
-            _options = new ErrorInfoProviderOptions();
-            optionsBuilder(_options);
-        }
-
-        /// <inheritdoc/>
-        public virtual ErrorInfo GetInfo(ExecutionError executionError)
-        {
-            if (executionError == null)
-                throw new ArgumentNullException(nameof(executionError));
-
-            IDictionary<string, object?>? extensions = null;
-
-            if (_options.ExposeExtensions)
+            if (code != null || codes != null || data != null || details != null || userExtensions?.Count > 0)
             {
-                var code = _options.ExposeCode ? executionError.Code : null;
-                var codes = _options.ExposeCodes ? GetCodesForError(executionError).ToList() : null;
-                if (codes?.Count == 0)
-                    codes = null;
-                var number = _options.ExposeCode && executionError is ValidationError validationError ? validationError.Number : null;
-                var data = _options.ExposeData && executionError.Data?.Count > 0 ? executionError.Data : null;
-                var details = _options.ExposeExceptionDetails && _options.ExposeExceptionDetailsMode == ExposeExceptionDetailsMode.Extensions
-                    ? executionError.ToString()
-                    : null;
-                var userExtensions = executionError.Extensions;
-
-                if (code != null || codes != null || data != null || details != null || userExtensions?.Count > 0)
+                extensions = new Dictionary<string, object?>();
+                if (code != null)
+                    extensions.Add("code", code);
+                if (codes != null)
+                    extensions.Add("codes", codes);
+                if (number != null)
+                    extensions.Add("number", number);
+                if (data != null)
+                    extensions.Add("data", data);
+                if (details != null)
+                    extensions.Add("details", details);
+                // Extensions from ExecutionError set by user have a precedence over other so they overwrite existing ones if any
+                if (userExtensions?.Count > 0)
                 {
-                    extensions = new Dictionary<string, object?>();
-                    if (code != null)
-                        extensions.Add("code", code);
-                    if (codes != null)
-                        extensions.Add("codes", codes);
-                    if (number != null)
-                        extensions.Add("number", number);
-                    if (data != null)
-                        extensions.Add("data", data);
-                    if (details != null)
-                        extensions.Add("details", details);
-                    // Extensions from ExecutionError set by user have a precedence over other so they overwrite existing ones if any
-                    if (userExtensions?.Count > 0)
-                    {
-                        foreach (var item in userExtensions)
-                            extensions[item.Key] = item.Value;
-                    }
+                    foreach (var item in userExtensions)
+                        extensions[item.Key] = item.Value;
                 }
             }
-
-            return new ErrorInfo
-            {
-                Message = _options.ExposeExceptionDetails && _options.ExposeExceptionDetailsMode == ExposeExceptionDetailsMode.Message ? executionError.ToString() : executionError.Message,
-                Extensions = extensions,
-            };
         }
 
-        /// <summary>
-        /// <para>Returns a list of error codes derived from a specified <see cref="ExecutionError"/> instance.</para>
-        /// <para>
-        /// By default, this returns the <see cref="ExecutionError.Code"/> value if set, along with
-        /// codes generated from the type of the <see cref="Exception.InnerException"/> and all their inner exceptions.
-        /// </para>
-        /// </summary>
-        protected virtual IEnumerable<string> GetCodesForError(ExecutionError executionError)
+        return new ErrorInfo
         {
-            // Code could be set explicitly, and not through the constructor with the exception
-            if (executionError.Code != null && (executionError.InnerException == null || executionError.Code != GetErrorCode(executionError.InnerException)))
-                yield return executionError.Code;
+            Message = _options.ExposeExceptionDetails && _options.ExposeExceptionDetailsMode == ExposeExceptionDetailsMode.Message ? executionError.ToString() : executionError.Message,
+            Extensions = extensions,
+        };
+    }
 
-            var current = executionError.InnerException;
+    /// <summary>
+    /// <para>Returns a list of error codes derived from a specified <see cref="ExecutionError"/> instance.</para>
+    /// <para>
+    /// By default, this returns the <see cref="ExecutionError.Code"/> value if set, along with
+    /// codes generated from the type of the <see cref="Exception.InnerException"/> and all their inner exceptions.
+    /// </para>
+    /// </summary>
+    protected virtual IEnumerable<string> GetCodesForError(ExecutionError executionError)
+    {
+        // Code could be set explicitly, and not through the constructor with the exception
+        if (executionError.Code != null && (executionError.InnerException == null || executionError.Code != GetErrorCode(executionError.InnerException)))
+            yield return executionError.Code;
 
-            while (current != null)
-            {
-                yield return GetErrorCode(current);
-                current = current.InnerException;
-            }
-        }
+        var current = executionError.InnerException;
 
-        /// <summary>
-        /// Generates an normalized error code for the specified exception by taking the type name, removing the "GraphQL" prefix, if any,
-        /// removing the "Exception" suffix, if any, and then converting the result from PascalCase to UPPER_CASE.
-        /// </summary>
-        public static string GetErrorCode(Type exceptionType) => _exceptionErrorCodes.GetOrAdd(exceptionType, NormalizeErrorCode);
-
-        /// <summary>
-        /// Generates an normalized error code for the specified exception by taking the type name, removing the "GraphQL" prefix, if any,
-        /// removing the "Exception" suffix, if any, and then converting the result from PascalCase to UPPER_CASE.
-        /// </summary>
-        public static string GetErrorCode<T>() where T : Exception => GetErrorCode(typeof(T));
-
-        /// <summary>
-        /// Generates an normalized error code for the specified exception by taking the type name, removing the "GraphQL" prefix, if any,
-        /// removing the "Exception" suffix, if any, and then converting the result from PascalCase to UPPER_CASE.
-        /// </summary>
-        public static string GetErrorCode(Exception exception) => GetErrorCode(exception.GetType());
-
-        private static string NormalizeErrorCode(Type exceptionType)
+        while (current != null)
         {
-            var code = exceptionType.Name;
-
-            if (code.EndsWith(nameof(Exception), StringComparison.InvariantCulture))
-            {
-                code = code.Substring(0, code.Length - nameof(Exception).Length);
-            }
-
-            if (code.StartsWith("GraphQL", StringComparison.InvariantCulture))
-            {
-                code = code.Substring("GraphQL".Length);
-            }
-
-            var tickIndex = code.IndexOf('`');
-            if (tickIndex >= 0)
-            {
-                code = code.Substring(0, tickIndex);
-            }
-
-            return code.ToConstantCase();
+            yield return GetErrorCode(current);
+            current = current.InnerException;
         }
+    }
+
+    /// <summary>
+    /// Generates an normalized error code for the specified exception by taking the type name, removing the "GraphQL" prefix, if any,
+    /// removing the "Exception" suffix, if any, and then converting the result from PascalCase to UPPER_CASE.
+    /// </summary>
+    public static string GetErrorCode(Type exceptionType) => _exceptionErrorCodes.GetOrAdd(exceptionType, NormalizeErrorCode);
+
+    /// <summary>
+    /// Generates an normalized error code for the specified exception by taking the type name, removing the "GraphQL" prefix, if any,
+    /// removing the "Exception" suffix, if any, and then converting the result from PascalCase to UPPER_CASE.
+    /// </summary>
+    public static string GetErrorCode<T>() where T : Exception => GetErrorCode(typeof(T));
+
+    /// <summary>
+    /// Generates an normalized error code for the specified exception by taking the type name, removing the "GraphQL" prefix, if any,
+    /// removing the "Exception" suffix, if any, and then converting the result from PascalCase to UPPER_CASE.
+    /// </summary>
+    public static string GetErrorCode(Exception exception) => GetErrorCode(exception.GetType());
+
+    private static string NormalizeErrorCode(Type exceptionType)
+    {
+        var code = exceptionType.Name;
+
+        if (code.EndsWith(nameof(Exception), StringComparison.InvariantCulture))
+        {
+            code = code.Substring(0, code.Length - nameof(Exception).Length);
+        }
+
+        if (code.StartsWith("GraphQL", StringComparison.InvariantCulture))
+        {
+            code = code.Substring("GraphQL".Length);
+        }
+
+        var tickIndex = code.IndexOf('`');
+        if (tickIndex >= 0)
+        {
+            code = code.Substring(0, tickIndex);
+        }
+
+        return code.ToConstantCase();
     }
 }

--- a/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
+++ b/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
@@ -1,75 +1,74 @@
 using GraphQL.Validation;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Provides options to be used with <see cref="ErrorInfoProvider"/>
+/// </summary>
+public class ErrorInfoProviderOptions
 {
     /// <summary>
-    /// Provides options to be used with <see cref="ErrorInfoProvider"/>
+    /// Specifies whether stack traces should be serialized.
     /// </summary>
-    public class ErrorInfoProviderOptions
+    [Obsolete("Use ExposeExceptionDetails property instead")]
+    public bool ExposeExceptionStackTrace
     {
-        /// <summary>
-        /// Specifies whether stack traces should be serialized.
-        /// </summary>
-        [Obsolete("Use ExposeExceptionDetails property instead")]
-        public bool ExposeExceptionStackTrace
+        get => ExposeExceptionDetails;
+        set
         {
-            get => ExposeExceptionDetails;
-            set
-            {
-                ExposeExceptionDetails = value;
-                if (value)
-                    ExposeExceptionDetailsMode = ExposeExceptionDetailsMode.Message;
-            }
+            ExposeExceptionDetails = value;
+            if (value)
+                ExposeExceptionDetailsMode = ExposeExceptionDetailsMode.Message;
         }
-
-        /// <summary>
-        /// Specifies whether detailed exception information (exception types, stack traces, inner exceptions)
-        /// should be serialized.
-        /// </summary>
-        public bool ExposeExceptionDetails { get; set; }
-
-        /// <inheritdoc cref="Execution.ExposeExceptionDetailsMode"/>
-        public ExposeExceptionDetailsMode ExposeExceptionDetailsMode { get; set; } = ExposeExceptionDetailsMode.Extensions;
-
-        /// <summary>
-        /// Specifies whether the extensions property, including by default the 'code',
-        /// 'codes', 'data' and 'details' properties, should be serialized.
-        /// </summary>
-        public bool ExposeExtensions { get; set; } = true;
-
-        /// <summary>
-        /// Specifies whether the code of this error should be returned.
-        /// For validation errors, also returns the <see cref="ValidationError.Number"/>.
-        /// Not applicable when <see cref="ExposeExtensions"/> is <see langword="false"/>.
-        /// </summary>
-        public bool ExposeCode { get; set; } = true;
-
-        /// <summary>
-        /// Specifies whether the codes of this error and inner exceptions should be returned.
-        /// Not applicable when <see cref="ExposeExtensions"/> is <see langword="false"/>.
-        /// </summary>
-        public bool ExposeCodes { get; set; } = true;
-
-        /// <summary>
-        /// Specifies whether data (typically from inner exceptions) should be returned.
-        /// Not applicable when <see cref="ExposeExtensions"/> is <see langword="false"/>.
-        /// </summary>
-        public bool ExposeData { get; set; }
     }
 
     /// <summary>
-    /// Mode to control location of exception details.
+    /// Specifies whether detailed exception information (exception types, stack traces, inner exceptions)
+    /// should be serialized.
     /// </summary>
-    public enum ExposeExceptionDetailsMode
-    {
-        /// <summary>
-        /// Exception details are located along with exception message.
-        /// </summary>
-        Message,
+    public bool ExposeExceptionDetails { get; set; }
 
-        /// <summary>
-        /// Exception details are located within "extensions.details" separately from exception message itself.
-        /// </summary>
-        Extensions
-    }
+    /// <inheritdoc cref="Execution.ExposeExceptionDetailsMode"/>
+    public ExposeExceptionDetailsMode ExposeExceptionDetailsMode { get; set; } = ExposeExceptionDetailsMode.Extensions;
+
+    /// <summary>
+    /// Specifies whether the extensions property, including by default the 'code',
+    /// 'codes', 'data' and 'details' properties, should be serialized.
+    /// </summary>
+    public bool ExposeExtensions { get; set; } = true;
+
+    /// <summary>
+    /// Specifies whether the code of this error should be returned.
+    /// For validation errors, also returns the <see cref="ValidationError.Number"/>.
+    /// Not applicable when <see cref="ExposeExtensions"/> is <see langword="false"/>.
+    /// </summary>
+    public bool ExposeCode { get; set; } = true;
+
+    /// <summary>
+    /// Specifies whether the codes of this error and inner exceptions should be returned.
+    /// Not applicable when <see cref="ExposeExtensions"/> is <see langword="false"/>.
+    /// </summary>
+    public bool ExposeCodes { get; set; } = true;
+
+    /// <summary>
+    /// Specifies whether data (typically from inner exceptions) should be returned.
+    /// Not applicable when <see cref="ExposeExtensions"/> is <see langword="false"/>.
+    /// </summary>
+    public bool ExposeData { get; set; }
+}
+
+/// <summary>
+/// Mode to control location of exception details.
+/// </summary>
+public enum ExposeExceptionDetailsMode
+{
+    /// <summary>
+    /// Exception details are located along with exception message.
+    /// </summary>
+    Message,
+
+    /// <summary>
+    /// Exception details are located within "extensions.details" separately from exception message itself.
+    /// </summary>
+    Extensions
 }

--- a/src/GraphQL/Execution/Errors/DocumentError.cs
+++ b/src/GraphQL/Execution/Errors/DocumentError.cs
@@ -1,21 +1,20 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an error generated while parsing or validating the document or its associated variables.
+/// </summary>
+public abstract class DocumentError : ExecutionError
 {
     /// <summary>
-    /// Represents an error generated while parsing or validating the document or its associated variables.
+    /// Initializes a new instance of the <see cref="DocumentError"/> class with a specified error message.
     /// </summary>
-    public abstract class DocumentError : ExecutionError
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DocumentError"/> class with a specified error message.
-        /// </summary>
-        public DocumentError(string message) : base(message) { }
+    public DocumentError(string message) : base(message) { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DocumentError"/> class with a specified
-        /// error message and inner exception. Sets the <see cref="ExecutionError.Code">Code</see>
-        /// property based on the inner exception. Loads any exception data from the inner exception
-        /// into this instance.
-        /// </summary>
-        public DocumentError(string message, Exception? innerException) : base(message, innerException) { }
-    }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentError"/> class with a specified
+    /// error message and inner exception. Sets the <see cref="ExecutionError.Code">Code</see>
+    /// property based on the inner exception. Loads any exception data from the inner exception
+    /// into this instance.
+    /// </summary>
+    public DocumentError(string message, Exception? innerException) : base(message, innerException) { }
 }

--- a/src/GraphQL/Execution/Errors/ExecutionError.cs
+++ b/src/GraphQL/Execution/Errors/ExecutionError.cs
@@ -3,124 +3,123 @@ using GraphQL.Execution;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Represents an error generated while processing a document and
+/// intended to be returned within an <see cref="ExecutionResult"/>.
+/// </summary>
+[Serializable]
+public class ExecutionError : Exception
 {
     /// <summary>
-    /// Represents an error generated while processing a document and
-    /// intended to be returned within an <see cref="ExecutionResult"/>.
+    /// Initializes a new instance of the <see cref="ExecutionError"/> class with a specified error message.
     /// </summary>
-    [Serializable]
-    public class ExecutionError : Exception
+    public ExecutionError(string message)
+        : base(message)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExecutionError"/> class with a specified error message.
-        /// </summary>
-        public ExecutionError(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExecutionError"/>
-        /// class with a specified error message and exception data.
-        /// </summary>
-        public ExecutionError(string message, IDictionary data)
-            : base(message)
-        {
-            SetData(data);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExecutionError"/> class with a specified
-        /// error message and inner exception. Sets the <see cref="Code"/> property based on the
-        /// inner exception. Loads any exception data from the inner exception into this instance.
-        /// </summary>
-        public ExecutionError(string message, Exception? innerException)
-            : base(message, innerException)
-        {
-            SetCode(innerException);
-            SetData(innerException);
-        }
-
-        /// <summary>
-        /// Returns a list of locations (if any) within the document that this error applies to.
-        /// </summary>
-        public List<Location>? Locations { get; private set; }
-
-        /// <summary>
-        /// Gets or sets a code for this error. Code is typically used to write the 'code'
-        /// property to the execution result 'extensions' property.
-        /// </summary>
-        public string? Code { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path within the GraphQL document where this error applies to.
-        /// </summary>
-        public IEnumerable<object>? Path { get; set; }
-
-        /// <summary>
-        /// Gets or sets additional information about error.
-        /// </summary>
-        public Dictionary<string, object?>? Extensions { get; set; }
-
-        /// <summary>
-        /// Adds a location to the list of locations that this error applies to.
-        /// </summary>
-        public void AddLocation(Location location)
-        {
-            (Locations ??= new()).Add(location);
-        }
-
-        private void SetCode(Exception? exception)
-        {
-            if (exception != null)
-                Code = ErrorInfoProvider.GetErrorCode(exception);
-        }
-
-        private void SetData(Exception? exception)
-        {
-            if (exception?.Data != null)
-                SetData(exception.Data);
-        }
-
-        private void SetData(IDictionary dict)
-        {
-            if (dict != null)
-            {
-                foreach (DictionaryEntry keyValuePair in dict)
-                {
-                    Data[keyValuePair.Key] = keyValuePair.Value;
-                }
-            }
-        }
     }
 
     /// <summary>
-    /// Provides extension methods for <see cref="ExecutionError"/> instances.
+    /// Initializes a new instance of the <see cref="ExecutionError"/>
+    /// class with a specified error message and exception data.
     /// </summary>
-    public static class ExecutionErrorExtensions
+    public ExecutionError(string message, IDictionary data)
+        : base(message)
     {
-        /// <summary>
-        /// Adds a location to an <see cref="ExecutionError"/> based on a <see cref="ASTNode"/> within a <see cref="GraphQLDocument"/>.
-        /// </summary>
-        public static TError AddLocation<TError>(this TError error, ASTNode? abstractNode, GraphQLDocument? document)
-            where TError : ExecutionError
-        {
-            if (abstractNode == null || abstractNode.Location == default || document == null || document.Source.IsEmpty)
-                return error;
+        SetData(data);
+    }
 
-            error.AddLocation(Location.FromLinearPosition(document.Source, abstractNode.Location.Start));
-            return error;
-        }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutionError"/> class with a specified
+    /// error message and inner exception. Sets the <see cref="Code"/> property based on the
+    /// inner exception. Loads any exception data from the inner exception into this instance.
+    /// </summary>
+    public ExecutionError(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+        SetCode(innerException);
+        SetData(innerException);
+    }
 
-        /// <summary>
-        /// Adds an extension to <see cref="ExecutionError.Extensions"/>.
-        /// </summary>
-        public static TError AddExtension<TError>(this TError error, string key, object? value)
-             where TError : ExecutionError
+    /// <summary>
+    /// Returns a list of locations (if any) within the document that this error applies to.
+    /// </summary>
+    public List<Location>? Locations { get; private set; }
+
+    /// <summary>
+    /// Gets or sets a code for this error. Code is typically used to write the 'code'
+    /// property to the execution result 'extensions' property.
+    /// </summary>
+    public string? Code { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path within the GraphQL document where this error applies to.
+    /// </summary>
+    public IEnumerable<object>? Path { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional information about error.
+    /// </summary>
+    public Dictionary<string, object?>? Extensions { get; set; }
+
+    /// <summary>
+    /// Adds a location to the list of locations that this error applies to.
+    /// </summary>
+    public void AddLocation(Location location)
+    {
+        (Locations ??= new()).Add(location);
+    }
+
+    private void SetCode(Exception? exception)
+    {
+        if (exception != null)
+            Code = ErrorInfoProvider.GetErrorCode(exception);
+    }
+
+    private void SetData(Exception? exception)
+    {
+        if (exception?.Data != null)
+            SetData(exception.Data);
+    }
+
+    private void SetData(IDictionary dict)
+    {
+        if (dict != null)
         {
-            (error.Extensions ??= new())[key] = value;
-            return error;
+            foreach (DictionaryEntry keyValuePair in dict)
+            {
+                Data[keyValuePair.Key] = keyValuePair.Value;
+            }
         }
+    }
+}
+
+/// <summary>
+/// Provides extension methods for <see cref="ExecutionError"/> instances.
+/// </summary>
+public static class ExecutionErrorExtensions
+{
+    /// <summary>
+    /// Adds a location to an <see cref="ExecutionError"/> based on a <see cref="ASTNode"/> within a <see cref="GraphQLDocument"/>.
+    /// </summary>
+    public static TError AddLocation<TError>(this TError error, ASTNode? abstractNode, GraphQLDocument? document)
+        where TError : ExecutionError
+    {
+        if (abstractNode == null || abstractNode.Location == default || document == null || document.Source.IsEmpty)
+            return error;
+
+        error.AddLocation(Location.FromLinearPosition(document.Source, abstractNode.Location.Start));
+        return error;
+    }
+
+    /// <summary>
+    /// Adds an extension to <see cref="ExecutionError.Extensions"/>.
+    /// </summary>
+    public static TError AddExtension<TError>(this TError error, string key, object? value)
+         where TError : ExecutionError
+    {
+        (error.Extensions ??= new())[key] = value;
+        return error;
     }
 }

--- a/src/GraphQL/Execution/Errors/ExecutionErrors.cs
+++ b/src/GraphQL/Execution/Errors/ExecutionErrors.cs
@@ -1,72 +1,71 @@
 using System.Collections;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Contains a list of execution errors. Thread safe except <see cref="IEnumerable{T}"/> methods.
+/// </summary>
+public class ExecutionErrors : IEnumerable<ExecutionError>
 {
-    /// <summary>
-    /// Contains a list of execution errors. Thread safe except <see cref="IEnumerable{T}"/> methods.
-    /// </summary>
-    public class ExecutionErrors : IEnumerable<ExecutionError>
+    private readonly object _lock = new();
+    internal List<ExecutionError>? List;
+
+    internal ExecutionErrors(int capacity)
     {
-        private readonly object _lock = new();
-        internal List<ExecutionError>? List;
-
-        internal ExecutionErrors(int capacity)
-        {
-            List = new List<ExecutionError>(capacity);
-        }
-
-        /// <summary>
-        /// Creates an instance of <see cref="ExecutionErrors"/>.
-        /// </summary>
-        public ExecutionErrors()
-        {
-        }
-
-        /// <summary>
-        /// Adds an execution error to the list.
-        /// </summary>
-        public virtual void Add(ExecutionError error)
-        {
-            lock (_lock)
-                (List ??= new()).Add(error ?? throw new ArgumentNullException(nameof(error)));
-        }
-
-        /// <summary>
-        /// Adds a list of execution errors to the list.
-        /// </summary>
-        public virtual void AddRange(IEnumerable<ExecutionError> errors)
-        {
-            foreach (var error in errors)
-                Add(error);
-        }
-
-        /// <summary>
-        /// Returns the number of execution errors in the list.
-        /// </summary>
-        public int Count => List?.Count ?? 0;
-
-        /// <summary>
-        /// Returns the execution error at the specified index.
-        /// </summary>
-        public ExecutionError this[int index] => List != null ? List[index] : throw new IndexOutOfRangeException();
-
-        /// <inheritdoc/>
-        public IEnumerator<ExecutionError> GetEnumerator() => (List ?? Enumerable.Empty<ExecutionError>()).GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        List = new List<ExecutionError>(capacity);
     }
 
     /// <summary>
-    /// Optimization for validation "green path" - does not allocate memory in managed heap.
+    /// Creates an instance of <see cref="ExecutionErrors"/>.
     /// </summary>
-    internal sealed class EmptyExecutionErrors : ExecutionErrors
+    public ExecutionErrors()
     {
-        private EmptyExecutionErrors() { }
-
-        public static readonly EmptyExecutionErrors Instance = new();
-
-        public override void Add(ExecutionError error) => throw new NotSupportedException();
-
-        public override void AddRange(IEnumerable<ExecutionError> errors) => throw new NotSupportedException();
     }
+
+    /// <summary>
+    /// Adds an execution error to the list.
+    /// </summary>
+    public virtual void Add(ExecutionError error)
+    {
+        lock (_lock)
+            (List ??= new()).Add(error ?? throw new ArgumentNullException(nameof(error)));
+    }
+
+    /// <summary>
+    /// Adds a list of execution errors to the list.
+    /// </summary>
+    public virtual void AddRange(IEnumerable<ExecutionError> errors)
+    {
+        foreach (var error in errors)
+            Add(error);
+    }
+
+    /// <summary>
+    /// Returns the number of execution errors in the list.
+    /// </summary>
+    public int Count => List?.Count ?? 0;
+
+    /// <summary>
+    /// Returns the execution error at the specified index.
+    /// </summary>
+    public ExecutionError this[int index] => List != null ? List[index] : throw new IndexOutOfRangeException();
+
+    /// <inheritdoc/>
+    public IEnumerator<ExecutionError> GetEnumerator() => (List ?? Enumerable.Empty<ExecutionError>()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+/// <summary>
+/// Optimization for validation "green path" - does not allocate memory in managed heap.
+/// </summary>
+internal sealed class EmptyExecutionErrors : ExecutionErrors
+{
+    private EmptyExecutionErrors() { }
+
+    public static readonly EmptyExecutionErrors Instance = new();
+
+    public override void Add(ExecutionError error) => throw new NotSupportedException();
+
+    public override void AddRange(IEnumerable<ExecutionError> errors) => throw new NotSupportedException();
 }

--- a/src/GraphQL/Execution/Errors/InvalidOperationError.cs
+++ b/src/GraphQL/Execution/Errors/InvalidOperationError.cs
@@ -1,18 +1,17 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an error triggered by an operation type being requested that is not configured for the schema.
+/// </summary>
+[Serializable]
+public class InvalidOperationError : DocumentError
 {
     /// <summary>
-    /// Represents an error triggered by an operation type being requested that is not configured for the schema.
+    /// Initializes a new instance of the <see cref="InvalidOperationError"/> class with a specified error message.
     /// </summary>
-    [Serializable]
-    public class InvalidOperationError : DocumentError
+    public InvalidOperationError(string message)
+        : base(message)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidOperationError"/> class with a specified error message.
-        /// </summary>
-        public InvalidOperationError(string message)
-            : base(message)
-        {
-            Code = "INVALID_OPERATION";
-        }
+        Code = "INVALID_OPERATION";
     }
 }

--- a/src/GraphQL/Execution/Errors/InvalidOperationNameError.cs
+++ b/src/GraphQL/Execution/Errors/InvalidOperationNameError.cs
@@ -1,18 +1,17 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an error triggered when a request specifies an operation name that is not listed in the document.
+/// </summary>
+[Serializable]
+public class InvalidOperationNameError : DocumentError
 {
     /// <summary>
-    /// Represents an error triggered when a request specifies an operation name that is not listed in the document.
+    /// Initializes a new instance of the <see cref="InvalidOperationNameError"/> class with a specified error message.
     /// </summary>
-    [Serializable]
-    public class InvalidOperationNameError : DocumentError
+    public InvalidOperationNameError(string operationName)
+        : base($"Document does not contain an operation named '{operationName}'.")
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidOperationNameError"/> class with a specified error message.
-        /// </summary>
-        public InvalidOperationNameError(string operationName)
-            : base($"Document does not contain an operation named '{operationName}'.")
-        {
-            Code = "INVALID_OPERATION_NAME";
-        }
+        Code = "INVALID_OPERATION_NAME";
     }
 }

--- a/src/GraphQL/Execution/Errors/MissingOperationError.cs
+++ b/src/GraphQL/Execution/Errors/MissingOperationError.cs
@@ -1,18 +1,17 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an error triggered when the document includes multiple operations, but no operation name was specified in the request.
+/// </summary>
+[Serializable]
+public class NoOperationNameError : DocumentError
 {
     /// <summary>
-    /// Represents an error triggered when the document includes multiple operations, but no operation name was specified in the request.
+    /// Initializes a new instance of the <see cref="NoOperationNameError"/> class.
     /// </summary>
-    [Serializable]
-    public class NoOperationNameError : DocumentError
+    public NoOperationNameError()
+        : base("Document contains more than one operation, but the operation name was not specified.")
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NoOperationNameError"/> class.
-        /// </summary>
-        public NoOperationNameError()
-            : base("Document contains more than one operation, but the operation name was not specified.")
-        {
-            Code = "NO_OPERATION_NAME";
-        }
+        Code = "NO_OPERATION_NAME";
     }
 }

--- a/src/GraphQL/Execution/Errors/NoOperationError.cs
+++ b/src/GraphQL/Execution/Errors/NoOperationError.cs
@@ -1,18 +1,17 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an error triggered when the document does not include any operations.
+/// </summary>
+[Serializable]
+public class NoOperationError : DocumentError
 {
     /// <summary>
-    /// Represents an error triggered when the document does not include any operations.
+    /// Initializes a new instance of the <see cref="NoOperationError"/> class.
     /// </summary>
-    [Serializable]
-    public class NoOperationError : DocumentError
+    public NoOperationError()
+        : base("Document does not contain any operations.")
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NoOperationError"/> class.
-        /// </summary>
-        public NoOperationError()
-            : base("Document does not contain any operations.")
-        {
-            Code = "NO_OPERATION";
-        }
+        Code = "NO_OPERATION";
     }
 }

--- a/src/GraphQL/Execution/Errors/SyntaxError.cs
+++ b/src/GraphQL/Execution/Errors/SyntaxError.cs
@@ -1,23 +1,22 @@
 using GraphQLParser.Exceptions;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an error generated while parsing the document.
+/// </summary>
+[Serializable]
+public class SyntaxError : DocumentError
 {
     /// <summary>
-    /// Represents an error generated while parsing the document.
+    /// Initializes a new instance of the <see cref="SyntaxError"/> class from a specified
+    /// <see cref="GraphQLSyntaxErrorException"/> instance, setting the <see cref="Exception.Message">Message</see>
+    /// and <see cref="ExecutionError.Locations">Locations</see> properties appropriately.
     /// </summary>
-    [Serializable]
-    public class SyntaxError : DocumentError
+    public SyntaxError(GraphQLSyntaxErrorException ex)
+        : base("Error parsing query: " + ex.Description, ex)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SyntaxError"/> class from a specified
-        /// <see cref="GraphQLSyntaxErrorException"/> instance, setting the <see cref="Exception.Message">Message</see>
-        /// and <see cref="ExecutionError.Locations">Locations</see> properties appropriately.
-        /// </summary>
-        public SyntaxError(GraphQLSyntaxErrorException ex)
-            : base("Error parsing query: " + ex.Description, ex)
-        {
-            // Code will contain SYNTAX_ERROR due to inner exception
-            AddLocation(ex.Location);
-        }
+        // Code will contain SYNTAX_ERROR due to inner exception
+        AddLocation(ex.Location);
     }
 }

--- a/src/GraphQL/Execution/Errors/UnhandledError.cs
+++ b/src/GraphQL/Execution/Errors/UnhandledError.cs
@@ -1,19 +1,18 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an unhandled exception caught during document or subscription processing.
+/// </summary>
+[Serializable]
+public class UnhandledError : ExecutionError
 {
     /// <summary>
-    /// Represents an unhandled exception caught during document or subscription processing.
+    /// Initializes a new instance of the <see cref="UnhandledError"/> class with a specified error message. Sets the
+    /// <see cref="ExecutionError.Code">Code</see> property based on the inner exception.
+    /// Loads any exception data from the inner exception into this instance.
     /// </summary>
-    [Serializable]
-    public class UnhandledError : ExecutionError
+    public UnhandledError(string message, Exception innerException)
+        : base(message, innerException)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UnhandledError"/> class with a specified error message. Sets the
-        /// <see cref="ExecutionError.Code">Code</see> property based on the inner exception.
-        /// Loads any exception data from the inner exception into this instance.
-        /// </summary>
-        public UnhandledError(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
     }
 }

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -4,186 +4,185 @@ using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Provides a mutable instance of <see cref="IExecutionContext"/>.
+/// </summary>
+public class ExecutionContext : IExecutionContext, IExecutionArrayPool, IDisposable
 {
-    /// <summary>
-    /// Provides a mutable instance of <see cref="IExecutionContext"/>.
-    /// </summary>
-    public class ExecutionContext : IExecutionContext, IExecutionArrayPool, IDisposable
-    {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        /// <summary>
-        /// Initializes a new instance.
-        /// </summary>
-        public ExecutionContext()
-        {
-        }
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    public ExecutionContext()
+    {
+    }
 
-        /// <summary>
-        /// Clones reusable state information from an existing instance; not any properties that
-        /// hold result information. Specifically, <see cref="Errors"/>, <see cref="Metrics"/>,
-        /// <see cref="OutputExtensions"/>, array pool reservations and internal reusable references
-        /// are not cloned.
-        /// </summary>
-        public ExecutionContext(ExecutionContext context)
-        {
-            ExecutionStrategy = context.ExecutionStrategy;
-            Document = context.Document;
-            Schema = context.Schema;
-            RootValue = context.RootValue;
-            UserContext = context.UserContext;
-            Operation = context.Operation;
-            Variables = context.Variables;
-            ArgumentValues = context.ArgumentValues;
-            DirectiveValues = context.DirectiveValues;
-            CancellationToken = context.CancellationToken;
-            Listeners = context.Listeners;
-            ThrowOnUnhandledException = context.ThrowOnUnhandledException;
-            UnhandledExceptionDelegate = context.UnhandledExceptionDelegate;
-            MaxParallelExecutionCount = context.MaxParallelExecutionCount;
-            InputExtensions = context.InputExtensions;
-            RequestServices = context.RequestServices;
-            User = context.User;
-        }
+    /// <summary>
+    /// Clones reusable state information from an existing instance; not any properties that
+    /// hold result information. Specifically, <see cref="Errors"/>, <see cref="Metrics"/>,
+    /// <see cref="OutputExtensions"/>, array pool reservations and internal reusable references
+    /// are not cloned.
+    /// </summary>
+    public ExecutionContext(ExecutionContext context)
+    {
+        ExecutionStrategy = context.ExecutionStrategy;
+        Document = context.Document;
+        Schema = context.Schema;
+        RootValue = context.RootValue;
+        UserContext = context.UserContext;
+        Operation = context.Operation;
+        Variables = context.Variables;
+        ArgumentValues = context.ArgumentValues;
+        DirectiveValues = context.DirectiveValues;
+        CancellationToken = context.CancellationToken;
+        Listeners = context.Listeners;
+        ThrowOnUnhandledException = context.ThrowOnUnhandledException;
+        UnhandledExceptionDelegate = context.UnhandledExceptionDelegate;
+        MaxParallelExecutionCount = context.MaxParallelExecutionCount;
+        InputExtensions = context.InputExtensions;
+        RequestServices = context.RequestServices;
+        User = context.User;
+    }
 
-        /// <inheritdoc/>
-        public IExecutionStrategy ExecutionStrategy { get; set; }
+    /// <inheritdoc/>
+    public IExecutionStrategy ExecutionStrategy { get; set; }
 
-        /// <inheritdoc/>
-        public GraphQLDocument Document { get; set; }
+    /// <inheritdoc/>
+    public GraphQLDocument Document { get; set; }
 
-        /// <inheritdoc/>
-        public ISchema Schema { get; set; }
+    /// <inheritdoc/>
+    public ISchema Schema { get; set; }
 
-        /// <inheritdoc/>
-        public object? RootValue { get; set; }
+    /// <inheritdoc/>
+    public object? RootValue { get; set; }
 
-        /// <inheritdoc/>
-        public IDictionary<string, object?> UserContext { get; set; }
+    /// <inheritdoc/>
+    public IDictionary<string, object?> UserContext { get; set; }
 
-        /// <inheritdoc/>
-        public GraphQLOperationDefinition Operation { get; set; }
+    /// <inheritdoc/>
+    public GraphQLOperationDefinition Operation { get; set; }
 
-        /// <inheritdoc/>
-        public Variables Variables { get; set; }
+    /// <inheritdoc/>
+    public Variables Variables { get; set; }
 
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; }
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; }
 
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; }
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; }
 
-        /// <inheritdoc/>
-        public ExecutionErrors Errors { get; set; }
+    /// <inheritdoc/>
+    public ExecutionErrors Errors { get; set; }
 
-        /// <inheritdoc/>
-        public CancellationToken CancellationToken { get; set; }
+    /// <inheritdoc/>
+    public CancellationToken CancellationToken { get; set; }
 
-        /// <inheritdoc/>
-        public Metrics Metrics { get; set; }
+    /// <inheritdoc/>
+    public Metrics Metrics { get; set; }
 
-        /// <inheritdoc/>
-        public List<IDocumentExecutionListener> Listeners { get; set; }
+    /// <inheritdoc/>
+    public List<IDocumentExecutionListener> Listeners { get; set; }
 
-        /// <inheritdoc/>
-        public bool ThrowOnUnhandledException { get; set; }
+    /// <inheritdoc/>
+    public bool ThrowOnUnhandledException { get; set; }
 
-        /// <inheritdoc/>
-        public Func<UnhandledExceptionContext, Task> UnhandledExceptionDelegate { get; set; } = _ => Task.CompletedTask;
+    /// <inheritdoc/>
+    public Func<UnhandledExceptionContext, Task> UnhandledExceptionDelegate { get; set; } = _ => Task.CompletedTask;
 
-        /// <inheritdoc/>
-        public int? MaxParallelExecutionCount { get; set; }
+    /// <inheritdoc/>
+    public int? MaxParallelExecutionCount { get; set; }
 
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
 
-        /// <inheritdoc/>
-        public Dictionary<string, object?> OutputExtensions { get; set; }
+    /// <inheritdoc/>
+    public Dictionary<string, object?> OutputExtensions { get; set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
-        /// <inheritdoc/>
-        public IServiceProvider? RequestServices { get; set; }
+    /// <inheritdoc/>
+    public IServiceProvider? RequestServices { get; set; }
 
-        /// <inheritdoc/>
-        public ClaimsPrincipal? User { get; set; }
+    /// <inheritdoc/>
+    public ClaimsPrincipal? User { get; set; }
 
-        /// <inheritdoc/>
-        public TElement[] Rent<TElement>(int minimumLength)
-        {
-            var array = System.Buffers.ArrayPool<TElement>.Shared.Rent(minimumLength);
-            lock (_trackedArrays)
-                _trackedArrays.Add(array);
-            return array;
-        }
-
-        private readonly List<Array> _trackedArrays = new();
-
-        /// <summary>
-        /// Clears all state in this context.
-        /// Releases any rented arrays back to the backing memory pool.
-        /// </summary>
-        public void Dispose()
-        {
-            ClearContext();
-        }
-
-        /// <summary>
-        /// Clears all state in this context including any rented arrays.
-        /// </summary>
-        protected virtual void ClearContext()
-        {
-            // clearing or re-using the context will break any instances of ReadonlyResolveFieldContext from being
-            // able to access many of their properties. This is not typically a problem since the context is re-used
-            // once a field resolver finishes executing. However, a ReadonlyResolveFieldContext instance is not re-used
-            // when an exception within a field resolver is thrown, and the FAQ says that calls to UnhandledExceptionDelegate
-            // will be provided with a context that is not re-used. If we clear or re-use execution contexts, we should
-            // at least provide UnhandledExceptionDelegate with a copy (e.g. create one with ReadonlyResolveFieldContext
-            // and then Copy it) so that it is unaffected by clearing the execution context. Also note that subscription
-            // execution will be affected by clearing the execution context.
-
-            //TODO:
-            //Document = null;
-            //Schema = null;
-            //RootValue = null;
-            //UserContext = null;
-            //Operation = null;
-            //Fragments = null;
-            //Variables = null;
-            //Errors = null;
-            //CancellationToken = default;
-            //Metrics = null;
-            //Listeners = null;
-            //ThrowOnUnhandledException = false;
-            //UnhandledExceptionDelegate = null;
-            //MaxParallelExecutionCount = null;
-            //Extensions = null;
-            //RequestServices = null;
-            //User = null;
-
-            // arrays rented after the execution context has been 'disposed' will still rent just fine, but will
-            // not be returned to the pool (since Dispose has already been run) and will be garbage collected.
-            lock (_trackedArrays)
-            {
-                foreach (var array in _trackedArrays)
-                    array.Return();
-                _trackedArrays.Clear();
-            }
-        }
-
-        /// <summary>
-        /// Allows for an execution strategy to reuse an instance of <see cref="ReadonlyResolveFieldContext"/>.
-        /// This field may be accessed by multiple threads at the same time, so
-        /// access is restricted to <see cref="Interlocked.Exchange{T}(ref T, T)"/>
-        /// and <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>.
-        /// </summary>
-        internal ReadonlyResolveFieldContext? ReusableReadonlyResolveFieldContext;
-
-        /// <summary>
-        /// Allows for an execution strategy to reuse an instance of <see cref="Dictionary{TKey, TValue}"/>.
-        /// This field may be accessed by multiple threads at the same time, so
-        /// access is restricted to <see cref="Interlocked.Exchange{T}(ref T, T)"/>
-        /// and <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>.
-        /// </summary>
-        internal Dictionary<string, (GraphQLField field, FieldType fieldType)>? ReusableFields;
+    /// <inheritdoc/>
+    public TElement[] Rent<TElement>(int minimumLength)
+    {
+        var array = System.Buffers.ArrayPool<TElement>.Shared.Rent(minimumLength);
+        lock (_trackedArrays)
+            _trackedArrays.Add(array);
+        return array;
     }
+
+    private readonly List<Array> _trackedArrays = new();
+
+    /// <summary>
+    /// Clears all state in this context.
+    /// Releases any rented arrays back to the backing memory pool.
+    /// </summary>
+    public void Dispose()
+    {
+        ClearContext();
+    }
+
+    /// <summary>
+    /// Clears all state in this context including any rented arrays.
+    /// </summary>
+    protected virtual void ClearContext()
+    {
+        // clearing or re-using the context will break any instances of ReadonlyResolveFieldContext from being
+        // able to access many of their properties. This is not typically a problem since the context is re-used
+        // once a field resolver finishes executing. However, a ReadonlyResolveFieldContext instance is not re-used
+        // when an exception within a field resolver is thrown, and the FAQ says that calls to UnhandledExceptionDelegate
+        // will be provided with a context that is not re-used. If we clear or re-use execution contexts, we should
+        // at least provide UnhandledExceptionDelegate with a copy (e.g. create one with ReadonlyResolveFieldContext
+        // and then Copy it) so that it is unaffected by clearing the execution context. Also note that subscription
+        // execution will be affected by clearing the execution context.
+
+        //TODO:
+        //Document = null;
+        //Schema = null;
+        //RootValue = null;
+        //UserContext = null;
+        //Operation = null;
+        //Fragments = null;
+        //Variables = null;
+        //Errors = null;
+        //CancellationToken = default;
+        //Metrics = null;
+        //Listeners = null;
+        //ThrowOnUnhandledException = false;
+        //UnhandledExceptionDelegate = null;
+        //MaxParallelExecutionCount = null;
+        //Extensions = null;
+        //RequestServices = null;
+        //User = null;
+
+        // arrays rented after the execution context has been 'disposed' will still rent just fine, but will
+        // not be returned to the pool (since Dispose has already been run) and will be garbage collected.
+        lock (_trackedArrays)
+        {
+            foreach (var array in _trackedArrays)
+                array.Return();
+            _trackedArrays.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Allows for an execution strategy to reuse an instance of <see cref="ReadonlyResolveFieldContext"/>.
+    /// This field may be accessed by multiple threads at the same time, so
+    /// access is restricted to <see cref="Interlocked.Exchange{T}(ref T, T)"/>
+    /// and <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>.
+    /// </summary>
+    internal ReadonlyResolveFieldContext? ReusableReadonlyResolveFieldContext;
+
+    /// <summary>
+    /// Allows for an execution strategy to reuse an instance of <see cref="Dictionary{TKey, TValue}"/>.
+    /// This field may be accessed by multiple threads at the same time, so
+    /// access is restricted to <see cref="Interlocked.Exchange{T}(ref T, T)"/>
+    /// and <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>.
+    /// </summary>
+    internal Dictionary<string, (GraphQLField field, FieldType fieldType)>? ReusableFields;
 }

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -4,343 +4,342 @@ using GraphQL.Validation;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Provides helper methods for document execution.
+/// </summary>
+public static class ExecutionHelper
 {
+    private static readonly IDictionary<string, ArgumentValue> _emptyDirectiveArguments = new ReadOnlyDictionary<string, ArgumentValue>(new Dictionary<string, ArgumentValue>());
+
     /// <summary>
-    /// Provides helper methods for document execution.
+    /// Returns a dictionary of directives with their arguments values for a node (field, fragment spread, inline fragment).
+    /// Values will be retrieved from literals or variables as specified by the document.
     /// </summary>
-    public static class ExecutionHelper
+    public static IDictionary<string, DirectiveInfo>? GetDirectives(IHasDirectivesNode node, Variables? variables, ISchema schema, GraphQLDocument document)
     {
-        private static readonly IDictionary<string, ArgumentValue> _emptyDirectiveArguments = new ReadOnlyDictionary<string, ArgumentValue>(new Dictionary<string, ArgumentValue>());
+        if (node.Directives == null || node.Directives.Count == 0)
+            return null;
 
-        /// <summary>
-        /// Returns a dictionary of directives with their arguments values for a node (field, fragment spread, inline fragment).
-        /// Values will be retrieved from literals or variables as specified by the document.
-        /// </summary>
-        public static IDictionary<string, DirectiveInfo>? GetDirectives(IHasDirectivesNode node, Variables? variables, ISchema schema, GraphQLDocument document)
+        Dictionary<string, DirectiveInfo>? directives = null;
+
+        foreach (var dir in node.Directives.Items)
         {
-            if (node.Directives == null || node.Directives.Count == 0)
-                return null;
+            var dirDefinition = schema.Directives.Find(dir.Name);
 
-            Dictionary<string, DirectiveInfo>? directives = null;
+            // KnownDirectivesInAllowedLocations validation rule should handle unknown directives, so
+            // if someone purposely removed the validation rule, it would ignore unknown directives
+            // while executing the request
+            if (dirDefinition == null)
+                continue;
 
-            foreach (var dir in node.Directives.Items)
-            {
-                var dirDefinition = schema.Directives.Find(dir.Name);
-
-                // KnownDirectivesInAllowedLocations validation rule should handle unknown directives, so
-                // if someone purposely removed the validation rule, it would ignore unknown directives
-                // while executing the request
-                if (dirDefinition == null)
-                    continue;
-
-                (directives ??= new())[dirDefinition.Name] = new DirectiveInfo(
-                    dirDefinition,
-                    GetArguments(dirDefinition.Arguments, dir.Arguments, variables, document, (ASTNode)node, dir) ?? _emptyDirectiveArguments);
-            }
-
-            return directives;
+            (directives ??= new())[dirDefinition.Name] = new DirectiveInfo(
+                dirDefinition,
+                GetArguments(dirDefinition.Arguments, dir.Arguments, variables, document, (ASTNode)node, dir) ?? _emptyDirectiveArguments);
         }
 
-        /// <summary>
-        /// Returns a dictionary of arguments and their values for a field or directive.
-        /// Values will be retrieved from literals or variables as specified by the document.
-        /// </summary>
-        public static Dictionary<string, ArgumentValue>? GetArguments(QueryArguments? definitionArguments, GraphQLArguments? astArguments, Variables? variables, GraphQLDocument document, ASTNode fieldOrFragmentSpread, GraphQLDirective? directive)
+        return directives;
+    }
+
+    /// <summary>
+    /// Returns a dictionary of arguments and their values for a field or directive.
+    /// Values will be retrieved from literals or variables as specified by the document.
+    /// </summary>
+    public static Dictionary<string, ArgumentValue>? GetArguments(QueryArguments? definitionArguments, GraphQLArguments? astArguments, Variables? variables, GraphQLDocument document, ASTNode fieldOrFragmentSpread, GraphQLDirective? directive)
+    {
+        if (definitionArguments == null || definitionArguments.Count == 0)
+            return null;
+
+        var values = new Dictionary<string, ArgumentValue>(definitionArguments.Count);
+
+        foreach (var arg in definitionArguments.List!)
         {
-            if (definitionArguments == null || definitionArguments.Count == 0)
-                return null;
-
-            var values = new Dictionary<string, ArgumentValue>(definitionArguments.Count);
-
-            foreach (var arg in definitionArguments.List!)
+            GraphQLArgument? argNode = null;
+            if (astArguments != null)
             {
-                GraphQLArgument? argNode = null;
-                if (astArguments != null)
+                foreach (var node in astArguments)
                 {
-                    foreach (var node in astArguments)
+                    if (node.Name.Value.Equals(arg.Name))
                     {
-                        if (node.Name.Value.Equals(arg.Name))
-                        {
-                            argNode = node;
-                        }
+                        argNode = node;
                     }
                 }
-                var value = argNode?.Value;
-                var type = arg.ResolvedType!;
+            }
+            var value = argNode?.Value;
+            var type = arg.ResolvedType!;
 
-                var argValue = CoerceValue(type, value, new CoerceValueContext
-                {
-                    Argument = argNode,
-                    Document = document,
-                    Directive = directive,
-                    ParentNode = fieldOrFragmentSpread,
-                    Variables = variables,
-                }, arg.DefaultValue);
+            var argValue = CoerceValue(type, value, new CoerceValueContext
+            {
+                Argument = argNode,
+                Document = document,
+                Directive = directive,
+                ParentNode = fieldOrFragmentSpread,
+                Variables = variables,
+            }, arg.DefaultValue);
 
-                if (value != null) // if value is null, it's a default value (and argValue.Source == ArgumentSource.FieldDefault)
+            if (value != null) // if value is null, it's a default value (and argValue.Source == ArgumentSource.FieldDefault)
+            {
+                object? parsedValue = argValue.Value;
+                if (parsedValue != null)
                 {
-                    object? parsedValue = argValue.Value;
-                    if (parsedValue != null)
+                    try
                     {
-                        try
-                        {
-                            if (arg.Parser != null)
-                                parsedValue = arg.Parser(parsedValue);
-                            if (parsedValue != null && arg.Validator != null)
-                                arg.Validator(parsedValue);
-                        }
-                        catch (ValidationError ex)
-                        {
-                            if (argNode != null)
-                                ex.AddNode(document.Source, argNode);
-                            throw;
-                        }
-                        catch (ExecutionError ex)
-                        {
-                            if (argNode != null)
-                                ex.AddLocation(Location.FromLinearPosition(document.Source, argNode.Location.Start));
-                            throw;
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new InvalidValueError(document, fieldOrFragmentSpread, directive, argNode, value, ex);
-                        }
+                        if (arg.Parser != null)
+                            parsedValue = arg.Parser(parsedValue);
+                        if (parsedValue != null && arg.Validator != null)
+                            arg.Validator(parsedValue);
                     }
-                    argValue = new(parsedValue, argValue.Source);
+                    catch (ValidationError ex)
+                    {
+                        if (argNode != null)
+                            ex.AddNode(document.Source, argNode);
+                        throw;
+                    }
+                    catch (ExecutionError ex)
+                    {
+                        if (argNode != null)
+                            ex.AddLocation(Location.FromLinearPosition(document.Source, argNode.Location.Start));
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidValueError(document, fieldOrFragmentSpread, directive, argNode, value, ex);
+                    }
+                }
+                argValue = new(parsedValue, argValue.Source);
+            }
+
+            values[arg.Name] = argValue;
+        }
+
+        return values;
+    }
+
+    internal readonly ref struct CoerceValueContext
+    {
+        public GraphQLDocument? Document { get; init; }
+        /// <summary>
+        /// This is typically either a field, a fragment spread, or variable definition.
+        /// </summary>
+        public ASTNode? ParentNode { get; init; }
+        public GraphQLDirective? Directive { get; init; }
+        public GraphQLArgument? Argument { get; init; }
+        public Variables? Variables { get; init; }
+    }
+
+    /// <summary>
+    /// Coerces a literal value to a compatible .NET type for the variable's graph type.
+    /// Typically this is a value for a field argument or default value for a variable.
+    /// Exceptions thrown by scalars are passed through.
+    /// </summary>
+    public static ArgumentValue CoerceValue(IGraphType type, GraphQLValue? input, Variables? variables = null, object? fieldDefault = null)
+        => CoerceValue(type, input, new CoerceValueContext { Variables = variables }, fieldDefault);
+
+    /// <summary>
+    /// Coerces a literal value to a compatible .NET type for the variable's graph type.
+    /// Typically this is a value for a field argument or default value for a variable.
+    /// Exceptions thrown by scalars are wrapped in <see cref="InvalidLiteralError"/>
+    /// if <see cref="CoerceValueContext.Document"/> and <see cref="CoerceValueContext.ParentNode"/> are set.
+    /// </summary>
+    internal static ArgumentValue CoerceValue(IGraphType type, GraphQLValue? input, CoerceValueContext context, object? fieldDefault = null)
+    {
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (type is NonNullGraphType nonNull)
+        {
+            // validation rules have verified that this is not null; if the validation rule was not executed, it
+            // is assumed that the caller does not wish this check to be executed
+            return CoerceValue(nonNull.ResolvedType!, input, context, fieldDefault);
+        }
+
+        if (input == null)
+        {
+            return new ArgumentValue(fieldDefault, ArgumentSource.FieldDefault);
+        }
+
+        if (input is GraphQLVariable variable)
+        {
+            var v = context.Variables?.Find(variable.Name);
+            if (v != null && (v.IsDefault || v.ValueSpecified))
+            {
+                // get the variable value
+                var value = v.Value;
+
+                // wrap list if necessary
+                // todo: v.Definition != null for backwards compatibility for 7.x; remove in 8.x
+                if (value != null && v.Definition != null && !IsASTListType(v.Definition.Type))
+                {
+                    //---THE FOLLOWING CODE CRASHES THE .NET 7.0.304 COMPILER
+                    //
+                    //while (type is ListGraphType listType2)
+                    //{
+                    //    value = new object?[] { value };
+                    //    type = listType2.ResolvedType!;
+                    //}
+                    //
+                    //---SO INSTEAD WE HAVE:
+                    while (WrapType(ref type, ref value))
+                    {
+                    }
+
+                    static bool WrapType(ref IGraphType type, ref object? value)
+                    {
+                        if (type is ListGraphType listType)
+                        {
+                            value = new object?[] { value };
+                            type = listType.ResolvedType!;
+                            return true;
+                        }
+                        return false;
+                    }
+                    //-----
                 }
 
-                values[arg.Name] = argValue;
+                // return the variable
+                return new ArgumentValue(value, v.IsDefault ? ArgumentSource.VariableDefault : ArgumentSource.Variable);
+
+                static bool IsASTListType(GraphQLType type)
+                    => type is GraphQLListType || (type is GraphQLNonNullType nonNullType && nonNullType.Type is GraphQLListType);
             }
-
-            return values;
-        }
-
-        internal readonly ref struct CoerceValueContext
-        {
-            public GraphQLDocument? Document { get; init; }
-            /// <summary>
-            /// This is typically either a field, a fragment spread, or variable definition.
-            /// </summary>
-            public ASTNode? ParentNode { get; init; }
-            public GraphQLDirective? Directive { get; init; }
-            public GraphQLArgument? Argument { get; init; }
-            public Variables? Variables { get; init; }
-        }
-
-        /// <summary>
-        /// Coerces a literal value to a compatible .NET type for the variable's graph type.
-        /// Typically this is a value for a field argument or default value for a variable.
-        /// Exceptions thrown by scalars are passed through.
-        /// </summary>
-        public static ArgumentValue CoerceValue(IGraphType type, GraphQLValue? input, Variables? variables = null, object? fieldDefault = null)
-            => CoerceValue(type, input, new CoerceValueContext { Variables = variables }, fieldDefault);
-
-        /// <summary>
-        /// Coerces a literal value to a compatible .NET type for the variable's graph type.
-        /// Typically this is a value for a field argument or default value for a variable.
-        /// Exceptions thrown by scalars are wrapped in <see cref="InvalidLiteralError"/>
-        /// if <see cref="CoerceValueContext.Document"/> and <see cref="CoerceValueContext.ParentNode"/> are set.
-        /// </summary>
-        internal static ArgumentValue CoerceValue(IGraphType type, GraphQLValue? input, CoerceValueContext context, object? fieldDefault = null)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            if (type is NonNullGraphType nonNull)
-            {
-                // validation rules have verified that this is not null; if the validation rule was not executed, it
-                // is assumed that the caller does not wish this check to be executed
-                return CoerceValue(nonNull.ResolvedType!, input, context, fieldDefault);
-            }
-
-            if (input == null)
+            else
             {
                 return new ArgumentValue(fieldDefault, ArgumentSource.FieldDefault);
             }
-
-            if (input is GraphQLVariable variable)
-            {
-                var v = context.Variables?.Find(variable.Name);
-                if (v != null && (v.IsDefault || v.ValueSpecified))
-                {
-                    // get the variable value
-                    var value = v.Value;
-
-                    // wrap list if necessary
-                    // todo: v.Definition != null for backwards compatibility for 7.x; remove in 8.x
-                    if (value != null && v.Definition != null && !IsASTListType(v.Definition.Type))
-                    {
-                        //---THE FOLLOWING CODE CRASHES THE .NET 7.0.304 COMPILER
-                        //
-                        //while (type is ListGraphType listType2)
-                        //{
-                        //    value = new object?[] { value };
-                        //    type = listType2.ResolvedType!;
-                        //}
-                        //
-                        //---SO INSTEAD WE HAVE:
-                        while (WrapType(ref type, ref value))
-                        {
-                        }
-
-                        static bool WrapType(ref IGraphType type, ref object? value)
-                        {
-                            if (type is ListGraphType listType)
-                            {
-                                value = new object?[] { value };
-                                type = listType.ResolvedType!;
-                                return true;
-                            }
-                            return false;
-                        }
-                        //-----
-                    }
-
-                    // return the variable
-                    return new ArgumentValue(value, v.IsDefault ? ArgumentSource.VariableDefault : ArgumentSource.Variable);
-
-                    static bool IsASTListType(GraphQLType type)
-                        => type is GraphQLListType || (type is GraphQLNonNullType nonNullType && nonNullType.Type is GraphQLListType);
-                }
-                else
-                {
-                    return new ArgumentValue(fieldDefault, ArgumentSource.FieldDefault);
-                }
-            }
-
-            if (type is ScalarGraphType scalarType)
-            {
-                try
-                {
-                    return new ArgumentValue(scalarType.ParseLiteral(input), ArgumentSource.Literal);
-                }
-                catch (Exception ex) when (context.Document != null && context.ParentNode != null)
-                {
-                    throw new InvalidLiteralError(context.Document, context.ParentNode, context.Directive, context.Argument, input, ex);
-                }
-            }
-
-            if (input is GraphQLNullValue)
-            {
-                return ArgumentValue.NullLiteral;
-            }
-
-            if (type is ListGraphType listType)
-            {
-                var listItemType = listType.ResolvedType!;
-
-                if (input is GraphQLListValue list)
-                {
-                    var count = list.Values?.Count ?? 0;
-                    if (count == 0)
-                        return new ArgumentValue(Array.Empty<object>(), ArgumentSource.Literal);
-
-                    var values = new object?[count];
-                    for (int i = 0; i < count; ++i)
-                        values[i] = CoerceValue(listItemType, list.Values![i], context).Value;
-                    return new ArgumentValue(values, ArgumentSource.Literal);
-                }
-                else
-                {
-                    return new ArgumentValue(new[] { CoerceValue(listItemType, input, context).Value }, ArgumentSource.Literal);
-                }
-            }
-
-            if (type is IInputObjectGraphType inputObjectGraphType)
-            {
-                if (input is not GraphQLObjectValue objectValue)
-                {
-                    if (context.Document != null && context.ParentNode != null)
-                    {
-                        throw new InvalidLiteralError(context.Document, context.ParentNode, context.Directive, context.Argument, input,
-                            $"Expected object value for '{inputObjectGraphType.Name}', found not an object '{input.Print()}'.");
-                    }
-                    else
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(input), $"Expected object value for '{inputObjectGraphType.Name}', found not an object '{input.Print()}'.");
-                    }
-                }
-
-                var obj = new Dictionary<string, object?>();
-
-                foreach (var field in inputObjectGraphType.Fields.List)
-                {
-                    // https://spec.graphql.org/October2021/#sec-Input-Objects
-                    var objectField = objectValue.Field(field.Name);
-                    if (objectField != null)
-                    {
-                        // Rules covered:
-
-                        // If a literal value is provided for an input object field, an entry in the coerced unordered map is
-                        // given the result of coercing that value according to the input coercion rules for the type of that field.
-
-                        // If a variable is provided for an input object field, the runtime value of that variable must be used.
-                        // If the runtime value is null and the field type is non‐null, a field error must be thrown.
-                        // If no runtime value is provided, the variable definition’s default value should be used.
-                        // If the variable definition does not provide a default value, the input object field definition’s
-                        // default value should be used.
-
-                        var value = CoerceValue(field.ResolvedType!, objectField.Value, context, field.DefaultValue);
-                        // when a optional variable is specified for the input field, and the variable is not defined, and
-                        //   when there is no default value specified for the input field, then do not add the entry to the
-                        //   unordered map.
-                        if (value.Source != ArgumentSource.FieldDefault)
-                        {
-                            var parsedValue = value.Value;
-                            if (parsedValue != null)
-                            {
-                                try
-                                {
-                                    if (field.Parser != null)
-                                        parsedValue = field.Parser(parsedValue);
-                                    if (parsedValue != null && field.Validator != null)
-                                        field.Validator(parsedValue);
-                                }
-                                catch (ValidationError ex) when (context.Document != null)
-                                {
-                                    ex.AddNode(context.Document.Source, objectField);
-                                    throw;
-                                }
-                                catch (ExecutionError ex) when (context.Document != null)
-                                {
-                                    ex.AddLocation(Location.FromLinearPosition(context.Document.Source, objectField.Value.Location.Start));
-                                    throw;
-                                }
-                                catch (Exception ex) when (context.Document != null && context.ParentNode != null)
-                                {
-                                    throw new InvalidValueError(context.Document, context.ParentNode, context.Directive, context.Argument, objectField.Value, ex);
-                                }
-                            }
-                            obj[field.Name] = parsedValue;
-                        }
-                        else if (value.Value != null)
-                            obj[field.Name] = value.Value;
-                    }
-                    else if (field.DefaultValue != null)
-                    {
-                        // If no value is provided for a defined input object field and that field definition provides a default value,
-                        // the default value should be used.
-                        obj[field.Name] = field.DefaultValue;
-                    }
-                    // Otherwise, if the field is not required, then no entry is added to the coerced unordered map.
-
-                    // Covered by validation rules:
-                    // If no default value is provided and the input object field’s type is non‐null, an error should be
-                    // thrown.
-                }
-
-                try
-                {
-                    return new ArgumentValue(inputObjectGraphType.ParseDictionary(obj), ArgumentSource.Literal);
-                }
-                catch (Exception ex) when (context.Document != null && context.ParentNode != null)
-                {
-                    throw new InvalidLiteralError(context.Document, context.ParentNode, context.Directive, context.Argument, input, ex);
-                }
-            }
-
-            throw new ArgumentOutOfRangeException(nameof(input), $"Unknown type of input object '{type.GetType()}'");
         }
+
+        if (type is ScalarGraphType scalarType)
+        {
+            try
+            {
+                return new ArgumentValue(scalarType.ParseLiteral(input), ArgumentSource.Literal);
+            }
+            catch (Exception ex) when (context.Document != null && context.ParentNode != null)
+            {
+                throw new InvalidLiteralError(context.Document, context.ParentNode, context.Directive, context.Argument, input, ex);
+            }
+        }
+
+        if (input is GraphQLNullValue)
+        {
+            return ArgumentValue.NullLiteral;
+        }
+
+        if (type is ListGraphType listType)
+        {
+            var listItemType = listType.ResolvedType!;
+
+            if (input is GraphQLListValue list)
+            {
+                var count = list.Values?.Count ?? 0;
+                if (count == 0)
+                    return new ArgumentValue(Array.Empty<object>(), ArgumentSource.Literal);
+
+                var values = new object?[count];
+                for (int i = 0; i < count; ++i)
+                    values[i] = CoerceValue(listItemType, list.Values![i], context).Value;
+                return new ArgumentValue(values, ArgumentSource.Literal);
+            }
+            else
+            {
+                return new ArgumentValue(new[] { CoerceValue(listItemType, input, context).Value }, ArgumentSource.Literal);
+            }
+        }
+
+        if (type is IInputObjectGraphType inputObjectGraphType)
+        {
+            if (input is not GraphQLObjectValue objectValue)
+            {
+                if (context.Document != null && context.ParentNode != null)
+                {
+                    throw new InvalidLiteralError(context.Document, context.ParentNode, context.Directive, context.Argument, input,
+                        $"Expected object value for '{inputObjectGraphType.Name}', found not an object '{input.Print()}'.");
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(nameof(input), $"Expected object value for '{inputObjectGraphType.Name}', found not an object '{input.Print()}'.");
+                }
+            }
+
+            var obj = new Dictionary<string, object?>();
+
+            foreach (var field in inputObjectGraphType.Fields.List)
+            {
+                // https://spec.graphql.org/October2021/#sec-Input-Objects
+                var objectField = objectValue.Field(field.Name);
+                if (objectField != null)
+                {
+                    // Rules covered:
+
+                    // If a literal value is provided for an input object field, an entry in the coerced unordered map is
+                    // given the result of coercing that value according to the input coercion rules for the type of that field.
+
+                    // If a variable is provided for an input object field, the runtime value of that variable must be used.
+                    // If the runtime value is null and the field type is non‐null, a field error must be thrown.
+                    // If no runtime value is provided, the variable definition’s default value should be used.
+                    // If the variable definition does not provide a default value, the input object field definition’s
+                    // default value should be used.
+
+                    var value = CoerceValue(field.ResolvedType!, objectField.Value, context, field.DefaultValue);
+                    // when a optional variable is specified for the input field, and the variable is not defined, and
+                    //   when there is no default value specified for the input field, then do not add the entry to the
+                    //   unordered map.
+                    if (value.Source != ArgumentSource.FieldDefault)
+                    {
+                        var parsedValue = value.Value;
+                        if (parsedValue != null)
+                        {
+                            try
+                            {
+                                if (field.Parser != null)
+                                    parsedValue = field.Parser(parsedValue);
+                                if (parsedValue != null && field.Validator != null)
+                                    field.Validator(parsedValue);
+                            }
+                            catch (ValidationError ex) when (context.Document != null)
+                            {
+                                ex.AddNode(context.Document.Source, objectField);
+                                throw;
+                            }
+                            catch (ExecutionError ex) when (context.Document != null)
+                            {
+                                ex.AddLocation(Location.FromLinearPosition(context.Document.Source, objectField.Value.Location.Start));
+                                throw;
+                            }
+                            catch (Exception ex) when (context.Document != null && context.ParentNode != null)
+                            {
+                                throw new InvalidValueError(context.Document, context.ParentNode, context.Directive, context.Argument, objectField.Value, ex);
+                            }
+                        }
+                        obj[field.Name] = parsedValue;
+                    }
+                    else if (value.Value != null)
+                        obj[field.Name] = value.Value;
+                }
+                else if (field.DefaultValue != null)
+                {
+                    // If no value is provided for a defined input object field and that field definition provides a default value,
+                    // the default value should be used.
+                    obj[field.Name] = field.DefaultValue;
+                }
+                // Otherwise, if the field is not required, then no entry is added to the coerced unordered map.
+
+                // Covered by validation rules:
+                // If no default value is provided and the input object field’s type is non‐null, an error should be
+                // thrown.
+            }
+
+            try
+            {
+                return new ArgumentValue(inputObjectGraphType.ParseDictionary(obj), ArgumentSource.Literal);
+            }
+            catch (Exception ex) when (context.Document != null && context.ParentNode != null)
+            {
+                throw new InvalidLiteralError(context.Document, context.ParentNode, context.Directive, context.Argument, input, ex);
+            }
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(input), $"Unknown type of input object '{type.GetType()}'");
     }
 }

--- a/src/GraphQL/Execution/ExecutionOptions.cs
+++ b/src/GraphQL/Execution/ExecutionOptions.cs
@@ -4,79 +4,78 @@ using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQLParser.AST;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>Configuration options to be passed to <see cref="IDocumentExecuter"/> to execute a query</summary>
+public class ExecutionOptions : IProvideUserContext
 {
-    /// <summary>Configuration options to be passed to <see cref="IDocumentExecuter"/> to execute a query</summary>
-    public class ExecutionOptions : IProvideUserContext
-    {
-        /// <summary>
-        /// Schema of graph to use; required
-        /// <br/><br/>
-        /// Schema will be initialized if it has not yet been initialized.
-        /// </summary>
-        public ISchema? Schema { get; set; }
+    /// <summary>
+    /// Schema of graph to use; required
+    /// <br/><br/>
+    /// Schema will be initialized if it has not yet been initialized.
+    /// </summary>
+    public ISchema? Schema { get; set; }
 
-        /// <summary>Object to pass to the <see cref="IResolveFieldContext.Source"/> property of first-level resolvers</summary>
-        public object? Root { get; set; }
+    /// <summary>Object to pass to the <see cref="IResolveFieldContext.Source"/> property of first-level resolvers</summary>
+    public object? Root { get; set; }
 
-        /// <summary>GraphQL query to parse and execute; required</summary>
-        public string? Query { get; set; }
+    /// <summary>GraphQL query to parse and execute; required</summary>
+    public string? Query { get; set; }
 
-        /// <summary>GraphQL query operation name; optional, defaults to first (if any) operation defined in query</summary>
-        public string? OperationName { get; set; }
+    /// <summary>GraphQL query operation name; optional, defaults to first (if any) operation defined in query</summary>
+    public string? OperationName { get; set; }
 
-        /// <summary>
-        /// Parsed GraphQL request; can be used to increase performance when implementing a cache of parsed
-        /// GraphQL requests (a <see cref="GraphQLDocument"/>). If not set, it will be parsed from <see cref="Query"/>.
-        /// </summary>
-        public GraphQLDocument? Document { get; set; }
+    /// <summary>
+    /// Parsed GraphQL request; can be used to increase performance when implementing a cache of parsed
+    /// GraphQL requests (a <see cref="GraphQLDocument"/>). If not set, it will be parsed from <see cref="Query"/>.
+    /// </summary>
+    public GraphQLDocument? Document { get; set; }
 
-        /// <summary>Input variables to GraphQL request</summary>
-        public Inputs? Variables { get; set; }
+    /// <summary>Input variables to GraphQL request</summary>
+    public Inputs? Variables { get; set; }
 
-        /// <summary>Input extensions to GraphQL request</summary>
-        public Inputs? Extensions { get; set; }
+    /// <summary>Input extensions to GraphQL request</summary>
+    public Inputs? Extensions { get; set; }
 
-        /// <summary><see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel the request at any stage of its execution; defaults to <see cref="CancellationToken.None"/></summary>
-        public CancellationToken CancellationToken { get; set; }
+    /// <summary><see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel the request at any stage of its execution; defaults to <see cref="CancellationToken.None"/></summary>
+    public CancellationToken CancellationToken { get; set; }
 
-        /// <summary>Validation rules to be used by the <see cref="IDocumentValidator"/> when a cached document is used. Since documents are only cached after they are validated, this defaults to an empty set so no validation is performed.</summary>
-        public IEnumerable<IValidationRule>? CachedDocumentValidationRules { get; set; }
+    /// <summary>Validation rules to be used by the <see cref="IDocumentValidator"/> when a cached document is used. Since documents are only cached after they are validated, this defaults to an empty set so no validation is performed.</summary>
+    public IEnumerable<IValidationRule>? CachedDocumentValidationRules { get; set; }
 
-        /// <summary>Validation rules to be used by the <see cref="IDocumentValidator"/>; defaults to standard list of validation rules - see <see cref="DocumentValidator.CoreRules"/></summary>
-        public IEnumerable<IValidationRule>? ValidationRules { get; set; }
+    /// <summary>Validation rules to be used by the <see cref="IDocumentValidator"/>; defaults to standard list of validation rules - see <see cref="DocumentValidator.CoreRules"/></summary>
+    public IEnumerable<IValidationRule>? ValidationRules { get; set; }
 
-        /// <inheritdoc/>
-        public IDictionary<string, object?> UserContext { get; set; } = new Dictionary<string, object?>();
+    /// <inheritdoc/>
+    public IDictionary<string, object?> UserContext { get; set; } = new Dictionary<string, object?>();
 
-        /// <summary>A list of <see cref="IDocumentExecutionListener"/>s, enabling code to be executed at various points during the processing of the GraphQL query</summary>
-        public List<IDocumentExecutionListener> Listeners { get; } = new List<IDocumentExecutionListener>();
+    /// <summary>A list of <see cref="IDocumentExecutionListener"/>s, enabling code to be executed at various points during the processing of the GraphQL query</summary>
+    public List<IDocumentExecutionListener> Listeners { get; } = new List<IDocumentExecutionListener>();
 
-        /// <summary>This setting essentially allows Apollo Tracing. Disabling will increase performance.</summary>
-        public bool EnableMetrics { get; set; }
+    /// <summary>This setting essentially allows Apollo Tracing. Disabling will increase performance.</summary>
+    public bool EnableMetrics { get; set; }
 
-        /// <summary>When <see langword="false"/>, captures unhandled exceptions and returns them within <see cref="ExecutionResult.Errors">ExecutionResult.Errors</see></summary>
-        public bool ThrowOnUnhandledException { get; set; }
+    /// <summary>When <see langword="false"/>, captures unhandled exceptions and returns them within <see cref="ExecutionResult.Errors">ExecutionResult.Errors</see></summary>
+    public bool ThrowOnUnhandledException { get; set; }
 
-        /// <summary>
-        /// A delegate that can override, hide, modify, or log unhandled exceptions before they are stored
-        /// within <see cref="ExecutionResult.Errors"/> as an <see cref="ExecutionError"/>.
-        /// This can be useful for hiding error messages that reveal server implementation details.
-        /// </summary>
-        public Func<UnhandledExceptionContext, Task> UnhandledExceptionDelegate { get; set; } = _ => Task.CompletedTask;
+    /// <summary>
+    /// A delegate that can override, hide, modify, or log unhandled exceptions before they are stored
+    /// within <see cref="ExecutionResult.Errors"/> as an <see cref="ExecutionError"/>.
+    /// This can be useful for hiding error messages that reveal server implementation details.
+    /// </summary>
+    public Func<UnhandledExceptionContext, Task> UnhandledExceptionDelegate { get; set; } = _ => Task.CompletedTask;
 
-        /// <summary>If set, limits the maximum number of nodes executed in parallel</summary>
-        public int? MaxParallelExecutionCount { get; set; }
+    /// <summary>If set, limits the maximum number of nodes executed in parallel</summary>
+    public int? MaxParallelExecutionCount { get; set; }
 
-        /// <summary>
-        /// The service provider for the executing request. Typically this is set to a scoped service provider
-        /// from your dependency injection framework.
-        /// </summary>
-        public IServiceProvider? RequestServices { get; set; }
+    /// <summary>
+    /// The service provider for the executing request. Typically this is set to a scoped service provider
+    /// from your dependency injection framework.
+    /// </summary>
+    public IServiceProvider? RequestServices { get; set; }
 
-        /// <summary>
-        /// Gets or sets security information for the executing request.
-        /// </summary>
-        public ClaimsPrincipal? User { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets security information for the executing request.
+    /// </summary>
+    public ClaimsPrincipal? User { get; set; }
 }

--- a/src/GraphQL/Execution/ExecutionResult.cs
+++ b/src/GraphQL/Execution/ExecutionResult.cs
@@ -4,129 +4,128 @@ using GraphQLParser;
 using GraphQLParser.AST;
 using ExecutionContext = GraphQL.Execution.ExecutionContext;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Represents the result of an execution.
+/// </summary>
+public class ExecutionResult
 {
     /// <summary>
-    /// Represents the result of an execution.
+    /// Indicates if the operation included execution. If an error was encountered BEFORE execution begins,
+    /// the data entry SHOULD NOT be present in the result. If an error was encountered DURING the execution
+    /// that prevented a valid response, the data entry in the response SHOULD BE <see langword="null"/>.
     /// </summary>
-    public class ExecutionResult
+    public bool Executed { get; set; }
+
+    /// <summary>
+    /// Returns the data from the graph resolvers. This property is serialized as part of the GraphQL json response.
+    /// Should be set to <see langword="null"/> for subscription results.
+    /// </summary>
+    public object? Data { get; set; }
+
+    /// <summary>
+    /// Gets or sets a dictionary of returned subscription fields along with their
+    /// response streams as <see cref="IObservable{T}"/> implementations.
+    /// Should be set to <see langword="null"/> for query or mutation results.
+    /// According to the GraphQL specification this dictionary should have exactly one item.
+    /// </summary>
+    public IDictionary<string, IObservable<ExecutionResult>>? Streams { get; set; }
+
+    /// <summary>
+    /// Returns a set of errors that occurred during any stage of processing (parsing, validating, executing, etc.). This property is serialized as part of the GraphQL json response.
+    /// </summary>
+    public ExecutionErrors? Errors { get; set; }
+
+    /// <summary>
+    /// Returns the original GraphQL query.
+    /// </summary>
+    public ROM Query { get; set; }
+
+    /// <summary>
+    /// Returns the parsed GraphQL request.
+    /// </summary>
+    public GraphQLDocument? Document { get; set; }
+
+    /// <summary>
+    /// Returns the GraphQL operation that is being executed.
+    /// </summary>
+    public GraphQLOperationDefinition? Operation { get; set; }
+
+    /// <summary>
+    /// Returns the performance metrics (Apollo Tracing) when enabled by <see cref="ExecutionOptions.EnableMetrics"/>.
+    /// </summary>
+    public PerfRecord[]? Perf { get; set; }
+
+    /// <summary>
+    /// Returns additional user-defined data; see <see cref="IExecutionContext.OutputExtensions"/> and <see cref="IResolveFieldContext.OutputExtensions"/>. This property is serialized as part of the GraphQL json response.
+    /// </summary>
+    public Dictionary<string, object?>? Extensions { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance with all properties set to their defaults.
+    /// </summary>
+    public ExecutionResult()
     {
-        /// <summary>
-        /// Indicates if the operation included execution. If an error was encountered BEFORE execution begins,
-        /// the data entry SHOULD NOT be present in the result. If an error was encountered DURING the execution
-        /// that prevented a valid response, the data entry in the response SHOULD BE <see langword="null"/>.
-        /// </summary>
-        public bool Executed { get; set; }
+    }
 
-        /// <summary>
-        /// Returns the data from the graph resolvers. This property is serialized as part of the GraphQL json response.
-        /// Should be set to <see langword="null"/> for subscription results.
-        /// </summary>
-        public object? Data { get; set; }
+    /// <summary>
+    /// Initializes a new instance as a clone of an existing <see cref="ExecutionResult"/>.
+    /// </summary>
+    public ExecutionResult(ExecutionResult result)
+    {
+        if (result == null)
+            throw new ArgumentNullException(nameof(result));
 
-        /// <summary>
-        /// Gets or sets a dictionary of returned subscription fields along with their
-        /// response streams as <see cref="IObservable{T}"/> implementations.
-        /// Should be set to <see langword="null"/> for query or mutation results.
-        /// According to the GraphQL specification this dictionary should have exactly one item.
-        /// </summary>
-        public IDictionary<string, IObservable<ExecutionResult>>? Streams { get; set; }
+        Executed = result.Executed;
+        Data = result.Data;
+        Streams = result.Streams;
+        Errors = result.Errors;
+        Query = result.Query;
+        Document = result.Document;
+        Operation = result.Operation;
+        Perf = result.Perf;
+        Extensions = result.Extensions;
+    }
 
-        /// <summary>
-        /// Returns a set of errors that occurred during any stage of processing (parsing, validating, executing, etc.). This property is serialized as part of the GraphQL json response.
-        /// </summary>
-        public ExecutionErrors? Errors { get; set; }
+    /// <summary>
+    /// Initializes a new instance with the <see cref="Query"/>, <see cref="Document"/>,
+    /// <see cref="Operation"/> and <see cref="Extensions"/> properties set from the
+    /// specified <see cref="ExecutionContext"/>.
+    /// </summary>
+    internal ExecutionResult(ExecutionContext context)
+    {
+        Query = context.Document.Source;
+        Document = context.Document;
+        Operation = context.Operation;
+        Extensions = context.OutputExtensions;
+    }
 
-        /// <summary>
-        /// Returns the original GraphQL query.
-        /// </summary>
-        public ROM Query { get; set; }
+    /// <summary>
+    /// Adds the specified error to <see cref="Errors"/>.
+    /// </summary>
+    /// <returns>Reference to this.</returns>
+    public ExecutionResult AddError(ExecutionError error)
+    {
+        (Errors ??= new()).Add(error);
+        return this;
+    }
 
-        /// <summary>
-        /// Returns the parsed GraphQL request.
-        /// </summary>
-        public GraphQLDocument? Document { get; set; }
-
-        /// <summary>
-        /// Returns the GraphQL operation that is being executed.
-        /// </summary>
-        public GraphQLOperationDefinition? Operation { get; set; }
-
-        /// <summary>
-        /// Returns the performance metrics (Apollo Tracing) when enabled by <see cref="ExecutionOptions.EnableMetrics"/>.
-        /// </summary>
-        public PerfRecord[]? Perf { get; set; }
-
-        /// <summary>
-        /// Returns additional user-defined data; see <see cref="IExecutionContext.OutputExtensions"/> and <see cref="IResolveFieldContext.OutputExtensions"/>. This property is serialized as part of the GraphQL json response.
-        /// </summary>
-        public Dictionary<string, object?>? Extensions { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance with all properties set to their defaults.
-        /// </summary>
-        public ExecutionResult()
+    /// <summary>
+    /// Adds errors from the specified <see cref="ExecutionErrors"/> to <see cref="Errors"/>.
+    /// </summary>
+    /// <param name="errors">List of execution errors.</param>
+    /// <returns>Reference to this.</returns>
+    public ExecutionResult AddErrors(ExecutionErrors errors)
+    {
+        if (errors?.Count > 0)
         {
+            Errors ??= new(errors.Count);
+
+            foreach (var error in errors.List!)
+                Errors.Add(error);
         }
 
-        /// <summary>
-        /// Initializes a new instance as a clone of an existing <see cref="ExecutionResult"/>.
-        /// </summary>
-        public ExecutionResult(ExecutionResult result)
-        {
-            if (result == null)
-                throw new ArgumentNullException(nameof(result));
-
-            Executed = result.Executed;
-            Data = result.Data;
-            Streams = result.Streams;
-            Errors = result.Errors;
-            Query = result.Query;
-            Document = result.Document;
-            Operation = result.Operation;
-            Perf = result.Perf;
-            Extensions = result.Extensions;
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the <see cref="Query"/>, <see cref="Document"/>,
-        /// <see cref="Operation"/> and <see cref="Extensions"/> properties set from the
-        /// specified <see cref="ExecutionContext"/>.
-        /// </summary>
-        internal ExecutionResult(ExecutionContext context)
-        {
-            Query = context.Document.Source;
-            Document = context.Document;
-            Operation = context.Operation;
-            Extensions = context.OutputExtensions;
-        }
-
-        /// <summary>
-        /// Adds the specified error to <see cref="Errors"/>.
-        /// </summary>
-        /// <returns>Reference to this.</returns>
-        public ExecutionResult AddError(ExecutionError error)
-        {
-            (Errors ??= new()).Add(error);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds errors from the specified <see cref="ExecutionErrors"/> to <see cref="Errors"/>.
-        /// </summary>
-        /// <param name="errors">List of execution errors.</param>
-        /// <returns>Reference to this.</returns>
-        public ExecutionResult AddErrors(ExecutionErrors errors)
-        {
-            if (errors?.Count > 0)
-            {
-                Errors ??= new(errors.Count);
-
-                foreach (var error in errors.List!)
-                    Errors.Add(error);
-            }
-
-            return this;
-        }
+        return this;
     }
 }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -7,658 +7,657 @@ using GraphQL.Types;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// The base class for the included serial and parallel execution strategies.
+/// </summary>
+public abstract class ExecutionStrategy : IExecutionStrategy
 {
     /// <summary>
-    /// The base class for the included serial and parallel execution strategies.
+    /// Executes a GraphQL request and returns the result. The default implementation builds the root node
+    /// and passes execution to <see cref="ExecuteNodeTreeAsync(ExecutionContext, ExecutionNode)"/>.
+    /// Once complete, the values are collected into an object that is ready to be serialized and returned
+    /// within an <see cref="ExecutionResult"/>.
     /// </summary>
-    public abstract class ExecutionStrategy : IExecutionStrategy
+    public virtual async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
     {
-        /// <summary>
-        /// Executes a GraphQL request and returns the result. The default implementation builds the root node
-        /// and passes execution to <see cref="ExecuteNodeTreeAsync(ExecutionContext, ExecutionNode)"/>.
-        /// Once complete, the values are collected into an object that is ready to be serialized and returned
-        /// within an <see cref="ExecutionResult"/>.
-        /// </summary>
-        public virtual async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
+        var rootType = GetOperationRootType(context);
+        var rootNode = BuildExecutionRootNode(context, rootType);
+
+        await ExecuteNodeTreeAsync(context, rootNode).ConfigureAwait(false);
+
+        // After the entire node tree has been executed, get the values
+        object? data = rootNode.PropagateNull() ? null : rootNode;
+
+        return new ExecutionResult(context)
         {
-            var rootType = GetOperationRootType(context);
-            var rootNode = BuildExecutionRootNode(context, rootType);
+            Executed = true,
+            Data = data,
+        };
+    }
 
-            await ExecuteNodeTreeAsync(context, rootNode).ConfigureAwait(false);
+    /// <inheritdoc/>
+    public abstract Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode);
 
-            // After the entire node tree has been executed, get the values
-            object? data = rootNode.PropagateNull() ? null : rootNode;
+    /// <summary>
+    /// Returns the root graph type for the execution -- for a specified schema and operation type.
+    /// </summary>
+    protected virtual IObjectGraphType GetOperationRootType(ExecutionContext context)
+    {
+        IObjectGraphType? type;
 
-            return new ExecutionResult(context)
-            {
-                Executed = true,
-                Data = data,
-            };
+        switch (context.Operation.Operation)
+        {
+            case OperationType.Query:
+                type = context.Schema.Query;
+                // note that per the GraphQL specification, a query root type is required; but currently
+                // the schema validation check is disabled to allow for test schemas
+                // that only contain a mutation or subscription root type.
+                if (type == null)
+                    throw new InvalidOperationError("Schema is not configured for queries").AddLocation(context.Operation, context.Document);
+                break;
+
+            case OperationType.Mutation:
+                type = context.Schema.Mutation;
+                if (type == null)
+                    throw new InvalidOperationError("Schema is not configured for mutations").AddLocation(context.Operation, context.Document);
+                break;
+
+            case OperationType.Subscription:
+                type = context.Schema.Subscription;
+                if (type == null)
+                    throw new InvalidOperationError("Schema is not configured for subscriptions").AddLocation(context.Operation, context.Document);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException($"{nameof(context)}.{nameof(ExecutionContext.Operation)}", "Can only execute queries, mutations and subscriptions.");
         }
 
-        /// <inheritdoc/>
-        public abstract Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode);
+        return type;
+    }
 
-        /// <summary>
-        /// Returns the root graph type for the execution -- for a specified schema and operation type.
-        /// </summary>
-        protected virtual IObjectGraphType GetOperationRootType(ExecutionContext context)
+    /// <summary>
+    /// Builds the root execution node.
+    /// </summary>
+    protected virtual RootExecutionNode BuildExecutionRootNode(ExecutionContext context, IObjectGraphType rootType)
+    {
+        var root = new RootExecutionNode(rootType, context.Operation.SelectionSet)
         {
-            IObjectGraphType? type;
+            Result = context.RootValue
+        };
 
-            switch (context.Operation.Operation)
-            {
-                case OperationType.Query:
-                    type = context.Schema.Query;
-                    // note that per the GraphQL specification, a query root type is required; but currently
-                    // the schema validation check is disabled to allow for test schemas
-                    // that only contain a mutation or subscription root type.
-                    if (type == null)
-                        throw new InvalidOperationError("Schema is not configured for queries").AddLocation(context.Operation, context.Document);
-                    break;
+        SetSubFieldNodes(context, root);
 
-                case OperationType.Mutation:
-                    type = context.Schema.Mutation;
-                    if (type == null)
-                        throw new InvalidOperationError("Schema is not configured for mutations").AddLocation(context.Operation, context.Document);
-                    break;
+        return root;
+    }
 
-                case OperationType.Subscription:
-                    type = context.Schema.Subscription;
-                    if (type == null)
-                        throw new InvalidOperationError("Schema is not configured for subscriptions").AddLocation(context.Operation, context.Document);
-                    break;
+    /// <summary>
+    /// Builds an execution node with the specified parameters.
+    /// </summary>
+    protected virtual ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode = null)
+    {
+        if (graphType is NonNullGraphType nonNullFieldType)
+            graphType = nonNullFieldType.ResolvedType!;
 
-                default:
-                    throw new ArgumentOutOfRangeException($"{nameof(context)}.{nameof(ExecutionContext.Operation)}", "Can only execute queries, mutations and subscriptions.");
-            }
-
-            return type;
-        }
-
-        /// <summary>
-        /// Builds the root execution node.
-        /// </summary>
-        protected virtual RootExecutionNode BuildExecutionRootNode(ExecutionContext context, IObjectGraphType rootType)
+        return graphType switch
         {
-            var root = new RootExecutionNode(rootType, context.Operation.SelectionSet)
-            {
-                Result = context.RootValue
-            };
+            ListGraphType _ => new ArrayExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
+            IObjectGraphType _ => new ObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
+            IAbstractGraphType _ => new ObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
+            ScalarGraphType scalarGraphType => new ValueExecutionNode(parent, scalarGraphType, field, fieldDefinition, indexInParentNode),
+            _ => throw new InvalidOperationException($"Unexpected type: {graphType}")
+        };
+    }
 
-            SetSubFieldNodes(context, root);
-
-            return root;
-        }
-
-        /// <summary>
-        /// Builds an execution node with the specified parameters.
-        /// </summary>
-        protected virtual ExecutionNode BuildExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode = null)
+    /// <summary>
+    /// Examines @skip and @include directives for a node and returns a value indicating if the node should be included or not.
+    /// <br/><br/>
+    /// Note: Neither @skip nor @include has precedence over the other. In the case that both the @skip and @include
+    /// directives are provided on the same field or fragment, it must be queried only if the @skip condition
+    /// is <see langword="false"/> and the @include condition is <see langword="true"/>. Stated conversely, the field or
+    /// fragment must not be queried if either the @skip condition is <see langword="true"/> or the @include condition is <see langword="false"/>.
+    /// </summary>
+    protected virtual bool ShouldIncludeNode<TASTNode>(ExecutionContext context, TASTNode node)
+        where TASTNode : ASTNode, IHasDirectivesNode
+    {
+        if (context.DirectiveValues?.TryGetValue(node, out var directives) ?? false)
         {
-            if (graphType is NonNullGraphType nonNullFieldType)
-                graphType = nonNullFieldType.ResolvedType!;
-
-            return graphType switch
-            {
-                ListGraphType _ => new ArrayExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
-                IObjectGraphType _ => new ObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
-                IAbstractGraphType _ => new ObjectExecutionNode(parent, graphType, field, fieldDefinition, indexInParentNode),
-                ScalarGraphType scalarGraphType => new ValueExecutionNode(parent, scalarGraphType, field, fieldDefinition, indexInParentNode),
-                _ => throw new InvalidOperationException($"Unexpected type: {graphType}")
-            };
-        }
-
-        /// <summary>
-        /// Examines @skip and @include directives for a node and returns a value indicating if the node should be included or not.
-        /// <br/><br/>
-        /// Note: Neither @skip nor @include has precedence over the other. In the case that both the @skip and @include
-        /// directives are provided on the same field or fragment, it must be queried only if the @skip condition
-        /// is <see langword="false"/> and the @include condition is <see langword="true"/>. Stated conversely, the field or
-        /// fragment must not be queried if either the @skip condition is <see langword="true"/> or the @include condition is <see langword="false"/>.
-        /// </summary>
-        protected virtual bool ShouldIncludeNode<TASTNode>(ExecutionContext context, TASTNode node)
-            where TASTNode : ASTNode, IHasDirectivesNode
-        {
-            if (context.DirectiveValues?.TryGetValue(node, out var directives) ?? false)
-            {
-                // where @skip and @include are used, validation will ensure that the 'if' argument exists and is a non-null boolean
-                if (directives.TryGetValue(context.Schema.Directives.Skip.Name, out var skipDirective) &&
-                    (bool)skipDirective.Arguments["if"].Value!)
-                {
-                    return false;
-                }
-
-                if (directives.TryGetValue(context.Schema.Directives.Include.Name, out var includeDirective) &&
-                    !(bool)includeDirective.Arguments["if"].Value!)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Creates execution nodes for child fields of an object execution node. Only run if
-        /// the object execution node result is not <see langword="null"/> or object execution
-        /// node is <see cref="RootExecutionNode"/>.
-        /// </summary>
-        protected virtual void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent)
-        {
-            Debug.Assert(parent.Result != null || parent is RootExecutionNode);
-
-            var parentType = parent.GetObjectGraphType(context.Schema) ?? parent.GraphType;
-            var fields = Interlocked.Exchange(ref context.ReusableFields, null);
-            fields = CollectFieldsFrom(context, parentType, parent.SelectionSet!, fields);
-
-            var subFields = new ExecutionNode[fields.Count];
-
-            int i = 0;
-            foreach (var kvp in fields)
-            {
-                (var field, var fieldDefinition) = kvp.Value;
-                var node = BuildExecutionNode(parent, fieldDefinition.ResolvedType!, field, fieldDefinition);
-                subFields[i++] = node;
-            }
-
-            parent.SubFields = subFields;
-
-            fields.Clear();
-            Interlocked.CompareExchange(ref context.ReusableFields, fields, null);
-        }
-
-        /// <summary>
-        /// Returns a <see cref="FieldType"/> for the specified AST <see cref="GraphQLField"/> within a specified parent
-        /// output graph type within a given schema. For meta-fields, returns the proper meta-field field type.
-        /// </summary>
-        protected FieldType? GetFieldDefinition(ISchema schema, IComplexGraphType parentType, GraphQLField field)
-        {
-            if (field.Name == schema.SchemaMetaFieldType.Name && schema.Query == parentType)
-            {
-                return schema.SchemaMetaFieldType;
-            }
-            if (field.Name == schema.TypeMetaFieldType.Name && schema.Query == parentType)
-            {
-                return schema.TypeMetaFieldType;
-            }
-            if (field.Name == schema.TypeNameMetaFieldType.Name)
-            {
-                return schema.TypeNameMetaFieldType;
-            }
-
-            if (parentType == null)
-            {
-                throw new ArgumentNullException(nameof(parentType), $"Schema is not configured correctly to fetch field '{field.Name}'. Are you missing a root type?");
-            }
-
-            return parentType.GetField(field.Name);
-        }
-
-        /// <inheritdoc/>
-        public virtual Dictionary<string, (GraphQLField field, FieldType fieldType)>? GetSubFields(ExecutionContext context, ExecutionNode node)
-        {
-            return node.Field?.SelectionSet?.Selections?.Count > 0
-                ? CollectFieldsFrom(context, node.FieldDefinition!.ResolvedType!, node.Field.SelectionSet, null)
-                : null;
-        }
-
-        /// <summary>
-        /// Before execution, the selection set is converted to a grouped field set by calling CollectFields().
-        /// Each entry in the grouped field set is a list of fields that share a response key (the alias if defined,
-        /// otherwise the field name). This ensures all fields with the same response key included via referenced
-        /// fragments are executed at the same time.
-        /// <br/><br/>
-        /// <see href="https://spec.graphql.org/October2021/#sec-Field-Collection"/> and <see href="https://spec.graphql.org/October2021/#CollectFields()"/>
-        /// </summary>
-        /// <param name="context">The execution context.</param>
-        /// <param name="specificType">The graph type to compare the selection set against. May be <see langword="null"/> for root execution node.</param>
-        /// <param name="selectionSet">The selection set from the document.</param>
-        /// <param name="fields">A dictionary to append the collected list of fields to; if <see langword="null"/>, a new dictionary will be created.</param>
-        /// <returns>A list of collected fields</returns>
-        protected virtual Dictionary<string, (GraphQLField field, FieldType fieldType)> CollectFieldsFrom(ExecutionContext context, IGraphType specificType, GraphQLSelectionSet selectionSet, Dictionary<string, (GraphQLField field, FieldType fieldType)>? fields)
-        {
-            //Debug.Assert(specificType is not IAbstractGraphType); //TODO: think about it
-
-            fields ??= new();
-
-            // TODO: DESIGN REVIEW NEEDED
-            // https://github.com/graphql-dotnet/graphql-dotnet/pull/3416
-            // SetSubFieldNodes calls CollectFieldsFrom always with IComplexGraphType resolved type even for unions and interfaces since
-            // GetObjectGraphType works well when ExecutionNode.Result is already set. In case of GetSubFields (that is called usually
-            // from IResolveFieldContext.SubFields) we have a problem - there is no ExecutionNode.Result yet (resolver did not return yet)
-            // so GetObjectGraphType returns null in case of abstract graph type (interface or union) and we try to solve it by choosing
-            // an "approximate" type - interface/union type itself. For interface it works better than for union - at least we can return
-            // fields of interface, it makes sense. What should we return in case of union? First/last/random union member? Probably the
-            // best answer here - nothing. See 'GetFieldDefinition(context.Schema, (specificType as IComplexGraphType)!, field)' call inside
-            // CollectFields that effectively filters out all unions allowing only __typename field.
-
-            // optimization for majority of cases: 0 or 1 fragment spread in selection set, so nothing to track
-            int countOfSpreads = GetFragmentSpreads(context, selectionSet);
-            ROM[]? visitedFragmentNames = null;
-            if (countOfSpreads > 1)
-                visitedFragmentNames = ArrayPool<ROM>.Shared.Rent(countOfSpreads);
-
-            CollectFields(context, specificType.GetNamedType(), selectionSet, fields, visitedFragmentNames, 0);
-
-            if (visitedFragmentNames != null)
-                ArrayPool<ROM>.Shared.Return(visitedFragmentNames, true);
-
-            return fields;
-
-            void CollectFields(ExecutionContext context, IGraphType specificType, GraphQLSelectionSet selectionSet, Dictionary<string, (GraphQLField field, FieldType fieldType)> fields, ROM[]? visitedFragmentNames, int foundFragments)
-            {
-                static bool Contains(ROM[] array, ROM item, int count)
-                {
-                    for (int i = 0; i < count; ++i)
-                    {
-                        if (array[i] == item)
-                            return true;
-                    }
-                    return false;
-                }
-
-                if (selectionSet != null)
-                {
-                    foreach (var selection in selectionSet.Selections)
-                    {
-                        if (selection is GraphQLField field)
-                        {
-                            if (ShouldIncludeNode(context, field))
-                            {
-                                // parentType argument for GetFieldDefinition may be null in case of union field, in that case
-                                // GetFieldDefinition will not throw only if field is __typename
-                                var fieldType = GetFieldDefinition(context.Schema, (specificType as IComplexGraphType)!, field)
-                                    ?? throw new InvalidOperationException($"Schema is not configured correctly to fetch field '{field.Name}' from type '{specificType.Name}'.");
-
-                                Add(fields, field, fieldType);
-                            }
-                        }
-                        else if (selection is GraphQLFragmentSpread spread)
-                        {
-                            if ((visitedFragmentNames == null || !Contains(visitedFragmentNames, spread.FragmentName.Name, foundFragments)) && ShouldIncludeNode(context, spread))
-                            {
-                                if (visitedFragmentNames != null)
-                                    visitedFragmentNames[foundFragments++] = spread.FragmentName.Name;
-
-                                var fragment = context.Document.FindFragmentDefinition(spread.FragmentName.Name);
-                                if (fragment != null && ShouldIncludeNode(context, fragment) && DoesFragmentConditionMatch(context, fragment.TypeCondition.Type.Name, specificType))
-                                    CollectFields(context, specificType, fragment.SelectionSet, fields, visitedFragmentNames, foundFragments);
-                            }
-                        }
-                        else if (selection is GraphQLInlineFragment inline)
-                        {
-                            // inline.Type may be null
-                            // See [2.8.2] Inline Fragments: If the TypeCondition is omitted, an inline fragment is considered to be of the same type as the enclosing context.
-                            if (ShouldIncludeNode(context, inline) && DoesFragmentConditionMatch(context, inline.TypeCondition != null ? inline.TypeCondition.Type.Name : specificType.Name, specificType))
-                                CollectFields(context, specificType, inline.SelectionSet, fields, visitedFragmentNames, foundFragments);
-                        }
-                    }
-                }
-            }
-
-            static void Add(Dictionary<string, (GraphQLField Field, FieldType FieldType)> fields, GraphQLField field, FieldType fieldType)
-            {
-                string name = field.Alias != null ? field.Alias.Name.StringValue : fieldType.Name; //ISSUE:allocation in case of alias
-
-                fields[name] = fields.TryGetValue(name, out var original)
-                    ? (new GraphQLField(original.Field.Name) // Sets a new field selection node with the child field selection nodes merged with another field's child field selection nodes.
-                    {
-                        Alias = original.Field.Alias,
-                        Arguments = original.Field.Arguments,
-                        SelectionSet = Merge(original.Field.SelectionSet, field.SelectionSet),
-                        Directives = original.Field.Directives,
-                        Location = original.Field.Location,
-                    }, original.FieldType)
-                    : (field, fieldType);
-            }
-
-            // Returns a new selection set node with the contents merged with another selection set node's contents.
-            static GraphQLSelectionSet? Merge(GraphQLSelectionSet? selection, GraphQLSelectionSet? otherSelection)
-            {
-                if (selection == null)
-                    return otherSelection;
-
-                if (otherSelection == null)
-                    return selection;
-
-                return new GraphQLSelectionSet(selection.Selections.Union(otherSelection.Selections).ToList());
-            }
-
-            static int GetFragmentSpreads(ExecutionContext context, GraphQLSelectionSet selectionSet)
-            {
-                int count = 0;
-
-                foreach (var selection in selectionSet.Selections)
-                {
-                    if (selection is GraphQLFragmentSpread spread)
-                    {
-                        ++count;
-
-                        var fragment = context.Document.FindFragmentDefinition(spread.FragmentName.Name);
-                        if (fragment != null)
-                        {
-                            count += GetFragmentSpreads(context, fragment.SelectionSet);
-                        }
-                    }
-                    else if (selection is GraphQLInlineFragment inline)
-                    {
-                        count += GetFragmentSpreads(context, inline.SelectionSet);
-                    }
-                }
-
-                return count;
-            }
-        }
-
-        /// <summary>
-        /// This method calculates the criterion for matching fragment definition (spread or inline) to a given graph type.
-        /// This criterion determines the need to fill the resulting selection set with fields from such a fragment.
-        /// <br/><br/>
-        /// <see href="https://spec.graphql.org/October2021/#DoesFragmentTypeApply()"/>
-        /// </summary>
-        protected bool DoesFragmentConditionMatch(ExecutionContext context, ROM fragmentName, IGraphType type /* should be named type*/)
-        {
-            if (fragmentName.IsEmpty)
-                throw new ArgumentException("Fragment name can not be empty", nameof(fragmentName));
-
-            var conditionalType = context.Schema.AllTypes[fragmentName];
-
-            if (conditionalType == null)
+            // where @skip and @include are used, validation will ensure that the 'if' argument exists and is a non-null boolean
+            if (directives.TryGetValue(context.Schema.Directives.Skip.Name, out var skipDirective) &&
+                (bool)skipDirective.Arguments["if"].Value!)
             {
                 return false;
             }
 
-            if (conditionalType.Equals(type))
+            if (directives.TryGetValue(context.Schema.Directives.Include.Name, out var includeDirective) &&
+                !(bool)includeDirective.Arguments["if"].Value!)
             {
-                return true;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Creates execution nodes for child fields of an object execution node. Only run if
+    /// the object execution node result is not <see langword="null"/> or object execution
+    /// node is <see cref="RootExecutionNode"/>.
+    /// </summary>
+    protected virtual void SetSubFieldNodes(ExecutionContext context, ObjectExecutionNode parent)
+    {
+        Debug.Assert(parent.Result != null || parent is RootExecutionNode);
+
+        var parentType = parent.GetObjectGraphType(context.Schema) ?? parent.GraphType;
+        var fields = Interlocked.Exchange(ref context.ReusableFields, null);
+        fields = CollectFieldsFrom(context, parentType, parent.SelectionSet!, fields);
+
+        var subFields = new ExecutionNode[fields.Count];
+
+        int i = 0;
+        foreach (var kvp in fields)
+        {
+            (var field, var fieldDefinition) = kvp.Value;
+            var node = BuildExecutionNode(parent, fieldDefinition.ResolvedType!, field, fieldDefinition);
+            subFields[i++] = node;
+        }
+
+        parent.SubFields = subFields;
+
+        fields.Clear();
+        Interlocked.CompareExchange(ref context.ReusableFields, fields, null);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="FieldType"/> for the specified AST <see cref="GraphQLField"/> within a specified parent
+    /// output graph type within a given schema. For meta-fields, returns the proper meta-field field type.
+    /// </summary>
+    protected FieldType? GetFieldDefinition(ISchema schema, IComplexGraphType parentType, GraphQLField field)
+    {
+        if (field.Name == schema.SchemaMetaFieldType.Name && schema.Query == parentType)
+        {
+            return schema.SchemaMetaFieldType;
+        }
+        if (field.Name == schema.TypeMetaFieldType.Name && schema.Query == parentType)
+        {
+            return schema.TypeMetaFieldType;
+        }
+        if (field.Name == schema.TypeNameMetaFieldType.Name)
+        {
+            return schema.TypeNameMetaFieldType;
+        }
+
+        if (parentType == null)
+        {
+            throw new ArgumentNullException(nameof(parentType), $"Schema is not configured correctly to fetch field '{field.Name}'. Are you missing a root type?");
+        }
+
+        return parentType.GetField(field.Name);
+    }
+
+    /// <inheritdoc/>
+    public virtual Dictionary<string, (GraphQLField field, FieldType fieldType)>? GetSubFields(ExecutionContext context, ExecutionNode node)
+    {
+        return node.Field?.SelectionSet?.Selections?.Count > 0
+            ? CollectFieldsFrom(context, node.FieldDefinition!.ResolvedType!, node.Field.SelectionSet, null)
+            : null;
+    }
+
+    /// <summary>
+    /// Before execution, the selection set is converted to a grouped field set by calling CollectFields().
+    /// Each entry in the grouped field set is a list of fields that share a response key (the alias if defined,
+    /// otherwise the field name). This ensures all fields with the same response key included via referenced
+    /// fragments are executed at the same time.
+    /// <br/><br/>
+    /// <see href="https://spec.graphql.org/October2021/#sec-Field-Collection"/> and <see href="https://spec.graphql.org/October2021/#CollectFields()"/>
+    /// </summary>
+    /// <param name="context">The execution context.</param>
+    /// <param name="specificType">The graph type to compare the selection set against. May be <see langword="null"/> for root execution node.</param>
+    /// <param name="selectionSet">The selection set from the document.</param>
+    /// <param name="fields">A dictionary to append the collected list of fields to; if <see langword="null"/>, a new dictionary will be created.</param>
+    /// <returns>A list of collected fields</returns>
+    protected virtual Dictionary<string, (GraphQLField field, FieldType fieldType)> CollectFieldsFrom(ExecutionContext context, IGraphType specificType, GraphQLSelectionSet selectionSet, Dictionary<string, (GraphQLField field, FieldType fieldType)>? fields)
+    {
+        //Debug.Assert(specificType is not IAbstractGraphType); //TODO: think about it
+
+        fields ??= new();
+
+        // TODO: DESIGN REVIEW NEEDED
+        // https://github.com/graphql-dotnet/graphql-dotnet/pull/3416
+        // SetSubFieldNodes calls CollectFieldsFrom always with IComplexGraphType resolved type even for unions and interfaces since
+        // GetObjectGraphType works well when ExecutionNode.Result is already set. In case of GetSubFields (that is called usually
+        // from IResolveFieldContext.SubFields) we have a problem - there is no ExecutionNode.Result yet (resolver did not return yet)
+        // so GetObjectGraphType returns null in case of abstract graph type (interface or union) and we try to solve it by choosing
+        // an "approximate" type - interface/union type itself. For interface it works better than for union - at least we can return
+        // fields of interface, it makes sense. What should we return in case of union? First/last/random union member? Probably the
+        // best answer here - nothing. See 'GetFieldDefinition(context.Schema, (specificType as IComplexGraphType)!, field)' call inside
+        // CollectFields that effectively filters out all unions allowing only __typename field.
+
+        // optimization for majority of cases: 0 or 1 fragment spread in selection set, so nothing to track
+        int countOfSpreads = GetFragmentSpreads(context, selectionSet);
+        ROM[]? visitedFragmentNames = null;
+        if (countOfSpreads > 1)
+            visitedFragmentNames = ArrayPool<ROM>.Shared.Rent(countOfSpreads);
+
+        CollectFields(context, specificType.GetNamedType(), selectionSet, fields, visitedFragmentNames, 0);
+
+        if (visitedFragmentNames != null)
+            ArrayPool<ROM>.Shared.Return(visitedFragmentNames, true);
+
+        return fields;
+
+        void CollectFields(ExecutionContext context, IGraphType specificType, GraphQLSelectionSet selectionSet, Dictionary<string, (GraphQLField field, FieldType fieldType)> fields, ROM[]? visitedFragmentNames, int foundFragments)
+        {
+            static bool Contains(ROM[] array, ROM item, int count)
+            {
+                for (int i = 0; i < count; ++i)
+                {
+                    if (array[i] == item)
+                        return true;
+                }
+                return false;
             }
 
-            if (conditionalType is IAbstractGraphType abstractType)
+            if (selectionSet != null)
             {
-                return abstractType.IsPossibleType(type);
+                foreach (var selection in selectionSet.Selections)
+                {
+                    if (selection is GraphQLField field)
+                    {
+                        if (ShouldIncludeNode(context, field))
+                        {
+                            // parentType argument for GetFieldDefinition may be null in case of union field, in that case
+                            // GetFieldDefinition will not throw only if field is __typename
+                            var fieldType = GetFieldDefinition(context.Schema, (specificType as IComplexGraphType)!, field)
+                                ?? throw new InvalidOperationException($"Schema is not configured correctly to fetch field '{field.Name}' from type '{specificType.Name}'.");
+
+                            Add(fields, field, fieldType);
+                        }
+                    }
+                    else if (selection is GraphQLFragmentSpread spread)
+                    {
+                        if ((visitedFragmentNames == null || !Contains(visitedFragmentNames, spread.FragmentName.Name, foundFragments)) && ShouldIncludeNode(context, spread))
+                        {
+                            if (visitedFragmentNames != null)
+                                visitedFragmentNames[foundFragments++] = spread.FragmentName.Name;
+
+                            var fragment = context.Document.FindFragmentDefinition(spread.FragmentName.Name);
+                            if (fragment != null && ShouldIncludeNode(context, fragment) && DoesFragmentConditionMatch(context, fragment.TypeCondition.Type.Name, specificType))
+                                CollectFields(context, specificType, fragment.SelectionSet, fields, visitedFragmentNames, foundFragments);
+                        }
+                    }
+                    else if (selection is GraphQLInlineFragment inline)
+                    {
+                        // inline.Type may be null
+                        // See [2.8.2] Inline Fragments: If the TypeCondition is omitted, an inline fragment is considered to be of the same type as the enclosing context.
+                        if (ShouldIncludeNode(context, inline) && DoesFragmentConditionMatch(context, inline.TypeCondition != null ? inline.TypeCondition.Type.Name : specificType.Name, specificType))
+                            CollectFields(context, specificType, inline.SelectionSet, fields, visitedFragmentNames, foundFragments);
+                    }
+                }
+            }
+        }
+
+        static void Add(Dictionary<string, (GraphQLField Field, FieldType FieldType)> fields, GraphQLField field, FieldType fieldType)
+        {
+            string name = field.Alias != null ? field.Alias.Name.StringValue : fieldType.Name; //ISSUE:allocation in case of alias
+
+            fields[name] = fields.TryGetValue(name, out var original)
+                ? (new GraphQLField(original.Field.Name) // Sets a new field selection node with the child field selection nodes merged with another field's child field selection nodes.
+                {
+                    Alias = original.Field.Alias,
+                    Arguments = original.Field.Arguments,
+                    SelectionSet = Merge(original.Field.SelectionSet, field.SelectionSet),
+                    Directives = original.Field.Directives,
+                    Location = original.Field.Location,
+                }, original.FieldType)
+                : (field, fieldType);
+        }
+
+        // Returns a new selection set node with the contents merged with another selection set node's contents.
+        static GraphQLSelectionSet? Merge(GraphQLSelectionSet? selection, GraphQLSelectionSet? otherSelection)
+        {
+            if (selection == null)
+                return otherSelection;
+
+            if (otherSelection == null)
+                return selection;
+
+            return new GraphQLSelectionSet(selection.Selections.Union(otherSelection.Selections).ToList());
+        }
+
+        static int GetFragmentSpreads(ExecutionContext context, GraphQLSelectionSet selectionSet)
+        {
+            int count = 0;
+
+            foreach (var selection in selectionSet.Selections)
+            {
+                if (selection is GraphQLFragmentSpread spread)
+                {
+                    ++count;
+
+                    var fragment = context.Document.FindFragmentDefinition(spread.FragmentName.Name);
+                    if (fragment != null)
+                    {
+                        count += GetFragmentSpreads(context, fragment.SelectionSet);
+                    }
+                }
+                else if (selection is GraphQLInlineFragment inline)
+                {
+                    count += GetFragmentSpreads(context, inline.SelectionSet);
+                }
             }
 
+            return count;
+        }
+    }
+
+    /// <summary>
+    /// This method calculates the criterion for matching fragment definition (spread or inline) to a given graph type.
+    /// This criterion determines the need to fill the resulting selection set with fields from such a fragment.
+    /// <br/><br/>
+    /// <see href="https://spec.graphql.org/October2021/#DoesFragmentTypeApply()"/>
+    /// </summary>
+    protected bool DoesFragmentConditionMatch(ExecutionContext context, ROM fragmentName, IGraphType type /* should be named type*/)
+    {
+        if (fragmentName.IsEmpty)
+            throw new ArgumentException("Fragment name can not be empty", nameof(fragmentName));
+
+        var conditionalType = context.Schema.AllTypes[fragmentName];
+
+        if (conditionalType == null)
+        {
             return false;
         }
 
-        /// <summary>
-        /// Creates execution nodes for array elements of an array execution node. Only run if
-        /// the array execution node result is not <see langword="null"/>.
-        /// </summary>
-        protected virtual async Task SetArrayItemNodesAsync(ExecutionContext context, ArrayExecutionNode parent)
+        if (conditionalType.Equals(type))
         {
-            var listType = (ListGraphType)parent.GraphType!;
-            var itemType = listType.ResolvedType!;
-
-            if (itemType is NonNullGraphType nonNullGraphType)
-                itemType = nonNullGraphType.ResolvedType!;
-
-            if (parent.Result is not IEnumerable data)
-            {
-                throw new InvalidOperationException($"Expected an IEnumerable list though did not find one. Found: {parent.Result?.GetType().Name}");
-            }
-
-            int index = 0;
-            var arrayItems = (data is ICollection collection)
-                ? new List<ExecutionNode>(collection.Count)
-                : new List<ExecutionNode>();
-
-            if (data is IList list)
-            {
-                for (int i = 0; i < list.Count; ++i)
-                    await SetArrayItemNode(list[i]).ConfigureAwait(false);
-            }
-            else
-            {
-                foreach (object? d in data)
-                    await SetArrayItemNode(d).ConfigureAwait(false);
-            }
-
-            parent.Items = arrayItems;
-
-            // local function uses 'struct closure' without heap allocation
-            async Task SetArrayItemNode(object? d)
-            {
-                var node = BuildExecutionNode(parent, itemType, parent.Field!, parent.FieldDefinition!, index++);
-                node.Result = d;
-
-                if (d is not IDataLoaderResult)
-                {
-                    await CompleteNodeAsync(context, node).ConfigureAwait(false);
-                }
-
-                arrayItems.Add(node);
-            }
+            return true;
         }
 
-        /// <summary>
-        /// Selects resolver for the specified execution node. By default returns resolver from
-        /// <see cref="ExecutionNode.FieldDefinition"/> if specified. Otherwise returns
-        /// <see cref="SourceFieldResolver.Instance"/> for top level nodes of subscriptions or
-        /// <see cref="NameFieldResolver.Instance"/> for all other cases.
-        /// </summary>
-        protected virtual IFieldResolver SelectResolver(ExecutionNode node, ExecutionContext context)
-            => node.FieldDefinition.Resolver ?? (node.Parent is RootExecutionNode && context.Operation.Operation == OperationType.Subscription ? SourceFieldResolver.Instance : NameFieldResolver.Instance);
-
-        /// <summary>
-        /// Executes a single node. If the node does not return an <see cref="IDataLoaderResult"/>,
-        /// it will pass execution to <see cref="CompleteNodeAsync(ExecutionContext, ExecutionNode)"/>.
-        /// </summary>
-        protected virtual async Task ExecuteNodeAsync(ExecutionContext context, ExecutionNode node)
+        if (conditionalType is IAbstractGraphType abstractType)
         {
-            context.CancellationToken.ThrowIfCancellationRequested();
-
-            // these are the only conditions upon which a node has already been executed when this method is called
-            if (node is RootExecutionNode || node.Parent is ArrayExecutionNode)
-                return;
-
-            try
-            {
-                var resolveContext = Interlocked.Exchange(ref context.ReusableReadonlyResolveFieldContext, null);
-                resolveContext = resolveContext != null ? resolveContext.Reset(node, context) : new ReadonlyResolveFieldContext(node, context);
-
-                var resolver = SelectResolver(node, context);
-                object? result = await resolver.ResolveAsync(resolveContext).ConfigureAwait(false);
-
-                node.Result = result;
-
-                if (result is not IDataLoaderResult)
-                {
-                    await CompleteNodeAsync(context, node).ConfigureAwait(false);
-                    // for non-dataloader nodes that completed without throwing an error, we can re-use the context,
-                    // except for enumerable lists - in case the user returned a value with LINQ that is based on the context source
-                    if (result is not IEnumerable || result is string)
-                    {
-                        // also see FuncFieldResolver.GetResolverFor as it relates to context re-use
-                        resolveContext.Reset(null, null);
-                        Interlocked.CompareExchange(ref context.ReusableReadonlyResolveFieldContext, resolveContext, null);
-                    }
-                }
-            }
-            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (ExecutionError error)
-            {
-                SetNodeError(context, node, error);
-            }
-            catch (Exception ex)
-            {
-                if (await ProcessNodeUnhandledExceptionAsync(context, node, ex).ConfigureAwait(false))
-                    throw;
-            }
+            return abstractType.IsPossibleType(type);
         }
 
-        /// <summary>
-        /// Completes a pending data loader node. If the node does not return an <see cref="IDataLoaderResult"/>,
-        /// it will pass execution to <see cref="CompleteNodeAsync(ExecutionContext, ExecutionNode)"/>.
-        /// </summary>
-        protected virtual async Task CompleteDataLoaderNodeAsync(ExecutionContext context, ExecutionNode node)
+        return false;
+    }
+
+    /// <summary>
+    /// Creates execution nodes for array elements of an array execution node. Only run if
+    /// the array execution node result is not <see langword="null"/>.
+    /// </summary>
+    protected virtual async Task SetArrayItemNodesAsync(ExecutionContext context, ArrayExecutionNode parent)
+    {
+        var listType = (ListGraphType)parent.GraphType!;
+        var itemType = listType.ResolvedType!;
+
+        if (itemType is NonNullGraphType nonNullGraphType)
+            itemType = nonNullGraphType.ResolvedType!;
+
+        if (parent.Result is not IEnumerable data)
         {
-            if (node.Result is not IDataLoaderResult dataLoaderResult)
-                throw new InvalidOperationException("This execution node is not pending completion");
-
-            try
-            {
-                node.Result = await dataLoaderResult.GetResultAsync(context.CancellationToken).ConfigureAwait(false);
-
-                if (node.Result is not IDataLoaderResult)
-                {
-                    await CompleteNodeAsync(context, node).ConfigureAwait(false);
-                }
-            }
-            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (ExecutionError error)
-            {
-                SetNodeError(context, node, error);
-            }
-            catch (Exception ex)
-            {
-                if (await ProcessNodeUnhandledExceptionAsync(context, node, ex).ConfigureAwait(false))
-                    throw;
-            }
+            throw new InvalidOperationException($"Expected an IEnumerable list though did not find one. Found: {parent.Result?.GetType().Name}");
         }
 
-        /// <summary>
-        /// Validates a node result. Builds child nodes via <see cref="SetSubFieldNodes(ExecutionContext, ObjectExecutionNode)">SetSubFieldNodes</see>
-        /// and <see cref="SetArrayItemNodesAsync(ExecutionContext, ArrayExecutionNode)">SetArrayItemNodes</see>, but does not execute them. For value
-        /// execution nodes, it will run <see cref="ScalarGraphType.Serialize(object)"/> to serialize the result.
-        /// </summary>
-        protected virtual async Task CompleteNodeAsync(ExecutionContext context, ExecutionNode node)
+        int index = 0;
+        var arrayItems = (data is ICollection collection)
+            ? new List<ExecutionNode>(collection.Count)
+            : new List<ExecutionNode>();
+
+        if (data is IList list)
         {
-            try
-            {
-                if (node is ValueExecutionNode valueNode)
-                {
-                    node.Result = valueNode.GraphType.Serialize(node.Result);
-                }
-
-                ValidateNodeResult(context, node);
-
-                // Build child nodes
-                if (node.Result != null)
-                {
-                    if (node is ObjectExecutionNode objectNode)
-                    {
-                        SetSubFieldNodes(context, objectNode);
-                    }
-                    else if (node is ArrayExecutionNode arrayNode)
-                    {
-                        await SetArrayItemNodesAsync(context, arrayNode).ConfigureAwait(false);
-                    }
-                }
-            }
-            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (ExecutionError error)
-            {
-                SetNodeError(context, node, error);
-            }
-            catch (Exception ex)
-            {
-                if (await ProcessNodeUnhandledExceptionAsync(context, node, ex).ConfigureAwait(false))
-                    throw;
-            }
+            for (int i = 0; i < list.Count; ++i)
+                await SetArrayItemNode(list[i]).ConfigureAwait(false);
+        }
+        else
+        {
+            foreach (object? d in data)
+                await SetArrayItemNode(d).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sets the location and path information to the error and adds it to the document. Sets the node result to <see langword="null"/>.
-        /// </summary>
-        protected virtual void SetNodeError(ExecutionContext context, ExecutionNode node, ExecutionError error)
+        parent.Items = arrayItems;
+
+        // local function uses 'struct closure' without heap allocation
+        async Task SetArrayItemNode(object? d)
         {
-            error.AddLocation(node.Field, context.Document);
-            error.Path = node.ResponsePath;
-            context.Errors.Add(error);
+            var node = BuildExecutionNode(parent, itemType, parent.Field!, parent.FieldDefinition!, index++);
+            node.Result = d;
 
-            node.Result = null;
-        }
-
-        /// <summary>
-        /// Processes unhandled field resolver exceptions.
-        /// </summary>
-        /// <returns>A value that indicates when the exception should be rethrown.</returns>
-        protected virtual async Task<bool> ProcessNodeUnhandledExceptionAsync(ExecutionContext context, ExecutionNode node, Exception ex)
-        {
-            if (context.ThrowOnUnhandledException)
-                return true;
-
-            UnhandledExceptionContext? exceptionContext = null;
-            if (context.UnhandledExceptionDelegate != null)
+            if (d is not IDataLoaderResult)
             {
-                // be sure not to re-use this instance of `IResolveFieldContext`
-                var resolveContext = new ReadonlyResolveFieldContext(node, context);
-                exceptionContext = new UnhandledExceptionContext(context, resolveContext, ex);
-                await context.UnhandledExceptionDelegate(exceptionContext).ConfigureAwait(false);
-                ex = exceptionContext.Exception;
+                await CompleteNodeAsync(context, node).ConfigureAwait(false);
             }
 
-            var error = ex is ExecutionError executionError ? executionError : new UnhandledError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve field '{node.Name}'.", ex);
+            arrayItems.Add(node);
+        }
+    }
 
+    /// <summary>
+    /// Selects resolver for the specified execution node. By default returns resolver from
+    /// <see cref="ExecutionNode.FieldDefinition"/> if specified. Otherwise returns
+    /// <see cref="SourceFieldResolver.Instance"/> for top level nodes of subscriptions or
+    /// <see cref="NameFieldResolver.Instance"/> for all other cases.
+    /// </summary>
+    protected virtual IFieldResolver SelectResolver(ExecutionNode node, ExecutionContext context)
+        => node.FieldDefinition.Resolver ?? (node.Parent is RootExecutionNode && context.Operation.Operation == OperationType.Subscription ? SourceFieldResolver.Instance : NameFieldResolver.Instance);
+
+    /// <summary>
+    /// Executes a single node. If the node does not return an <see cref="IDataLoaderResult"/>,
+    /// it will pass execution to <see cref="CompleteNodeAsync(ExecutionContext, ExecutionNode)"/>.
+    /// </summary>
+    protected virtual async Task ExecuteNodeAsync(ExecutionContext context, ExecutionNode node)
+    {
+        context.CancellationToken.ThrowIfCancellationRequested();
+
+        // these are the only conditions upon which a node has already been executed when this method is called
+        if (node is RootExecutionNode || node.Parent is ArrayExecutionNode)
+            return;
+
+        try
+        {
+            var resolveContext = Interlocked.Exchange(ref context.ReusableReadonlyResolveFieldContext, null);
+            resolveContext = resolveContext != null ? resolveContext.Reset(node, context) : new ReadonlyResolveFieldContext(node, context);
+
+            var resolver = SelectResolver(node, context);
+            object? result = await resolver.ResolveAsync(resolveContext).ConfigureAwait(false);
+
+            node.Result = result;
+
+            if (result is not IDataLoaderResult)
+            {
+                await CompleteNodeAsync(context, node).ConfigureAwait(false);
+                // for non-dataloader nodes that completed without throwing an error, we can re-use the context,
+                // except for enumerable lists - in case the user returned a value with LINQ that is based on the context source
+                if (result is not IEnumerable || result is string)
+                {
+                    // also see FuncFieldResolver.GetResolverFor as it relates to context re-use
+                    resolveContext.Reset(null, null);
+                    Interlocked.CompareExchange(ref context.ReusableReadonlyResolveFieldContext, resolveContext, null);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (ExecutionError error)
+        {
             SetNodeError(context, node, error);
-
-            return false;
         }
-
-        /// <summary>
-        /// Validates the <see cref="ExecutionNode.Result"/> to ensure that it is valid for the node.
-        /// Errors typically occur when a null value is returned for a non-null graph type. Also validates the
-        /// object type when <see cref="IObjectGraphType.IsTypeOf"/> is assigned, or when the graph type
-        /// is an <see cref="IAbstractGraphType"/>.
-        /// </summary>
-        protected virtual void ValidateNodeResult(ExecutionContext context, ExecutionNode node)
+        catch (Exception ex)
         {
-            object? result = node.Result;
+            if (await ProcessNodeUnhandledExceptionAsync(context, node, ex).ConfigureAwait(false))
+                throw;
+        }
+    }
 
-            IGraphType? fieldType = node.ResolvedType;
+    /// <summary>
+    /// Completes a pending data loader node. If the node does not return an <see cref="IDataLoaderResult"/>,
+    /// it will pass execution to <see cref="CompleteNodeAsync(ExecutionContext, ExecutionNode)"/>.
+    /// </summary>
+    protected virtual async Task CompleteDataLoaderNodeAsync(ExecutionContext context, ExecutionNode node)
+    {
+        if (node.Result is not IDataLoaderResult dataLoaderResult)
+            throw new InvalidOperationException("This execution node is not pending completion");
 
-            if (fieldType is NonNullGraphType nonNullType)
+        try
+        {
+            node.Result = await dataLoaderResult.GetResultAsync(context.CancellationToken).ConfigureAwait(false);
+
+            if (node.Result is not IDataLoaderResult)
             {
-                if (result == null)
-                {
-                    throw new InvalidOperationException("Cannot return null for a non-null type."
-                        + $" Field: {node.Name}, Type: {nonNullType}.");
-                }
+                await CompleteNodeAsync(context, node).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (ExecutionError error)
+        {
+            SetNodeError(context, node, error);
+        }
+        catch (Exception ex)
+        {
+            if (await ProcessNodeUnhandledExceptionAsync(context, node, ex).ConfigureAwait(false))
+                throw;
+        }
+    }
 
-                fieldType = nonNullType.ResolvedType;
+    /// <summary>
+    /// Validates a node result. Builds child nodes via <see cref="SetSubFieldNodes(ExecutionContext, ObjectExecutionNode)">SetSubFieldNodes</see>
+    /// and <see cref="SetArrayItemNodesAsync(ExecutionContext, ArrayExecutionNode)">SetArrayItemNodes</see>, but does not execute them. For value
+    /// execution nodes, it will run <see cref="ScalarGraphType.Serialize(object)"/> to serialize the result.
+    /// </summary>
+    protected virtual async Task CompleteNodeAsync(ExecutionContext context, ExecutionNode node)
+    {
+        try
+        {
+            if (node is ValueExecutionNode valueNode)
+            {
+                node.Result = valueNode.GraphType.Serialize(node.Result);
             }
 
+            ValidateNodeResult(context, node);
+
+            // Build child nodes
+            if (node.Result != null)
+            {
+                if (node is ObjectExecutionNode objectNode)
+                {
+                    SetSubFieldNodes(context, objectNode);
+                }
+                else if (node is ArrayExecutionNode arrayNode)
+                {
+                    await SetArrayItemNodesAsync(context, arrayNode).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (ExecutionError error)
+        {
+            SetNodeError(context, node, error);
+        }
+        catch (Exception ex)
+        {
+            if (await ProcessNodeUnhandledExceptionAsync(context, node, ex).ConfigureAwait(false))
+                throw;
+        }
+    }
+
+    /// <summary>
+    /// Sets the location and path information to the error and adds it to the document. Sets the node result to <see langword="null"/>.
+    /// </summary>
+    protected virtual void SetNodeError(ExecutionContext context, ExecutionNode node, ExecutionError error)
+    {
+        error.AddLocation(node.Field, context.Document);
+        error.Path = node.ResponsePath;
+        context.Errors.Add(error);
+
+        node.Result = null;
+    }
+
+    /// <summary>
+    /// Processes unhandled field resolver exceptions.
+    /// </summary>
+    /// <returns>A value that indicates when the exception should be rethrown.</returns>
+    protected virtual async Task<bool> ProcessNodeUnhandledExceptionAsync(ExecutionContext context, ExecutionNode node, Exception ex)
+    {
+        if (context.ThrowOnUnhandledException)
+            return true;
+
+        UnhandledExceptionContext? exceptionContext = null;
+        if (context.UnhandledExceptionDelegate != null)
+        {
+            // be sure not to re-use this instance of `IResolveFieldContext`
+            var resolveContext = new ReadonlyResolveFieldContext(node, context);
+            exceptionContext = new UnhandledExceptionContext(context, resolveContext, ex);
+            await context.UnhandledExceptionDelegate(exceptionContext).ConfigureAwait(false);
+            ex = exceptionContext.Exception;
+        }
+
+        var error = ex is ExecutionError executionError ? executionError : new UnhandledError(exceptionContext?.ErrorMessage ?? $"Error trying to resolve field '{node.Name}'.", ex);
+
+        SetNodeError(context, node, error);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Validates the <see cref="ExecutionNode.Result"/> to ensure that it is valid for the node.
+    /// Errors typically occur when a null value is returned for a non-null graph type. Also validates the
+    /// object type when <see cref="IObjectGraphType.IsTypeOf"/> is assigned, or when the graph type
+    /// is an <see cref="IAbstractGraphType"/>.
+    /// </summary>
+    protected virtual void ValidateNodeResult(ExecutionContext context, ExecutionNode node)
+    {
+        object? result = node.Result;
+
+        IGraphType? fieldType = node.ResolvedType;
+
+        if (fieldType is NonNullGraphType nonNullType)
+        {
             if (result == null)
             {
-                return;
+                throw new InvalidOperationException("Cannot return null for a non-null type."
+                    + $" Field: {node.Name}, Type: {nonNullType}.");
             }
 
-            var objectType = fieldType as IObjectGraphType;
+            fieldType = nonNullType.ResolvedType;
+        }
 
-            if (fieldType is IAbstractGraphType abstractType)
+        if (result == null)
+        {
+            return;
+        }
+
+        var objectType = fieldType as IObjectGraphType;
+
+        if (fieldType is IAbstractGraphType abstractType)
+        {
+            objectType = abstractType.GetObjectType(result, context.Schema);
+
+            if (objectType == null)
             {
-                objectType = abstractType.GetObjectType(result, context.Schema);
-
-                if (objectType == null)
-                {
-                    throw new InvalidOperationException(
-                        $"Abstract type {abstractType.Name} must resolve to an Object type at " +
-                        $"runtime for field {(node.IndexInParentNode.HasValue ? node.Parent?.Parent : node.Parent)?.GraphType?.Name}.{node.FieldDefinition.Name} " +
-                        $"with value '{result}', received 'null'.");
-                }
-
-                if (!abstractType.IsPossibleType(objectType))
-                {
-                    throw new InvalidOperationException($"Runtime Object type '{objectType}' is not a possible type for '{abstractType}'.");
-                }
+                throw new InvalidOperationException(
+                    $"Abstract type {abstractType.Name} must resolve to an Object type at " +
+                    $"runtime for field {(node.IndexInParentNode.HasValue ? node.Parent?.Parent : node.Parent)?.GraphType?.Name}.{node.FieldDefinition.Name} " +
+                    $"with value '{result}', received 'null'.");
             }
 
-            if (objectType?.IsTypeOf != null && !objectType.IsTypeOf(result))
+            if (!abstractType.IsPossibleType(objectType))
             {
-                throw new InvalidOperationException($"'{result}' value of type '{result.GetType()}' is not allowed for '{objectType.Name}'. Either change IsTypeOf method of '{objectType.Name}' to accept this value or return another value from your resolver.");
+                throw new InvalidOperationException($"Runtime Object type '{objectType}' is not a possible type for '{abstractType}'.");
             }
+        }
+
+        if (objectType?.IsTypeOf != null && !objectType.IsTypeOf(result))
+        {
+            throw new InvalidOperationException($"'{result}' value of type '{result.GetType()}' is not allowed for '{objectType.Name}'. Either change IsTypeOf method of '{objectType.Name}' to accept this value or return another value from your resolver.");
         }
     }
 }

--- a/src/GraphQL/Execution/ExecutionStrategyRegistration.cs
+++ b/src/GraphQL/Execution/ExecutionStrategyRegistration.cs
@@ -1,11 +1,10 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
-{
-    /// <summary>
-    /// Represents a registration for a specific execution strategy to be used for a specific GraphQL operation type.
-    /// </summary>
-    /// <param name="Strategy">The execution strategy to be used.</param>
-    /// <param name="Operation">The GraphQL operation type the execution strategy applies to.</param>
-    public record ExecutionStrategyRegistration(IExecutionStrategy Strategy, OperationType Operation);
-}
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents a registration for a specific execution strategy to be used for a specific GraphQL operation type.
+/// </summary>
+/// <param name="Strategy">The execution strategy to be used.</param>
+/// <param name="Operation">The GraphQL operation type the execution strategy applies to.</param>
+public record ExecutionStrategyRegistration(IExecutionStrategy Strategy, OperationType Operation);

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -2,57 +2,56 @@ using GraphQLParser;
 using GraphQLParser.AST;
 using GraphQLParser.Exceptions;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// <inheritdoc cref="IDocumentBuilder"/>
+/// <br/><br/>
+/// Default instance of <see cref="IDocumentBuilder"/>.
+/// </summary>
+public class GraphQLDocumentBuilder : IDocumentBuilder
 {
     /// <summary>
-    /// <inheritdoc cref="IDocumentBuilder"/>
-    /// <br/><br/>
-    /// Default instance of <see cref="IDocumentBuilder"/>.
+    /// Specifies whether to ignore comments when parsing GraphQL document.
+    /// By default, all comments are ignored.
     /// </summary>
-    public class GraphQLDocumentBuilder : IDocumentBuilder
+    public bool IgnoreComments { get; set; } = true;
+
+    /// <summary>
+    /// Specifies whether to ignore token locations when parsing GraphQL document.
+    /// By default, all token locations are taken into account.
+    /// </summary>
+    public bool IgnoreLocations { get; set; }
+
+    /// <summary>
+    /// Maximum allowed recursion depth during parsing.
+    /// Depth is calculated in terms of AST nodes.
+    /// <br/>
+    /// Defaults to 128 if not set.
+    /// Minimum value is 1.
+    /// </summary>
+    public int? MaxDepth { get; set; }
+
+    /// <inheritdoc/>
+    public GraphQLDocument Build(string body)
     {
-        /// <summary>
-        /// Specifies whether to ignore comments when parsing GraphQL document.
-        /// By default, all comments are ignored.
-        /// </summary>
-        public bool IgnoreComments { get; set; } = true;
-
-        /// <summary>
-        /// Specifies whether to ignore token locations when parsing GraphQL document.
-        /// By default, all token locations are taken into account.
-        /// </summary>
-        public bool IgnoreLocations { get; set; }
-
-        /// <summary>
-        /// Maximum allowed recursion depth during parsing.
-        /// Depth is calculated in terms of AST nodes.
-        /// <br/>
-        /// Defaults to 128 if not set.
-        /// Minimum value is 1.
-        /// </summary>
-        public int? MaxDepth { get; set; }
-
-        /// <inheritdoc/>
-        public GraphQLDocument Build(string body)
+        try
         {
-            try
-            {
-                return Parser.Parse(body, new ParserOptions { Ignore = CreateIgnoreOptions(), MaxDepth = MaxDepth });
-            }
-            catch (GraphQLSyntaxErrorException ex)
-            {
-                throw new SyntaxError(ex);
-            }
+            return Parser.Parse(body, new ParserOptions { Ignore = CreateIgnoreOptions(), MaxDepth = MaxDepth });
         }
-
-        private IgnoreOptions CreateIgnoreOptions()
+        catch (GraphQLSyntaxErrorException ex)
         {
-            var options = IgnoreOptions.None;
-            if (IgnoreComments)
-                options |= IgnoreOptions.Comments;
-            if (IgnoreLocations)
-                options |= IgnoreOptions.Locations;
-            return options;
+            throw new SyntaxError(ex);
         }
+    }
+
+    private IgnoreOptions CreateIgnoreOptions()
+    {
+        var options = IgnoreOptions.None;
+        if (IgnoreComments)
+            options |= IgnoreOptions.Comments;
+        if (IgnoreLocations)
+            options |= IgnoreOptions.Locations;
+        return options;
     }
 }

--- a/src/GraphQL/Execution/IDocumentBuilder.cs
+++ b/src/GraphQL/Execution/IDocumentBuilder.cs
@@ -1,15 +1,14 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Creates a <see cref="GraphQLDocument">Document</see> representing a GraphQL AST from a plain GraphQL query string
+/// </summary>
+public interface IDocumentBuilder
 {
     /// <summary>
-    /// Creates a <see cref="GraphQLDocument">Document</see> representing a GraphQL AST from a plain GraphQL query string
+    /// Parse a GraphQL request and return a <see cref="GraphQLDocument">Document</see> representing the GraphQL request AST
     /// </summary>
-    public interface IDocumentBuilder
-    {
-        /// <summary>
-        /// Parse a GraphQL request and return a <see cref="GraphQLDocument">Document</see> representing the GraphQL request AST
-        /// </summary>
-        GraphQLDocument Build(string body);
-    }
+    GraphQLDocument Build(string body);
 }

--- a/src/GraphQL/Execution/IDocumentExecuter.cs
+++ b/src/GraphQL/Execution/IDocumentExecuter.cs
@@ -1,53 +1,52 @@
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Processes an entire GraphQL request, given an input GraphQL request string. This is intended to
+/// be called by user code to process a query.
+/// <br/><br/>
+/// Typical implementation starts metrics if enabled (see <see cref="Instrumentation.Metrics">Metrics</see>),
+/// relies on <see cref="Execution.IDocumentBuilder">IDocumentBuilder</see> to parse the query and
+/// <see cref="Validation.IDocumentValidator">IDocumentValidator</see> to validate it.
+/// Then it executes document listeners if attached, selects an execution strategy, and executes the query
+/// via <see cref="Execution.IExecutionStrategy">IExecutionStrategy</see>. Unhandled exceptions are handled as appropriate for the selected options.
+/// </summary>
+public interface IDocumentExecuter
 {
     /// <summary>
-    /// Processes an entire GraphQL request, given an input GraphQL request string. This is intended to
-    /// be called by user code to process a query.
-    /// <br/><br/>
-    /// Typical implementation starts metrics if enabled (see <see cref="Instrumentation.Metrics">Metrics</see>),
-    /// relies on <see cref="Execution.IDocumentBuilder">IDocumentBuilder</see> to parse the query and
-    /// <see cref="Validation.IDocumentValidator">IDocumentValidator</see> to validate it.
-    /// Then it executes document listeners if attached, selects an execution strategy, and executes the query
-    /// via <see cref="Execution.IExecutionStrategy">IExecutionStrategy</see>. Unhandled exceptions are handled as appropriate for the selected options.
+    /// Executes a GraphQL request and returns the result
     /// </summary>
-    public interface IDocumentExecuter
-    {
-        /// <summary>
-        /// Executes a GraphQL request and returns the result
-        /// </summary>
-        /// <param name="options">The options of the execution</param>
-        Task<ExecutionResult> ExecuteAsync(ExecutionOptions options);
-    }
+    /// <param name="options">The options of the execution</param>
+    Task<ExecutionResult> ExecuteAsync(ExecutionOptions options);
+}
 
+/// <summary>
+/// Process an entire GraphQL request against a specific schema, given an input GraphQL request string.
+/// This is intended to be called by user code to process a query.
+/// </summary>
+public interface IDocumentExecuter<TSchema> : IDocumentExecuter
+    where TSchema : ISchema
+{
+}
+
+/// <summary>
+/// Extension methods for <see cref="IDocumentExecuter"/>.
+/// </summary>
+public static class DocumentExecuterExtensions
+{
     /// <summary>
-    /// Process an entire GraphQL request against a specific schema, given an input GraphQL request string.
-    /// This is intended to be called by user code to process a query.
+    /// Executes a GraphQL request and returns the result
     /// </summary>
-    public interface IDocumentExecuter<TSchema> : IDocumentExecuter
-        where TSchema : ISchema
+    /// <param name="executer">An instance of <see cref="IDocumentExecuter"/> to use to execute the query</param>
+    /// <param name="configure">A delegate which configures the execution options</param>
+    public static Task<ExecutionResult> ExecuteAsync(this IDocumentExecuter executer, Action<ExecutionOptions> configure)
     {
-    }
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
 
-    /// <summary>
-    /// Extension methods for <see cref="IDocumentExecuter"/>.
-    /// </summary>
-    public static class DocumentExecuterExtensions
-    {
-        /// <summary>
-        /// Executes a GraphQL request and returns the result
-        /// </summary>
-        /// <param name="executer">An instance of <see cref="IDocumentExecuter"/> to use to execute the query</param>
-        /// <param name="configure">A delegate which configures the execution options</param>
-        public static Task<ExecutionResult> ExecuteAsync(this IDocumentExecuter executer, Action<ExecutionOptions> configure)
-        {
-            if (configure == null)
-                throw new ArgumentNullException(nameof(configure));
-
-            var options = new ExecutionOptions();
-            configure(options);
-            return executer.ExecuteAsync(options);
-        }
+        var options = new ExecutionOptions();
+        configure(options);
+        return executer.ExecuteAsync(options);
     }
 }

--- a/src/GraphQL/Execution/IErrorInfoProvider.cs
+++ b/src/GraphQL/Execution/IErrorInfoProvider.cs
@@ -1,13 +1,12 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Prepares <see cref="ExecutionError"/>s for serialization by the <see cref="IGraphQLSerializer"/>
+/// </summary>
+public interface IErrorInfoProvider
 {
     /// <summary>
-    /// Prepares <see cref="ExecutionError"/>s for serialization by the <see cref="IGraphQLSerializer"/>
+    /// Parses an <see cref="ExecutionError"/> into a <see cref="ErrorInfo"/> struct
     /// </summary>
-    public interface IErrorInfoProvider
-    {
-        /// <summary>
-        /// Parses an <see cref="ExecutionError"/> into a <see cref="ErrorInfo"/> struct
-        /// </summary>
-        ErrorInfo GetInfo(ExecutionError executionError);
-    }
+    ErrorInfo GetInfo(ExecutionError executionError);
 }

--- a/src/GraphQL/Execution/IExecutionArrayPool.cs
+++ b/src/GraphQL/Execution/IExecutionArrayPool.cs
@@ -1,21 +1,20 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Provides a resource pool of temporary arrays during query execution.
+/// Can be used to return lists of data from field resolvers.
+/// </summary>
+public interface IExecutionArrayPool
 {
     /// <summary>
-    /// Provides a resource pool of temporary arrays during query execution.
-    /// Can be used to return lists of data from field resolvers.
+    /// Gets an array of the specified minimum length from the execution's array pool.
+    /// This array will be returned to the pool once the execution completes. It is
+    /// important that you do not use this array after execution; otherwise its
+    /// contents may be overwritten at any point in time. This method is safe
+    /// for multi-threaded operation.
     /// </summary>
-    public interface IExecutionArrayPool
-    {
-        /// <summary>
-        /// Gets an array of the specified minimum length from the execution's array pool.
-        /// This array will be returned to the pool once the execution completes. It is
-        /// important that you do not use this array after execution; otherwise its
-        /// contents may be overwritten at any point in time. This method is safe
-        /// for multi-threaded operation.
-        /// </summary>
-        /// <typeparam name="TElement">Array element type.</typeparam>
-        /// <param name="minimumLength">The minimum length of the array.</param>
-        /// <returns>Array from pool.</returns>
-        TElement[] Rent<TElement>(int minimumLength);
-    }
+    /// <typeparam name="TElement">Array element type.</typeparam>
+    /// <param name="minimumLength">The minimum length of the array.</param>
+    /// <returns>Array from pool.</returns>
+    TElement[] Rent<TElement>(int minimumLength);
 }

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -4,109 +4,108 @@ using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Provides information regarding the currently executing document.
+/// </summary>
+public interface IExecutionContext : IProvideUserContext
 {
     /// <summary>
-    /// Provides information regarding the currently executing document.
+    /// Execution strategy for the currently executing document.
     /// </summary>
-    public interface IExecutionContext : IProvideUserContext
-    {
-        /// <summary>
-        /// Execution strategy for the currently executing document.
-        /// </summary>
-        IExecutionStrategy ExecutionStrategy { get; }
+    IExecutionStrategy ExecutionStrategy { get; }
 
-        /// <summary>
-        /// Propagates notification that the GraphQL request should be canceled.
-        /// </summary>
-        CancellationToken CancellationToken { get; }
+    /// <summary>
+    /// Propagates notification that the GraphQL request should be canceled.
+    /// </summary>
+    CancellationToken CancellationToken { get; }
 
-        /// <summary>
-        /// The parsed GraphQL request.
-        /// </summary>
-        GraphQLDocument Document { get; }
+    /// <summary>
+    /// The parsed GraphQL request.
+    /// </summary>
+    GraphQLDocument Document { get; }
 
-        /// <summary>
-        /// A list of errors generated during GraphQL request processing.
-        /// </summary>
-        ExecutionErrors Errors { get; }
+    /// <summary>
+    /// A list of errors generated during GraphQL request processing.
+    /// </summary>
+    ExecutionErrors Errors { get; }
 
-        /// <summary>
-        /// A list of <see cref="IDocumentExecutionListener"/>s, enabling code to be executed at various points during the processing of the GraphQL query.
-        /// </summary>
-        List<IDocumentExecutionListener> Listeners { get; }
+    /// <summary>
+    /// A list of <see cref="IDocumentExecutionListener"/>s, enabling code to be executed at various points during the processing of the GraphQL query.
+    /// </summary>
+    List<IDocumentExecutionListener> Listeners { get; }
 
-        /// <summary>
-        /// If set, limits the maximum number of nodes (in other words GraphQL fields) executed in parallel.
-        /// </summary>
-        int? MaxParallelExecutionCount { get; }
+    /// <summary>
+    /// If set, limits the maximum number of nodes (in other words GraphQL fields) executed in parallel.
+    /// </summary>
+    int? MaxParallelExecutionCount { get; }
 
-        /// <summary>
-        /// Provides performance metrics logging capabilities.
-        /// </summary>
-        Metrics Metrics { get; }
+    /// <summary>
+    /// Provides performance metrics logging capabilities.
+    /// </summary>
+    Metrics Metrics { get; }
 
-        /// <summary>
-        /// The GraphQL operation that is being executed.
-        /// </summary>
-        GraphQLOperationDefinition Operation { get; }
+    /// <summary>
+    /// The GraphQL operation that is being executed.
+    /// </summary>
+    GraphQLOperationDefinition Operation { get; }
 
-        /// <summary>
-        /// Object to pass to the <see cref="IResolveFieldContext.Source"/> property of first-level resolvers.
-        /// </summary>
-        object? RootValue { get; }
+    /// <summary>
+    /// Object to pass to the <see cref="IResolveFieldContext.Source"/> property of first-level resolvers.
+    /// </summary>
+    object? RootValue { get; }
 
-        /// <summary>
-        /// Schema of the graph to use.
-        /// </summary>
-        ISchema Schema { get; }
+    /// <summary>
+    /// Schema of the graph to use.
+    /// </summary>
+    ISchema Schema { get; }
 
-        /// <summary>
-        /// When <see langword="false"/>, <see cref="DocumentExecuter"/> and <see cref="ExecutionStrategy"/> capture unhandled
-        /// exceptions and store them within <see cref="Errors">Errors</see>.
-        /// </summary>
-        bool ThrowOnUnhandledException { get; }
+    /// <summary>
+    /// When <see langword="false"/>, <see cref="DocumentExecuter"/> and <see cref="ExecutionStrategy"/> capture unhandled
+    /// exceptions and store them within <see cref="Errors">Errors</see>.
+    /// </summary>
+    bool ThrowOnUnhandledException { get; }
 
-        /// <summary>
-        /// A delegate that can override, hide, modify, or log unhandled exceptions before they are stored.
-        /// within <see cref="Errors"/> as an <see cref="ExecutionError"/>.
-        /// </summary>
-        Func<UnhandledExceptionContext, Task> UnhandledExceptionDelegate { get; }
+    /// <summary>
+    /// A delegate that can override, hide, modify, or log unhandled exceptions before they are stored.
+    /// within <see cref="Errors"/> as an <see cref="ExecutionError"/>.
+    /// </summary>
+    Func<UnhandledExceptionContext, Task> UnhandledExceptionDelegate { get; }
 
-        /// <summary>
-        /// Input variables to the GraphQL request.
-        /// </summary>
-        Variables Variables { get; }
+    /// <summary>
+    /// Input variables to the GraphQL request.
+    /// </summary>
+    Variables Variables { get; }
 
-        /// <inheritdoc cref="IValidationResult.ArgumentValues"/>
-        IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; }
+    /// <inheritdoc cref="IValidationResult.ArgumentValues"/>
+    IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; }
 
-        /// <inheritdoc cref="IValidationResult.DirectiveValues"/>
-        IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; }
+    /// <inheritdoc cref="IValidationResult.DirectiveValues"/>
+    IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; }
 
-        /// <summary>
-        /// A dictionary of extra information supplied with the GraphQL request.
-        /// This is reserved for implementors to extend the protocol however they see fit, and
-        /// hence there are no additional restrictions on its contents.
-        /// </summary>
-        IReadOnlyDictionary<string, object?> InputExtensions { get; }
+    /// <summary>
+    /// A dictionary of extra information supplied with the GraphQL request.
+    /// This is reserved for implementors to extend the protocol however they see fit, and
+    /// hence there are no additional restrictions on its contents.
+    /// </summary>
+    IReadOnlyDictionary<string, object?> InputExtensions { get; }
 
-        /// <summary>
-        /// The response map may also contain an entry with key extensions. This entry is
-        /// reserved for implementors to extend the protocol however they see fit, and
-        /// hence there are no additional restrictions on its contents.
-        /// </summary>
-        Dictionary<string, object?> OutputExtensions { get; }
+    /// <summary>
+    /// The response map may also contain an entry with key extensions. This entry is
+    /// reserved for implementors to extend the protocol however they see fit, and
+    /// hence there are no additional restrictions on its contents.
+    /// </summary>
+    Dictionary<string, object?> OutputExtensions { get; }
 
-        /// <summary>
-        /// The service provider for the executing request. Typically this is a scoped service provider
-        /// from your dependency injection framework.
-        /// </summary>
-        IServiceProvider? RequestServices { get; }
+    /// <summary>
+    /// The service provider for the executing request. Typically this is a scoped service provider
+    /// from your dependency injection framework.
+    /// </summary>
+    IServiceProvider? RequestServices { get; }
 
-        /// <summary>
-        /// Gets security information for the executing request.
-        /// </summary>
-        ClaimsPrincipal? User { get; }
-    }
+    /// <summary>
+    /// Gets security information for the executing request.
+    /// </summary>
+    ClaimsPrincipal? User { get; }
 }

--- a/src/GraphQL/Execution/IExecutionStrategy.cs
+++ b/src/GraphQL/Execution/IExecutionStrategy.cs
@@ -1,33 +1,32 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Processes a parsed GraphQL request, resolving all the nodes and returning the result; exceptions
+/// are unhandled. Should not run any <see cref="IDocumentExecutionListener">IDocumentExecutionListener</see>s.
+/// </summary>
+public interface IExecutionStrategy
 {
     /// <summary>
-    /// Processes a parsed GraphQL request, resolving all the nodes and returning the result; exceptions
-    /// are unhandled. Should not run any <see cref="IDocumentExecutionListener">IDocumentExecutionListener</see>s.
+    /// Executes a GraphQL request and returns the result
     /// </summary>
-    public interface IExecutionStrategy
-    {
-        /// <summary>
-        /// Executes a GraphQL request and returns the result
-        /// </summary>
-        /// <param name="context">The execution parameters</param>
-        Task<ExecutionResult> ExecuteAsync(ExecutionContext context);
+    /// <param name="context">The execution parameters</param>
+    Task<ExecutionResult> ExecuteAsync(ExecutionContext context);
 
-        /// <summary>
-        /// Executes an execution node and all of its child nodes. This is typically only executed upon
-        /// the root execution node.
-        /// </summary>
-        Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode);
+    /// <summary>
+    /// Executes an execution node and all of its child nodes. This is typically only executed upon
+    /// the root execution node.
+    /// </summary>
+    Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode);
 
-        /// <summary>
-        /// Returns the children fields for a specified node. Note that this set will be completely defined only for
-        /// fields of a concrete type (i.e. not interface or union field) or when <paramref name="executionNode"/>
-        /// result was set. For interface field this method returns requested fields in terms of this interface. For
-        /// union field this method returns empty set since we don't know the concrete union member if <see cref="ExecutionNode.Result"/>
-        /// was not set yet.
-        /// </summary>
-        Dictionary<string, (GraphQLField field, FieldType fieldType)>? GetSubFields(ExecutionContext executionContext, ExecutionNode executionNode);
-    }
+    /// <summary>
+    /// Returns the children fields for a specified node. Note that this set will be completely defined only for
+    /// fields of a concrete type (i.e. not interface or union field) or when <paramref name="executionNode"/>
+    /// result was set. For interface field this method returns requested fields in terms of this interface. For
+    /// union field this method returns empty set since we don't know the concrete union member if <see cref="ExecutionNode.Result"/>
+    /// was not set yet.
+    /// </summary>
+    Dictionary<string, (GraphQLField field, FieldType fieldType)>? GetSubFields(ExecutionContext executionContext, ExecutionNode executionNode);
 }

--- a/src/GraphQL/Execution/IExecutionStrategySelector.cs
+++ b/src/GraphQL/Execution/IExecutionStrategySelector.cs
@@ -1,11 +1,10 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Returns an instance of an <see cref="IExecutionStrategy"/> for a specified <see cref="ExecutionContext"/>.
+/// </summary>
+public interface IExecutionStrategySelector
 {
-    /// <summary>
-    /// Returns an instance of an <see cref="IExecutionStrategy"/> for a specified <see cref="ExecutionContext"/>.
-    /// </summary>
-    public interface IExecutionStrategySelector
-    {
-        /// <inheritdoc cref="IExecutionStrategySelector"/>
-        IExecutionStrategy Select(ExecutionContext context);
-    }
+    /// <inheritdoc cref="IExecutionStrategySelector"/>
+    IExecutionStrategy Select(ExecutionContext context);
 }

--- a/src/GraphQL/Execution/IProvideUserContext.cs
+++ b/src/GraphQL/Execution/IProvideUserContext.cs
@@ -1,16 +1,15 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Provides access to a mutable user-defined context for the duration of the query
+/// </summary>
+public interface IProvideUserContext
 {
     /// <summary>
-    /// Provides access to a mutable user-defined context for the duration of the query
+    /// Mutable user-defined context to be passed to and shared by all field resolvers.
+    /// <br/><br/>
+    /// A custom implementation of <see cref="IDictionary{TKey, TValue}">IDictionary</see> may be
+    /// used in place of the default <see cref="Dictionary{TKey, TValue}">Dictionary</see>.
     /// </summary>
-    public interface IProvideUserContext
-    {
-        /// <summary>
-        /// Mutable user-defined context to be passed to and shared by all field resolvers.
-        /// <br/><br/>
-        /// A custom implementation of <see cref="IDictionary{TKey, TValue}">IDictionary</see> may be
-        /// used in place of the default <see cref="Dictionary{TKey, TValue}">Dictionary</see>.
-        /// </summary>
-        IDictionary<string, object?> UserContext { get; }
-    }
+    IDictionary<string, object?> UserContext { get; }
 }

--- a/src/GraphQL/Execution/Inputs.cs
+++ b/src/GraphQL/Execution/Inputs.cs
@@ -1,26 +1,25 @@
 using System.Collections.ObjectModel;
 using GraphQL.Validation;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Represents a readonly dictionary of variable inputs to a document. Typically this
+/// contains the deserialized 'variables' property from the GraphQL request. During document execution,
+/// these inputs will be validated and coerced into a <see cref="Variables"/> dictionary.
+/// </summary>
+public class Inputs : ReadOnlyDictionary<string, object?>
 {
     /// <summary>
-    /// Represents a readonly dictionary of variable inputs to a document. Typically this
-    /// contains the deserialized 'variables' property from the GraphQL request. During document execution,
-    /// these inputs will be validated and coerced into a <see cref="Variables"/> dictionary.
+    /// Returns an empty set of inputs.
     /// </summary>
-    public class Inputs : ReadOnlyDictionary<string, object?>
-    {
-        /// <summary>
-        /// Returns an empty set of inputs.
-        /// </summary>
-        public static readonly Inputs Empty = new(new Dictionary<string, object?>());
+    public static readonly Inputs Empty = new(new Dictionary<string, object?>());
 
-        /// <summary>
-        /// Initializes a new instance that is a wrapper for the specified dictionary of elements.
-        /// </summary>
-        public Inputs(IDictionary<string, object?> dictionary)
-            : base(dictionary)
-        {
-        }
+    /// <summary>
+    /// Initializes a new instance that is a wrapper for the specified dictionary of elements.
+    /// </summary>
+    public Inputs(IDictionary<string, object?> dictionary)
+        : base(dictionary)
+    {
     }
 }

--- a/src/GraphQL/Execution/InputsExtensions.cs
+++ b/src/GraphQL/Execution/InputsExtensions.cs
@@ -1,16 +1,15 @@
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Provides extension methods for converting a dictionary into <see cref="Inputs"/>.
+/// </summary>
+public static class InputsExtensions
 {
     /// <summary>
-    /// Provides extension methods for converting a dictionary into <see cref="Inputs"/>.
+    /// Converts a dictionary into an <see cref="Inputs"/>.
     /// </summary>
-    public static class InputsExtensions
-    {
-        /// <summary>
-        /// Converts a dictionary into an <see cref="Inputs"/>.
-        /// </summary>
-        /// <param name="dictionary">A dictionary.</param>
-        /// <returns>Inputs.</returns>
-        public static Inputs ToInputs(this Dictionary<string, object?> dictionary)
-            => dictionary?.Count > 0 ? new Inputs(dictionary) : Inputs.Empty;
-    }
+    /// <param name="dictionary">A dictionary.</param>
+    /// <returns>Inputs.</returns>
+    public static Inputs ToInputs(this Dictionary<string, object?> dictionary)
+        => dictionary?.Count > 0 ? new Inputs(dictionary) : Inputs.Empty;
 }

--- a/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
@@ -1,94 +1,93 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an execution node of a <see cref="ListGraphType"/>.
+/// </summary>
+public class ArrayExecutionNode : ExecutionNode, IParentExecutionNode
 {
     /// <summary>
-    /// Represents an execution node of a <see cref="ListGraphType"/>.
+    /// Returns a list of child execution nodes.
     /// </summary>
-    public class ArrayExecutionNode : ExecutionNode, IParentExecutionNode
+    public List<ExecutionNode>? Items { get; set; }
+
+    /// <summary>
+    /// Initializes an <see cref="ArrayExecutionNode"/> instance with the specified values.
+    /// </summary>
+    public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
+        : base(parent, graphType, field, fieldDefinition, indexInParentNode)
     {
-        /// <summary>
-        /// Returns a list of child execution nodes.
-        /// </summary>
-        public List<ExecutionNode>? Items { get; set; }
+    }
 
-        /// <summary>
-        /// Initializes an <see cref="ArrayExecutionNode"/> instance with the specified values.
-        /// </summary>
-        public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+    /// <summary>
+    /// Returns an object array containing the results of the child execution nodes.
+    /// <see cref="PropagateNull"/> must be called prior to calling this method.
+    /// </summary>
+    public override object? ToValue()
+    {
+        if (Items == null)
+            return null;
+
+        var items = new object?[Items.Count];
+        for (int i = 0; i < Items.Count; ++i)
         {
+            items[i] = Items[i].ToValue();
         }
 
-        /// <summary>
-        /// Returns an object array containing the results of the child execution nodes.
-        /// <see cref="PropagateNull"/> must be called prior to calling this method.
-        /// </summary>
-        public override object? ToValue()
-        {
-            if (Items == null)
-                return null;
+        return items;
+    }
 
-            var items = new object?[Items.Count];
-            for (int i = 0; i < Items.Count; ++i)
-            {
-                items[i] = Items[i].ToValue();
-            }
+    /// <inheritdoc/>
+    public override bool PropagateNull()
+    {
+        if (Items == null)
+            return true;
 
-            return items;
-        }
-
-        /// <inheritdoc/>
-        public override bool PropagateNull()
-        {
-            if (Items == null)
-                return true;
-
-            if (Items.Count == 0)
-                return false;
-
-            var isNullableType = false;
-
-            for (int i = 0; i < Items.Count; ++i)
-            {
-                var item = Items[i];
-                bool valueIsNull = item.PropagateNull();
-
-                if (valueIsNull && !isNullableType)
-                {
-                    if (((ListGraphType)GraphType!).ResolvedType is NonNullGraphType)
-                    {
-                        Items = null;
-                        return true;
-                    }
-                    else
-                    {
-                        isNullableType = true;
-                    }
-                }
-            }
-
+        if (Items.Count == 0)
             return false;
-        }
 
-        IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes() => Items ?? Enumerable.Empty<ExecutionNode>();
+        var isNullableType = false;
 
-        /// <inheritdoc/>
-        public void ApplyToChildren<TState>(Action<ExecutionNode, TState> action, TState state, bool reverse = false)
+        for (int i = 0; i < Items.Count; ++i)
         {
-            if (Items != null)
+            var item = Items[i];
+            bool valueIsNull = item.PropagateNull();
+
+            if (valueIsNull && !isNullableType)
             {
-                if (reverse)
+                if (((ListGraphType)GraphType!).ResolvedType is NonNullGraphType)
                 {
-                    for (int i = Items.Count - 1; i >= 0; --i)
-                        action(Items[i], state);
+                    Items = null;
+                    return true;
                 }
                 else
                 {
-                    foreach (var item in Items)
-                        action(item, state);
+                    isNullableType = true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes() => Items ?? Enumerable.Empty<ExecutionNode>();
+
+    /// <inheritdoc/>
+    public void ApplyToChildren<TState>(Action<ExecutionNode, TState> action, TState state, bool reverse = false)
+    {
+        if (Items != null)
+        {
+            if (reverse)
+            {
+                for (int i = Items.Count - 1; i >= 0; --i)
+                    action(Items[i], state);
+            }
+            else
+            {
+                foreach (var item in Items)
+                    action(item, state);
             }
         }
     }

--- a/src/GraphQL/Execution/Nodes/ExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ExecutionNode.cs
@@ -3,187 +3,186 @@ using GraphQL.DataLoader;
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents a node to be executed.
+/// </summary>
+public abstract class ExecutionNode
 {
     /// <summary>
-    /// Represents a node to be executed.
+    /// Returns the parent node, or <see langword="null"/> if this is the root node.
     /// </summary>
-    public abstract class ExecutionNode
+    public ExecutionNode Parent { get; }
+
+    /// <summary>
+    /// Returns the graph type of this node, unwrapped if it is a <see cref="NonNullGraphType"/>.
+    /// Array nodes will be a <see cref="ListGraphType"/> instance.
+    /// </summary>
+    public IGraphType GraphType { get; }
+
+    /// <summary>
+    /// Returns the AST field of this node.
+    /// </summary>
+    public GraphQLField Field { get; }
+
+    /// <summary>
+    /// Returns the graph's field type of this node.
+    /// </summary>
+    public FieldType FieldDefinition { get; }
+
+    /// <summary>
+    /// For child array item nodes of a <see cref="ListGraphType"/>, returns the index of this array item within the field; otherwise, <see langword="null"/>.
+    /// </summary>
+    public int? IndexInParentNode { get; }
+
+    /// <summary>
+    /// Returns the underlying graph type of this node, retaining the <see cref="NonNullGraphType"/> wrapping if applicable.
+    /// For child nodes of an array execution node, this property unwraps the <see cref="ListGraphType"/> instance and returns
+    /// the underlying graph type, retaining the <see cref="NonNullGraphType"/> wrapping if applicable.
+    /// </summary>
+    internal IGraphType? ResolvedType
     {
-        /// <summary>
-        /// Returns the parent node, or <see langword="null"/> if this is the root node.
-        /// </summary>
-        public ExecutionNode Parent { get; }
-
-        /// <summary>
-        /// Returns the graph type of this node, unwrapped if it is a <see cref="NonNullGraphType"/>.
-        /// Array nodes will be a <see cref="ListGraphType"/> instance.
-        /// </summary>
-        public IGraphType GraphType { get; }
-
-        /// <summary>
-        /// Returns the AST field of this node.
-        /// </summary>
-        public GraphQLField Field { get; }
-
-        /// <summary>
-        /// Returns the graph's field type of this node.
-        /// </summary>
-        public FieldType FieldDefinition { get; }
-
-        /// <summary>
-        /// For child array item nodes of a <see cref="ListGraphType"/>, returns the index of this array item within the field; otherwise, <see langword="null"/>.
-        /// </summary>
-        public int? IndexInParentNode { get; }
-
-        /// <summary>
-        /// Returns the underlying graph type of this node, retaining the <see cref="NonNullGraphType"/> wrapping if applicable.
-        /// For child nodes of an array execution node, this property unwraps the <see cref="ListGraphType"/> instance and returns
-        /// the underlying graph type, retaining the <see cref="NonNullGraphType"/> wrapping if applicable.
-        /// </summary>
-        internal IGraphType? ResolvedType
+        get
         {
-            get
-            {
-                return IndexInParentNode.HasValue
-                    ? ((ListGraphType?)Parent!.GraphType)?.ResolvedType
-                    : FieldDefinition?.ResolvedType;
-            }
+            return IndexInParentNode.HasValue
+                ? ((ListGraphType?)Parent!.GraphType)?.ResolvedType
+                : FieldDefinition?.ResolvedType;
+        }
+    }
+
+    /// <summary>
+    /// Returns the AST field alias, if specified, or AST field name otherwise.
+    /// </summary>
+    public string? Name => Field?.Alias != null ? Field.Alias.Name.StringValue : FieldDefinition?.Name; //ISSUE:allocation in case of alias
+
+    /// <summary>
+    /// Sets or returns the result of the execution node. May return a <see cref="IDataLoaderResult"/> if a node returns a data loader
+    /// result that has not yet finished executing.
+    /// </summary>
+    public object? Result { get; set; }
+
+    /// <summary>
+    /// Returns the parent node's result.
+    /// </summary>
+    public virtual object? Source => Parent?.Result;
+
+    /// <summary>
+    /// Initializes an instance of <see cref="ExecutionNode"/> with the specified values
+    /// </summary>
+    /// <param name="parent">The parent node, or <see langword="null"/> if this is the root node</param>
+    /// <param name="graphType">The graph type of this node, unwrapped if it is a <see cref="NonNullGraphType"/>. Array nodes will be a <see cref="ListGraphType"/> instance.</param>
+    /// <param name="field">The AST field of this node</param>
+    /// <param name="fieldDefinition">The graph's field type of this node</param>
+    /// <param name="indexInParentNode">For child array item nodes of a <see cref="ListGraphType"/>, the index of this array item within the field; otherwise, <see langword="null"/></param>
+    protected ExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
+    {
+        Debug.Assert(field?.Name == fieldDefinition?.Name); // ? for RootExecutionNode
+
+        Parent = parent;
+        GraphType = graphType;
+        Field = field!;
+        FieldDefinition = fieldDefinition!;
+        IndexInParentNode = indexInParentNode;
+    }
+
+    /// <summary>
+    /// Returns an object that represents the result of this node.
+    /// </summary>
+    public abstract object? ToValue();
+
+    /// <summary>
+    /// Prepares this node and children nodes for serialization. Returns <see langword="true"/> if this node should return <see langword="null"/>.
+    /// </summary>
+    public virtual bool PropagateNull() => ToValue() == null;
+
+    /// <summary>
+    /// Returns the parent graph type of this node.
+    /// </summary>
+    public IObjectGraphType? GetParentType(ISchema schema)
+    {
+        IGraphType? parentType = Parent?.GraphType;
+
+        if (parentType is IObjectGraphType objectType)
+            return objectType;
+
+        if (parentType is IAbstractGraphType abstractType)
+            return abstractType.GetObjectType(Parent!.Result!, schema);
+
+        return null;
+    }
+
+    /// <summary>
+    /// The path for the current node within the query.
+    /// </summary>
+    public IEnumerable<object> Path => GeneratePath(preferAlias: false);
+
+    /// <summary>
+    /// The path for the current node within the response.
+    /// </summary>
+    public IEnumerable<object> ResponsePath => GeneratePath(preferAlias: true);
+
+    private static readonly object _num0 = 0;
+    private static readonly object _num1 = 1;
+    private static readonly object _num2 = 2;
+    private static readonly object _num3 = 3;
+    private static readonly object _num4 = 4;
+    private static readonly object _num5 = 5;
+    private static readonly object _num6 = 6;
+    private static readonly object _num7 = 7;
+    private static readonly object _num8 = 8;
+    private static readonly object _num9 = 9;
+    private static readonly object _num10 = 10;
+    private static readonly object _num11 = 11;
+    private static readonly object _num12 = 12;
+    private static readonly object _num13 = 13;
+    private static readonly object _num14 = 14;
+    private static readonly object _num15 = 15;
+    private static object GetObjectIndex(int index) => index switch
+    {
+        0 => _num0,
+        1 => _num1,
+        2 => _num2,
+        3 => _num3,
+        4 => _num4,
+        5 => _num5,
+        6 => _num6,
+        7 => _num7,
+        8 => _num8,
+        9 => _num9,
+        10 => _num10,
+        11 => _num11,
+        12 => _num12,
+        13 => _num13,
+        14 => _num14,
+        15 => _num15,
+        _ => index
+    };
+
+    private IEnumerable<object> GeneratePath(bool preferAlias)
+    {
+        var node = this;
+        var count = 0;
+        while (node is not RootExecutionNode)
+        {
+            node = node.Parent!;
+            ++count;
         }
 
-        /// <summary>
-        /// Returns the AST field alias, if specified, or AST field name otherwise.
-        /// </summary>
-        public string? Name => Field?.Alias != null ? Field.Alias.Name.StringValue : FieldDefinition?.Name; //ISSUE:allocation in case of alias
+        if (count == 0)
+            return Array.Empty<object>();
 
-        /// <summary>
-        /// Sets or returns the result of the execution node. May return a <see cref="IDataLoaderResult"/> if a node returns a data loader
-        /// result that has not yet finished executing.
-        /// </summary>
-        public object? Result { get; set; }
-
-        /// <summary>
-        /// Returns the parent node's result.
-        /// </summary>
-        public virtual object? Source => Parent?.Result;
-
-        /// <summary>
-        /// Initializes an instance of <see cref="ExecutionNode"/> with the specified values
-        /// </summary>
-        /// <param name="parent">The parent node, or <see langword="null"/> if this is the root node</param>
-        /// <param name="graphType">The graph type of this node, unwrapped if it is a <see cref="NonNullGraphType"/>. Array nodes will be a <see cref="ListGraphType"/> instance.</param>
-        /// <param name="field">The AST field of this node</param>
-        /// <param name="fieldDefinition">The graph's field type of this node</param>
-        /// <param name="indexInParentNode">For child array item nodes of a <see cref="ListGraphType"/>, the index of this array item within the field; otherwise, <see langword="null"/></param>
-        protected ExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
+        var pathList = new object[count];
+        var index = count;
+        node = this;
+        while (node is not RootExecutionNode)
         {
-            Debug.Assert(field?.Name == fieldDefinition?.Name); // ? for RootExecutionNode
-
-            Parent = parent;
-            GraphType = graphType;
-            Field = field!;
-            FieldDefinition = fieldDefinition!;
-            IndexInParentNode = indexInParentNode;
+            pathList[--index] = node.IndexInParentNode.HasValue
+                ? GetObjectIndex(node.IndexInParentNode.Value)
+                : preferAlias ? node.Name! : node.FieldDefinition.Name;
+            node = node.Parent!;
         }
 
-        /// <summary>
-        /// Returns an object that represents the result of this node.
-        /// </summary>
-        public abstract object? ToValue();
-
-        /// <summary>
-        /// Prepares this node and children nodes for serialization. Returns <see langword="true"/> if this node should return <see langword="null"/>.
-        /// </summary>
-        public virtual bool PropagateNull() => ToValue() == null;
-
-        /// <summary>
-        /// Returns the parent graph type of this node.
-        /// </summary>
-        public IObjectGraphType? GetParentType(ISchema schema)
-        {
-            IGraphType? parentType = Parent?.GraphType;
-
-            if (parentType is IObjectGraphType objectType)
-                return objectType;
-
-            if (parentType is IAbstractGraphType abstractType)
-                return abstractType.GetObjectType(Parent!.Result!, schema);
-
-            return null;
-        }
-
-        /// <summary>
-        /// The path for the current node within the query.
-        /// </summary>
-        public IEnumerable<object> Path => GeneratePath(preferAlias: false);
-
-        /// <summary>
-        /// The path for the current node within the response.
-        /// </summary>
-        public IEnumerable<object> ResponsePath => GeneratePath(preferAlias: true);
-
-        private static readonly object _num0 = 0;
-        private static readonly object _num1 = 1;
-        private static readonly object _num2 = 2;
-        private static readonly object _num3 = 3;
-        private static readonly object _num4 = 4;
-        private static readonly object _num5 = 5;
-        private static readonly object _num6 = 6;
-        private static readonly object _num7 = 7;
-        private static readonly object _num8 = 8;
-        private static readonly object _num9 = 9;
-        private static readonly object _num10 = 10;
-        private static readonly object _num11 = 11;
-        private static readonly object _num12 = 12;
-        private static readonly object _num13 = 13;
-        private static readonly object _num14 = 14;
-        private static readonly object _num15 = 15;
-        private static object GetObjectIndex(int index) => index switch
-        {
-            0 => _num0,
-            1 => _num1,
-            2 => _num2,
-            3 => _num3,
-            4 => _num4,
-            5 => _num5,
-            6 => _num6,
-            7 => _num7,
-            8 => _num8,
-            9 => _num9,
-            10 => _num10,
-            11 => _num11,
-            12 => _num12,
-            13 => _num13,
-            14 => _num14,
-            15 => _num15,
-            _ => index
-        };
-
-        private IEnumerable<object> GeneratePath(bool preferAlias)
-        {
-            var node = this;
-            var count = 0;
-            while (node is not RootExecutionNode)
-            {
-                node = node.Parent!;
-                ++count;
-            }
-
-            if (count == 0)
-                return Array.Empty<object>();
-
-            var pathList = new object[count];
-            var index = count;
-            node = this;
-            while (node is not RootExecutionNode)
-            {
-                pathList[--index] = node.IndexInParentNode.HasValue
-                    ? GetObjectIndex(node.IndexInParentNode.Value)
-                    : preferAlias ? node.Name! : node.FieldDefinition.Name;
-                node = node.Parent!;
-            }
-
-            return pathList;
-        }
+        return pathList;
     }
 }

--- a/src/GraphQL/Execution/Nodes/IParentExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/IParentExecutionNode.cs
@@ -1,22 +1,21 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an execution node with child nodes.
+/// </summary>
+public interface IParentExecutionNode
 {
     /// <summary>
-    /// Represents an execution node with child nodes.
+    /// Returns a list of child execution nodes.
     /// </summary>
-    public interface IParentExecutionNode
-    {
-        /// <summary>
-        /// Returns a list of child execution nodes.
-        /// </summary>
-        IEnumerable<ExecutionNode> GetChildNodes();
+    IEnumerable<ExecutionNode> GetChildNodes();
 
-        /// <summary>
-        /// Applies the specified delegate to child execution nodes.
-        /// </summary>
-        /// <typeparam name="TState">Type of the provided state.</typeparam>
-        /// <param name="action">Delegate to execute on every child node of this node.</param>
-        /// <param name="state">An arbitrary state passed by the caller.</param>
-        /// <param name="reverse">Specifies the direct or reverse direction of child nodes traversal.</param>
-        void ApplyToChildren<TState>(Action<ExecutionNode, TState> action, TState state, bool reverse = false);
-    }
+    /// <summary>
+    /// Applies the specified delegate to child execution nodes.
+    /// </summary>
+    /// <typeparam name="TState">Type of the provided state.</typeparam>
+    /// <param name="action">Delegate to execute on every child node of this node.</param>
+    /// <param name="state">An arbitrary state passed by the caller.</param>
+    /// <param name="reverse">Specifies the direct or reverse direction of child nodes traversal.</param>
+    void ApplyToChildren<TState>(Action<ExecutionNode, TState> action, TState state, bool reverse = false);
 }

--- a/src/GraphQL/Execution/Nodes/NullExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/NullExecutionNode.cs
@@ -1,25 +1,24 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an execution node which always returns <see langword="null"/>.
+/// </summary>
+public class NullExecutionNode : ExecutionNode
 {
     /// <summary>
-    /// Represents an execution node which always returns <see langword="null"/>.
+    /// Initializes an instance of <see cref="NullExecutionNode"/> with the specified values.
     /// </summary>
-    public class NullExecutionNode : ExecutionNode
+    public NullExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
+        : base(parent, graphType, field, fieldDefinition, indexInParentNode)
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="NullExecutionNode"/> with the specified values.
-        /// </summary>
-        public NullExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
-        {
-            Result = null;
-        }
-
-        /// <summary>
-        /// Returns <see langword="null"/>.
-        /// </summary>
-        public override object? ToValue() => null;
+        Result = null;
     }
+
+    /// <summary>
+    /// Returns <see langword="null"/>.
+    /// </summary>
+    public override object? ToValue() => null;
 }

--- a/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ObjectExecutionNode.cs
@@ -1,105 +1,104 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents an object execution node, which will contain child execution nodes.
+/// </summary>
+public class ObjectExecutionNode : ExecutionNode, IParentExecutionNode
 {
     /// <summary>
-    /// Represents an object execution node, which will contain child execution nodes.
+    /// Returns an array of child execution nodes.
     /// </summary>
-    public class ObjectExecutionNode : ExecutionNode, IParentExecutionNode
+    public ExecutionNode[]? SubFields { get; set; }
+
+    /// <summary>
+    /// Initializes an instance of <see cref="ObjectExecutionNode"/> with the specified values.
+    /// </summary>
+    public ObjectExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
+        : base(parent, graphType, field, fieldDefinition, indexInParentNode)
     {
-        /// <summary>
-        /// Returns an array of child execution nodes.
-        /// </summary>
-        public ExecutionNode[]? SubFields { get; set; }
+    }
 
-        /// <summary>
-        /// Initializes an instance of <see cref="ObjectExecutionNode"/> with the specified values.
-        /// </summary>
-        public ObjectExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+    /// <summary>
+    /// For execution nodes that represent a field that is an <see cref="IAbstractGraphType"/>, returns the
+    /// proper <see cref="IObjectGraphType"/> based on the set <see cref="ExecutionNode.Result"/>.
+    /// Otherwise returns the value of <see cref="ExecutionNode.GraphType"/>.
+    /// </summary>
+    public IObjectGraphType? GetObjectGraphType(ISchema schema)
+    {
+        var objectGraphType = GraphType as IObjectGraphType;
+
+        if (GraphType is IAbstractGraphType abstractGraphType)
+            objectGraphType = abstractGraphType.GetObjectType(Result!, schema);
+
+        return objectGraphType;
+    }
+
+    /// <summary>
+    /// Returns a representation of the result of this execution node and its children
+    /// within a <see cref="Dictionary{TKey, TValue}"/>.
+    /// <see cref="PropagateNull"/> must be called prior to calling this method.
+    /// </summary>
+    public override object? ToValue()
+    {
+        if (SubFields == null)
+            return null;
+
+        var fields = new Dictionary<string, object?>(SubFields.Length);
+
+        for (int i = 0; i < SubFields.Length; ++i)
         {
+            var child = SubFields[i];
+            fields.Add(child.Name!, child.ToValue());
         }
 
-        /// <summary>
-        /// For execution nodes that represent a field that is an <see cref="IAbstractGraphType"/>, returns the
-        /// proper <see cref="IObjectGraphType"/> based on the set <see cref="ExecutionNode.Result"/>.
-        /// Otherwise returns the value of <see cref="ExecutionNode.GraphType"/>.
-        /// </summary>
-        public IObjectGraphType? GetObjectGraphType(ISchema schema)
+        return fields;
+    }
+
+    /// <inheritdoc/>
+    public override bool PropagateNull()
+    {
+        if (SubFields == null)
+            return true;
+
+        for (int i = 0; i < SubFields.Length; ++i)
         {
-            var objectGraphType = GraphType as IObjectGraphType;
+            var child = SubFields[i];
+            bool valueIsNull = child.PropagateNull();
 
-            if (GraphType is IAbstractGraphType abstractGraphType)
-                objectGraphType = abstractGraphType.GetObjectType(Result!, schema);
-
-            return objectGraphType;
-        }
-
-        /// <summary>
-        /// Returns a representation of the result of this execution node and its children
-        /// within a <see cref="Dictionary{TKey, TValue}"/>.
-        /// <see cref="PropagateNull"/> must be called prior to calling this method.
-        /// </summary>
-        public override object? ToValue()
-        {
-            if (SubFields == null)
-                return null;
-
-            var fields = new Dictionary<string, object?>(SubFields.Length);
-
-            for (int i = 0; i < SubFields.Length; ++i)
+            if (valueIsNull && child.FieldDefinition!.ResolvedType is NonNullGraphType)
             {
-                var child = SubFields[i];
-                fields.Add(child.Name!, child.ToValue());
-            }
-
-            return fields;
-        }
-
-        /// <inheritdoc/>
-        public override bool PropagateNull()
-        {
-            if (SubFields == null)
+                SubFields = null;
                 return true;
-
-            for (int i = 0; i < SubFields.Length; ++i)
-            {
-                var child = SubFields[i];
-                bool valueIsNull = child.PropagateNull();
-
-                if (valueIsNull && child.FieldDefinition!.ResolvedType is NonNullGraphType)
-                {
-                    SubFields = null;
-                    return true;
-                }
             }
-
-            return false;
         }
 
-        IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes() => SubFields ?? Enumerable.Empty<ExecutionNode>();
+        return false;
+    }
 
-        /// <summary>
-        /// Returns the selection set from <see cref="ExecutionNode.Field"/>.
-        /// </summary>
-        public virtual GraphQLSelectionSet? SelectionSet => Field?.SelectionSet;
+    IEnumerable<ExecutionNode> IParentExecutionNode.GetChildNodes() => SubFields ?? Enumerable.Empty<ExecutionNode>();
 
-        /// <inheritdoc/>
-        public void ApplyToChildren<TState>(Action<ExecutionNode, TState> action, TState state, bool reverse = false)
+    /// <summary>
+    /// Returns the selection set from <see cref="ExecutionNode.Field"/>.
+    /// </summary>
+    public virtual GraphQLSelectionSet? SelectionSet => Field?.SelectionSet;
+
+    /// <inheritdoc/>
+    public void ApplyToChildren<TState>(Action<ExecutionNode, TState> action, TState state, bool reverse = false)
+    {
+        if (SubFields != null)
         {
-            if (SubFields != null)
+            if (reverse)
             {
-                if (reverse)
-                {
-                    for (int i = SubFields.Length - 1; i >= 0; --i)
-                        action(SubFields[i], state);
-                }
-                else
-                {
-                    foreach (var item in SubFields)
-                        action(item, state);
-                }
+                for (int i = SubFields.Length - 1; i >= 0; --i)
+                    action(SubFields[i], state);
+            }
+            else
+            {
+                foreach (var item in SubFields)
+                    action(item, state);
             }
         }
     }

--- a/src/GraphQL/Execution/Nodes/RootExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/RootExecutionNode.cs
@@ -1,23 +1,22 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents a root execution node.
+/// </summary>
+public class RootExecutionNode : ObjectExecutionNode
 {
     /// <summary>
-    /// Represents a root execution node.
+    /// Initializes a new instance for the specified root graph type.
     /// </summary>
-    public class RootExecutionNode : ObjectExecutionNode
+    public RootExecutionNode(IObjectGraphType graphType, GraphQLSelectionSet? selectionSet)
+        : base(null!, graphType, null!, null!, null)
     {
-        /// <summary>
-        /// Initializes a new instance for the specified root graph type.
-        /// </summary>
-        public RootExecutionNode(IObjectGraphType graphType, GraphQLSelectionSet? selectionSet)
-            : base(null!, graphType, null!, null!, null)
-        {
-            SelectionSet = selectionSet;
-        }
-
-        /// <inheritdoc/>
-        public override GraphQLSelectionSet? SelectionSet { get; }
+        SelectionSet = selectionSet;
     }
+
+    /// <inheritdoc/>
+    public override GraphQLSelectionSet? SelectionSet { get; }
 }

--- a/src/GraphQL/Execution/Nodes/SubscriptionArrayExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionArrayExecutionNode.cs
@@ -1,21 +1,20 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
-{
-    /// <inheritdoc/>
-    public class SubscriptionArrayExecutionNode : ArrayExecutionNode
-    {
-        /// <summary>
-        /// Initializes an <see cref="SubscriptionArrayExecutionNode"/> instance with the specified values.
-        /// </summary>
-        public SubscriptionArrayExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode, object source)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
-        {
-            Source = source;
-        }
+namespace GraphQL.Execution;
 
-        /// <inheritdoc/>
-        public override object Source { get; }
+/// <inheritdoc/>
+public class SubscriptionArrayExecutionNode : ArrayExecutionNode
+{
+    /// <summary>
+    /// Initializes an <see cref="SubscriptionArrayExecutionNode"/> instance with the specified values.
+    /// </summary>
+    public SubscriptionArrayExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode, object source)
+        : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+    {
+        Source = source;
     }
+
+    /// <inheritdoc/>
+    public override object Source { get; }
 }

--- a/src/GraphQL/Execution/Nodes/SubscriptionObjectExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionObjectExecutionNode.cs
@@ -1,21 +1,20 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
-{
-    /// <inheritdoc/>
-    public class SubscriptionObjectExecutionNode : ObjectExecutionNode
-    {
-        /// <summary>
-        /// Initializes an instance of <see cref="SubscriptionObjectExecutionNode"/> with the specified values.
-        /// </summary>
-        public SubscriptionObjectExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode, object source)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
-        {
-            Source = source;
-        }
+namespace GraphQL.Execution;
 
-        /// <inheritdoc/>
-        public override object Source { get; }
+/// <inheritdoc/>
+public class SubscriptionObjectExecutionNode : ObjectExecutionNode
+{
+    /// <summary>
+    /// Initializes an instance of <see cref="SubscriptionObjectExecutionNode"/> with the specified values.
+    /// </summary>
+    public SubscriptionObjectExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode, object source)
+        : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+    {
+        Source = source;
     }
+
+    /// <inheritdoc/>
+    public override object Source { get; }
 }

--- a/src/GraphQL/Execution/Nodes/SubscriptionValueExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/SubscriptionValueExecutionNode.cs
@@ -1,21 +1,20 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
-{
-    /// <inheritdoc/>
-    public class SubscriptionValueExecutionNode : ValueExecutionNode
-    {
-        /// <summary>
-        /// Initializes an <see cref="SubscriptionValueExecutionNode"/> instance with the specified values.
-        /// </summary>
-        public SubscriptionValueExecutionNode(ExecutionNode parent, ScalarGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode, object source)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
-        {
-            Source = source;
-        }
+namespace GraphQL.Execution;
 
-        /// <inheritdoc/>
-        public override object Source { get; }
+/// <inheritdoc/>
+public class SubscriptionValueExecutionNode : ValueExecutionNode
+{
+    /// <summary>
+    /// Initializes an <see cref="SubscriptionValueExecutionNode"/> instance with the specified values.
+    /// </summary>
+    public SubscriptionValueExecutionNode(ExecutionNode parent, ScalarGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode, object source)
+        : base(parent, graphType, field, fieldDefinition, indexInParentNode)
+    {
+        Source = source;
     }
+
+    /// <inheritdoc/>
+    public override object Source { get; }
 }

--- a/src/GraphQL/Execution/Nodes/ValueExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ValueExecutionNode.cs
@@ -1,29 +1,28 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Represents a execution node of a <see cref="ScalarGraphType"/>.
+/// </summary>
+public class ValueExecutionNode : ExecutionNode
 {
     /// <summary>
-    /// Represents a execution node of a <see cref="ScalarGraphType"/>.
+    /// Initializes an instance of <see cref="ValueExecutionNode"/> with the specified values.
     /// </summary>
-    public class ValueExecutionNode : ExecutionNode
+    public ValueExecutionNode(ExecutionNode parent, ScalarGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
+        : base(parent, graphType, field, fieldDefinition, indexInParentNode)
     {
-        /// <summary>
-        /// Initializes an instance of <see cref="ValueExecutionNode"/> with the specified values.
-        /// </summary>
-        public ValueExecutionNode(ExecutionNode parent, ScalarGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
-            : base(parent, graphType, field, fieldDefinition, indexInParentNode)
-        {
-        }
-
-        /// <summary>
-        /// Returns <see cref="ExecutionNode.Result"/>, which has already been serialized by <see cref="ScalarGraphType.Serialize(object)"/>
-        /// within <see cref="ExecutionStrategy.CompleteNodeAsync(ExecutionContext, ExecutionNode)"/> or
-        /// <see cref="ExecutionStrategy.SetArrayItemNodesAsync(ExecutionContext, ArrayExecutionNode)"/>.
-        /// </summary>
-        public override object? ToValue() => Result;
-
-        /// <inheritdoc cref="ExecutionNode.GraphType"/>
-        public new ScalarGraphType GraphType => (ScalarGraphType)base.GraphType!;
     }
+
+    /// <summary>
+    /// Returns <see cref="ExecutionNode.Result"/>, which has already been serialized by <see cref="ScalarGraphType.Serialize(object)"/>
+    /// within <see cref="ExecutionStrategy.CompleteNodeAsync(ExecutionContext, ExecutionNode)"/> or
+    /// <see cref="ExecutionStrategy.SetArrayItemNodesAsync(ExecutionContext, ArrayExecutionNode)"/>.
+    /// </summary>
+    public override object? ToValue() => Result;
+
+    /// <inheritdoc cref="ExecutionNode.GraphType"/>
+    public new ScalarGraphType GraphType => (ScalarGraphType)base.GraphType!;
 }

--- a/src/GraphQL/Execution/ParallelExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ParallelExecutionStrategy.cs
@@ -1,130 +1,129 @@
 using GraphQL.DataLoader;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <inheritdoc cref="ExecuteNodeTreeAsync(ExecutionContext, ExecutionNode)"/>
+public class ParallelExecutionStrategy : ExecutionStrategy
 {
-    /// <inheritdoc cref="ExecuteNodeTreeAsync(ExecutionContext, ExecutionNode)"/>
-    public class ParallelExecutionStrategy : ExecutionStrategy
+    // frequently reused objects
+    private Queue<ExecutionNode>? _reusablePendingNodes;
+    private Queue<ExecutionNode>? _reusablePendingDataLoaders;
+    private List<Task>? _reusableCurrentTasks;
+    private List<ExecutionNode>? _reusableCurrentNodes;
+
+    /// <summary>
+    /// Gets a static instance of <see cref="ParallelExecutionStrategy"/> strategy.
+    /// </summary>
+    public static ParallelExecutionStrategy Instance { get; } = new ParallelExecutionStrategy();
+
+    /// <summary>
+    /// Executes document nodes in parallel. Field resolvers must be designed for multi-threaded use.
+    /// Nodes that return a <see cref="IDataLoaderResult"/> will execute once all other pending nodes
+    /// have been completed.
+    /// </summary>
+    public override async Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode)
     {
-        // frequently reused objects
-        private Queue<ExecutionNode>? _reusablePendingNodes;
-        private Queue<ExecutionNode>? _reusablePendingDataLoaders;
-        private List<Task>? _reusableCurrentTasks;
-        private List<ExecutionNode>? _reusableCurrentNodes;
+        var pendingNodes = Interlocked.Exchange(ref _reusablePendingNodes, null) ?? new Queue<ExecutionNode>();
+        pendingNodes.Enqueue(rootNode);
+        var pendingDataLoaders = Interlocked.Exchange(ref _reusablePendingDataLoaders, null) ?? new Queue<ExecutionNode>();
 
-        /// <summary>
-        /// Gets a static instance of <see cref="ParallelExecutionStrategy"/> strategy.
-        /// </summary>
-        public static ParallelExecutionStrategy Instance { get; } = new ParallelExecutionStrategy();
+        var currentTasks = Interlocked.Exchange(ref _reusableCurrentTasks, null) ?? new List<Task>();
+        var currentNodes = Interlocked.Exchange(ref _reusableCurrentNodes, null) ?? new List<ExecutionNode>();
 
-        /// <summary>
-        /// Executes document nodes in parallel. Field resolvers must be designed for multi-threaded use.
-        /// Nodes that return a <see cref="IDataLoaderResult"/> will execute once all other pending nodes
-        /// have been completed.
-        /// </summary>
-        public override async Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode)
+        try
         {
-            var pendingNodes = Interlocked.Exchange(ref _reusablePendingNodes, null) ?? new Queue<ExecutionNode>();
-            pendingNodes.Enqueue(rootNode);
-            var pendingDataLoaders = Interlocked.Exchange(ref _reusablePendingDataLoaders, null) ?? new Queue<ExecutionNode>();
-
-            var currentTasks = Interlocked.Exchange(ref _reusableCurrentTasks, null) ?? new List<Task>();
-            var currentNodes = Interlocked.Exchange(ref _reusableCurrentNodes, null) ?? new List<ExecutionNode>();
-
-            try
+            while (pendingNodes.Count > 0 || pendingDataLoaders.Count > 0 || currentTasks.Count > 0)
             {
-                while (pendingNodes.Count > 0 || pendingDataLoaders.Count > 0 || currentTasks.Count > 0)
+                while (pendingNodes.Count > 0 || currentTasks.Count > 0)
                 {
-                    while (pendingNodes.Count > 0 || currentTasks.Count > 0)
+                    // Start executing pending nodes, while limiting the maximum number of parallel executed nodes to the set limit
+                    while ((context.MaxParallelExecutionCount == null || currentTasks.Count < context.MaxParallelExecutionCount)
+                        && pendingNodes.Count > 0)
                     {
-                        // Start executing pending nodes, while limiting the maximum number of parallel executed nodes to the set limit
-                        while ((context.MaxParallelExecutionCount == null || currentTasks.Count < context.MaxParallelExecutionCount)
-                            && pendingNodes.Count > 0)
+                        context.CancellationToken.ThrowIfCancellationRequested();
+                        var pendingNode = pendingNodes.Dequeue();
+                        var pendingNodeTask = ExecuteNodeAsync(context, pendingNode);
+                        if (pendingNodeTask.IsCompleted)
                         {
-                            context.CancellationToken.ThrowIfCancellationRequested();
-                            var pendingNode = pendingNodes.Dequeue();
-                            var pendingNodeTask = ExecuteNodeAsync(context, pendingNode);
-                            if (pendingNodeTask.IsCompleted)
-                            {
-                                // Throw any caught exceptions
-                                await pendingNodeTask.ConfigureAwait(false);
+                            // Throw any caught exceptions
+                            await pendingNodeTask.ConfigureAwait(false);
 
-                                // Node completed synchronously, so no need to add it to the list of currently executing nodes
-                                // instead add any child nodes to the pendingNodes queue directly here
-                                if (pendingNode.Result is IDataLoaderResult)
-                                {
-                                    pendingDataLoaders.Enqueue(pendingNode);
-                                }
-                                else if (pendingNode is IParentExecutionNode parentExecutionNode)
-                                {
-                                    parentExecutionNode.ApplyToChildren((node, state) => state.Enqueue(node), pendingNodes);
-                                }
-                            }
-                            else
+                            // Node completed synchronously, so no need to add it to the list of currently executing nodes
+                            // instead add any child nodes to the pendingNodes queue directly here
+                            if (pendingNode.Result is IDataLoaderResult)
                             {
-                                // Node is actually asynchronous, so add it to the list of current tasks being executed in parallel
-                                currentTasks.Add(pendingNodeTask);
-                                currentNodes.Add(pendingNode);
+                                pendingDataLoaders.Enqueue(pendingNode);
+                            }
+                            else if (pendingNode is IParentExecutionNode parentExecutionNode)
+                            {
+                                parentExecutionNode.ApplyToChildren((node, state) => state.Enqueue(node), pendingNodes);
                             }
                         }
-
-                        // Await tasks for this execution step
-                        await Task.WhenAll(currentTasks)
-                            .ConfigureAwait(false);
-
-                        // Add child nodes to pending nodes to execute the next level in parallel
-                        foreach (var node in currentNodes)
+                        else
                         {
-                            if (node.Result is IDataLoaderResult)
-                            {
-                                pendingDataLoaders.Enqueue(node);
-                            }
-                            else if (node is IParentExecutionNode p)
-                            {
-                                p.ApplyToChildren((node, state) => state.Enqueue(node), pendingNodes);
-                            }
+                            // Node is actually asynchronous, so add it to the list of current tasks being executed in parallel
+                            currentTasks.Add(pendingNodeTask);
+                            currentNodes.Add(pendingNode);
                         }
-
-                        currentTasks.Clear();
-                        currentNodes.Clear();
                     }
 
-                    //run pending data loaders
-                    while (pendingDataLoaders.Count > 0)
+                    // Await tasks for this execution step
+                    await Task.WhenAll(currentTasks)
+                        .ConfigureAwait(false);
+
+                    // Add child nodes to pending nodes to execute the next level in parallel
+                    foreach (var node in currentNodes)
                     {
-                        var dataLoaderNode = pendingDataLoaders.Dequeue();
-                        currentTasks.Add(CompleteDataLoaderNodeAsync(context, dataLoaderNode));
-                        currentNodes.Add(dataLoaderNode);
+                        if (node.Result is IDataLoaderResult)
+                        {
+                            pendingDataLoaders.Enqueue(node);
+                        }
+                        else if (node is IParentExecutionNode p)
+                        {
+                            p.ApplyToChildren((node, state) => state.Enqueue(node), pendingNodes);
+                        }
                     }
+
+                    currentTasks.Clear();
+                    currentNodes.Clear();
                 }
-            }
-            catch (Exception original)
-            {
-                if (currentTasks.Count > 0)
+
+                //run pending data loaders
+                while (pendingDataLoaders.Count > 0)
                 {
-                    try
-                    {
-                        await Task.WhenAll(currentTasks).ConfigureAwait(false);
-                    }
-                    catch (Exception awaited)
-                    {
-                        if (original.Data?.IsReadOnly == false)
-                            original.Data["GRAPHQL_ALL_TASKS_AWAITED_EXCEPTION"] = awaited;
-                    }
+                    var dataLoaderNode = pendingDataLoaders.Dequeue();
+                    currentTasks.Add(CompleteDataLoaderNodeAsync(context, dataLoaderNode));
+                    currentNodes.Add(dataLoaderNode);
                 }
-                throw;
             }
-            finally
+        }
+        catch (Exception original)
+        {
+            if (currentTasks.Count > 0)
             {
-                pendingNodes.Clear();
-                pendingDataLoaders.Clear();
-                currentTasks.Clear();
-                currentNodes.Clear();
-
-                _ = Interlocked.CompareExchange(ref _reusablePendingNodes, pendingNodes, null);
-                _ = Interlocked.CompareExchange(ref _reusablePendingDataLoaders, pendingDataLoaders, null);
-                _ = Interlocked.CompareExchange(ref _reusableCurrentTasks, currentTasks, null);
-                _ = Interlocked.CompareExchange(ref _reusableCurrentNodes, currentNodes, null);
+                try
+                {
+                    await Task.WhenAll(currentTasks).ConfigureAwait(false);
+                }
+                catch (Exception awaited)
+                {
+                    if (original.Data?.IsReadOnly == false)
+                        original.Data["GRAPHQL_ALL_TASKS_AWAITED_EXCEPTION"] = awaited;
+                }
             }
+            throw;
+        }
+        finally
+        {
+            pendingNodes.Clear();
+            pendingDataLoaders.Clear();
+            currentTasks.Clear();
+            currentNodes.Clear();
+
+            _ = Interlocked.CompareExchange(ref _reusablePendingNodes, pendingNodes, null);
+            _ = Interlocked.CompareExchange(ref _reusablePendingDataLoaders, pendingDataLoaders, null);
+            _ = Interlocked.CompareExchange(ref _reusableCurrentTasks, currentTasks, null);
+            _ = Interlocked.CompareExchange(ref _reusableCurrentNodes, currentNodes, null);
         }
     }
 }

--- a/src/GraphQL/Execution/SerialExecutionStrategy.cs
+++ b/src/GraphQL/Execution/SerialExecutionStrategy.cs
@@ -1,88 +1,87 @@
 using GraphQL.DataLoader;
 
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <inheritdoc cref="ExecuteNodeTreeAsync(ExecutionContext, ExecutionNode)"/>
+public class SerialExecutionStrategy : ExecutionStrategy
 {
-    /// <inheritdoc cref="ExecuteNodeTreeAsync(ExecutionContext, ExecutionNode)"/>
-    public class SerialExecutionStrategy : ExecutionStrategy
+    // frequently reused objects
+    private Stack<ExecutionNode>? _reusableNodes;
+    private Queue<ExecutionNode>? _reusableDataLoaderNodes;
+    private Stack<ExecutionNode>? _reusableAddlNodes;
+
+    /// <summary>
+    /// Gets a static instance of <see cref="SerialExecutionStrategy"/> strategy.
+    /// </summary>
+    public static SerialExecutionStrategy Instance { get; } = new SerialExecutionStrategy();
+
+    /// <summary>
+    /// Executes document nodes serially. Nodes that return a <see cref="IDataLoaderResult"/> will
+    /// execute once all other pending nodes have been completed.
+    /// </summary>
+    public override async Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode)
     {
-        // frequently reused objects
-        private Stack<ExecutionNode>? _reusableNodes;
-        private Queue<ExecutionNode>? _reusableDataLoaderNodes;
-        private Stack<ExecutionNode>? _reusableAddlNodes;
+        // Use a stack to track all nodes in the tree that need to be executed
+        var nodes = Interlocked.Exchange(ref _reusableNodes, null) ?? new Stack<ExecutionNode>();
+        nodes.Push(rootNode);
+        var dataLoaderNodes = Interlocked.Exchange(ref _reusableDataLoaderNodes, null) ?? new Queue<ExecutionNode>();
+        var addlNodes = Interlocked.Exchange(ref _reusableAddlNodes, null) ?? new Stack<ExecutionNode>();
 
-        /// <summary>
-        /// Gets a static instance of <see cref="SerialExecutionStrategy"/> strategy.
-        /// </summary>
-        public static SerialExecutionStrategy Instance { get; } = new SerialExecutionStrategy();
-
-        /// <summary>
-        /// Executes document nodes serially. Nodes that return a <see cref="IDataLoaderResult"/> will
-        /// execute once all other pending nodes have been completed.
-        /// </summary>
-        public override async Task ExecuteNodeTreeAsync(ExecutionContext context, ExecutionNode rootNode)
+        try
         {
-            // Use a stack to track all nodes in the tree that need to be executed
-            var nodes = Interlocked.Exchange(ref _reusableNodes, null) ?? new Stack<ExecutionNode>();
-            nodes.Push(rootNode);
-            var dataLoaderNodes = Interlocked.Exchange(ref _reusableDataLoaderNodes, null) ?? new Queue<ExecutionNode>();
-            var addlNodes = Interlocked.Exchange(ref _reusableAddlNodes, null) ?? new Stack<ExecutionNode>();
-
-            try
+            // Process each node on the stack one by one
+            while (nodes.Count > 0 || dataLoaderNodes.Count > 0)
             {
-                // Process each node on the stack one by one
-                while (nodes.Count > 0 || dataLoaderNodes.Count > 0)
+                while (nodes.Count > 0)
                 {
-                    while (nodes.Count > 0)
-                    {
-                        var node = nodes.Pop();
-                        await ExecuteNodeAsync(context, node).ConfigureAwait(false);
+                    var node = nodes.Pop();
+                    await ExecuteNodeAsync(context, node).ConfigureAwait(false);
 
-                        // Push any child nodes on top of the stack
-                        if (node.Result is IDataLoaderResult)
-                        {
-                            dataLoaderNodes.Enqueue(node);
-                        }
-                        else if (node is IParentExecutionNode parentNode)
-                        {
-                            // Add in reverse order so fields are executed in the correct order
-                            parentNode.ApplyToChildren((node, state) => state.Push(node), nodes, reverse: true);
-                        }
+                    // Push any child nodes on top of the stack
+                    if (node.Result is IDataLoaderResult)
+                    {
+                        dataLoaderNodes.Enqueue(node);
                     }
-
-                    while (dataLoaderNodes.Count > 0)
+                    else if (node is IParentExecutionNode parentNode)
                     {
-                        var node = dataLoaderNodes.Dequeue();
-                        await CompleteDataLoaderNodeAsync(context, node).ConfigureAwait(false);
-
-                        // Push any child nodes on top of the stack
-                        if (node.Result is IDataLoaderResult)
-                        {
-                            dataLoaderNodes.Enqueue(node);
-                        }
-                        else if (node is IParentExecutionNode parentNode)
-                        {
-                            // Do not reverse the order of the nodes here
-                            parentNode.ApplyToChildren((node, state) => state.Push(node), addlNodes, reverse: false);
-                        }
-                    }
-
-                    // Reverse order of queued nodes from data loader nodes so they are executed in the correct order
-                    while (addlNodes.Count > 0)
-                    {
-                        nodes.Push(addlNodes.Pop());
+                        // Add in reverse order so fields are executed in the correct order
+                        parentNode.ApplyToChildren((node, state) => state.Push(node), nodes, reverse: true);
                     }
                 }
-            }
-            finally
-            {
-                nodes.Clear();
-                dataLoaderNodes.Clear();
-                addlNodes.Clear();
 
-                _ = Interlocked.CompareExchange(ref _reusableNodes, nodes, null);
-                _ = Interlocked.CompareExchange(ref _reusableDataLoaderNodes, dataLoaderNodes, null);
-                _ = Interlocked.CompareExchange(ref _reusableAddlNodes, addlNodes, null);
+                while (dataLoaderNodes.Count > 0)
+                {
+                    var node = dataLoaderNodes.Dequeue();
+                    await CompleteDataLoaderNodeAsync(context, node).ConfigureAwait(false);
+
+                    // Push any child nodes on top of the stack
+                    if (node.Result is IDataLoaderResult)
+                    {
+                        dataLoaderNodes.Enqueue(node);
+                    }
+                    else if (node is IParentExecutionNode parentNode)
+                    {
+                        // Do not reverse the order of the nodes here
+                        parentNode.ApplyToChildren((node, state) => state.Push(node), addlNodes, reverse: false);
+                    }
+                }
+
+                // Reverse order of queued nodes from data loader nodes so they are executed in the correct order
+                while (addlNodes.Count > 0)
+                {
+                    nodes.Push(addlNodes.Pop());
+                }
             }
+        }
+        finally
+        {
+            nodes.Clear();
+            dataLoaderNodes.Clear();
+            addlNodes.Clear();
+
+            _ = Interlocked.CompareExchange(ref _reusableNodes, nodes, null);
+            _ = Interlocked.CompareExchange(ref _reusableDataLoaderNodes, dataLoaderNodes, null);
+            _ = Interlocked.CompareExchange(ref _reusableAddlNodes, addlNodes, null);
         }
     }
 }

--- a/src/GraphQL/Execution/UnhandledExceptionContext.cs
+++ b/src/GraphQL/Execution/UnhandledExceptionContext.cs
@@ -1,46 +1,45 @@
-namespace GraphQL.Execution
+namespace GraphQL.Execution;
+
+/// <summary>
+/// Provides contextual information for the unhandled exception delegate, <see cref="ExecutionContext.UnhandledExceptionDelegate"/>.
+/// </summary>
+public class UnhandledExceptionContext
 {
     /// <summary>
-    /// Provides contextual information for the unhandled exception delegate, <see cref="ExecutionContext.UnhandledExceptionDelegate"/>.
+    /// Initializes a new instance with the specified properties.
     /// </summary>
-    public class UnhandledExceptionContext
+    public UnhandledExceptionContext(IExecutionContext? context, IResolveFieldContext? fieldContext, Exception originalException)
     {
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public UnhandledExceptionContext(IExecutionContext? context, IResolveFieldContext? fieldContext, Exception originalException)
-        {
-            Context = context;
-            FieldContext = fieldContext;
-            OriginalException = originalException;
-            Exception = originalException;
-        }
-
-        /// <summary>
-        /// Returns the execution context.
-        /// </summary>
-        public IExecutionContext? Context { get; }
-
-        /// <summary>
-        /// Field context whose resolver generated an error. Will be <see langword="null"/> if the error came from
-        /// <see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)"/>, for example, validation stage.
-        /// Also will be <see langword="null"/> between resolvers execution if <c>cancellationToken</c> is canceled.
-        /// </summary>
-        public IResolveFieldContext? FieldContext { get; }
-
-        /// <summary>
-        /// Original exception from field resolver or <see cref="DocumentExecuter"/>.
-        /// </summary>
-        public Exception OriginalException { get; }
-
-        /// <summary>
-        /// Allows to change resulting exception keeping original exception unmodified.
-        /// </summary>
-        public Exception Exception { get; set; }
-
-        /// <summary>
-        /// Allows to change resulting error message from default one.
-        /// </summary>
-        public string? ErrorMessage { get; set; }
+        Context = context;
+        FieldContext = fieldContext;
+        OriginalException = originalException;
+        Exception = originalException;
     }
+
+    /// <summary>
+    /// Returns the execution context.
+    /// </summary>
+    public IExecutionContext? Context { get; }
+
+    /// <summary>
+    /// Field context whose resolver generated an error. Will be <see langword="null"/> if the error came from
+    /// <see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)"/>, for example, validation stage.
+    /// Also will be <see langword="null"/> between resolvers execution if <c>cancellationToken</c> is canceled.
+    /// </summary>
+    public IResolveFieldContext? FieldContext { get; }
+
+    /// <summary>
+    /// Original exception from field resolver or <see cref="DocumentExecuter"/>.
+    /// </summary>
+    public Exception OriginalException { get; }
+
+    /// <summary>
+    /// Allows to change resulting exception keeping original exception unmodified.
+    /// </summary>
+    public Exception Exception { get; set; }
+
+    /// <summary>
+    /// Allows to change resulting error message from default one.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
 }

--- a/src/GraphQL/Extensions/AssemblyExtensions.cs
+++ b/src/GraphQL/Extensions/AssemblyExtensions.cs
@@ -1,85 +1,84 @@
 using System.Reflection;
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+internal static class AssemblyExtensions
 {
-    internal static class AssemblyExtensions
+    /// <summary>
+    /// Contains a list of types that are scanned for, from which a clr type mapping will be matched
+    /// </summary>
+    private static readonly Type[] _typesToRegister = new Type[]
     {
-        /// <summary>
-        /// Contains a list of types that are scanned for, from which a clr type mapping will be matched
-        /// </summary>
-        private static readonly Type[] _typesToRegister = new Type[]
-        {
-            typeof(ObjectGraphType<>),
-            typeof(InputObjectGraphType<>),
-            typeof(EnumerationGraphType<>),
-        };
+        typeof(ObjectGraphType<>),
+        typeof(InputObjectGraphType<>),
+        typeof(EnumerationGraphType<>),
+    };
 
-        /// <summary>
-        /// Scans the specified assembly for classes that inherit from <see cref="ObjectGraphType{TSourceType}"/>,
-        /// <see cref="InputObjectGraphType{TSourceType}"/>, or <see cref="EnumerationGraphType{TEnum}"/>, and
-        /// returns a list of mappings between matched classes and the source type or underlying enum type.
-        /// Skips classes where the source type is <see cref="object"/>, or where the class is marked with
-        /// the <see cref="DoNotMapClrTypeAttribute"/>.
-        /// </summary>
-        public static List<(Type ClrType, Type GraphType)> GetClrTypeMappings(this Assembly assembly)
-        {
-            //create a list of type mappings
-            var typeMappings = new List<(Type clrType, Type graphType)>();
+    /// <summary>
+    /// Scans the specified assembly for classes that inherit from <see cref="ObjectGraphType{TSourceType}"/>,
+    /// <see cref="InputObjectGraphType{TSourceType}"/>, or <see cref="EnumerationGraphType{TEnum}"/>, and
+    /// returns a list of mappings between matched classes and the source type or underlying enum type.
+    /// Skips classes where the source type is <see cref="object"/>, or where the class is marked with
+    /// the <see cref="DoNotMapClrTypeAttribute"/>.
+    /// </summary>
+    public static List<(Type ClrType, Type GraphType)> GetClrTypeMappings(this Assembly assembly)
+    {
+        //create a list of type mappings
+        var typeMappings = new List<(Type clrType, Type graphType)>();
 
-            //loop through each type in the specified assembly
-            foreach (var graphType in assembly.GetTypes())
+        //loop through each type in the specified assembly
+        foreach (var graphType in assembly.GetTypes())
+        {
+            //skip types that are not graph types
+            if (!typeof(IGraphType).IsAssignableFrom(graphType))
+                continue;
+
+            //skip abstract types and interfaces
+            if (graphType.IsAbstract || graphType.IsInterface)
+                continue;
+
+            //skip types marked with the DoNotRegister attribute
+            if (graphType.IsDefined(typeof(DoNotMapClrTypeAttribute)))
+                continue;
+
+            //start with the base type
+            var baseType = graphType.BaseType;
+            while (baseType != null)
             {
-                //skip types that are not graph types
-                if (!typeof(IGraphType).IsAssignableFrom(graphType))
-                    continue;
-
-                //skip abstract types and interfaces
-                if (graphType.IsAbstract || graphType.IsInterface)
-                    continue;
-
                 //skip types marked with the DoNotRegister attribute
-                if (graphType.IsDefined(typeof(DoNotMapClrTypeAttribute)))
-                    continue;
+                if (baseType.IsDefined(typeof(DoNotMapClrTypeAttribute)))
+                    break;
 
-                //start with the base type
-                var baseType = graphType.BaseType;
-                while (baseType != null)
+                //look for generic types that match our list above
+                if (baseType.IsConstructedGenericType && _typesToRegister.Contains(baseType.GetGenericTypeDefinition()))
                 {
-                    //skip types marked with the DoNotRegister attribute
-                    if (baseType.IsDefined(typeof(DoNotMapClrTypeAttribute)))
-                        break;
+                    //get the base type
+                    var clrType = baseType.GetGenericArguments()[0];
 
-                    //look for generic types that match our list above
-                    if (baseType.IsConstructedGenericType && _typesToRegister.Contains(baseType.GetGenericTypeDefinition()))
-                    {
-                        //get the base type
-                        var clrType = baseType.GetGenericArguments()[0];
+                    //as long as it's not of type 'object', register it
+                    if (clrType != typeof(object) && !clrType.IsDefined(typeof(DoNotMapClrTypeAttribute)))
+                        typeMappings.Add((clrType, graphType));
 
-                        //as long as it's not of type 'object', register it
-                        if (clrType != typeof(object) && !clrType.IsDefined(typeof(DoNotMapClrTypeAttribute)))
-                            typeMappings.Add((clrType, graphType));
-
-                        //skip to the next type
-                        break;
-                    }
-
-                    //look up the inheritance chain for a match
-                    baseType = baseType.BaseType;
+                    //skip to the next type
+                    break;
                 }
+
+                //look up the inheritance chain for a match
+                baseType = baseType.BaseType;
             }
-
-            //return the list of type mappings
-            return typeMappings;
         }
 
-        internal static string? GetNuGetVersion(this Assembly assembly)
-        {
-            var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-            if (version == null)
-                return null;
-            var i = version.LastIndexOf('+');
-            return i == -1 ? version : version.Substring(0, i);
-        }
+        //return the list of type mappings
+        return typeMappings;
+    }
+
+    internal static string? GetNuGetVersion(this Assembly assembly)
+    {
+        var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (version == null)
+            return null;
+        var i = version.LastIndexOf('+');
+        return i == -1 ? version : version.Substring(0, i);
     }
 }

--- a/src/GraphQL/Extensions/AuthorizationExtensions.cs
+++ b/src/GraphQL/Extensions/AuthorizationExtensions.cs
@@ -1,193 +1,192 @@
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Extension methods to configure authorization requirements for GraphQL elements: types, fields, schema.
+/// </summary>
+public static class AuthorizationExtensions
 {
     /// <summary>
-    /// Extension methods to configure authorization requirements for GraphQL elements: types, fields, schema.
+    /// Metadata key name for storing authorization policy names. Value of this key
+    /// is a simple list of strings.
     /// </summary>
-    public static class AuthorizationExtensions
+    public const string POLICY_KEY = "Authorization__Policies";
+
+    /// <summary>
+    /// Metadata key name for storing authorization role names. Value of this key
+    /// is a simple list of strings.
+    /// </summary>
+    public const string ROLE_KEY = "Authorization__Roles";
+
+    /// <summary>
+    /// Metadata key name for indicating that the user must be authorized (strictly speaking, authenticated) to access the resource.
+    /// Value of this key is a boolean value.
+    /// </summary>
+    public const string AUTHORIZE_KEY = "Authorization__Required";
+
+    /// <summary>
+    /// Metadata key name for typically indicating if anonymous access should be allowed to a field of a graph type
+    /// requiring authorization, providing that no other fields were selected.
+    /// </summary>
+    public const string ANONYMOUS_KEY = "Authorization__AllowAnonymous";
+
+    /// <summary>
+    /// Gets a list of authorization policy names for the specified metadata provider if any.
+    /// Otherwise returns <see langword="null"/>.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <returns>List of authorization policy names applied to this metadata provider.</returns>
+    public static List<string>? GetPolicies(this IMetadataReader provider) => provider.GetMetadata<List<string>>(POLICY_KEY);
+
+    /// <summary>
+    /// Gets a list of authorization roles names for the specified metadata provider if any.
+    /// Otherwise returns <see langword="null"/>.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <returns>List of authorization role names applied to this metadata provider.</returns>
+    public static List<string>? GetRoles(this IMetadataReader provider) => provider.GetMetadata<List<string>>(ROLE_KEY);
+
+    /// <summary>
+    /// Returns a boolean typically indicating if anonymous access should be allowed to a field of a graph type
+    /// requiring authorization, providing that no other fields were selected.
+    /// </summary>
+    public static bool IsAnonymousAllowed(this IMetadataReader provider) => provider.GetMetadata(ANONYMOUS_KEY, false);
+
+    /// <summary>
+    /// Adds metadata to typically indicate that anonymous access should be allowed to a field of a graph type
+    /// requiring authorization, providing that no other fields were selected.
+    /// </summary>
+    public static TMetadataProvider AllowAnonymous<TMetadataProvider>(this TMetadataProvider provider)
+        where TMetadataProvider : IMetadataWriter
     {
-        /// <summary>
-        /// Metadata key name for storing authorization policy names. Value of this key
-        /// is a simple list of strings.
-        /// </summary>
-        public const string POLICY_KEY = "Authorization__Policies";
+        provider.Metadata[ANONYMOUS_KEY] = true;
+        return provider;
+    }
 
-        /// <summary>
-        /// Metadata key name for storing authorization role names. Value of this key
-        /// is a simple list of strings.
-        /// </summary>
-        public const string ROLE_KEY = "Authorization__Roles";
+    /// <summary>
+    /// Gets a boolean value that determines whether any authorization policy is applied to this metadata provider.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <returns><see langword="true"/> if any authorization policy is applied, otherwise <see langword="false"/>.</returns>
+    public static bool IsAuthorizationRequired(this IMetadataReader provider)
+        => provider.GetMetadata(AUTHORIZE_KEY, false) || GetPolicies(provider)?.Count > 0 || GetRoles(provider)?.Count > 0;
 
-        /// <summary>
-        /// Metadata key name for indicating that the user must be authorized (strictly speaking, authenticated) to access the resource.
-        /// Value of this key is a boolean value.
-        /// </summary>
-        public const string AUTHORIZE_KEY = "Authorization__Required";
+    /// <summary>
+    /// Adds metadata to indicate that the resource requires that the user has successfully authenticated.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    public static TMetadataProvider Authorize<TMetadataProvider>(this TMetadataProvider provider)
+        where TMetadataProvider : IMetadataWriter
+    {
+        provider.Metadata[AUTHORIZE_KEY] = true;
+        return provider;
+    }
 
-        /// <summary>
-        /// Metadata key name for typically indicating if anonymous access should be allowed to a field of a graph type
-        /// requiring authorization, providing that no other fields were selected.
-        /// </summary>
-        public const string ANONYMOUS_KEY = "Authorization__AllowAnonymous";
+    /// <summary>
+    /// Adds authorization policy to the specified metadata provider. If the provider already contains
+    /// a policy with the same name, then it will not be added twice.
+    /// </summary>
+    /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
+    /// let compiler infer the returning type to allow methods chaining.
+    /// </typeparam>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="policy">Authorization policy name.</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider AuthorizeWithPolicy<TMetadataProvider>(this TMetadataProvider provider, string policy)
+        where TMetadataProvider : IMetadataWriter
+    {
+        if (policy == null)
+            throw new ArgumentNullException(nameof(policy));
 
-        /// <summary>
-        /// Gets a list of authorization policy names for the specified metadata provider if any.
-        /// Otherwise returns <see langword="null"/>.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <returns>List of authorization policy names applied to this metadata provider.</returns>
-        public static List<string>? GetPolicies(this IMetadataReader provider) => provider.GetMetadata<List<string>>(POLICY_KEY);
+        var list = provider.MetadataReader.GetPolicies() ?? new List<string>();
 
-        /// <summary>
-        /// Gets a list of authorization roles names for the specified metadata provider if any.
-        /// Otherwise returns <see langword="null"/>.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <returns>List of authorization role names applied to this metadata provider.</returns>
-        public static List<string>? GetRoles(this IMetadataReader provider) => provider.GetMetadata<List<string>>(ROLE_KEY);
+        if (!list.Contains(policy))
+            list.Add(policy);
 
-        /// <summary>
-        /// Returns a boolean typically indicating if anonymous access should be allowed to a field of a graph type
-        /// requiring authorization, providing that no other fields were selected.
-        /// </summary>
-        public static bool IsAnonymousAllowed(this IMetadataReader provider) => provider.GetMetadata(ANONYMOUS_KEY, false);
+        provider.Metadata[POLICY_KEY] = list;
+        provider.Authorize();
+        return provider;
+    }
 
-        /// <summary>
-        /// Adds metadata to typically indicate that anonymous access should be allowed to a field of a graph type
-        /// requiring authorization, providing that no other fields were selected.
-        /// </summary>
-        public static TMetadataProvider AllowAnonymous<TMetadataProvider>(this TMetadataProvider provider)
-            where TMetadataProvider : IMetadataWriter
+    /// <summary>
+    /// Adds authorization role(s) to the specified metadata provider. Roles should
+    /// be comma-separated and role names will be trimmed. If the underlying field already
+    /// contains a role with the same name, then it will not be added twice.
+    /// </summary>
+    /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
+    /// let compiler infer the returning type to allow methods chaining.
+    /// </typeparam>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="roles">Comma-separated list of authorization role name(s).</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, string roles)
+        where TMetadataProvider : IMetadataWriter
+    {
+        if (roles == null)
+            throw new ArgumentNullException(nameof(roles));
+
+        var list = provider.MetadataReader.GetRoles() ?? new List<string>();
+
+        foreach (var role in roles.Split(','))
         {
-            provider.Metadata[ANONYMOUS_KEY] = true;
-            return provider;
+            var role2 = role.Trim();
+            if (role2 != "" && !list.Contains(role2))
+                list.Add(role2);
         }
 
-        /// <summary>
-        /// Gets a boolean value that determines whether any authorization policy is applied to this metadata provider.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <returns><see langword="true"/> if any authorization policy is applied, otherwise <see langword="false"/>.</returns>
-        public static bool IsAuthorizationRequired(this IMetadataReader provider)
-            => provider.GetMetadata(AUTHORIZE_KEY, false) || GetPolicies(provider)?.Count > 0 || GetRoles(provider)?.Count > 0;
+        provider.Metadata[ROLE_KEY] = list;
+        provider.Authorize();
+        return provider;
+    }
 
-        /// <summary>
-        /// Adds metadata to indicate that the resource requires that the user has successfully authenticated.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        public static TMetadataProvider Authorize<TMetadataProvider>(this TMetadataProvider provider)
-            where TMetadataProvider : IMetadataWriter
+    /// <summary>
+    /// Adds authorization role(s) to the specified metadata provider.  If the underlying field already
+    /// contains a role with the same name, then it will not be added twice.
+    /// </summary>
+    /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
+    /// let compiler infer the returning type to allow methods chaining.
+    /// </typeparam>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="roles">List of authorization role name(s).</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, params string[] roles)
+        where TMetadataProvider : IMetadataWriter
+    {
+        if (roles == null)
+            throw new ArgumentNullException(nameof(roles));
+
+        var list = provider.MetadataReader.GetRoles() ?? new List<string>();
+
+        foreach (var role in roles)
         {
-            provider.Metadata[AUTHORIZE_KEY] = true;
-            return provider;
+            if (role != "" && !list.Contains(role))
+                list.Add(role);
         }
 
-        /// <summary>
-        /// Adds authorization policy to the specified metadata provider. If the provider already contains
-        /// a policy with the same name, then it will not be added twice.
-        /// </summary>
-        /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
-        /// let compiler infer the returning type to allow methods chaining.
-        /// </typeparam>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="policy">Authorization policy name.</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider AuthorizeWithPolicy<TMetadataProvider>(this TMetadataProvider provider, string policy)
-            where TMetadataProvider : IMetadataWriter
-        {
-            if (policy == null)
-                throw new ArgumentNullException(nameof(policy));
-
-            var list = provider.MetadataReader.GetPolicies() ?? new List<string>();
-
-            if (!list.Contains(policy))
-                list.Add(policy);
-
-            provider.Metadata[POLICY_KEY] = list;
-            provider.Authorize();
-            return provider;
-        }
-
-        /// <summary>
-        /// Adds authorization role(s) to the specified metadata provider. Roles should
-        /// be comma-separated and role names will be trimmed. If the underlying field already
-        /// contains a role with the same name, then it will not be added twice.
-        /// </summary>
-        /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
-        /// let compiler infer the returning type to allow methods chaining.
-        /// </typeparam>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="roles">Comma-separated list of authorization role name(s).</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, string roles)
-            where TMetadataProvider : IMetadataWriter
-        {
-            if (roles == null)
-                throw new ArgumentNullException(nameof(roles));
-
-            var list = provider.MetadataReader.GetRoles() ?? new List<string>();
-
-            foreach (var role in roles.Split(','))
-            {
-                var role2 = role.Trim();
-                if (role2 != "" && !list.Contains(role2))
-                    list.Add(role2);
-            }
-
-            provider.Metadata[ROLE_KEY] = list;
-            provider.Authorize();
-            return provider;
-        }
-
-        /// <summary>
-        /// Adds authorization role(s) to the specified metadata provider.  If the underlying field already
-        /// contains a role with the same name, then it will not be added twice.
-        /// </summary>
-        /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
-        /// let compiler infer the returning type to allow methods chaining.
-        /// </typeparam>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="roles">List of authorization role name(s).</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider AuthorizeWithRoles<TMetadataProvider>(this TMetadataProvider provider, params string[] roles)
-            where TMetadataProvider : IMetadataWriter
-        {
-            if (roles == null)
-                throw new ArgumentNullException(nameof(roles));
-
-            var list = provider.MetadataReader.GetRoles() ?? new List<string>();
-
-            foreach (var role in roles)
-            {
-                if (role != "" && !list.Contains(role))
-                    list.Add(role);
-            }
-
-            provider.Metadata[ROLE_KEY] = list;
-            provider.Authorize();
-            return provider;
-        }
+        provider.Metadata[ROLE_KEY] = list;
+        provider.Authorize();
+        return provider;
     }
 }

--- a/src/GraphQL/Extensions/DirectivesExtensions.cs
+++ b/src/GraphQL/Extensions/DirectivesExtensions.cs
@@ -1,200 +1,199 @@
 using GraphQL.Introspection;
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Extension methods to configure directives applied to GraphQL elements: types, fields, arguments, etc.
+/// </summary>
+public static class DirectivesExtensions
 {
+    private const string DIRECTIVES_KEY = "__APPLIED__DIRECTIVES__";
+
     /// <summary>
-    /// Extension methods to configure directives applied to GraphQL elements: types, fields, arguments, etc.
+    /// Indicates whether provider has any applied directives.
+    /// Note that built-in @deprecated directive is not taken into account and ignored.
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
     /// </summary>
-    public static class DirectivesExtensions
+    public static bool HasAppliedDirectives(this IMetadataReader provider) => provider.GetAppliedDirectives()?.Count > 0;
+
+    /// <summary>
+    /// Provides all directives applied to this provider if any. Otherwise returns <see langword="null"/>.
+    /// Note that built-in @deprecated directive is not taken into account and ignored.
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// </summary>
+    public static AppliedDirectives? GetAppliedDirectives(this IMetadataReader provider) => provider.GetMetadata<AppliedDirectives>(DIRECTIVES_KEY);
+
+    /// <summary>
+    /// Finds applied directive by its name from the specified provider if any. Otherwise returns <see langword="null"/>.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="name">Directive name.</param>
+    public static AppliedDirective? FindAppliedDirective(this IMetadataReader provider, string name) => provider.GetAppliedDirectives()?.Find(name);
+
+    /// <summary>
+    /// Apply directive without specifying arguments. If the directive declaration has arguments,
+    /// then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="name">Directive name.</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name)
+        where TMetadataProvider : IMetadataWriter => provider.ApplyDirective(name, _ => { });
+
+    /// <summary>
+    /// Apply directive specifying one argument. If the directive declaration has other arguments,
+    /// then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="name">Directive name.</param>
+    /// <param name="argumentName">Argument name.</param>
+    /// <param name="argumentValue">Argument value.</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, string argumentName, object? argumentValue)
+        where TMetadataProvider : IMetadataWriter
+        => provider.ApplyDirective(name, directive => directive.AddArgument(new DirectiveArgument(argumentName) { Value = argumentValue }));
+
+    /// <summary>
+    /// Apply directive specifying two arguments. If the directive declaration has other arguments,
+    /// then their default values (if any) will be used.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="name">Directive name.</param>
+    /// <param name="argument1Name">First argument name.</param>
+    /// <param name="argument1Value">First argument value.</param>
+    /// <param name="argument2Name">Second argument name.</param>
+    /// <param name="argument2Value">Second argument value.</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value)
+        where TMetadataProvider : IMetadataWriter
+        => provider.ApplyDirective(name, directive => directive
+                                            .AddArgument(new DirectiveArgument(argument1Name) { Value = argument1Value })
+                                            .AddArgument(new DirectiveArgument(argument2Name) { Value = argument2Value }));
+
+    /// <summary>
+    /// Apply directive with configuration delegate.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="name">Directive name.</param>
+    /// <param name="configure">Configuration delegate.</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, Action<AppliedDirective> configure)
+        where TMetadataProvider : IMetadataWriter
     {
-        private const string DIRECTIVES_KEY = "__APPLIED__DIRECTIVES__";
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
 
-        /// <summary>
-        /// Indicates whether provider has any applied directives.
-        /// Note that built-in @deprecated directive is not taken into account and ignored.
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// </summary>
-        public static bool HasAppliedDirectives(this IMetadataReader provider) => provider.GetAppliedDirectives()?.Count > 0;
+        var directive = new AppliedDirective(name);
+        configure(directive);
 
-        /// <summary>
-        /// Provides all directives applied to this provider if any. Otherwise returns <see langword="null"/>.
-        /// Note that built-in @deprecated directive is not taken into account and ignored.
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// </summary>
-        public static AppliedDirectives? GetAppliedDirectives(this IMetadataReader provider) => provider.GetMetadata<AppliedDirectives>(DIRECTIVES_KEY);
+        var directives = provider.MetadataReader.GetAppliedDirectives() ?? new AppliedDirectives();
+        directives.Add(directive);
 
-        /// <summary>
-        /// Finds applied directive by its name from the specified provider if any. Otherwise returns <see langword="null"/>.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="name">Directive name.</param>
-        public static AppliedDirective? FindAppliedDirective(this IMetadataReader provider, string name) => provider.GetAppliedDirectives()?.Find(name);
+        provider.Metadata[DIRECTIVES_KEY] = directives;
 
-        /// <summary>
-        /// Apply directive without specifying arguments. If the directive declaration has arguments,
-        /// then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="name">Directive name.</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name)
-            where TMetadataProvider : IMetadataWriter => provider.ApplyDirective(name, _ => { });
+        return provider;
+    }
 
-        /// <summary>
-        /// Apply directive specifying one argument. If the directive declaration has other arguments,
-        /// then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="name">Directive name.</param>
-        /// <param name="argumentName">Argument name.</param>
-        /// <param name="argumentValue">Argument value.</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, string argumentName, object? argumentValue)
-            where TMetadataProvider : IMetadataWriter
-            => provider.ApplyDirective(name, directive => directive.AddArgument(new DirectiveArgument(argumentName) { Value = argumentValue }));
+    /// <summary>
+    /// Remove applied directive by its name.
+    /// </summary>
+    /// <param name="provider">
+    /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// </param>
+    /// <param name="name">Directive name.</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider RemoveAppliedDirective<TMetadataProvider>(this TMetadataProvider provider, string name)
+         where TMetadataProvider : IMetadataWriter
+    {
+        provider.MetadataReader.GetAppliedDirectives()?.Remove(name);
+        return provider;
+    }
 
-        /// <summary>
-        /// Apply directive specifying two arguments. If the directive declaration has other arguments,
-        /// then their default values (if any) will be used.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="name">Directive name.</param>
-        /// <param name="argument1Name">First argument name.</param>
-        /// <param name="argument1Value">First argument value.</param>
-        /// <param name="argument2Name">Second argument name.</param>
-        /// <param name="argument2Value">Second argument value.</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value)
-            where TMetadataProvider : IMetadataWriter
-            => provider.ApplyDirective(name, directive => directive
-                                                .AddArgument(new DirectiveArgument(argument1Name) { Value = argument1Value })
-                                                .AddArgument(new DirectiveArgument(argument2Name) { Value = argument2Value }));
+    internal static string? GetDeprecationReason(this IMetadataReader provider)
+    {
+        var deprecated = provider.FindAppliedDirective("deprecated");
 
-        /// <summary>
-        /// Apply directive with configuration delegate.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="name">Directive name.</param>
-        /// <param name="configure">Configuration delegate.</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider ApplyDirective<TMetadataProvider>(this TMetadataProvider provider, string name, Action<AppliedDirective> configure)
-            where TMetadataProvider : IMetadataWriter
+        return deprecated == null
+            ? null
+            : deprecated.FindArgument("reason")?.Value is string str
+                ? str
+                : "No longer supported";
+    }
+
+    internal static void SetDeprecationReason(this IMetadataWriter provider, string? reason)
+    {
+        if (reason == null)
         {
-            if (configure == null)
-                throw new ArgumentNullException(nameof(configure));
-
-            var directive = new AppliedDirective(name);
-            configure(directive);
-
-            var directives = provider.MetadataReader.GetAppliedDirectives() ?? new AppliedDirectives();
-            directives.Add(directive);
-
-            provider.Metadata[DIRECTIVES_KEY] = directives;
-
-            return provider;
+            provider.RemoveAppliedDirective("deprecated");
         }
-
-        /// <summary>
-        /// Remove applied directive by its name.
-        /// </summary>
-        /// <param name="provider">
-        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
-        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
-        /// </param>
-        /// <param name="name">Directive name.</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider RemoveAppliedDirective<TMetadataProvider>(this TMetadataProvider provider, string name)
-             where TMetadataProvider : IMetadataWriter
+        else
         {
-            provider.MetadataReader.GetAppliedDirectives()?.Remove(name);
-            return provider;
-        }
-
-        internal static string? GetDeprecationReason(this IMetadataReader provider)
-        {
-            var deprecated = provider.FindAppliedDirective("deprecated");
-
-            return deprecated == null
-                ? null
-                : deprecated.FindArgument("reason")?.Value is string str
-                    ? str
-                    : "No longer supported";
-        }
-
-        internal static void SetDeprecationReason(this IMetadataWriter provider, string? reason)
-        {
-            if (reason == null)
+            var deprecated = provider.MetadataReader.FindAppliedDirective("deprecated");
+            if (deprecated == null)
             {
-                provider.RemoveAppliedDirective("deprecated");
+                provider.ApplyDirective("deprecated", "reason", reason);
             }
             else
             {
-                var deprecated = provider.MetadataReader.FindAppliedDirective("deprecated");
-                if (deprecated == null)
-                {
-                    provider.ApplyDirective("deprecated", "reason", reason);
-                }
+                var arg = deprecated.FindArgument("reason");
+                if (arg != null)
+                    arg.Value = reason;
                 else
-                {
-                    var arg = deprecated.FindArgument("reason");
-                    if (arg != null)
-                        arg.Value = reason;
-                    else
-                        deprecated.AddArgument(new DirectiveArgument("reason") { Value = reason });
-                }
+                    deprecated.AddArgument(new DirectiveArgument("reason") { Value = reason });
             }
         }
+    }
 
-        internal static void AddAppliedDirectivesField<TSourceType>(this ComplexGraphType<TSourceType> type, string element)
-            where TSourceType : IMetadataReader
-        {
-            type.Field<NonNullGraphType<ListGraphType<NonNullGraphType<__AppliedDirective>>>>("appliedDirectives")
-                .Description($"Directives applied to the {element}")
-                .ResolveAsync(async context =>
+    internal static void AddAppliedDirectivesField<TSourceType>(this ComplexGraphType<TSourceType> type, string element)
+        where TSourceType : IMetadataReader
+    {
+        type.Field<NonNullGraphType<ListGraphType<NonNullGraphType<__AppliedDirective>>>>("appliedDirectives")
+            .Description($"Directives applied to the {element}")
+            .ResolveAsync(async context =>
+            {
+                if (context.Source!.HasAppliedDirectives())
                 {
-                    if (context.Source!.HasAppliedDirectives())
+                    var appliedDirectives = context.Source!.GetAppliedDirectives();
+                    var result = context.ArrayPool.Rent<AppliedDirective>(appliedDirectives!.Count);
+
+                    int index = 0;
+                    foreach (var applied in appliedDirectives.List!)
                     {
-                        var appliedDirectives = context.Source!.GetAppliedDirectives();
-                        var result = context.ArrayPool.Rent<AppliedDirective>(appliedDirectives!.Count);
-
-                        int index = 0;
-                        foreach (var applied in appliedDirectives.List!)
+                        // return only registered directives allowed by filter
+                        var schemaDirective = context.Schema.Directives.Find(applied.Name);
+                        if (schemaDirective != null && await context.Schema.Filter.AllowDirective(schemaDirective).ConfigureAwait(false))
                         {
-                            // return only registered directives allowed by filter
-                            var schemaDirective = context.Schema.Directives.Find(applied.Name);
-                            if (schemaDirective != null && await context.Schema.Filter.AllowDirective(schemaDirective).ConfigureAwait(false))
-                            {
-                                result[index++] = applied;
-                            }
+                            result[index++] = applied;
                         }
-
-                        return result.Constrained(index);
                     }
 
-                    return Array.Empty<AppliedDirective>();
-                });
-        }
+                    return result.Constrained(index);
+                }
+
+                return Array.Empty<AppliedDirective>();
+            });
     }
 }

--- a/src/GraphQL/Extensions/ExpressionExtensions.cs
+++ b/src/GraphQL/Extensions/ExpressionExtensions.cs
@@ -1,44 +1,43 @@
 using System.Linq.Expressions;
 
-namespace GraphQL
-{
-    internal static class ExpressionExtensions
-    {
-        /// <summary>
-        /// Replaces all occurrences of <paramref name="oldParameter"/> with <paramref name="newBody"/> within <paramref name="expression"/>.
-        /// </summary>
-        public static Expression Replace(this Expression expression, ParameterExpression oldParameter, Expression newBody)
-        {
-            if (expression == null)
-                throw new ArgumentNullException(nameof(expression));
-            if (oldParameter == null)
-                throw new ArgumentNullException(nameof(oldParameter));
-            if (newBody == null)
-                throw new ArgumentNullException(nameof(newBody));
-            if (expression is LambdaExpression)
-                throw new InvalidOperationException("The search & replace operation must be performed on the body of the lambda.");
-            if (oldParameter.Type != newBody.Type)
-                throw new InvalidOperationException("The old parameter and its replacement expression must be of the same type.");
+namespace GraphQL;
 
-            return new ParameterReplacerVisitor(oldParameter, newBody).Visit(expression);
+internal static class ExpressionExtensions
+{
+    /// <summary>
+    /// Replaces all occurrences of <paramref name="oldParameter"/> with <paramref name="newBody"/> within <paramref name="expression"/>.
+    /// </summary>
+    public static Expression Replace(this Expression expression, ParameterExpression oldParameter, Expression newBody)
+    {
+        if (expression == null)
+            throw new ArgumentNullException(nameof(expression));
+        if (oldParameter == null)
+            throw new ArgumentNullException(nameof(oldParameter));
+        if (newBody == null)
+            throw new ArgumentNullException(nameof(newBody));
+        if (expression is LambdaExpression)
+            throw new InvalidOperationException("The search & replace operation must be performed on the body of the lambda.");
+        if (oldParameter.Type != newBody.Type)
+            throw new InvalidOperationException("The old parameter and its replacement expression must be of the same type.");
+
+        return new ParameterReplacerVisitor(oldParameter, newBody).Visit(expression);
+    }
+
+    private class ParameterReplacerVisitor : ExpressionVisitor
+    {
+        private readonly ParameterExpression _source;
+        private readonly Expression _target;
+
+        public ParameterReplacerVisitor(ParameterExpression source, Expression target)
+        {
+            _source = source;
+            _target = target;
         }
 
-        private class ParameterReplacerVisitor : ExpressionVisitor
+        protected override Expression VisitParameter(ParameterExpression node)
         {
-            private readonly ParameterExpression _source;
-            private readonly Expression _target;
-
-            public ParameterReplacerVisitor(ParameterExpression source, Expression target)
-            {
-                _source = source;
-                _target = target;
-            }
-
-            protected override Expression VisitParameter(ParameterExpression node)
-            {
-                // Replace the source with the target, visit other params as usual.
-                return node.Equals(_source) ? _target : base.VisitParameter(node);
-            }
+            // Replace the source with the target, visit other params as usual.
+            return node.Equals(_source) ? _target : base.VisitParameter(node);
         }
     }
 }

--- a/src/GraphQL/Extensions/GraphQLExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLExtensions.cs
@@ -6,663 +6,662 @@ using GraphQL.Types;
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Provides extension methods for working with graph types.
+/// </summary>
+public static class GraphQLExtensions
 {
     /// <summary>
-    /// Provides extension methods for working with graph types.
+    /// Determines if this graph type is an introspection type.
     /// </summary>
-    public static class GraphQLExtensions
+    internal static bool IsIntrospectionType(this IGraphType type) => type?.Name?.StartsWith("__", StringComparison.InvariantCulture) ?? false;
+
+    /// <summary>
+    /// Indicates if the graph type is a union, interface or object graph type.
+    /// </summary>
+    public static bool IsCompositeType(this IGraphType type)
     {
-        /// <summary>
-        /// Determines if this graph type is an introspection type.
-        /// </summary>
-        internal static bool IsIntrospectionType(this IGraphType type) => type?.Name?.StartsWith("__", StringComparison.InvariantCulture) ?? false;
+        return type is IObjectGraphType ||
+               type is IInterfaceGraphType ||
+               type is UnionGraphType;
+    }
 
-        /// <summary>
-        /// Indicates if the graph type is a union, interface or object graph type.
-        /// </summary>
-        public static bool IsCompositeType(this IGraphType type)
+    /// <summary>
+    /// Indicates if the graph type is a scalar graph type.
+    /// </summary>
+    public static bool IsLeafType(this IGraphType type)
+    {
+        var (namedType, namedType2) = type.GetNamedTypes();
+        return namedType is ScalarGraphType ||
+               typeof(ScalarGraphType).IsAssignableFrom(namedType2);
+    }
+
+    // https://spec.graphql.org/October2021/#sec-Input-and-Output-Types
+    /// <summary>
+    /// Indicates if the type is an input graph type (scalar or input object).
+    /// </summary>
+    public static bool IsInputType(this Type type)
+    {
+        if (type.IsGenericType)
         {
-            return type is IObjectGraphType ||
-                   type is IInterfaceGraphType ||
-                   type is UnionGraphType;
-        }
-
-        /// <summary>
-        /// Indicates if the graph type is a scalar graph type.
-        /// </summary>
-        public static bool IsLeafType(this IGraphType type)
-        {
-            var (namedType, namedType2) = type.GetNamedTypes();
-            return namedType is ScalarGraphType ||
-                   typeof(ScalarGraphType).IsAssignableFrom(namedType2);
-        }
-
-        // https://spec.graphql.org/October2021/#sec-Input-and-Output-Types
-        /// <summary>
-        /// Indicates if the type is an input graph type (scalar or input object).
-        /// </summary>
-        public static bool IsInputType(this Type type)
-        {
-            if (type.IsGenericType)
-            {
-                var genericDef = type.GetGenericTypeDefinition();
-
-                if (genericDef == typeof(GraphQLClrInputTypeReference<>))
-                    return true;
-
-                if (genericDef == typeof(GraphQLClrOutputTypeReference<>))
-                    return false;
-
-                if (genericDef == typeof(NonNullGraphType<>) || genericDef == typeof(ListGraphType<>))
-                    return type.GenericTypeArguments[0].IsInputType();
-            }
-
-            return typeof(ScalarGraphType).IsAssignableFrom(type) ||
-                   typeof(IInputObjectGraphType).IsAssignableFrom(type);
-        }
-
-        // https://spec.graphql.org/October2021/#sec-Input-and-Output-Types
-        /// <summary>
-        /// Indicates if the graph type is an input graph type (scalar or input object).
-        /// </summary>
-        public static bool IsInputType(this IGraphType type)
-        {
-            var (namedType, namedType2) = type.GetNamedTypes();
-            return namedType is ScalarGraphType ||
-                   namedType is IInputObjectGraphType ||
-                   typeof(ScalarGraphType).IsAssignableFrom(namedType2) ||
-                   typeof(IInputObjectGraphType).IsAssignableFrom(namedType2);
-        }
-
-        // https://spec.graphql.org/October2021/#sec-Input-and-Output-Types
-        /// <summary>
-        /// Indicates if the type is an output graph type (scalar, object, interface or union).
-        /// </summary>
-        public static bool IsOutputType(this Type type)
-        {
-            if (type.IsGenericType)
-            {
-                var genericDef = type.GetGenericTypeDefinition();
-
-                if (genericDef == typeof(GraphQLClrInputTypeReference<>))
-                    return false;
-
-                if (genericDef == typeof(GraphQLClrOutputTypeReference<>))
-                    return true;
-
-                if (genericDef == typeof(NonNullGraphType<>) || genericDef == typeof(ListGraphType<>))
-                    return type.GenericTypeArguments[0].IsOutputType();
-            }
-
-            return typeof(ScalarGraphType).IsAssignableFrom(type) ||
-                   typeof(IObjectGraphType).IsAssignableFrom(type) ||
-                   typeof(IInterfaceGraphType).IsAssignableFrom(type) ||
-                   typeof(UnionGraphType).IsAssignableFrom(type);
-        }
-
-        // https://spec.graphql.org/October2021/#sec-Input-and-Output-Types
-        /// <summary>
-        /// Indicates if the graph type is an output graph type (scalar, object, interface or union).
-        /// </summary>
-        public static bool IsOutputType(this IGraphType type)
-        {
-            var (namedType, namedType2) = type.GetNamedTypes();
-            return namedType is ScalarGraphType ||
-                   namedType is IObjectGraphType ||
-                   namedType is IInterfaceGraphType ||
-                   namedType is UnionGraphType ||
-                   typeof(ScalarGraphType).IsAssignableFrom(namedType2) ||
-                   typeof(IObjectGraphType).IsAssignableFrom(namedType2) ||
-                   typeof(IInterfaceGraphType).IsAssignableFrom(namedType2) ||
-                   typeof(UnionGraphType).IsAssignableFrom(namedType2);
-        }
-
-        /// <summary>
-        /// Indicates if the graph type is an input object graph type.
-        /// </summary>
-        public static bool IsInputObjectType(this IGraphType type)
-        {
-            var (namedType, namedType2) = type.GetNamedTypes();
-            return namedType is IInputObjectGraphType ||
-                   typeof(IInputObjectGraphType).IsAssignableFrom(namedType2);
-        }
-
-        internal static bool IsGraphQLTypeReference(this IGraphType? type)
-        {
-            var (namedType, _) = type.GetNamedTypes();
-            return namedType is GraphQLTypeReference;
-        }
-
-        internal static (IGraphType? resolvedType, Type? type) GetNamedTypes(this IGraphType? type)
-        {
-            return type switch
-            {
-                NonNullGraphType nonNull => nonNull.ResolvedType != null ? GetNamedTypes(nonNull.ResolvedType) : (null, GetNamedType(nonNull.Type!)),
-                ListGraphType list => list.ResolvedType != null ? GetNamedTypes(list.ResolvedType) : (null, GetNamedType(list.Type!)),
-                _ => (type, null)
-            };
-        }
-
-        /// <summary>
-        /// Unwraps any list/non-null graph type wrappers from a graph type and returns the base graph type.
-        /// </summary>
-        public static IGraphType GetNamedType(this IGraphType type)
-        {
-            if (type == null)
-                return null!;
-
-            var (namedType, _) = type.GetNamedTypes();
-            return namedType ?? throw new NotSupportedException("Please set ResolvedType property before calling this method or call GetNamedType(this Type type) instead");
-        }
-
-        /// <summary>
-        /// Unwraps any list/non-null graph type wrappers from a graph type and returns the base graph type.
-        /// </summary>
-        public static Type GetNamedType(this Type type)
-        {
-            if (!type.IsGenericType)
-                return type;
-
             var genericDef = type.GetGenericTypeDefinition();
-            return genericDef == typeof(NonNullGraphType<>) || genericDef == typeof(ListGraphType<>)
-                ? GetNamedType(type.GenericTypeArguments[0])
-                : type;
+
+            if (genericDef == typeof(GraphQLClrInputTypeReference<>))
+                return true;
+
+            if (genericDef == typeof(GraphQLClrOutputTypeReference<>))
+                return false;
+
+            if (genericDef == typeof(NonNullGraphType<>) || genericDef == typeof(ListGraphType<>))
+                return type.GenericTypeArguments[0].IsInputType();
         }
 
-        /// <summary>
-        /// An Interface defines a list of fields; Object types that implement that interface are guaranteed to implement those fields.
-        /// Whenever the type system claims it will return an interface, it will return a valid implementing type.
-        /// </summary>
-        /// <param name="iface">The interface graph type.</param>
-        /// <param name="type">The object graph type to verify it against.</param>
-        /// <param name="throwError">Set to <see langword="true"/> to generate an error if the type does not match the interface.</param>
-        public static bool IsValidInterfaceFor(this IInterfaceGraphType iface, IObjectGraphType type, bool throwError = true)
+        return typeof(ScalarGraphType).IsAssignableFrom(type) ||
+               typeof(IInputObjectGraphType).IsAssignableFrom(type);
+    }
+
+    // https://spec.graphql.org/October2021/#sec-Input-and-Output-Types
+    /// <summary>
+    /// Indicates if the graph type is an input graph type (scalar or input object).
+    /// </summary>
+    public static bool IsInputType(this IGraphType type)
+    {
+        var (namedType, namedType2) = type.GetNamedTypes();
+        return namedType is ScalarGraphType ||
+               namedType is IInputObjectGraphType ||
+               typeof(ScalarGraphType).IsAssignableFrom(namedType2) ||
+               typeof(IInputObjectGraphType).IsAssignableFrom(namedType2);
+    }
+
+    // https://spec.graphql.org/October2021/#sec-Input-and-Output-Types
+    /// <summary>
+    /// Indicates if the type is an output graph type (scalar, object, interface or union).
+    /// </summary>
+    public static bool IsOutputType(this Type type)
+    {
+        if (type.IsGenericType)
         {
-            foreach (var field in iface.Fields)
+            var genericDef = type.GetGenericTypeDefinition();
+
+            if (genericDef == typeof(GraphQLClrInputTypeReference<>))
+                return false;
+
+            if (genericDef == typeof(GraphQLClrOutputTypeReference<>))
+                return true;
+
+            if (genericDef == typeof(NonNullGraphType<>) || genericDef == typeof(ListGraphType<>))
+                return type.GenericTypeArguments[0].IsOutputType();
+        }
+
+        return typeof(ScalarGraphType).IsAssignableFrom(type) ||
+               typeof(IObjectGraphType).IsAssignableFrom(type) ||
+               typeof(IInterfaceGraphType).IsAssignableFrom(type) ||
+               typeof(UnionGraphType).IsAssignableFrom(type);
+    }
+
+    // https://spec.graphql.org/October2021/#sec-Input-and-Output-Types
+    /// <summary>
+    /// Indicates if the graph type is an output graph type (scalar, object, interface or union).
+    /// </summary>
+    public static bool IsOutputType(this IGraphType type)
+    {
+        var (namedType, namedType2) = type.GetNamedTypes();
+        return namedType is ScalarGraphType ||
+               namedType is IObjectGraphType ||
+               namedType is IInterfaceGraphType ||
+               namedType is UnionGraphType ||
+               typeof(ScalarGraphType).IsAssignableFrom(namedType2) ||
+               typeof(IObjectGraphType).IsAssignableFrom(namedType2) ||
+               typeof(IInterfaceGraphType).IsAssignableFrom(namedType2) ||
+               typeof(UnionGraphType).IsAssignableFrom(namedType2);
+    }
+
+    /// <summary>
+    /// Indicates if the graph type is an input object graph type.
+    /// </summary>
+    public static bool IsInputObjectType(this IGraphType type)
+    {
+        var (namedType, namedType2) = type.GetNamedTypes();
+        return namedType is IInputObjectGraphType ||
+               typeof(IInputObjectGraphType).IsAssignableFrom(namedType2);
+    }
+
+    internal static bool IsGraphQLTypeReference(this IGraphType? type)
+    {
+        var (namedType, _) = type.GetNamedTypes();
+        return namedType is GraphQLTypeReference;
+    }
+
+    internal static (IGraphType? resolvedType, Type? type) GetNamedTypes(this IGraphType? type)
+    {
+        return type switch
+        {
+            NonNullGraphType nonNull => nonNull.ResolvedType != null ? GetNamedTypes(nonNull.ResolvedType) : (null, GetNamedType(nonNull.Type!)),
+            ListGraphType list => list.ResolvedType != null ? GetNamedTypes(list.ResolvedType) : (null, GetNamedType(list.Type!)),
+            _ => (type, null)
+        };
+    }
+
+    /// <summary>
+    /// Unwraps any list/non-null graph type wrappers from a graph type and returns the base graph type.
+    /// </summary>
+    public static IGraphType GetNamedType(this IGraphType type)
+    {
+        if (type == null)
+            return null!;
+
+        var (namedType, _) = type.GetNamedTypes();
+        return namedType ?? throw new NotSupportedException("Please set ResolvedType property before calling this method or call GetNamedType(this Type type) instead");
+    }
+
+    /// <summary>
+    /// Unwraps any list/non-null graph type wrappers from a graph type and returns the base graph type.
+    /// </summary>
+    public static Type GetNamedType(this Type type)
+    {
+        if (!type.IsGenericType)
+            return type;
+
+        var genericDef = type.GetGenericTypeDefinition();
+        return genericDef == typeof(NonNullGraphType<>) || genericDef == typeof(ListGraphType<>)
+            ? GetNamedType(type.GenericTypeArguments[0])
+            : type;
+    }
+
+    /// <summary>
+    /// An Interface defines a list of fields; Object types that implement that interface are guaranteed to implement those fields.
+    /// Whenever the type system claims it will return an interface, it will return a valid implementing type.
+    /// </summary>
+    /// <param name="iface">The interface graph type.</param>
+    /// <param name="type">The object graph type to verify it against.</param>
+    /// <param name="throwError">Set to <see langword="true"/> to generate an error if the type does not match the interface.</param>
+    public static bool IsValidInterfaceFor(this IInterfaceGraphType iface, IObjectGraphType type, bool throwError = true)
+    {
+        foreach (var field in iface.Fields)
+        {
+            var found = type.GetField(field.Name);
+
+            if (found == null)
             {
-                var found = type.GetField(field.Name);
-
-                if (found == null)
-                {
-                    return throwError ? throw new ArgumentException($"Type {type.GetType().GetFriendlyName()} with name '{type.Name}' does not implement interface {iface.GetType().GetFriendlyName()} with name '{iface.Name}'. It has no field '{field.Name}'.") : false;
-                }
-
-                if (found.ResolvedType != null && field.ResolvedType != null && found.ResolvedType is not GraphQLTypeReference && field.ResolvedType is not GraphQLTypeReference)
-                {
-                    if (!IsSubtypeOf(found.ResolvedType, field.ResolvedType))
-                        return throwError ? throw new ArgumentException($"Type {type.GetType().GetFriendlyName()} with name '{type.Name}' does not implement interface {iface.GetType().GetFriendlyName()} with name '{iface.Name}'. Field '{field.Name}' must be of type '{field.ResolvedType}' or covariant from it, but in fact it is of type '{found.ResolvedType}'.") : false;
-                }
+                return throwError ? throw new ArgumentException($"Type {type.GetType().GetFriendlyName()} with name '{type.Name}' does not implement interface {iface.GetType().GetFriendlyName()} with name '{iface.Name}'. It has no field '{field.Name}'.") : false;
             }
 
+            if (found.ResolvedType != null && field.ResolvedType != null && found.ResolvedType is not GraphQLTypeReference && field.ResolvedType is not GraphQLTypeReference)
+            {
+                if (!IsSubtypeOf(found.ResolvedType, field.ResolvedType))
+                    return throwError ? throw new ArgumentException($"Type {type.GetType().GetFriendlyName()} with name '{type.Name}' does not implement interface {iface.GetType().GetFriendlyName()} with name '{iface.Name}'. Field '{field.Name}' must be of type '{field.ResolvedType}' or covariant from it, but in fact it is of type '{found.ResolvedType}'.") : false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Examines a simple lambda expression and returns the name of the member it references.
+    /// For instance, returns <c>Widget</c> given an expression of <c>x => x.Widget</c>.
+    /// Unable to parse any expressions that are more complex than a simple member access.
+    /// Throws an <see cref="InvalidCastException"/> if the expression is not a simple member access.
+    /// </summary>
+    public static string NameOf<TSourceType, TProperty>(this Expression<Func<TSourceType, TProperty>> expression)
+    {
+        var member = (MemberExpression)expression.Body;
+        return member.Member.Name;
+    }
+
+    /// <summary>
+    /// Examines a simple lambda expression and returns the description of the member it
+    /// references as listed by a <see cref="DescriptionAttribute"/>.
+    /// Unable to parse any expressions that are more complex than a simple member access.
+    /// Returns <see langword="null"/> if the expression is not a simple member access.
+    /// </summary>
+    public static string? DescriptionOf<TSourceType, TProperty>(this Expression<Func<TSourceType, TProperty>> expression)
+    {
+        return expression.Body is MemberExpression expr
+            ? expr.Member.Description()
+            : null;
+    }
+
+    /// <summary>
+    /// Examines a simple lambda expression and returns the deprecation reason of the member it
+    /// references as listed by a <see cref="ObsoleteAttribute"/>.
+    /// Unable to parse any expressions that are more complex than a simple member access.
+    /// Returns <see langword="null"/> if the expression is not a simple member access.
+    /// </summary>
+    public static string? DeprecationReasonOf<TSourceType, TProperty>(this Expression<Func<TSourceType, TProperty>> expression)
+    {
+        return expression.Body is MemberExpression expr
+            ? expr.Member.ObsoleteMessage()
+            : null;
+    }
+
+    /// <summary>
+    /// Examines a simple lambda expression and returns the default value of the member it
+    /// references as listed by a <see cref="DefaultValueAttribute"/>.
+    /// Unable to parse any expressions that are more complex than a simple member access.
+    /// Returns <see langword="null"/> if the expression is not a simple member access.
+    /// </summary>
+    public static object? DefaultValueOf<TSourceType, TProperty>(this Expression<Func<TSourceType, TProperty>> expression)
+    {
+        return expression.Body is MemberExpression expr
+            ? expr.Member.DefaultValue()
+            : null;
+    }
+
+    /// <summary>
+    /// Adds a key-value metadata pair to the specified provider.
+    /// </summary>
+    /// <typeparam name="TMetadataProvider">The type of metadata provider. Generics are used here to let compiler infer the returning type to allow methods chaining.</typeparam>
+    /// <param name="provider">Metadata provider which must implement <see cref="IMetadataWriter"/> interface.</param>
+    /// <param name="key">String key.</param>
+    /// <param name="value">Arbitrary value.</param>
+    /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
+    public static TMetadataProvider WithMetadata<TMetadataProvider>(this TMetadataProvider provider, string key, object? value)
+        where TMetadataProvider : IMetadataWriter
+    {
+        provider.Metadata[key] = value;
+        return provider;
+    }
+
+    /// <summary>
+    /// Provided a type and a super type, return <see langword="true"/> if the first type is either
+    /// equal or a subset of the second super type (covariant).
+    /// </summary>
+    public static bool IsSubtypeOf(this IGraphType maybeSubType, IGraphType superType)
+        => IsSubtypeOf(maybeSubType, superType, false);
+
+    /// <summary>
+    /// Provided a type and a super type, return <see langword="true"/> if the first type is either
+    /// equal or a subset of the second super type (covariant).
+    /// When <paramref name="allowScalarsForLists"/> is <see langword="true"/>, it will allow
+    /// scalar types to match list types, as long as the inner types match, pursuant to the
+    /// GraphQL June 2018 Specification, section 3.11 "List: Input Coercion".
+    /// </summary>
+    // TODO: roll this into IsSubtypeOf and remove the allowScalarsForLists parameter
+    public static bool IsSubtypeOf(this IGraphType maybeSubType, IGraphType superType, bool allowScalarsForLists)
+    {
+        //maybeSubType = variableType
+        //superType = locationType
+
+        // >> - Return {true} if {variableType} and {locationType} are identical, otherwise {false}.
+        if (maybeSubType.Equals(superType))
+        {
             return true;
         }
 
-        /// <summary>
-        /// Examines a simple lambda expression and returns the name of the member it references.
-        /// For instance, returns <c>Widget</c> given an expression of <c>x => x.Widget</c>.
-        /// Unable to parse any expressions that are more complex than a simple member access.
-        /// Throws an <see cref="InvalidCastException"/> if the expression is not a simple member access.
-        /// </summary>
-        public static string NameOf<TSourceType, TProperty>(this Expression<Func<TSourceType, TProperty>> expression)
+        // >> If {locationType} is a non-null type
+        // If superType is non-null, maybeSubType must also be nullable.
+        if (superType is NonNullGraphType sup1)
         {
-            var member = (MemberExpression)expression.Body;
-            return member.Member.Name;
+            // >> - If {variableType} is NOT a non-null type, return {false}.
+            if (maybeSubType is not NonNullGraphType sub)
+                return false;
+
+            // >> - Let {nullableLocationType} be the unwrapped nullable type of {locationType}.
+            // >> - Let {nullableVariableType} be the unwrapped nullable type of {variableType}.
+            // >> - Return {AreTypesCompatible(nullableVariableType, nullableLocationType)}.
+            return IsSubtypeOf(sub.ResolvedType!, sup1.ResolvedType!, allowScalarsForLists);
+        }
+        // >> - Otherwise, if {variableType} is a non-null type:
+        else if (maybeSubType is NonNullGraphType sub)
+        {
+            // >> - Let {nullableVariableType} be the nullable type of {variableType}.
+            // >> - Return {AreTypesCompatible(nullableVariableType, locationType)}.
+            return IsSubtypeOf(sub.ResolvedType!, superType, allowScalarsForLists);
         }
 
-        /// <summary>
-        /// Examines a simple lambda expression and returns the description of the member it
-        /// references as listed by a <see cref="DescriptionAttribute"/>.
-        /// Unable to parse any expressions that are more complex than a simple member access.
-        /// Returns <see langword="null"/> if the expression is not a simple member access.
-        /// </summary>
-        public static string? DescriptionOf<TSourceType, TProperty>(this Expression<Func<TSourceType, TProperty>> expression)
+        // If superType type is a list, maybeSubType type must also be a list, unless allowScalarsForLists is true.
+        // >> Otherwise, if {locationType} is a list type:
+        if (superType is ListGraphType sup)
         {
-            return expression.Body is MemberExpression expr
-                ? expr.Member.Description()
-                : null;
-        }
+            // >> Let {itemLocationType} be the unwrapped item type of {locationType}.
+            //var itemLocationType = sup.ResolvedType!;
 
-        /// <summary>
-        /// Examines a simple lambda expression and returns the deprecation reason of the member it
-        /// references as listed by a <see cref="ObsoleteAttribute"/>.
-        /// Unable to parse any expressions that are more complex than a simple member access.
-        /// Returns <see langword="null"/> if the expression is not a simple member access.
-        /// </summary>
-        public static string? DeprecationReasonOf<TSourceType, TProperty>(this Expression<Func<TSourceType, TProperty>> expression)
-        {
-            return expression.Body is MemberExpression expr
-                ? expr.Member.ObsoleteMessage()
-                : null;
-        }
-
-        /// <summary>
-        /// Examines a simple lambda expression and returns the default value of the member it
-        /// references as listed by a <see cref="DefaultValueAttribute"/>.
-        /// Unable to parse any expressions that are more complex than a simple member access.
-        /// Returns <see langword="null"/> if the expression is not a simple member access.
-        /// </summary>
-        public static object? DefaultValueOf<TSourceType, TProperty>(this Expression<Func<TSourceType, TProperty>> expression)
-        {
-            return expression.Body is MemberExpression expr
-                ? expr.Member.DefaultValue()
-                : null;
-        }
-
-        /// <summary>
-        /// Adds a key-value metadata pair to the specified provider.
-        /// </summary>
-        /// <typeparam name="TMetadataProvider">The type of metadata provider. Generics are used here to let compiler infer the returning type to allow methods chaining.</typeparam>
-        /// <param name="provider">Metadata provider which must implement <see cref="IMetadataWriter"/> interface.</param>
-        /// <param name="key">String key.</param>
-        /// <param name="value">Arbitrary value.</param>
-        /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
-        public static TMetadataProvider WithMetadata<TMetadataProvider>(this TMetadataProvider provider, string key, object? value)
-            where TMetadataProvider : IMetadataWriter
-        {
-            provider.Metadata[key] = value;
-            return provider;
-        }
-
-        /// <summary>
-        /// Provided a type and a super type, return <see langword="true"/> if the first type is either
-        /// equal or a subset of the second super type (covariant).
-        /// </summary>
-        public static bool IsSubtypeOf(this IGraphType maybeSubType, IGraphType superType)
-            => IsSubtypeOf(maybeSubType, superType, false);
-
-        /// <summary>
-        /// Provided a type and a super type, return <see langword="true"/> if the first type is either
-        /// equal or a subset of the second super type (covariant).
-        /// When <paramref name="allowScalarsForLists"/> is <see langword="true"/>, it will allow
-        /// scalar types to match list types, as long as the inner types match, pursuant to the
-        /// GraphQL June 2018 Specification, section 3.11 "List: Input Coercion".
-        /// </summary>
-        // TODO: roll this into IsSubtypeOf and remove the allowScalarsForLists parameter
-        public static bool IsSubtypeOf(this IGraphType maybeSubType, IGraphType superType, bool allowScalarsForLists)
-        {
-            //maybeSubType = variableType
-            //superType = locationType
-
-            // >> - Return {true} if {variableType} and {locationType} are identical, otherwise {false}.
-            if (maybeSubType.Equals(superType))
+            // >> If {variableType} is NOT a list type:
+            if (maybeSubType is not ListGraphType sub)
             {
-                return true;
-            }
-
-            // >> If {locationType} is a non-null type
-            // If superType is non-null, maybeSubType must also be nullable.
-            if (superType is NonNullGraphType sup1)
-            {
-                // >> - If {variableType} is NOT a non-null type, return {false}.
-                if (maybeSubType is not NonNullGraphType sub)
-                    return false;
-
-                // >> - Let {nullableLocationType} be the unwrapped nullable type of {locationType}.
-                // >> - Let {nullableVariableType} be the unwrapped nullable type of {variableType}.
-                // >> - Return {AreTypesCompatible(nullableVariableType, nullableLocationType)}.
-                return IsSubtypeOf(sub.ResolvedType!, sup1.ResolvedType!, allowScalarsForLists);
-            }
-            // >> - Otherwise, if {variableType} is a non-null type:
-            else if (maybeSubType is NonNullGraphType sub)
-            {
-                // >> - Let {nullableVariableType} be the nullable type of {variableType}.
-                // >> - Return {AreTypesCompatible(nullableVariableType, locationType)}.
-                return IsSubtypeOf(sub.ResolvedType!, superType, allowScalarsForLists);
-            }
-
-            // If superType type is a list, maybeSubType type must also be a list, unless allowScalarsForLists is true.
-            // >> Otherwise, if {locationType} is a list type:
-            if (superType is ListGraphType sup)
-            {
-                // >> Let {itemLocationType} be the unwrapped item type of {locationType}.
-                //var itemLocationType = sup.ResolvedType!;
-
-                // >> If {variableType} is NOT a list type:
-                if (maybeSubType is not ListGraphType sub)
+                if (allowScalarsForLists)
                 {
-                    if (allowScalarsForLists)
+                    // >> - If {itemLocationType} is a non-null type:
+                    if (sup.ResolvedType is NonNullGraphType sup2)
                     {
-                        // >> - If {itemLocationType} is a non-null type:
-                        if (sup.ResolvedType is NonNullGraphType sup2)
-                        {
-                            // >>   - Let {nullableItemLocationType} be the unwrapped nullable type of {itemLocationType}.
-                            // >>   - Return {AreTypesCompatible(variableType, nullableItemLocationType)}.
-                            return IsSubtypeOf(maybeSubType, sup2);
-                        }
-                        else
-                        {
-                            // >> - Otherwise, return {AreTypesCompatible(variableType, itemLocationType)}.
-                            return IsSubtypeOf(maybeSubType, sup.ResolvedType!, allowScalarsForLists);
-                        }
+                        // >>   - Let {nullableItemLocationType} be the unwrapped nullable type of {itemLocationType}.
+                        // >>   - Return {AreTypesCompatible(variableType, nullableItemLocationType)}.
+                        return IsSubtypeOf(maybeSubType, sup2);
                     }
                     else
                     {
-                        return false;
+                        // >> - Otherwise, return {AreTypesCompatible(variableType, itemLocationType)}.
+                        return IsSubtypeOf(maybeSubType, sup.ResolvedType!, allowScalarsForLists);
                     }
                 }
                 else
                 {
-                    // >> - Let {itemVariableType} be the unwrapped item type of {variableType}.
-                    // >> - Return {AreTypesCompatible(itemVariableType, itemLocationType)}.
-                    return IsSubtypeOf(sub.ResolvedType!, sup.ResolvedType!, allowScalarsForLists);
+                    return false;
                 }
             }
-            // >> - Otherwise, if {variableType} is a list type, return {false}.
-            else if (maybeSubType is ListGraphType)
+            else
             {
-                // If superType is not a list, maybeSubType must also be not a list.
+                // >> - Let {itemVariableType} be the unwrapped item type of {variableType}.
+                // >> - Return {AreTypesCompatible(itemVariableType, itemLocationType)}.
+                return IsSubtypeOf(sub.ResolvedType!, sup.ResolvedType!, allowScalarsForLists);
+            }
+        }
+        // >> - Otherwise, if {variableType} is a list type, return {false}.
+        else if (maybeSubType is ListGraphType)
+        {
+            // If superType is not a list, maybeSubType must also be not a list.
+            return false;
+        }
+
+        // >> - Return {true} if {variableType} and {locationType} are identical, otherwise {false}.
+        // If superType type is an abstract type, maybeSubType type may be a currently
+        // possible object type.
+        if (superType is IAbstractGraphType type && maybeSubType is IObjectGraphType)
+        {
+            return type.IsPossibleType(maybeSubType);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Provided two composite types, determine if they "overlap". Two composite
+    /// types overlap when the Sets of possible concrete types for each intersect.
+    ///
+    /// This is often used to determine if a fragment of a given type could possibly
+    /// be visited in a context of another type.
+    ///
+    /// This function is commutative.
+    /// </summary>
+    public static bool DoTypesOverlap(IGraphType typeA, IGraphType typeB)
+    {
+        if (typeA.Equals(typeB))
+        {
+            return true;
+        }
+
+        var b = typeB as IAbstractGraphType;
+
+        if (typeA is IAbstractGraphType a)
+        {
+            if (b != null)
+            {
+                // DO NOT USE LINQ ON HOT PATH
+                foreach (var type in a.PossibleTypes.List)
+                {
+                    if (b.IsPossibleType(type))
+                        return true;
+                }
+
                 return false;
             }
 
-            // >> - Return {true} if {variableType} and {locationType} are identical, otherwise {false}.
-            // If superType type is an abstract type, maybeSubType type may be a currently
-            // possible object type.
-            if (superType is IAbstractGraphType type && maybeSubType is IObjectGraphType)
-            {
-                return type.IsPossibleType(maybeSubType);
-            }
-
-            return false;
+            return a.IsPossibleType(typeB);
         }
 
-        /// <summary>
-        /// Provided two composite types, determine if they "overlap". Two composite
-        /// types overlap when the Sets of possible concrete types for each intersect.
-        ///
-        /// This is often used to determine if a fragment of a given type could possibly
-        /// be visited in a context of another type.
-        ///
-        /// This function is commutative.
-        /// </summary>
-        public static bool DoTypesOverlap(IGraphType typeA, IGraphType typeB)
+        if (b != null)
         {
-            if (typeA.Equals(typeB))
+            return b.IsPossibleType(typeA);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns a value indicating whether the provided value is a valid default value
+    /// for the specified input graph type.
+    /// </summary>
+    public static bool IsValidDefault(this IGraphType type, object? value)
+    {
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (type is NonNullGraphType nonNullGraphType)
+        {
+            return value != null && nonNullGraphType.ResolvedType!.IsValidDefault(value);
+        }
+
+        if (value == null)
+        {
+            return true;
+        }
+
+        // Convert IEnumerable to GraphQL list. If the GraphQLType is a list, but
+        // the value is not an IEnumerable, convert the value using the list's item type.
+        if (type is ListGraphType listType)
+        {
+            var itemType = listType.ResolvedType!;
+
+            if (value is not string && value is IEnumerable list)
             {
+                foreach (var item in list)
+                {
+                    if (!IsValidDefault(itemType, item))
+                        return false;
+                }
                 return true;
             }
-
-            var b = typeB as IAbstractGraphType;
-
-            if (typeA is IAbstractGraphType a)
+            else
             {
-                if (b != null)
-                {
-                    // DO NOT USE LINQ ON HOT PATH
-                    foreach (var type in a.PossibleTypes.List)
-                    {
-                        if (b.IsPossibleType(type))
-                            return true;
-                    }
-
-                    return false;
-                }
-
-                return a.IsPossibleType(typeB);
+                return IsValidDefault(itemType, value);
             }
-
-            if (b != null)
-            {
-                return b.IsPossibleType(typeA);
-            }
-
-            return false;
         }
 
-        /// <summary>
-        /// Returns a value indicating whether the provided value is a valid default value
-        /// for the specified input graph type.
-        /// </summary>
-        public static bool IsValidDefault(this IGraphType type, object? value)
+        if (type is IInputObjectGraphType inputObjectGraphType)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            if (type is NonNullGraphType nonNullGraphType)
-            {
-                return value != null && nonNullGraphType.ResolvedType!.IsValidDefault(value);
-            }
-
-            if (value == null)
-            {
-                return true;
-            }
-
-            // Convert IEnumerable to GraphQL list. If the GraphQLType is a list, but
-            // the value is not an IEnumerable, convert the value using the list's item type.
-            if (type is ListGraphType listType)
-            {
-                var itemType = listType.ResolvedType!;
-
-                if (value is not string && value is IEnumerable list)
-                {
-                    foreach (var item in list)
-                    {
-                        if (!IsValidDefault(itemType, item))
-                            return false;
-                    }
-                    return true;
-                }
-                else
-                {
-                    return IsValidDefault(itemType, value);
-                }
-            }
-
-            if (type is IInputObjectGraphType inputObjectGraphType)
-            {
-                return inputObjectGraphType.IsValidDefault(value);
-            }
-
-            if (type is ScalarGraphType scalar)
-                return scalar.IsValidDefault(value);
-
-            throw new ArgumentOutOfRangeException(nameof(type), $"Must provide Input Type, cannot use {type.GetType().Name} '{type}'");
+            return inputObjectGraphType.IsValidDefault(value);
         }
 
-        /// <summary>
-        /// Attempts to serialize a value into an AST representation for a specified graph type.
-        /// May throw exceptions during the serialization process.
-        /// </summary>
-        public static GraphQLValue ToAST(this IGraphType type, object? value)
+        if (type is ScalarGraphType scalar)
+            return scalar.IsValidDefault(value);
+
+        throw new ArgumentOutOfRangeException(nameof(type), $"Must provide Input Type, cannot use {type.GetType().Name} '{type}'");
+    }
+
+    /// <summary>
+    /// Attempts to serialize a value into an AST representation for a specified graph type.
+    /// May throw exceptions during the serialization process.
+    /// </summary>
+    public static GraphQLValue ToAST(this IGraphType type, object? value)
+    {
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (type is NonNullGraphType nonnull)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
+            var astValue = ToAST(nonnull.ResolvedType!, value);
 
-            if (type is NonNullGraphType nonnull)
-            {
-                var astValue = ToAST(nonnull.ResolvedType!, value);
+            if (astValue is GraphQLNullValue)
+                throw new InvalidOperationException($"Unable to get an AST representation of {(value == null ? "null" : $"'{value}'")} value for type '{nonnull}'.");
 
-                if (astValue is GraphQLNullValue)
-                    throw new InvalidOperationException($"Unable to get an AST representation of {(value == null ? "null" : $"'{value}'")} value for type '{nonnull}'.");
-
-                return astValue;
-            }
-
-            if (type is ScalarGraphType scalar)
-            {
-                return scalar.ToAST(value) ?? scalar.ThrowASTConversionError(value);
-            }
-
-            if (value == null)
-            {
-                return GraphQLValuesCache.Null;
-            }
-
-            // Convert IEnumerable to GraphQL list. If the GraphQLType is a list, but
-            // the value is not an IEnumerable, convert the value using the list's item type.
-            if (type is ListGraphType listType)
-            {
-                var itemType = listType.ResolvedType!;
-
-                if (value is not string && value is IEnumerable list)
-                {
-                    var values = list
-                        .Cast<object>()
-                        .Select(item => ToAST(itemType, item))
-                        .ToList();
-
-                    return new GraphQLListValue { Values = values };
-                }
-
-                return ToAST(itemType, value);
-            }
-
-            // Populate the fields of the input object by creating ASTs from each value
-            // in the dictionary according to the fields in the input type.
-            if (type is IInputObjectGraphType input)
-            {
-                return input.ToAST(value) ?? throw new InvalidOperationException($"Unable to get an AST representation of the input object type '{input.Name}' for '{value}'.");
-            }
-
-            throw new ArgumentOutOfRangeException(nameof(type), $"Must provide Input Type, cannot use {type.GetType().Name} '{type}'");
+            return astValue;
         }
 
-        internal static string? MergeComments(this ASTNode node)
+        if (type is ScalarGraphType scalar)
         {
-            string? merged = null;
-            if (node.Comments?.Count > 0)
+            return scalar.ToAST(value) ?? scalar.ThrowASTConversionError(value);
+        }
+
+        if (value == null)
+        {
+            return GraphQLValuesCache.Null;
+        }
+
+        // Convert IEnumerable to GraphQL list. If the GraphQLType is a list, but
+        // the value is not an IEnumerable, convert the value using the list's item type.
+        if (type is ListGraphType listType)
+        {
+            var itemType = listType.ResolvedType!;
+
+            if (value is not string && value is IEnumerable list)
             {
-                //TODO: rewrite this when migrating from comments to descriptions
-                for (int i = 0; i < node.Comments!.Count; ++i)
-                {
-                    merged += node.Comments[i].Value;
-                    if (i < node.Comments.Count - 1)
-                        merged += Environment.NewLine;
-                }
+                var values = list
+                    .Cast<object>()
+                    .Select(item => ToAST(itemType, item))
+                    .ToList();
+
+                return new GraphQLListValue { Values = values };
             }
-            return merged;
+
+            return ToAST(itemType, value);
         }
 
-        // optimized version of Print(this ASTNode node) for primitive values
-        internal static string Print(this IGraphType type, object value)
+        // Populate the fields of the input object by creating ASTs from each value
+        // in the dictionary according to the fields in the input type.
+        if (type is IInputObjectGraphType input)
         {
-            return (type, value) switch
+            return input.ToAST(value) ?? throw new InvalidOperationException($"Unable to get an AST representation of the input object type '{input.Name}' for '{value}'.");
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(type), $"Must provide Input Type, cannot use {type.GetType().Name} '{type}'");
+    }
+
+    internal static string? MergeComments(this ASTNode node)
+    {
+        string? merged = null;
+        if (node.Comments?.Count > 0)
+        {
+            //TODO: rewrite this when migrating from comments to descriptions
+            for (int i = 0; i < node.Comments!.Count; ++i)
             {
-                (StringGraphType, string s) when s.IndexOfAny(_escapes) == -1 => "\"" + s + "\"",
-                (BooleanGraphType, false) => "false",
-                (BooleanGraphType, true) => "true",
-                _ => type.ToAST(value).Print(),
-            };
+                merged += node.Comments[i].Value;
+                if (i < node.Comments.Count - 1)
+                    merged += Environment.NewLine;
+            }
         }
+        return merged;
+    }
 
-        private static readonly char[] _escapes = new char[] { '\b', '\f', '\n', '\r', '\t', '\\', '"' };
-
-        /// <summary>
-        /// Returns a string representation of the specified node.
-        /// </summary>
-        internal static string Print(this ASTNode node)
+    // optimized version of Print(this ASTNode node) for primitive values
+    internal static string Print(this IGraphType type, object value)
+    {
+        return (type, value) switch
         {
-            using var writer = new StringWriter();
-            _sdlPrinter.PrintAsync(node, writer).GetAwaiter().GetResult(); // actually is sync
-            return writer.ToString()!;
-        }
-
-        private static readonly SDLPrinter _sdlPrinter = new();
-
-        internal static object? ParseAnyLiteral(this GraphQLValue value) => value switch
-        {
-            GraphQLObjectValue v => ParseObject(v),
-            GraphQLListValue v => ParseList(v),
-            GraphQLIntValue v => ParseInt(v),
-            GraphQLFloatValue v => ParseFloat(v),
-            GraphQLStringValue v => v.Value.Length == 0 ? string.Empty : (string)v.Value,
-            GraphQLBooleanValue v => (v.Value == "true").Boxed(),
-            GraphQLEnumValue e => e.Name.StringValue, //TODO:think about it later if/when refactoring federation
-            GraphQLNullValue _ => null,
-            _ => ThrowLiteralConversionError(value)
+            (StringGraphType, string s) when s.IndexOfAny(_escapes) == -1 => "\"" + s + "\"",
+            (BooleanGraphType, false) => "false",
+            (BooleanGraphType, true) => "true",
+            _ => type.ToAST(value).Print(),
         };
+    }
 
-        private static readonly ReadOnlyDictionary<string, object?> _empty = new(new Dictionary<string, object?>());
+    private static readonly char[] _escapes = new char[] { '\b', '\f', '\n', '\r', '\t', '\\', '"' };
 
-        private static IDictionary<string, object?> ParseObject(GraphQLObjectValue v)
+    /// <summary>
+    /// Returns a string representation of the specified node.
+    /// </summary>
+    internal static string Print(this ASTNode node)
+    {
+        using var writer = new StringWriter();
+        _sdlPrinter.PrintAsync(node, writer).GetAwaiter().GetResult(); // actually is sync
+        return writer.ToString()!;
+    }
+
+    private static readonly SDLPrinter _sdlPrinter = new();
+
+    internal static object? ParseAnyLiteral(this GraphQLValue value) => value switch
+    {
+        GraphQLObjectValue v => ParseObject(v),
+        GraphQLListValue v => ParseList(v),
+        GraphQLIntValue v => ParseInt(v),
+        GraphQLFloatValue v => ParseFloat(v),
+        GraphQLStringValue v => v.Value.Length == 0 ? string.Empty : (string)v.Value,
+        GraphQLBooleanValue v => (v.Value == "true").Boxed(),
+        GraphQLEnumValue e => e.Name.StringValue, //TODO:think about it later if/when refactoring federation
+        GraphQLNullValue _ => null,
+        _ => ThrowLiteralConversionError(value)
+    };
+
+    private static readonly ReadOnlyDictionary<string, object?> _empty = new(new Dictionary<string, object?>());
+
+    private static IDictionary<string, object?> ParseObject(GraphQLObjectValue v)
+    {
+        if (v.Fields == null || v.Fields.Count == 0)
         {
-            if (v.Fields == null || v.Fields.Count == 0)
-            {
-                return _empty;
-            }
-            else
-            {
-                var @object = new Dictionary<string, object?>(v.Fields.Count);
-                foreach (var field in v.Fields)
-                    @object.Add(field.Name.StringValue, ParseAnyLiteral(field.Value));
-                return @object;
-            }
+            return _empty;
+        }
+        else
+        {
+            var @object = new Dictionary<string, object?>(v.Fields.Count);
+            foreach (var field in v.Fields)
+                @object.Add(field.Name.StringValue, ParseAnyLiteral(field.Value));
+            return @object;
+        }
+    }
+
+    private static IList<object?> ParseList(GraphQLListValue v)
+    {
+        if (v.Values == null || v.Values.Count == 0)
+        {
+            return Array.Empty<object?>();
+        }
+        else
+        {
+            var array = new object?[v.Values.Count];
+            for (int i = 0; i < v.Values.Count; ++i)
+                array[i] = ParseAnyLiteral(v.Values[i]);
+            return array;
+        }
+    }
+
+    private static object ParseInt(GraphQLIntValue v)
+    {
+        if (v.Value.Length == 0)
+            throw new InvalidOperationException("Invalid number (empty string)");
+
+        if (Int.TryParse(v.Value, out int intResult))
+        {
+            return intResult;
         }
 
-        private static IList<object?> ParseList(GraphQLListValue v)
+        // If the value doesn't fit in an integer, revert to using long...
+        if (Long.TryParse(v.Value, out long longResult))
         {
-            if (v.Values == null || v.Values.Count == 0)
-            {
-                return Array.Empty<object?>();
-            }
-            else
-            {
-                var array = new object?[v.Values.Count];
-                for (int i = 0; i < v.Values.Count; ++i)
-                    array[i] = ParseAnyLiteral(v.Values[i]);
-                return array;
-            }
+            return longResult;
         }
 
-        private static object ParseInt(GraphQLIntValue v)
+        // If the value doesn't fit in an decimal, revert to using BigInteger...
+        if (BigInt.TryParse(v.Value, out var bigIntegerResult))
         {
-            if (v.Value.Length == 0)
-                throw new InvalidOperationException("Invalid number (empty string)");
-
-            if (Int.TryParse(v.Value, out int intResult))
-            {
-                return intResult;
-            }
-
-            // If the value doesn't fit in an integer, revert to using long...
-            if (Long.TryParse(v.Value, out long longResult))
-            {
-                return longResult;
-            }
-
-            // If the value doesn't fit in an decimal, revert to using BigInteger...
-            if (BigInt.TryParse(v.Value, out var bigIntegerResult))
-            {
-                return bigIntegerResult;
-            }
-
-            // Since BigInteger can contain any valid integer (arbitrarily large), this is impossible to trigger via an invalid query
-            throw new InvalidOperationException($"Invalid number {v.Value}");
+            return bigIntegerResult;
         }
 
-        private static object ParseFloat(GraphQLFloatValue v)
+        // Since BigInteger can contain any valid integer (arbitrarily large), this is impossible to trigger via an invalid query
+        throw new InvalidOperationException($"Invalid number {v.Value}");
+    }
+
+    private static object ParseFloat(GraphQLFloatValue v)
+    {
+        if (v.Value.Length == 0)
+            throw new InvalidOperationException("Invalid number (empty string)");
+
+        // the idea is to see if there is a loss of accuracy of value
+        // for example, 12.1 or 12.11 is double but 12.10 is decimal
+        if (!Double.TryParse(v.Value, out double dbl))
         {
-            if (v.Value.Length == 0)
-                throw new InvalidOperationException("Invalid number (empty string)");
-
-            // the idea is to see if there is a loss of accuracy of value
-            // for example, 12.1 or 12.11 is double but 12.10 is decimal
-            if (!Double.TryParse(v.Value, out double dbl))
-            {
-                ThrowLiteralConversionError(v);
-            }
-
-            //it is possible for a FloatValue to overflow a decimal; however, with a double, it just returns Infinity or -Infinity
-            if (Decimal.TryParse(v.Value, out decimal dec))
-            {
-                // Cast the decimal to our struct to avoid the decimal.GetBits allocations.
-                var decBits = System.Runtime.CompilerServices.Unsafe.As<decimal, DecimalData>(ref dec);
-                decimal temp = new(dbl);
-                var dblAsDecBits = System.Runtime.CompilerServices.Unsafe.As<decimal, DecimalData>(ref temp);
-                if (!decBits.Equals(dblAsDecBits))
-                    return dec;
-            }
-
-            return dbl;
+            ThrowLiteralConversionError(v);
         }
 
-        private static object ThrowLiteralConversionError(GraphQLValue input, string? description = null)
+        //it is possible for a FloatValue to overflow a decimal; however, with a double, it just returns Infinity or -Infinity
+        if (Decimal.TryParse(v.Value, out decimal dec))
         {
-            var value = input is IHasValueNode node ? node.Value.ToString() : input?.ToString();
-            if (description != null)
-                description = "; " + description;
-            throw new InvalidOperationException($"Unable to convert '{value}' literal from AST representation to any possible type{description}");
+            // Cast the decimal to our struct to avoid the decimal.GetBits allocations.
+            var decBits = System.Runtime.CompilerServices.Unsafe.As<decimal, DecimalData>(ref dec);
+            decimal temp = new(dbl);
+            var dblAsDecBits = System.Runtime.CompilerServices.Unsafe.As<decimal, DecimalData>(ref temp);
+            if (!decBits.Equals(dblAsDecBits))
+                return dec;
         }
+
+        return dbl;
+    }
+
+    private static object ThrowLiteralConversionError(GraphQLValue input, string? description = null)
+    {
+        var value = input is IHasValueNode node ? node.Value.ToString() : input?.ToString();
+        if (description != null)
+            description = "; " + description;
+        throw new InvalidOperationException($"Unable to convert '{value}' literal from AST representation to any possible type{description}");
     }
 }

--- a/src/GraphQL/Extensions/MemoryExtensions.cs
+++ b/src/GraphQL/Extensions/MemoryExtensions.cs
@@ -1,51 +1,50 @@
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Provides extension methods for working with arrays and pools.
+/// </summary>
+public static class MemoryExtensions
 {
-    /// <summary>
-    /// Provides extension methods for working with arrays and pools.
-    /// </summary>
-    public static class MemoryExtensions
+    private static readonly ConcurrentDictionary<Type, Action<Array>> _delegates = new();
+    private static readonly Func<Type, Action<Array>> _factory = CreateDelegate;
+
+    internal static void Return(this Array array) => _delegates.GetOrAdd(array.GetType(), _factory)(array);
+
+    // 'ArrayPool.Return' method takes generic T[] parameter for returned array, therefore it is required
+    // to generate a method-adapter which takes 'Array' parameter and then casts it to the required type.
+    //
+    // Example:
+    //
+    // arr => ArrayPool<ElementType>.Shared.Return((ElementType[])arr, true)
+    private static Action<Array> CreateDelegate(Type arrayType)
     {
-        private static readonly ConcurrentDictionary<Type, Action<Array>> _delegates = new();
-        private static readonly Func<Type, Action<Array>> _factory = CreateDelegate;
+        var poolType = typeof(System.Buffers.ArrayPool<>).MakeGenericType(arrayType.GetElementType()!);
+        var parameter = Expression.Parameter(typeof(Array), "arr");
 
-        internal static void Return(this Array array) => _delegates.GetOrAdd(array.GetType(), _factory)(array);
+        var lambda = Expression.Lambda<Action<Array>>(
+            Expression.Call(
+                Expression.Property(null, poolType.GetProperty(nameof(System.Buffers.ArrayPool<object>.Shared))!),
+                poolType.GetMethod(nameof(System.Buffers.ArrayPool<object>.Return))!,
+            Expression.Convert(parameter, arrayType),
+            Expression.Constant(true, typeof(bool))), parameter);
 
-        // 'ArrayPool.Return' method takes generic T[] parameter for returned array, therefore it is required
-        // to generate a method-adapter which takes 'Array' parameter and then casts it to the required type.
-        //
-        // Example:
-        //
-        // arr => ArrayPool<ElementType>.Shared.Return((ElementType[])arr, true)
-        private static Action<Array> CreateDelegate(Type arrayType)
-        {
-            var poolType = typeof(System.Buffers.ArrayPool<>).MakeGenericType(arrayType.GetElementType()!);
-            var parameter = Expression.Parameter(typeof(Array), "arr");
+        return lambda.Compile();
+    }
 
-            var lambda = Expression.Lambda<Action<Array>>(
-                Expression.Call(
-                    Expression.Property(null, poolType.GetProperty(nameof(System.Buffers.ArrayPool<object>.Shared))!),
-                    poolType.GetMethod(nameof(System.Buffers.ArrayPool<object>.Return))!,
-                Expression.Convert(parameter, arrayType),
-                Expression.Constant(true, typeof(bool))), parameter);
+    /// <summary>
+    /// Returns an array or array-like object of a given length.
+    /// </summary>
+    public static IList<T> Constrained<T>(this T[] array, int count)
+    {
+        if (count == 0)
+            return Array.Empty<T>();
 
-            return lambda.Compile();
-        }
+        if (array.Length == count)
+            return array;
 
-        /// <summary>
-        /// Returns an array or array-like object of a given length.
-        /// </summary>
-        public static IList<T> Constrained<T>(this T[] array, int count)
-        {
-            if (count == 0)
-                return Array.Empty<T>();
-
-            if (array.Length == count)
-                return array;
-
-            return new ConstrainedArray<T>(array, count);
-        }
+        return new ConstrainedArray<T>(array, count);
     }
 }

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -5,488 +5,487 @@ using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using GraphQL.Types;
 
-namespace GraphQL
-{
-    /// <summary>
-    /// Provides extension methods for objects and a method for converting a dictionary into a strongly typed object.
-    /// </summary>
-    public static partial class ObjectExtensions
-    {
-        private static readonly ConcurrentDictionary<Type, (ConstructorInfo Constructor, ParameterInfo[] ConstructorParameters)> _types = new();
-        private static readonly ConcurrentDictionary<(Type Type, string PropertyName), (MemberInfo MemberInfo, bool IsInitOnly, bool IsRequired)> _members = new();
+namespace GraphQL;
 
-        /// <summary>
-        /// Creates a new instance of the indicated type, populating it with the dictionary.
-        /// Can use any constructor of the indicated type, provided that there are keys in the
-        /// dictionary that correspond (case insensitive) to the names of the constructor parameters.
-        /// </summary>
-        /// <param name="source">The source of values.</param>
-        /// <param name="type">The type to create.</param>
-        /// <param name="mappedType">
-        /// GraphType for matching dictionary keys with <paramref name="type"/> property names.
-        /// GraphType contains information about this matching in Metadata property.
-        /// In case of configuring field as Field("FirstName", x => x.FName) source dictionary
-        /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
-        /// </param>
-        public static object ToObject(
-            this IDictionary<string, object?> source,
+/// <summary>
+/// Provides extension methods for objects and a method for converting a dictionary into a strongly typed object.
+/// </summary>
+public static partial class ObjectExtensions
+{
+    private static readonly ConcurrentDictionary<Type, (ConstructorInfo Constructor, ParameterInfo[] ConstructorParameters)> _types = new();
+    private static readonly ConcurrentDictionary<(Type Type, string PropertyName), (MemberInfo MemberInfo, bool IsInitOnly, bool IsRequired)> _members = new();
+
+    /// <summary>
+    /// Creates a new instance of the indicated type, populating it with the dictionary.
+    /// Can use any constructor of the indicated type, provided that there are keys in the
+    /// dictionary that correspond (case insensitive) to the names of the constructor parameters.
+    /// </summary>
+    /// <param name="source">The source of values.</param>
+    /// <param name="type">The type to create.</param>
+    /// <param name="mappedType">
+    /// GraphType for matching dictionary keys with <paramref name="type"/> property names.
+    /// GraphType contains information about this matching in Metadata property.
+    /// In case of configuring field as Field("FirstName", x => x.FName) source dictionary
+    /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
+    /// </param>
+    public static object ToObject(
+        this IDictionary<string, object?> source,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type type,
+        IGraphType mappedType)
+    {
+        var inputGraphType = (mappedType is NonNullGraphType nonNullGraphType
+            ? nonNullGraphType.ResolvedType as IInputObjectGraphType
+            : mappedType as IInputObjectGraphType)
+            ?? throw new InvalidOperationException($"Graph type supplied is not an input object graph type.");
+
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        // if conversion from IDictionary<string, object> to desired type is registered then use it
+        if (ValueConverter.TryConvertTo(source, type, out object? result, typeof(IDictionary<string, object>)))
+            return result!;
+
+        var reflectionInfo = GetReflectionInformation(type, inputGraphType);
+        return ToObject(source, reflectionInfo);
+    }
+
+    /// <summary>
+    /// Creates a new instance of the indicated type, populating it with the dictionary.
+    /// Uses the constructor and properties specified by the supplied <see cref="ReflectionInfo"/>.
+    /// </summary>
+    private static object ToObject(this IDictionary<string, object?> source, ReflectionInfo reflectionInfo)
+    {
+        // build the constructor arguments
+        object?[] ctorArguments = reflectionInfo.CtorFields.Length == 0
+            ? Array.Empty<object>()
+            : new object[reflectionInfo.CtorFields.Length];
+
+        for (int i = 0; i < reflectionInfo.CtorFields.Length; ++i)
+        {
+            var ctorField = reflectionInfo.CtorFields[i];
+            ctorArguments[i] = ctorField.Key != null
+                ? GetPropertyValue(source.TryGetValue(ctorField.Key, out var value) ? value : null, ctorField.ParameterInfo.ParameterType, ctorField.GraphType!)
+                : ctorField.ParameterInfo.DefaultValue;
+        }
+
+        // construct the object
+        object obj;
+        try
+        {
+            obj = reflectionInfo.CtorFields.Length == 0
+                ? Activator.CreateInstance(reflectionInfo.Type)!
+                : reflectionInfo.Constructor.Invoke(ctorArguments);
+        }
+        catch (TargetInvocationException ex)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
+            return ""; // never executed, necessary only for intellisense
+        }
+
+        // populate the remaining fields
+        foreach (var field in reflectionInfo.MemberFields)
+        {
+            if (source.TryGetValue(field.Key, out var value))
+            {
+                if (field.Member is PropertyInfo propertyInfo)
+                {
+                    var coercedValue = GetPropertyValue(value, propertyInfo.PropertyType, field.GraphType);
+                    propertyInfo.SetValue(obj, coercedValue); //issue: this works even if propertyInfo is ValueType and value is null
+                }
+                else if (field.Member is FieldInfo fieldInfo)
+                {
+                    var coercedValue = GetPropertyValue(value, fieldInfo.FieldType, field.GraphType);
+                    fieldInfo.SetValue(obj, coercedValue);
+                }
+            }
+            else if (field.IsInitOnly || field.IsRequired)
+            {
+                // initialize all unspecified init-only or required properties
+                if (field.Member is PropertyInfo propertyInfo)
+                {
+                    propertyInfo.SetValue(obj, null);
+                }
+                else
+                {
+                    ((FieldInfo)field.Member).SetValue(obj, null);
+                }
+            }
+        }
+
+        return obj;
+    }
+
+    private readonly ref struct ReflectionInfo
+    {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+        public readonly Type Type;
+        public readonly ConstructorInfo Constructor;
+        public readonly CtorParameterInfo[] CtorFields;
+        public readonly MemberFieldInfo[] MemberFields;
+
+        public ReflectionInfo(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
             Type type,
-            IGraphType mappedType)
+            ConstructorInfo constructor,
+            CtorParameterInfo[] ctorFields,
+            MemberFieldInfo[] memberFields)
         {
-            var inputGraphType = (mappedType is NonNullGraphType nonNullGraphType
-                ? nonNullGraphType.ResolvedType as IInputObjectGraphType
-                : mappedType as IInputObjectGraphType)
-                ?? throw new InvalidOperationException($"Graph type supplied is not an input object graph type.");
-
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-
-            // if conversion from IDictionary<string, object> to desired type is registered then use it
-            if (ValueConverter.TryConvertTo(source, type, out object? result, typeof(IDictionary<string, object>)))
-                return result!;
-
-            var reflectionInfo = GetReflectionInformation(type, inputGraphType);
-            return ToObject(source, reflectionInfo);
+            Type = type;
+            Constructor = constructor;
+            CtorFields = ctorFields;
+            MemberFields = memberFields;
         }
 
-        /// <summary>
-        /// Creates a new instance of the indicated type, populating it with the dictionary.
-        /// Uses the constructor and properties specified by the supplied <see cref="ReflectionInfo"/>.
-        /// </summary>
-        private static object ToObject(this IDictionary<string, object?> source, ReflectionInfo reflectionInfo)
+        public readonly struct CtorParameterInfo
         {
-            // build the constructor arguments
-            object?[] ctorArguments = reflectionInfo.CtorFields.Length == 0
-                ? Array.Empty<object>()
-                : new object[reflectionInfo.CtorFields.Length];
+            public readonly string? Key;
+            public readonly ParameterInfo ParameterInfo;
+            public readonly IGraphType? GraphType;
 
-            for (int i = 0; i < reflectionInfo.CtorFields.Length; ++i)
+            public CtorParameterInfo(string? key, ParameterInfo parameterInfo, IGraphType? graphType)
             {
-                var ctorField = reflectionInfo.CtorFields[i];
-                ctorArguments[i] = ctorField.Key != null
-                    ? GetPropertyValue(source.TryGetValue(ctorField.Key, out var value) ? value : null, ctorField.ParameterInfo.ParameterType, ctorField.GraphType!)
-                    : ctorField.ParameterInfo.DefaultValue;
-            }
-
-            // construct the object
-            object obj;
-            try
-            {
-                obj = reflectionInfo.CtorFields.Length == 0
-                    ? Activator.CreateInstance(reflectionInfo.Type)!
-                    : reflectionInfo.Constructor.Invoke(ctorArguments);
-            }
-            catch (TargetInvocationException ex)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
-                return ""; // never executed, necessary only for intellisense
-            }
-
-            // populate the remaining fields
-            foreach (var field in reflectionInfo.MemberFields)
-            {
-                if (source.TryGetValue(field.Key, out var value))
-                {
-                    if (field.Member is PropertyInfo propertyInfo)
-                    {
-                        var coercedValue = GetPropertyValue(value, propertyInfo.PropertyType, field.GraphType);
-                        propertyInfo.SetValue(obj, coercedValue); //issue: this works even if propertyInfo is ValueType and value is null
-                    }
-                    else if (field.Member is FieldInfo fieldInfo)
-                    {
-                        var coercedValue = GetPropertyValue(value, fieldInfo.FieldType, field.GraphType);
-                        fieldInfo.SetValue(obj, coercedValue);
-                    }
-                }
-                else if (field.IsInitOnly || field.IsRequired)
-                {
-                    // initialize all unspecified init-only or required properties
-                    if (field.Member is PropertyInfo propertyInfo)
-                    {
-                        propertyInfo.SetValue(obj, null);
-                    }
-                    else
-                    {
-                        ((FieldInfo)field.Member).SetValue(obj, null);
-                    }
-                }
-            }
-
-            return obj;
-        }
-
-        private readonly ref struct ReflectionInfo
-        {
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
-            public readonly Type Type;
-            public readonly ConstructorInfo Constructor;
-            public readonly CtorParameterInfo[] CtorFields;
-            public readonly MemberFieldInfo[] MemberFields;
-
-            public ReflectionInfo(
-                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
-                Type type,
-                ConstructorInfo constructor,
-                CtorParameterInfo[] ctorFields,
-                MemberFieldInfo[] memberFields)
-            {
-                Type = type;
-                Constructor = constructor;
-                CtorFields = ctorFields;
-                MemberFields = memberFields;
-            }
-
-            public readonly struct CtorParameterInfo
-            {
-                public readonly string? Key;
-                public readonly ParameterInfo ParameterInfo;
-                public readonly IGraphType? GraphType;
-
-                public CtorParameterInfo(string? key, ParameterInfo parameterInfo, IGraphType? graphType)
-                {
-                    Key = key;
-                    ParameterInfo = parameterInfo;
-                    GraphType = graphType;
-                }
-            }
-
-            public readonly struct MemberFieldInfo
-            {
-                public readonly string Key;
-                public readonly MemberInfo Member;
-                public readonly bool IsInitOnly;
-                public readonly bool IsRequired;
-                public readonly IGraphType GraphType;
-
-                public MemberFieldInfo(string key, MemberInfo member, bool isInitOnly, bool isRequired, IGraphType graphType)
-                {
-                    Key = key;
-                    Member = member;
-                    IsInitOnly = isInitOnly;
-                    IsRequired = isRequired;
-                    GraphType = graphType;
-                }
+                Key = key;
+                ParameterInfo = parameterInfo;
+                GraphType = graphType;
             }
         }
 
-        /// <summary>
-        /// Gets reflection information based on the specified CLR type and graph type.
-        /// </summary>
-        private static ReflectionInfo GetReflectionInformation(
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
-            Type clrType,
-            IInputObjectGraphType graphType)
+        public readonly struct MemberFieldInfo
         {
-            // gather for each field: dictionary key, clr property name, and graph type
-            var fields = new (string Key, string? MemberName, IGraphType ResolvedType)[graphType.Fields.Count];
-            for (var i = 0; i < graphType.Fields.Count; i++)
-            {
-                var fieldType = graphType.Fields.List[i];
-                // get clr property name (also used for matching on field name or constructor parameter name)
-                var fieldName = fieldType.GetMetadata<string>(InputObjectGraphType.ORIGINAL_EXPRESSION_PROPERTY_NAME) ?? fieldType.Name;
-                // get graph type
-                var resolvedType = fieldType.ResolvedType
-                    ?? throw new InvalidOperationException($"Field '{fieldType.Name}' of graph type '{graphType.Name}' does not have the ResolvedType property set.");
-                // verify no other fields have the same name
-                for (var j = 0; j < i; j++)
-                {
-                    if (fields[j].MemberName == fieldName)
-                        throw new InvalidOperationException($"Two fields within graph type '{graphType.Name}' were mapped to the same member '{fieldName}'.");
-                }
-                // add to list
-                fields[i] = (fieldType.Name, fieldName, resolvedType);
-            }
+            public readonly string Key;
+            public readonly MemberInfo Member;
+            public readonly bool IsInitOnly;
+            public readonly bool IsRequired;
+            public readonly IGraphType GraphType;
 
-            // find best constructor to use
-            var (bestConstructor, ctorParameters) = _types.GetOrAdd(
-                clrType,
-                static clrType =>
-                {
+            public MemberFieldInfo(string key, MemberInfo member, bool isInitOnly, bool isRequired, IGraphType graphType)
+            {
+                Key = key;
+                Member = member;
+                IsInitOnly = isInitOnly;
+                IsRequired = isRequired;
+                GraphType = graphType;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets reflection information based on the specified CLR type and graph type.
+    /// </summary>
+    private static ReflectionInfo GetReflectionInformation(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type clrType,
+        IInputObjectGraphType graphType)
+    {
+        // gather for each field: dictionary key, clr property name, and graph type
+        var fields = new (string Key, string? MemberName, IGraphType ResolvedType)[graphType.Fields.Count];
+        for (var i = 0; i < graphType.Fields.Count; i++)
+        {
+            var fieldType = graphType.Fields.List[i];
+            // get clr property name (also used for matching on field name or constructor parameter name)
+            var fieldName = fieldType.GetMetadata<string>(InputObjectGraphType.ORIGINAL_EXPRESSION_PROPERTY_NAME) ?? fieldType.Name;
+            // get graph type
+            var resolvedType = fieldType.ResolvedType
+                ?? throw new InvalidOperationException($"Field '{fieldType.Name}' of graph type '{graphType.Name}' does not have the ResolvedType property set.");
+            // verify no other fields have the same name
+            for (var j = 0; j < i; j++)
+            {
+                if (fields[j].MemberName == fieldName)
+                    throw new InvalidOperationException($"Two fields within graph type '{graphType.Name}' were mapped to the same member '{fieldName}'.");
+            }
+            // add to list
+            fields[i] = (fieldType.Name, fieldName, resolvedType);
+        }
+
+        // find best constructor to use
+        var (bestConstructor, ctorParameters) = _types.GetOrAdd(
+            clrType,
+            static clrType =>
+            {
 #pragma warning disable IL2067 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                    var constructor = AutoRegisteringHelper.GetConstructor(clrType);
+                var constructor = AutoRegisteringHelper.GetConstructor(clrType);
 #pragma warning restore IL2067 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                    var parameters = constructor.GetParameters();
-                    return (constructor, parameters);
-                });
+                var parameters = constructor.GetParameters();
+                return (constructor, parameters);
+            });
 
-            // pull out parameters that are applicable for that constructor
-            var memberCount = fields.Length;
-            var ctorFields = ctorParameters.Length > 0
-                ? new ReflectionInfo.CtorParameterInfo[ctorParameters.Length]
-                : Array.Empty<ReflectionInfo.CtorParameterInfo>();
-            for (var i = 0; i < ctorParameters.Length; i++)
+        // pull out parameters that are applicable for that constructor
+        var memberCount = fields.Length;
+        var ctorFields = ctorParameters.Length > 0
+            ? new ReflectionInfo.CtorParameterInfo[ctorParameters.Length]
+            : Array.Empty<ReflectionInfo.CtorParameterInfo>();
+        for (var i = 0; i < ctorParameters.Length; i++)
+        {
+            var ctorParam = ctorParameters[i];
+            // look for a field that matches the constructor parameter name
+            var index = Array.FindIndex<(string, string? MemberName, IGraphType)>(fields, 0, fields.Length, x => string.Equals(x.MemberName, ctorParam.Name, StringComparison.OrdinalIgnoreCase));
+            if (index == -1)
             {
-                var ctorParam = ctorParameters[i];
-                // look for a field that matches the constructor parameter name
-                var index = Array.FindIndex<(string, string? MemberName, IGraphType)>(fields, 0, fields.Length, x => string.Equals(x.MemberName, ctorParam.Name, StringComparison.OrdinalIgnoreCase));
-                if (index == -1)
-                {
-                    if (ctorParam.IsOptional)
-                        ctorFields[i] = new(key: null, ctorParam, graphType: null);
-                    else
-                        throw new InvalidOperationException($"Cannot find field named '{ctorParam.Name}' on graph type '{graphType.Name}' to fulfill constructor parameter for CLR type '{clrType.GetFriendlyName()}'.");
-                }
+                if (ctorParam.IsOptional)
+                    ctorFields[i] = new(key: null, ctorParam, graphType: null);
                 else
-                {
-                    // add to list, and mark to be removed from fields
-                    var value = fields[index];
-                    ctorFields[i] = new(value.Key, ctorParam, value.ResolvedType);
-                    value.MemberName = null;
-                    fields[index] = value;
-                    memberCount--;
-                }
+                    throw new InvalidOperationException($"Cannot find field named '{ctorParam.Name}' on graph type '{graphType.Name}' to fulfill constructor parameter for CLR type '{clrType.GetFriendlyName()}'.");
             }
-
-            // find other members
-            var members = memberCount > 0
-                ? new ReflectionInfo.MemberFieldInfo[memberCount]
-                : Array.Empty<ReflectionInfo.MemberFieldInfo>();
-            var memberIndex = 0;
-            for (var i = 0; i < fields.Length; i++)
+            else
             {
-                var field = fields[i];
-                // skip fields handled by constructor
-                if (field.MemberName == null)
-                    continue;
-                // look for match on type
+                // add to list, and mark to be removed from fields
+                var value = fields[index];
+                ctorFields[i] = new(value.Key, ctorParam, value.ResolvedType);
+                value.MemberName = null;
+                fields[index] = value;
+                memberCount--;
+            }
+        }
+
+        // find other members
+        var members = memberCount > 0
+            ? new ReflectionInfo.MemberFieldInfo[memberCount]
+            : Array.Empty<ReflectionInfo.MemberFieldInfo>();
+        var memberIndex = 0;
+        for (var i = 0; i < fields.Length; i++)
+        {
+            var field = fields[i];
+            // skip fields handled by constructor
+            if (field.MemberName == null)
+                continue;
+            // look for match on type
 #pragma warning disable IL2077 // 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'FindMatchingMember(Type, String)'. The field '(System.Type, System.String).Item1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-                var (member, initOnly, isRequired) = _members.GetOrAdd((clrType, field.MemberName), static info => FindMatchingMember(info.Type, info.PropertyName));
+            var (member, initOnly, isRequired) = _members.GetOrAdd((clrType, field.MemberName), static info => FindMatchingMember(info.Type, info.PropertyName));
 #pragma warning restore IL2077 // 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'FindMatchingMember(Type, String)'. The field '(System.Type, System.String).Item1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-                members[memberIndex++] = new(field.Key, member, initOnly, isRequired, field.ResolvedType);
-            }
-
-            return new ReflectionInfo(clrType, bestConstructor, ctorFields, members);
-
-            static (MemberInfo MemberInfo, bool IsInitOnly, bool IsRequired) FindMatchingMember(
-                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
-                Type type,
-                string propertyName)
-            {
-                PropertyInfo? propertyInfo = null;
-
-                // note: analzyer raises false IL2070 warning due to BindingFlags.IgnoreCase being present
-
-                try
-                {
-#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                    propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                }
-                catch (AmbiguousMatchException)
-                {
-#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                    propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                }
-
-                if (propertyInfo?.SetMethod?.IsPublic ?? false)
-                {
-                    var isExternalInit = propertyInfo.SetMethod.ReturnParameter.GetRequiredCustomModifiers()
-                        .Any(type => type.FullName == typeof(IsExternalInit).FullName);
-
-                    var isRequired = propertyInfo.CustomAttributes.Any(x => x.AttributeType.FullName == typeof(RequiredMemberAttribute).FullName);
-
-                    return (propertyInfo, isExternalInit, isRequired);
-                }
-
-                FieldInfo? fieldInfo;
-
-                try
-                {
-#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                    fieldInfo = type.GetField(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                }
-                catch (AmbiguousMatchException)
-                {
-#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                    fieldInfo = type.GetField(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                }
-
-                if (fieldInfo != null)
-                {
-                    if (fieldInfo.IsInitOnly)
-                        throw new InvalidOperationException($"Field named '{propertyName}' on CLR type '{type.GetFriendlyName()}' is defined as a read-only field. Please add a constructor parameter with the same name to initialize this field.");
-
-                    var isRequired = fieldInfo.CustomAttributes.Any(x => x.AttributeType.FullName == typeof(RequiredMemberAttribute).FullName);
-
-                    return (fieldInfo, false, isRequired);
-                }
-
-                throw new InvalidOperationException($"Cannot find member named '{propertyName}' on CLR type '{type.GetFriendlyName()}'.");
-            }
+            members[memberIndex++] = new(field.Key, member, initOnly, isRequired, field.ResolvedType);
         }
 
-        /// <summary>
-        /// Converts the indicated value into a type that is compatible with fieldType.
-        /// </summary>
-        /// <param name="propertyValue">The value to be converted.</param>
-        /// <param name="fieldType">The desired type.</param>
-        /// <param name="mappedType">
-        /// GraphType for matching dictionary keys with <paramref name="fieldType"/> property names.
-        /// GraphType contains information about this matching in Metadata property.
-        /// In case of configuring field as Field("FirstName", x => x.FName) source dictionary
-        /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
-        /// </param>
-        /// <remarks>There is special handling for strings, IEnumerable&lt;T&gt;, Nullable&lt;T&gt;, and Enum.</remarks>
-        public static object? GetPropertyValue(this object? propertyValue, Type fieldType, IGraphType mappedType)
+        return new ReflectionInfo(clrType, bestConstructor, ctorFields, members);
+
+        static (MemberInfo MemberInfo, bool IsInitOnly, bool IsRequired) FindMatchingMember(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+            Type type,
+            string propertyName)
         {
-            if (mappedType == null)
-            {
-                throw new ArgumentNullException(nameof(mappedType));
-            }
+            PropertyInfo? propertyInfo = null;
 
-            if (mappedType is NonNullGraphType nonNullGraphType)
-            {
-                mappedType = nonNullGraphType.ResolvedType
-                    ?? throw new InvalidOperationException("ResolvedType not set for non-null graph type.");
-            }
+            // note: analzyer raises false IL2070 warning due to BindingFlags.IgnoreCase being present
 
-            // Short-circuit conversion if the property value already of the right type
-            if (propertyValue == null || fieldType == typeof(object) || fieldType.IsInstanceOfType(propertyValue))
-            {
-                return propertyValue;
-            }
-
-            if (ValueConverter.TryConvertTo(propertyValue, fieldType, out object? result))
-                return result;
-
-            var enumerableInterface = fieldType.Name == "IEnumerable`1"
-              ? fieldType
-              : fieldType.GetInterface("IEnumerable`1");
-
-            if (mappedType is ListGraphType listGraphType && fieldType != typeof(string) && enumerableInterface != null)
-            {
-                var itemGraphType = listGraphType.ResolvedType
-                    ?? throw new InvalidOperationException("Graph type is not a list graph type or ResolvedType not set.");
-                IList newCollection;
-                var elementType = enumerableInterface.GetGenericArguments()[0];
-                var underlyingType = Nullable.GetUnderlyingType(elementType) ?? elementType;
-                var fieldTypeImplementsIList = fieldType.GetInterface("IList") != null;
-
-                var propertyValueAsIList = propertyValue as IList;
-
-                // Custom container
-                if (fieldTypeImplementsIList && !fieldType.IsArray)
-                {
-                    newCollection = (IList)Activator.CreateInstance(fieldType)!;
-                }
-                // Array of known size is created immediately
-                else if (fieldType.IsArray && propertyValueAsIList != null)
-                {
-                    newCollection = Array.CreateInstance(elementType, propertyValueAsIList.Count);
-                }
-                // List<T>
-                else
-                {
-                    var genericListType = typeof(List<>).MakeGenericType(elementType);
-                    newCollection = (IList)Activator.CreateInstance(genericListType)!;
-                }
-
-                if (propertyValue is not IEnumerable valueList)
-                    throw new InvalidOperationException($"Cannot coerce collection of CLR type '{propertyValue.GetType().GetFriendlyName()}' to IEnumerable for graph type '{mappedType}'.");
-
-                // Array of known size is populated in-place
-                if (fieldType.IsArray && propertyValueAsIList != null)
-                {
-                    for (int i = 0; i < propertyValueAsIList.Count; ++i)
-                    {
-                        var listItem = propertyValueAsIList[i];
-                        newCollection[i] = listItem == null ? null : GetPropertyValue(listItem, underlyingType, itemGraphType);
-                    }
-                }
-                // Array of unknown size is created only after populating list
-                else
-                {
-                    foreach (var listItem in valueList)
-                    {
-                        newCollection.Add(listItem == null ? null : GetPropertyValue(listItem, underlyingType, itemGraphType));
-                    }
-
-                    if (fieldType.IsArray)
-                        newCollection = ((dynamic)newCollection!).ToArray();
-                }
-
-                return newCollection;
-            }
-
-            var value = propertyValue;
-
-            var nullableFieldType = Nullable.GetUnderlyingType(fieldType);
-
-            // if this is a nullable type and the value is null, return null
-            if (nullableFieldType != null && value == null)
-            {
-                return null;
-            }
-
-            if (nullableFieldType != null)
-            {
-                fieldType = nullableFieldType;
-            }
-
-            if (propertyValue is IDictionary<string, object?> objects)
-            {
-                return ToObject(objects, fieldType, mappedType);
-            }
-
-            if (fieldType.IsEnum)
-            {
-                if (value == null)
-                {
-                    var enumNames = Enum.GetNames(fieldType);
-                    value = enumNames[0];
-                }
-
-                if (!IsDefinedEnumValue(fieldType, value))
-                {
-                    throw new InvalidOperationException($"Unknown value '{value}' for enum '{fieldType.Name}'.");
-                }
-
-                string str = value.ToString()!;
-                value = Enum.Parse(fieldType, str, true);
-            }
-
-            return ValueConverter.ConvertTo(value, fieldType);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the value is <see langword="null"/>, value.ToString equals an empty string, or the value can be converted into a named enum value.
-        /// </summary>
-        /// <param name="type">An enum type.</param>
-        /// <param name="value">The value being tested.</param>
-        public static bool IsDefinedEnumValue(Type type, object? value) //TODO: rewrite, comment above seems wrong
-        {
             try
             {
-                var names = Enum.GetNames(type);
-                if (names.Contains(value?.ToString() ?? "", StringComparer.OrdinalIgnoreCase))
+#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+            }
+            catch (AmbiguousMatchException)
+            {
+#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+            }
+
+            if (propertyInfo?.SetMethod?.IsPublic ?? false)
+            {
+                var isExternalInit = propertyInfo.SetMethod.ReturnParameter.GetRequiredCustomModifiers()
+                    .Any(type => type.FullName == typeof(IsExternalInit).FullName);
+
+                var isRequired = propertyInfo.CustomAttributes.Any(x => x.AttributeType.FullName == typeof(RequiredMemberAttribute).FullName);
+
+                return (propertyInfo, isExternalInit, isRequired);
+            }
+
+            FieldInfo? fieldInfo;
+
+            try
+            {
+#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                fieldInfo = type.GetField(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+            }
+            catch (AmbiguousMatchException)
+            {
+#pragma warning disable IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+                fieldInfo = type.GetField(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+#pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+            }
+
+            if (fieldInfo != null)
+            {
+                if (fieldInfo.IsInitOnly)
+                    throw new InvalidOperationException($"Field named '{propertyName}' on CLR type '{type.GetFriendlyName()}' is defined as a read-only field. Please add a constructor parameter with the same name to initialize this field.");
+
+                var isRequired = fieldInfo.CustomAttributes.Any(x => x.AttributeType.FullName == typeof(RequiredMemberAttribute).FullName);
+
+                return (fieldInfo, false, isRequired);
+            }
+
+            throw new InvalidOperationException($"Cannot find member named '{propertyName}' on CLR type '{type.GetFriendlyName()}'.");
+        }
+    }
+
+    /// <summary>
+    /// Converts the indicated value into a type that is compatible with fieldType.
+    /// </summary>
+    /// <param name="propertyValue">The value to be converted.</param>
+    /// <param name="fieldType">The desired type.</param>
+    /// <param name="mappedType">
+    /// GraphType for matching dictionary keys with <paramref name="fieldType"/> property names.
+    /// GraphType contains information about this matching in Metadata property.
+    /// In case of configuring field as Field("FirstName", x => x.FName) source dictionary
+    /// will have 'FirstName' key but its value should be set to 'FName' property of created object.
+    /// </param>
+    /// <remarks>There is special handling for strings, IEnumerable&lt;T&gt;, Nullable&lt;T&gt;, and Enum.</remarks>
+    public static object? GetPropertyValue(this object? propertyValue, Type fieldType, IGraphType mappedType)
+    {
+        if (mappedType == null)
+        {
+            throw new ArgumentNullException(nameof(mappedType));
+        }
+
+        if (mappedType is NonNullGraphType nonNullGraphType)
+        {
+            mappedType = nonNullGraphType.ResolvedType
+                ?? throw new InvalidOperationException("ResolvedType not set for non-null graph type.");
+        }
+
+        // Short-circuit conversion if the property value already of the right type
+        if (propertyValue == null || fieldType == typeof(object) || fieldType.IsInstanceOfType(propertyValue))
+        {
+            return propertyValue;
+        }
+
+        if (ValueConverter.TryConvertTo(propertyValue, fieldType, out object? result))
+            return result;
+
+        var enumerableInterface = fieldType.Name == "IEnumerable`1"
+          ? fieldType
+          : fieldType.GetInterface("IEnumerable`1");
+
+        if (mappedType is ListGraphType listGraphType && fieldType != typeof(string) && enumerableInterface != null)
+        {
+            var itemGraphType = listGraphType.ResolvedType
+                ?? throw new InvalidOperationException("Graph type is not a list graph type or ResolvedType not set.");
+            IList newCollection;
+            var elementType = enumerableInterface.GetGenericArguments()[0];
+            var underlyingType = Nullable.GetUnderlyingType(elementType) ?? elementType;
+            var fieldTypeImplementsIList = fieldType.GetInterface("IList") != null;
+
+            var propertyValueAsIList = propertyValue as IList;
+
+            // Custom container
+            if (fieldTypeImplementsIList && !fieldType.IsArray)
+            {
+                newCollection = (IList)Activator.CreateInstance(fieldType)!;
+            }
+            // Array of known size is created immediately
+            else if (fieldType.IsArray && propertyValueAsIList != null)
+            {
+                newCollection = Array.CreateInstance(elementType, propertyValueAsIList.Count);
+            }
+            // List<T>
+            else
+            {
+                var genericListType = typeof(List<>).MakeGenericType(elementType);
+                newCollection = (IList)Activator.CreateInstance(genericListType)!;
+            }
+
+            if (propertyValue is not IEnumerable valueList)
+                throw new InvalidOperationException($"Cannot coerce collection of CLR type '{propertyValue.GetType().GetFriendlyName()}' to IEnumerable for graph type '{mappedType}'.");
+
+            // Array of known size is populated in-place
+            if (fieldType.IsArray && propertyValueAsIList != null)
+            {
+                for (int i = 0; i < propertyValueAsIList.Count; ++i)
+                {
+                    var listItem = propertyValueAsIList[i];
+                    newCollection[i] = listItem == null ? null : GetPropertyValue(listItem, underlyingType, itemGraphType);
+                }
+            }
+            // Array of unknown size is created only after populating list
+            else
+            {
+                foreach (var listItem in valueList)
+                {
+                    newCollection.Add(listItem == null ? null : GetPropertyValue(listItem, underlyingType, itemGraphType));
+                }
+
+                if (fieldType.IsArray)
+                    newCollection = ((dynamic)newCollection!).ToArray();
+            }
+
+            return newCollection;
+        }
+
+        var value = propertyValue;
+
+        var nullableFieldType = Nullable.GetUnderlyingType(fieldType);
+
+        // if this is a nullable type and the value is null, return null
+        if (nullableFieldType != null && value == null)
+        {
+            return null;
+        }
+
+        if (nullableFieldType != null)
+        {
+            fieldType = nullableFieldType;
+        }
+
+        if (propertyValue is IDictionary<string, object?> objects)
+        {
+            return ToObject(objects, fieldType, mappedType);
+        }
+
+        if (fieldType.IsEnum)
+        {
+            if (value == null)
+            {
+                var enumNames = Enum.GetNames(fieldType);
+                value = enumNames[0];
+            }
+
+            if (!IsDefinedEnumValue(fieldType, value))
+            {
+                throw new InvalidOperationException($"Unknown value '{value}' for enum '{fieldType.Name}'.");
+            }
+
+            string str = value.ToString()!;
+            value = Enum.Parse(fieldType, str, true);
+        }
+
+        return ValueConverter.ConvertTo(value, fieldType);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the value is <see langword="null"/>, value.ToString equals an empty string, or the value can be converted into a named enum value.
+    /// </summary>
+    /// <param name="type">An enum type.</param>
+    /// <param name="value">The value being tested.</param>
+    public static bool IsDefinedEnumValue(Type type, object? value) //TODO: rewrite, comment above seems wrong
+    {
+        try
+        {
+            var names = Enum.GetNames(type);
+            if (names.Contains(value?.ToString() ?? "", StringComparer.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var underlyingType = Enum.GetUnderlyingType(type);
+            var converted = Convert.ChangeType(value, underlyingType);
+
+            var values = Enum.GetValues(type);
+
+            foreach (var val in values)
+            {
+                var convertedVal = Convert.ChangeType(val, underlyingType);
+                if (convertedVal.Equals(converted))
                 {
                     return true;
                 }
-
-                var underlyingType = Enum.GetUnderlyingType(type);
-                var converted = Convert.ChangeType(value, underlyingType);
-
-                var values = Enum.GetValues(type);
-
-                foreach (var val in values)
-                {
-                    var convertedVal = Convert.ChangeType(val, underlyingType);
-                    if (convertedVal.Equals(converted))
-                    {
-                        return true;
-                    }
-                }
             }
-            catch
-            {
-                // TODO: refactor IsDefinedEnumValue
-            }
-
-            return false;
         }
+        catch
+        {
+            // TODO: refactor IsDefinedEnumValue
+        }
+
+        return false;
     }
 }

--- a/src/GraphQL/Extensions/SchemaExtensions.cs
+++ b/src/GraphQL/Extensions/SchemaExtensions.cs
@@ -6,449 +6,448 @@ using GraphQL.Utilities.Visitors;
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Provides extension methods for schemas.
+/// </summary>
+public static class SchemaExtensions
 {
     /// <summary>
-    /// Provides extension methods for schemas.
+    /// Adds the specified visitor type to the schema. When initializing a schema, all
+    /// registered visitors will be executed on each schema element when it is traversed.
     /// </summary>
-    public static class SchemaExtensions
+    public static void RegisterVisitor<TVisitor>(this ISchema schema)
+        where TVisitor : ISchemaNodeVisitor
     {
-        /// <summary>
-        /// Adds the specified visitor type to the schema. When initializing a schema, all
-        /// registered visitors will be executed on each schema element when it is traversed.
-        /// </summary>
-        public static void RegisterVisitor<TVisitor>(this ISchema schema)
-            where TVisitor : ISchemaNodeVisitor
+        schema.RegisterVisitor(typeof(TVisitor));
+    }
+
+    /// <summary>
+    /// Adds the specified graph type to the schema.
+    /// <br/><br/>
+    /// Not typically required as schema initialization will scan the <see cref="ISchema.Query"/>,
+    /// <see cref="ISchema.Mutation"/> and <see cref="ISchema.Subscription"/> graphs, creating
+    /// instances of <see cref="IGraphType"/>s referenced therein as necessary.
+    /// </summary>
+    public static void RegisterType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this ISchema schema)
+        where T : IGraphType
+    {
+        schema.RegisterType(typeof(T));
+    }
+
+    /// <summary>
+    /// Adds the specified graph types to the schema. Each type must implement <see cref="IGraphType"/>.
+    /// <br/><br/>
+    /// Not typically required as schema initialization will scan the <see cref="ISchema.Query"/>,
+    /// <see cref="ISchema.Mutation"/> and <see cref="ISchema.Subscription"/> graphs, creating
+    /// instances of <see cref="IGraphType"/>s referenced therein as necessary.
+    /// </summary>
+    [RequiresUnreferencedCode("Please ensure that the graph types' constructors are not trimmed by the compiler.")]
+    public static TSchema RegisterTypes<TSchema>(this TSchema schema, params Type[] types)
+        where TSchema : ISchema
+    {
+        if (types == null)
         {
-            schema.RegisterVisitor(typeof(TVisitor));
+            throw new ArgumentNullException(nameof(types));
         }
 
-        /// <summary>
-        /// Adds the specified graph type to the schema.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="ISchema.Query"/>,
-        /// <see cref="ISchema.Mutation"/> and <see cref="ISchema.Subscription"/> graphs, creating
-        /// instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        public static void RegisterType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this ISchema schema)
-            where T : IGraphType
+        foreach (var type in types)
         {
-            schema.RegisterType(typeof(T));
+            schema.RegisterType(type);
         }
 
-        /// <summary>
-        /// Adds the specified graph types to the schema. Each type must implement <see cref="IGraphType"/>.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="ISchema.Query"/>,
-        /// <see cref="ISchema.Mutation"/> and <see cref="ISchema.Subscription"/> graphs, creating
-        /// instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        [RequiresUnreferencedCode("Please ensure that the graph types' constructors are not trimmed by the compiler.")]
-        public static TSchema RegisterTypes<TSchema>(this TSchema schema, params Type[] types)
-            where TSchema : ISchema
-        {
-            if (types == null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
+        return schema;
+    }
 
-            foreach (var type in types)
-            {
-                schema.RegisterType(type);
-            }
+    /// <summary>
+    /// Adds the specified instances of <see cref="IGraphType"/>s to the schema.
+    /// <br/><br/>
+    /// Not typically required as schema initialization will scan the <see cref="ISchema.Query"/>,
+    /// <see cref="ISchema.Mutation"/> and <see cref="ISchema.Subscription"/> graphs, creating
+    /// instances of <see cref="IGraphType"/>s referenced therein as necessary.
+    /// </summary>
+    public static void RegisterTypes<TSchema>(this TSchema schema, params IGraphType[] types)
+        where TSchema : ISchema
+    {
+        foreach (var type in types)
+            schema.RegisterType(type);
+    }
 
-            return schema;
-        }
+    /// <summary>
+    /// Registers type mapping from CLR type to GraphType.
+    /// <br/>
+    /// These mappings are used for type inference when constructing fields using expressions:
+    /// <br/>
+    /// <c>
+    /// Field(x => x.Filters);
+    /// </c>
+    /// </summary>
+    /// <typeparam name="TClrType">The CLR property type from which to infer the GraphType.</typeparam>
+    /// <typeparam name="TGraphType">Inferred GraphType.</typeparam>
+    public static void RegisterTypeMapping<TClrType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(this ISchema schema)
+        where TGraphType : IGraphType
+    {
+        Preserve<GraphQLClrInputTypeReference<TClrType>>();
+        Preserve<GraphQLClrOutputTypeReference<TClrType>>();
+        schema.RegisterTypeMapping(typeof(TClrType), typeof(TGraphType));
+    }
 
-        /// <summary>
-        /// Adds the specified instances of <see cref="IGraphType"/>s to the schema.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="ISchema.Query"/>,
-        /// <see cref="ISchema.Mutation"/> and <see cref="ISchema.Subscription"/> graphs, creating
-        /// instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        public static void RegisterTypes<TSchema>(this TSchema schema, params IGraphType[] types)
-            where TSchema : ISchema
-        {
-            foreach (var type in types)
-                schema.RegisterType(type);
-        }
+    /// <summary>
+    /// Prevents <typeparamref name="T"/> from being trimmed by the linker.
+    /// </summary>
+    private static void Preserve<T>() => GC.KeepAlive(typeof(T));
 
-        /// <summary>
-        /// Registers type mapping from CLR type to GraphType.
-        /// <br/>
-        /// These mappings are used for type inference when constructing fields using expressions:
-        /// <br/>
-        /// <c>
-        /// Field(x => x.Filters);
-        /// </c>
-        /// </summary>
-        /// <typeparam name="TClrType">The CLR property type from which to infer the GraphType.</typeparam>
-        /// <typeparam name="TGraphType">Inferred GraphType.</typeparam>
-        public static void RegisterTypeMapping<TClrType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(this ISchema schema)
-            where TGraphType : IGraphType
-        {
-            Preserve<GraphQLClrInputTypeReference<TClrType>>();
-            Preserve<GraphQLClrOutputTypeReference<TClrType>>();
-            schema.RegisterTypeMapping(typeof(TClrType), typeof(TGraphType));
-        }
-
-        /// <summary>
-        /// Prevents <typeparamref name="T"/> from being trimmed by the linker.
-        /// </summary>
-        private static void Preserve<T>() => GC.KeepAlive(typeof(T));
-
-        /// <summary>
-        /// Prints the schema to a string using the specified options.
-        /// </summary>
-        public static string Print(this ISchema schema, PrintOptions? options = null)
-        {
-            using var writer = new StringWriter();
+    /// <summary>
+    /// Prints the schema to a string using the specified options.
+    /// </summary>
+    public static string Print(this ISchema schema, PrintOptions? options = null)
+    {
+        using var writer = new StringWriter();
 #pragma warning disable CA2012 // Use ValueTasks correctly
-            schema.PrintAsync(writer, options).GetAwaiter().GetResult();
+        schema.PrintAsync(writer, options).GetAwaiter().GetResult();
 #pragma warning restore CA2012 // Use ValueTasks correctly
-            return writer.ToString();
-        }
-
-        /// <summary>
-        /// Prints the schema to a specified <see cref="TextWriter"/>.
-        /// </summary>
-        public static ValueTask PrintAsync(this ISchema schema, TextWriter writer, PrintOptions? options = null, CancellationToken cancellationToken = default)
-        {
-            var sdl = schema.ToAST();
-            options ??= new();
-            if (!options.IncludeDeprecationReasons)
-            {
-                RemoveDeprecationReasonsVisitor.Visit(sdl);
-            }
-            if (!options.IncludeDescriptions)
-            {
-                RemoveDescriptionsVisitor.Visit(sdl);
-            }
-            if (!options.IncludeFederationTypes)
-            {
-                RemoveFederationTypesVisitor.Visit(sdl);
-            }
-            if (options.StringComparison != null)
-            {
-                SDLSorter.Sort(sdl, new(options.StringComparison.Value));
-            }
-            var printer = new SDLPrinter(options);
-            return printer.PrintAsync(sdl, writer, cancellationToken);
-        }
-
-        /// <summary>
-        /// Registers type mapping from CLR type to <see cref="AutoRegisteringObjectGraphType{T}"/> and/or <see cref="AutoRegisteringInputObjectGraphType{T}"/>.
-        /// <br/>
-        /// These mappings are used for type inference when constructing fields using expressions:
-        /// <br/>
-        /// <c>
-        /// Field(x => x.Filters);
-        /// </c>
-        /// </summary>
-        /// <param name="schema">The schema for which the mapping is registered.</param>
-        /// <param name="clrType">The CLR property type from which to infer the GraphType.</param>
-        /// <param name="mode">Which registering mode to use - input only, output only or both.</param>
-        [RequiresUnreferencedCode("Please ensure that the CLR type and the related auto-registering graph type are not trimmed by the compiler.")]
-        public static void AutoRegister(this ISchema schema, Type clrType, AutoRegisteringMode mode = AutoRegisteringMode.Both)
-        {
-            if (mode.HasFlag(AutoRegisteringMode.Output))
-                schema.RegisterTypeMapping(clrType, typeof(AutoRegisteringObjectGraphType<>).MakeGenericType(clrType));
-            if (mode.HasFlag(AutoRegisteringMode.Input))
-                schema.RegisterTypeMapping(clrType, typeof(AutoRegisteringInputObjectGraphType<>).MakeGenericType(clrType));
-        }
-
-        /// <summary>
-        /// Registers type mapping from CLR type to <see cref="AutoRegisteringObjectGraphType{T}"/> and/or <see cref="AutoRegisteringInputObjectGraphType{T}"/>.
-        /// <br/>
-        /// These mappings are used for type inference when constructing fields using expressions:
-        /// <br/>
-        /// <c>
-        /// Field(x => x.Filters);
-        /// </c>
-        /// </summary>
-        /// <param name="schema">The schema for which the mapping is registered.</param>
-        /// <typeparam name="TClrType">The CLR property type from which to infer the GraphType.</typeparam>
-        /// <param name="mode">Which registering mode to use - input only, output only or both.</param>
-        public static void AutoRegister<TClrType>(this ISchema schema, AutoRegisteringMode mode = AutoRegisteringMode.Both)
-        {
-            if (mode.HasFlag(AutoRegisteringMode.Output))
-                schema.RegisterTypeMapping<TClrType, AutoRegisteringObjectGraphType<TClrType>>();
-            if (mode.HasFlag(AutoRegisteringMode.Input))
-                schema.RegisterTypeMapping<TClrType, AutoRegisteringInputObjectGraphType<TClrType>>();
-        }
-
-        /// <summary>
-        /// Scans the calling assembly for classes that inherit from <see cref="ObjectGraphType{TSourceType}"/>,
-        /// <see cref="InputObjectGraphType{TSourceType}"/>, or <see cref="EnumerationGraphType{TEnum}"/>, and
-        /// registers clr type mappings on the schema between that class and the source type or underlying enum type.
-        /// Skips classes where the source type is <see cref="object"/>, or where the class is marked with
-        /// the <see cref="DoNotMapClrTypeAttribute"/>.
-        /// </summary>
-        /// <remarks>
-        /// This method uses reflection and therefor is inheritly slow, especially with a large assembly.
-        /// When using a scoped schema, it is faster to call
-        /// <see cref="GraphQLBuilderExtensions.AddClrTypeMappings(DI.IGraphQLBuilder)"/> as it will precompute
-        /// the mappings prior to execution.
-        /// </remarks>
-        [RequiresUnreferencedCode("Please ensure that the graph types used by your schema and their constructors are not trimmed by the compiler.")]
-        public static void RegisterTypeMappings(this ISchema schema)
-            => schema.RegisterTypeMappings(Assembly.GetCallingAssembly());
-
-        /// <summary>
-        /// Scans the specified assembly for classes that inherit from <see cref="ObjectGraphType{TSourceType}"/>,
-        /// <see cref="InputObjectGraphType{TSourceType}"/>, or <see cref="EnumerationGraphType{TEnum}"/>, and
-        /// registers clr type mappings on the schema between that class and the source type or underlying enum type.
-        /// Skips classes where the source type is <see cref="object"/>, or where the class is marked with
-        /// the <see cref="DoNotMapClrTypeAttribute"/>.
-        /// </summary>
-        /// <remarks>
-        /// This method uses reflection and therefor is inheritly slow, especially with a large assembly.
-        /// When using a scoped schema, it is faster to call
-        /// <see cref="GraphQLBuilderExtensions.AddClrTypeMappings(DI.IGraphQLBuilder, Assembly)"/> as it will
-        /// precompute the mappings prior to execution.
-        /// </remarks>
-        [RequiresUnreferencedCode("Please ensure that the graph types used by your schema and their constructors are not trimmed by the compiler.")]
-        public static void RegisterTypeMappings(this ISchema schema, Assembly assembly)
-        {
-            if (assembly == null)
-                throw new ArgumentNullException(nameof(assembly));
-
-            foreach (var typeMapping in assembly.GetClrTypeMappings())
-            {
-                schema.RegisterTypeMapping(typeMapping.ClrType, typeMapping.GraphType);
-            }
-        }
-
-        /// <summary>
-        /// Enables some experimental features that are not in the official specification, i.e. ability to expose
-        /// user-defined meta-information via introspection. See https://github.com/graphql/graphql-spec/issues/300
-        /// for more information. This method must be called before schema initialization.
-        /// <br/><br/>
-        /// Keep in mind that the implementation of experimental features can change over time, up to their complete
-        /// removal, if the official specification is supplemented with all the missing features.
-        /// </summary>
-        /// <typeparam name="TSchema">Type of the schema.</typeparam>
-        /// <param name="schema">The schema for which the features are enabled.</param>
-        /// <param name="mode">Experimental features mode.</param>
-        /// <returns>Reference to the provided <paramref name="schema"/>.</returns>
-        public static TSchema EnableExperimentalIntrospectionFeatures<TSchema>(this TSchema schema, ExperimentalIntrospectionFeaturesMode mode = ExperimentalIntrospectionFeaturesMode.ExecutionOnly)
-            where TSchema : ISchema
-        {
-            if (schema.Initialized)
-                throw new InvalidOperationException("Schema is already initialized");
-
-            schema.Features.AppliedDirectives = true;
-            schema.Features.RepeatableDirectives = true;
-            schema.Features.DeprecationOfInputValues = true;
-
-            if (mode == ExperimentalIntrospectionFeaturesMode.IntrospectionAndExecution)
-                schema.Filter = new ExperimentalIntrospectionFeaturesSchemaFilter();
-
-            return schema;
-        }
-
-        /// <summary>
-        /// Executes a GraphQL request with the default <see cref="DocumentExecuter"/>, serializes the result using the specified <see cref="IGraphQLTextSerializer"/>, and returns the result
-        /// </summary>
-        /// <param name="schema">An instance of <see cref="ISchema"/> to use to execute the query</param>
-        /// <param name="serializer">An instance of <see cref="IGraphQLTextSerializer"/> to use to serialize the result</param>
-        /// <param name="configure">A delegate which configures the execution options</param>
-        public static async Task<string> ExecuteAsync(this ISchema schema, IGraphQLTextSerializer serializer, Action<ExecutionOptions> configure)
-        {
-            if (configure == null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
-
-            var executor = new DocumentExecuter();
-            var result = await executor.ExecuteAsync(options =>
-            {
-                options.Schema = schema;
-                configure(options);
-            }).ConfigureAwait(false);
-
-            return serializer.Serialize(result);
-        }
-
-        /// <summary>
-        /// Runs the specified visitor on the specified schema. This method traverses
-        /// all the schema elements and calls the appropriate visitor methods.
-        /// </summary>
-        public static void Run(this ISchemaNodeVisitor visitor, ISchema schema)
-        {
-            visitor.VisitSchema(schema);
-
-            foreach (var directive in schema.Directives.List)
-            {
-                visitor.VisitDirective(directive, schema);
-
-                if (directive.Arguments?.Count > 0)
-                {
-                    foreach (var argument in directive.Arguments.List!)
-                        visitor.VisitDirectiveArgumentDefinition(argument, directive, schema);
-                }
-            }
-
-            foreach (var item in schema.AllTypes.Dictionary)
-            {
-                switch (item.Value)
-                {
-                    case EnumerationGraphType e:
-                        visitor.VisitEnum(e, schema);
-                        foreach (var value in e.Values) //ISSUE:allocation
-                            visitor.VisitEnumValue(value, e, schema);
-                        break;
-
-                    case ScalarGraphType scalar:
-                        visitor.VisitScalar(scalar, schema);
-                        break;
-
-                    case UnionGraphType union:
-                        visitor.VisitUnion(union, schema);
-                        break;
-
-                    case IInterfaceGraphType iface:
-                        visitor.VisitInterface(iface, schema);
-                        foreach (var field in iface.Fields.List) // List is always non-null
-                        {
-                            visitor.VisitInterfaceFieldDefinition(field, iface, schema);
-                            if (field.Arguments?.Count > 0)
-                            {
-                                foreach (var argument in field.Arguments.List!)
-                                    visitor.VisitInterfaceFieldArgumentDefinition(argument, field, iface, schema);
-                            }
-                        }
-                        break;
-
-                    case IObjectGraphType output:
-                        visitor.VisitObject(output, schema);
-                        foreach (var field in output.Fields.List) // List is always non-null
-                        {
-                            visitor.VisitObjectFieldDefinition(field, output, schema);
-                            if (field.Arguments?.Count > 0)
-                            {
-                                foreach (var argument in field.Arguments.List!)
-                                    visitor.VisitObjectFieldArgumentDefinition(argument, field, output, schema);
-                            }
-                        }
-                        break;
-
-                    case IInputObjectGraphType input:
-                        visitor.VisitInputObject(input, schema);
-                        foreach (var field in input.Fields.List) // List is always non-null
-                            visitor.VisitInputObjectFieldDefinition(field, input, schema);
-                        break;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Replaces one scalar in the schema to another with the same name.
-        /// </summary>
-        /// <typeparam name="TSchema">Type of the schema.</typeparam>
-        /// <param name="schema">The schema for which to replace the scalar.</param>
-        /// <param name="scalar">New scalar. The replacement occurs by its name.</param>
-        /// <returns>Reference to the provided <paramref name="schema"/>.</returns>
-        public static TSchema ReplaceScalar<TSchema>(this TSchema schema, ScalarGraphType scalar)
-            where TSchema : ISchema
-        {
-            new ReplaceScalarVisitor(scalar).Run(schema);
-            return schema;
-        }
-
-        private sealed class ReplaceScalarVisitor : BaseSchemaNodeVisitor
-        {
-            private readonly ScalarGraphType _replacement;
-
-            public ReplaceScalarVisitor(ScalarGraphType replacement)
-            {
-                _replacement = replacement ?? throw new ArgumentNullException(nameof(replacement));
-            }
-
-            public override void VisitSchema(ISchema schema)
-            {
-                if (schema.AllTypes.Dictionary.TryGetValue(_replacement.Name, out var type))
-                {
-                    schema.AllTypes.Dictionary[_replacement.Name] = type is ScalarGraphType
-                        ? _replacement
-                        : throw new InvalidOperationException($"The scalar should be replaced only by another scalar. You are trying to replace non scalar type '{type.GetType().Name}' with name '{type.Name}' to scalar type '{_replacement.GetType().Name}'.");
-                }
-            }
-
-            public override void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema) => Replace(argument);
-
-            public override void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema) => Replace(field);
-
-            public override void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema) => Replace(argument);
-
-            public override void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema) => Replace(field);
-
-            public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema) => Replace(argument);
-
-            public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema) => Replace(field);
-
-            private void Replace(IProvideResolvedType provider)
-            {
-                if (provider.ResolvedType is IProvideResolvedType wrappedProvider)
-                    Replace(wrappedProvider);
-                else if (provider.ResolvedType is ScalarGraphType scalar && scalar.Name == _replacement.Name)
-                    provider.ResolvedType = _replacement;
-            }
-        }
-
-
-        /// <summary>
-        /// Exports the specified schema as a <see cref="GraphQLDocument"/>.
-        /// </summary>
-        public static GraphQLDocument ToAST(this ISchema schema)
-            => new SchemaExporter(schema).Export();
+        return writer.ToString();
     }
 
     /// <summary>
-    /// A way to use experimental features.
+    /// Prints the schema to a specified <see cref="TextWriter"/>.
     /// </summary>
-    public enum ExperimentalIntrospectionFeaturesMode
+    public static ValueTask PrintAsync(this ISchema schema, TextWriter writer, PrintOptions? options = null, CancellationToken cancellationToken = default)
     {
-        /// <summary>
-        /// Allow experimental features only for client queries but not for standard introspection
-        /// request. This means that the client, in response to a standard introspection request,
-        /// receives a standard response without any new fields and types. However, client CAN
-        /// make requests to the server using the new fields and types. This mode is needed in order
-        /// to bypass the problem of tools such as GraphQL Playground, Voyager, GraphiQL that require
-        /// a standard response to an introspection request and refuse to work correctly if there are
-        /// any unknown fields or types in the response.
-        /// </summary>
-        ExecutionOnly,
-
-        /// <summary>
-        /// Allow experimental features for both standard introspection query and client queries.
-        /// This means that the client, in response to a standard introspection request, receives
-        /// a response augmented with the new fields and types. Client can make requests to the
-        /// server using the new fields and types.
-        /// </summary>
-        IntrospectionAndExecution
+        var sdl = schema.ToAST();
+        options ??= new();
+        if (!options.IncludeDeprecationReasons)
+        {
+            RemoveDeprecationReasonsVisitor.Visit(sdl);
+        }
+        if (!options.IncludeDescriptions)
+        {
+            RemoveDescriptionsVisitor.Visit(sdl);
+        }
+        if (!options.IncludeFederationTypes)
+        {
+            RemoveFederationTypesVisitor.Visit(sdl);
+        }
+        if (options.StringComparison != null)
+        {
+            SDLSorter.Sort(sdl, new(options.StringComparison.Value));
+        }
+        var printer = new SDLPrinter(options);
+        return printer.PrintAsync(sdl, writer, cancellationToken);
     }
 
     /// <summary>
-    /// Mode used for <see cref="SchemaExtensions.AutoRegister"/> method.
+    /// Registers type mapping from CLR type to <see cref="AutoRegisteringObjectGraphType{T}"/> and/or <see cref="AutoRegisteringInputObjectGraphType{T}"/>.
+    /// <br/>
+    /// These mappings are used for type inference when constructing fields using expressions:
+    /// <br/>
+    /// <c>
+    /// Field(x => x.Filters);
+    /// </c>
     /// </summary>
-    [Flags]
-    public enum AutoRegisteringMode
+    /// <param name="schema">The schema for which the mapping is registered.</param>
+    /// <param name="clrType">The CLR property type from which to infer the GraphType.</param>
+    /// <param name="mode">Which registering mode to use - input only, output only or both.</param>
+    [RequiresUnreferencedCode("Please ensure that the CLR type and the related auto-registering graph type are not trimmed by the compiler.")]
+    public static void AutoRegister(this ISchema schema, Type clrType, AutoRegisteringMode mode = AutoRegisteringMode.Both)
     {
-        /// <summary>
-        /// Register only input type mapping.
-        /// </summary>
-        Input = 1,
-
-        /// <summary>
-        /// Register only output type mapping.
-        /// </summary>
-        Output = 2,
-
-        /// <summary>
-        /// Register both input and output type mappings.
-        /// </summary>
-        Both = Input | Output,
+        if (mode.HasFlag(AutoRegisteringMode.Output))
+            schema.RegisterTypeMapping(clrType, typeof(AutoRegisteringObjectGraphType<>).MakeGenericType(clrType));
+        if (mode.HasFlag(AutoRegisteringMode.Input))
+            schema.RegisterTypeMapping(clrType, typeof(AutoRegisteringInputObjectGraphType<>).MakeGenericType(clrType));
     }
+
+    /// <summary>
+    /// Registers type mapping from CLR type to <see cref="AutoRegisteringObjectGraphType{T}"/> and/or <see cref="AutoRegisteringInputObjectGraphType{T}"/>.
+    /// <br/>
+    /// These mappings are used for type inference when constructing fields using expressions:
+    /// <br/>
+    /// <c>
+    /// Field(x => x.Filters);
+    /// </c>
+    /// </summary>
+    /// <param name="schema">The schema for which the mapping is registered.</param>
+    /// <typeparam name="TClrType">The CLR property type from which to infer the GraphType.</typeparam>
+    /// <param name="mode">Which registering mode to use - input only, output only or both.</param>
+    public static void AutoRegister<TClrType>(this ISchema schema, AutoRegisteringMode mode = AutoRegisteringMode.Both)
+    {
+        if (mode.HasFlag(AutoRegisteringMode.Output))
+            schema.RegisterTypeMapping<TClrType, AutoRegisteringObjectGraphType<TClrType>>();
+        if (mode.HasFlag(AutoRegisteringMode.Input))
+            schema.RegisterTypeMapping<TClrType, AutoRegisteringInputObjectGraphType<TClrType>>();
+    }
+
+    /// <summary>
+    /// Scans the calling assembly for classes that inherit from <see cref="ObjectGraphType{TSourceType}"/>,
+    /// <see cref="InputObjectGraphType{TSourceType}"/>, or <see cref="EnumerationGraphType{TEnum}"/>, and
+    /// registers clr type mappings on the schema between that class and the source type or underlying enum type.
+    /// Skips classes where the source type is <see cref="object"/>, or where the class is marked with
+    /// the <see cref="DoNotMapClrTypeAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method uses reflection and therefor is inheritly slow, especially with a large assembly.
+    /// When using a scoped schema, it is faster to call
+    /// <see cref="GraphQLBuilderExtensions.AddClrTypeMappings(DI.IGraphQLBuilder)"/> as it will precompute
+    /// the mappings prior to execution.
+    /// </remarks>
+    [RequiresUnreferencedCode("Please ensure that the graph types used by your schema and their constructors are not trimmed by the compiler.")]
+    public static void RegisterTypeMappings(this ISchema schema)
+        => schema.RegisterTypeMappings(Assembly.GetCallingAssembly());
+
+    /// <summary>
+    /// Scans the specified assembly for classes that inherit from <see cref="ObjectGraphType{TSourceType}"/>,
+    /// <see cref="InputObjectGraphType{TSourceType}"/>, or <see cref="EnumerationGraphType{TEnum}"/>, and
+    /// registers clr type mappings on the schema between that class and the source type or underlying enum type.
+    /// Skips classes where the source type is <see cref="object"/>, or where the class is marked with
+    /// the <see cref="DoNotMapClrTypeAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method uses reflection and therefor is inheritly slow, especially with a large assembly.
+    /// When using a scoped schema, it is faster to call
+    /// <see cref="GraphQLBuilderExtensions.AddClrTypeMappings(DI.IGraphQLBuilder, Assembly)"/> as it will
+    /// precompute the mappings prior to execution.
+    /// </remarks>
+    [RequiresUnreferencedCode("Please ensure that the graph types used by your schema and their constructors are not trimmed by the compiler.")]
+    public static void RegisterTypeMappings(this ISchema schema, Assembly assembly)
+    {
+        if (assembly == null)
+            throw new ArgumentNullException(nameof(assembly));
+
+        foreach (var typeMapping in assembly.GetClrTypeMappings())
+        {
+            schema.RegisterTypeMapping(typeMapping.ClrType, typeMapping.GraphType);
+        }
+    }
+
+    /// <summary>
+    /// Enables some experimental features that are not in the official specification, i.e. ability to expose
+    /// user-defined meta-information via introspection. See https://github.com/graphql/graphql-spec/issues/300
+    /// for more information. This method must be called before schema initialization.
+    /// <br/><br/>
+    /// Keep in mind that the implementation of experimental features can change over time, up to their complete
+    /// removal, if the official specification is supplemented with all the missing features.
+    /// </summary>
+    /// <typeparam name="TSchema">Type of the schema.</typeparam>
+    /// <param name="schema">The schema for which the features are enabled.</param>
+    /// <param name="mode">Experimental features mode.</param>
+    /// <returns>Reference to the provided <paramref name="schema"/>.</returns>
+    public static TSchema EnableExperimentalIntrospectionFeatures<TSchema>(this TSchema schema, ExperimentalIntrospectionFeaturesMode mode = ExperimentalIntrospectionFeaturesMode.ExecutionOnly)
+        where TSchema : ISchema
+    {
+        if (schema.Initialized)
+            throw new InvalidOperationException("Schema is already initialized");
+
+        schema.Features.AppliedDirectives = true;
+        schema.Features.RepeatableDirectives = true;
+        schema.Features.DeprecationOfInputValues = true;
+
+        if (mode == ExperimentalIntrospectionFeaturesMode.IntrospectionAndExecution)
+            schema.Filter = new ExperimentalIntrospectionFeaturesSchemaFilter();
+
+        return schema;
+    }
+
+    /// <summary>
+    /// Executes a GraphQL request with the default <see cref="DocumentExecuter"/>, serializes the result using the specified <see cref="IGraphQLTextSerializer"/>, and returns the result
+    /// </summary>
+    /// <param name="schema">An instance of <see cref="ISchema"/> to use to execute the query</param>
+    /// <param name="serializer">An instance of <see cref="IGraphQLTextSerializer"/> to use to serialize the result</param>
+    /// <param name="configure">A delegate which configures the execution options</param>
+    public static async Task<string> ExecuteAsync(this ISchema schema, IGraphQLTextSerializer serializer, Action<ExecutionOptions> configure)
+    {
+        if (configure == null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        var executor = new DocumentExecuter();
+        var result = await executor.ExecuteAsync(options =>
+        {
+            options.Schema = schema;
+            configure(options);
+        }).ConfigureAwait(false);
+
+        return serializer.Serialize(result);
+    }
+
+    /// <summary>
+    /// Runs the specified visitor on the specified schema. This method traverses
+    /// all the schema elements and calls the appropriate visitor methods.
+    /// </summary>
+    public static void Run(this ISchemaNodeVisitor visitor, ISchema schema)
+    {
+        visitor.VisitSchema(schema);
+
+        foreach (var directive in schema.Directives.List)
+        {
+            visitor.VisitDirective(directive, schema);
+
+            if (directive.Arguments?.Count > 0)
+            {
+                foreach (var argument in directive.Arguments.List!)
+                    visitor.VisitDirectiveArgumentDefinition(argument, directive, schema);
+            }
+        }
+
+        foreach (var item in schema.AllTypes.Dictionary)
+        {
+            switch (item.Value)
+            {
+                case EnumerationGraphType e:
+                    visitor.VisitEnum(e, schema);
+                    foreach (var value in e.Values) //ISSUE:allocation
+                        visitor.VisitEnumValue(value, e, schema);
+                    break;
+
+                case ScalarGraphType scalar:
+                    visitor.VisitScalar(scalar, schema);
+                    break;
+
+                case UnionGraphType union:
+                    visitor.VisitUnion(union, schema);
+                    break;
+
+                case IInterfaceGraphType iface:
+                    visitor.VisitInterface(iface, schema);
+                    foreach (var field in iface.Fields.List) // List is always non-null
+                    {
+                        visitor.VisitInterfaceFieldDefinition(field, iface, schema);
+                        if (field.Arguments?.Count > 0)
+                        {
+                            foreach (var argument in field.Arguments.List!)
+                                visitor.VisitInterfaceFieldArgumentDefinition(argument, field, iface, schema);
+                        }
+                    }
+                    break;
+
+                case IObjectGraphType output:
+                    visitor.VisitObject(output, schema);
+                    foreach (var field in output.Fields.List) // List is always non-null
+                    {
+                        visitor.VisitObjectFieldDefinition(field, output, schema);
+                        if (field.Arguments?.Count > 0)
+                        {
+                            foreach (var argument in field.Arguments.List!)
+                                visitor.VisitObjectFieldArgumentDefinition(argument, field, output, schema);
+                        }
+                    }
+                    break;
+
+                case IInputObjectGraphType input:
+                    visitor.VisitInputObject(input, schema);
+                    foreach (var field in input.Fields.List) // List is always non-null
+                        visitor.VisitInputObjectFieldDefinition(field, input, schema);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces one scalar in the schema to another with the same name.
+    /// </summary>
+    /// <typeparam name="TSchema">Type of the schema.</typeparam>
+    /// <param name="schema">The schema for which to replace the scalar.</param>
+    /// <param name="scalar">New scalar. The replacement occurs by its name.</param>
+    /// <returns>Reference to the provided <paramref name="schema"/>.</returns>
+    public static TSchema ReplaceScalar<TSchema>(this TSchema schema, ScalarGraphType scalar)
+        where TSchema : ISchema
+    {
+        new ReplaceScalarVisitor(scalar).Run(schema);
+        return schema;
+    }
+
+    private sealed class ReplaceScalarVisitor : BaseSchemaNodeVisitor
+    {
+        private readonly ScalarGraphType _replacement;
+
+        public ReplaceScalarVisitor(ScalarGraphType replacement)
+        {
+            _replacement = replacement ?? throw new ArgumentNullException(nameof(replacement));
+        }
+
+        public override void VisitSchema(ISchema schema)
+        {
+            if (schema.AllTypes.Dictionary.TryGetValue(_replacement.Name, out var type))
+            {
+                schema.AllTypes.Dictionary[_replacement.Name] = type is ScalarGraphType
+                    ? _replacement
+                    : throw new InvalidOperationException($"The scalar should be replaced only by another scalar. You are trying to replace non scalar type '{type.GetType().Name}' with name '{type.Name}' to scalar type '{_replacement.GetType().Name}'.");
+            }
+        }
+
+        public override void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema) => Replace(argument);
+
+        public override void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema) => Replace(field);
+
+        public override void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema) => Replace(argument);
+
+        public override void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema) => Replace(field);
+
+        public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema) => Replace(argument);
+
+        public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema) => Replace(field);
+
+        private void Replace(IProvideResolvedType provider)
+        {
+            if (provider.ResolvedType is IProvideResolvedType wrappedProvider)
+                Replace(wrappedProvider);
+            else if (provider.ResolvedType is ScalarGraphType scalar && scalar.Name == _replacement.Name)
+                provider.ResolvedType = _replacement;
+        }
+    }
+
+
+    /// <summary>
+    /// Exports the specified schema as a <see cref="GraphQLDocument"/>.
+    /// </summary>
+    public static GraphQLDocument ToAST(this ISchema schema)
+        => new SchemaExporter(schema).Export();
+}
+
+/// <summary>
+/// A way to use experimental features.
+/// </summary>
+public enum ExperimentalIntrospectionFeaturesMode
+{
+    /// <summary>
+    /// Allow experimental features only for client queries but not for standard introspection
+    /// request. This means that the client, in response to a standard introspection request,
+    /// receives a standard response without any new fields and types. However, client CAN
+    /// make requests to the server using the new fields and types. This mode is needed in order
+    /// to bypass the problem of tools such as GraphQL Playground, Voyager, GraphiQL that require
+    /// a standard response to an introspection request and refuse to work correctly if there are
+    /// any unknown fields or types in the response.
+    /// </summary>
+    ExecutionOnly,
+
+    /// <summary>
+    /// Allow experimental features for both standard introspection query and client queries.
+    /// This means that the client, in response to a standard introspection request, receives
+    /// a response augmented with the new fields and types. Client can make requests to the
+    /// server using the new fields and types.
+    /// </summary>
+    IntrospectionAndExecution
+}
+
+/// <summary>
+/// Mode used for <see cref="SchemaExtensions.AutoRegister"/> method.
+/// </summary>
+[Flags]
+public enum AutoRegisteringMode
+{
+    /// <summary>
+    /// Register only input type mapping.
+    /// </summary>
+    Input = 1,
+
+    /// <summary>
+    /// Register only output type mapping.
+    /// </summary>
+    Output = 2,
+
+    /// <summary>
+    /// Register both input and output type mappings.
+    /// </summary>
+    Both = Input | Output,
 }

--- a/src/GraphQL/Extensions/StringExtensions.cs
+++ b/src/GraphQL/Extensions/StringExtensions.cs
@@ -1,123 +1,122 @@
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Provides extension methods for strings.
+/// </summary>
+public static class StringExtensions
 {
     /// <summary>
-    /// Provides extension methods for strings.
+    /// Equivalent to String.Format.
     /// </summary>
-    public static class StringExtensions
+    /// <param name="format">The format string in String.Format style.</param>
+    /// <param name="args">The arguments.</param>
+    internal static string ToFormat(this string format, params object?[] args) //TODO: remove in v5
+        => string.Format(format, args);
+
+    /// <summary>
+    /// Returns a camel case version of the string.
+    /// </summary>
+    /// <param name="s">The source string.</param>
+    /// <returns>System.String.</returns>
+    public static string ToCamelCase(this string s)
     {
-        /// <summary>
-        /// Equivalent to String.Format.
-        /// </summary>
-        /// <param name="format">The format string in String.Format style.</param>
-        /// <param name="args">The arguments.</param>
-        internal static string ToFormat(this string format, params object?[] args) //TODO: remove in v5
-            => string.Format(format, args);
-
-        /// <summary>
-        /// Returns a camel case version of the string.
-        /// </summary>
-        /// <param name="s">The source string.</param>
-        /// <returns>System.String.</returns>
-        public static string ToCamelCase(this string s)
+        if (string.IsNullOrWhiteSpace(s))
         {
-            if (string.IsNullOrWhiteSpace(s))
-            {
-                return string.Empty;
-            }
-
-            var newFirstLetter = char.ToLowerInvariant(s[0]);
-            if (newFirstLetter == s[0])
-                return s;
-
-            return s.Length <= 256
-                ? FastChangeFirstLetter(newFirstLetter, s)
-                : newFirstLetter + s.Substring(1);
+            return string.Empty;
         }
 
-        /// <summary>
-        /// Returns a pascal case version of the string.
-        /// </summary>
-        /// <param name="s">The source string.</param>
-        /// <returns>System.String.</returns>
-        public static string ToPascalCase(this string s)
-        {
-            if (string.IsNullOrWhiteSpace(s))
-            {
-                return string.Empty;
-            }
+        var newFirstLetter = char.ToLowerInvariant(s[0]);
+        if (newFirstLetter == s[0])
+            return s;
 
-            var newFirstLetter = char.ToUpperInvariant(s[0]);
-            if (newFirstLetter == s[0])
-                return s;
-
-            return s.Length <= 256
-               ? FastChangeFirstLetter(newFirstLetter, s)
-               : newFirstLetter + s.Substring(1);
-        }
-
-        private static string FastChangeFirstLetter(char newFirstLetter, string s)
-        {
-            Span<char> buffer = stackalloc char[s.Length];
-            buffer[0] = newFirstLetter;
-            s.AsSpan().Slice(1).CopyTo(buffer.Slice(1));
-            return buffer.ToString();
-        }
-
-        /// <summary>
-        /// Returns a constant case version of this string. For example, converts 'StringError' into 'STRING_ERROR'.
-        /// </summary>
-        public static string ToConstantCase(this string value) //TODO: rewrite to stackalloc/ string.Create()
-        {
-            int i;
-            int strLength = value.Length;
-            // iterate through each character in the string, stopping a character short of the end
-            for (i = 0; i < strLength - 1; ++i)
-            {
-                var curChar = value[i];
-                var nextChar = value[i + 1];
-                // look for the pattern [a-z][A-Z]
-                if (char.IsLower(curChar) && char.IsUpper(nextChar))
-                {
-                    InsertUnderscore();
-                    // then skip the remaining match checks since we already found a match here
-                    continue;
-                }
-                // look for the pattern [0-9][A-Za-z]
-                if (char.IsDigit(curChar) && char.IsLetter(nextChar))
-                {
-                    InsertUnderscore();
-                    continue;
-                }
-                // look for the pattern [A-Za-z][0-9]
-                if (char.IsLetter(curChar) && char.IsDigit(nextChar))
-                {
-                    InsertUnderscore();
-                    continue;
-                }
-                // if there's enough characters left, look for the pattern [A-Z][A-Z][a-z]
-                if (i < strLength - 2 && char.IsUpper(curChar) && char.IsUpper(nextChar) && char.IsLower(value[i + 2]))
-                {
-                    InsertUnderscore();
-                    continue;
-                }
-            }
-            // convert the resulting string to uppercase
-            return value.ToUpperInvariant();
-
-            void InsertUnderscore()
-            {
-                // add an underscore between the two characters, increment i to skip the underscore, and increase strLength because the string is longer now
-                value = value.Substring(0, ++i) + '_' + value.Substring(i);
-                ++strLength;
-            }
-        }
-
-        private static readonly char[] _bangs = new char[] { '!', '[', ']' };
-
-        /// <summary>
-        /// Removes brackets and exclamation points from a GraphQL type name -- for example,
-        /// converts <c>[Int!]</c> to <c>Int</c>
-        /// </summary>
-        public static string TrimGraphQLTypes(this string name) => name.Trim().Trim(_bangs);
+        return s.Length <= 256
+            ? FastChangeFirstLetter(newFirstLetter, s)
+            : newFirstLetter + s.Substring(1);
     }
+
+    /// <summary>
+    /// Returns a pascal case version of the string.
+    /// </summary>
+    /// <param name="s">The source string.</param>
+    /// <returns>System.String.</returns>
+    public static string ToPascalCase(this string s)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            return string.Empty;
+        }
+
+        var newFirstLetter = char.ToUpperInvariant(s[0]);
+        if (newFirstLetter == s[0])
+            return s;
+
+        return s.Length <= 256
+           ? FastChangeFirstLetter(newFirstLetter, s)
+           : newFirstLetter + s.Substring(1);
+    }
+
+    private static string FastChangeFirstLetter(char newFirstLetter, string s)
+    {
+        Span<char> buffer = stackalloc char[s.Length];
+        buffer[0] = newFirstLetter;
+        s.AsSpan().Slice(1).CopyTo(buffer.Slice(1));
+        return buffer.ToString();
+    }
+
+    /// <summary>
+    /// Returns a constant case version of this string. For example, converts 'StringError' into 'STRING_ERROR'.
+    /// </summary>
+    public static string ToConstantCase(this string value) //TODO: rewrite to stackalloc/ string.Create()
+    {
+        int i;
+        int strLength = value.Length;
+        // iterate through each character in the string, stopping a character short of the end
+        for (i = 0; i < strLength - 1; ++i)
+        {
+            var curChar = value[i];
+            var nextChar = value[i + 1];
+            // look for the pattern [a-z][A-Z]
+            if (char.IsLower(curChar) && char.IsUpper(nextChar))
+            {
+                InsertUnderscore();
+                // then skip the remaining match checks since we already found a match here
+                continue;
+            }
+            // look for the pattern [0-9][A-Za-z]
+            if (char.IsDigit(curChar) && char.IsLetter(nextChar))
+            {
+                InsertUnderscore();
+                continue;
+            }
+            // look for the pattern [A-Za-z][0-9]
+            if (char.IsLetter(curChar) && char.IsDigit(nextChar))
+            {
+                InsertUnderscore();
+                continue;
+            }
+            // if there's enough characters left, look for the pattern [A-Z][A-Z][a-z]
+            if (i < strLength - 2 && char.IsUpper(curChar) && char.IsUpper(nextChar) && char.IsLower(value[i + 2]))
+            {
+                InsertUnderscore();
+                continue;
+            }
+        }
+        // convert the resulting string to uppercase
+        return value.ToUpperInvariant();
+
+        void InsertUnderscore()
+        {
+            // add an underscore between the two characters, increment i to skip the underscore, and increase strLength because the string is longer now
+            value = value.Substring(0, ++i) + '_' + value.Substring(i);
+            ++strLength;
+        }
+    }
+
+    private static readonly char[] _bangs = new char[] { '!', '[', ']' };
+
+    /// <summary>
+    /// Removes brackets and exclamation points from a GraphQL type name -- for example,
+    /// converts <c>[Int!]</c> to <c>Int</c>
+    /// </summary>
+    public static string TrimGraphQLTypes(this string name) => name.Trim().Trim(_bangs);
 }

--- a/src/GraphQL/Extensions/TypeExtensions.cs
+++ b/src/GraphQL/Extensions/TypeExtensions.cs
@@ -6,462 +6,461 @@ using GraphQL.DataLoader;
 using GraphQL.Types;
 using GraphQL.Utilities;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Provides extension methods for types.
+/// </summary>
+public static class TypeExtensions
 {
     /// <summary>
-    /// Provides extension methods for types.
+    /// Determines whether the indicated type implements IGraphType.
     /// </summary>
-    public static class TypeExtensions
+    /// <param name="type">The type.</param>
+    /// <returns>
+    ///   <see langword="true"/> if the indicated type implements IGraphType; otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool IsGraphType(this Type type)
+        => typeof(IGraphType).IsAssignableFrom(type);
+
+    /// <summary>
+    /// Determines if the specified type represents a named graph type (not a wrapper type such as <see cref="ListGraphType"/>).
+    /// </summary>
+    internal static bool IsNamedType(this Type type)
     {
-        /// <summary>
-        /// Determines whether the indicated type implements IGraphType.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>
-        ///   <see langword="true"/> if the indicated type implements IGraphType; otherwise, <see langword="false"/>.
-        /// </returns>
-        public static bool IsGraphType(this Type type)
-            => typeof(IGraphType).IsAssignableFrom(type);
-
-        /// <summary>
-        /// Determines if the specified type represents a named graph type (not a wrapper type such as <see cref="ListGraphType"/>).
-        /// </summary>
-        internal static bool IsNamedType(this Type type)
+        if (!IsGraphType(type))
+            return false;
+        if (type.IsGenericType)
         {
-            if (!IsGraphType(type))
-                return false;
-            if (type.IsGenericType)
-            {
-                var genericType = type.GetGenericTypeDefinition();
-                if (genericType == typeof(NonNullGraphType<>) ||
-                    genericType == typeof(ListGraphType<>))
-                {
-                    return false;
-                }
-            }
-            else if (type == typeof(NonNullGraphType) || type == typeof(ListGraphType))
+            var genericType = type.GetGenericTypeDefinition();
+            if (genericType == typeof(NonNullGraphType<>) ||
+                genericType == typeof(ListGraphType<>))
             {
                 return false;
             }
-
-            return true;
         }
-
-        /// <summary>
-        /// Gets the GraphQL name of the type. This is derived from the type name and can
-        /// be overridden by the <see cref="GraphQLMetadataAttribute"/>. The name is chosen
-        /// depending on <see cref="GlobalSwitches.UseLegacyTypeNaming"/>.
-        /// </summary>
-        /// <param name="type">The indicated type.</param>
-        /// <returns>A string containing a GraphQL compatible type name.</returns>
-        public static string GraphQLName(this Type type)
+        else if (type == typeof(NonNullGraphType) || type == typeof(ListGraphType))
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (!GlobalSwitches.UseLegacyTypeNaming)
-#pragma warning restore CS0618 // Type or member is obsolete
-            {
-                return NameOf(type)
-                    .Replace('@', '_'); // F# anonymous class support
-
-                static string NameOf(Type type)
-                {
-                    type = type.GetNamedType();
-
-                    if (!typeof(IGraphType).IsAssignableFrom(type))
-                    {
-                        var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
-                        if (!string.IsNullOrEmpty(attr?.Name))
-                        {
-                            return attr!.Name!;
-                        }
-                    }
-
-                    var name = type.Name;
-
-                    if (type.IsGenericType)
-                        name = name.Substring(0, name.IndexOf('`'));
-
-                    if (name != "GraphType" && name != "Type")
-                    {
-                        if (name.EndsWith("GraphType", StringComparison.Ordinal))
-                        {
-                            name = name.Substring(0, name.Length - "GraphType".Length);
-                        }
-                        else if (name.EndsWith("Type", StringComparison.Ordinal))
-                        {
-                            name = name.Substring(0, name.Length - "Type".Length);
-                        }
-                    }
-
-                    if (GlobalSwitches.UseDeclaringTypeNames)
-                    {
-                        var parent = type.DeclaringType;
-                        while (parent != null)
-                        {
-                            name = $"{parent.Name}_{name}";
-                            parent = parent.DeclaringType;
-                        }
-                    }
-
-                    if (!type.IsGenericType)
-                        return name;
-                    var sb = new StringBuilder();
-                    foreach (var arg in type.GetGenericArguments())
-                    {
-                        sb.Append(NameOf(arg));
-                    }
-                    sb.Append(name);
-                    return sb.ToString();
-                }
-            }
-
-            type = type.GetNamedType();
-
-            var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
-
-            if (!string.IsNullOrEmpty(attr?.Name))
-            {
-                return attr!.Name!;
-            }
-
-            var typeName = type.Name;
-
-            if (type.IsGenericType)
-            {
-                typeName = typeName.Substring(0, typeName.IndexOf('`'));
-            }
-
-            if (typeName == nameof(GraphType) || typeName == nameof(Type))
-                return typeName;
-
-            typeName = typeName.Replace(nameof(GraphType), nameof(Type));
-
-            return typeName.EndsWith(nameof(Type), StringComparison.InvariantCulture)
-                ? typeName.Remove(typeName.Length - nameof(Type).Length)
-                : typeName;
+            return false;
         }
 
-        /// <summary>
-        /// Gets the graph type for the indicated type.
-        /// </summary>
-        /// <param name="type">The type for which a graph type is desired.</param>
-        /// <param name="isNullable">if set to <see langword="false"/> if the type explicitly non-nullable.</param>
-        /// <param name="mode">Mode to use when mapping CLR type to GraphType.</param>
-        /// <returns>A Type object representing a GraphType that matches the indicated type.</returns>
-        /// <remarks>This can handle arrays, lists and other collections implementing IEnumerable.</remarks>
-        public static Type GetGraphTypeFromType(this Type type, bool isNullable = false, TypeMappingMode mode = TypeMappingMode.UseBuiltInScalarMappings)
-        {
-            if (typeof(IGraphType).IsAssignableFrom(type))
-            {
-                throw new ArgumentOutOfRangeException(nameof(type), $"The graph type '{type.GetFriendlyName()}' cannot be used as a CLR type.");
-            }
-
-            while (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDataLoaderResult<>))
-            {
-                type = type.GetGenericArguments()[0];
-            }
-
-            if (type == typeof(IDataLoaderResult))
-            {
-                type = typeof(object);
-            }
-
-            if (typeof(Task).IsAssignableFrom(type))
-                throw new ArgumentOutOfRangeException(nameof(type), "Task types cannot be coerced to a graph type; please unwrap the task type before calling this method.");
-
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
-                type = type.GetGenericArguments()[0];
-                if (!isNullable)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(isNullable),
-                        $"Explicitly nullable type: Nullable<{type.Name}> cannot be coerced to a non nullable GraphQL type.");
-                }
-            }
-
-            Type? graphType = null;
-
-            if (type.IsArray)
-            {
-                var clrElementType = type.GetElementType()!;
-                var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent array
-                graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
-            }
-            else if (TryGetEnumerableElementType(type, out var clrElementType))
-            {
-                var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent container
-                graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
-            }
-            else
-            {
-#pragma warning disable CS0618 // Type or member is obsolete
-                var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
-                if (attr != null)
-                {
-                    if (mode == TypeMappingMode.InputType)
-                        graphType = attr.InputType;
-                    else if (mode == TypeMappingMode.OutputType)
-                        graphType = attr.OutputType;
-                    else if (attr.InputType == attr.OutputType) // scalar
-                        graphType = attr.InputType;
-                }
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                if (mode == TypeMappingMode.InputType)
-                {
-                    var inputAttr = type.GetCustomAttribute<InputTypeAttribute>();
-                    if (inputAttr != null)
-                        graphType = inputAttr.InputType;
-                }
-                else if (mode == TypeMappingMode.OutputType)
-                {
-                    var outputAttr = type.GetCustomAttribute<OutputTypeAttribute>();
-                    if (outputAttr != null)
-                        graphType = outputAttr.OutputType;
-                }
-
-                if (graphType == null)
-                {
-                    if (mode == TypeMappingMode.UseBuiltInScalarMappings)
-                    {
-                        if (!SchemaTypes.BuiltInScalarMappings.TryGetValue(type, out graphType))
-                        {
-                            if (type.IsEnum)
-                            {
-                                graphType = typeof(EnumerationGraphType<>).MakeGenericType(type);
-                            }
-                            else
-                            {
-                                throw new ArgumentOutOfRangeException(nameof(type), $"The CLR type '{type.FullName}' cannot be coerced effectively to a GraphQL type.");
-                            }
-                        }
-                    }
-                    else
-                    {
-                        graphType = (mode == TypeMappingMode.OutputType ? typeof(GraphQLClrOutputTypeReference<>) : typeof(GraphQLClrInputTypeReference<>)).MakeGenericType(type);
-                    }
-                }
-            }
-
-            if (!isNullable)
-            {
-                graphType = typeof(NonNullGraphType<>).MakeGenericType(graphType);
-            }
-
-            return graphType;
-
-            //TODO: rewrite nullability condition in v5
-            static bool IsNullableType(Type type) => !type.IsValueType || type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
-        }
-
-        /// <summary>
-        /// Returns the friendly name of a type, using C# angle-bracket syntax for generics.
-        /// </summary>
-        /// <param name="type">The type of which you are inquiring.</param>
-        /// <returns>A string representing the friendly name.</returns>
-        internal static string GetFriendlyName(this Type type)
-        {
-            string friendlyName = type.Name;
-
-            var genericArgs = type.GetGenericArguments();
-
-            if (genericArgs.Length > 0)
-            {
-                int iBacktick = friendlyName.IndexOf('`');
-                if (iBacktick > 0)
-                {
-                    friendlyName = friendlyName.Remove(iBacktick);
-                }
-                friendlyName += "<";
-                Type[] typeParameters = genericArgs;
-                for (int i = 0; i < typeParameters.Length; ++i)
-                {
-                    string typeParamName = GetFriendlyName(typeParameters[i]);
-                    friendlyName += i == 0 ? typeParamName : "," + typeParamName;
-                }
-                friendlyName += ">";
-            }
-
-            return friendlyName;
-        }
-
-        /// <summary>
-        /// Returns the type of element for a one-dimensional container type.
-        /// </summary>
-        private static bool TryGetEnumerableElementType(Type type, [NotNullWhen(true)] out Type? elementType)
-        {
-            if (type == typeof(IEnumerable))
-            {
-                elementType = typeof(object);
-                return true;
-            }
-
-            if (!type.IsGenericType || !TypeInformation.EnumerableListTypes.Contains(type.GetGenericTypeDefinition()))
-            {
-                elementType = null;
-                return false;
-            }
-
-            elementType = type.GetGenericArguments()[0];
-            return true;
-        }
-
-        /// <summary>
-        /// Returns whether or not the given <paramref name="type"/> implements <paramref name="genericType"/>
-        /// by testing itself, and then recursively up it's base types hierarchy.
-        /// </summary>
-        /// <param name="type">Type to test.</param>
-        /// <param name="genericType">Type to test for.</param>
-        /// <returns>
-        ///   <see langword="true"/> if the indicated type implements <paramref name="genericType"/>; otherwise, <see langword="false"/>.
-        /// </returns>
-        public static bool ImplementsGenericType(this Type type, Type genericType)
-        {
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == genericType)
-            {
-                return true;
-            }
-
-            var interfaceTypes = type.GetInterfaces();
-            foreach (var it in interfaceTypes)
-            {
-                if (it.IsGenericType && it.GetGenericTypeDefinition() == genericType)
-                {
-                    return true;
-                }
-            }
-
-            var baseType = type.BaseType;
-            return baseType != null && ImplementsGenericType(baseType, genericType);
-        }
-
-        /// <summary>
-        /// Looks for a <see cref="DescriptionAttribute"/> on the specified member and returns
-        /// the <see cref="DescriptionAttribute.Description">description</see>, if any. Otherwise
-        /// returns XML documentation on the specified member, if any. Note that behavior of this
-        /// method depends from <see cref="GlobalSwitches.EnableReadDescriptionFromAttributes"/>
-        /// and <see cref="GlobalSwitches.EnableReadDescriptionFromXmlDocumentation"/> settings.
-        /// </summary>
-        public static string? Description(this MemberInfo memberInfo)
-        {
-            string? description = null;
-
-            if (GlobalSwitches.EnableReadDescriptionFromAttributes)
-            {
-                description = (memberInfo.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault() as DescriptionAttribute)?.Description;
-                if (description != null)
-                    return description;
-            }
-
-            if (GlobalSwitches.EnableReadDescriptionFromXmlDocumentation)
-            {
-                description = memberInfo.GetXmlDocumentation();
-            }
-
-            return description;
-        }
-
-        /// <summary>
-        /// Looks for a <see cref="DescriptionAttribute"/> on the specified parameter and returns
-        /// the <see cref="DescriptionAttribute.Description">description</see>, if any. Otherwise
-        /// returns XML documentation on the specified member, if any. Note that behavior of this
-        /// method depends from <see cref="GlobalSwitches.EnableReadDescriptionFromAttributes"/>
-        /// and <see cref="GlobalSwitches.EnableReadDescriptionFromXmlDocumentation"/> settings.
-        /// </summary>
-        public static string? Description(this ParameterInfo parameterInfo)
-        {
-            string? description = null;
-
-            if (GlobalSwitches.EnableReadDescriptionFromAttributes)
-            {
-                description = (parameterInfo.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault() as DescriptionAttribute)?.Description;
-                if (description != null)
-                    return description;
-            }
-
-            if (GlobalSwitches.EnableReadDescriptionFromXmlDocumentation)
-            {
-                description = parameterInfo.GetXmlDocumentation();
-            }
-
-            return description;
-        }
-
-        /// <summary>
-        /// Looks for a <see cref="ObsoleteAttribute"/> on the specified member and returns
-        /// the <see cref="ObsoleteAttribute.Message">message</see>, if any. Note that behavior of this
-        /// method depends from <see cref="GlobalSwitches.EnableReadDeprecationReasonFromAttributes"/> setting.
-        /// </summary>
-        public static string? ObsoleteMessage(this MemberInfo memberInfo)
-        {
-            return GlobalSwitches.EnableReadDeprecationReasonFromAttributes
-                ? (memberInfo.GetCustomAttributes(typeof(ObsoleteAttribute), false).FirstOrDefault() as ObsoleteAttribute)?.Message
-                : null;
-        }
-
-        /// <summary>
-        /// Looks for a <see cref="DefaultValueAttribute"/> on the specified member and returns
-        /// the <see cref="DefaultValueAttribute.Value">value</see>, if any. Note that behavior of this
-        /// method depends from <see cref="GlobalSwitches.EnableReadDefaultValueFromAttributes"/> setting.
-        /// </summary>
-        public static object? DefaultValue(this MemberInfo memberInfo)
-        {
-            return GlobalSwitches.EnableReadDefaultValueFromAttributes
-                ? (memberInfo.GetCustomAttributes(typeof(DefaultValueAttribute), false).FirstOrDefault() as DefaultValueAttribute)?.Value
-                : null;
-        }
-
-        /// <summary>
-        /// Returns the set of <see cref="GraphQLAttribute"/>s applied to the specified member or its
-        /// owning module or assembly, or are listed within <see cref="GlobalSwitches.GlobalAttributes"/>.
-        /// Attributes are sorted by <see cref="GraphQLAttribute.Priority"/>, lowest first.
-        /// </summary>
-        public static IEnumerable<GraphQLAttribute> GetGraphQLAttributes(this MemberInfo memberInfo)
-        {
-            var module = memberInfo.Module;
-            var assembly = module.Assembly;
-            return memberInfo.GetCustomAttributes<GraphQLAttribute>()
-                .Concat(module.GetCustomAttributes<GraphQLAttribute>())
-                .Concat(assembly.GetCustomAttributes<GraphQLAttribute>())
-                .Concat(GlobalSwitches.GlobalAttributes)
-                .OrderBy(x => x.Priority);
-        }
-
-        /// <summary>
-        /// Returns the set of <see cref="GraphQLAttribute"/>s applied to the specified parameter or its
-        /// owning module or assembly, or are listed within <see cref="GlobalSwitches.GlobalAttributes"/>.
-        /// Attributes are sorted by <see cref="GraphQLAttribute.Priority"/>, lowest first.
-        /// </summary>
-        public static IEnumerable<GraphQLAttribute> GetGraphQLAttributes(this ParameterInfo parameterInfo)
-        {
-            var module = parameterInfo.Member.Module;
-            var assembly = module.Assembly;
-            return parameterInfo.GetCustomAttributes<GraphQLAttribute>()
-                .Concat(module.GetCustomAttributes<GraphQLAttribute>())
-                .Concat(assembly.GetCustomAttributes<GraphQLAttribute>())
-                .Concat(GlobalSwitches.GlobalAttributes)
-                .OrderBy(x => x.Priority);
-        }
+        return true;
     }
 
     /// <summary>
-    /// Mode used when mapping CLR type to GraphType in <see cref="TypeExtensions.GetGraphTypeFromType"/>.
+    /// Gets the GraphQL name of the type. This is derived from the type name and can
+    /// be overridden by the <see cref="GraphQLMetadataAttribute"/>. The name is chosen
+    /// depending on <see cref="GlobalSwitches.UseLegacyTypeNaming"/>.
     /// </summary>
-    public enum TypeMappingMode
+    /// <param name="type">The indicated type.</param>
+    /// <returns>A string containing a GraphQL compatible type name.</returns>
+    public static string GraphQLName(this Type type)
     {
-        /// <summary>
-        /// This mode is left for backward compatibility in cases where you call <see cref="TypeExtensions.GetGraphTypeFromType"/> directly.
-        /// </summary>
-        UseBuiltInScalarMappings,
+#pragma warning disable CS0618 // Type or member is obsolete
+        if (!GlobalSwitches.UseLegacyTypeNaming)
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
+            return NameOf(type)
+                .Replace('@', '_'); // F# anonymous class support
 
-        /// <summary>
-        /// Map CLR type as input type.
-        /// </summary>
-        InputType,
+            static string NameOf(Type type)
+            {
+                type = type.GetNamedType();
 
-        /// <summary>
-        /// Map CLR type as output type.
-        /// </summary>
-        OutputType,
+                if (!typeof(IGraphType).IsAssignableFrom(type))
+                {
+                    var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
+                    if (!string.IsNullOrEmpty(attr?.Name))
+                    {
+                        return attr!.Name!;
+                    }
+                }
+
+                var name = type.Name;
+
+                if (type.IsGenericType)
+                    name = name.Substring(0, name.IndexOf('`'));
+
+                if (name != "GraphType" && name != "Type")
+                {
+                    if (name.EndsWith("GraphType", StringComparison.Ordinal))
+                    {
+                        name = name.Substring(0, name.Length - "GraphType".Length);
+                    }
+                    else if (name.EndsWith("Type", StringComparison.Ordinal))
+                    {
+                        name = name.Substring(0, name.Length - "Type".Length);
+                    }
+                }
+
+                if (GlobalSwitches.UseDeclaringTypeNames)
+                {
+                    var parent = type.DeclaringType;
+                    while (parent != null)
+                    {
+                        name = $"{parent.Name}_{name}";
+                        parent = parent.DeclaringType;
+                    }
+                }
+
+                if (!type.IsGenericType)
+                    return name;
+                var sb = new StringBuilder();
+                foreach (var arg in type.GetGenericArguments())
+                {
+                    sb.Append(NameOf(arg));
+                }
+                sb.Append(name);
+                return sb.ToString();
+            }
+        }
+
+        type = type.GetNamedType();
+
+        var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
+
+        if (!string.IsNullOrEmpty(attr?.Name))
+        {
+            return attr!.Name!;
+        }
+
+        var typeName = type.Name;
+
+        if (type.IsGenericType)
+        {
+            typeName = typeName.Substring(0, typeName.IndexOf('`'));
+        }
+
+        if (typeName == nameof(GraphType) || typeName == nameof(Type))
+            return typeName;
+
+        typeName = typeName.Replace(nameof(GraphType), nameof(Type));
+
+        return typeName.EndsWith(nameof(Type), StringComparison.InvariantCulture)
+            ? typeName.Remove(typeName.Length - nameof(Type).Length)
+            : typeName;
     }
+
+    /// <summary>
+    /// Gets the graph type for the indicated type.
+    /// </summary>
+    /// <param name="type">The type for which a graph type is desired.</param>
+    /// <param name="isNullable">if set to <see langword="false"/> if the type explicitly non-nullable.</param>
+    /// <param name="mode">Mode to use when mapping CLR type to GraphType.</param>
+    /// <returns>A Type object representing a GraphType that matches the indicated type.</returns>
+    /// <remarks>This can handle arrays, lists and other collections implementing IEnumerable.</remarks>
+    public static Type GetGraphTypeFromType(this Type type, bool isNullable = false, TypeMappingMode mode = TypeMappingMode.UseBuiltInScalarMappings)
+    {
+        if (typeof(IGraphType).IsAssignableFrom(type))
+        {
+            throw new ArgumentOutOfRangeException(nameof(type), $"The graph type '{type.GetFriendlyName()}' cannot be used as a CLR type.");
+        }
+
+        while (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDataLoaderResult<>))
+        {
+            type = type.GetGenericArguments()[0];
+        }
+
+        if (type == typeof(IDataLoaderResult))
+        {
+            type = typeof(object);
+        }
+
+        if (typeof(Task).IsAssignableFrom(type))
+            throw new ArgumentOutOfRangeException(nameof(type), "Task types cannot be coerced to a graph type; please unwrap the task type before calling this method.");
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+        {
+            type = type.GetGenericArguments()[0];
+            if (!isNullable)
+            {
+                throw new ArgumentOutOfRangeException(nameof(isNullable),
+                    $"Explicitly nullable type: Nullable<{type.Name}> cannot be coerced to a non nullable GraphQL type.");
+            }
+        }
+
+        Type? graphType = null;
+
+        if (type.IsArray)
+        {
+            var clrElementType = type.GetElementType()!;
+            var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent array
+            graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
+        }
+        else if (TryGetEnumerableElementType(type, out var clrElementType))
+        {
+            var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent container
+            graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
+        }
+        else
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
+            if (attr != null)
+            {
+                if (mode == TypeMappingMode.InputType)
+                    graphType = attr.InputType;
+                else if (mode == TypeMappingMode.OutputType)
+                    graphType = attr.OutputType;
+                else if (attr.InputType == attr.OutputType) // scalar
+                    graphType = attr.InputType;
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            if (mode == TypeMappingMode.InputType)
+            {
+                var inputAttr = type.GetCustomAttribute<InputTypeAttribute>();
+                if (inputAttr != null)
+                    graphType = inputAttr.InputType;
+            }
+            else if (mode == TypeMappingMode.OutputType)
+            {
+                var outputAttr = type.GetCustomAttribute<OutputTypeAttribute>();
+                if (outputAttr != null)
+                    graphType = outputAttr.OutputType;
+            }
+
+            if (graphType == null)
+            {
+                if (mode == TypeMappingMode.UseBuiltInScalarMappings)
+                {
+                    if (!SchemaTypes.BuiltInScalarMappings.TryGetValue(type, out graphType))
+                    {
+                        if (type.IsEnum)
+                        {
+                            graphType = typeof(EnumerationGraphType<>).MakeGenericType(type);
+                        }
+                        else
+                        {
+                            throw new ArgumentOutOfRangeException(nameof(type), $"The CLR type '{type.FullName}' cannot be coerced effectively to a GraphQL type.");
+                        }
+                    }
+                }
+                else
+                {
+                    graphType = (mode == TypeMappingMode.OutputType ? typeof(GraphQLClrOutputTypeReference<>) : typeof(GraphQLClrInputTypeReference<>)).MakeGenericType(type);
+                }
+            }
+        }
+
+        if (!isNullable)
+        {
+            graphType = typeof(NonNullGraphType<>).MakeGenericType(graphType);
+        }
+
+        return graphType;
+
+        //TODO: rewrite nullability condition in v5
+        static bool IsNullableType(Type type) => !type.IsValueType || type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+    }
+
+    /// <summary>
+    /// Returns the friendly name of a type, using C# angle-bracket syntax for generics.
+    /// </summary>
+    /// <param name="type">The type of which you are inquiring.</param>
+    /// <returns>A string representing the friendly name.</returns>
+    internal static string GetFriendlyName(this Type type)
+    {
+        string friendlyName = type.Name;
+
+        var genericArgs = type.GetGenericArguments();
+
+        if (genericArgs.Length > 0)
+        {
+            int iBacktick = friendlyName.IndexOf('`');
+            if (iBacktick > 0)
+            {
+                friendlyName = friendlyName.Remove(iBacktick);
+            }
+            friendlyName += "<";
+            Type[] typeParameters = genericArgs;
+            for (int i = 0; i < typeParameters.Length; ++i)
+            {
+                string typeParamName = GetFriendlyName(typeParameters[i]);
+                friendlyName += i == 0 ? typeParamName : "," + typeParamName;
+            }
+            friendlyName += ">";
+        }
+
+        return friendlyName;
+    }
+
+    /// <summary>
+    /// Returns the type of element for a one-dimensional container type.
+    /// </summary>
+    private static bool TryGetEnumerableElementType(Type type, [NotNullWhen(true)] out Type? elementType)
+    {
+        if (type == typeof(IEnumerable))
+        {
+            elementType = typeof(object);
+            return true;
+        }
+
+        if (!type.IsGenericType || !TypeInformation.EnumerableListTypes.Contains(type.GetGenericTypeDefinition()))
+        {
+            elementType = null;
+            return false;
+        }
+
+        elementType = type.GetGenericArguments()[0];
+        return true;
+    }
+
+    /// <summary>
+    /// Returns whether or not the given <paramref name="type"/> implements <paramref name="genericType"/>
+    /// by testing itself, and then recursively up it's base types hierarchy.
+    /// </summary>
+    /// <param name="type">Type to test.</param>
+    /// <param name="genericType">Type to test for.</param>
+    /// <returns>
+    ///   <see langword="true"/> if the indicated type implements <paramref name="genericType"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool ImplementsGenericType(this Type type, Type genericType)
+    {
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == genericType)
+        {
+            return true;
+        }
+
+        var interfaceTypes = type.GetInterfaces();
+        foreach (var it in interfaceTypes)
+        {
+            if (it.IsGenericType && it.GetGenericTypeDefinition() == genericType)
+            {
+                return true;
+            }
+        }
+
+        var baseType = type.BaseType;
+        return baseType != null && ImplementsGenericType(baseType, genericType);
+    }
+
+    /// <summary>
+    /// Looks for a <see cref="DescriptionAttribute"/> on the specified member and returns
+    /// the <see cref="DescriptionAttribute.Description">description</see>, if any. Otherwise
+    /// returns XML documentation on the specified member, if any. Note that behavior of this
+    /// method depends from <see cref="GlobalSwitches.EnableReadDescriptionFromAttributes"/>
+    /// and <see cref="GlobalSwitches.EnableReadDescriptionFromXmlDocumentation"/> settings.
+    /// </summary>
+    public static string? Description(this MemberInfo memberInfo)
+    {
+        string? description = null;
+
+        if (GlobalSwitches.EnableReadDescriptionFromAttributes)
+        {
+            description = (memberInfo.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault() as DescriptionAttribute)?.Description;
+            if (description != null)
+                return description;
+        }
+
+        if (GlobalSwitches.EnableReadDescriptionFromXmlDocumentation)
+        {
+            description = memberInfo.GetXmlDocumentation();
+        }
+
+        return description;
+    }
+
+    /// <summary>
+    /// Looks for a <see cref="DescriptionAttribute"/> on the specified parameter and returns
+    /// the <see cref="DescriptionAttribute.Description">description</see>, if any. Otherwise
+    /// returns XML documentation on the specified member, if any. Note that behavior of this
+    /// method depends from <see cref="GlobalSwitches.EnableReadDescriptionFromAttributes"/>
+    /// and <see cref="GlobalSwitches.EnableReadDescriptionFromXmlDocumentation"/> settings.
+    /// </summary>
+    public static string? Description(this ParameterInfo parameterInfo)
+    {
+        string? description = null;
+
+        if (GlobalSwitches.EnableReadDescriptionFromAttributes)
+        {
+            description = (parameterInfo.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault() as DescriptionAttribute)?.Description;
+            if (description != null)
+                return description;
+        }
+
+        if (GlobalSwitches.EnableReadDescriptionFromXmlDocumentation)
+        {
+            description = parameterInfo.GetXmlDocumentation();
+        }
+
+        return description;
+    }
+
+    /// <summary>
+    /// Looks for a <see cref="ObsoleteAttribute"/> on the specified member and returns
+    /// the <see cref="ObsoleteAttribute.Message">message</see>, if any. Note that behavior of this
+    /// method depends from <see cref="GlobalSwitches.EnableReadDeprecationReasonFromAttributes"/> setting.
+    /// </summary>
+    public static string? ObsoleteMessage(this MemberInfo memberInfo)
+    {
+        return GlobalSwitches.EnableReadDeprecationReasonFromAttributes
+            ? (memberInfo.GetCustomAttributes(typeof(ObsoleteAttribute), false).FirstOrDefault() as ObsoleteAttribute)?.Message
+            : null;
+    }
+
+    /// <summary>
+    /// Looks for a <see cref="DefaultValueAttribute"/> on the specified member and returns
+    /// the <see cref="DefaultValueAttribute.Value">value</see>, if any. Note that behavior of this
+    /// method depends from <see cref="GlobalSwitches.EnableReadDefaultValueFromAttributes"/> setting.
+    /// </summary>
+    public static object? DefaultValue(this MemberInfo memberInfo)
+    {
+        return GlobalSwitches.EnableReadDefaultValueFromAttributes
+            ? (memberInfo.GetCustomAttributes(typeof(DefaultValueAttribute), false).FirstOrDefault() as DefaultValueAttribute)?.Value
+            : null;
+    }
+
+    /// <summary>
+    /// Returns the set of <see cref="GraphQLAttribute"/>s applied to the specified member or its
+    /// owning module or assembly, or are listed within <see cref="GlobalSwitches.GlobalAttributes"/>.
+    /// Attributes are sorted by <see cref="GraphQLAttribute.Priority"/>, lowest first.
+    /// </summary>
+    public static IEnumerable<GraphQLAttribute> GetGraphQLAttributes(this MemberInfo memberInfo)
+    {
+        var module = memberInfo.Module;
+        var assembly = module.Assembly;
+        return memberInfo.GetCustomAttributes<GraphQLAttribute>()
+            .Concat(module.GetCustomAttributes<GraphQLAttribute>())
+            .Concat(assembly.GetCustomAttributes<GraphQLAttribute>())
+            .Concat(GlobalSwitches.GlobalAttributes)
+            .OrderBy(x => x.Priority);
+    }
+
+    /// <summary>
+    /// Returns the set of <see cref="GraphQLAttribute"/>s applied to the specified parameter or its
+    /// owning module or assembly, or are listed within <see cref="GlobalSwitches.GlobalAttributes"/>.
+    /// Attributes are sorted by <see cref="GraphQLAttribute.Priority"/>, lowest first.
+    /// </summary>
+    public static IEnumerable<GraphQLAttribute> GetGraphQLAttributes(this ParameterInfo parameterInfo)
+    {
+        var module = parameterInfo.Member.Module;
+        var assembly = module.Assembly;
+        return parameterInfo.GetCustomAttributes<GraphQLAttribute>()
+            .Concat(module.GetCustomAttributes<GraphQLAttribute>())
+            .Concat(assembly.GetCustomAttributes<GraphQLAttribute>())
+            .Concat(GlobalSwitches.GlobalAttributes)
+            .OrderBy(x => x.Priority);
+    }
+}
+
+/// <summary>
+/// Mode used when mapping CLR type to GraphType in <see cref="TypeExtensions.GetGraphTypeFromType"/>.
+/// </summary>
+public enum TypeMappingMode
+{
+    /// <summary>
+    /// This mode is left for backward compatibility in cases where you call <see cref="TypeExtensions.GetGraphTypeFromType"/> directly.
+    /// </summary>
+    UseBuiltInScalarMappings,
+
+    /// <summary>
+    /// Map CLR type as input type.
+    /// </summary>
+    InputType,
+
+    /// <summary>
+    /// Map CLR type as output type.
+    /// </summary>
+    OutputType,
 }

--- a/src/GraphQL/Instrumentation/ApolloTrace.cs
+++ b/src/GraphQL/Instrumentation/ApolloTrace.cs
@@ -1,115 +1,114 @@
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Contains Apollo tracing metrics.
+/// </summary>
+public class ApolloTrace
 {
     /// <summary>
-    /// Contains Apollo tracing metrics.
+    /// Initializes a new instance with the specified parameters.
     /// </summary>
-    public class ApolloTrace
+    /// <param name="start">The date and time that the GraphQL document began execution. If not UTC, this value will be converted to UTC.</param>
+    /// <param name="durationMs">The number of milliseconds that it took to execute the GraphQL document.</param>
+    public ApolloTrace(DateTime start, double durationMs)
+    {
+        StartTime = start.ToUniversalTime();
+        // https://github.com/dotnet/runtime/pull/73198 fixes AddMilliseconds, but it is only available NET7+
+        // Use AddTicks instead to fix it for all frameworks
+        EndTime = StartTime.AddTicks((long)(durationMs * TimeSpan.TicksPerMillisecond));
+        Duration = ConvertTime(durationMs);
+    }
+
+    /// <summary>
+    /// Returns the Apollo tracing version number.
+    /// </summary>
+    public int Version => 1;
+
+    /// <summary>
+    /// Returns the UTC date and time when the document began execution. Should be serialized as a RFC 3339 string.
+    /// </summary>
+    public DateTime StartTime { get; }
+
+    /// <summary>
+    /// Returns the UTC date and time when the document completed execution. Should be serialized as a RFC 3339 string.
+    /// </summary>
+    public DateTime EndTime { get; }
+
+    /// <summary>
+    /// Returns the duration of the document's execution, in nanoseconds.
+    /// </summary>
+    public long Duration { get; }
+
+    /// <summary>
+    /// Returns the parsing metrics.
+    /// </summary>
+    public OperationTrace Parsing { get; } = new OperationTrace();
+
+    /// <summary>
+    /// Returns the validation metrics.
+    /// </summary>
+    public OperationTrace Validation { get; } = new OperationTrace();
+
+    /// <summary>
+    /// Returns the execution metrics.
+    /// </summary>
+    public ExecutionTrace Execution { get; } = new ExecutionTrace();
+
+    /// <summary>
+    /// Converts a quantity of milliseconds to nanoseconds.
+    /// </summary>
+    internal static long ConvertTime(double ms) => (long)(ms * 1000 * 1000);
+
+    /// <summary>
+    /// Represents the start offset and duration of an operation.
+    /// </summary>
+    public class OperationTrace
     {
         /// <summary>
-        /// Initializes a new instance with the specified parameters.
+        /// Gets or sets the start offset of the operation, in nanoseconds.
         /// </summary>
-        /// <param name="start">The date and time that the GraphQL document began execution. If not UTC, this value will be converted to UTC.</param>
-        /// <param name="durationMs">The number of milliseconds that it took to execute the GraphQL document.</param>
-        public ApolloTrace(DateTime start, double durationMs)
-        {
-            StartTime = start.ToUniversalTime();
-            // https://github.com/dotnet/runtime/pull/73198 fixes AddMilliseconds, but it is only available NET7+
-            // Use AddTicks instead to fix it for all frameworks
-            EndTime = StartTime.AddTicks((long)(durationMs * TimeSpan.TicksPerMillisecond));
-            Duration = ConvertTime(durationMs);
-        }
+        public long StartOffset { get; set; }
 
         /// <summary>
-        /// Returns the Apollo tracing version number.
+        /// Gets or sets the duration of the operation, in nanoseconds.
         /// </summary>
-        public int Version => 1;
+        public long Duration { get; set; }
+    }
+
+    /// <summary>
+    /// Represents metrics pertaining to the execution of a GraphQL document.
+    /// </summary>
+    public class ExecutionTrace
+    {
+        /// <summary>
+        /// Returns a list of resolvers executed during the execution of a GraphQL document.
+        /// </summary>
+        public List<ResolverTrace> Resolvers { get; } = new List<ResolverTrace>();
+    }
+
+    /// <summary>
+    /// Represents metrics pertaining to the execution of a field resolver.
+    /// </summary>
+    public class ResolverTrace : OperationTrace
+    {
+        /// <summary>
+        /// Gets or sets the path of the field.
+        /// </summary>
+        public List<object>? Path { get; set; }
 
         /// <summary>
-        /// Returns the UTC date and time when the document began execution. Should be serialized as a RFC 3339 string.
+        /// Gets or sets the parent graph type name.
         /// </summary>
-        public DateTime StartTime { get; }
+        public string? ParentType { get; set; }
 
         /// <summary>
-        /// Returns the UTC date and time when the document completed execution. Should be serialized as a RFC 3339 string.
+        /// Gets or sets the field name.
         /// </summary>
-        public DateTime EndTime { get; }
+        public string? FieldName { get; set; }
 
         /// <summary>
-        /// Returns the duration of the document's execution, in nanoseconds.
+        /// Gets or sets the returned graph type name.
         /// </summary>
-        public long Duration { get; }
-
-        /// <summary>
-        /// Returns the parsing metrics.
-        /// </summary>
-        public OperationTrace Parsing { get; } = new OperationTrace();
-
-        /// <summary>
-        /// Returns the validation metrics.
-        /// </summary>
-        public OperationTrace Validation { get; } = new OperationTrace();
-
-        /// <summary>
-        /// Returns the execution metrics.
-        /// </summary>
-        public ExecutionTrace Execution { get; } = new ExecutionTrace();
-
-        /// <summary>
-        /// Converts a quantity of milliseconds to nanoseconds.
-        /// </summary>
-        internal static long ConvertTime(double ms) => (long)(ms * 1000 * 1000);
-
-        /// <summary>
-        /// Represents the start offset and duration of an operation.
-        /// </summary>
-        public class OperationTrace
-        {
-            /// <summary>
-            /// Gets or sets the start offset of the operation, in nanoseconds.
-            /// </summary>
-            public long StartOffset { get; set; }
-
-            /// <summary>
-            /// Gets or sets the duration of the operation, in nanoseconds.
-            /// </summary>
-            public long Duration { get; set; }
-        }
-
-        /// <summary>
-        /// Represents metrics pertaining to the execution of a GraphQL document.
-        /// </summary>
-        public class ExecutionTrace
-        {
-            /// <summary>
-            /// Returns a list of resolvers executed during the execution of a GraphQL document.
-            /// </summary>
-            public List<ResolverTrace> Resolvers { get; } = new List<ResolverTrace>();
-        }
-
-        /// <summary>
-        /// Represents metrics pertaining to the execution of a field resolver.
-        /// </summary>
-        public class ResolverTrace : OperationTrace
-        {
-            /// <summary>
-            /// Gets or sets the path of the field.
-            /// </summary>
-            public List<object>? Path { get; set; }
-
-            /// <summary>
-            /// Gets or sets the parent graph type name.
-            /// </summary>
-            public string? ParentType { get; set; }
-
-            /// <summary>
-            /// Gets or sets the field name.
-            /// </summary>
-            public string? FieldName { get; set; }
-
-            /// <summary>
-            /// Gets or sets the returned graph type name.
-            /// </summary>
-            public string? ReturnType { get; set; }
-        }
+        public string? ReturnType { get; set; }
     }
 }

--- a/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
+++ b/src/GraphQL/Instrumentation/ApolloTracingExtensions.cs
@@ -1,69 +1,68 @@
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Methods to add Apollo tracing metrics to an <see cref="ExecutionResult"/> instance.
+/// </summary>
+public static class ApolloTracingExtensions
 {
     /// <summary>
-    /// Methods to add Apollo tracing metrics to an <see cref="ExecutionResult"/> instance.
+    /// Adds Apollo tracing metrics to an <see cref="ExecutionResult"/> instance,
+    /// stored within <see cref="ExecutionResult.Extensions"/>["tracing"].
+    /// Requires that the GraphQL document was executed with metrics enabled;
+    /// see <see cref="ExecutionOptions.EnableMetrics"/>. With <see cref="InstrumentFieldsMiddleware"/>
+    /// installed, also includes metrics from field resolvers.
     /// </summary>
-    public static class ApolloTracingExtensions
+    /// <param name="result">An <see cref="ExecutionResult"/> instance.</param>
+    /// <param name="start">The date and time that the GraphQL document began execution. If not UTC, this value will be converted to UTC.</param>
+    public static void EnrichWithApolloTracing(this ExecutionResult result, DateTime start)
     {
-        /// <summary>
-        /// Adds Apollo tracing metrics to an <see cref="ExecutionResult"/> instance,
-        /// stored within <see cref="ExecutionResult.Extensions"/>["tracing"].
-        /// Requires that the GraphQL document was executed with metrics enabled;
-        /// see <see cref="ExecutionOptions.EnableMetrics"/>. With <see cref="InstrumentFieldsMiddleware"/>
-        /// installed, also includes metrics from field resolvers.
-        /// </summary>
-        /// <param name="result">An <see cref="ExecutionResult"/> instance.</param>
-        /// <param name="start">The date and time that the GraphQL document began execution. If not UTC, this value will be converted to UTC.</param>
-        public static void EnrichWithApolloTracing(this ExecutionResult result, DateTime start)
+        var perf = result?.Perf;
+        if (perf != null)
+            (result!.Extensions ??= new())["tracing"] = CreateTrace(perf, start);
+    }
+
+    /// <summary>
+    /// Initializes an <see cref="ApolloTrace"/> instance and populates it with performance
+    /// metrics gathered during the GraphQL document execution.
+    /// </summary>
+    /// <param name="perf">A list of performance records; typically as returned from <see cref="Metrics.Finish"/>.</param>
+    /// <param name="start">The date and time that the GraphQL document began execution. If not UTC, this value will be converted to UTC.</param>
+    public static ApolloTrace CreateTrace(PerfRecord[] perf, DateTime start)
+    {
+        var operationStat = perf.Single(x => x.Category == "operation"); // always exists
+        var trace = new ApolloTrace(start, operationStat.Duration);
+
+        var documentStats = perf.Where(x => x.Category == "document");
+
+        var parsingStat = documentStats.FirstOrDefault(x => x.Subject == "Building document");
+        if (parsingStat != null) // can be null if exception occurred
         {
-            var perf = result?.Perf;
-            if (perf != null)
-                (result!.Extensions ??= new())["tracing"] = CreateTrace(perf, start);
+            trace.Parsing.StartOffset = ApolloTrace.ConvertTime(parsingStat.Start);
+            trace.Parsing.Duration = ApolloTrace.ConvertTime(parsingStat.Duration);
         }
 
-        /// <summary>
-        /// Initializes an <see cref="ApolloTrace"/> instance and populates it with performance
-        /// metrics gathered during the GraphQL document execution.
-        /// </summary>
-        /// <param name="perf">A list of performance records; typically as returned from <see cref="Metrics.Finish"/>.</param>
-        /// <param name="start">The date and time that the GraphQL document began execution. If not UTC, this value will be converted to UTC.</param>
-        public static ApolloTrace CreateTrace(PerfRecord[] perf, DateTime start)
+        var validationStat = documentStats.FirstOrDefault(x => x.Subject == "Validating document");
+        if (validationStat != null) // can be null if exception occurred
         {
-            var operationStat = perf.Single(x => x.Category == "operation"); // always exists
-            var trace = new ApolloTrace(start, operationStat.Duration);
-
-            var documentStats = perf.Where(x => x.Category == "document");
-
-            var parsingStat = documentStats.FirstOrDefault(x => x.Subject == "Building document");
-            if (parsingStat != null) // can be null if exception occurred
-            {
-                trace.Parsing.StartOffset = ApolloTrace.ConvertTime(parsingStat.Start);
-                trace.Parsing.Duration = ApolloTrace.ConvertTime(parsingStat.Duration);
-            }
-
-            var validationStat = documentStats.FirstOrDefault(x => x.Subject == "Validating document");
-            if (validationStat != null) // can be null if exception occurred
-            {
-                trace.Validation.StartOffset = ApolloTrace.ConvertTime(validationStat.Start);
-                trace.Validation.Duration = ApolloTrace.ConvertTime(validationStat.Duration);
-            }
-
-            var fieldStats = perf.Where(x => x.Category == "field");
-            foreach (var fieldStat in fieldStats)
-            {
-                trace.Execution.Resolvers.Add(
-                    new ApolloTrace.ResolverTrace
-                    {
-                        FieldName = fieldStat.MetaField<string>("fieldName"),
-                        Path = fieldStat.MetaField<IEnumerable<object>>("path")!.ToList(),
-                        ParentType = fieldStat.MetaField<string>("typeName"),
-                        ReturnType = fieldStat.MetaField<string>("returnTypeName"),
-                        StartOffset = ApolloTrace.ConvertTime(fieldStat.Start),
-                        Duration = ApolloTrace.ConvertTime(fieldStat.Duration),
-                    });
-            }
-
-            return trace;
+            trace.Validation.StartOffset = ApolloTrace.ConvertTime(validationStat.Start);
+            trace.Validation.Duration = ApolloTrace.ConvertTime(validationStat.Duration);
         }
+
+        var fieldStats = perf.Where(x => x.Category == "field");
+        foreach (var fieldStat in fieldStats)
+        {
+            trace.Execution.Resolvers.Add(
+                new ApolloTrace.ResolverTrace
+                {
+                    FieldName = fieldStat.MetaField<string>("fieldName"),
+                    Path = fieldStat.MetaField<IEnumerable<object>>("path")!.ToList(),
+                    ParentType = fieldStat.MetaField<string>("typeName"),
+                    ReturnType = fieldStat.MetaField<string>("returnTypeName"),
+                    StartOffset = ApolloTrace.ConvertTime(fieldStat.Start),
+                    Duration = ApolloTrace.ConvertTime(fieldStat.Duration),
+                });
+        }
+
+        return trace;
     }
 }

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilder.cs
@@ -1,42 +1,41 @@
 using GraphQL.Resolvers;
 
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Default implementation of <see cref="IFieldMiddlewareBuilder"/>.
+/// </summary>
+public class FieldMiddlewareBuilder : IFieldMiddlewareBuilder
 {
-    /// <summary>
-    /// Default implementation of <see cref="IFieldMiddlewareBuilder"/>.
-    /// </summary>
-    public class FieldMiddlewareBuilder : IFieldMiddlewareBuilder
+    private Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate>? _middleware;
+
+    /// <inheritdoc/>
+    public IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
     {
-        private Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate>? _middleware;
+        if (middleware == null)
+            throw new ArgumentNullException(nameof(middleware));
 
-        /// <inheritdoc/>
-        public IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware)
+        if (_middleware == null)
         {
-            if (middleware == null)
-                throw new ArgumentNullException(nameof(middleware));
-
-            if (_middleware == null)
-            {
-                _middleware = middleware;
-            }
-            else
-            {
-                var firstMiddleware = _middleware;
-                _middleware = next => firstMiddleware(middleware(next));
-            }
-
-            return this;
+            _middleware = middleware;
+        }
+        else
+        {
+            var firstMiddleware = _middleware;
+            _middleware = next => firstMiddleware(middleware(next));
         }
 
-        private static readonly FieldMiddlewareDelegate _defaultDelegate = context => NameFieldResolver.Instance.ResolveAsync(context);
+        return this;
+    }
 
-        /// <inheritdoc/>
-        public Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate>? Build()
-        {
-            if (_middleware == null)
-                return null;
+    private static readonly FieldMiddlewareDelegate _defaultDelegate = context => NameFieldResolver.Instance.ResolveAsync(context);
 
-            return start => _middleware(start ?? _defaultDelegate);
-        }
+    /// <inheritdoc/>
+    public Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate>? Build()
+    {
+        if (_middleware == null)
+            return null;
+
+        return start => _middleware(start ?? _defaultDelegate);
     }
 }

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -1,20 +1,19 @@
 using GraphQL.Types;
 
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Extension methods for <see cref="IFieldMiddlewareBuilder"/> to add middlewares.
+/// These methods are built on top of <see cref="IFieldMiddlewareBuilder.Use(Func{FieldMiddlewareDelegate, FieldMiddlewareDelegate})"/>.
+/// </summary>
+public static class FieldMiddlewareBuilderExtensions
 {
     /// <summary>
-    /// Extension methods for <see cref="IFieldMiddlewareBuilder"/> to add middlewares.
-    /// These methods are built on top of <see cref="IFieldMiddlewareBuilder.Use(Func{FieldMiddlewareDelegate, FieldMiddlewareDelegate})"/>.
+    /// Adds middleware to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
     /// </summary>
-    public static class FieldMiddlewareBuilderExtensions
-    {
-        /// <summary>
-        /// Adds middleware to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
-        /// </summary>
-        /// <param name="builder">Interface for connecting middlewares to a schema.</param>
-        /// <param name="middleware">Middleware instance.</param>
-        /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
-        public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, IFieldMiddleware middleware)
-            => builder.Use(next => context => middleware.ResolveAsync(context, next));
-    }
+    /// <param name="builder">Interface for connecting middlewares to a schema.</param>
+    /// <param name="middleware">Middleware instance.</param>
+    /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
+    public static IFieldMiddlewareBuilder Use(this IFieldMiddlewareBuilder builder, IFieldMiddleware middleware)
+        => builder.Use(next => context => middleware.ResolveAsync(context, next));
 }

--- a/src/GraphQL/Instrumentation/IFieldMiddleware.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddleware.cs
@@ -1,16 +1,15 @@
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Interface for field middleware.
+/// </summary>
+public interface IFieldMiddleware
 {
     /// <summary>
-    /// Interface for field middleware.
+    /// Handles execution of a field.
     /// </summary>
-    public interface IFieldMiddleware
-    {
-        /// <summary>
-        /// Handles execution of a field.
-        /// </summary>
-        /// <param name="context">Contains parameters pertaining to the currently executing field.</param>
-        /// <param name="next">The delegate representing the remaining middleware and field resolver in the pipeline.</param>
-        /// <returns>Asynchronously returns the result for the field.</returns>
-        ValueTask<object?> ResolveAsync(IResolveFieldContext context, FieldMiddlewareDelegate next);
-    }
+    /// <param name="context">Contains parameters pertaining to the currently executing field.</param>
+    /// <param name="next">The delegate representing the remaining middleware and field resolver in the pipeline.</param>
+    /// <returns>Asynchronously returns the result for the field.</returns>
+    ValueTask<object?> ResolveAsync(IResolveFieldContext context, FieldMiddlewareDelegate next);
 }

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -1,25 +1,24 @@
 using GraphQL.Types;
 
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Interface for connecting middlewares to a schema.
+/// </summary>
+public interface IFieldMiddlewareBuilder
 {
     /// <summary>
-    /// Interface for connecting middlewares to a schema.
+    /// Adds the specified delegate to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
+    /// <br/><br/>
+    /// The delegate is used to unify the different ways of specifying middleware. See additional methods in <see cref="FieldMiddlewareBuilderExtensions"/>.
     /// </summary>
-    public interface IFieldMiddlewareBuilder
-    {
-        /// <summary>
-        /// Adds the specified delegate to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypes.ApplyMiddleware(IFieldMiddlewareBuilder)"/>.
-        /// <br/><br/>
-        /// The delegate is used to unify the different ways of specifying middleware. See additional methods in <see cref="FieldMiddlewareBuilderExtensions"/>.
-        /// </summary>
-        /// <param name="middleware">Middleware delegate.</param>
-        /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
-        IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware);
+    /// <param name="middleware">Middleware delegate.</param>
+    /// <returns>Reference to the same <see cref="IFieldMiddlewareBuilder"/>.</returns>
+    IFieldMiddlewareBuilder Use(Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> middleware);
 
-        /// <summary>
-        /// Returns a transform for field resolvers, or <see langword="null"/> if no middleware is defined.
-        /// The transform is a cumulation of all middlewares configured within this builder.
-        /// </summary>
-        Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate>? Build();
-    }
+    /// <summary>
+    /// Returns a transform for field resolvers, or <see langword="null"/> if no middleware is defined.
+    /// The transform is a cumulation of all middlewares configured within this builder.
+    /// </summary>
+    Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate>? Build();
 }

--- a/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
+++ b/src/GraphQL/Instrumentation/InstrumentFieldsMiddleware.cs
@@ -1,67 +1,66 @@
 using GraphQL.DataLoader;
 
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Middleware required for Apollo tracing to record performance metrics of field resolvers.
+/// </summary>
+public class InstrumentFieldsMiddleware : IFieldMiddleware
 {
-    /// <summary>
-    /// Middleware required for Apollo tracing to record performance metrics of field resolvers.
-    /// </summary>
-    public class InstrumentFieldsMiddleware : IFieldMiddleware
+    /// <inheritdoc/>
+    public ValueTask<object?> ResolveAsync(IResolveFieldContext context, FieldMiddlewareDelegate next)
     {
-        /// <inheritdoc/>
-        public ValueTask<object?> ResolveAsync(IResolveFieldContext context, FieldMiddlewareDelegate next)
+        return context.Metrics.Enabled
+            ? ResolveWhenMetricsEnabledAsync(context, next)
+            : next(context);
+    }
+
+    private async ValueTask<object?> ResolveWhenMetricsEnabledAsync(IResolveFieldContext context, FieldMiddlewareDelegate next)
+    {
+        var name = context.FieldAst.Name.StringValue; //ISSUE:allocation
+
+        var metadata = new Dictionary<string, object?>
         {
-            return context.Metrics.Enabled
-                ? ResolveWhenMetricsEnabledAsync(context, next)
-                : next(context);
+            { "typeName", context.ParentType.Name },
+            { "fieldName", name },
+            { "returnTypeName", context.FieldDefinition.ResolvedType!.ToString() },
+            { "path", context.ResponsePath },
+        };
+
+        var marker = context.Metrics.Subject("field", name, metadata);
+        var disposeMarker = true;
+        try
+        {
+            var ret = await next(context).ConfigureAwait(false);
+            if (ret is IDataLoaderResult dataLoaderResult)
+            {
+                disposeMarker = false;
+                return new CompleteDataLoaderResult(dataLoaderResult, marker);
+            }
+            return ret;
+        }
+        finally
+        {
+            if (disposeMarker)
+                marker.Dispose();
+        }
+    }
+
+    private class CompleteDataLoaderResult : IDataLoaderResult
+    {
+        private readonly IDataLoaderResult _baseDataLoaderResult;
+        private readonly Metrics.Marker _marker;
+
+        public CompleteDataLoaderResult(IDataLoaderResult baseDataLoaderResult, Metrics.Marker marker)
+        {
+            _baseDataLoaderResult = baseDataLoaderResult;
+            _marker = marker;
         }
 
-        private async ValueTask<object?> ResolveWhenMetricsEnabledAsync(IResolveFieldContext context, FieldMiddlewareDelegate next)
+        public async Task<object?> GetResultAsync(CancellationToken cancellationToken = default)
         {
-            var name = context.FieldAst.Name.StringValue; //ISSUE:allocation
-
-            var metadata = new Dictionary<string, object?>
-            {
-                { "typeName", context.ParentType.Name },
-                { "fieldName", name },
-                { "returnTypeName", context.FieldDefinition.ResolvedType!.ToString() },
-                { "path", context.ResponsePath },
-            };
-
-            var marker = context.Metrics.Subject("field", name, metadata);
-            var disposeMarker = true;
-            try
-            {
-                var ret = await next(context).ConfigureAwait(false);
-                if (ret is IDataLoaderResult dataLoaderResult)
-                {
-                    disposeMarker = false;
-                    return new CompleteDataLoaderResult(dataLoaderResult, marker);
-                }
-                return ret;
-            }
-            finally
-            {
-                if (disposeMarker)
-                    marker.Dispose();
-            }
-        }
-
-        private class CompleteDataLoaderResult : IDataLoaderResult
-        {
-            private readonly IDataLoaderResult _baseDataLoaderResult;
-            private readonly Metrics.Marker _marker;
-
-            public CompleteDataLoaderResult(IDataLoaderResult baseDataLoaderResult, Metrics.Marker marker)
-            {
-                _baseDataLoaderResult = baseDataLoaderResult;
-                _marker = marker;
-            }
-
-            public async Task<object?> GetResultAsync(CancellationToken cancellationToken = default)
-            {
-                using (_marker)
-                    return await _baseDataLoaderResult.GetResultAsync(cancellationToken).ConfigureAwait(false);
-            }
+            using (_marker)
+                return await _baseDataLoaderResult.GetResultAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/GraphQL/Instrumentation/Metrics.cs
+++ b/src/GraphQL/Instrumentation/Metrics.cs
@@ -1,129 +1,128 @@
 using GraphQLParser;
 
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Records metrics during execution of a GraphQL document.
+/// </summary>
+public class Metrics
 {
+    private ValueStopwatch _stopwatch;
+    private readonly List<PerfRecord>? _records;
+    private PerfRecord? _main;
+
     /// <summary>
-    /// Records metrics during execution of a GraphQL document.
+    /// Gets an instance of the metrics for which metrics collection is disabled.
     /// </summary>
-    public class Metrics
+    public static Metrics None { get; } = new Metrics(false);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Metrics"/> class.
+    /// </summary>
+    /// <param name="enabled">Indicates if metrics should be recorded for this execution.</param>
+    public Metrics(bool enabled = true)
     {
-        private ValueStopwatch _stopwatch;
-        private readonly List<PerfRecord>? _records;
-        private PerfRecord? _main;
+        Enabled = enabled;
+        if (enabled)
+            _records = new List<PerfRecord>();
+    }
 
-        /// <summary>
-        /// Gets an instance of the metrics for which metrics collection is disabled.
-        /// </summary>
-        public static Metrics None { get; } = new Metrics(false);
+    /// <summary>
+    /// Shows whether metrics collection is enabled.
+    /// </summary>
+    public bool Enabled { get; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Metrics"/> class.
-        /// </summary>
-        /// <param name="enabled">Indicates if metrics should be recorded for this execution.</param>
-        public Metrics(bool enabled = true)
+    /// <summary>
+    /// Logs the start of the execution.
+    /// </summary>
+    /// <param name="operationName">The name of the GraphQL operation.</param>
+    public Metrics Start(string? operationName)
+    {
+        if (Enabled)
         {
-            Enabled = enabled;
-            if (enabled)
-                _records = new List<PerfRecord>();
+            if (_main != null)
+                throw new InvalidOperationException("Metrics.Start has already been called");
+
+            _main = new PerfRecord("operation", operationName, 0);
+            _records!.Add(_main);
+            _stopwatch = ValueStopwatch.StartNew();
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the name of the GraphQL operation.
+    /// </summary>
+    public Metrics SetOperationName(ROM name)
+    {
+        if (Enabled && _main != null)
+            _main.Subject = name.IsEmpty ? null : (string)name;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Records an performance metric.
+    /// </summary>
+    /// <param name="category">The category name for recorded metric, for example, "document" or "field".</param>
+    /// <param name="subject">The subject for recorded metric, for example, "Initializing schema" or "Building document".</param>
+    /// <param name="metadata">A dictionary of additional metadata for metric.</param>
+    /// <returns><see cref="Marker"/></returns>
+    public Marker Subject(string category, string? subject, Dictionary<string, object?>? metadata = null)
+    {
+        if (!Enabled)
+            return Marker.Empty;
+
+        if (_main == null)
+            throw new InvalidOperationException("Metrics.Start should be called before calling Metrics.Subject");
+
+        var record = new PerfRecord(category, subject, _stopwatch.Elapsed.TotalMilliseconds, metadata);
+        lock (_records!)
+            _records!.Add(record);
+        return new Marker(record, _stopwatch);
+    }
+
+    /// <summary>
+    /// Returns the collected performance metrics.
+    /// </summary>
+    public PerfRecord[]? Finish()
+    {
+        if (!Enabled)
+            return null;
+
+        _main?.MarkEnd(_stopwatch.Elapsed.TotalMilliseconds);
+        return _records!.OrderBy(x => x.Start).ToArray();
+    }
+
+    /// <summary>
+    /// An object that, when disposed, records the completion time of a performance metric in an assigned <see cref="PerfRecord"/>.
+    /// </summary>
+    public readonly struct Marker : IDisposable
+    {
+        private readonly PerfRecord _record;
+        private readonly ValueStopwatch _stopwatch;
+
+        /// <summary>
+        /// Returns an instance that does not perform any action when disposed.
+        /// </summary>
+        public static readonly Marker Empty;
+
+        /// <summary>
+        /// Initializes an instance with the specified performance metric and running stopwatch.
+        /// </summary>
+        public Marker(PerfRecord record, ValueStopwatch stopwatch)
+        {
+            _record = record;
+            _stopwatch = stopwatch;
         }
 
         /// <summary>
-        /// Shows whether metrics collection is enabled.
+        /// Stores the completion time of the assigned performance metric.
         /// </summary>
-        public bool Enabled { get; }
-
-        /// <summary>
-        /// Logs the start of the execution.
-        /// </summary>
-        /// <param name="operationName">The name of the GraphQL operation.</param>
-        public Metrics Start(string? operationName)
+        public void Dispose()
         {
-            if (Enabled)
-            {
-                if (_main != null)
-                    throw new InvalidOperationException("Metrics.Start has already been called");
-
-                _main = new PerfRecord("operation", operationName, 0);
-                _records!.Add(_main);
-                _stopwatch = ValueStopwatch.StartNew();
-            }
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the name of the GraphQL operation.
-        /// </summary>
-        public Metrics SetOperationName(ROM name)
-        {
-            if (Enabled && _main != null)
-                _main.Subject = name.IsEmpty ? null : (string)name;
-
-            return this;
-        }
-
-        /// <summary>
-        /// Records an performance metric.
-        /// </summary>
-        /// <param name="category">The category name for recorded metric, for example, "document" or "field".</param>
-        /// <param name="subject">The subject for recorded metric, for example, "Initializing schema" or "Building document".</param>
-        /// <param name="metadata">A dictionary of additional metadata for metric.</param>
-        /// <returns><see cref="Marker"/></returns>
-        public Marker Subject(string category, string? subject, Dictionary<string, object?>? metadata = null)
-        {
-            if (!Enabled)
-                return Marker.Empty;
-
-            if (_main == null)
-                throw new InvalidOperationException("Metrics.Start should be called before calling Metrics.Subject");
-
-            var record = new PerfRecord(category, subject, _stopwatch.Elapsed.TotalMilliseconds, metadata);
-            lock (_records!)
-                _records!.Add(record);
-            return new Marker(record, _stopwatch);
-        }
-
-        /// <summary>
-        /// Returns the collected performance metrics.
-        /// </summary>
-        public PerfRecord[]? Finish()
-        {
-            if (!Enabled)
-                return null;
-
-            _main?.MarkEnd(_stopwatch.Elapsed.TotalMilliseconds);
-            return _records!.OrderBy(x => x.Start).ToArray();
-        }
-
-        /// <summary>
-        /// An object that, when disposed, records the completion time of a performance metric in an assigned <see cref="PerfRecord"/>.
-        /// </summary>
-        public readonly struct Marker : IDisposable
-        {
-            private readonly PerfRecord _record;
-            private readonly ValueStopwatch _stopwatch;
-
-            /// <summary>
-            /// Returns an instance that does not perform any action when disposed.
-            /// </summary>
-            public static readonly Marker Empty;
-
-            /// <summary>
-            /// Initializes an instance with the specified performance metric and running stopwatch.
-            /// </summary>
-            public Marker(PerfRecord record, ValueStopwatch stopwatch)
-            {
-                _record = record;
-                _stopwatch = stopwatch;
-            }
-
-            /// <summary>
-            /// Stores the completion time of the assigned performance metric.
-            /// </summary>
-            public void Dispose()
-            {
-                _record?.MarkEnd(_stopwatch.Elapsed.TotalMilliseconds);
-            }
+            _record?.MarkEnd(_stopwatch.Elapsed.TotalMilliseconds);
         }
     }
 }

--- a/src/GraphQL/Instrumentation/PerfRecord.cs
+++ b/src/GraphQL/Instrumentation/PerfRecord.cs
@@ -1,68 +1,67 @@
 using System.Diagnostics;
 
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// Records a performance metric.
+/// </summary>
+[DebuggerDisplay("Type={Category} Subject={Subject} Duration={Duration}")]
+public class PerfRecord
 {
     /// <summary>
-    /// Records a performance metric.
+    /// Initializes a new instance with the specified properties.
     /// </summary>
-    [DebuggerDisplay("Type={Category} Subject={Subject} Duration={Duration}")]
-    public class PerfRecord
+    public PerfRecord(string category, string? subject, double start, Dictionary<string, object?>? metadata = null)
     {
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public PerfRecord(string category, string? subject, double start, Dictionary<string, object?>? metadata = null)
-        {
-            Category = category;
-            Subject = subject;
-            Start = start;
-            Metadata = metadata;
-        }
+        Category = category;
+        Subject = subject;
+        Start = start;
+        Metadata = metadata;
+    }
 
-        /// <summary>
-        /// Sets the completion time, represented as an offset in milliseconds from starting the GraphQL operation's execution.
-        /// </summary>
-        public void MarkEnd(double end) => End = end;
+    /// <summary>
+    /// Sets the completion time, represented as an offset in milliseconds from starting the GraphQL operation's execution.
+    /// </summary>
+    public void MarkEnd(double end) => End = end;
 
-        /// <summary>
-        /// Gets or sets the category name.
-        /// </summary>
-        public string Category { get; set; }
+    /// <summary>
+    /// Gets or sets the category name.
+    /// </summary>
+    public string Category { get; set; }
 
-        /// <summary>
-        /// Gets or sets the subject name.
-        /// </summary>
-        public string? Subject { get; set; }
+    /// <summary>
+    /// Gets or sets the subject name.
+    /// </summary>
+    public string? Subject { get; set; }
 
-        /// <summary>
-        /// Gets or sets a dictionary of additional metadata.
-        /// </summary>
-        public Dictionary<string, object?>? Metadata { get; set; }
+    /// <summary>
+    /// Gets or sets a dictionary of additional metadata.
+    /// </summary>
+    public Dictionary<string, object?>? Metadata { get; set; }
 
-        /// <summary>
-        /// Gets or sets the start time, represented as an offset in milliseconds from starting the GraphQL operation's execution.
-        /// </summary>
-        public double Start { get; set; }
+    /// <summary>
+    /// Gets or sets the start time, represented as an offset in milliseconds from starting the GraphQL operation's execution.
+    /// </summary>
+    public double Start { get; set; }
 
-        /// <summary>
-        /// Gets or sets the completion time, represented as an offset in milliseconds from starting the GraphQL operation's execution.
-        /// </summary>
-        public double End { get; set; }
+    /// <summary>
+    /// Gets or sets the completion time, represented as an offset in milliseconds from starting the GraphQL operation's execution.
+    /// </summary>
+    public double End { get; set; }
 
-        /// <summary>
-        /// Returns the total number of milliseconds required to execute the operation represented by this performance metric.
-        /// </summary>
-        public double Duration => End - Start;
+    /// <summary>
+    /// Returns the total number of milliseconds required to execute the operation represented by this performance metric.
+    /// </summary>
+    public double Duration => End - Start;
 
-        /// <summary>
-        /// Returns metadata for the specified key. Similar to <see cref="Metadata"/>[<paramref name="key"/>],
-        /// but returns <c>default</c> if <see cref="Metadata"/> is <see langword="null"/> or the specified
-        /// key does not exist.
-        /// </summary>
-        public T? MetaField<T>(string key)
-        {
-            var local = Metadata;
-            return local != null && local.TryGetValue(key, out var value) ? (T?)value : default;
-        }
+    /// <summary>
+    /// Returns metadata for the specified key. Similar to <see cref="Metadata"/>[<paramref name="key"/>],
+    /// but returns <c>default</c> if <see cref="Metadata"/> is <see langword="null"/> or the specified
+    /// key does not exist.
+    /// </summary>
+    public T? MetaField<T>(string key)
+    {
+        var local = Metadata;
+        return local != null && local.TryGetValue(key, out var value) ? (T?)value : default;
     }
 }

--- a/src/GraphQL/Instrumentation/ValueStopwatch.cs
+++ b/src/GraphQL/Instrumentation/ValueStopwatch.cs
@@ -1,42 +1,41 @@
 using System.Diagnostics;
 
-namespace GraphQL.Instrumentation
+namespace GraphQL.Instrumentation;
+
+/// <summary>
+/// This is already familiar <see cref="Stopwatch"/> but as a readonly struct. Doesn't allocate memory on the managed heap.
+/// </summary>
+public readonly struct ValueStopwatch
 {
-    /// <summary>
-    /// This is already familiar <see cref="Stopwatch"/> but as a readonly struct. Doesn't allocate memory on the managed heap.
-    /// </summary>
-    public readonly struct ValueStopwatch
+    private static readonly double _timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+    private readonly long _startTimestamp;
+
+    /// <inheritdoc cref="Stopwatch.IsRunning"/>
+    public bool IsActive => _startTimestamp != 0;
+
+    private ValueStopwatch(long startTimestamp)
     {
-        private static readonly double _timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+        _startTimestamp = startTimestamp;
+    }
 
-        private readonly long _startTimestamp;
+    /// <inheritdoc cref="Stopwatch.StartNew"/>
+    public static ValueStopwatch StartNew() => new(Stopwatch.GetTimestamp());
 
-        /// <inheritdoc cref="Stopwatch.IsRunning"/>
-        public bool IsActive => _startTimestamp != 0;
-
-        private ValueStopwatch(long startTimestamp)
+    /// <inheritdoc cref="Stopwatch.Elapsed"/>
+    public TimeSpan Elapsed
+    {
+        get
         {
-            _startTimestamp = startTimestamp;
-        }
+            // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+            // So it being 0 is a clear indication of default(ValueStopwatch)
+            if (!IsActive)
+                throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
 
-        /// <inheritdoc cref="Stopwatch.StartNew"/>
-        public static ValueStopwatch StartNew() => new(Stopwatch.GetTimestamp());
-
-        /// <inheritdoc cref="Stopwatch.Elapsed"/>
-        public TimeSpan Elapsed
-        {
-            get
-            {
-                // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
-                // So it being 0 is a clear indication of default(ValueStopwatch)
-                if (!IsActive)
-                    throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
-
-                long end = Stopwatch.GetTimestamp();
-                long timestampDelta = end - _startTimestamp;
-                long ticks = (long)(_timestampToTicks * timestampDelta);
-                return new TimeSpan(ticks);
-            }
+            long end = Stopwatch.GetTimestamp();
+            long timestampDelta = end - _startTimestamp;
+            long ticks = (long)(_timestampToTicks * timestampDelta);
+            return new TimeSpan(ticks);
         }
     }
 }

--- a/src/GraphQL/Introspection/ISchemaComparer.cs
+++ b/src/GraphQL/Introspection/ISchemaComparer.cs
@@ -1,116 +1,115 @@
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// Provides the ability to order the schema elements upon introspection or printing.
+/// </summary>
+public interface ISchemaComparer
 {
     /// <summary>
-    /// Provides the ability to order the schema elements upon introspection or printing.
+    /// Returns a comparer for GraphQL types.
+    /// If this returns <see langword="null"/> then the original type ordering is preserved.
     /// </summary>
-    public interface ISchemaComparer
-    {
-        /// <summary>
-        /// Returns a comparer for GraphQL types.
-        /// If this returns <see langword="null"/> then the original type ordering is preserved.
-        /// </summary>
-        IComparer<IGraphType>? TypeComparer { get; }
-
-        /// <summary>
-        /// Returns a comparer for fields withing enclosing type.
-        /// If this returns <see langword="null"/> then the original field ordering is preserved.
-        /// </summary>
-        /// <param name="parent">Parent type to which the fields belong.</param>
-        IComparer<IFieldType>? FieldComparer(IGraphType parent);
-
-        /// <summary>
-        /// Returns a comparer for field arguments.
-        /// If this returns <see langword="null"/> then the original argument ordering is preserved.
-        /// </summary>
-        /// <param name="field">The field to which the arguments belong.</param>
-        IComparer<QueryArgument>? ArgumentComparer(IFieldType field);
-
-        /// <summary>
-        /// Returns a comparer for enum values.
-        /// If this returns <see langword="null"/> then the original enum value ordering is preserved.
-        /// </summary>
-        /// <param name="parent">The enumeration to which the enum values belong.</param>
-        IComparer<EnumValueDefinition>? EnumValueComparer(EnumerationGraphType parent);
-
-        /// <summary>
-        /// Returns a comparer for GraphQL directives.
-        /// If this returns <see langword="null"/> then the original directive ordering is preserved.
-        /// </summary>
-        IComparer<Directive>? DirectiveComparer { get; }
-    }
+    IComparer<IGraphType>? TypeComparer { get; }
 
     /// <summary>
-    /// Default schema comparer. By default all elements are returned as is, no sorting is applied.
+    /// Returns a comparer for fields withing enclosing type.
+    /// If this returns <see langword="null"/> then the original field ordering is preserved.
     /// </summary>
-    public class DefaultSchemaComparer : ISchemaComparer
-    {
-        /// <inheritdoc/>
-        public virtual IComparer<IGraphType>? TypeComparer => null;
-
-        /// <inheritdoc/>
-        public virtual IComparer<Directive>? DirectiveComparer => null;
-
-        /// <inheritdoc/>
-        public virtual IComparer<QueryArgument>? ArgumentComparer(IFieldType field) => null;
-
-        /// <inheritdoc/>
-        public virtual IComparer<EnumValueDefinition>? EnumValueComparer(EnumerationGraphType parent) => null;
-
-        /// <inheritdoc/>
-        public virtual IComparer<IFieldType>? FieldComparer(IGraphType parent) => null;
-    }
+    /// <param name="parent">Parent type to which the fields belong.</param>
+    IComparer<IFieldType>? FieldComparer(IGraphType parent);
 
     /// <summary>
-    /// All elements are sorted in alphabetical order of their names.
+    /// Returns a comparer for field arguments.
+    /// If this returns <see langword="null"/> then the original argument ordering is preserved.
     /// </summary>
-    public class AlphabeticalSchemaComparer : ISchemaComparer
+    /// <param name="field">The field to which the arguments belong.</param>
+    IComparer<QueryArgument>? ArgumentComparer(IFieldType field);
+
+    /// <summary>
+    /// Returns a comparer for enum values.
+    /// If this returns <see langword="null"/> then the original enum value ordering is preserved.
+    /// </summary>
+    /// <param name="parent">The enumeration to which the enum values belong.</param>
+    IComparer<EnumValueDefinition>? EnumValueComparer(EnumerationGraphType parent);
+
+    /// <summary>
+    /// Returns a comparer for GraphQL directives.
+    /// If this returns <see langword="null"/> then the original directive ordering is preserved.
+    /// </summary>
+    IComparer<Directive>? DirectiveComparer { get; }
+}
+
+/// <summary>
+/// Default schema comparer. By default all elements are returned as is, no sorting is applied.
+/// </summary>
+public class DefaultSchemaComparer : ISchemaComparer
+{
+    /// <inheritdoc/>
+    public virtual IComparer<IGraphType>? TypeComparer => null;
+
+    /// <inheritdoc/>
+    public virtual IComparer<Directive>? DirectiveComparer => null;
+
+    /// <inheritdoc/>
+    public virtual IComparer<QueryArgument>? ArgumentComparer(IFieldType field) => null;
+
+    /// <inheritdoc/>
+    public virtual IComparer<EnumValueDefinition>? EnumValueComparer(EnumerationGraphType parent) => null;
+
+    /// <inheritdoc/>
+    public virtual IComparer<IFieldType>? FieldComparer(IGraphType parent) => null;
+}
+
+/// <summary>
+/// All elements are sorted in alphabetical order of their names.
+/// </summary>
+public class AlphabeticalSchemaComparer : ISchemaComparer
+{
+    private static readonly TypeByNameComparer _instance1 = new();
+    private static readonly DirectiveByNameComparer _instance2 = new();
+    private static readonly ArgumentByNameComparer _instance3 = new();
+    private static readonly EnumValueByNameComparer _instance4 = new();
+    private static readonly FieldByNameComparer _instance5 = new();
+
+    private sealed class TypeByNameComparer : IComparer<IGraphType>
     {
-        private static readonly TypeByNameComparer _instance1 = new();
-        private static readonly DirectiveByNameComparer _instance2 = new();
-        private static readonly ArgumentByNameComparer _instance3 = new();
-        private static readonly EnumValueByNameComparer _instance4 = new();
-        private static readonly FieldByNameComparer _instance5 = new();
-
-        private sealed class TypeByNameComparer : IComparer<IGraphType>
-        {
-            public int Compare(IGraphType? x, IGraphType? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
-        }
-
-        private sealed class DirectiveByNameComparer : IComparer<Directive>
-        {
-            public int Compare(Directive? x, Directive? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
-        }
-
-        private sealed class ArgumentByNameComparer : IComparer<QueryArgument>
-        {
-            public int Compare(QueryArgument? x, QueryArgument? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
-        }
-
-        private sealed class EnumValueByNameComparer : IComparer<EnumValueDefinition>
-        {
-            public int Compare(EnumValueDefinition? x, EnumValueDefinition? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
-        }
-
-        private sealed class FieldByNameComparer : IComparer<IFieldType>
-        {
-            public int Compare(IFieldType? x, IFieldType? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
-        }
-
-        /// <inheritdoc/>
-        public virtual IComparer<IGraphType> TypeComparer => _instance1;
-
-        /// <inheritdoc/>
-        public virtual IComparer<Directive> DirectiveComparer => _instance2;
-
-        /// <inheritdoc/>
-        public virtual IComparer<QueryArgument> ArgumentComparer(IFieldType field) => _instance3;
-
-        /// <inheritdoc/>
-        public virtual IComparer<EnumValueDefinition> EnumValueComparer(EnumerationGraphType parent) => _instance4;
-
-        /// <inheritdoc/>
-        public virtual IComparer<IFieldType> FieldComparer(IGraphType parent) => _instance5;
+        public int Compare(IGraphType? x, IGraphType? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
     }
+
+    private sealed class DirectiveByNameComparer : IComparer<Directive>
+    {
+        public int Compare(Directive? x, Directive? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
+    }
+
+    private sealed class ArgumentByNameComparer : IComparer<QueryArgument>
+    {
+        public int Compare(QueryArgument? x, QueryArgument? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
+    }
+
+    private sealed class EnumValueByNameComparer : IComparer<EnumValueDefinition>
+    {
+        public int Compare(EnumValueDefinition? x, EnumValueDefinition? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
+    }
+
+    private sealed class FieldByNameComparer : IComparer<IFieldType>
+    {
+        public int Compare(IFieldType? x, IFieldType? y) => (x?.Name ?? "").CompareTo(y?.Name ?? "");
+    }
+
+    /// <inheritdoc/>
+    public virtual IComparer<IGraphType> TypeComparer => _instance1;
+
+    /// <inheritdoc/>
+    public virtual IComparer<Directive> DirectiveComparer => _instance2;
+
+    /// <inheritdoc/>
+    public virtual IComparer<QueryArgument> ArgumentComparer(IFieldType field) => _instance3;
+
+    /// <inheritdoc/>
+    public virtual IComparer<EnumValueDefinition> EnumValueComparer(EnumerationGraphType parent) => _instance4;
+
+    /// <inheritdoc/>
+    public virtual IComparer<IFieldType> FieldComparer(IGraphType parent) => _instance5;
 }

--- a/src/GraphQL/Introspection/ISchemaFilter.cs
+++ b/src/GraphQL/Introspection/ISchemaFilter.cs
@@ -1,118 +1,117 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// Provides the ability to filter the schema upon introspection to hide types, fields, arguments, enum values, and directives.
+/// Can be used to hide information, such as graph types, from clients that have an inadequate permission level.
+/// </summary>
+public interface ISchemaFilter
 {
     /// <summary>
-    /// Provides the ability to filter the schema upon introspection to hide types, fields, arguments, enum values, and directives.
-    /// Can be used to hide information, such as graph types, from clients that have an inadequate permission level.
+    /// Returns a boolean indicating whether the specified graph type should be returned within the introspection query.
     /// </summary>
-    public interface ISchemaFilter
-    {
-        /// <summary>
-        /// Returns a boolean indicating whether the specified graph type should be returned within the introspection query.
-        /// </summary>
-        /// <param name="type">The graph type to consider.</param>
-        Task<bool> AllowType(IGraphType type);
-
-        /// <summary>
-        /// Returns a boolean indicating whether the specified field should be returned within the introspection query.
-        /// </summary>
-        /// <param name="parent">The parent type to which the field belongs.</param>
-        /// <param name="field">The field to consider.</param>
-        Task<bool> AllowField(IGraphType parent, IFieldType field);
-
-        /// <summary>
-        /// Returns a boolean indicating whether the specified argument should be returned within the introspection query.
-        /// </summary>
-        /// <param name="field">The field to which the argument belongs.</param>
-        /// <param name="argument">The argument to consider.</param>
-        Task<bool> AllowArgument(IFieldType field, QueryArgument argument);
-
-        /// <summary>
-        /// Returns a boolean indicating whether the specified enumeration value should be returned within the introspection query.
-        /// </summary>
-        /// <param name="parent">The enumeration to which the enumeration value belongs.</param>
-        /// <param name="enumValue">The enumeration value to consider.</param>
-        Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue);
-
-        /// <summary>
-        /// Returns a boolean indicating whether the specified directive should be returned within the introspection query.
-        /// </summary>
-        /// <param name="directive">The directive to consider.</param>
-        Task<bool> AllowDirective(Directive directive);
-    }
+    /// <param name="type">The graph type to consider.</param>
+    Task<bool> AllowType(IGraphType type);
 
     /// <summary>
-    /// The default schema filter. By default nothing is hidden. Please note
-    /// that some features that are not in the official specification may be
-    /// hidden by default. These features can be unlocked using special
-    /// <see cref="ExperimentalIntrospectionFeaturesSchemaFilter"/> filter.
+    /// Returns a boolean indicating whether the specified field should be returned within the introspection query.
     /// </summary>
-    public class DefaultSchemaFilter : ISchemaFilter
+    /// <param name="parent">The parent type to which the field belongs.</param>
+    /// <param name="field">The field to consider.</param>
+    Task<bool> AllowField(IGraphType parent, IFieldType field);
+
+    /// <summary>
+    /// Returns a boolean indicating whether the specified argument should be returned within the introspection query.
+    /// </summary>
+    /// <param name="field">The field to which the argument belongs.</param>
+    /// <param name="argument">The argument to consider.</param>
+    Task<bool> AllowArgument(IFieldType field, QueryArgument argument);
+
+    /// <summary>
+    /// Returns a boolean indicating whether the specified enumeration value should be returned within the introspection query.
+    /// </summary>
+    /// <param name="parent">The enumeration to which the enumeration value belongs.</param>
+    /// <param name="enumValue">The enumeration value to consider.</param>
+    Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue);
+
+    /// <summary>
+    /// Returns a boolean indicating whether the specified directive should be returned within the introspection query.
+    /// </summary>
+    /// <param name="directive">The directive to consider.</param>
+    Task<bool> AllowDirective(Directive directive);
+}
+
+/// <summary>
+/// The default schema filter. By default nothing is hidden. Please note
+/// that some features that are not in the official specification may be
+/// hidden by default. These features can be unlocked using special
+/// <see cref="ExperimentalIntrospectionFeaturesSchemaFilter"/> filter.
+/// </summary>
+public class DefaultSchemaFilter : ISchemaFilter
+{
+    /// <summary>
+    /// Cached <c>Task.FromResult(true)</c>.
+    /// </summary>
+    protected static readonly Task<bool> Allowed = Task.FromResult(true);
+
+    /// <summary>
+    /// Cached <c>Task.FromResult(false)</c>.
+    /// </summary>
+    protected static readonly Task<bool> Forbidden = Task.FromResult(false);
+
+    /// <inheritdoc/>
+    public virtual Task<bool> AllowType(IGraphType type) => type is __AppliedDirective || type is __DirectiveArgument ? Forbidden : Allowed;
+
+    /// <inheritdoc/>
+    public virtual Task<bool> AllowField(IGraphType parent, IFieldType field) => parent.IsIntrospectionType() && (field.Name == "appliedDirectives" || field.Name == "isRepeatable") ? Forbidden : Allowed;
+
+    /// <inheritdoc/>
+    public virtual Task<bool> AllowArgument(IFieldType field, QueryArgument argument) => Allowed;
+
+    /// <inheritdoc/>
+    public virtual Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue) => Allowed;
+
+    /// <inheritdoc/>
+    public virtual Task<bool> AllowDirective(Directive directive)
     {
-        /// <summary>
-        /// Cached <c>Task.FromResult(true)</c>.
-        /// </summary>
-        protected static readonly Task<bool> Allowed = Task.FromResult(true);
+        if (directive.Introspectable.HasValue)
+            return directive.Introspectable.Value ? Allowed : Forbidden;
 
-        /// <summary>
-        /// Cached <c>Task.FromResult(false)</c>.
-        /// </summary>
-        protected static readonly Task<bool> Forbidden = Task.FromResult(false);
-
-        /// <inheritdoc/>
-        public virtual Task<bool> AllowType(IGraphType type) => type is __AppliedDirective || type is __DirectiveArgument ? Forbidden : Allowed;
-
-        /// <inheritdoc/>
-        public virtual Task<bool> AllowField(IGraphType parent, IFieldType field) => parent.IsIntrospectionType() && (field.Name == "appliedDirectives" || field.Name == "isRepeatable") ? Forbidden : Allowed;
-
-        /// <inheritdoc/>
-        public virtual Task<bool> AllowArgument(IFieldType field, QueryArgument argument) => Allowed;
-
-        /// <inheritdoc/>
-        public virtual Task<bool> AllowEnumValue(EnumerationGraphType parent, EnumValueDefinition enumValue) => Allowed;
-
-        /// <inheritdoc/>
-        public virtual Task<bool> AllowDirective(Directive directive)
+        // If the directive has all its locations of type ExecutableDirectiveLocation,
+        // only then it will be present in the introspection response.
+        foreach (var location in directive.Locations)
         {
-            if (directive.Introspectable.HasValue)
-                return directive.Introspectable.Value ? Allowed : Forbidden;
-
-            // If the directive has all its locations of type ExecutableDirectiveLocation,
-            // only then it will be present in the introspection response.
-            foreach (var location in directive.Locations)
+            if (!(
+                location == DirectiveLocation.Query ||
+                location == DirectiveLocation.Mutation ||
+                location == DirectiveLocation.Subscription ||
+                location == DirectiveLocation.Field ||
+                location == DirectiveLocation.FragmentDefinition ||
+                location == DirectiveLocation.FragmentSpread ||
+                location == DirectiveLocation.InlineFragment ||
+                location == DirectiveLocation.VariableDefinition))
             {
-                if (!(
-                    location == DirectiveLocation.Query ||
-                    location == DirectiveLocation.Mutation ||
-                    location == DirectiveLocation.Subscription ||
-                    location == DirectiveLocation.Field ||
-                    location == DirectiveLocation.FragmentDefinition ||
-                    location == DirectiveLocation.FragmentSpread ||
-                    location == DirectiveLocation.InlineFragment ||
-                    location == DirectiveLocation.VariableDefinition))
-                {
-                    return Forbidden;
-                }
+                return Forbidden;
             }
-
-            return Allowed;
         }
-    }
 
-    /// <summary>
-    /// Schema filter that enables some experimental features that are not in the
-    /// official specification, i.e. ability to expose user-defined meta-information
-    /// via introspection. See https://github.com/graphql/graphql-spec/issues/300
-    /// for more information.
-    /// </summary>
-    public class ExperimentalIntrospectionFeaturesSchemaFilter : DefaultSchemaFilter
-    {
-        /// <inheritdoc/>
-        public override Task<bool> AllowType(IGraphType type) => Allowed;
-
-        /// <inheritdoc/>
-        public override Task<bool> AllowField(IGraphType parent, IFieldType field) => Allowed;
+        return Allowed;
     }
+}
+
+/// <summary>
+/// Schema filter that enables some experimental features that are not in the
+/// official specification, i.e. ability to expose user-defined meta-information
+/// via introspection. See https://github.com/graphql/graphql-spec/issues/300
+/// for more information.
+/// </summary>
+public class ExperimentalIntrospectionFeaturesSchemaFilter : DefaultSchemaFilter
+{
+    /// <inheritdoc/>
+    public override Task<bool> AllowType(IGraphType type) => Allowed;
+
+    /// <inheritdoc/>
+    public override Task<bool> AllowField(IGraphType parent, IFieldType field) => Allowed;
 }

--- a/src/GraphQL/Introspection/SchemaMetaFieldType.cs
+++ b/src/GraphQL/Introspection/SchemaMetaFieldType.cs
@@ -1,23 +1,22 @@
 using GraphQL.Resolvers;
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <c>__schema</c> meta-field is available on the root of a query operation and
+/// returns a <see cref="__Schema"/> graph type for the schema.
+/// </summary>
+public class SchemaMetaFieldType : FieldType
 {
     /// <summary>
-    /// The <c>__schema</c> meta-field is available on the root of a query operation and
-    /// returns a <see cref="__Schema"/> graph type for the schema.
+    /// Initializes a new instance of the <c>__schema</c> meta-field.
     /// </summary>
-    public class SchemaMetaFieldType : FieldType
+    public SchemaMetaFieldType()
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>__schema</c> meta-field.
-        /// </summary>
-        public SchemaMetaFieldType()
-        {
-            SetName("__schema", validate: false);
-            Type = typeof(__Schema);
-            Description = "Access the current type schema of this server.";
-            Resolver = new FuncFieldResolver<ISchema>(context => context.Schema);
-        }
+        SetName("__schema", validate: false);
+        Type = typeof(__Schema);
+        Description = "Access the current type schema of this server.";
+        Resolver = new FuncFieldResolver<ISchema>(context => context.Schema);
     }
 }

--- a/src/GraphQL/Introspection/TypeKind.cs
+++ b/src/GraphQL/Introspection/TypeKind.cs
@@ -1,73 +1,72 @@
 using System.ComponentModel;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// An enumeration representing a kind of GraphQL type.
+/// </summary>
+public enum TypeKind
 {
     /// <summary>
-    /// An enumeration representing a kind of GraphQL type.
+    /// Indicates this type is a scalar.
     /// </summary>
-    public enum TypeKind
-    {
-        /// <summary>
-        /// Indicates this type is a scalar.
-        /// </summary>
-        [Description("Indicates this type is a scalar.")]
-        SCALAR = 0,
-
-        /// <summary>
-        /// Indicates this type is an object. `fields` and `possibleTypes` are valid fields.
-        /// </summary>
-        [Description("Indicates this type is an object. `fields` and `possibleTypes` are valid fields.")]
-        OBJECT = 1,
-
-        /// <summary>
-        /// Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.
-        /// </summary>
-        [Description("Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.")]
-        INTERFACE = 2,
-
-        /// <summary>
-        /// Indicates this type is a union. `possibleTypes` is a valid field.
-        /// </summary>
-        [Description("Indicates this type is a union. `possibleTypes` is a valid field.")]
-        UNION = 3,
-
-        /// <summary>
-        /// Indicates this type is an enum. `enumValues` is a valid field.
-        /// </summary>
-        [Description("Indicates this type is an enum. `enumValues` is a valid field.")]
-        ENUM = 4,
-
-        /// <summary>
-        /// Indicates this type is an input object. `inputFields` is a valid field.
-        /// </summary>
-        [Description("Indicates this type is an input object. `inputFields` is a valid field.")]
-        INPUT_OBJECT = 5,
-
-        /// <summary>
-        /// Indicates this type is a list. `ofType` is a valid field.
-        /// </summary>
-        [Description("Indicates this type is a list. `ofType` is a valid field.")]
-        LIST = 6,
-
-        /// <summary>
-        /// Indicates this type is a non-null. `ofType` is a valid field.
-        /// </summary>
-        [Description("Indicates this type is a non-null. `ofType` is a valid field.")]
-        NON_NULL = 7
-    }
+    [Description("Indicates this type is a scalar.")]
+    SCALAR = 0,
 
     /// <summary>
-    /// Shared and already boxed instances of <see cref="TypeKind"/> to avoid further boxing at runtime.
+    /// Indicates this type is an object. `fields` and `possibleTypes` are valid fields.
     /// </summary>
-    internal static class TypeKindBoxed
-    {
-        public static readonly object SCALAR = TypeKind.SCALAR;
-        public static readonly object OBJECT = TypeKind.OBJECT;
-        public static readonly object INTERFACE = TypeKind.INTERFACE;
-        public static readonly object UNION = TypeKind.UNION;
-        public static readonly object ENUM = TypeKind.ENUM;
-        public static readonly object INPUT_OBJECT = TypeKind.INPUT_OBJECT;
-        public static readonly object LIST = TypeKind.LIST;
-        public static readonly object NON_NULL = TypeKind.NON_NULL;
-    }
+    [Description("Indicates this type is an object. `fields` and `possibleTypes` are valid fields.")]
+    OBJECT = 1,
+
+    /// <summary>
+    /// Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.
+    /// </summary>
+    [Description("Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.")]
+    INTERFACE = 2,
+
+    /// <summary>
+    /// Indicates this type is a union. `possibleTypes` is a valid field.
+    /// </summary>
+    [Description("Indicates this type is a union. `possibleTypes` is a valid field.")]
+    UNION = 3,
+
+    /// <summary>
+    /// Indicates this type is an enum. `enumValues` is a valid field.
+    /// </summary>
+    [Description("Indicates this type is an enum. `enumValues` is a valid field.")]
+    ENUM = 4,
+
+    /// <summary>
+    /// Indicates this type is an input object. `inputFields` is a valid field.
+    /// </summary>
+    [Description("Indicates this type is an input object. `inputFields` is a valid field.")]
+    INPUT_OBJECT = 5,
+
+    /// <summary>
+    /// Indicates this type is a list. `ofType` is a valid field.
+    /// </summary>
+    [Description("Indicates this type is a list. `ofType` is a valid field.")]
+    LIST = 6,
+
+    /// <summary>
+    /// Indicates this type is a non-null. `ofType` is a valid field.
+    /// </summary>
+    [Description("Indicates this type is a non-null. `ofType` is a valid field.")]
+    NON_NULL = 7
+}
+
+/// <summary>
+/// Shared and already boxed instances of <see cref="TypeKind"/> to avoid further boxing at runtime.
+/// </summary>
+internal static class TypeKindBoxed
+{
+    public static readonly object SCALAR = TypeKind.SCALAR;
+    public static readonly object OBJECT = TypeKind.OBJECT;
+    public static readonly object INTERFACE = TypeKind.INTERFACE;
+    public static readonly object UNION = TypeKind.UNION;
+    public static readonly object ENUM = TypeKind.ENUM;
+    public static readonly object INPUT_OBJECT = TypeKind.INPUT_OBJECT;
+    public static readonly object LIST = TypeKind.LIST;
+    public static readonly object NON_NULL = TypeKind.NON_NULL;
 }

--- a/src/GraphQL/Introspection/TypeMetaFieldType.cs
+++ b/src/GraphQL/Introspection/TypeMetaFieldType.cs
@@ -1,24 +1,23 @@
 using GraphQL.Resolvers;
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <c>__type</c> meta-field is available on the root of a query operation and
+/// returns a <see cref="__Type"/> graph type for a specified graph type name.
+/// </summary>
+public class TypeMetaFieldType : FieldType
 {
     /// <summary>
-    /// The <c>__type</c> meta-field is available on the root of a query operation and
-    /// returns a <see cref="__Type"/> graph type for a specified graph type name.
+    /// Initializes a new instance of the <c>__type</c> meta-field.
     /// </summary>
-    public class TypeMetaFieldType : FieldType
+    public TypeMetaFieldType()
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>__type</c> meta-field.
-        /// </summary>
-        public TypeMetaFieldType()
-        {
-            SetName("__type", validate: false);
-            Type = typeof(__Type);
-            Description = "Request the type information of a single type.";
-            Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "name" });
-            Resolver = new FuncFieldResolver<object>(context => context.Schema.AllTypes[context.GetArgument<string>("name")!]);
-        }
+        SetName("__type", validate: false);
+        Type = typeof(__Type);
+        Description = "Request the type information of a single type.";
+        Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "name" });
+        Resolver = new FuncFieldResolver<object>(context => context.Schema.AllTypes[context.GetArgument<string>("name")!]);
     }
 }

--- a/src/GraphQL/Introspection/TypeNameMetaFieldType.cs
+++ b/src/GraphQL/Introspection/TypeNameMetaFieldType.cs
@@ -1,23 +1,22 @@
 using GraphQL.Resolvers;
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <c>__typename</c> meta-field is available on every type and
+/// returns the name of the type on which it was requested.
+/// </summary>
+public class TypeNameMetaFieldType : FieldType
 {
     /// <summary>
-    /// The <c>__typename</c> meta-field is available on every type and
-    /// returns the name of the type on which it was requested.
+    /// Initializes a new instance of the <c>__typename</c> meta-field.
     /// </summary>
-    public class TypeNameMetaFieldType : FieldType
+    public TypeNameMetaFieldType()
     {
-        /// <summary>
-        /// Initializes a new instance of the <c>__typename</c> meta-field.
-        /// </summary>
-        public TypeNameMetaFieldType()
-        {
-            SetName("__typename", validate: false);
-            Type = typeof(NonNullGraphType<StringGraphType>);
-            Description = "The name of the current Object type at runtime.";
-            Resolver = new FuncFieldResolver<object>(context => context.ParentType.Name);
-        }
+        SetName("__typename", validate: false);
+        Type = typeof(NonNullGraphType<StringGraphType>);
+        Description = "The name of the current Object type at runtime.";
+        Resolver = new FuncFieldResolver<object>(context => context.ParentType.Name);
     }
 }

--- a/src/GraphQL/Introspection/__AppliedDirective.cs
+++ b/src/GraphQL/Introspection/__AppliedDirective.cs
@@ -1,30 +1,29 @@
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <see cref="__AppliedDirective"/> introspection type represents
+/// a directive applied to a schema element - type, field, argument, etc.
+/// </summary>
+public class __AppliedDirective : ObjectGraphType<AppliedDirective>
 {
     /// <summary>
-    /// The <see cref="__AppliedDirective"/> introspection type represents
-    /// a directive applied to a schema element - type, field, argument, etc.
+    /// Initializes a new instance of this graph type.
     /// </summary>
-    public class __AppliedDirective : ObjectGraphType<AppliedDirective>
+    public __AppliedDirective()
     {
-        /// <summary>
-        /// Initializes a new instance of this graph type.
-        /// </summary>
-        public __AppliedDirective()
-        {
-            SetName(nameof(__AppliedDirective), validate: false);
+        SetName(nameof(__AppliedDirective), validate: false);
 
-            Description =
-                "Directive applied to a schema element";
+        Description =
+            "Directive applied to a schema element";
 
-            Field<NonNullGraphType<StringGraphType>>("name")
-                .Description("Directive name")
-                .Resolve(context => context.Source!.Name);
+        Field<NonNullGraphType<StringGraphType>>("name")
+            .Description("Directive name")
+            .Resolve(context => context.Source!.Name);
 
-            Field<NonNullGraphType<ListGraphType<NonNullGraphType<__DirectiveArgument>>>>("args")
-                .Description("Values of explicitly specified directive arguments")
-                .Resolve(context => context.Source!.List ?? Enumerable.Empty<DirectiveArgument>());
-        }
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<__DirectiveArgument>>>>("args")
+            .Description("Values of explicitly specified directive arguments")
+            .Resolve(context => context.Source!.List ?? Enumerable.Empty<DirectiveArgument>());
     }
 }

--- a/src/GraphQL/Introspection/__Directive.cs
+++ b/src/GraphQL/Introspection/__Directive.cs
@@ -1,63 +1,62 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <see cref="__Directive"/> introspection type represents a directive that a server supports.
+/// </summary>
+public class __Directive : ObjectGraphType<Directive>
 {
     /// <summary>
-    /// The <see cref="__Directive"/> introspection type represents a directive that a server supports.
+    /// Initializes a new instance of the <see cref="__Directive"/> introspection type.
     /// </summary>
-    public class __Directive : ObjectGraphType<Directive>
+    /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
+    /// <param name="allowRepeatable">Allows 'isRepeatable' field for this type. This feature is from a working draft of the specification.</param>
+    public __Directive(bool allowAppliedDirectives = false, bool allowRepeatable = false)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__Directive"/> introspection type.
-        /// </summary>
-        /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
-        /// <param name="allowRepeatable">Allows 'isRepeatable' field for this type. This feature is from a working draft of the specification.</param>
-        public __Directive(bool allowAppliedDirectives = false, bool allowRepeatable = false)
-        {
-            SetName(nameof(__Directive), validate: false);
+        SetName(nameof(__Directive), validate: false);
 
-            Description =
-                "A Directive provides a way to describe alternate runtime execution and " +
-                "type validation behavior in a GraphQL document." +
-               @"
+        Description =
+            "A Directive provides a way to describe alternate runtime execution and " +
+            "type validation behavior in a GraphQL document." +
+           @"
 
 " +
-                "In some cases, you need to provide options to alter GraphQL's " +
-                "execution behavior in ways field arguments will not suffice, such as " +
-                "conditionally including or skipping a field. Directives provide this by " +
-                "describing additional information to the executor.";
+            "In some cases, you need to provide options to alter GraphQL's " +
+            "execution behavior in ways field arguments will not suffice, such as " +
+            "conditionally including or skipping a field. Directives provide this by " +
+            "describing additional information to the executor.";
 
-            Field<NonNullGraphType<StringGraphType>>("name").Resolve(context => context.Source!.Name);
+        Field<NonNullGraphType<StringGraphType>>("name").Resolve(context => context.Source!.Name);
 
-            Field<StringGraphType>("description").Resolve(context => context.Source!.Description);
+        Field<StringGraphType>("description").Resolve(context => context.Source!.Description);
 
-            Field<NonNullGraphType<ListGraphType<NonNullGraphType<__DirectiveLocation>>>>("locations")
-                .Resolve(context => context.Source!.Locations);
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<__DirectiveLocation>>>>("locations")
+            .Resolve(context => context.Source!.Locations);
 
-            Field<NonNullGraphType<ListGraphType<NonNullGraphType<__InputValue>>>>("args")
-                .Resolve(context => context.Source!.Arguments?.List ?? Enumerable.Empty<QueryArgument>());
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<__InputValue>>>>("args")
+            .Resolve(context => context.Source!.Arguments?.List ?? Enumerable.Empty<QueryArgument>());
 
-            if (allowRepeatable)
-                Field<NonNullGraphType<BooleanGraphType>>("isRepeatable").Resolve(context => context.Source!.Repeatable);
+        if (allowRepeatable)
+            Field<NonNullGraphType<BooleanGraphType>>("isRepeatable").Resolve(context => context.Source!.Repeatable);
 
-            Field<NonNullGraphType<BooleanGraphType>>("onOperation").DeprecationReason("Use 'locations'.")
-                .Resolve(context => context.Source!.Locations.Any(l =>
-                        l == DirectiveLocation.Query ||
-                        l == DirectiveLocation.Mutation ||
-                        l == DirectiveLocation.Subscription));
+        Field<NonNullGraphType<BooleanGraphType>>("onOperation").DeprecationReason("Use 'locations'.")
+            .Resolve(context => context.Source!.Locations.Any(l =>
+                    l == DirectiveLocation.Query ||
+                    l == DirectiveLocation.Mutation ||
+                    l == DirectiveLocation.Subscription));
 
-            Field<NonNullGraphType<BooleanGraphType>>("onFragment").DeprecationReason("Use 'locations'.")
-                .Resolve(context => context.Source!.Locations.Any(l =>
-                        l == DirectiveLocation.FragmentSpread ||
-                        l == DirectiveLocation.InlineFragment ||
-                        l == DirectiveLocation.FragmentDefinition));
+        Field<NonNullGraphType<BooleanGraphType>>("onFragment").DeprecationReason("Use 'locations'.")
+            .Resolve(context => context.Source!.Locations.Any(l =>
+                    l == DirectiveLocation.FragmentSpread ||
+                    l == DirectiveLocation.InlineFragment ||
+                    l == DirectiveLocation.FragmentDefinition));
 
-            Field<NonNullGraphType<BooleanGraphType>>("onField").DeprecationReason("Use 'locations'.")
-                .Resolve(context => context.Source!.Locations.Any(l => l == DirectiveLocation.Field));
+        Field<NonNullGraphType<BooleanGraphType>>("onField").DeprecationReason("Use 'locations'.")
+            .Resolve(context => context.Source!.Locations.Any(l => l == DirectiveLocation.Field));
 
-            if (allowAppliedDirectives)
-                this.AddAppliedDirectivesField("directive");
-        }
+        if (allowAppliedDirectives)
+            this.AddAppliedDirectivesField("directive");
     }
 }

--- a/src/GraphQL/Introspection/__DirectiveArgument.cs
+++ b/src/GraphQL/Introspection/__DirectiveArgument.cs
@@ -1,47 +1,46 @@
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <see cref="__DirectiveArgument"/> introspection type represents an argument of
+/// a directive applied to a schema element - type, field, argument, etc.
+/// <br/><br/>
+/// Note that this class describes only explicitly specified arguments. If the argument in the directive
+/// definition has default value and this argument was not specified when applying the directive to schema
+/// element, then such an argument with default value will not be returned.
+/// </summary>
+public class __DirectiveArgument : ObjectGraphType<DirectiveArgument>
 {
     /// <summary>
-    /// The <see cref="__DirectiveArgument"/> introspection type represents an argument of
-    /// a directive applied to a schema element - type, field, argument, etc.
-    /// <br/><br/>
-    /// Note that this class describes only explicitly specified arguments. If the argument in the directive
-    /// definition has default value and this argument was not specified when applying the directive to schema
-    /// element, then such an argument with default value will not be returned.
+    /// Initializes a new instance of this graph type.
     /// </summary>
-    public class __DirectiveArgument : ObjectGraphType<DirectiveArgument>
+    public __DirectiveArgument()
     {
-        /// <summary>
-        /// Initializes a new instance of this graph type.
-        /// </summary>
-        public __DirectiveArgument()
-        {
-            SetName(nameof(__DirectiveArgument), validate: false);
+        SetName(nameof(__DirectiveArgument), validate: false);
 
-            Description =
-                "Value of an argument provided to directive";
+        Description =
+            "Value of an argument provided to directive";
 
-            Field<NonNullGraphType<StringGraphType>>("name")
-                .Description("Argument name")
-                .Resolve(context => context.Source!.Name);
+        Field<NonNullGraphType<StringGraphType>>("name")
+            .Description("Argument name")
+            .Resolve(context => context.Source!.Name);
 
-            Field<NonNullGraphType<StringGraphType>>("value")
-                .Description("A GraphQL-formatted string representing the value for argument.")
-                .Resolve(context =>
-                {
-                    var argument = context.Source!;
-                    if (argument.Value == null)
-                        return "null";
+        Field<NonNullGraphType<StringGraphType>>("value")
+            .Description("A GraphQL-formatted string representing the value for argument.")
+            .Resolve(context =>
+            {
+                var argument = context.Source!;
+                if (argument.Value == null)
+                    return "null";
 
-                    var grandParent = context.Parent!.Parent!;
-                    int index = (int)grandParent.Path.Last();
-                    var appliedDirective = ((IList<AppliedDirective>)grandParent.Source!)[index];
-                    var directiveDefinition = context.Schema.Directives.Find(appliedDirective.Name);
-                    var argumentDefinition = directiveDefinition!.Arguments!.Find(argument.Name);
+                var grandParent = context.Parent!.Parent!;
+                int index = (int)grandParent.Path.Last();
+                var appliedDirective = ((IList<AppliedDirective>)grandParent.Source!)[index];
+                var directiveDefinition = context.Schema.Directives.Find(appliedDirective.Name);
+                var argumentDefinition = directiveDefinition!.Arguments!.Find(argument.Name);
 
-                    return argumentDefinition!.ResolvedType!.Print(argument.Value);
-                });
-        }
+                return argumentDefinition!.ResolvedType!.Print(argument.Value);
+            });
     }
 }

--- a/src/GraphQL/Introspection/__DirectiveLocation.cs
+++ b/src/GraphQL/Introspection/__DirectiveLocation.cs
@@ -1,24 +1,23 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Introspection
-{
-    /// <summary>
-    /// An enumeration representing a location that a directive may be placed.
-    /// </summary>
-    public class __DirectiveLocation : EnumerationGraphType<DirectiveLocation>
-    {
-        internal static readonly __DirectiveLocation Instance = new();
+namespace GraphQL.Introspection;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__DirectiveLocation"/> graph type.
-        /// </summary>
-        public __DirectiveLocation()
-        {
-            SetName(nameof(__DirectiveLocation), validate: false);
-            Description =
-                "A Directive can be adjacent to many parts of the GraphQL language, a " +
-                "__DirectiveLocation describes one such possible adjacencies.";
-        }
+/// <summary>
+/// An enumeration representing a location that a directive may be placed.
+/// </summary>
+public class __DirectiveLocation : EnumerationGraphType<DirectiveLocation>
+{
+    internal static readonly __DirectiveLocation Instance = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="__DirectiveLocation"/> graph type.
+    /// </summary>
+    public __DirectiveLocation()
+    {
+        SetName(nameof(__DirectiveLocation), validate: false);
+        Description =
+            "A Directive can be adjacent to many parts of the GraphQL language, a " +
+            "__DirectiveLocation describes one such possible adjacencies.";
     }
 }

--- a/src/GraphQL/Introspection/__EnumValue.cs
+++ b/src/GraphQL/Introspection/__EnumValue.cs
@@ -1,32 +1,31 @@
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <see cref="__EnumValue"/> introspection type represents one of possible values of an enum.
+/// </summary>
+public class __EnumValue : ObjectGraphType<EnumValueDefinition>
 {
     /// <summary>
-    /// The <see cref="__EnumValue"/> introspection type represents one of possible values of an enum.
+    /// Initializes a new instance of the <see cref="__EnumValue"/> introspection type.
     /// </summary>
-    public class __EnumValue : ObjectGraphType<EnumValueDefinition>
+    /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
+    public __EnumValue(bool allowAppliedDirectives = false)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__EnumValue"/> introspection type.
-        /// </summary>
-        /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
-        public __EnumValue(bool allowAppliedDirectives = false)
-        {
-            SetName(nameof(__EnumValue), validate: false);
-            Description =
-                "One possible value for a given Enum. Enum values are unique values, not " +
-                "a placeholder for a string or numeric value. However an Enum value is " +
-                "returned in a JSON response as a string.";
+        SetName(nameof(__EnumValue), validate: false);
+        Description =
+            "One possible value for a given Enum. Enum values are unique values, not " +
+            "a placeholder for a string or numeric value. However an Enum value is " +
+            "returned in a JSON response as a string.";
 
-            Field<NonNullGraphType<StringGraphType>>("name").Resolve(context => context.Source!.Name);
-            Field<StringGraphType>("description").Resolve(context => context.Source!.Description);
+        Field<NonNullGraphType<StringGraphType>>("name").Resolve(context => context.Source!.Name);
+        Field<StringGraphType>("description").Resolve(context => context.Source!.Description);
 
-            Field<NonNullGraphType<BooleanGraphType>>("isDeprecated").Resolve(context => (!string.IsNullOrWhiteSpace(context.Source?.DeprecationReason)).Boxed());
-            Field<StringGraphType>("deprecationReason").Resolve(context => context.Source!.DeprecationReason);
+        Field<NonNullGraphType<BooleanGraphType>>("isDeprecated").Resolve(context => (!string.IsNullOrWhiteSpace(context.Source?.DeprecationReason)).Boxed());
+        Field<StringGraphType>("deprecationReason").Resolve(context => context.Source!.DeprecationReason);
 
-            if (allowAppliedDirectives)
-                this.AddAppliedDirectivesField("enum value");
-        }
+        if (allowAppliedDirectives)
+            this.AddAppliedDirectivesField("enum value");
     }
 }

--- a/src/GraphQL/Introspection/__Field.cs
+++ b/src/GraphQL/Introspection/__Field.cs
@@ -1,78 +1,77 @@
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <see cref="__Field"/> introspection type represents each field in an Object or Interface type.
+/// </summary>
+public class __Field : ObjectGraphType<IFieldType>
 {
     /// <summary>
-    /// The <see cref="__Field"/> introspection type represents each field in an Object or Interface type.
+    /// Initializes a new instance of the <see cref="__Field"/> introspection type.
     /// </summary>
-    public class __Field : ObjectGraphType<IFieldType>
+    /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
+    public __Field(bool allowAppliedDirectives = false)
+        : this(allowAppliedDirectives, false)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__Field"/> introspection type.
-        /// </summary>
-        /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
-        public __Field(bool allowAppliedDirectives = false)
-            : this(allowAppliedDirectives, false)
-        {
-        }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__Field"/> introspection type.
-        /// </summary>
-        /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
-        /// <param name="deprecationOfInputValues">
-        /// Allows deprecation of input values - arguments on a field or input fields on an input type.
-        /// This feature is from a working draft of the specification.
-        /// </param>
-        public __Field(bool allowAppliedDirectives = false, bool deprecationOfInputValues = false)
-        {
-            SetName(nameof(__Field), validate: false);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="__Field"/> introspection type.
+    /// </summary>
+    /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
+    /// <param name="deprecationOfInputValues">
+    /// Allows deprecation of input values - arguments on a field or input fields on an input type.
+    /// This feature is from a working draft of the specification.
+    /// </param>
+    public __Field(bool allowAppliedDirectives = false, bool deprecationOfInputValues = false)
+    {
+        SetName(nameof(__Field), validate: false);
 
-            Description =
-                "Object and Interface types are described by a list of Fields, each of " +
-                "which has a name, potentially a list of arguments, and a return type.";
+        Description =
+            "Object and Interface types are described by a list of Fields, each of " +
+            "which has a name, potentially a list of arguments, and a return type.";
 
-            Field<NonNullGraphType<StringGraphType>>("name").Resolve(context => context.Source.Name);
+        Field<NonNullGraphType<StringGraphType>>("name").Resolve(context => context.Source.Name);
 
-            Field<StringGraphType>("description").Resolve(context => context.Source.Description);
+        Field<StringGraphType>("description").Resolve(context => context.Source.Description);
 
-            var argsField = Field<NonNullGraphType<ListGraphType<NonNullGraphType<__InputValue>>>>("args")
-                .ResolveAsync(async context =>
+        var argsField = Field<NonNullGraphType<ListGraphType<NonNullGraphType<__InputValue>>>>("args")
+            .ResolveAsync(async context =>
+            {
+                var source = context.Source;
+                if (source.Arguments?.Count > 0)
                 {
-                    var source = context.Source;
-                    if (source.Arguments?.Count > 0)
+                    var arguments = context.ArrayPool.Rent<QueryArgument>(source.Arguments.Count);
+
+                    bool includeDeprecated = context.GetArgument<bool>("includeDeprecated");
+
+                    int index = 0;
+                    foreach (var argument in source.Arguments.List!)
                     {
-                        var arguments = context.ArrayPool.Rent<QueryArgument>(source.Arguments.Count);
-
-                        bool includeDeprecated = context.GetArgument<bool>("includeDeprecated");
-
-                        int index = 0;
-                        foreach (var argument in source.Arguments.List!)
-                        {
-                            if ((includeDeprecated || string.IsNullOrWhiteSpace(argument.DeprecationReason)) && await context.Schema.Filter.AllowArgument(source, argument).ConfigureAwait(false))
-                                arguments[index++] = argument;
-                        }
-
-                        var comparer = context.Schema.Comparer.ArgumentComparer(source);
-                        if (comparer != null)
-                            Array.Sort(arguments, 0, index, comparer);
-
-                        return arguments.Constrained(index);
+                        if ((includeDeprecated || string.IsNullOrWhiteSpace(argument.DeprecationReason)) && await context.Schema.Filter.AllowArgument(source, argument).ConfigureAwait(false))
+                            arguments[index++] = argument;
                     }
 
-                    return Array.Empty<QueryArgument>();
-                });
-            if (deprecationOfInputValues)
-                argsField.Argument<BooleanGraphType>("includeDeprecated", arg => arg.DefaultValue = BoolBox.False);
+                    var comparer = context.Schema.Comparer.ArgumentComparer(source);
+                    if (comparer != null)
+                        Array.Sort(arguments, 0, index, comparer);
 
-            Field<NonNullGraphType<__Type>>("type").Resolve(context => context.Source.ResolvedType);
+                    return arguments.Constrained(index);
+                }
 
-            Field<NonNullGraphType<BooleanGraphType>>("isDeprecated").Resolve(context => (!string.IsNullOrWhiteSpace(context.Source.DeprecationReason)).Boxed());
+                return Array.Empty<QueryArgument>();
+            });
+        if (deprecationOfInputValues)
+            argsField.Argument<BooleanGraphType>("includeDeprecated", arg => arg.DefaultValue = BoolBox.False);
 
-            Field<StringGraphType>("deprecationReason").Resolve(context => context.Source.DeprecationReason);
+        Field<NonNullGraphType<__Type>>("type").Resolve(context => context.Source.ResolvedType);
 
-            if (allowAppliedDirectives)
-                this.AddAppliedDirectivesField("field");
-        }
+        Field<NonNullGraphType<BooleanGraphType>>("isDeprecated").Resolve(context => (!string.IsNullOrWhiteSpace(context.Source.DeprecationReason)).Boxed());
+
+        Field<StringGraphType>("deprecationReason").Resolve(context => context.Source.DeprecationReason);
+
+        if (allowAppliedDirectives)
+            this.AddAppliedDirectivesField("field");
     }
 }

--- a/src/GraphQL/Introspection/__InputValue.cs
+++ b/src/GraphQL/Introspection/__InputValue.cs
@@ -1,64 +1,63 @@
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// The <see cref="__InputValue"/> introspection type represents field and directive arguments as well as the inputFields of an input object.
+/// </summary>
+public class __InputValue : ObjectGraphType<IMetadataReader> // context.Source either QueryArgument or FieldType
 {
     /// <summary>
-    /// The <see cref="__InputValue"/> introspection type represents field and directive arguments as well as the inputFields of an input object.
+    /// Initializes a new instance of the <see cref="__InputValue"/> introspection type.
     /// </summary>
-    public class __InputValue : ObjectGraphType<IMetadataReader> // context.Source either QueryArgument or FieldType
+    /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
+    public __InputValue(bool allowAppliedDirectives = false)
+        : this(allowAppliedDirectives, false)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__InputValue"/> introspection type.
-        /// </summary>
-        /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
-        public __InputValue(bool allowAppliedDirectives = false)
-            : this(allowAppliedDirectives, false)
-        {
-        }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__InputValue"/> introspection type.
-        /// </summary>
-        /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
-        /// <param name="deprecationOfInputValues">
-        /// Allows deprecation of input values - arguments on a field or input fields on an input type.
-        /// This feature is from a working draft of the specification.
-        /// </param>
-        public __InputValue(bool allowAppliedDirectives = false, bool deprecationOfInputValues = false)
-        {
-            SetName(nameof(__InputValue), validate: false);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="__InputValue"/> introspection type.
+    /// </summary>
+    /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
+    /// <param name="deprecationOfInputValues">
+    /// Allows deprecation of input values - arguments on a field or input fields on an input type.
+    /// This feature is from a working draft of the specification.
+    /// </param>
+    public __InputValue(bool allowAppliedDirectives = false, bool deprecationOfInputValues = false)
+    {
+        SetName(nameof(__InputValue), validate: false);
 
-            Description =
-                "Arguments provided to Fields or Directives and the input fields of an " +
-                "InputObject are represented as Input Values which describe their type " +
-                "and optionally a default value.";
+        Description =
+            "Arguments provided to Fields or Directives and the input fields of an " +
+            "InputObject are represented as Input Values which describe their type " +
+            "and optionally a default value.";
 
-            Field<NonNullGraphType<StringGraphType>>("name")
-                .Resolve(context => context.Source is QueryArgument arg ? arg.Name : ((FieldType)context.Source).Name); // avoid implicit use of FieldNameResolver here to make the code compatible with AOT compilation
+        Field<NonNullGraphType<StringGraphType>>("name")
+            .Resolve(context => context.Source is QueryArgument arg ? arg.Name : ((FieldType)context.Source).Name); // avoid implicit use of FieldNameResolver here to make the code compatible with AOT compilation
 
-            Field<StringGraphType>("description")
-                .Resolve(context => context.Source is QueryArgument arg ? arg.Description : ((FieldType)context.Source).Description);
+        Field<StringGraphType>("description")
+            .Resolve(context => context.Source is QueryArgument arg ? arg.Description : ((FieldType)context.Source).Description);
 
-            Field<NonNullGraphType<__Type>>("type").Resolve(context => ((IProvideResolvedType)context.Source!).ResolvedType);
+        Field<NonNullGraphType<__Type>>("type").Resolve(context => ((IProvideResolvedType)context.Source!).ResolvedType);
 
-            Field<StringGraphType>("defaultValue")
-                .Description("A GraphQL-formatted string representing the default value for this input value.")
-                .Resolve(context =>
-                {
-                    return context.Source is IHaveDefaultValue hasDefault && hasDefault.DefaultValue != null
-                        ? hasDefault.ResolvedType!.Print(hasDefault.DefaultValue)
-                        : null;
-                });
-
-            if (deprecationOfInputValues)
+        Field<StringGraphType>("defaultValue")
+            .Description("A GraphQL-formatted string representing the default value for this input value.")
+            .Resolve(context =>
             {
-                // context.Source either QueryArgument or FieldType
-                Field<NonNullGraphType<BooleanGraphType>>("isDeprecated").Resolve(context => (!string.IsNullOrWhiteSpace(((IProvideDeprecationReason)context.Source).DeprecationReason)).Boxed());
-                Field<StringGraphType>("deprecationReason").Resolve(context => ((IProvideDeprecationReason)context.Source).DeprecationReason);
-            }
+                return context.Source is IHaveDefaultValue hasDefault && hasDefault.DefaultValue != null
+                    ? hasDefault.ResolvedType!.Print(hasDefault.DefaultValue)
+                    : null;
+            });
 
-            if (allowAppliedDirectives)
-                this.AddAppliedDirectivesField("input value");
+        if (deprecationOfInputValues)
+        {
+            // context.Source either QueryArgument or FieldType
+            Field<NonNullGraphType<BooleanGraphType>>("isDeprecated").Resolve(context => (!string.IsNullOrWhiteSpace(((IProvideDeprecationReason)context.Source).DeprecationReason)).Boxed());
+            Field<StringGraphType>("deprecationReason").Resolve(context => ((IProvideDeprecationReason)context.Source).DeprecationReason);
         }
+
+        if (allowAppliedDirectives)
+            this.AddAppliedDirectivesField("input value");
     }
 }

--- a/src/GraphQL/Introspection/__Type.cs
+++ b/src/GraphQL/Introspection/__Type.cs
@@ -1,210 +1,209 @@
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// <see cref="__Type"/> is at the core of the type introspection system.
+/// It represents scalars, interfaces, object types, unions, enums in the system.
+/// </summary>
+public class __Type : ObjectGraphType<IGraphType>
 {
     /// <summary>
-    /// <see cref="__Type"/> is at the core of the type introspection system.
-    /// It represents scalars, interfaces, object types, unions, enums in the system.
+    /// Initializes a new instance of the <see cref="__Type"/> introspection type.
     /// </summary>
-    public class __Type : ObjectGraphType<IGraphType>
+    /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
+    public __Type(bool allowAppliedDirectives = false)
+        : this(allowAppliedDirectives, false)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__Type"/> introspection type.
-        /// </summary>
-        /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
-        public __Type(bool allowAppliedDirectives = false)
-            : this(allowAppliedDirectives, false)
-        {
-        }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__Type"/> introspection type.
-        /// </summary>
-        /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
-        /// <param name="deprecationOfInputValues">
-        /// Allows deprecation of input values - arguments on a field or input fields on an input type.
-        /// This feature is from a working draft of the specification.
-        /// </param>
-        public __Type(bool allowAppliedDirectives = false, bool deprecationOfInputValues = false)
-        {
-            SetName(nameof(__Type), validate: false);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="__Type"/> introspection type.
+    /// </summary>
+    /// <param name="allowAppliedDirectives">Allows 'appliedDirectives' field for this type. It is an experimental feature.</param>
+    /// <param name="deprecationOfInputValues">
+    /// Allows deprecation of input values - arguments on a field or input fields on an input type.
+    /// This feature is from a working draft of the specification.
+    /// </param>
+    public __Type(bool allowAppliedDirectives = false, bool deprecationOfInputValues = false)
+    {
+        SetName(nameof(__Type), validate: false);
 
-            Description =
-                "The fundamental unit of any GraphQL Schema is the type. There are " +
-                "many kinds of types in GraphQL as represented by the `__TypeKind` enum." +
-               @"
+        Description =
+            "The fundamental unit of any GraphQL Schema is the type. There are " +
+            "many kinds of types in GraphQL as represented by the `__TypeKind` enum." +
+           @"
 
 " +
-                "Depending on the kind of a type, certain fields describe " +
-                "information about that type. Scalar types provide no information " +
-                "beyond a name and description, while Enum types provide their values. " +
-                "Object and Interface types provide the fields they describe. Abstract " +
-                "types, Union and Interface, provide the Object types possible " +
-                "at runtime. List and NonNull types compose other types.";
+            "Depending on the kind of a type, certain fields describe " +
+            "information about that type. Scalar types provide no information " +
+            "beyond a name and description, while Enum types provide their values. " +
+            "Object and Interface types provide the fields they describe. Abstract " +
+            "types, Union and Interface, provide the Object types possible " +
+            "at runtime. List and NonNull types compose other types.";
 
-            Field<NonNullGraphType<__TypeKind>>("kind").Resolve(context =>
+        Field<NonNullGraphType<__TypeKind>>("kind").Resolve(context =>
+        {
+            return context.Source is IGraphType type
+                ? KindForInstance(type)
+                : throw new InvalidOperationException($"Unknown kind of type: {context.Source}");
+        });
+
+        Field<StringGraphType>("name").Resolve(context => context.Source!.Name);
+
+        Field<StringGraphType>("description").Resolve(context => context.Source!.Description);
+
+        Field<ListGraphType<NonNullGraphType<__Field>>>("fields")
+            .Argument<BooleanGraphType>("includeDeprecated", arg => arg.DefaultValue = BoolBox.False)
+            .ResolveAsync(async context =>
             {
-                return context.Source is IGraphType type
-                    ? KindForInstance(type)
-                    : throw new InvalidOperationException($"Unknown kind of type: {context.Source}");
-            });
-
-            Field<StringGraphType>("name").Resolve(context => context.Source!.Name);
-
-            Field<StringGraphType>("description").Resolve(context => context.Source!.Description);
-
-            Field<ListGraphType<NonNullGraphType<__Field>>>("fields")
-                .Argument<BooleanGraphType>("includeDeprecated", arg => arg.DefaultValue = BoolBox.False)
-                .ResolveAsync(async context =>
+                if (context.Source is IObjectGraphType || context.Source is IInterfaceGraphType)
                 {
-                    if (context.Source is IObjectGraphType || context.Source is IInterfaceGraphType)
-                    {
-                        var type = (IComplexGraphType)context.Source;
-                        var fields = context.ArrayPool.Rent<FieldType>(type.Fields.Count);
+                    var type = (IComplexGraphType)context.Source;
+                    var fields = context.ArrayPool.Rent<FieldType>(type.Fields.Count);
 
-                        bool includeDeprecated = context.GetArgument<bool>("includeDeprecated");
-
-                        int index = 0;
-                        foreach (var field in type.Fields.List)
-                        {
-                            if ((includeDeprecated || string.IsNullOrWhiteSpace(field.DeprecationReason)) && await context.Schema.Filter.AllowField(type, field).ConfigureAwait(false))
-                                fields[index++] = field;
-                        }
-
-                        var comparer = context.Schema.Comparer.FieldComparer(type);
-                        if (comparer != null)
-                            Array.Sort(fields, 0, index, comparer);
-
-                        return fields.Constrained(index);
-                    }
-                    return null;
-                });
-
-            Field<ListGraphType<NonNullGraphType<__Type>>>("interfaces").ResolveAsync(async context =>
-            {
-                if (context.Source is IImplementInterfaces type)
-                {
-                    var interfaces = context.ArrayPool.Rent<IInterfaceGraphType>(type.ResolvedInterfaces.Count);
-
-                    int index = 0;
-                    foreach (var resolved in type.ResolvedInterfaces.List)
-                    {
-                        if (await context.Schema.Filter.AllowType(resolved).ConfigureAwait(false))
-                            interfaces[index++] = resolved;
-                    }
-
-                    var comparer = context.Schema.Comparer.TypeComparer;
-                    if (comparer != null)
-                        Array.Sort(interfaces, 0, index, comparer);
-
-                    return interfaces.Constrained(index);
-                }
-
-                return null;
-            });
-
-            Field<ListGraphType<NonNullGraphType<__Type>>>("possibleTypes").ResolveAsync(async context =>
-            {
-                if (context.Source is IAbstractGraphType type)
-                {
-                    var possibleTypes = context.ArrayPool.Rent<IObjectGraphType>(type.PossibleTypes.Count);
-
-                    int index = 0;
-                    foreach (var possible in type.PossibleTypes.List)
-                    {
-                        if (await context.Schema.Filter.AllowType(possible).ConfigureAwait(false))
-                            possibleTypes[index++] = possible;
-                    }
-
-                    var comparer = context.Schema.Comparer.TypeComparer;
-                    if (comparer != null)
-                        Array.Sort(possibleTypes, 0, index, comparer);
-
-                    return possibleTypes.Constrained(index);
-                }
-
-                return null;
-            });
-
-            Field<ListGraphType<NonNullGraphType<__EnumValue>>>("enumValues")
-                .Argument<BooleanGraphType>("includeDeprecated", arg => arg.DefaultValue = BoolBox.False)
-                .ResolveAsync(async context =>
-                {
-                    if (context.Source is EnumerationGraphType type)
-                    {
-                        var enumValueDefinitions = context.ArrayPool.Rent<EnumValueDefinition>(type.Values.Count);
-
-                        bool includeDeprecated = context.GetArgument<bool>("includeDeprecated");
-
-                        int index = 0;
-                        foreach (var def in type.Values) //ISSUE:allocation
-                        {
-                            if ((includeDeprecated || string.IsNullOrWhiteSpace(def.DeprecationReason)) && await context.Schema.Filter.AllowEnumValue(type, def).ConfigureAwait(false))
-                                enumValueDefinitions[index++] = def;
-                        }
-
-                        var comparer = context.Schema.Comparer.EnumValueComparer(type);
-                        if (comparer != null)
-                            Array.Sort(enumValueDefinitions, 0, index, comparer);
-
-                        return enumValueDefinitions.Constrained(index);
-                    }
-
-                    return null;
-                });
-
-            var inputFieldsField = Field<ListGraphType<NonNullGraphType<__InputValue>>>("inputFields").ResolveAsync(async context =>
-            {
-                if (context.Source is IInputObjectGraphType type)
-                {
-                    var inputFields = context.ArrayPool.Rent<FieldType>(type.Fields.Count);
-
-                    bool includeDeprecated = context.GetArgument<bool>("includeDeprecated", !deprecationOfInputValues);
+                    bool includeDeprecated = context.GetArgument<bool>("includeDeprecated");
 
                     int index = 0;
                     foreach (var field in type.Fields.List)
                     {
                         if ((includeDeprecated || string.IsNullOrWhiteSpace(field.DeprecationReason)) && await context.Schema.Filter.AllowField(type, field).ConfigureAwait(false))
-                            inputFields[index++] = field;
+                            fields[index++] = field;
                     }
 
                     var comparer = context.Schema.Comparer.FieldComparer(type);
                     if (comparer != null)
-                        Array.Sort(inputFields, 0, index, comparer);
+                        Array.Sort(fields, 0, index, comparer);
 
-                    return inputFields.Constrained(index);
+                    return fields.Constrained(index);
+                }
+                return null;
+            });
+
+        Field<ListGraphType<NonNullGraphType<__Type>>>("interfaces").ResolveAsync(async context =>
+        {
+            if (context.Source is IImplementInterfaces type)
+            {
+                var interfaces = context.ArrayPool.Rent<IInterfaceGraphType>(type.ResolvedInterfaces.Count);
+
+                int index = 0;
+                foreach (var resolved in type.ResolvedInterfaces.List)
+                {
+                    if (await context.Schema.Filter.AllowType(resolved).ConfigureAwait(false))
+                        interfaces[index++] = resolved;
+                }
+
+                var comparer = context.Schema.Comparer.TypeComparer;
+                if (comparer != null)
+                    Array.Sort(interfaces, 0, index, comparer);
+
+                return interfaces.Constrained(index);
+            }
+
+            return null;
+        });
+
+        Field<ListGraphType<NonNullGraphType<__Type>>>("possibleTypes").ResolveAsync(async context =>
+        {
+            if (context.Source is IAbstractGraphType type)
+            {
+                var possibleTypes = context.ArrayPool.Rent<IObjectGraphType>(type.PossibleTypes.Count);
+
+                int index = 0;
+                foreach (var possible in type.PossibleTypes.List)
+                {
+                    if (await context.Schema.Filter.AllowType(possible).ConfigureAwait(false))
+                        possibleTypes[index++] = possible;
+                }
+
+                var comparer = context.Schema.Comparer.TypeComparer;
+                if (comparer != null)
+                    Array.Sort(possibleTypes, 0, index, comparer);
+
+                return possibleTypes.Constrained(index);
+            }
+
+            return null;
+        });
+
+        Field<ListGraphType<NonNullGraphType<__EnumValue>>>("enumValues")
+            .Argument<BooleanGraphType>("includeDeprecated", arg => arg.DefaultValue = BoolBox.False)
+            .ResolveAsync(async context =>
+            {
+                if (context.Source is EnumerationGraphType type)
+                {
+                    var enumValueDefinitions = context.ArrayPool.Rent<EnumValueDefinition>(type.Values.Count);
+
+                    bool includeDeprecated = context.GetArgument<bool>("includeDeprecated");
+
+                    int index = 0;
+                    foreach (var def in type.Values) //ISSUE:allocation
+                    {
+                        if ((includeDeprecated || string.IsNullOrWhiteSpace(def.DeprecationReason)) && await context.Schema.Filter.AllowEnumValue(type, def).ConfigureAwait(false))
+                            enumValueDefinitions[index++] = def;
+                    }
+
+                    var comparer = context.Schema.Comparer.EnumValueComparer(type);
+                    if (comparer != null)
+                        Array.Sort(enumValueDefinitions, 0, index, comparer);
+
+                    return enumValueDefinitions.Constrained(index);
                 }
 
                 return null;
             });
-            if (deprecationOfInputValues)
-                inputFieldsField.Argument<BooleanGraphType>("includeDeprecated", arg => arg.DefaultValue = BoolBox.False);
 
-            Field<__Type>("ofType").Resolve(context =>
-            {
-                return context.Source switch
-                {
-                    NonNullGraphType nonNull => nonNull.ResolvedType,
-                    ListGraphType list => list.ResolvedType,
-                    _ => null
-                };
-            });
-
-            if (allowAppliedDirectives)
-                this.AddAppliedDirectivesField("type");
-        }
-
-        private static object KindForInstance(IGraphType type) => type switch
+        var inputFieldsField = Field<ListGraphType<NonNullGraphType<__InputValue>>>("inputFields").ResolveAsync(async context =>
         {
-            EnumerationGraphType _ => TypeKindBoxed.ENUM,
-            ScalarGraphType _ => TypeKindBoxed.SCALAR,
-            IObjectGraphType _ => TypeKindBoxed.OBJECT,
-            IInterfaceGraphType _ => TypeKindBoxed.INTERFACE,
-            UnionGraphType _ => TypeKindBoxed.UNION,
-            IInputObjectGraphType _ => TypeKindBoxed.INPUT_OBJECT,
-            ListGraphType _ => TypeKindBoxed.LIST,
-            NonNullGraphType _ => TypeKindBoxed.NON_NULL,
-            _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unknown kind of type: {type}")
-        };
+            if (context.Source is IInputObjectGraphType type)
+            {
+                var inputFields = context.ArrayPool.Rent<FieldType>(type.Fields.Count);
+
+                bool includeDeprecated = context.GetArgument<bool>("includeDeprecated", !deprecationOfInputValues);
+
+                int index = 0;
+                foreach (var field in type.Fields.List)
+                {
+                    if ((includeDeprecated || string.IsNullOrWhiteSpace(field.DeprecationReason)) && await context.Schema.Filter.AllowField(type, field).ConfigureAwait(false))
+                        inputFields[index++] = field;
+                }
+
+                var comparer = context.Schema.Comparer.FieldComparer(type);
+                if (comparer != null)
+                    Array.Sort(inputFields, 0, index, comparer);
+
+                return inputFields.Constrained(index);
+            }
+
+            return null;
+        });
+        if (deprecationOfInputValues)
+            inputFieldsField.Argument<BooleanGraphType>("includeDeprecated", arg => arg.DefaultValue = BoolBox.False);
+
+        Field<__Type>("ofType").Resolve(context =>
+        {
+            return context.Source switch
+            {
+                NonNullGraphType nonNull => nonNull.ResolvedType,
+                ListGraphType list => list.ResolvedType,
+                _ => null
+            };
+        });
+
+        if (allowAppliedDirectives)
+            this.AddAppliedDirectivesField("type");
     }
+
+    private static object KindForInstance(IGraphType type) => type switch
+    {
+        EnumerationGraphType _ => TypeKindBoxed.ENUM,
+        ScalarGraphType _ => TypeKindBoxed.SCALAR,
+        IObjectGraphType _ => TypeKindBoxed.OBJECT,
+        IInterfaceGraphType _ => TypeKindBoxed.INTERFACE,
+        UnionGraphType _ => TypeKindBoxed.UNION,
+        IInputObjectGraphType _ => TypeKindBoxed.INPUT_OBJECT,
+        ListGraphType _ => TypeKindBoxed.LIST,
+        NonNullGraphType _ => TypeKindBoxed.NON_NULL,
+        _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unknown kind of type: {type}")
+    };
 }

--- a/src/GraphQL/Introspection/__TypeKind.cs
+++ b/src/GraphQL/Introspection/__TypeKind.cs
@@ -1,19 +1,18 @@
 using GraphQL.Types;
 
-namespace GraphQL.Introspection
+namespace GraphQL.Introspection;
+
+/// <summary>
+/// An enumeration representing a kind of GraphQL type.
+/// </summary>
+public class __TypeKind : EnumerationGraphType<TypeKind>
 {
     /// <summary>
-    /// An enumeration representing a kind of GraphQL type.
+    /// Initializes a new instance of the <see cref="__TypeKind"/> introspection type.
     /// </summary>
-    public class __TypeKind : EnumerationGraphType<TypeKind>
+    public __TypeKind()
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="__TypeKind"/> introspection type.
-        /// </summary>
-        public __TypeKind()
-        {
-            SetName(nameof(__TypeKind), validate: false);
-            Description = "An enum describing what kind of type a given __Type is.";
-        }
+        SetName(nameof(__TypeKind), validate: false);
+        Description = "An enum describing what kind of type a given __Type is.";
     }
 }

--- a/src/GraphQL/Reflection/IAccessor.cs
+++ b/src/GraphQL/Reflection/IAccessor.cs
@@ -1,50 +1,49 @@
 using System.Reflection;
 
-namespace GraphQL.Reflection
+namespace GraphQL.Reflection;
+
+/// <summary>
+/// An abstraction around accessing a property or method on a object instance.
+/// </summary>
+public interface IAccessor
 {
     /// <summary>
-    /// An abstraction around accessing a property or method on a object instance.
+    /// Returns the name of the member that this accessor points to.
     /// </summary>
-    public interface IAccessor
-    {
-        /// <summary>
-        /// Returns the name of the member that this accessor points to.
-        /// </summary>
-        string FieldName { get; }
+    string FieldName { get; }
 
-        /// <summary>
-        /// Returns the data type that the member returns.
-        /// </summary>
-        Type ReturnType { get; }
+    /// <summary>
+    /// Returns the data type that the member returns.
+    /// </summary>
+    Type ReturnType { get; }
 
-        /// <summary>
-        /// Returns the type where the member is defined.
-        /// </summary>
-        Type DeclaringType { get; }
+    /// <summary>
+    /// Returns the type where the member is defined.
+    /// </summary>
+    Type DeclaringType { get; }
 
-        /// <summary>
-        /// For methods, returns a list of parameters defined for the method, otherwise <see langword="null"/>.
-        /// </summary>
-        ParameterInfo[]? Parameters { get; }
+    /// <summary>
+    /// For methods, returns a list of parameters defined for the method, otherwise <see langword="null"/>.
+    /// </summary>
+    ParameterInfo[]? Parameters { get; }
 
-        /// <summary>
-        /// Returns a <see cref="MethodInfo"/> instance that points to the member.
-        /// For properties, this points to the property getter.
-        /// </summary>
-        MethodInfo MethodInfo { get; }
+    /// <summary>
+    /// Returns a <see cref="MethodInfo"/> instance that points to the member.
+    /// For properties, this points to the property getter.
+    /// </summary>
+    MethodInfo MethodInfo { get; }
 
-        /// <summary>
-        /// Get return value of method or property.
-        /// </summary>
-        /// <param name="target">Target object.</param>
-        /// <param name="arguments">Arguments for method; not used for property.</param>
-        /// <returns>Return value.</returns>
-        object? GetValue(object target, object?[]? arguments);
+    /// <summary>
+    /// Get return value of method or property.
+    /// </summary>
+    /// <param name="target">Target object.</param>
+    /// <param name="arguments">Arguments for method; not used for property.</param>
+    /// <returns>Return value.</returns>
+    object? GetValue(object target, object?[]? arguments);
 
-        /// <summary>
-        /// Returns a list of attributes of the specified type defined on the member.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        IEnumerable<T> GetAttributes<T>() where T : Attribute;
-    }
+    /// <summary>
+    /// Returns a list of attributes of the specified type defined on the member.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    IEnumerable<T> GetAttributes<T>() where T : Attribute;
 }

--- a/src/GraphQL/Reflection/ReflectionHelper.cs
+++ b/src/GraphQL/Reflection/ReflectionHelper.cs
@@ -1,77 +1,76 @@
 using System.Reflection;
 
-namespace GraphQL.Reflection
+namespace GraphQL.Reflection;
+
+internal static class ReflectionHelper
 {
-    internal static class ReflectionHelper
+    /// <summary>
+    /// Creates an <see cref="IAccessor"/> for the indicated GraphQL field
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="field">The desired field.</param>
+    /// <param name="resolverType">defaults to Resolver</param>
+    public static IAccessor? ToAccessor(this Type? type, string field, ResolverType resolverType)
     {
-        /// <summary>
-        /// Creates an <see cref="IAccessor"/> for the indicated GraphQL field
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <param name="field">The desired field.</param>
-        /// <param name="resolverType">defaults to Resolver</param>
-        public static IAccessor? ToAccessor(this Type? type, string field, ResolverType resolverType)
+        if (type == null)
+            return null;
+
+        var methodInfo = type.MethodForField(field, resolverType);
+        if (methodInfo != null)
         {
-            if (type == null)
-                return null;
+            return new SingleMethodAccessor(type, methodInfo);
+        }
 
-            var methodInfo = type.MethodForField(field, resolverType);
-            if (methodInfo != null)
-            {
-                return new SingleMethodAccessor(type, methodInfo);
-            }
-
-            if (resolverType != ResolverType.Resolver)
-            {
-                return null;
-            }
-
-            var propertyInfo = type.PropertyForField(field);
-            if (propertyInfo != null)
-            {
-                return new SinglePropertyAccessor(type, propertyInfo);
-            }
-
+        if (resolverType != ResolverType.Resolver)
+        {
             return null;
         }
 
-        /// <summary>
-        /// Returns the method associated with the indicated GraphQL field
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <param name="field">The desired field.</param>
-        /// <param name="resolverType">Indicates if a resolver or stream resolver method is requested.</param>
-        public static MethodInfo? MethodForField(this Type type, string field, ResolverType resolverType)
+        var propertyInfo = type.PropertyForField(field);
+        if (propertyInfo != null)
         {
-            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-
-            var method = methods.FirstOrDefault(m =>
-            {
-                var attr = m.GetCustomAttribute<GraphQLMetadataAttribute>();
-                var name = attr?.Name ?? m.Name;
-                return string.Equals(field, name, StringComparison.OrdinalIgnoreCase) && resolverType == (attr?.ResolverType ?? ResolverType.Resolver);
-            });
-
-            return method;
+            return new SinglePropertyAccessor(type, propertyInfo);
         }
 
-        /// <summary>
-        /// Returns the property associated with the indicated GraphQL field
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <param name="field">The desired field.</param>
-        public static PropertyInfo? PropertyForField(this Type type, string field)
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the method associated with the indicated GraphQL field
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="field">The desired field.</param>
+    /// <param name="resolverType">Indicates if a resolver or stream resolver method is requested.</param>
+    public static MethodInfo? MethodForField(this Type type, string field, ResolverType resolverType)
+    {
+        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+
+        var method = methods.FirstOrDefault(m =>
         {
-            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var attr = m.GetCustomAttribute<GraphQLMetadataAttribute>();
+            var name = attr?.Name ?? m.Name;
+            return string.Equals(field, name, StringComparison.OrdinalIgnoreCase) && resolverType == (attr?.ResolverType ?? ResolverType.Resolver);
+        });
 
-            var property = properties.FirstOrDefault(m =>
-            {
-                var attr = m.GetCustomAttribute<GraphQLMetadataAttribute>();
-                var name = attr?.Name ?? m.Name;
-                return string.Equals(field, name, StringComparison.OrdinalIgnoreCase);
-            });
+        return method;
+    }
 
-            return property;
-        }
+    /// <summary>
+    /// Returns the property associated with the indicated GraphQL field
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="field">The desired field.</param>
+    public static PropertyInfo? PropertyForField(this Type type, string field)
+    {
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        var property = properties.FirstOrDefault(m =>
+        {
+            var attr = m.GetCustomAttribute<GraphQLMetadataAttribute>();
+            var name = attr?.Name ?? m.Name;
+            return string.Equals(field, name, StringComparison.OrdinalIgnoreCase);
+        });
+
+        return property;
     }
 }

--- a/src/GraphQL/Reflection/SinglePropertyAccessor.cs
+++ b/src/GraphQL/Reflection/SinglePropertyAccessor.cs
@@ -1,41 +1,40 @@
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 
-namespace GraphQL.Reflection
+namespace GraphQL.Reflection;
+
+internal class SinglePropertyAccessor : IAccessor
 {
-    internal class SinglePropertyAccessor : IAccessor
+    private readonly PropertyInfo _property;
+
+    public SinglePropertyAccessor(Type declaringType, PropertyInfo property)
     {
-        private readonly PropertyInfo _property;
+        DeclaringType = declaringType; // may be a derived type rather than property.DeclaringType
+        _property = property;
+    }
 
-        public SinglePropertyAccessor(Type declaringType, PropertyInfo property)
+    public string FieldName => _property.Name;
+
+    public Type ReturnType => _property.PropertyType;
+
+    public Type DeclaringType { get; }
+
+    public ParameterInfo[]? Parameters => null;
+
+    public MethodInfo MethodInfo => _property.GetMethod!;
+
+    public IEnumerable<T> GetAttributes<T>() where T : Attribute => _property.GetCustomAttributes<T>();
+
+    public object? GetValue(object target, object?[]? arguments)
+    {
+        try
         {
-            DeclaringType = declaringType; // may be a derived type rather than property.DeclaringType
-            _property = property;
+            return _property.GetValue(target, null);
         }
-
-        public string FieldName => _property.Name;
-
-        public Type ReturnType => _property.PropertyType;
-
-        public Type DeclaringType { get; }
-
-        public ParameterInfo[]? Parameters => null;
-
-        public MethodInfo MethodInfo => _property.GetMethod!;
-
-        public IEnumerable<T> GetAttributes<T>() where T : Attribute => _property.GetCustomAttributes<T>();
-
-        public object? GetValue(object target, object?[]? arguments)
+        catch (TargetInvocationException ex)
         {
-            try
-            {
-                return _property.GetValue(target, null);
-            }
-            catch (TargetInvocationException ex)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
-                return null; // never executed, necessary only for intellisense
-            }
+            ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
+            return null; // never executed, necessary only for intellisense
         }
     }
 }

--- a/src/GraphQL/ResolveFieldContext/IResolveConnectionContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveConnectionContext.cs
@@ -1,48 +1,47 @@
 using GraphQL.Resolvers;
 
-namespace GraphQL.Builders
+namespace GraphQL.Builders;
+
+/// <summary>
+/// Contains parameters pertaining to the currently executing <see cref="IFieldResolver"/>, along
+/// with helper properties for resolving forward and backward pagination requests on a
+/// connection type.
+/// </summary>
+public interface IResolveConnectionContext : IResolveFieldContext
 {
     /// <summary>
-    /// Contains parameters pertaining to the currently executing <see cref="IFieldResolver"/>, along
-    /// with helper properties for resolving forward and backward pagination requests on a
-    /// connection type.
+    /// Indicates if this connection only allows forward pagination requests.
     /// </summary>
-    public interface IResolveConnectionContext : IResolveFieldContext
-    {
-        /// <summary>
-        /// Indicates if this connection only allows forward pagination requests.
-        /// </summary>
-        bool IsUnidirectional { get; }
+    bool IsUnidirectional { get; }
 
-        /// <summary>
-        /// For a forward pagination request, returns the maximum number of edges to be returned.
-        /// </summary>
-        int? First { get; }
+    /// <summary>
+    /// For a forward pagination request, returns the maximum number of edges to be returned.
+    /// </summary>
+    int? First { get; }
 
-        /// <summary>
-        /// For a backwards pagination request, returns the maximum number of edges to be returned.
-        /// </summary>
-        int? Last { get; }
+    /// <summary>
+    /// For a backwards pagination request, returns the maximum number of edges to be returned.
+    /// </summary>
+    int? Last { get; }
 
-        /// <summary>
-        /// For a forward pagination request, returned edges should start immediately after the edge identified by this cursor.
-        /// </summary>
-        string? After { get; }
+    /// <summary>
+    /// For a forward pagination request, returned edges should start immediately after the edge identified by this cursor.
+    /// </summary>
+    string? After { get; }
 
-        /// <summary>
-        /// For a backwards pagination request, returned edges should end immediately prior to the edge identified by this cursor.
-        /// </summary>
-        string? Before { get; }
+    /// <summary>
+    /// For a backwards pagination request, returned edges should end immediately prior to the edge identified by this cursor.
+    /// </summary>
+    string? Before { get; }
 
-        /// <summary>
-        /// The maximum number of edges to be returned, or the specified default page size if <see cref="First"/> and
-        /// <see cref="Last"/> are not specified.
-        /// </summary>
-        int? PageSize { get; }
-    }
+    /// <summary>
+    /// The maximum number of edges to be returned, or the specified default page size if <see cref="First"/> and
+    /// <see cref="Last"/> are not specified.
+    /// </summary>
+    int? PageSize { get; }
+}
 
-    /// <inheritdoc cref="IResolveConnectionContext"/>
-    public interface IResolveConnectionContext<out T> : IResolveFieldContext<T>, IResolveConnectionContext
-    {
-    }
+/// <inheritdoc cref="IResolveConnectionContext"/>
+public interface IResolveConnectionContext<out T> : IResolveFieldContext<T>, IResolveConnectionContext
+{
 }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -7,123 +7,122 @@ using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQLParser.AST;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Contains parameters pertaining to the currently executing <see cref="IFieldResolver"/>.
+/// This object is only valid during the execution of the field; it is re-used once the field
+/// has resolved. Use <see cref="ResolveFieldContextExtensions.Copy(IResolveFieldContext)"/>
+/// if you need to preserve a copy of the context for later use or copy required properties from the context.
+/// </summary>
+public interface IResolveFieldContext : IProvideUserContext
 {
+    /// <summary>The <see cref="GraphQLField"/> AST as derived from the query request.</summary>
+    GraphQLField FieldAst { get; }
+
+    /// <summary>The <see cref="FieldType"/> definition specified in the parent graph type.</summary>
+    FieldType FieldDefinition { get; }
+
+    /// <summary>The field's parent graph type.</summary>
+    IObjectGraphType ParentType { get; }
+
     /// <summary>
-    /// Contains parameters pertaining to the currently executing <see cref="IFieldResolver"/>.
-    /// This object is only valid during the execution of the field; it is re-used once the field
-    /// has resolved. Use <see cref="ResolveFieldContextExtensions.Copy(IResolveFieldContext)"/>
-    /// if you need to preserve a copy of the context for later use or copy required properties from the context.
+    /// Provides access to the parent context (up to the root). This may be needed to get the parameters of parent nodes.
+    /// Returns <see langword="null"/> when called on the root.
     /// </summary>
-    public interface IResolveFieldContext : IProvideUserContext
-    {
-        /// <summary>The <see cref="GraphQLField"/> AST as derived from the query request.</summary>
-        GraphQLField FieldAst { get; }
+    IResolveFieldContext? Parent { get; }
 
-        /// <summary>The <see cref="FieldType"/> definition specified in the parent graph type.</summary>
-        FieldType FieldDefinition { get; }
+    /// <summary>
+    /// A dictionary of arguments passed to the field, or <see langword="null"/> if no arguments were defined for the field.
+    /// It is recommended to use the <see cref="ResolveFieldContextExtensions.GetArgument{TType}(IResolveFieldContext, string, TType)">GetArgument</see>
+    /// and <see cref="ResolveFieldContextExtensions.HasArgument(IResolveFieldContext, string)">HasArgument</see> extension
+    /// methods rather than this dictionary, so the names can be converted by the selected <see cref="INameConverter"/>.
+    /// </summary>
+    IDictionary<string, ArgumentValue>? Arguments { get; }
 
-        /// <summary>The field's parent graph type.</summary>
-        IObjectGraphType ParentType { get; }
+    /// <summary>
+    /// A dictionary of directives with their arguments passed to the field, or <see langword="null"/> if no directives were defined for the field.
+    /// It is recommended to use the <see cref="ResolveFieldContextExtensions.GetDirective(IResolveFieldContext, string)">GetDirective</see>
+    /// and <see cref="ResolveFieldContextExtensions.HasDirective(IResolveFieldContext, string)">HasDirective</see> extension
+    /// methods rather than this dictionary directly.
+    /// </summary>
+    IDictionary<string, DirectiveInfo>? Directives { get; }
 
-        /// <summary>
-        /// Provides access to the parent context (up to the root). This may be needed to get the parameters of parent nodes.
-        /// Returns <see langword="null"/> when called on the root.
-        /// </summary>
-        IResolveFieldContext? Parent { get; }
+    /// <summary>The root value of the graph, as defined by <see cref="ExecutionOptions.Root"/>.</summary>
+    object? RootValue { get; }
 
-        /// <summary>
-        /// A dictionary of arguments passed to the field, or <see langword="null"/> if no arguments were defined for the field.
-        /// It is recommended to use the <see cref="ResolveFieldContextExtensions.GetArgument{TType}(IResolveFieldContext, string, TType)">GetArgument</see>
-        /// and <see cref="ResolveFieldContextExtensions.HasArgument(IResolveFieldContext, string)">HasArgument</see> extension
-        /// methods rather than this dictionary, so the names can be converted by the selected <see cref="INameConverter"/>.
-        /// </summary>
-        IDictionary<string, ArgumentValue>? Arguments { get; }
+    /// <summary>The value of the parent object in the graph.</summary>
+    object? Source { get; }
 
-        /// <summary>
-        /// A dictionary of directives with their arguments passed to the field, or <see langword="null"/> if no directives were defined for the field.
-        /// It is recommended to use the <see cref="ResolveFieldContextExtensions.GetDirective(IResolveFieldContext, string)">GetDirective</see>
-        /// and <see cref="ResolveFieldContextExtensions.HasDirective(IResolveFieldContext, string)">HasDirective</see> extension
-        /// methods rather than this dictionary directly.
-        /// </summary>
-        IDictionary<string, DirectiveInfo>? Directives { get; }
+    /// <summary>The graph schema.</summary>
+    ISchema Schema { get; }
 
-        /// <summary>The root value of the graph, as defined by <see cref="ExecutionOptions.Root"/>.</summary>
-        object? RootValue { get; }
+    /// <summary>The current GraphQL request, parsed into an AST document.</summary>
+    GraphQLDocument Document { get; }
 
-        /// <summary>The value of the parent object in the graph.</summary>
-        object? Source { get; }
+    /// <summary>The operation type (i.e. query, mutation, or subscription) of the current GraphQL request.</summary>
+    GraphQLOperationDefinition Operation { get; }
 
-        /// <summary>The graph schema.</summary>
-        ISchema Schema { get; }
+    /// <summary>The input variables of the current GraphQL request.</summary>
+    Variables Variables { get; }
 
-        /// <summary>The current GraphQL request, parsed into an AST document.</summary>
-        GraphQLDocument Document { get; }
+    /// <summary>A <see cref="System.Threading.CancellationToken">CancellationToken</see> to indicate if and when the request has been canceled.</summary>
+    CancellationToken CancellationToken { get; }
 
-        /// <summary>The operation type (i.e. query, mutation, or subscription) of the current GraphQL request.</summary>
-        GraphQLOperationDefinition Operation { get; }
+    /// <summary>Allows logging of performance metrics.</summary>
+    Metrics Metrics { get; }
 
-        /// <summary>The input variables of the current GraphQL request.</summary>
-        Variables Variables { get; }
+    /// <summary>Can be used to return specific errors back to the GraphQL request caller.</summary>
+    ExecutionErrors Errors { get; }
 
-        /// <summary>A <see cref="System.Threading.CancellationToken">CancellationToken</see> to indicate if and when the request has been canceled.</summary>
-        CancellationToken CancellationToken { get; }
+    /// <summary>The path to the current executing field from the request root as it would appear in the query.</summary>
+    IEnumerable<object> Path { get; }
 
-        /// <summary>Allows logging of performance metrics.</summary>
-        Metrics Metrics { get; }
+    /// <summary>The path to the current executing field from the request root as it would appear in the response.</summary>
+    IEnumerable<object> ResponsePath { get; }
 
-        /// <summary>Can be used to return specific errors back to the GraphQL request caller.</summary>
-        ExecutionErrors Errors { get; }
+    /// <summary>
+    /// Returns a set of child fields requested for the current field. Note that this set will be completely defined
+    /// (when called from field resolver) only for fields of a concrete type (i.e. not interface or union field). For
+    /// interface field this method returns requested fields in terms of this interface. For union field this method
+    /// returns empty set since we don't know the concrete union member until we get a concrete runtime value from
+    /// the resolver.
+    /// </summary>
+    Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields { get; }
 
-        /// <summary>The path to the current executing field from the request root as it would appear in the query.</summary>
-        IEnumerable<object> Path { get; }
+    /// <summary>
+    /// A dictionary of extra information supplied with the GraphQL request.
+    /// This is reserved for implementors to extend the protocol however they see fit,
+    /// and hence there are no additional restrictions on its contents. Also you may use
+    /// <see cref="ResolveFieldContextExtensions.GetInputExtension(IResolveFieldContext, string)">GetInputExtension</see> method.
+    /// </summary>
+    IReadOnlyDictionary<string, object?> InputExtensions { get; }
 
-        /// <summary>The path to the current executing field from the request root as it would appear in the response.</summary>
-        IEnumerable<object> ResponsePath { get; }
+    /// <summary>
+    /// The response map may also contain an entry with key extensions. This entry is reserved for implementors to extend the
+    /// protocol however they see fit, and hence there are no additional restrictions on its contents. This dictionary is shared
+    /// by all running resolvers and is not thread safe. Also you may use <see cref="ResolveFieldContextExtensions.GetOutputExtension(IResolveFieldContext, string)">GetOutputExtension</see>
+    /// and <see cref="ResolveFieldContextExtensions.SetOutputExtension(IResolveFieldContext, string, object)">SetOutputExtension</see>
+    /// methods.
+    /// </summary>
+    IDictionary<string, object?> OutputExtensions { get; }
 
-        /// <summary>
-        /// Returns a set of child fields requested for the current field. Note that this set will be completely defined
-        /// (when called from field resolver) only for fields of a concrete type (i.e. not interface or union field). For
-        /// interface field this method returns requested fields in terms of this interface. For union field this method
-        /// returns empty set since we don't know the concrete union member until we get a concrete runtime value from
-        /// the resolver.
-        /// </summary>
-        Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields { get; }
+    /// <summary>The service provider for the executing request.</summary>
+    IServiceProvider? RequestServices { get; }
 
-        /// <summary>
-        /// A dictionary of extra information supplied with the GraphQL request.
-        /// This is reserved for implementors to extend the protocol however they see fit,
-        /// and hence there are no additional restrictions on its contents. Also you may use
-        /// <see cref="ResolveFieldContextExtensions.GetInputExtension(IResolveFieldContext, string)">GetInputExtension</see> method.
-        /// </summary>
-        IReadOnlyDictionary<string, object?> InputExtensions { get; }
+    /// <summary>
+    /// Returns a resource pool from which arrays can be rented during the current execution.
+    /// Can be used to return lists of data from field resolvers.
+    /// </summary>
+    IExecutionArrayPool ArrayPool { get; }
 
-        /// <summary>
-        /// The response map may also contain an entry with key extensions. This entry is reserved for implementors to extend the
-        /// protocol however they see fit, and hence there are no additional restrictions on its contents. This dictionary is shared
-        /// by all running resolvers and is not thread safe. Also you may use <see cref="ResolveFieldContextExtensions.GetOutputExtension(IResolveFieldContext, string)">GetOutputExtension</see>
-        /// and <see cref="ResolveFieldContextExtensions.SetOutputExtension(IResolveFieldContext, string, object)">SetOutputExtension</see>
-        /// methods.
-        /// </summary>
-        IDictionary<string, object?> OutputExtensions { get; }
+    /// <inheritdoc cref="IExecutionContext.User"/>
+    ClaimsPrincipal? User { get; }
+}
 
-        /// <summary>The service provider for the executing request.</summary>
-        IServiceProvider? RequestServices { get; }
-
-        /// <summary>
-        /// Returns a resource pool from which arrays can be rented during the current execution.
-        /// Can be used to return lists of data from field resolvers.
-        /// </summary>
-        IExecutionArrayPool ArrayPool { get; }
-
-        /// <inheritdoc cref="IExecutionContext.User"/>
-        ClaimsPrincipal? User { get; }
-    }
-
-    /// <inheritdoc cref="IResolveFieldContext"/>
-    public interface IResolveFieldContext<out TSource> : IResolveFieldContext
-    {
-        /// <inheritdoc cref="IResolveFieldContext.Source"/>
-        new TSource Source { get; }
-    }
+/// <inheritdoc cref="IResolveFieldContext"/>
+public interface IResolveFieldContext<out TSource> : IResolveFieldContext
+{
+    /// <inheritdoc cref="IResolveFieldContext.Source"/>
+    new TSource Source { get; }
 }

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -6,129 +6,128 @@ using GraphQL.Validation;
 using GraphQLParser.AST;
 using ExecutionContext = GraphQL.Execution.ExecutionContext;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// A readonly implementation of <see cref="IResolveFieldContext"/>.
+/// </summary>
+public class ReadonlyResolveFieldContext : IResolveFieldContext<object?>
 {
+    // WARNING: if you add a new field here, then don't forget to clear it in Reset method!
+    private ExecutionNode _executionNode;
+    private ExecutionContext _executionContext;
+    private Dictionary<string, (GraphQLField Field, FieldType FieldType)>? _subFields;
+    private IResolveFieldContext? _parent;
+
     /// <summary>
-    /// A readonly implementation of <see cref="IResolveFieldContext"/>.
+    /// Initializes an instance with the specified <see cref="ExecutionNode"/> and <see cref="ExecutionContext"/>.
     /// </summary>
-    public class ReadonlyResolveFieldContext : IResolveFieldContext<object?>
+    public ReadonlyResolveFieldContext(ExecutionNode node, ExecutionContext context)
     {
-        // WARNING: if you add a new field here, then don't forget to clear it in Reset method!
-        private ExecutionNode _executionNode;
-        private ExecutionContext _executionContext;
-        private Dictionary<string, (GraphQLField Field, FieldType FieldType)>? _subFields;
-        private IResolveFieldContext? _parent;
-
-        /// <summary>
-        /// Initializes an instance with the specified <see cref="ExecutionNode"/> and <see cref="ExecutionContext"/>.
-        /// </summary>
-        public ReadonlyResolveFieldContext(ExecutionNode node, ExecutionContext context)
-        {
-            _executionNode = node ?? throw new ArgumentNullException(nameof(node));
-            _executionContext = context ?? throw new ArgumentNullException(nameof(context));
-        }
-
-        internal ReadonlyResolveFieldContext Reset(ExecutionNode? node, ExecutionContext? context)
-        {
-            _executionNode = node!;
-            _executionContext = context!;
-            _subFields = null;
-            _parent = null;
-
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public object? Source => _executionNode.Source;
-
-        /// <inheritdoc/>
-        public GraphQLField FieldAst => _executionNode.Field!;
-
-        /// <inheritdoc/>
-        public FieldType FieldDefinition => _executionNode.FieldDefinition!;
-
-        /// <inheritdoc/>
-        public IObjectGraphType ParentType => _executionNode.GetParentType(_executionContext.Schema)!;
-
-        /// <inheritdoc/>
-        public IResolveFieldContext? Parent
-        {
-            get
-            {
-                if (_parent == null)
-                {
-                    var parent = _executionNode.Parent;
-                    while (parent is ArrayExecutionNode)
-                        parent = parent.Parent;
-
-                    if (parent != null && parent is not RootExecutionNode)
-                        _parent = new ReadonlyResolveFieldContext(parent, _executionContext);
-                }
-
-                return _parent;
-            }
-        }
-
-        /// <inheritdoc/>
-        public IDictionary<string, ArgumentValue>? Arguments
-            => _executionContext.ArgumentValues?.TryGetValue(FieldAst, out var ret) ?? false ? ret : FieldDefinition.DefaultArgumentValues;
-
-        /// <inheritdoc/>
-        public IDictionary<string, DirectiveInfo>? Directives
-            => _executionContext.DirectiveValues?.TryGetValue(FieldAst, out var ret) ?? false ? ret : null;
-
-        /// <inheritdoc/>
-        public object? RootValue => _executionContext.RootValue;
-
-        /// <inheritdoc/>
-        public ISchema Schema => _executionContext.Schema;
-
-        /// <inheritdoc/>
-        public GraphQLDocument Document => _executionContext.Document;
-
-        /// <inheritdoc/>
-        public GraphQLOperationDefinition Operation => _executionContext.Operation;
-
-        /// <inheritdoc/>
-        public Variables Variables => _executionContext.Variables;
-
-        /// <inheritdoc/>
-        public CancellationToken CancellationToken => _executionContext.CancellationToken;
-
-        /// <inheritdoc/>
-        public Metrics Metrics => _executionContext.Metrics;
-
-        /// <inheritdoc/>
-        public ExecutionErrors Errors => _executionContext.Errors;
-
-        /// <inheritdoc/>
-        public IEnumerable<object> Path => _executionNode.Path;
-
-        /// <inheritdoc/>
-        public IEnumerable<object> ResponsePath => _executionNode.ResponsePath;
-
-        /// <inheritdoc/>
-        public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields
-            => _subFields ??= _executionContext.ExecutionStrategy.GetSubFields(_executionContext, _executionNode);
-
-        /// <inheritdoc/>
-        public IDictionary<string, object?> UserContext => _executionContext.UserContext;
-
-        object? IResolveFieldContext.Source => _executionNode.Source;
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<string, object?> InputExtensions => _executionContext.InputExtensions;
-
-        /// <inheritdoc/>
-        public IDictionary<string, object?> OutputExtensions => _executionContext.OutputExtensions;
-
-        /// <inheritdoc/>
-        public IServiceProvider? RequestServices => _executionContext.RequestServices;
-
-        /// <inheritdoc/>
-        public IExecutionArrayPool ArrayPool => _executionContext;
-
-        /// <inheritdoc/>
-        public ClaimsPrincipal? User => _executionContext.User;
+        _executionNode = node ?? throw new ArgumentNullException(nameof(node));
+        _executionContext = context ?? throw new ArgumentNullException(nameof(context));
     }
+
+    internal ReadonlyResolveFieldContext Reset(ExecutionNode? node, ExecutionContext? context)
+    {
+        _executionNode = node!;
+        _executionContext = context!;
+        _subFields = null;
+        _parent = null;
+
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public object? Source => _executionNode.Source;
+
+    /// <inheritdoc/>
+    public GraphQLField FieldAst => _executionNode.Field!;
+
+    /// <inheritdoc/>
+    public FieldType FieldDefinition => _executionNode.FieldDefinition!;
+
+    /// <inheritdoc/>
+    public IObjectGraphType ParentType => _executionNode.GetParentType(_executionContext.Schema)!;
+
+    /// <inheritdoc/>
+    public IResolveFieldContext? Parent
+    {
+        get
+        {
+            if (_parent == null)
+            {
+                var parent = _executionNode.Parent;
+                while (parent is ArrayExecutionNode)
+                    parent = parent.Parent;
+
+                if (parent != null && parent is not RootExecutionNode)
+                    _parent = new ReadonlyResolveFieldContext(parent, _executionContext);
+            }
+
+            return _parent;
+        }
+    }
+
+    /// <inheritdoc/>
+    public IDictionary<string, ArgumentValue>? Arguments
+        => _executionContext.ArgumentValues?.TryGetValue(FieldAst, out var ret) ?? false ? ret : FieldDefinition.DefaultArgumentValues;
+
+    /// <inheritdoc/>
+    public IDictionary<string, DirectiveInfo>? Directives
+        => _executionContext.DirectiveValues?.TryGetValue(FieldAst, out var ret) ?? false ? ret : null;
+
+    /// <inheritdoc/>
+    public object? RootValue => _executionContext.RootValue;
+
+    /// <inheritdoc/>
+    public ISchema Schema => _executionContext.Schema;
+
+    /// <inheritdoc/>
+    public GraphQLDocument Document => _executionContext.Document;
+
+    /// <inheritdoc/>
+    public GraphQLOperationDefinition Operation => _executionContext.Operation;
+
+    /// <inheritdoc/>
+    public Variables Variables => _executionContext.Variables;
+
+    /// <inheritdoc/>
+    public CancellationToken CancellationToken => _executionContext.CancellationToken;
+
+    /// <inheritdoc/>
+    public Metrics Metrics => _executionContext.Metrics;
+
+    /// <inheritdoc/>
+    public ExecutionErrors Errors => _executionContext.Errors;
+
+    /// <inheritdoc/>
+    public IEnumerable<object> Path => _executionNode.Path;
+
+    /// <inheritdoc/>
+    public IEnumerable<object> ResponsePath => _executionNode.ResponsePath;
+
+    /// <inheritdoc/>
+    public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields
+        => _subFields ??= _executionContext.ExecutionStrategy.GetSubFields(_executionContext, _executionNode);
+
+    /// <inheritdoc/>
+    public IDictionary<string, object?> UserContext => _executionContext.UserContext;
+
+    object? IResolveFieldContext.Source => _executionNode.Source;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, object?> InputExtensions => _executionContext.InputExtensions;
+
+    /// <inheritdoc/>
+    public IDictionary<string, object?> OutputExtensions => _executionContext.OutputExtensions;
+
+    /// <inheritdoc/>
+    public IServiceProvider? RequestServices => _executionContext.RequestServices;
+
+    /// <inheritdoc/>
+    public IExecutionArrayPool ArrayPool => _executionContext;
+
+    /// <inheritdoc/>
+    public ClaimsPrincipal? User => _executionContext.User;
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveConnectionContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveConnectionContext.cs
@@ -1,70 +1,69 @@
-namespace GraphQL.Builders
+namespace GraphQL.Builders;
+
+/// <summary>
+/// A mutable implementation of <see cref="IResolveConnectionContext{T}"/>
+/// </summary>
+public class ResolveConnectionContext<T> : ResolveFieldContext<T>, IResolveConnectionContext<T>
 {
+    private readonly int? _defaultPageSize;
+
     /// <summary>
-    /// A mutable implementation of <see cref="IResolveConnectionContext{T}"/>
+    /// Initializes an instance which mirrors the specified <see cref="IResolveFieldContext"/>
+    /// with the specified properties and defaults
     /// </summary>
-    public class ResolveConnectionContext<T> : ResolveFieldContext<T>, IResolveConnectionContext<T>
+    /// <param name="context">The underlying <see cref="IResolveFieldContext"/> to mirror</param>
+    /// <param name="isUnidirectional">Indicates if the connection only allows forward paging requests</param>
+    /// <param name="defaultPageSize">Indicates the default page size if not specified by the request</param>
+    public ResolveConnectionContext(IResolveFieldContext context, bool isUnidirectional, int? defaultPageSize)
+        : base(context)
     {
-        private readonly int? _defaultPageSize;
-
-        /// <summary>
-        /// Initializes an instance which mirrors the specified <see cref="IResolveFieldContext"/>
-        /// with the specified properties and defaults
-        /// </summary>
-        /// <param name="context">The underlying <see cref="IResolveFieldContext"/> to mirror</param>
-        /// <param name="isUnidirectional">Indicates if the connection only allows forward paging requests</param>
-        /// <param name="defaultPageSize">Indicates the default page size if not specified by the request</param>
-        public ResolveConnectionContext(IResolveFieldContext context, bool isUnidirectional, int? defaultPageSize)
-            : base(context)
-        {
-            IsUnidirectional = isUnidirectional;
-            _defaultPageSize = defaultPageSize;
-        }
-
-        /// <inheritdoc/>
-        public bool IsUnidirectional { get; private set; }
-
-        /// <inheritdoc/>
-        public int? First
-        {
-            get
-            {
-                var first = FirstInternal;
-                if (!first.HasValue && !Last.HasValue)
-                {
-                    return _defaultPageSize;
-                }
-
-                return first;
-            }
-        }
-
-        private int? FirstInternal
-        {
-            get
-            {
-                var first = this.GetArgument<int?>("first");
-                return first.HasValue ? (int?)Math.Abs(first.Value) : null;
-            }
-        }
-
-        /// <inheritdoc/>
-        public int? Last
-        {
-            get
-            {
-                var last = this.GetArgument<int?>("last");
-                return last.HasValue ? (int?)Math.Abs(last.Value) : null;
-            }
-        }
-
-        /// <inheritdoc/>
-        public string? After => this.GetArgument<string>("after");
-
-        /// <inheritdoc/>
-        public string? Before => this.GetArgument<string>("before");
-
-        /// <inheritdoc/>
-        public int? PageSize => First ?? Last ?? _defaultPageSize;
+        IsUnidirectional = isUnidirectional;
+        _defaultPageSize = defaultPageSize;
     }
+
+    /// <inheritdoc/>
+    public bool IsUnidirectional { get; private set; }
+
+    /// <inheritdoc/>
+    public int? First
+    {
+        get
+        {
+            var first = FirstInternal;
+            if (!first.HasValue && !Last.HasValue)
+            {
+                return _defaultPageSize;
+            }
+
+            return first;
+        }
+    }
+
+    private int? FirstInternal
+    {
+        get
+        {
+            var first = this.GetArgument<int?>("first");
+            return first.HasValue ? (int?)Math.Abs(first.Value) : null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public int? Last
+    {
+        get
+        {
+            var last = this.GetArgument<int?>("last");
+            return last.HasValue ? (int?)Math.Abs(last.Value) : null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public string? After => this.GetArgument<string>("after");
+
+    /// <inheritdoc/>
+    public string? Before => this.GetArgument<string>("before");
+
+    /// <inheritdoc/>
+    public int? PageSize => First ?? Last ?? _defaultPageSize;
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -5,147 +5,146 @@ using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQLParser.AST;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// A mutable implementation of <see cref="IResolveFieldContext"/>
+/// </summary>
+public class ResolveFieldContext : IResolveFieldContext<object?>
 {
+    /// <inheritdoc/>
+    public GraphQLField FieldAst { get; set; }
+
+    /// <inheritdoc/>
+    public FieldType FieldDefinition { get; set; }
+
+    /// <inheritdoc/>
+    public IObjectGraphType ParentType { get; set; }
+
+    /// <inheritdoc/>
+    public IResolveFieldContext? Parent { get; set; }
+
+    /// <inheritdoc/>
+    public IDictionary<string, ArgumentValue>? Arguments { get; set; }
+
+    /// <inheritdoc/>
+    public IDictionary<string, DirectiveInfo>? Directives { get; set; }
+
+    /// <inheritdoc/>
+    public object? RootValue { get; set; }
+
+    /// <inheritdoc/>
+    public IDictionary<string, object?> UserContext { get; set; }
+
+    /// <inheritdoc/>
+    public object? Source { get; set; }
+
+    /// <inheritdoc/>
+    public ISchema Schema { get; set; }
+
+    /// <inheritdoc/>
+    public GraphQLDocument Document { get; set; }
+
+    /// <inheritdoc/>
+    public GraphQLOperationDefinition Operation { get; set; }
+
+    /// <inheritdoc/>
+    public Variables Variables { get; set; }
+
+    /// <inheritdoc/>
+    public CancellationToken CancellationToken { get; set; }
+
+    /// <inheritdoc/>
+    public Metrics Metrics { get; set; }
+
+    /// <inheritdoc/>
+    public ExecutionErrors Errors { get; set; }
+
+    /// <inheritdoc/>
+    public IEnumerable<object> Path { get; set; }
+
+    /// <inheritdoc/>
+    public IEnumerable<object> ResponsePath { get; set; }
+
+    /// <inheritdoc/>
+    public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields { get; set; }
+
+    /// <inheritdoc/>
+    public IServiceProvider? RequestServices { get; set; }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
+
+    /// <inheritdoc/>
+    public IDictionary<string, object?> OutputExtensions { get; set; }
+
+    /// <inheritdoc/>
+    public IExecutionArrayPool ArrayPool { get; set; }
+
+    /// <inheritdoc/>
+    public ClaimsPrincipal? User { get; set; }
+
     /// <summary>
-    /// A mutable implementation of <see cref="IResolveFieldContext"/>
+    /// Initializes a new instance with all fields set to their default values.
     /// </summary>
-    public class ResolveFieldContext : IResolveFieldContext<object?>
-    {
-        /// <inheritdoc/>
-        public GraphQLField FieldAst { get; set; }
-
-        /// <inheritdoc/>
-        public FieldType FieldDefinition { get; set; }
-
-        /// <inheritdoc/>
-        public IObjectGraphType ParentType { get; set; }
-
-        /// <inheritdoc/>
-        public IResolveFieldContext? Parent { get; set; }
-
-        /// <inheritdoc/>
-        public IDictionary<string, ArgumentValue>? Arguments { get; set; }
-
-        /// <inheritdoc/>
-        public IDictionary<string, DirectiveInfo>? Directives { get; set; }
-
-        /// <inheritdoc/>
-        public object? RootValue { get; set; }
-
-        /// <inheritdoc/>
-        public IDictionary<string, object?> UserContext { get; set; }
-
-        /// <inheritdoc/>
-        public object? Source { get; set; }
-
-        /// <inheritdoc/>
-        public ISchema Schema { get; set; }
-
-        /// <inheritdoc/>
-        public GraphQLDocument Document { get; set; }
-
-        /// <inheritdoc/>
-        public GraphQLOperationDefinition Operation { get; set; }
-
-        /// <inheritdoc/>
-        public Variables Variables { get; set; }
-
-        /// <inheritdoc/>
-        public CancellationToken CancellationToken { get; set; }
-
-        /// <inheritdoc/>
-        public Metrics Metrics { get; set; }
-
-        /// <inheritdoc/>
-        public ExecutionErrors Errors { get; set; }
-
-        /// <inheritdoc/>
-        public IEnumerable<object> Path { get; set; }
-
-        /// <inheritdoc/>
-        public IEnumerable<object> ResponsePath { get; set; }
-
-        /// <inheritdoc/>
-        public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields { get; set; }
-
-        /// <inheritdoc/>
-        public IServiceProvider? RequestServices { get; set; }
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
-
-        /// <inheritdoc/>
-        public IDictionary<string, object?> OutputExtensions { get; set; }
-
-        /// <inheritdoc/>
-        public IExecutionArrayPool ArrayPool { get; set; }
-
-        /// <inheritdoc/>
-        public ClaimsPrincipal? User { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance with all fields set to their default values.
-        /// </summary>
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public ResolveFieldContext() { }
+    public ResolveFieldContext() { }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
-        /// <summary>
-        /// Clone the specified <see cref="IResolveFieldContext"/>.
-        /// </summary>
-        public ResolveFieldContext(IResolveFieldContext context)
-        {
-            Source = context.Source;
-            FieldAst = context.FieldAst;
-            FieldDefinition = context.FieldDefinition;
-            ParentType = context.ParentType;
-            Parent = context.Parent;
-            Arguments = context.Arguments;
-            Directives = context.Directives;
-            Schema = context.Schema;
-            Document = context.Document;
-            RootValue = context.RootValue;
-            UserContext = context.UserContext;
-            User = context.User;
-            Operation = context.Operation;
-            Variables = context.Variables;
-            CancellationToken = context.CancellationToken;
-            Metrics = context.Metrics;
-            Errors = context.Errors;
-            SubFields = context.SubFields;
-            Path = context.Path;
-            ResponsePath = context.ResponsePath;
-            RequestServices = context.RequestServices;
-            InputExtensions = context.InputExtensions;
-            OutputExtensions = context.OutputExtensions;
-            ArrayPool = context.ArrayPool;
-        }
+    /// <summary>
+    /// Clone the specified <see cref="IResolveFieldContext"/>.
+    /// </summary>
+    public ResolveFieldContext(IResolveFieldContext context)
+    {
+        Source = context.Source;
+        FieldAst = context.FieldAst;
+        FieldDefinition = context.FieldDefinition;
+        ParentType = context.ParentType;
+        Parent = context.Parent;
+        Arguments = context.Arguments;
+        Directives = context.Directives;
+        Schema = context.Schema;
+        Document = context.Document;
+        RootValue = context.RootValue;
+        UserContext = context.UserContext;
+        User = context.User;
+        Operation = context.Operation;
+        Variables = context.Variables;
+        CancellationToken = context.CancellationToken;
+        Metrics = context.Metrics;
+        Errors = context.Errors;
+        SubFields = context.SubFields;
+        Path = context.Path;
+        ResponsePath = context.ResponsePath;
+        RequestServices = context.RequestServices;
+        InputExtensions = context.InputExtensions;
+        OutputExtensions = context.OutputExtensions;
+        ArrayPool = context.ArrayPool;
+    }
+}
+
+/// <inheritdoc cref="ResolveFieldContext"/>
+public class ResolveFieldContext<TSource> : ResolveFieldContext, IResolveFieldContext<TSource>
+{
+    /// <inheritdoc cref="ResolveFieldContext()"/>
+    public ResolveFieldContext()
+    {
     }
 
-    /// <inheritdoc cref="ResolveFieldContext"/>
-    public class ResolveFieldContext<TSource> : ResolveFieldContext, IResolveFieldContext<TSource>
+    /// <summary>
+    /// Clone the specified <see cref="IResolveFieldContext"/>
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to <typeparamref name="TSource"/></exception>
+    public ResolveFieldContext(IResolveFieldContext context) : base(context)
     {
-        /// <inheritdoc cref="ResolveFieldContext()"/>
-        public ResolveFieldContext()
-        {
-        }
+        if (context.Source != null && context.Source is not TSource)
+            throw new ArgumentException($"IResolveFieldContext.Source must be an instance of type '{typeof(TSource).Name}'", nameof(context));
+    }
 
-        /// <summary>
-        /// Clone the specified <see cref="IResolveFieldContext"/>
-        /// </summary>
-        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to <typeparamref name="TSource"/></exception>
-        public ResolveFieldContext(IResolveFieldContext context) : base(context)
-        {
-            if (context.Source != null && context.Source is not TSource)
-                throw new ArgumentException($"IResolveFieldContext.Source must be an instance of type '{typeof(TSource).Name}'", nameof(context));
-        }
-
-        /// <inheritdoc cref="ResolveFieldContext.Source"/>
-        public new TSource Source
-        {
-            get => (TSource)base.Source!;
-            set => base.Source = value;
-        }
+    /// <inheritdoc cref="ResolveFieldContext.Source"/>
+    public new TSource Source
+    {
+        get => (TSource)base.Source!;
+        set => base.Source = value;
     }
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -5,103 +5,102 @@ using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQLParser.AST;
 
-namespace GraphQL
+namespace GraphQL;
+
+internal sealed class ResolveFieldContextAdapter<T> : IResolveFieldContext<T>
 {
-    internal sealed class ResolveFieldContextAdapter<T> : IResolveFieldContext<T>
-    {
-        private IResolveFieldContext _baseContext;
-        private static readonly bool _acceptNulls = !typeof(T).IsValueType || typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>);
+    private IResolveFieldContext _baseContext;
+    private static readonly bool _acceptNulls = !typeof(T).IsValueType || typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>);
 
-        /// <summary>
-        /// Creates an instance that maps to the specified base <see cref="IResolveFieldContext"/>
-        /// </summary>
-        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>
+    /// <summary>
+    /// Creates an instance that maps to the specified base <see cref="IResolveFieldContext"/>
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public ResolveFieldContextAdapter(IResolveFieldContext baseContext)
+    public ResolveFieldContextAdapter(IResolveFieldContext baseContext)
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            Set(baseContext);
-        }
-
-        internal void Reset()
-        {
-            _baseContext = null!;
-            Source = default!;
-        }
-
-        internal ResolveFieldContextAdapter<T> Set(IResolveFieldContext baseContext)
-        {
-            _baseContext = baseContext ?? throw new ArgumentNullException(nameof(baseContext));
-
-            if (baseContext.Source == null && !_acceptNulls)
-            {
-                throw new ArgumentException("baseContext.Source is null and cannot be cast to non-nullable value type " + typeof(T).Name, nameof(baseContext));
-            }
-            else
-            {
-                try
-                {
-                    Source = (T)baseContext.Source!;
-                }
-                catch (InvalidCastException)
-                {
-                    throw new ArgumentException("baseContext.Source is not of type " + typeof(T).Name, nameof(baseContext));
-                }
-            }
-
-            return this;
-        }
-
-        public T Source { get; private set; }
-
-        public GraphQLField FieldAst => _baseContext.FieldAst;
-
-        public FieldType FieldDefinition => _baseContext.FieldDefinition;
-
-        public IObjectGraphType ParentType => _baseContext.ParentType;
-
-        public IResolveFieldContext? Parent => _baseContext.Parent;
-
-        public IDictionary<string, ArgumentValue>? Arguments => _baseContext.Arguments;
-
-        public IDictionary<string, DirectiveInfo>? Directives => _baseContext.Directives;
-
-        public object? RootValue => _baseContext.RootValue;
-
-        public ISchema Schema => _baseContext.Schema;
-
-        public GraphQLDocument Document => _baseContext.Document;
-
-        public GraphQLOperationDefinition Operation => _baseContext.Operation;
-
-        public Variables Variables => _baseContext.Variables;
-
-        public CancellationToken CancellationToken => _baseContext.CancellationToken;
-
-        public Metrics Metrics => _baseContext.Metrics;
-
-        public ExecutionErrors Errors => _baseContext.Errors;
-
-        public IEnumerable<object> Path => _baseContext.Path;
-
-        public IEnumerable<object> ResponsePath => _baseContext.ResponsePath;
-
-        public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields => _baseContext.SubFields;
-
-        public IDictionary<string, object?> UserContext => _baseContext.UserContext;
-
-        public IReadOnlyDictionary<string, object?> InputExtensions => _baseContext.InputExtensions;
-
-        public IDictionary<string, object?> OutputExtensions => _baseContext.OutputExtensions;
-
-        object? IResolveFieldContext.Source => Source;
-
-        public IServiceProvider? RequestServices => _baseContext.RequestServices;
-
-        /// <inheritdoc/>
-        public IExecutionArrayPool ArrayPool => _baseContext.ArrayPool;
-
-        /// <inheritdoc/>
-        public ClaimsPrincipal? User => _baseContext.User;
+    {
+        Set(baseContext);
     }
+
+    internal void Reset()
+    {
+        _baseContext = null!;
+        Source = default!;
+    }
+
+    internal ResolveFieldContextAdapter<T> Set(IResolveFieldContext baseContext)
+    {
+        _baseContext = baseContext ?? throw new ArgumentNullException(nameof(baseContext));
+
+        if (baseContext.Source == null && !_acceptNulls)
+        {
+            throw new ArgumentException("baseContext.Source is null and cannot be cast to non-nullable value type " + typeof(T).Name, nameof(baseContext));
+        }
+        else
+        {
+            try
+            {
+                Source = (T)baseContext.Source!;
+            }
+            catch (InvalidCastException)
+            {
+                throw new ArgumentException("baseContext.Source is not of type " + typeof(T).Name, nameof(baseContext));
+            }
+        }
+
+        return this;
+    }
+
+    public T Source { get; private set; }
+
+    public GraphQLField FieldAst => _baseContext.FieldAst;
+
+    public FieldType FieldDefinition => _baseContext.FieldDefinition;
+
+    public IObjectGraphType ParentType => _baseContext.ParentType;
+
+    public IResolveFieldContext? Parent => _baseContext.Parent;
+
+    public IDictionary<string, ArgumentValue>? Arguments => _baseContext.Arguments;
+
+    public IDictionary<string, DirectiveInfo>? Directives => _baseContext.Directives;
+
+    public object? RootValue => _baseContext.RootValue;
+
+    public ISchema Schema => _baseContext.Schema;
+
+    public GraphQLDocument Document => _baseContext.Document;
+
+    public GraphQLOperationDefinition Operation => _baseContext.Operation;
+
+    public Variables Variables => _baseContext.Variables;
+
+    public CancellationToken CancellationToken => _baseContext.CancellationToken;
+
+    public Metrics Metrics => _baseContext.Metrics;
+
+    public ExecutionErrors Errors => _baseContext.Errors;
+
+    public IEnumerable<object> Path => _baseContext.Path;
+
+    public IEnumerable<object> ResponsePath => _baseContext.ResponsePath;
+
+    public Dictionary<string, (GraphQLField Field, FieldType FieldType)>? SubFields => _baseContext.SubFields;
+
+    public IDictionary<string, object?> UserContext => _baseContext.UserContext;
+
+    public IReadOnlyDictionary<string, object?> InputExtensions => _baseContext.InputExtensions;
+
+    public IDictionary<string, object?> OutputExtensions => _baseContext.OutputExtensions;
+
+    object? IResolveFieldContext.Source => Source;
+
+    public IServiceProvider? RequestServices => _baseContext.RequestServices;
+
+    /// <inheritdoc/>
+    public IExecutionArrayPool ArrayPool => _baseContext.ArrayPool;
+
+    /// <inheritdoc/>
+    public ClaimsPrincipal? User => _baseContext.User;
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextExtensions.cs
@@ -1,252 +1,251 @@
 using GraphQL.Execution;
 using GraphQL.Types;
 
-namespace GraphQL
+namespace GraphQL;
+
+/// <summary>
+/// Provides extension methods for <see cref="IResolveFieldContext"/> instances.
+/// </summary>
+public static class ResolveFieldContextExtensions
 {
     /// <summary>
-    /// Provides extension methods for <see cref="IResolveFieldContext"/> instances.
+    /// Determines if currently executed field has any directives provided in the GraphQL query request.
     /// </summary>
-    public static class ResolveFieldContextExtensions
+    public static bool HasDirectives(this IResolveFieldContext context)
     {
-        /// <summary>
-        /// Determines if currently executed field has any directives provided in the GraphQL query request.
-        /// </summary>
-        public static bool HasDirectives(this IResolveFieldContext context)
+        return context.Directives?.Count > 0;
+    }
+
+    /// <summary>
+    /// Determines if the specified directive has been provided in the GraphQL query request for currently executed field.
+    /// </summary>
+    public static bool HasDirective(this IResolveFieldContext context, string name)
+    {
+        return context.Directives != null && context.Directives.ContainsKey(name);
+    }
+
+    /// <summary>
+    /// Gets directive provided in the GraphQL query request by its name.
+    /// </summary>
+    public static DirectiveInfo? GetDirective(this IResolveFieldContext context, string name)
+    {
+        return context.Directives != null && context.Directives.TryGetValue(name, out var value)
+            ? value
+            : null;
+    }
+
+    /// <summary>
+    /// Returns the value of the specified field argument, or <paramref name="defaultValue"/> when unspecified or when specified as <see langword="null"/>.
+    /// Field and variable default values take precedence over the <paramref name="defaultValue"/> parameter.
+    /// </summary>
+    public static TType GetArgument<TType>(this IResolveFieldContext context, string name, TType defaultValue = default!)
+    {
+        bool exists = context.TryGetArgument(typeof(TType), name, out object? result);
+        return exists
+            ? result == null ? defaultValue : (TType)result
+            : defaultValue;
+    }
+
+    /// <inheritdoc cref="GetArgument{TType}(IResolveFieldContext, string, TType)"/>
+    public static object? GetArgument(this IResolveFieldContext context, Type argumentType, string name, object? defaultValue = null)
+    {
+        bool exists = context.TryGetArgument(argumentType, name, out object? result);
+        return exists
+            ? result ?? defaultValue
+            : defaultValue;
+    }
+
+    internal static bool TryGetArgument(this IResolveFieldContext context, Type argumentType, string name, out object? result)
+    {
+        var isIntrospection = context.ParentType == null ? context.FieldDefinition.IsIntrospectionField() : context.ParentType.IsIntrospectionType();
+        var argumentName = isIntrospection ? name : (context.Schema?.NameConverter.NameForArgument(name, context.ParentType!, context.FieldDefinition) ?? name);
+
+        return TryGetArgumentExact(context, argumentType, argumentName, out result);
+    }
+
+    internal static bool TryGetArgumentExact(this IResolveFieldContext context, Type argumentType, string argumentName, out object? result)
+    {
+        if (context.Arguments == null || !context.Arguments.TryGetValue(argumentName, out var arg))
         {
-            return context.Directives?.Count > 0;
+            result = null;
+            return false;
         }
 
-        /// <summary>
-        /// Determines if the specified directive has been provided in the GraphQL query request for currently executed field.
-        /// </summary>
-        public static bool HasDirective(this IResolveFieldContext context, string name)
+        if (arg.Value == null || argumentType.IsInstanceOfType(arg.Value))
         {
-            return context.Directives != null && context.Directives.ContainsKey(name);
+            result = arg.Value;
+            return true;
         }
 
-        /// <summary>
-        /// Gets directive provided in the GraphQL query request by its name.
-        /// </summary>
-        public static DirectiveInfo? GetDirective(this IResolveFieldContext context, string name)
+        var resolvedType = context.FieldDefinition?.Arguments?.Find(argumentName)?.ResolvedType
+            ?? throw new InvalidOperationException($"Could not obtain graph type instance for argument '{argumentName}'");
+
+        if (arg.Value is IDictionary<string, object?> inputObject)
         {
-            return context.Directives != null && context.Directives.TryGetValue(name, out var value)
-                ? value
-                : null;
-        }
-
-        /// <summary>
-        /// Returns the value of the specified field argument, or <paramref name="defaultValue"/> when unspecified or when specified as <see langword="null"/>.
-        /// Field and variable default values take precedence over the <paramref name="defaultValue"/> parameter.
-        /// </summary>
-        public static TType GetArgument<TType>(this IResolveFieldContext context, string name, TType defaultValue = default!)
-        {
-            bool exists = context.TryGetArgument(typeof(TType), name, out object? result);
-            return exists
-                ? result == null ? defaultValue : (TType)result
-                : defaultValue;
-        }
-
-        /// <inheritdoc cref="GetArgument{TType}(IResolveFieldContext, string, TType)"/>
-        public static object? GetArgument(this IResolveFieldContext context, Type argumentType, string name, object? defaultValue = null)
-        {
-            bool exists = context.TryGetArgument(argumentType, name, out object? result);
-            return exists
-                ? result ?? defaultValue
-                : defaultValue;
-        }
-
-        internal static bool TryGetArgument(this IResolveFieldContext context, Type argumentType, string name, out object? result)
-        {
-            var isIntrospection = context.ParentType == null ? context.FieldDefinition.IsIntrospectionField() : context.ParentType.IsIntrospectionType();
-            var argumentName = isIntrospection ? name : (context.Schema?.NameConverter.NameForArgument(name, context.ParentType!, context.FieldDefinition) ?? name);
-
-            return TryGetArgumentExact(context, argumentType, argumentName, out result);
-        }
-
-        internal static bool TryGetArgumentExact(this IResolveFieldContext context, Type argumentType, string argumentName, out object? result)
-        {
-            if (context.Arguments == null || !context.Arguments.TryGetValue(argumentName, out var arg))
-            {
-                result = null;
-                return false;
-            }
-
-            if (arg.Value == null || argumentType.IsInstanceOfType(arg.Value))
+            if (argumentType == typeof(object))
             {
                 result = arg.Value;
                 return true;
             }
 
-            var resolvedType = context.FieldDefinition?.Arguments?.Find(argumentName)?.ResolvedType
-                ?? throw new InvalidOperationException($"Could not obtain graph type instance for argument '{argumentName}'");
-
-            if (arg.Value is IDictionary<string, object?> inputObject)
-            {
-                if (argumentType == typeof(object))
-                {
-                    result = arg.Value;
-                    return true;
-                }
-
-                result = inputObject.ToObject(argumentType, resolvedType);
-                return true;
-            }
-
-            result = arg.Value.GetPropertyValue(argumentType, resolvedType);
+            result = inputObject.ToObject(argumentType, resolvedType);
             return true;
         }
 
-        /// <summary>Determines if the specified field argument has been provided in the GraphQL query request.</summary>
-        public static bool HasArgument(this IResolveFieldContext context, string name)
+        result = arg.Value.GetPropertyValue(argumentType, resolvedType);
+        return true;
+    }
+
+    /// <summary>Determines if the specified field argument has been provided in the GraphQL query request.</summary>
+    public static bool HasArgument(this IResolveFieldContext context, string name)
+    {
+        var isIntrospection = context.ParentType == null ? context.FieldDefinition.IsIntrospectionField() : context.ParentType.IsIntrospectionType();
+        var argumentName = isIntrospection ? name : (context.Schema?.NameConverter.NameForArgument(name, context.ParentType!, context.FieldDefinition) ?? name);
+        return context.Arguments != null && context.Arguments.TryGetValue(argumentName, out var value) && value.Source != ArgumentSource.FieldDefault;
+    }
+
+    /// <summary>
+    /// Determines if this field is an introspection field (__schema, __type, __typename) -- but not if it is a field of an introspection type.
+    /// </summary>
+    private static bool IsIntrospectionField(this FieldType fieldType) => fieldType?.Name?.StartsWith("__") ?? false;
+
+    /// <summary>Returns the <see cref="IResolveFieldContext"/> typed as an <see cref="IResolveFieldContext{TSource}"/></summary>
+    /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>
+    public static IResolveFieldContext<TSourceType> As<TSourceType>(this IResolveFieldContext context)
+    {
+        if (context is IResolveFieldContext<TSourceType> typedContext)
+            return typedContext;
+
+        return new ResolveFieldContextAdapter<TSourceType>(context);
+    }
+
+    private static readonly char[] _separators = { '.' };
+
+    /// <summary>
+    /// Method to get value by path (key1.key2.keyN) from input extensions dictionary.
+    /// </summary>
+    /// <param name="context">Context with dictionary of extra information supplied with the GraphQL request.</param>
+    /// <param name="path">Path to value in key1.key2.keyN format.</param>
+    /// <returns>Value, if any exists on the specified path, otherwise <see langword="null"/>.</returns>
+    public static object? GetInputExtension(this IResolveFieldContext context, string path)
+    {
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
+
+        return GetByPath(context.InputExtensions, path, false);
+    }
+
+    /// <summary>
+    /// Thread safe method to get value by path (key1.key2.keyN) from output extensions dictionary.
+    /// </summary>
+    /// <param name="context">Context with extensions response map.</param>
+    /// <param name="path">Path to value in key1.key2.keyN format.</param>
+    /// <returns>Value, if any exists on the specified path, otherwise <see langword="null"/>.</returns>
+    public static object? GetOutputExtension(this IResolveFieldContext context, string path)
+    {
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
+
+        // Actually Dictionary<TKey, TValue> (as a widely used class) implements IReadOnlyDictionary<TKey, TValue>
+        // so this cast should never hurt for majority of cases.
+        return GetByPath(context.OutputExtensions as IReadOnlyDictionary<string, object?>, path, true);
+    }
+
+    private static object? GetByPath(IReadOnlyDictionary<string, object?>? dictionary, string path, bool useLock)
+    {
+        object? Get()
         {
-            var isIntrospection = context.ParentType == null ? context.FieldDefinition.IsIntrospectionField() : context.ParentType.IsIntrospectionType();
-            var argumentName = isIntrospection ? name : (context.Schema?.NameConverter.NameForArgument(name, context.ParentType!, context.FieldDefinition) ?? name);
-            return context.Arguments != null && context.Arguments.TryGetValue(argumentName, out var value) && value.Source != ArgumentSource.FieldDefault;
-        }
+            var values = dictionary;
 
-        /// <summary>
-        /// Determines if this field is an introspection field (__schema, __type, __typename) -- but not if it is a field of an introspection type.
-        /// </summary>
-        private static bool IsIntrospectionField(this FieldType fieldType) => fieldType?.Name?.StartsWith("__") ?? false;
-
-        /// <summary>Returns the <see cref="IResolveFieldContext"/> typed as an <see cref="IResolveFieldContext{TSource}"/></summary>
-        /// <exception cref="ArgumentException">Thrown if the <see cref="IResolveFieldContext.Source"/> property cannot be cast to the specified type</exception>
-        public static IResolveFieldContext<TSourceType> As<TSourceType>(this IResolveFieldContext context)
-        {
-            if (context is IResolveFieldContext<TSourceType> typedContext)
-                return typedContext;
-
-            return new ResolveFieldContextAdapter<TSourceType>(context);
-        }
-
-        private static readonly char[] _separators = { '.' };
-
-        /// <summary>
-        /// Method to get value by path (key1.key2.keyN) from input extensions dictionary.
-        /// </summary>
-        /// <param name="context">Context with dictionary of extra information supplied with the GraphQL request.</param>
-        /// <param name="path">Path to value in key1.key2.keyN format.</param>
-        /// <returns>Value, if any exists on the specified path, otherwise <see langword="null"/>.</returns>
-        public static object? GetInputExtension(this IResolveFieldContext context, string path)
-        {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
-
-            return GetByPath(context.InputExtensions, path, false);
-        }
-
-        /// <summary>
-        /// Thread safe method to get value by path (key1.key2.keyN) from output extensions dictionary.
-        /// </summary>
-        /// <param name="context">Context with extensions response map.</param>
-        /// <param name="path">Path to value in key1.key2.keyN format.</param>
-        /// <returns>Value, if any exists on the specified path, otherwise <see langword="null"/>.</returns>
-        public static object? GetOutputExtension(this IResolveFieldContext context, string path)
-        {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
-
-            // Actually Dictionary<TKey, TValue> (as a widely used class) implements IReadOnlyDictionary<TKey, TValue>
-            // so this cast should never hurt for majority of cases.
-            return GetByPath(context.OutputExtensions as IReadOnlyDictionary<string, object?>, path, true);
-        }
-
-        private static object? GetByPath(IReadOnlyDictionary<string, object?>? dictionary, string path, bool useLock)
-        {
-            object? Get()
+            if (path.IndexOf('.') != -1)
             {
-                var values = dictionary;
+                string[] keys = path.Split(_separators);
 
-                if (path.IndexOf('.') != -1)
+                for (int i = 0; i < keys.Length - 1; ++i)
                 {
-                    string[] keys = path.Split(_separators);
-
-                    for (int i = 0; i < keys.Length - 1; ++i)
-                    {
-                        if (values.TryGetValue(keys[i], out object? v) && v is IReadOnlyDictionary<string, object?> d)
-                            values = d;
-                        else
-                            return null;
-                    }
-
-                    return values.TryGetValue(keys[keys.Length - 1], out object? result) ? result : null;
+                    if (values.TryGetValue(keys[i], out object? v) && v is IReadOnlyDictionary<string, object?> d)
+                        values = d;
+                    else
+                        return null;
                 }
-                else
-                {
-                    return values.TryGetValue(path, out object? result) ? result : null;
-                }
-            }
 
-            if (dictionary == null || dictionary.Count == 0)
-                return null;
-
-            if (useLock)
-            {
-                lock (dictionary)
-                    return Get();
+                return values.TryGetValue(keys[keys.Length - 1], out object? result) ? result : null;
             }
             else
             {
-                return Get();
+                return values.TryGetValue(path, out object? result) ? result : null;
             }
         }
 
-        /// <summary>
-        /// Thread safe method to set value by path (key1.key2.keyN) to output extensions dictionary.
-        /// if the given path or its part contains values, then they will be overwritten.
-        /// </summary>
-        /// <param name="context">Context with extensions response map.</param>
-        /// <param name="path">Path to value in key1.key2.keyN format.</param>
-        /// <param name="value">Value to set.</param>
-        public static void SetOutputExtension(this IResolveFieldContext context, string path, object? value)
+        if (dictionary == null || dictionary.Count == 0)
+            return null;
+
+        if (useLock)
         {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            lock (dictionary)
+                return Get();
+        }
+        else
+        {
+            return Get();
+        }
+    }
 
-            if (context.OutputExtensions == null)
-                throw new ArgumentException("Extensions property is null", nameof(context));
+    /// <summary>
+    /// Thread safe method to set value by path (key1.key2.keyN) to output extensions dictionary.
+    /// if the given path or its part contains values, then they will be overwritten.
+    /// </summary>
+    /// <param name="context">Context with extensions response map.</param>
+    /// <param name="path">Path to value in key1.key2.keyN format.</param>
+    /// <param name="value">Value to set.</param>
+    public static void SetOutputExtension(this IResolveFieldContext context, string path, object? value)
+    {
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
 
-            lock (context.OutputExtensions)
+        if (context.OutputExtensions == null)
+            throw new ArgumentException("Extensions property is null", nameof(context));
+
+        lock (context.OutputExtensions)
+        {
+            var values = context.OutputExtensions;
+
+            if (path.IndexOf('.') != -1)
             {
-                var values = context.OutputExtensions;
+                string[] keys = path.Split(_separators);
 
-                if (path.IndexOf('.') != -1)
+                for (int i = 0; i < keys.Length - 1; ++i)
                 {
-                    string[] keys = path.Split(_separators);
-
-                    for (int i = 0; i < keys.Length - 1; ++i)
+                    if (values.TryGetValue(keys[i], out object? v) && v is IDictionary<string, object?> d)
                     {
-                        if (values.TryGetValue(keys[i], out object? v) && v is IDictionary<string, object?> d)
-                        {
-                            values = d;
-                        }
-                        else
-                        {
-                            var temp = new Dictionary<string, object?>();
-                            values[keys[i]] = temp; // overwrite value if any
-                            values = temp;
-                        }
+                        values = d;
                     }
+                    else
+                    {
+                        var temp = new Dictionary<string, object?>();
+                        values[keys[i]] = temp; // overwrite value if any
+                        values = temp;
+                    }
+                }
 
-                    values[keys[keys.Length - 1]] = value;
-                }
-                else
-                {
-                    values[path] = value;
-                }
+                values[keys[keys.Length - 1]] = value;
+            }
+            else
+            {
+                values[path] = value;
             }
         }
-
-        /// <summary>
-        /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
-        /// accessed at a later time.
-        /// </summary>
-        public static IResolveFieldContext Copy(this IResolveFieldContext context) => new ResolveFieldContext(context);
-
-        /// <summary>
-        /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
-        /// accessed at a later time.
-        /// </summary>
-        public static IResolveFieldContext<TSource> Copy<TSource>(this IResolveFieldContext<TSource> context) => new ResolveFieldContext<TSource>(context);
     }
+
+    /// <summary>
+    /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
+    /// accessed at a later time.
+    /// </summary>
+    public static IResolveFieldContext Copy(this IResolveFieldContext context) => new ResolveFieldContext(context);
+
+    /// <summary>
+    /// Make a copy of the specified <see cref="IResolveFieldContext"/> instance so it can be
+    /// accessed at a later time.
+    /// </summary>
+    public static IResolveFieldContext<TSource> Copy<TSource>(this IResolveFieldContext<TSource> context) => new ResolveFieldContext<TSource>(context);
 }

--- a/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
+++ b/src/GraphQL/Resolvers/ExpressionFieldResolver.cs
@@ -1,37 +1,36 @@
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace GraphQL.Resolvers
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// Returns a value from the field's graph type's source object, based on a predefined expression.
+/// <br/><br/>
+/// Supports asynchronous return types.
+/// <br/><br/>
+/// Note: this class uses dynamic compilation and therefore allocates a relatively large amount of
+/// memory in managed heap, ~1KB. Do not use this class in cases with limited memory requirements.
+/// </summary>
+public class ExpressionFieldResolver<TSourceType, TProperty> : IFieldResolver
 {
+    private readonly Func<IResolveFieldContext, ValueTask<object?>> _resolver;
+
     /// <summary>
-    /// Returns a value from the field's graph type's source object, based on a predefined expression.
-    /// <br/><br/>
-    /// Supports asynchronous return types.
-    /// <br/><br/>
-    /// Note: this class uses dynamic compilation and therefore allocates a relatively large amount of
-    /// memory in managed heap, ~1KB. Do not use this class in cases with limited memory requirements.
+    /// Initializes a new instance that runs the specified expression when resolving a field.
+    /// <see cref="Task{TResult}"/> and <see cref="ValueTask{TResult}"/> return types are also supported.
     /// </summary>
-    public class ExpressionFieldResolver<TSourceType, TProperty> : IFieldResolver
+    public ExpressionFieldResolver(Expression<Func<TSourceType, TProperty>> property)
     {
-        private readonly Func<IResolveFieldContext, ValueTask<object?>> _resolver;
-
-        /// <summary>
-        /// Initializes a new instance that runs the specified expression when resolving a field.
-        /// <see cref="Task{TResult}"/> and <see cref="ValueTask{TResult}"/> return types are also supported.
-        /// </summary>
-        public ExpressionFieldResolver(Expression<Func<TSourceType, TProperty>> property)
-        {
-            var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
-            var source = Expression.MakeMemberAccess(param, _sourcePropertyInfo);
-            var cast = Expression.Convert(source, typeof(TSourceType));
-            var body = property.Body.Replace(property.Parameters[0], cast);
-            _resolver = MemberResolver.BuildFieldResolverInternal(param, body);
-        }
-
-        private static readonly PropertyInfo _sourcePropertyInfo = typeof(IResolveFieldContext).GetProperty(nameof(IResolveFieldContext.Source))!;
-
-        /// <inheritdoc/>
-        ValueTask<object?> IFieldResolver.ResolveAsync(IResolveFieldContext context)
-            => _resolver(context);
+        var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
+        var source = Expression.MakeMemberAccess(param, _sourcePropertyInfo);
+        var cast = Expression.Convert(source, typeof(TSourceType));
+        var body = property.Body.Replace(property.Parameters[0], cast);
+        _resolver = MemberResolver.BuildFieldResolverInternal(param, body);
     }
+
+    private static readonly PropertyInfo _sourcePropertyInfo = typeof(IResolveFieldContext).GetProperty(nameof(IResolveFieldContext.Source))!;
+
+    /// <inheritdoc/>
+    ValueTask<object?> IFieldResolver.ResolveAsync(IResolveFieldContext context)
+        => _resolver(context);
 }

--- a/src/GraphQL/Resolvers/FuncFieldResolver.cs
+++ b/src/GraphQL/Resolvers/FuncFieldResolver.cs
@@ -1,147 +1,146 @@
 using System.Collections;
 using GraphQL.DataLoader;
 
-namespace GraphQL.Resolvers
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// When resolving a field, this implementation calls a predefined <see cref="Func{T, TResult}"/> and returns the result
+/// </summary>
+public class FuncFieldResolver<TReturnType> : IFieldResolver
 {
+    private readonly Func<IResolveFieldContext, ValueTask<object?>> _resolver;
+
     /// <summary>
-    /// When resolving a field, this implementation calls a predefined <see cref="Func{T, TResult}"/> and returns the result
+    /// Initializes a new instance that runs the specified delegate when resolving a field.
     /// </summary>
-    public class FuncFieldResolver<TReturnType> : IFieldResolver
+    public FuncFieldResolver(Func<IResolveFieldContext, TReturnType?> resolver)
     {
-        private readonly Func<IResolveFieldContext, ValueTask<object?>> _resolver;
+        if (resolver == null)
+            throw new ArgumentNullException(nameof(resolver));
 
-        /// <summary>
-        /// Initializes a new instance that runs the specified delegate when resolving a field.
-        /// </summary>
-        public FuncFieldResolver(Func<IResolveFieldContext, TReturnType?> resolver)
-        {
-            if (resolver == null)
-                throw new ArgumentNullException(nameof(resolver));
+        var returnType = resolver.Method.ReturnType; // in case the delegate was cast so TReturnType is just object, pull the original return type
+        if (typeof(Task).IsAssignableFrom(returnType) || (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>)))
+            throw new InvalidOperationException("Please use the proper FuncFieldResolver constructor for asynchronous delegates, or call FieldAsync when adding your field to the graph.");
 
-            var returnType = resolver.Method.ReturnType; // in case the delegate was cast so TReturnType is just object, pull the original return type
-            if (typeof(Task).IsAssignableFrom(returnType) || (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>)))
-                throw new InvalidOperationException("Please use the proper FuncFieldResolver constructor for asynchronous delegates, or call FieldAsync when adding your field to the graph.");
-
-            _resolver = context => new ValueTask<object?>(resolver(context));
-        }
-
-        /// <inheritdoc cref="FuncFieldResolver{TReturnType}(Func{IResolveFieldContext, TReturnType})"/>
-        public FuncFieldResolver(Func<IResolveFieldContext, ValueTask<TReturnType?>> resolver)
-        {
-            if (resolver == null)
-                throw new ArgumentNullException(nameof(resolver));
-
-            _resolver = resolver is Func<IResolveFieldContext, ValueTask<object?>> resolverObject
-                ? resolverObject
-                : async context => await resolver(context).ConfigureAwait(false);
-        }
-
-        /// <inheritdoc/>
-        public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => _resolver(context);
+        _resolver = context => new ValueTask<object?>(resolver(context));
     }
 
-    /// <summary>
-    /// <inheritdoc cref="FuncFieldResolver{TReturnType}"/>
-    /// <br/><br/>
-    /// This implementation provides a typed <see cref="IResolveFieldContext{TSource}"/> to the resolver function.
-    /// </summary>
-    public class FuncFieldResolver<TSourceType, TReturnType> : IFieldResolver
+    /// <inheritdoc cref="FuncFieldResolver{TReturnType}(Func{IResolveFieldContext, TReturnType})"/>
+    public FuncFieldResolver(Func<IResolveFieldContext, ValueTask<TReturnType?>> resolver)
     {
-        private readonly Func<IResolveFieldContext, ValueTask<object?>> _resolver;
-        private static ResolveFieldContextAdapter<TSourceType>? _sharedAdapter;
+        if (resolver == null)
+            throw new ArgumentNullException(nameof(resolver));
 
-        /// <inheritdoc cref="FuncFieldResolver{TReturnType}(Func{IResolveFieldContext, TReturnType})"/>
-        public FuncFieldResolver(Func<IResolveFieldContext<TSourceType>, TReturnType?> resolver)
+        _resolver = resolver is Func<IResolveFieldContext, ValueTask<object?>> resolverObject
+            ? resolverObject
+            : async context => await resolver(context).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => _resolver(context);
+}
+
+/// <summary>
+/// <inheritdoc cref="FuncFieldResolver{TReturnType}"/>
+/// <br/><br/>
+/// This implementation provides a typed <see cref="IResolveFieldContext{TSource}"/> to the resolver function.
+/// </summary>
+public class FuncFieldResolver<TSourceType, TReturnType> : IFieldResolver
+{
+    private readonly Func<IResolveFieldContext, ValueTask<object?>> _resolver;
+    private static ResolveFieldContextAdapter<TSourceType>? _sharedAdapter;
+
+    /// <inheritdoc cref="FuncFieldResolver{TReturnType}(Func{IResolveFieldContext, TReturnType})"/>
+    public FuncFieldResolver(Func<IResolveFieldContext<TSourceType>, TReturnType?> resolver)
+    {
+        if (resolver == null)
+            throw new ArgumentNullException(nameof(resolver));
+
+        _resolver = GetResolverFor(resolver);
+    }
+
+    /// <inheritdoc cref="FuncFieldResolver{TReturnType}(Func{IResolveFieldContext, TReturnType})"/>
+    public FuncFieldResolver(Func<IResolveFieldContext<TSourceType>, ValueTask<TReturnType?>> resolver)
+    {
+        if (resolver == null)
+            throw new ArgumentNullException(nameof(resolver));
+
+        _resolver = resolver is Func<IResolveFieldContext<TSourceType>, ValueTask<object?>> resolverObject
+            ? context => resolverObject(context.As<TSourceType>())
+            : async context => await resolver(context.As<TSourceType>()).ConfigureAwait(false);
+    }
+
+    private Func<IResolveFieldContext, ValueTask<object?>> GetResolverFor(Func<IResolveFieldContext<TSourceType>, TReturnType?> resolver)
+    {
+        var returnType = resolver.Method.ReturnType; // in case the delegate was cast so TReturnType is just object, pull the original return type
+        if (typeof(Task).IsAssignableFrom(returnType) || (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>)))
+            throw new InvalidOperationException("Please use the proper FuncFieldResolver constructor for asynchronous delegates, or call FieldAsync when adding your field to the graph.");
+
+        // also see ExecutionStrategy.ExecuteNodeAsync as it relates to context re-use
+
+        // when source type is object, just pass the context through, letting the execution strategy handle context re-use
+        if (typeof(TSourceType) == typeof(object))
         {
-            if (resolver == null)
-                throw new ArgumentNullException(nameof(resolver));
-
-            _resolver = GetResolverFor(resolver);
+            // ReadonlyResolveFieldContext implements IResolveFieldContext<object>
+            return (context) => new ValueTask<object?>(resolver(context.As<TSourceType>()));
         }
 
-        /// <inheritdoc cref="FuncFieldResolver{TReturnType}(Func{IResolveFieldContext, TReturnType})"/>
-        public FuncFieldResolver(Func<IResolveFieldContext<TSourceType>, ValueTask<TReturnType?>> resolver)
+        // for return types of IDataLoaderResult or IEnumerable
+        if (!CanReuseContextForType(returnType))
         {
-            if (resolver == null)
-                throw new ArgumentNullException(nameof(resolver));
-
-            _resolver = resolver is Func<IResolveFieldContext<TSourceType>, ValueTask<object?>> resolverObject
-                ? context => resolverObject(context.As<TSourceType>())
-                : async context => await resolver(context.As<TSourceType>()).ConfigureAwait(false);
+            // Data loaders and IEnumerable results cannot use pooled contexts
+            return (context) => new ValueTask<object?>(resolver(context.As<TSourceType>()));
         }
 
-        private Func<IResolveFieldContext, ValueTask<object?>> GetResolverFor(Func<IResolveFieldContext<TSourceType>, TReturnType?> resolver)
+        // for return types of object, examine the return type at runtime to determine if context re-use is applicable
+        if (returnType == typeof(object))
         {
-            var returnType = resolver.Method.ReturnType; // in case the delegate was cast so TReturnType is just object, pull the original return type
-            if (typeof(Task).IsAssignableFrom(returnType) || (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>)))
-                throw new InvalidOperationException("Please use the proper FuncFieldResolver constructor for asynchronous delegates, or call FieldAsync when adding your field to the graph.");
-
-            // also see ExecutionStrategy.ExecuteNodeAsync as it relates to context re-use
-
-            // when source type is object, just pass the context through, letting the execution strategy handle context re-use
-            if (typeof(TSourceType) == typeof(object))
-            {
-                // ReadonlyResolveFieldContext implements IResolveFieldContext<object>
-                return (context) => new ValueTask<object?>(resolver(context.As<TSourceType>()));
-            }
-
-            // for return types of IDataLoaderResult or IEnumerable
-            if (!CanReuseContextForType(returnType))
-            {
-                // Data loaders and IEnumerable results cannot use pooled contexts
-                return (context) => new ValueTask<object?>(resolver(context.As<TSourceType>()));
-            }
-
-            // for return types of object, examine the return type at runtime to determine if context re-use is applicable
-            if (returnType == typeof(object))
-            {
-                // must determine type at runtime
-                return (context) =>
-                {
-                    var adapter = Interlocked.Exchange(ref _sharedAdapter, null);
-                    if (adapter == null)
-                    {
-                        adapter = new ResolveFieldContextAdapter<TSourceType>(context);
-                    }
-                    else
-                    {
-                        adapter.Set(context);
-                    }
-                    var ret = resolver(adapter);
-                    // only re-use contexts that do not return an IDataLoaderResult or an IEnumerable (that may be based on the context source)
-                    if (CanReuseContextForValue(ret))
-                    {
-                        adapter.Reset();
-                        Interlocked.CompareExchange(ref _sharedAdapter, adapter, null);
-                    }
-                    return new ValueTask<object?>(ret);
-                };
-            }
-
-            // TSourceType is not object
-            // TReturnType is not an IEnumerable, IDataLoaderResult, or object
-            // use a pooled context
+            // must determine type at runtime
             return (context) =>
             {
                 var adapter = Interlocked.Exchange(ref _sharedAdapter, null);
-                adapter = adapter == null ? new ResolveFieldContextAdapter<TSourceType>(context) : adapter.Set(context);
+                if (adapter == null)
+                {
+                    adapter = new ResolveFieldContextAdapter<TSourceType>(context);
+                }
+                else
+                {
+                    adapter.Set(context);
+                }
                 var ret = resolver(adapter);
-                adapter.Reset();
-                Interlocked.CompareExchange(ref _sharedAdapter, adapter, null);
+                // only re-use contexts that do not return an IDataLoaderResult or an IEnumerable (that may be based on the context source)
+                if (CanReuseContextForValue(ret))
+                {
+                    adapter.Reset();
+                    Interlocked.CompareExchange(ref _sharedAdapter, adapter, null);
+                }
                 return new ValueTask<object?>(ret);
             };
-
-            static bool CanReuseContextForType(Type type) => !IsDataLoaderType(type) && !IsEnumerableType(type);
-            static bool CanReuseContextForValue(object? value) => !IsDataLoaderValue(value) && !IsEnumerableValue(value);
-
-            static bool IsEnumerableType(Type type) => typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string);
-            static bool IsEnumerableValue(object? value) => value is IEnumerable && value is not string;
-
-            static bool IsDataLoaderType(Type type) => typeof(IDataLoaderResult).IsAssignableFrom(type);
-            static bool IsDataLoaderValue(object? value) => value is IDataLoaderResult;
         }
 
-        /// <inheritdoc/>
-        public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => _resolver(context);
+        // TSourceType is not object
+        // TReturnType is not an IEnumerable, IDataLoaderResult, or object
+        // use a pooled context
+        return (context) =>
+        {
+            var adapter = Interlocked.Exchange(ref _sharedAdapter, null);
+            adapter = adapter == null ? new ResolveFieldContextAdapter<TSourceType>(context) : adapter.Set(context);
+            var ret = resolver(adapter);
+            adapter.Reset();
+            Interlocked.CompareExchange(ref _sharedAdapter, adapter, null);
+            return new ValueTask<object?>(ret);
+        };
+
+        static bool CanReuseContextForType(Type type) => !IsDataLoaderType(type) && !IsEnumerableType(type);
+        static bool CanReuseContextForValue(object? value) => !IsDataLoaderValue(value) && !IsEnumerableValue(value);
+
+        static bool IsEnumerableType(Type type) => typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string);
+        static bool IsEnumerableValue(object? value) => value is IEnumerable && value is not string;
+
+        static bool IsDataLoaderType(Type type) => typeof(IDataLoaderResult).IsAssignableFrom(type);
+        static bool IsDataLoaderValue(object? value) => value is IDataLoaderResult;
     }
+
+    /// <inheritdoc/>
+    public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => _resolver(context);
 }

--- a/src/GraphQL/Resolvers/IFieldResolver.cs
+++ b/src/GraphQL/Resolvers/IFieldResolver.cs
@@ -1,31 +1,30 @@
 using GraphQL.Types;
 
-namespace GraphQL.Resolvers
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// <para>
+/// A field resolver returns an object for a given field within a graph.
+/// </para><para>
+/// The <see cref="FieldType.Resolver"/> property defines the field resolver to be used for the field.
+/// </para><para>
+/// Typically an instance of <see cref="FuncFieldResolver{TSourceType, TReturnType}">FuncFieldResolver</see>
+/// is created when code needs to execute within the field resolver - typically by calling
+/// <see cref="Builders.FieldBuilder{TSourceType, TReturnType}">FieldBuilder</see>.<see cref="Builders.FieldBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveFieldContext{TSourceType}, TReturnType})">Resolve</see>
+/// or <see cref="Builders.FieldBuilder{TSourceType, TReturnType}">FieldBuilder</see>.<see cref="Builders.FieldBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveFieldContext{TSourceType}, Task{TReturnType}})">ResolveAsync</see>.
+/// </para><para>
+/// When mapping fields to source object properties via
+/// <see cref="ComplexGraphType{TSourceType}.Field{TProperty}(System.Linq.Expressions.Expression{Func{TSourceType, TProperty}}, bool, Type)">Field(x => x.Name)</see>,
+/// <see cref="ExpressionFieldResolver{TSourceType, TProperty}">ExpressionFieldResolver</see> is used.
+/// </para><para>
+/// When a field resolver is not defined, such as with <see cref="ComplexGraphType{TSourceType}.Field{TGraphType, TReturnType}(string)">Field("Name")</see>,
+/// the static instance of <see cref="NameFieldResolver"/> is used.
+/// </para>
+/// </summary>
+public interface IFieldResolver
 {
     /// <summary>
-    /// <para>
-    /// A field resolver returns an object for a given field within a graph.
-    /// </para><para>
-    /// The <see cref="FieldType.Resolver"/> property defines the field resolver to be used for the field.
-    /// </para><para>
-    /// Typically an instance of <see cref="FuncFieldResolver{TSourceType, TReturnType}">FuncFieldResolver</see>
-    /// is created when code needs to execute within the field resolver - typically by calling
-    /// <see cref="Builders.FieldBuilder{TSourceType, TReturnType}">FieldBuilder</see>.<see cref="Builders.FieldBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveFieldContext{TSourceType}, TReturnType})">Resolve</see>
-    /// or <see cref="Builders.FieldBuilder{TSourceType, TReturnType}">FieldBuilder</see>.<see cref="Builders.FieldBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveFieldContext{TSourceType}, Task{TReturnType}})">ResolveAsync</see>.
-    /// </para><para>
-    /// When mapping fields to source object properties via
-    /// <see cref="ComplexGraphType{TSourceType}.Field{TProperty}(System.Linq.Expressions.Expression{Func{TSourceType, TProperty}}, bool, Type)">Field(x => x.Name)</see>,
-    /// <see cref="ExpressionFieldResolver{TSourceType, TProperty}">ExpressionFieldResolver</see> is used.
-    /// </para><para>
-    /// When a field resolver is not defined, such as with <see cref="ComplexGraphType{TSourceType}.Field{TGraphType, TReturnType}(string)">Field("Name")</see>,
-    /// the static instance of <see cref="NameFieldResolver"/> is used.
-    /// </para>
+    /// Returns an <see cref="ValueTask{TResult}"/> wrapping an object or <see langword="null"/> for the specified field.
     /// </summary>
-    public interface IFieldResolver
-    {
-        /// <summary>
-        /// Returns an <see cref="ValueTask{TResult}"/> wrapping an object or <see langword="null"/> for the specified field.
-        /// </summary>
-        ValueTask<object?> ResolveAsync(IResolveFieldContext context);
-    }
+    ValueTask<object?> ResolveAsync(IResolveFieldContext context);
 }

--- a/src/GraphQL/Resolvers/ISourceStreamResolver.cs
+++ b/src/GraphQL/Resolvers/ISourceStreamResolver.cs
@@ -1,14 +1,13 @@
-namespace GraphQL.Resolvers
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// Returns an <see cref="IObservable{T}"/> for a field. The <see cref="IObservable{T}"/> provides
+/// a sequence of event notifications (aka 'an event stream') to the subscription execution engine,
+/// which will resolve child fields using the event data as the source. Then the resolved graph is
+/// returned to the client, and the process repeats for further event notifications. 
+/// </summary>
+public interface ISourceStreamResolver
 {
-    /// <summary>
-    /// Returns an <see cref="IObservable{T}"/> for a field. The <see cref="IObservable{T}"/> provides
-    /// a sequence of event notifications (aka 'an event stream') to the subscription execution engine,
-    /// which will resolve child fields using the event data as the source. Then the resolved graph is
-    /// returned to the client, and the process repeats for further event notifications. 
-    /// </summary>
-    public interface ISourceStreamResolver
-    {
-        /// <inheritdoc cref="ISourceStreamResolver"/>
-        ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context);
-    }
+    /// <inheritdoc cref="ISourceStreamResolver"/>
+    ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context);
 }

--- a/src/GraphQL/Resolvers/MemberResolver.cs
+++ b/src/GraphQL/Resolvers/MemberResolver.cs
@@ -1,189 +1,188 @@
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace GraphQL.Resolvers
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// A precompiled field resolver for a specific <see cref="MethodInfo"/>, <see cref="PropertyInfo"/> or <see cref="FieldInfo"/>.
+/// Returns the specified field or property, or for methods, calls the specified method (with the specified arguments)
+/// and returns the value of the method.
+/// </summary>
+public class MemberResolver : IFieldResolver
 {
+    private readonly Func<IResolveFieldContext, ValueTask<object?>> _resolver;
+
     /// <summary>
-    /// A precompiled field resolver for a specific <see cref="MethodInfo"/>, <see cref="PropertyInfo"/> or <see cref="FieldInfo"/>.
-    /// Returns the specified field or property, or for methods, calls the specified method (with the specified arguments)
-    /// and returns the value of the method.
+    /// Initializes an instance for the specified field, using the specified instance expression to access the instance of the field.
+    /// <br/><br/>
+    /// An example of an instance expression would be as follows:
+    /// <code>context =&gt; (TSourceType)context.Source</code>
     /// </summary>
-    public class MemberResolver : IFieldResolver
+    public MemberResolver(FieldInfo fieldInfo, LambdaExpression instanceExpression)
     {
-        private readonly Func<IResolveFieldContext, ValueTask<object?>> _resolver;
+        if (fieldInfo == null)
+            throw new ArgumentNullException(nameof(fieldInfo));
+        if (instanceExpression == null)
+            throw new ArgumentNullException(nameof(instanceExpression));
 
-        /// <summary>
-        /// Initializes an instance for the specified field, using the specified instance expression to access the instance of the field.
-        /// <br/><br/>
-        /// An example of an instance expression would be as follows:
-        /// <code>context =&gt; (TSourceType)context.Source</code>
-        /// </summary>
-        public MemberResolver(FieldInfo fieldInfo, LambdaExpression instanceExpression)
+        if (instanceExpression.Parameters.Count != 1 ||
+            instanceExpression.Parameters[0].Type != typeof(IResolveFieldContext) ||
+            !fieldInfo.DeclaringType!.IsAssignableFrom(instanceExpression.ReturnType))
         {
-            if (fieldInfo == null)
-                throw new ArgumentNullException(nameof(fieldInfo));
-            if (instanceExpression == null)
-                throw new ArgumentNullException(nameof(instanceExpression));
-
-            if (instanceExpression.Parameters.Count != 1 ||
-                instanceExpression.Parameters[0].Type != typeof(IResolveFieldContext) ||
-                !fieldInfo.DeclaringType!.IsAssignableFrom(instanceExpression.ReturnType))
-            {
-                throw new ArgumentException($"Source lambda must be of type Func<IResolveFieldContext, {fieldInfo.DeclaringType!.Name}>.", nameof(instanceExpression));
-            }
-
-            var methodCallExpr = Expression.MakeMemberAccess(
-                fieldInfo.IsStatic ? null : instanceExpression.Body,
-                fieldInfo);
-
-            _resolver = BuildFieldResolver(instanceExpression.Parameters[0], methodCallExpr);
+            throw new ArgumentException($"Source lambda must be of type Func<IResolveFieldContext, {fieldInfo.DeclaringType!.Name}>.", nameof(instanceExpression));
         }
 
-        /// <summary>
-        /// Initializes an instance for the specified property, using the specified instance expression to access the instance of the property.
-        /// <br/><br/>
-        /// An example of an instance expression would be as follows:
-        /// <code>context =&gt; (TSourceType)context.Source</code>
-        /// </summary>
-        public MemberResolver(PropertyInfo propertyInfo, LambdaExpression instanceExpression)
-            : this((propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo))).GetMethod ?? throw new ArgumentException($"No 'get' method for the supplied {propertyInfo.Name} property.", nameof(propertyInfo)), instanceExpression, Array.Empty<LambdaExpression>())
-        {
-        }
+        var methodCallExpr = Expression.MakeMemberAccess(
+            fieldInfo.IsStatic ? null : instanceExpression.Body,
+            fieldInfo);
 
-        /// <summary>
-        /// Initializes an instance for the specified method, using the specified instance expression to access the instance of the method,
-        /// along with a list of arguments to be passed to the method. The method argument expressions must have return types that match
-        /// those of the method arguments.
-        /// <br/><br/>
-        /// An example of an instance expression would be as follows:
-        /// <code>context =&gt; (TSourceType)context.Source</code>
-        /// </summary>
-        public MemberResolver(MethodInfo methodInfo, LambdaExpression instanceExpression, IList<LambdaExpression> methodArgumentExpressions)
-        {
-            if (methodInfo == null)
-                throw new ArgumentNullException(nameof(methodInfo));
-            if (instanceExpression == null)
-                throw new ArgumentNullException(nameof(instanceExpression));
-            if (methodArgumentExpressions == null)
-                throw new ArgumentNullException(nameof(methodArgumentExpressions));
-            // verify that the expressions provided match the number of parameters
-            var methodParameters = methodInfo.GetParameters();
-            if (methodArgumentExpressions.Count != methodParameters.Length)
-            {
-                throw new InvalidOperationException("The number of expressions must equal the number of method parameters.");
-            }
-            if (instanceExpression.Parameters.Count != 1 ||
-                instanceExpression.Parameters[0].Type != typeof(IResolveFieldContext) ||
-                !methodInfo.DeclaringType!.IsAssignableFrom(instanceExpression.ReturnType))
-            {
-                throw new ArgumentException($"Source lambda must be of type Func<IResolveFieldContext, {methodInfo.DeclaringType!.Name}>.", nameof(instanceExpression));
-            }
-
-            // create a parameter expression for IResolveFieldContext
-            var resolveFieldContextParameter = Expression.Parameter(typeof(IResolveFieldContext), "context");
-
-            // convert each of the provided lambda expressions and pull the expression bodies, replacing the existing lambda's
-            // parameter with the new one, so each expression is using the same parameter
-            var expressionBodies = new Expression[methodArgumentExpressions.Count];
-            for (int i = 0; i < methodArgumentExpressions.Count; i++)
-            {
-                var expr = methodArgumentExpressions[i];
-                if (expr.Parameters.Count != 1 || expr.Parameters[0].Type != typeof(IResolveFieldContext) || expr.ReturnType != methodParameters[i].ParameterType)
-                {
-                    throw new InvalidOperationException($"A supplied expression is not a lambda delegate of type Func<IResolveFieldContext, {methodParameters[i].ParameterType.Name}>.");
-                }
-                expressionBodies[i] = expr.Body.Replace(expr.Parameters[0], resolveFieldContextParameter);
-            }
-
-            // create the method call expression
-            var methodCallExpr =
-                Expression.Call(
-                    methodInfo.IsStatic
-                        ? null
-                        : instanceExpression.Body.Replace(
-                            instanceExpression.Parameters[0],
-                            resolveFieldContextParameter),
-                    methodInfo,
-                    expressionBodies);
-
-            _resolver = BuildFieldResolver(resolveFieldContextParameter, methodCallExpr);
-        }
-
-        /// <summary>
-        /// Creates an appropriate resolver function based on the return type of the expression body.
-        /// </summary>
-        protected virtual Func<IResolveFieldContext, ValueTask<object?>> BuildFieldResolver(ParameterExpression resolveFieldContextParameter, Expression bodyExpression)
-            => BuildFieldResolverInternal(resolveFieldContextParameter, bodyExpression);
-
-        /// <inheritdoc cref="BuildFieldResolver(ParameterExpression, Expression)"/>
-        internal static Func<IResolveFieldContext, ValueTask<object?>> BuildFieldResolverInternal(ParameterExpression resolveFieldContextParameter, Expression bodyExpression)
-        {
-            Expression? valueTaskExpr = null;
-
-            if (bodyExpression.Type == typeof(ValueTask<object?>))
-            {
-                valueTaskExpr = bodyExpression;
-            }
-            else if (bodyExpression.Type == typeof(Task<object?>))
-            {
-                // e.g. valueTask = new ValueTask<object>(body);
-                var valueTaskType = typeof(ValueTask<object?>);
-                var constructor = valueTaskType.GetConstructor(new Type[] { typeof(Task<object?>) })!;
-                valueTaskExpr = Expression.New(constructor, bodyExpression);
-            }
-            else if (bodyExpression.Type.IsGenericType)
-            {
-                var genericType = bodyExpression.Type.GetGenericTypeDefinition();
-                if (genericType == typeof(ValueTask<>))
-                {
-                    // e.g. valueTask = MarshalValueTask(body);
-                    var underlyingType = bodyExpression.Type.GetGenericArguments()[0];
-                    var method = _marshalValueTaskAsyncMethod.MakeGenericMethod(underlyingType);
-                    valueTaskExpr = Expression.Call(
-                        method,
-                        bodyExpression);
-                }
-                else if (genericType == typeof(Task<>))
-                {
-                    // e.g. valueTask = MarshalTask(body);
-                    var underlyingType = bodyExpression.Type.GetGenericArguments()[0];
-                    var method = _marshalTaskAsyncMethod.MakeGenericMethod(underlyingType);
-                    valueTaskExpr = Expression.Call(
-                        method,
-                        bodyExpression);
-                }
-            }
-
-            if (valueTaskExpr == null)
-            {
-                // convert the result to type object
-                // e.g. var convert = (object)body;
-                Expression convertExpr = bodyExpression.Type == typeof(object)
-                    ? bodyExpression
-                    : Expression.Convert(bodyExpression, typeof(object));
-
-                // e.g. valueTask = new ValueTask<object>(convert);
-                var valueTaskType = typeof(ValueTask<object?>);
-                var constructor = valueTaskType.GetConstructor(new Type[] { typeof(object) })!;
-                valueTaskExpr = Expression.New(constructor, convertExpr);
-            }
-
-            // create the lambda
-            var lambdaExpr = Expression.Lambda<Func<IResolveFieldContext, ValueTask<object?>>>(
-                valueTaskExpr,
-                resolveFieldContextParameter);
-
-            // compile the lambda expression
-            return lambdaExpr.Compile();
-        }
-
-        private static readonly MethodInfo _marshalTaskAsyncMethod = typeof(MemberResolver).GetMethod(nameof(MarshalTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static async ValueTask<object?> MarshalTaskAsync<T>(Task<T> task) => await task.ConfigureAwait(false);
-
-        private static readonly MethodInfo _marshalValueTaskAsyncMethod = typeof(MemberResolver).GetMethod(nameof(MarshalValueTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static async ValueTask<object?> MarshalValueTaskAsync<T>(ValueTask<T> task) => await task.ConfigureAwait(false);
-
-        /// <inheritdoc/>
-        public virtual ValueTask<object?> ResolveAsync(IResolveFieldContext context) => _resolver(context);
+        _resolver = BuildFieldResolver(instanceExpression.Parameters[0], methodCallExpr);
     }
+
+    /// <summary>
+    /// Initializes an instance for the specified property, using the specified instance expression to access the instance of the property.
+    /// <br/><br/>
+    /// An example of an instance expression would be as follows:
+    /// <code>context =&gt; (TSourceType)context.Source</code>
+    /// </summary>
+    public MemberResolver(PropertyInfo propertyInfo, LambdaExpression instanceExpression)
+        : this((propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo))).GetMethod ?? throw new ArgumentException($"No 'get' method for the supplied {propertyInfo.Name} property.", nameof(propertyInfo)), instanceExpression, Array.Empty<LambdaExpression>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes an instance for the specified method, using the specified instance expression to access the instance of the method,
+    /// along with a list of arguments to be passed to the method. The method argument expressions must have return types that match
+    /// those of the method arguments.
+    /// <br/><br/>
+    /// An example of an instance expression would be as follows:
+    /// <code>context =&gt; (TSourceType)context.Source</code>
+    /// </summary>
+    public MemberResolver(MethodInfo methodInfo, LambdaExpression instanceExpression, IList<LambdaExpression> methodArgumentExpressions)
+    {
+        if (methodInfo == null)
+            throw new ArgumentNullException(nameof(methodInfo));
+        if (instanceExpression == null)
+            throw new ArgumentNullException(nameof(instanceExpression));
+        if (methodArgumentExpressions == null)
+            throw new ArgumentNullException(nameof(methodArgumentExpressions));
+        // verify that the expressions provided match the number of parameters
+        var methodParameters = methodInfo.GetParameters();
+        if (methodArgumentExpressions.Count != methodParameters.Length)
+        {
+            throw new InvalidOperationException("The number of expressions must equal the number of method parameters.");
+        }
+        if (instanceExpression.Parameters.Count != 1 ||
+            instanceExpression.Parameters[0].Type != typeof(IResolveFieldContext) ||
+            !methodInfo.DeclaringType!.IsAssignableFrom(instanceExpression.ReturnType))
+        {
+            throw new ArgumentException($"Source lambda must be of type Func<IResolveFieldContext, {methodInfo.DeclaringType!.Name}>.", nameof(instanceExpression));
+        }
+
+        // create a parameter expression for IResolveFieldContext
+        var resolveFieldContextParameter = Expression.Parameter(typeof(IResolveFieldContext), "context");
+
+        // convert each of the provided lambda expressions and pull the expression bodies, replacing the existing lambda's
+        // parameter with the new one, so each expression is using the same parameter
+        var expressionBodies = new Expression[methodArgumentExpressions.Count];
+        for (int i = 0; i < methodArgumentExpressions.Count; i++)
+        {
+            var expr = methodArgumentExpressions[i];
+            if (expr.Parameters.Count != 1 || expr.Parameters[0].Type != typeof(IResolveFieldContext) || expr.ReturnType != methodParameters[i].ParameterType)
+            {
+                throw new InvalidOperationException($"A supplied expression is not a lambda delegate of type Func<IResolveFieldContext, {methodParameters[i].ParameterType.Name}>.");
+            }
+            expressionBodies[i] = expr.Body.Replace(expr.Parameters[0], resolveFieldContextParameter);
+        }
+
+        // create the method call expression
+        var methodCallExpr =
+            Expression.Call(
+                methodInfo.IsStatic
+                    ? null
+                    : instanceExpression.Body.Replace(
+                        instanceExpression.Parameters[0],
+                        resolveFieldContextParameter),
+                methodInfo,
+                expressionBodies);
+
+        _resolver = BuildFieldResolver(resolveFieldContextParameter, methodCallExpr);
+    }
+
+    /// <summary>
+    /// Creates an appropriate resolver function based on the return type of the expression body.
+    /// </summary>
+    protected virtual Func<IResolveFieldContext, ValueTask<object?>> BuildFieldResolver(ParameterExpression resolveFieldContextParameter, Expression bodyExpression)
+        => BuildFieldResolverInternal(resolveFieldContextParameter, bodyExpression);
+
+    /// <inheritdoc cref="BuildFieldResolver(ParameterExpression, Expression)"/>
+    internal static Func<IResolveFieldContext, ValueTask<object?>> BuildFieldResolverInternal(ParameterExpression resolveFieldContextParameter, Expression bodyExpression)
+    {
+        Expression? valueTaskExpr = null;
+
+        if (bodyExpression.Type == typeof(ValueTask<object?>))
+        {
+            valueTaskExpr = bodyExpression;
+        }
+        else if (bodyExpression.Type == typeof(Task<object?>))
+        {
+            // e.g. valueTask = new ValueTask<object>(body);
+            var valueTaskType = typeof(ValueTask<object?>);
+            var constructor = valueTaskType.GetConstructor(new Type[] { typeof(Task<object?>) })!;
+            valueTaskExpr = Expression.New(constructor, bodyExpression);
+        }
+        else if (bodyExpression.Type.IsGenericType)
+        {
+            var genericType = bodyExpression.Type.GetGenericTypeDefinition();
+            if (genericType == typeof(ValueTask<>))
+            {
+                // e.g. valueTask = MarshalValueTask(body);
+                var underlyingType = bodyExpression.Type.GetGenericArguments()[0];
+                var method = _marshalValueTaskAsyncMethod.MakeGenericMethod(underlyingType);
+                valueTaskExpr = Expression.Call(
+                    method,
+                    bodyExpression);
+            }
+            else if (genericType == typeof(Task<>))
+            {
+                // e.g. valueTask = MarshalTask(body);
+                var underlyingType = bodyExpression.Type.GetGenericArguments()[0];
+                var method = _marshalTaskAsyncMethod.MakeGenericMethod(underlyingType);
+                valueTaskExpr = Expression.Call(
+                    method,
+                    bodyExpression);
+            }
+        }
+
+        if (valueTaskExpr == null)
+        {
+            // convert the result to type object
+            // e.g. var convert = (object)body;
+            Expression convertExpr = bodyExpression.Type == typeof(object)
+                ? bodyExpression
+                : Expression.Convert(bodyExpression, typeof(object));
+
+            // e.g. valueTask = new ValueTask<object>(convert);
+            var valueTaskType = typeof(ValueTask<object?>);
+            var constructor = valueTaskType.GetConstructor(new Type[] { typeof(object) })!;
+            valueTaskExpr = Expression.New(constructor, convertExpr);
+        }
+
+        // create the lambda
+        var lambdaExpr = Expression.Lambda<Func<IResolveFieldContext, ValueTask<object?>>>(
+            valueTaskExpr,
+            resolveFieldContextParameter);
+
+        // compile the lambda expression
+        return lambdaExpr.Compile();
+    }
+
+    private static readonly MethodInfo _marshalTaskAsyncMethod = typeof(MemberResolver).GetMethod(nameof(MarshalTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static async ValueTask<object?> MarshalTaskAsync<T>(Task<T> task) => await task.ConfigureAwait(false);
+
+    private static readonly MethodInfo _marshalValueTaskAsyncMethod = typeof(MemberResolver).GetMethod(nameof(MarshalValueTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static async ValueTask<object?> MarshalValueTaskAsync<T>(ValueTask<T> task) => await task.ConfigureAwait(false);
+
+    /// <inheritdoc/>
+    public virtual ValueTask<object?> ResolveAsync(IResolveFieldContext context) => _resolver(context);
 }

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -3,89 +3,88 @@ using System.Linq.Expressions;
 using System.Reflection;
 using GraphQL.Types;
 
-namespace GraphQL.Resolvers
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// <para>
+/// Attempts to return a value for a field from the graph's source object, matching the name of
+/// the field to a property or a method with the same name on the source object.
+/// </para><para>
+/// Call <see cref="Instance"/> to retrieve an instance of this class.
+/// </para>
+/// </summary>
+public class NameFieldResolver : IFieldResolver
 {
+    private static readonly ConcurrentDictionary<(Type targetType, string name), IFieldResolver> _resolvers = new();
+
+    private NameFieldResolver() { }
+
+    /// <summary>
+    /// Returns the static instance of the <see cref="NameFieldResolver"/> class.
+    /// </summary>
+    public static NameFieldResolver Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => Resolve(context, context.FieldDefinition.Name);
+
+    private static ValueTask<object?> Resolve(IResolveFieldContext context, string? name)
+    {
+        if (context.Source == null || name == null)
+            return default;
+
+        // We use reflection to create a delegate to access the property/method
+        // Then cache the delegate
+        // This is over 10x faster that just using reflection to get the property/method value
+        var resolver = _resolvers.GetOrAdd((context.Source.GetType(), name), t => CreateResolver(t.targetType, t.name));
+        return resolver.ResolveAsync(context);
+    }
+
     /// <summary>
     /// <para>
-    /// Attempts to return a value for a field from the graph's source object, matching the name of
-    /// the field to a property or a method with the same name on the source object.
+    /// Dynamically creates the necessary delegate in runtime to get the property/method value of the specified type.
     /// </para><para>
-    /// Call <see cref="Instance"/> to retrieve an instance of this class.
+    /// Example:
+    /// </para><code>
+    /// public class Person
+    /// {
+    ///     public int Age { get; set; }
+    /// }
+    /// </code>
+    /// <para>
+    /// So resulting Func will be generated as <c>{x => Convert(Convert(x, Person).Age, Object)}</c><br/>
+    /// 1. First, the input parameter 'x' is converted from the object to a specific type.<br/>
+    /// 2. The required property or method is extracted from casted value.<br/>
+    /// 3. Then result is converted again to the object and returned from the method.
     /// </para>
     /// </summary>
-    public class NameFieldResolver : IFieldResolver
+    /// <param name="target">The type from which you want to get the value.</param>
+    /// <param name="name">Property/method name.</param>
+    /// <returns>Compiled field resolver.</returns>
+    private static IFieldResolver CreateResolver(Type target, string name)
     {
-        private static readonly ConcurrentDictionary<(Type targetType, string name), IFieldResolver> _resolvers = new();
+        var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
+        var source = Expression.MakeMemberAccess(param, _sourcePropertyInfo);
+        var cast = Expression.Convert(source, target);
+        var instanceLambda = Expression.Lambda(cast, param);
 
-        private NameFieldResolver() { }
-
-        /// <summary>
-        /// Returns the static instance of the <see cref="NameFieldResolver"/> class.
-        /// </summary>
-        public static NameFieldResolver Instance { get; } = new();
-
-        /// <inheritdoc/>
-        public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => Resolve(context, context.FieldDefinition.Name);
-
-        private static ValueTask<object?> Resolve(IResolveFieldContext context, string? name)
+        MemberInfo? member = target.GetProperty(name, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+        if (member == null)
         {
-            if (context.Source == null || name == null)
-                return default;
-
-            // We use reflection to create a delegate to access the property/method
-            // Then cache the delegate
-            // This is over 10x faster that just using reflection to get the property/method value
-            var resolver = _resolvers.GetOrAdd((context.Source.GetType(), name), t => CreateResolver(t.targetType, t.name));
-            return resolver.ResolveAsync(context);
-        }
-
-        /// <summary>
-        /// <para>
-        /// Dynamically creates the necessary delegate in runtime to get the property/method value of the specified type.
-        /// </para><para>
-        /// Example:
-        /// </para><code>
-        /// public class Person
-        /// {
-        ///     public int Age { get; set; }
-        /// }
-        /// </code>
-        /// <para>
-        /// So resulting Func will be generated as <c>{x => Convert(Convert(x, Person).Age, Object)}</c><br/>
-        /// 1. First, the input parameter 'x' is converted from the object to a specific type.<br/>
-        /// 2. The required property or method is extracted from casted value.<br/>
-        /// 3. Then result is converted again to the object and returned from the method.
-        /// </para>
-        /// </summary>
-        /// <param name="target">The type from which you want to get the value.</param>
-        /// <param name="name">Property/method name.</param>
-        /// <returns>Compiled field resolver.</returns>
-        private static IFieldResolver CreateResolver(Type target, string name)
-        {
-            var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
-            var source = Expression.MakeMemberAccess(param, _sourcePropertyInfo);
-            var cast = Expression.Convert(source, target);
-            var instanceLambda = Expression.Lambda(cast, param);
-
-            MemberInfo? member = target.GetProperty(name, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+            try
+            {
+                member = target.GetMethod(name, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+            }
+            catch (AmbiguousMatchException)
+            {
+                throw new InvalidOperationException($"Expected to find a single property or method '{name}' on type '{target.Name}' but multiple methods were found.");
+            }
             if (member == null)
             {
-                try
-                {
-                    member = target.GetMethod(name, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
-                }
-                catch (AmbiguousMatchException)
-                {
-                    throw new InvalidOperationException($"Expected to find a single property or method '{name}' on type '{target.Name}' but multiple methods were found.");
-                }
-                if (member == null)
-                {
-                    throw new InvalidOperationException($"Expected to find property or method '{name}' on type '{target.Name}' but it does not exist.");
-                }
+                throw new InvalidOperationException($"Expected to find property or method '{name}' on type '{target.Name}' but it does not exist.");
             }
-            return AutoRegisteringHelper.BuildFieldResolver(member, target, null, instanceLambda);
         }
-
-        private static readonly PropertyInfo _sourcePropertyInfo = typeof(IResolveFieldContext).GetProperty(nameof(IResolveFieldContext.Source))!;
+        return AutoRegisteringHelper.BuildFieldResolver(member, target, null, instanceLambda);
     }
+
+    private static readonly PropertyInfo _sourcePropertyInfo = typeof(IResolveFieldContext).GetProperty(nameof(IResolveFieldContext.Source))!;
 }

--- a/src/GraphQL/Resolvers/SourceStreamMethodResolver.cs
+++ b/src/GraphQL/Resolvers/SourceStreamMethodResolver.cs
@@ -1,167 +1,166 @@
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace GraphQL.Resolvers
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// A precompiled source stream resolver for a specific <see cref="MethodInfo"/>.
+/// Calls the specified method (with the specified arguments) and returns the value of the method.
+/// </summary>
+public class SourceStreamMethodResolver : MemberResolver, ISourceStreamResolver
 {
+    private Func<IResolveFieldContext, ValueTask<IObservable<object?>>> _sourceStreamResolver = null!;
+
     /// <summary>
-    /// A precompiled source stream resolver for a specific <see cref="MethodInfo"/>.
-    /// Calls the specified method (with the specified arguments) and returns the value of the method.
+    /// Initializes an instance for the specified method, using the specified instance expression to access the instance of the method,
+    /// along with a list of arguments to be passed to the method. The method argument expressions must have return types that match
+    /// those of the method arguments.
+    /// <br/><br/>
+    /// An example of an instance expression would be as follows:
+    /// <code>context =&gt; (TSourceType)context.Source</code>
     /// </summary>
-    public class SourceStreamMethodResolver : MemberResolver, ISourceStreamResolver
+    public SourceStreamMethodResolver(MethodInfo methodInfo, LambdaExpression instanceExpression, IList<LambdaExpression> methodArgumentExpressions)
+        : base(methodInfo, instanceExpression, methodArgumentExpressions)
     {
-        private Func<IResolveFieldContext, ValueTask<IObservable<object?>>> _sourceStreamResolver = null!;
+    }
 
-        /// <summary>
-        /// Initializes an instance for the specified method, using the specified instance expression to access the instance of the method,
-        /// along with a list of arguments to be passed to the method. The method argument expressions must have return types that match
-        /// those of the method arguments.
-        /// <br/><br/>
-        /// An example of an instance expression would be as follows:
-        /// <code>context =&gt; (TSourceType)context.Source</code>
-        /// </summary>
-        public SourceStreamMethodResolver(MethodInfo methodInfo, LambdaExpression instanceExpression, IList<LambdaExpression> methodArgumentExpressions)
-            : base(methodInfo, instanceExpression, methodArgumentExpressions)
+    /// <inheritdoc/>
+    protected override Func<IResolveFieldContext, ValueTask<object?>> BuildFieldResolver(ParameterExpression resolveFieldContextParameter, Expression bodyExpression)
+    {
+        _sourceStreamResolver = BuildSourceStreamResolver(resolveFieldContextParameter, bodyExpression);
+        return context => new ValueTask<object?>(context.Source);
+    }
+
+    /// <summary>
+    /// Creates an appropriate event stream resolver function based on the return type of the expression body.
+    /// </summary>
+    protected virtual Func<IResolveFieldContext, ValueTask<IObservable<object?>>> BuildSourceStreamResolver(ParameterExpression resolveFieldContextParameter, Expression bodyExpression)
+    {
+        // ValueTask<IObservable<object?>>
+        if (bodyExpression.Type == typeof(ValueTask<IObservable<object?>>))
         {
+            return Compile(bodyExpression);
         }
-
-        /// <inheritdoc/>
-        protected override Func<IResolveFieldContext, ValueTask<object?>> BuildFieldResolver(ParameterExpression resolveFieldContextParameter, Expression bodyExpression)
+        // Task<IObservable<object?>>
+        else if (bodyExpression.Type == typeof(Task<IObservable<object?>>))
         {
-            _sourceStreamResolver = BuildSourceStreamResolver(resolveFieldContextParameter, bodyExpression);
-            return context => new ValueTask<object?>(context.Source);
+            return Compile(Expression.New(_valueTaskTaskObservableCtor, bodyExpression));
         }
-
-        /// <summary>
-        /// Creates an appropriate event stream resolver function based on the return type of the expression body.
-        /// </summary>
-        protected virtual Func<IResolveFieldContext, ValueTask<IObservable<object?>>> BuildSourceStreamResolver(ParameterExpression resolveFieldContextParameter, Expression bodyExpression)
+        // Task<T>
+        else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(Task<>))
         {
-            // ValueTask<IObservable<object?>>
-            if (bodyExpression.Type == typeof(ValueTask<IObservable<object?>>))
+            var type = bodyExpression.Type.GetGenericArguments()[0];
+            // Task<IObservable<T>>
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IObservable<>))
             {
-                return Compile(bodyExpression);
+                var innerType = type.GetGenericArguments()[0];
+                var method = innerType.IsValueType ? _castFromTask2AsyncMethodInfo : _castFromTaskAsyncMethodInfo;
+                return Compile(Expression.Call(method.MakeGenericMethod(innerType), bodyExpression));
             }
-            // Task<IObservable<object?>>
-            else if (bodyExpression.Type == typeof(Task<IObservable<object?>>))
+            // Task<IAsyncEnumerable<T>>
+            else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
             {
-                return Compile(Expression.New(_valueTaskTaskObservableCtor, bodyExpression));
-            }
-            // Task<T>
-            else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(Task<>))
-            {
-                var type = bodyExpression.Type.GetGenericArguments()[0];
-                // Task<IObservable<T>>
-                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IObservable<>))
-                {
-                    var innerType = type.GetGenericArguments()[0];
-                    var method = innerType.IsValueType ? _castFromTask2AsyncMethodInfo : _castFromTaskAsyncMethodInfo;
-                    return Compile(Expression.Call(method.MakeGenericMethod(innerType), bodyExpression));
-                }
-                // Task<IAsyncEnumerable<T>>
-                else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
-                {
-                    var innerType = type.GetGenericArguments()[0];
-                    var method = _convertFromTaskAsyncEnumerableMethodInfo.MakeGenericMethod(innerType);
-                    var func = method.CreateDelegate<Func<Expression, ParameterExpression, Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>>();
-                    return func(bodyExpression, resolveFieldContextParameter);
-                }
-            }
-            // ValueTask<T>
-            else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(ValueTask<>))
-            {
-                var type = bodyExpression.Type.GetGenericArguments()[0];
-                // ValueTask<IObservable<T>>
-                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IObservable<>))
-                {
-                    var innerType = type.GetGenericArguments()[0];
-                    var method = innerType.IsValueType ? _castFromValueTask2AsyncMethodInfo : _castFromValueTaskAsyncMethodInfo;
-                    return Compile(Expression.Call(method.MakeGenericMethod(innerType), bodyExpression));
-                }
-                // ValueTask<IAsyncEnumerable<T>>
-                else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
-                {
-                    var innerType = type.GetGenericArguments()[0];
-                    var method = _convertFromValueTaskAsyncEnumerableMethodInfo.MakeGenericMethod(innerType);
-                    var func = method.CreateDelegate<Func<Expression, ParameterExpression, Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>>();
-                    return func(bodyExpression, resolveFieldContextParameter);
-                }
-            }
-            // IObservable<T>
-            else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(IObservable<>))
-            {
-                var innerType = bodyExpression.Type.GetGenericArguments()[0];
-                if (innerType.IsValueType)
-                {
-                    var adapterType = typeof(ObservableAdapter<>).MakeGenericType(innerType);
-                    var ctor = adapterType.GetConstructor(new Type[] { bodyExpression.Type })!;
-                    bodyExpression = Expression.New(ctor, bodyExpression);
-                }
-                return Compile(Expression.New(_valueTaskObservableCtor, bodyExpression));
-            }
-            // IAsyncEnumerable<T>
-            else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
-            {
-                var innerType = bodyExpression.Type.GetGenericArguments()[0];
-                var method = _convertFromAsyncEnumerableMethodInfo.MakeGenericMethod(innerType);
+                var innerType = type.GetGenericArguments()[0];
+                var method = _convertFromTaskAsyncEnumerableMethodInfo.MakeGenericMethod(innerType);
                 var func = method.CreateDelegate<Func<Expression, ParameterExpression, Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>>();
                 return func(bodyExpression, resolveFieldContextParameter);
             }
-
-            throw new InvalidOperationException("Method must return a IObservable<T>, Task<IObservable<T>>, ValueTask<IObservable<T>>, IAsyncEnumerable<T>, Task<IAsyncEnumerable<T>> or ValueTask<IAsyncEnumerable<T>>.");
-
-            Func<IResolveFieldContext, ValueTask<IObservable<object?>>> Compile(Expression taskBodyExpression)
+        }
+        // ValueTask<T>
+        else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(ValueTask<>))
+        {
+            var type = bodyExpression.Type.GetGenericArguments()[0];
+            // ValueTask<IObservable<T>>
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IObservable<>))
             {
-                var lambda = Expression.Lambda<Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>(taskBodyExpression, resolveFieldContextParameter);
-                return lambda.Compile();
+                var innerType = type.GetGenericArguments()[0];
+                var method = innerType.IsValueType ? _castFromValueTask2AsyncMethodInfo : _castFromValueTaskAsyncMethodInfo;
+                return Compile(Expression.Call(method.MakeGenericMethod(innerType), bodyExpression));
+            }
+            // ValueTask<IAsyncEnumerable<T>>
+            else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+            {
+                var innerType = type.GetGenericArguments()[0];
+                var method = _convertFromValueTaskAsyncEnumerableMethodInfo.MakeGenericMethod(innerType);
+                var func = method.CreateDelegate<Func<Expression, ParameterExpression, Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>>();
+                return func(bodyExpression, resolveFieldContextParameter);
             }
         }
-
-        private static readonly ConstructorInfo _valueTaskObservableCtor = typeof(ValueTask<IObservable<object?>>).GetConstructor(new Type[] { typeof(IObservable<object?>) })!;
-        private static readonly ConstructorInfo _valueTaskTaskObservableCtor = typeof(ValueTask<IObservable<object?>>).GetConstructor(new Type[] { typeof(Task<IObservable<object?>>) })!;
-
-        private static readonly MethodInfo _convertFromAsyncEnumerableMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(ConvertFromAsyncEnumerable), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static Func<IResolveFieldContext, ValueTask<IObservable<object?>>> ConvertFromAsyncEnumerable<T>(Expression body, ParameterExpression resolveFieldContextParameter)
+        // IObservable<T>
+        else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(IObservable<>))
         {
-            var lambda = Expression.Lambda<Func<IResolveFieldContext, IAsyncEnumerable<T>>>(body, resolveFieldContextParameter);
-            var func = lambda.Compile();
-            return ObservableFromAsyncEnumerable<T>.Create(func);
+            var innerType = bodyExpression.Type.GetGenericArguments()[0];
+            if (innerType.IsValueType)
+            {
+                var adapterType = typeof(ObservableAdapter<>).MakeGenericType(innerType);
+                var ctor = adapterType.GetConstructor(new Type[] { bodyExpression.Type })!;
+                bodyExpression = Expression.New(ctor, bodyExpression);
+            }
+            return Compile(Expression.New(_valueTaskObservableCtor, bodyExpression));
+        }
+        // IAsyncEnumerable<T>
+        else if (bodyExpression.Type.IsGenericType && bodyExpression.Type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+        {
+            var innerType = bodyExpression.Type.GetGenericArguments()[0];
+            var method = _convertFromAsyncEnumerableMethodInfo.MakeGenericMethod(innerType);
+            var func = method.CreateDelegate<Func<Expression, ParameterExpression, Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>>();
+            return func(bodyExpression, resolveFieldContextParameter);
         }
 
-        private static readonly MethodInfo _convertFromTaskAsyncEnumerableMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(ConvertFromTaskAsyncEnumerable), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static Func<IResolveFieldContext, ValueTask<IObservable<object?>>> ConvertFromTaskAsyncEnumerable<T>(Expression body, ParameterExpression resolveFieldContextParameter)
+        throw new InvalidOperationException("Method must return a IObservable<T>, Task<IObservable<T>>, ValueTask<IObservable<T>>, IAsyncEnumerable<T>, Task<IAsyncEnumerable<T>> or ValueTask<IAsyncEnumerable<T>>.");
+
+        Func<IResolveFieldContext, ValueTask<IObservable<object?>>> Compile(Expression taskBodyExpression)
         {
-            var lambda = Expression.Lambda<Func<IResolveFieldContext, Task<IAsyncEnumerable<T>>>>(body, resolveFieldContextParameter);
-            var func = lambda.Compile();
-            return ObservableFromAsyncEnumerable<T>.Create(func);
+            var lambda = Expression.Lambda<Func<IResolveFieldContext, ValueTask<IObservable<object?>>>>(taskBodyExpression, resolveFieldContextParameter);
+            return lambda.Compile();
         }
-
-        private static readonly MethodInfo _convertFromValueTaskAsyncEnumerableMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(ConvertFromValueTaskAsyncEnumerable), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static Func<IResolveFieldContext, ValueTask<IObservable<object?>>> ConvertFromValueTaskAsyncEnumerable<T>(Expression body, ParameterExpression resolveFieldContextParameter)
-        {
-            var lambda = Expression.Lambda<Func<IResolveFieldContext, ValueTask<IAsyncEnumerable<T>>>>(body, resolveFieldContextParameter);
-            var func = lambda.Compile();
-            return ObservableFromAsyncEnumerable<T>.Create(func);
-        }
-
-        private static readonly MethodInfo _castFromValueTaskAsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromValueTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static async ValueTask<IObservable<object?>> CastFromValueTaskAsync<T>(ValueTask<IObservable<T>> task) where T : class
-            => await task.ConfigureAwait(false);
-
-        private static readonly MethodInfo _castFromValueTask2AsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromValueTask2Async), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static async ValueTask<IObservable<object?>> CastFromValueTask2Async<T>(ValueTask<IObservable<T>> task)
-            => new ObservableAdapter<T>(await task.ConfigureAwait(false));
-
-        private static readonly MethodInfo _castFromTaskAsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static async ValueTask<IObservable<object?>> CastFromTaskAsync<T>(Task<IObservable<T>> task) where T : class
-            => await task.ConfigureAwait(false);
-
-        private static readonly MethodInfo _castFromTask2AsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromTask2Async), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static async ValueTask<IObservable<object?>> CastFromTask2Async<T>(Task<IObservable<T>> task)
-            => new ObservableAdapter<T>(await task.ConfigureAwait(false));
-
-        /// <inheritdoc cref="ISourceStreamResolver.ResolveAsync(IResolveFieldContext)" />
-        public ValueTask<IObservable<object?>> ResolveStreamAsync(IResolveFieldContext context) => _sourceStreamResolver(context);
-
-        ValueTask<IObservable<object?>> ISourceStreamResolver.ResolveAsync(IResolveFieldContext context) => ResolveStreamAsync(context);
     }
+
+    private static readonly ConstructorInfo _valueTaskObservableCtor = typeof(ValueTask<IObservable<object?>>).GetConstructor(new Type[] { typeof(IObservable<object?>) })!;
+    private static readonly ConstructorInfo _valueTaskTaskObservableCtor = typeof(ValueTask<IObservable<object?>>).GetConstructor(new Type[] { typeof(Task<IObservable<object?>>) })!;
+
+    private static readonly MethodInfo _convertFromAsyncEnumerableMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(ConvertFromAsyncEnumerable), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static Func<IResolveFieldContext, ValueTask<IObservable<object?>>> ConvertFromAsyncEnumerable<T>(Expression body, ParameterExpression resolveFieldContextParameter)
+    {
+        var lambda = Expression.Lambda<Func<IResolveFieldContext, IAsyncEnumerable<T>>>(body, resolveFieldContextParameter);
+        var func = lambda.Compile();
+        return ObservableFromAsyncEnumerable<T>.Create(func);
+    }
+
+    private static readonly MethodInfo _convertFromTaskAsyncEnumerableMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(ConvertFromTaskAsyncEnumerable), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static Func<IResolveFieldContext, ValueTask<IObservable<object?>>> ConvertFromTaskAsyncEnumerable<T>(Expression body, ParameterExpression resolveFieldContextParameter)
+    {
+        var lambda = Expression.Lambda<Func<IResolveFieldContext, Task<IAsyncEnumerable<T>>>>(body, resolveFieldContextParameter);
+        var func = lambda.Compile();
+        return ObservableFromAsyncEnumerable<T>.Create(func);
+    }
+
+    private static readonly MethodInfo _convertFromValueTaskAsyncEnumerableMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(ConvertFromValueTaskAsyncEnumerable), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static Func<IResolveFieldContext, ValueTask<IObservable<object?>>> ConvertFromValueTaskAsyncEnumerable<T>(Expression body, ParameterExpression resolveFieldContextParameter)
+    {
+        var lambda = Expression.Lambda<Func<IResolveFieldContext, ValueTask<IAsyncEnumerable<T>>>>(body, resolveFieldContextParameter);
+        var func = lambda.Compile();
+        return ObservableFromAsyncEnumerable<T>.Create(func);
+    }
+
+    private static readonly MethodInfo _castFromValueTaskAsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromValueTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static async ValueTask<IObservable<object?>> CastFromValueTaskAsync<T>(ValueTask<IObservable<T>> task) where T : class
+        => await task.ConfigureAwait(false);
+
+    private static readonly MethodInfo _castFromValueTask2AsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromValueTask2Async), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static async ValueTask<IObservable<object?>> CastFromValueTask2Async<T>(ValueTask<IObservable<T>> task)
+        => new ObservableAdapter<T>(await task.ConfigureAwait(false));
+
+    private static readonly MethodInfo _castFromTaskAsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromTaskAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static async ValueTask<IObservable<object?>> CastFromTaskAsync<T>(Task<IObservable<T>> task) where T : class
+        => await task.ConfigureAwait(false);
+
+    private static readonly MethodInfo _castFromTask2AsyncMethodInfo = typeof(SourceStreamMethodResolver).GetMethod(nameof(CastFromTask2Async), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static async ValueTask<IObservable<object?>> CastFromTask2Async<T>(Task<IObservable<T>> task)
+        => new ObservableAdapter<T>(await task.ConfigureAwait(false));
+
+    /// <inheritdoc cref="ISourceStreamResolver.ResolveAsync(IResolveFieldContext)" />
+    public ValueTask<IObservable<object?>> ResolveStreamAsync(IResolveFieldContext context) => _sourceStreamResolver(context);
+
+    ValueTask<IObservable<object?>> ISourceStreamResolver.ResolveAsync(IResolveFieldContext context) => ResolveStreamAsync(context);
 }

--- a/src/GraphQL/Resolvers/SourceStreamResolver.cs
+++ b/src/GraphQL/Resolvers/SourceStreamResolver.cs
@@ -1,92 +1,91 @@
-namespace GraphQL.Resolvers
+namespace GraphQL.Resolvers;
+
+/// <summary>
+/// When resolving a subscription field, this implementation calls a predefined delegate and returns the result.
+/// </summary>
+public class SourceStreamResolver<TReturnType> : ISourceStreamResolver
 {
+    private readonly Func<IResolveFieldContext, ValueTask<IObservable<object?>>> _sourceStreamResolver;
+
     /// <summary>
-    /// When resolving a subscription field, this implementation calls a predefined delegate and returns the result.
+    /// Initializes a new instance that runs the specified delegate when resolving a subscription field.
     /// </summary>
-    public class SourceStreamResolver<TReturnType> : ISourceStreamResolver
+    public SourceStreamResolver(Func<IResolveFieldContext, IObservable<TReturnType?>> sourceStreamResolver)
     {
-        private readonly Func<IResolveFieldContext, ValueTask<IObservable<object?>>> _sourceStreamResolver;
+        if (sourceStreamResolver == null)
+            throw new ArgumentNullException(nameof(sourceStreamResolver));
 
-        /// <summary>
-        /// Initializes a new instance that runs the specified delegate when resolving a subscription field.
-        /// </summary>
-        public SourceStreamResolver(Func<IResolveFieldContext, IObservable<TReturnType?>> sourceStreamResolver)
+        if (typeof(TReturnType).IsValueType)
         {
-            if (sourceStreamResolver == null)
-                throw new ArgumentNullException(nameof(sourceStreamResolver));
-
-            if (typeof(TReturnType).IsValueType)
-            {
-                _sourceStreamResolver = context => new(new ObservableAdapter<TReturnType?>(sourceStreamResolver(context)));
-            }
-            else
-            {
-                _sourceStreamResolver = context => new((IObservable<object?>)sourceStreamResolver(context));
-            }
+            _sourceStreamResolver = context => new(new ObservableAdapter<TReturnType?>(sourceStreamResolver(context)));
         }
-
-        /// <inheritdoc cref="SourceStreamResolver{TReturnType}(Func{IResolveFieldContext, IObservable{TReturnType}})"/>
-        public SourceStreamResolver(Func<IResolveFieldContext, ValueTask<IObservable<TReturnType?>>> sourceStreamResolver)
+        else
         {
-            if (sourceStreamResolver == null)
-                throw new ArgumentNullException(nameof(sourceStreamResolver));
-
-            if (typeof(TReturnType).IsValueType)
-            {
-                _sourceStreamResolver = async context => new ObservableAdapter<TReturnType?>(await sourceStreamResolver(context).ConfigureAwait(false));
-            }
-            else
-            {
-                _sourceStreamResolver = async context => (IObservable<object?>)await sourceStreamResolver(context).ConfigureAwait(false);
-            }
+            _sourceStreamResolver = context => new((IObservable<object?>)sourceStreamResolver(context));
         }
-
-        /// <inheritdoc/>
-        public ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context)
-            => _sourceStreamResolver(context);
     }
 
-    /// <inheritdoc cref="SourceStreamResolver{TReturnType}"/>
-    public class SourceStreamResolver<TSourceType, TReturnType> : ISourceStreamResolver
+    /// <inheritdoc cref="SourceStreamResolver{TReturnType}(Func{IResolveFieldContext, IObservable{TReturnType}})"/>
+    public SourceStreamResolver(Func<IResolveFieldContext, ValueTask<IObservable<TReturnType?>>> sourceStreamResolver)
     {
-        private readonly Func<IResolveFieldContext, ValueTask<IObservable<object?>>> _sourceStreamResolver;
+        if (sourceStreamResolver == null)
+            throw new ArgumentNullException(nameof(sourceStreamResolver));
 
-        /// <inheritdoc cref="SourceStreamResolver{TReturnType}(Func{IResolveFieldContext, IObservable{TReturnType}})"/>
-        public SourceStreamResolver(Func<IResolveFieldContext<TSourceType>, IObservable<TReturnType?>> sourceStreamResolver)
+        if (typeof(TReturnType).IsValueType)
         {
-            if (sourceStreamResolver == null)
-                throw new ArgumentNullException(nameof(sourceStreamResolver));
-
-            if (typeof(TReturnType).IsValueType)
-            {
-                _sourceStreamResolver = context => new(new ObservableAdapter<TReturnType?>(sourceStreamResolver(context.As<TSourceType>())));
-            }
-            else
-            {
-                _sourceStreamResolver = context => new((IObservable<object?>)sourceStreamResolver(context.As<TSourceType>()));
-            }
+            _sourceStreamResolver = async context => new ObservableAdapter<TReturnType?>(await sourceStreamResolver(context).ConfigureAwait(false));
         }
-
-        /// <inheritdoc cref="SourceStreamResolver{TSourceType, TReturnType}(Func{IResolveFieldContext{TSourceType}, IObservable{TReturnType}})"/>
-        /// 
-        public SourceStreamResolver(Func<IResolveFieldContext<TSourceType>, ValueTask<IObservable<TReturnType?>>> sourceStreamResolver)
+        else
         {
-            if (sourceStreamResolver == null)
-                throw new ArgumentNullException(nameof(sourceStreamResolver));
-
-
-            if (typeof(TReturnType).IsValueType)
-            {
-                _sourceStreamResolver = async context => new ObservableAdapter<TReturnType?>(await sourceStreamResolver(context.As<TSourceType>()).ConfigureAwait(false));
-            }
-            else
-            {
-                _sourceStreamResolver = async context => (IObservable<object?>)await sourceStreamResolver(context.As<TSourceType>()).ConfigureAwait(false);
-            }
+            _sourceStreamResolver = async context => (IObservable<object?>)await sourceStreamResolver(context).ConfigureAwait(false);
         }
-
-        /// <inheritdoc/>
-        public ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context)
-            => _sourceStreamResolver(context);
     }
+
+    /// <inheritdoc/>
+    public ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context)
+        => _sourceStreamResolver(context);
+}
+
+/// <inheritdoc cref="SourceStreamResolver{TReturnType}"/>
+public class SourceStreamResolver<TSourceType, TReturnType> : ISourceStreamResolver
+{
+    private readonly Func<IResolveFieldContext, ValueTask<IObservable<object?>>> _sourceStreamResolver;
+
+    /// <inheritdoc cref="SourceStreamResolver{TReturnType}(Func{IResolveFieldContext, IObservable{TReturnType}})"/>
+    public SourceStreamResolver(Func<IResolveFieldContext<TSourceType>, IObservable<TReturnType?>> sourceStreamResolver)
+    {
+        if (sourceStreamResolver == null)
+            throw new ArgumentNullException(nameof(sourceStreamResolver));
+
+        if (typeof(TReturnType).IsValueType)
+        {
+            _sourceStreamResolver = context => new(new ObservableAdapter<TReturnType?>(sourceStreamResolver(context.As<TSourceType>())));
+        }
+        else
+        {
+            _sourceStreamResolver = context => new((IObservable<object?>)sourceStreamResolver(context.As<TSourceType>()));
+        }
+    }
+
+    /// <inheritdoc cref="SourceStreamResolver{TSourceType, TReturnType}(Func{IResolveFieldContext{TSourceType}, IObservable{TReturnType}})"/>
+    /// 
+    public SourceStreamResolver(Func<IResolveFieldContext<TSourceType>, ValueTask<IObservable<TReturnType?>>> sourceStreamResolver)
+    {
+        if (sourceStreamResolver == null)
+            throw new ArgumentNullException(nameof(sourceStreamResolver));
+
+
+        if (typeof(TReturnType).IsValueType)
+        {
+            _sourceStreamResolver = async context => new ObservableAdapter<TReturnType?>(await sourceStreamResolver(context.As<TSourceType>()).ConfigureAwait(false));
+        }
+        else
+        {
+            _sourceStreamResolver = async context => (IObservable<object?>)await sourceStreamResolver(context.As<TSourceType>()).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<IObservable<object?>> ResolveAsync(IResolveFieldContext context)
+        => _sourceStreamResolver(context);
 }

--- a/src/GraphQL/Types/ArgumentInformation.cs
+++ b/src/GraphQL/Types/ArgumentInformation.cs
@@ -1,201 +1,200 @@
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Contains information pertaining to a method parameter in preparation for building an
+/// expression or query argument for it.
+/// <br/><br/>
+/// If <see cref="Expression"/> is set, a query argument will not be added
+/// and the expression will be used to build the method resolver.
+/// <br/><br/>
+/// If not, a query argument will be generated and added to the field; the field resolver will
+/// use the argument's value to populate the method parameter.
+/// </summary>
+public class ArgumentInformation
 {
     /// <summary>
-    /// Contains information pertaining to a method parameter in preparation for building an
-    /// expression or query argument for it.
-    /// <br/><br/>
-    /// If <see cref="Expression"/> is set, a query argument will not be added
-    /// and the expression will be used to build the method resolver.
-    /// <br/><br/>
-    /// If not, a query argument will be generated and added to the field; the field resolver will
-    /// use the argument's value to populate the method parameter.
+    /// Initializes a new instance with the specified parameters.
     /// </summary>
-    public class ArgumentInformation
+    public ArgumentInformation(ParameterInfo parameterInfo, Type? sourceType, FieldType? fieldType, TypeInformation typeInformation, LambdaExpression? expression)
     {
-        /// <summary>
-        /// Initializes a new instance with the specified parameters.
-        /// </summary>
-        public ArgumentInformation(ParameterInfo parameterInfo, Type? sourceType, FieldType? fieldType, TypeInformation typeInformation, LambdaExpression? expression)
+        ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
+        FieldType = fieldType; // ?? throw new ArgumentNullException(nameof(fieldType));
+        SourceType = sourceType; // ?? throw new ArgumentNullException(nameof(sourceType));
+        TypeInformation = typeInformation ?? throw new ArgumentNullException(nameof(typeInformation));
+        Expression = expression;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified parameters.
+    /// If the parameter type is <see cref="IResolveFieldContext"/> or <see cref="CancellationToken"/>,
+    /// an expression is generated for the parameter and set within <see cref="Expression"/>; otherwise
+    /// <see cref="Expression"/> is set to <see langword="null"/>.
+    /// </summary>
+    public ArgumentInformation(ParameterInfo parameterInfo, Type? sourceType, FieldType? fieldType, TypeInformation typeInformation)
+        : this(parameterInfo, sourceType, fieldType, typeInformation, null)
+    {
+        if (parameterInfo.ParameterType == typeof(IResolveFieldContext))
         {
-            ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
-            FieldType = fieldType; // ?? throw new ArgumentNullException(nameof(fieldType));
-            SourceType = sourceType; // ?? throw new ArgumentNullException(nameof(sourceType));
-            TypeInformation = typeInformation ?? throw new ArgumentNullException(nameof(typeInformation));
-            Expression = expression;
+            Expression = (IResolveFieldContext x) => x;
         }
-
-        /// <summary>
-        /// Initializes a new instance with the specified parameters.
-        /// If the parameter type is <see cref="IResolveFieldContext"/> or <see cref="CancellationToken"/>,
-        /// an expression is generated for the parameter and set within <see cref="Expression"/>; otherwise
-        /// <see cref="Expression"/> is set to <see langword="null"/>.
-        /// </summary>
-        public ArgumentInformation(ParameterInfo parameterInfo, Type? sourceType, FieldType? fieldType, TypeInformation typeInformation)
-            : this(parameterInfo, sourceType, fieldType, typeInformation, null)
+        else if (parameterInfo.ParameterType == typeof(CancellationToken))
         {
-            if (parameterInfo.ParameterType == typeof(IResolveFieldContext))
-            {
-                Expression = (IResolveFieldContext x) => x;
-            }
-            else if (parameterInfo.ParameterType == typeof(CancellationToken))
-            {
-                Expression = (IResolveFieldContext x) => x.CancellationToken;
-            }
+            Expression = (IResolveFieldContext x) => x.CancellationToken;
         }
+    }
 
-        /// <summary>
-        /// The method parameter.
-        /// </summary>
-        public ParameterInfo ParameterInfo { get; }
+    /// <summary>
+    /// The method parameter.
+    /// </summary>
+    public ParameterInfo ParameterInfo { get; }
 
-        /// <summary>
-        /// The expected type of <see cref="IResolveFieldContext.Source"/>.
-        /// Should equal <c>TSourceType</c> within <see cref="AutoRegisteringObjectGraphType{TSourceType}"/>.
-        /// </summary>
-        public Type? SourceType { get; }
+    /// <summary>
+    /// The expected type of <see cref="IResolveFieldContext.Source"/>.
+    /// Should equal <c>TSourceType</c> within <see cref="AutoRegisteringObjectGraphType{TSourceType}"/>.
+    /// </summary>
+    public Type? SourceType { get; }
 
-        /// <summary>
-        /// The <see cref="Types.FieldType"/> that the query argument will be added to.
-        /// </summary>
-        public FieldType? FieldType { get; }
+    /// <summary>
+    /// The <see cref="Types.FieldType"/> that the query argument will be added to.
+    /// </summary>
+    public FieldType? FieldType { get; }
 
-        /// <summary>
-        /// The parsed type information of the method parameter.
-        /// </summary>
-        public TypeInformation TypeInformation { get; }
+    /// <summary>
+    /// The parsed type information of the method parameter.
+    /// </summary>
+    public TypeInformation TypeInformation { get; }
 
-        private LambdaExpression? _expression;
-        /// <summary>
-        /// Gets or sets a delegate in the form of a <see cref="LambdaExpression"/> to be used to populate
-        /// this method argument while building the field resolver.
-        /// <br/><br/>
-        /// If not set, a query argument will be added to the field and the argument's value will be used
-        /// to populate the method argument while building the field resolver.
-        /// <br/><br/>
-        /// The delegate must be of the type
-        /// <see cref="Expression{TDelegate}">Expression</see>&lt;<see cref="Func{T, TResult}">Func</see>&lt;<see cref="IResolveFieldContext"/>, TParameterType&gt;&gt;
-        /// where TParameterType matches <see cref="ParameterInfo">ParameterInfo</see>.<see cref="ParameterInfo.ParameterType">ParameterType</see>.
-        /// </summary>
-        public LambdaExpression? Expression
+    private LambdaExpression? _expression;
+    /// <summary>
+    /// Gets or sets a delegate in the form of a <see cref="LambdaExpression"/> to be used to populate
+    /// this method argument while building the field resolver.
+    /// <br/><br/>
+    /// If not set, a query argument will be added to the field and the argument's value will be used
+    /// to populate the method argument while building the field resolver.
+    /// <br/><br/>
+    /// The delegate must be of the type
+    /// <see cref="Expression{TDelegate}">Expression</see>&lt;<see cref="Func{T, TResult}">Func</see>&lt;<see cref="IResolveFieldContext"/>, TParameterType&gt;&gt;
+    /// where TParameterType matches <see cref="ParameterInfo">ParameterInfo</see>.<see cref="ParameterInfo.ParameterType">ParameterType</see>.
+    /// </summary>
+    public LambdaExpression? Expression
+    {
+        get => _expression;
+        set
         {
-            get => _expression;
-            set
+            if (value != null)
             {
-                if (value != null)
+                bool valid = value.Parameters.Count == 1 && value.Parameters[0].Type == typeof(IResolveFieldContext);
+                if (valid)
                 {
-                    bool valid = value.Parameters.Count == 1 && value.Parameters[0].Type == typeof(IResolveFieldContext);
-                    if (valid)
+                    if (value.ReturnType != ParameterInfo.ParameterType)
                     {
-                        if (value.ReturnType != ParameterInfo.ParameterType)
+                        if (value.Body is UnaryExpression unaryExpression &&
+                            unaryExpression.NodeType == ExpressionType.Convert &&
+                            unaryExpression.Operand.Type == ParameterInfo.ParameterType)
                         {
-                            if (value.Body is UnaryExpression unaryExpression &&
-                                unaryExpression.NodeType == ExpressionType.Convert &&
-                                unaryExpression.Operand.Type == ParameterInfo.ParameterType)
-                            {
-                                value = System.Linq.Expressions.Expression.Lambda(
-                                    unaryExpression.Operand,
-                                    value.Parameters[0]);
-                            }
-                            else
-                            {
-                                valid = false;
-                            }
+                            value = System.Linq.Expressions.Expression.Lambda(
+                                unaryExpression.Operand,
+                                value.Parameters[0]);
+                        }
+                        else
+                        {
+                            valid = false;
                         }
                     }
-                    if (!valid)
-                    {
-                        throw new ArgumentException($"Value must be a lambda expression delegate of type Func<IResolveFieldContext, {ParameterInfo.ParameterType.Name}>.");
-                    }
                 }
-                _expression = value;
+                if (!valid)
+                {
+                    throw new ArgumentException($"Value must be a lambda expression delegate of type Func<IResolveFieldContext, {ParameterInfo.ParameterType.Name}>.");
+                }
             }
+            _expression = value;
         }
+    }
 
-        /// <summary>
-        /// Sets a delegate to be used to populate this method argument while building the field resolver.
-        /// An expression is generated that calls <paramref name="argumentDelegate"/> and stored within <see cref="Expression"/>.
-        /// <br/><br/>
-        /// The delegate must be of the type
-        /// <see cref="Func{T, TResult}">Func</see>&lt;<see cref="IResolveFieldContext"/>, <typeparamref name="TParameterType"/>&gt;
-        /// where <typeparamref name="TParameterType"/> matches <see cref="ParameterInfo">ParameterInfo</see>.<see cref="ParameterInfo.ParameterType">ParameterType</see>.
-        /// <br/><br/>
-        /// As of .NET 7, this method cannot be used in AOT compilation scenarios.
-        /// </summary>
-        [RequiresDynamicCode("Please use the SetDelegateWithCast method when using with AOT compilation")]
-        public void SetDelegate<TParameterType>(Func<IResolveFieldContext, TParameterType?> argumentDelegate)
+    /// <summary>
+    /// Sets a delegate to be used to populate this method argument while building the field resolver.
+    /// An expression is generated that calls <paramref name="argumentDelegate"/> and stored within <see cref="Expression"/>.
+    /// <br/><br/>
+    /// The delegate must be of the type
+    /// <see cref="Func{T, TResult}">Func</see>&lt;<see cref="IResolveFieldContext"/>, <typeparamref name="TParameterType"/>&gt;
+    /// where <typeparamref name="TParameterType"/> matches <see cref="ParameterInfo">ParameterInfo</see>.<see cref="ParameterInfo.ParameterType">ParameterType</see>.
+    /// <br/><br/>
+    /// As of .NET 7, this method cannot be used in AOT compilation scenarios.
+    /// </summary>
+    [RequiresDynamicCode("Please use the SetDelegateWithCast method when using with AOT compilation")]
+    public void SetDelegate<TParameterType>(Func<IResolveFieldContext, TParameterType?> argumentDelegate)
+    {
+        // TODO: Determine if this method can be used in AOT compilation scenarios with future versions of .NET.
+        if (argumentDelegate == null)
+            throw new ArgumentNullException(nameof(argumentDelegate));
+        if (typeof(TParameterType) != ParameterInfo.ParameterType)
+            throw new ArgumentException($"Delegate must be of type Func<IResolveFieldContext, {ParameterInfo.ParameterType.Name}>.", nameof(argumentDelegate));
+
+        Expression = (IResolveFieldContext context) => argumentDelegate(context);
+    }
+
+    /// <summary>
+    /// Sets a delegate to be used to populate this method argument while building the field resolver.
+    /// An expression is generated that calls <paramref name="argumentDelegate"/> and stored within <see cref="Expression"/>.
+    /// The result of the delegate is cast to the method parameter type.
+    /// <br/><br/>
+    /// See <see cref="SetDelegate{TParameterType}(Func{IResolveFieldContext, TParameterType})"/> for a
+    /// type-safe version of this method, recommended for use with <see cref="GraphQLAttribute.Modify{TParameterType}(ArgumentInformation)"/>.
+    /// </summary>
+    public void SetDelegateWithCast(Func<IResolveFieldContext, object?> argumentDelegate)
+    {
+        if (argumentDelegate == null)
+            throw new ArgumentNullException(nameof(argumentDelegate));
+
+        Expression<Func<IResolveFieldContext, object?>> expr = (IResolveFieldContext context) => argumentDelegate(context);
+        Expression = System.Linq.Expressions.Expression.Lambda(
+            System.Linq.Expressions.Expression.Convert(expr.Body, ParameterInfo.ParameterType),
+            expr.Parameters[0]);
+    }
+
+    /// <summary>
+    /// Applies <see cref="GraphQLAttribute"/> attributes pulled from the <see cref="ArgumentInformation.ParameterInfo">ParameterInfo</see> onto this instance.
+    /// Also scans the parameter's owning module and assembly for globally-applied attributes.
+    /// </summary>
+    public virtual void ApplyAttributes()
+    {
+        var attributes = ParameterInfo.GetGraphQLAttributes();
+        foreach (var attr in attributes)
         {
-            // TODO: Determine if this method can be used in AOT compilation scenarios with future versions of .NET.
-            if (argumentDelegate == null)
-                throw new ArgumentNullException(nameof(argumentDelegate));
-            if (typeof(TParameterType) != ParameterInfo.ParameterType)
-                throw new ArgumentException($"Delegate must be of type Func<IResolveFieldContext, {ParameterInfo.ParameterType.Name}>.", nameof(argumentDelegate));
-
-            Expression = (IResolveFieldContext context) => argumentDelegate(context);
+            attr.Modify(this);
         }
+    }
 
-        /// <summary>
-        /// Sets a delegate to be used to populate this method argument while building the field resolver.
-        /// An expression is generated that calls <paramref name="argumentDelegate"/> and stored within <see cref="Expression"/>.
-        /// The result of the delegate is cast to the method parameter type.
-        /// <br/><br/>
-        /// See <see cref="SetDelegate{TParameterType}(Func{IResolveFieldContext, TParameterType})"/> for a
-        /// type-safe version of this method, recommended for use with <see cref="GraphQLAttribute.Modify{TParameterType}(ArgumentInformation)"/>.
-        /// </summary>
-        public void SetDelegateWithCast(Func<IResolveFieldContext, object?> argumentDelegate)
+    /// <summary>
+    /// Builds a query argument or expression from this instance.
+    /// <br/><br/>
+    /// If a query argument is returned, it will be added to the arguments list of the field type.
+    /// <br/><br/>
+    /// If an expression is returned, it will be used to populate the method argument within the field resolver;
+    /// if not, the query argument's value will be used to populate the method argument within the field resolver.
+    /// <br/><br/>
+    /// The default implementation will return either a <see cref="QueryArgument"/> or <see cref="LambdaExpression"/>
+    /// instance; not both. It is possible to return both, in which case the query argument will be added to the
+    /// field and the expression will be used to populate the method argument within the field resolver.
+    /// You cannot return <see langword="null"/> for both the query argument and expression.
+    /// </summary>
+    public virtual (QueryArgument? QueryArgument, LambdaExpression? Expression) ConstructQueryArgument()
+    {
+        if (Expression != null)
+            return (null, Expression);
+
+        var type = TypeInformation.ConstructGraphType();
+        var memberType = ParameterInfo.ParameterType;
+        var argument = new QueryArgument(type)
         {
-            if (argumentDelegate == null)
-                throw new ArgumentNullException(nameof(argumentDelegate));
-
-            Expression<Func<IResolveFieldContext, object?>> expr = (IResolveFieldContext context) => argumentDelegate(context);
-            Expression = System.Linq.Expressions.Expression.Lambda(
-                System.Linq.Expressions.Expression.Convert(expr.Body, ParameterInfo.ParameterType),
-                expr.Parameters[0]);
-        }
-
-        /// <summary>
-        /// Applies <see cref="GraphQLAttribute"/> attributes pulled from the <see cref="ArgumentInformation.ParameterInfo">ParameterInfo</see> onto this instance.
-        /// Also scans the parameter's owning module and assembly for globally-applied attributes.
-        /// </summary>
-        public virtual void ApplyAttributes()
-        {
-            var attributes = ParameterInfo.GetGraphQLAttributes();
-            foreach (var attr in attributes)
-            {
-                attr.Modify(this);
-            }
-        }
-
-        /// <summary>
-        /// Builds a query argument or expression from this instance.
-        /// <br/><br/>
-        /// If a query argument is returned, it will be added to the arguments list of the field type.
-        /// <br/><br/>
-        /// If an expression is returned, it will be used to populate the method argument within the field resolver;
-        /// if not, the query argument's value will be used to populate the method argument within the field resolver.
-        /// <br/><br/>
-        /// The default implementation will return either a <see cref="QueryArgument"/> or <see cref="LambdaExpression"/>
-        /// instance; not both. It is possible to return both, in which case the query argument will be added to the
-        /// field and the expression will be used to populate the method argument within the field resolver.
-        /// You cannot return <see langword="null"/> for both the query argument and expression.
-        /// </summary>
-        public virtual (QueryArgument? QueryArgument, LambdaExpression? Expression) ConstructQueryArgument()
-        {
-            if (Expression != null)
-                return (null, Expression);
-
-            var type = TypeInformation.ConstructGraphType();
-            var memberType = ParameterInfo.ParameterType;
-            var argument = new QueryArgument(type)
-            {
-                Name = ParameterInfo.Name!,
-                Description = ParameterInfo.Description(),
-                DefaultValue = ParameterInfo.IsOptional ? ParameterInfo.DefaultValue : null,
-            };
-            argument.Parser = value => memberType.IsInstanceOfType(value) ? value : value.GetPropertyValue(memberType, argument.ResolvedType!)!;
-            return (argument, null);
-        }
+            Name = ParameterInfo.Name!,
+            Description = ParameterInfo.Description(),
+            DefaultValue = ParameterInfo.IsOptional ? ParameterInfo.DefaultValue : null,
+        };
+        argument.Parser = value => memberType.IsInstanceOfType(value) ? value : value.GetPropertyValue(memberType, argument.ResolvedType!)!;
+        return (argument, null);
     }
 }

--- a/src/GraphQL/Types/Collections/AppliedDirectives.cs
+++ b/src/GraphQL/Types/Collections/AppliedDirectives.cs
@@ -1,63 +1,62 @@
 using System.Collections;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// A class that represents a list of directives applied to a schema element (type, field, argument, etc.).
+/// Note that built-in @deprecated directive is not taken into account and ignored.
+/// </summary>
+public class AppliedDirectives : IEnumerable<AppliedDirective>
 {
+    internal List<AppliedDirective>? List { get; private set; }
+
     /// <summary>
-    /// A class that represents a list of directives applied to a schema element (type, field, argument, etc.).
-    /// Note that built-in @deprecated directive is not taken into account and ignored.
+    /// Gets the count of applied directives.
     /// </summary>
-    public class AppliedDirectives : IEnumerable<AppliedDirective>
+    public int Count => List?.Count ?? 0;
+
+    /// <summary>
+    /// Adds directive to list.
+    /// </summary>
+    public void Add(AppliedDirective directive)
     {
-        internal List<AppliedDirective>? List { get; private set; }
+        if (directive == null)
+            throw new ArgumentNullException(nameof(directive));
 
-        /// <summary>
-        /// Gets the count of applied directives.
-        /// </summary>
-        public int Count => List?.Count ?? 0;
+        //TODO: rewrite for repeatable directives
+        if (List != null && List.Contains(directive))
+            throw new InvalidOperationException("Already exists");
 
-        /// <summary>
-        /// Adds directive to list.
-        /// </summary>
-        public void Add(AppliedDirective directive)
-        {
-            if (directive == null)
-                throw new ArgumentNullException(nameof(directive));
-
-            //TODO: rewrite for repeatable directives
-            if (List != null && List.Contains(directive))
-                throw new InvalidOperationException("Already exists");
-
-            (List ??= new()).Add(directive);
-        }
-
-        /// <summary>
-        /// Finds a directive by its name from the list. If the list contains several
-        /// directives with the given name, then the first one is returned.
-        /// </summary>
-        public AppliedDirective? Find(string name)
-        {
-            // DO NOT USE LINQ ON HOT PATH
-            if (List != null)
-            {
-                foreach (var arg in List)
-                {
-                    if (arg.Name == name)
-                        return arg;
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Removes a directive by its name from the list. If the list contains several
-        /// directives with the given name, then all such directives will be removed.
-        /// </summary>
-        public int Remove(string name) => List?.RemoveAll(d => d.Name == name) ?? 0;
-
-        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<AppliedDirective> GetEnumerator() => (List ?? System.Linq.Enumerable.Empty<AppliedDirective>()).GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        (List ??= new()).Add(directive);
     }
+
+    /// <summary>
+    /// Finds a directive by its name from the list. If the list contains several
+    /// directives with the given name, then the first one is returned.
+    /// </summary>
+    public AppliedDirective? Find(string name)
+    {
+        // DO NOT USE LINQ ON HOT PATH
+        if (List != null)
+        {
+            foreach (var arg in List)
+            {
+                if (arg.Name == name)
+                    return arg;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Removes a directive by its name from the list. If the list contains several
+    /// directives with the given name, then all such directives will be removed.
+    /// </summary>
+    public int Remove(string name) => List?.RemoveAll(d => d.Name == name) ?? 0;
+
+    /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+    public IEnumerator<AppliedDirective> GetEnumerator() => (List ?? System.Linq.Enumerable.Empty<AppliedDirective>()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GraphQL/Types/Collections/Interfaces.cs
+++ b/src/GraphQL/Types/Collections/Interfaces.cs
@@ -1,54 +1,53 @@
 using System.Collections;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// A class that represents a set of instances of supported GraphQL interface types for <see cref="IImplementInterfaces"/> i.e <see cref="ObjectGraphType{TSourceType}"/>.
+/// </summary>
+public class Interfaces : IEnumerable<Type>
 {
+    internal List<Type> List { get; } = new List<Type>();
+
     /// <summary>
-    /// A class that represents a set of instances of supported GraphQL interface types for <see cref="IImplementInterfaces"/> i.e <see cref="ObjectGraphType{TSourceType}"/>.
+    /// Gets the count of supported GraphQL interface types.
     /// </summary>
-    public class Interfaces : IEnumerable<Type>
+    public int Count => List.Count;
+
+    /// <summary>
+    /// Adds a GraphQL interface graph type to the list of GraphQL interfaces implemented by this graph type.
+    /// </summary>
+    public void Add<TInterface>()
+        where TInterface : IInterfaceGraphType
     {
-        internal List<Type> List { get; } = new List<Type>();
-
-        /// <summary>
-        /// Gets the count of supported GraphQL interface types.
-        /// </summary>
-        public int Count => List.Count;
-
-        /// <summary>
-        /// Adds a GraphQL interface graph type to the list of GraphQL interfaces implemented by this graph type.
-        /// </summary>
-        public void Add<TInterface>()
-            where TInterface : IInterfaceGraphType
-        {
-            if (!List.Contains(typeof(TInterface)))
-                List.Add(typeof(TInterface));
-        }
-
-        /// <summary>
-        /// Adds a GraphQL interface graph type to the list of GraphQL interfaces implemented by this graph type.
-        /// </summary>
-        public void Add(Type type)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            if (!typeof(IInterfaceGraphType).IsAssignableFrom(type))
-            {
-                throw new ArgumentException($"Interface '{type.Name}' must implement {nameof(IInterfaceGraphType)}", nameof(type));
-            }
-
-            if (!List.Contains(type))
-                List.Add(type);
-        }
-
-        /// <summary>
-        /// Determines if the specified interface type is in the list.
-        /// </summary>
-        public bool Contains(Type type) => List.Contains(type ?? throw new ArgumentNullException(nameof(type)));
-
-        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<Type> GetEnumerator() => List.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        if (!List.Contains(typeof(TInterface)))
+            List.Add(typeof(TInterface));
     }
+
+    /// <summary>
+    /// Adds a GraphQL interface graph type to the list of GraphQL interfaces implemented by this graph type.
+    /// </summary>
+    public void Add(Type type)
+    {
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (!typeof(IInterfaceGraphType).IsAssignableFrom(type))
+        {
+            throw new ArgumentException($"Interface '{type.Name}' must implement {nameof(IInterfaceGraphType)}", nameof(type));
+        }
+
+        if (!List.Contains(type))
+            List.Add(type);
+    }
+
+    /// <summary>
+    /// Determines if the specified interface type is in the list.
+    /// </summary>
+    public bool Contains(Type type) => List.Contains(type ?? throw new ArgumentNullException(nameof(type)));
+
+    /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+    public IEnumerator<Type> GetEnumerator() => List.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GraphQL/Types/Collections/PossibleTypes.cs
+++ b/src/GraphQL/Types/Collections/PossibleTypes.cs
@@ -1,36 +1,35 @@
 using System.Collections;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// A class that represents a set of possible types for <see cref="IAbstractGraphType"/> i.e. <see cref="InterfaceGraphType"/> or <see cref="UnionGraphType"/>.
+/// </summary>
+public class PossibleTypes : IEnumerable<IObjectGraphType>
 {
+    internal List<IObjectGraphType> List { get; } = new List<IObjectGraphType>();
+
     /// <summary>
-    /// A class that represents a set of possible types for <see cref="IAbstractGraphType"/> i.e. <see cref="InterfaceGraphType"/> or <see cref="UnionGraphType"/>.
+    /// Gets the count of possible types.
     /// </summary>
-    public class PossibleTypes : IEnumerable<IObjectGraphType>
+    public int Count => List.Count;
+
+    internal void Add(IObjectGraphType type)
     {
-        internal List<IObjectGraphType> List { get; } = new List<IObjectGraphType>();
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
 
-        /// <summary>
-        /// Gets the count of possible types.
-        /// </summary>
-        public int Count => List.Count;
-
-        internal void Add(IObjectGraphType type)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            if (!List.Contains(type))
-                List.Add(type);
-        }
-
-        /// <summary>
-        /// Determines if the specified graph type is in the list.
-        /// </summary>
-        public bool Contains(IObjectGraphType type) => List.Contains(type ?? throw new ArgumentNullException(nameof(type)));
-
-        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<IObjectGraphType> GetEnumerator() => List.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        if (!List.Contains(type))
+            List.Add(type);
     }
+
+    /// <summary>
+    /// Determines if the specified graph type is in the list.
+    /// </summary>
+    public bool Contains(IObjectGraphType type) => List.Contains(type ?? throw new ArgumentNullException(nameof(type)));
+
+    /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+    public IEnumerator<IObjectGraphType> GetEnumerator() => List.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GraphQL/Types/Collections/QueryArguments.cs
+++ b/src/GraphQL/Types/Collections/QueryArguments.cs
@@ -2,97 +2,96 @@ using System.Collections;
 using GraphQL.Utilities;
 using GraphQLParser;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+// TODO: better to rename QueryArguments and QueryArgument to something like GraphQLArguments and GraphQLArgument.
+/// <summary>
+/// Represents a list of arguments to a field or directive.
+/// </summary>
+public class QueryArguments : IEnumerable<QueryArgument>
 {
-    // TODO: better to rename QueryArguments and QueryArgument to something like GraphQLArguments and GraphQLArgument.
+    internal List<QueryArgument>? List { get; private set; }
+
     /// <summary>
-    /// Represents a list of arguments to a field or directive.
+    /// Initializes a new instance containing the specified arguments.
     /// </summary>
-    public class QueryArguments : IEnumerable<QueryArgument>
+    public QueryArguments(params QueryArgument[] args)
     {
-        internal List<QueryArgument>? List { get; private set; }
-
-        /// <summary>
-        /// Initializes a new instance containing the specified arguments.
-        /// </summary>
-        public QueryArguments(params QueryArgument[] args)
+        foreach (var arg in args)
         {
-            foreach (var arg in args)
-            {
-                Add(arg);
-            }
+            Add(arg);
         }
-
-        /// <summary>
-        /// Initializes a new instance containing the specified arguments.
-        /// </summary>
-        public QueryArguments(IEnumerable<QueryArgument> list)
-        {
-            foreach (var arg in list)
-            {
-                Add(arg);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the argument at the specified index.
-        /// </summary>
-        public QueryArgument this[int index]
-        {
-            get => List != null ? List[index] : throw new IndexOutOfRangeException();
-            set
-            {
-                if (value != null)
-                {
-                    NameValidator.ValidateName(value.Name, NamedElement.Argument);
-                }
-
-                if (List == null)
-                    throw new IndexOutOfRangeException();
-
-                List[index] = value!;
-            }
-        }
-
-        /// <summary>
-        /// Returns the number of arguments in the list.
-        /// </summary>
-        public int Count => List?.Count ?? 0;
-
-        /// <summary>
-        /// Adds an argument to the list.
-        /// </summary>
-        public void Add(QueryArgument argument)
-        {
-            if (argument == null)
-                throw new ArgumentNullException(nameof(argument));
-
-            NameValidator.ValidateName(argument.Name, NamedElement.Argument);
-
-            (List ??= new()).Add(argument);
-        }
-
-        /// <summary>
-        /// Finds an argument by its name from the list.
-        /// </summary>
-        public QueryArgument? Find(ROM name)
-        {
-            // DO NOT USE LINQ ON HOT PATH
-            if (List != null)
-            {
-                foreach (var arg in List)
-                {
-                    if (arg.Name == name)
-                        return arg;
-                }
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc/>
-        public IEnumerator<QueryArgument> GetEnumerator() => (List ?? System.Linq.Enumerable.Empty<QueryArgument>()).GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
+
+    /// <summary>
+    /// Initializes a new instance containing the specified arguments.
+    /// </summary>
+    public QueryArguments(IEnumerable<QueryArgument> list)
+    {
+        foreach (var arg in list)
+        {
+            Add(arg);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the argument at the specified index.
+    /// </summary>
+    public QueryArgument this[int index]
+    {
+        get => List != null ? List[index] : throw new IndexOutOfRangeException();
+        set
+        {
+            if (value != null)
+            {
+                NameValidator.ValidateName(value.Name, NamedElement.Argument);
+            }
+
+            if (List == null)
+                throw new IndexOutOfRangeException();
+
+            List[index] = value!;
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of arguments in the list.
+    /// </summary>
+    public int Count => List?.Count ?? 0;
+
+    /// <summary>
+    /// Adds an argument to the list.
+    /// </summary>
+    public void Add(QueryArgument argument)
+    {
+        if (argument == null)
+            throw new ArgumentNullException(nameof(argument));
+
+        NameValidator.ValidateName(argument.Name, NamedElement.Argument);
+
+        (List ??= new()).Add(argument);
+    }
+
+    /// <summary>
+    /// Finds an argument by its name from the list.
+    /// </summary>
+    public QueryArgument? Find(ROM name)
+    {
+        // DO NOT USE LINQ ON HOT PATH
+        if (List != null)
+        {
+            foreach (var arg in List)
+            {
+                if (arg.Name == name)
+                    return arg;
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<QueryArgument> GetEnumerator() => (List ?? System.Linq.Enumerable.Empty<QueryArgument>()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GraphQL/Types/Collections/ResolvedInterfaces.cs
+++ b/src/GraphQL/Types/Collections/ResolvedInterfaces.cs
@@ -1,36 +1,35 @@
 using System.Collections;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// A class that represents a set of instances of supported GraphQL interface types for <see cref="IImplementInterfaces"/> i.e <see cref="ObjectGraphType{TSourceType}"/>.
+/// </summary>
+public class ResolvedInterfaces : IEnumerable<IInterfaceGraphType>
 {
+    internal List<IInterfaceGraphType> List { get; } = new List<IInterfaceGraphType>();
+
     /// <summary>
-    /// A class that represents a set of instances of supported GraphQL interface types for <see cref="IImplementInterfaces"/> i.e <see cref="ObjectGraphType{TSourceType}"/>.
+    /// Gets the count of supported GraphQL interface types.
     /// </summary>
-    public class ResolvedInterfaces : IEnumerable<IInterfaceGraphType>
+    public int Count => List.Count;
+
+    internal void Add(IInterfaceGraphType type)
     {
-        internal List<IInterfaceGraphType> List { get; } = new List<IInterfaceGraphType>();
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
 
-        /// <summary>
-        /// Gets the count of supported GraphQL interface types.
-        /// </summary>
-        public int Count => List.Count;
-
-        internal void Add(IInterfaceGraphType type)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            if (!List.Contains(type))
-                List.Add(type);
-        }
-
-        /// <summary>
-        /// Determines if the specified interface type is in the list.
-        /// </summary>
-        public bool Contains(IInterfaceGraphType type) => List.Contains(type ?? throw new ArgumentNullException(nameof(type)));
-
-        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<IInterfaceGraphType> GetEnumerator() => List.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        if (!List.Contains(type))
+            List.Add(type);
     }
+
+    /// <summary>
+    /// Determines if the specified interface type is in the list.
+    /// </summary>
+    public bool Contains(IInterfaceGraphType type) => List.Contains(type ?? throw new ArgumentNullException(nameof(type)));
+
+    /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+    public IEnumerator<IInterfaceGraphType> GetEnumerator() => List.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GraphQL/Types/Collections/SchemaDirectives.cs
+++ b/src/GraphQL/Types/Collections/SchemaDirectives.cs
@@ -1,80 +1,79 @@
 using System.Collections;
 using GraphQLParser;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// A class that represents a list of directives supported by the schema.
+/// </summary>
+public class SchemaDirectives : IEnumerable<Directive>
 {
+    internal List<Directive> List { get; } = new List<Directive>();
+
     /// <summary>
-    /// A class that represents a list of directives supported by the schema.
+    /// Returns an instance of the predefined 'include' directive.
     /// </summary>
-    public class SchemaDirectives : IEnumerable<Directive>
+    public virtual IncludeDirective Include { get; } = new IncludeDirective();
+
+    /// <summary>
+    /// Returns an instance of the predefined 'skip' directive.
+    /// </summary>
+    public virtual SkipDirective Skip { get; } = new SkipDirective();
+
+    /// <summary>
+    /// Returns an instance of the predefined 'deprecated' directive.
+    /// </summary>
+    public virtual DeprecatedDirective Deprecated { get; } = new DeprecatedDirective();
+
+    /// <summary>
+    /// Gets the count of directives.
+    /// </summary>
+    public int Count => List.Count;
+
+    /// <summary>
+    /// Register the specified directive to the schema.
+    /// <br/><br/>
+    /// Directives are used by the GraphQL runtime as a way of modifying execution
+    /// behavior. Type system creators do not usually create them directly.
+    /// </summary>
+    public void Register(Directive directive)
     {
-        internal List<Directive> List { get; } = new List<Directive>();
+        if (directive == null)
+            throw new ArgumentNullException(nameof(directive));
 
-        /// <summary>
-        /// Returns an instance of the predefined 'include' directive.
-        /// </summary>
-        public virtual IncludeDirective Include { get; } = new IncludeDirective();
-
-        /// <summary>
-        /// Returns an instance of the predefined 'skip' directive.
-        /// </summary>
-        public virtual SkipDirective Skip { get; } = new SkipDirective();
-
-        /// <summary>
-        /// Returns an instance of the predefined 'deprecated' directive.
-        /// </summary>
-        public virtual DeprecatedDirective Deprecated { get; } = new DeprecatedDirective();
-
-        /// <summary>
-        /// Gets the count of directives.
-        /// </summary>
-        public int Count => List.Count;
-
-        /// <summary>
-        /// Register the specified directive to the schema.
-        /// <br/><br/>
-        /// Directives are used by the GraphQL runtime as a way of modifying execution
-        /// behavior. Type system creators do not usually create them directly.
-        /// </summary>
-        public void Register(Directive directive)
-        {
-            if (directive == null)
-                throw new ArgumentNullException(nameof(directive));
-
-            if (!List.Contains(directive))
-                List.Add(directive);
-        }
-
-        /// <summary>
-        /// Register the specified directives to the schema.
-        /// <br/><br/>
-        /// Directives are used by the GraphQL runtime as a way of modifying execution
-        /// behavior. Type system creators do not usually create them directly.
-        /// </summary>
-        public void Register(params Directive[] directives)
-        {
-            foreach (var directive in directives)
-                Register(directive);
-        }
-
-        /// <summary>
-        /// Searches the directive by its name and returns it.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        public Directive? Find(ROM name)
-        {
-            foreach (var directive in List)
-            {
-                if (directive.Name == name)
-                    return directive;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<Directive> GetEnumerator() => List.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        if (!List.Contains(directive))
+            List.Add(directive);
     }
+
+    /// <summary>
+    /// Register the specified directives to the schema.
+    /// <br/><br/>
+    /// Directives are used by the GraphQL runtime as a way of modifying execution
+    /// behavior. Type system creators do not usually create them directly.
+    /// </summary>
+    public void Register(params Directive[] directives)
+    {
+        foreach (var directive in directives)
+            Register(directive);
+    }
+
+    /// <summary>
+    /// Searches the directive by its name and returns it.
+    /// </summary>
+    /// <param name="name">Directive name.</param>
+    public Directive? Find(ROM name)
+    {
+        foreach (var directive in List)
+        {
+            if (directive.Name == name)
+                return directive;
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+    public IEnumerator<Directive> GetEnumerator() => List.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GraphQL/Types/Collections/TypeFields.cs
+++ b/src/GraphQL/Types/Collections/TypeFields.cs
@@ -1,70 +1,69 @@
 using System.Collections;
 using GraphQLParser;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// A class that represents a set of fields for <see cref="IComplexGraphType"/> i.e <see cref="ComplexGraphType{TSourceType}"/>.
+/// </summary>
+public class TypeFields : IEnumerable<FieldType>
 {
+    internal List<FieldType> List { get; } = new List<FieldType>();
+
     /// <summary>
-    /// A class that represents a set of fields for <see cref="IComplexGraphType"/> i.e <see cref="ComplexGraphType{TSourceType}"/>.
+    /// Gets the count of fields.
     /// </summary>
-    public class TypeFields : IEnumerable<FieldType>
+    public int Count => List.Count;
+
+    internal void Add(FieldType field)
     {
-        internal List<FieldType> List { get; } = new List<FieldType>();
+        if (field == null)
+            throw new ArgumentNullException(nameof(field));
 
-        /// <summary>
-        /// Gets the count of fields.
-        /// </summary>
-        public int Count => List.Count;
-
-        internal void Add(FieldType field)
-        {
-            if (field == null)
-                throw new ArgumentNullException(nameof(field));
-
-            if (!List.Contains(field))
-                List.Add(field);
-        }
-
-        /// <summary>
-        /// Searches the list for a field specified by its name and returns it.
-        /// </summary>
-        public FieldType? Find(string name)
-        {
-            foreach (var field in List)
-            {
-                if (field.Name == name)
-                    return field;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Searches the list for a field specified by its name and returns it.
-        /// </summary>
-        public FieldType? Find(ROM name)
-        {
-            foreach (var field in List)
-            {
-                if (field.Name == name)
-                    return field;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Determines if the specified field type is in the list.
-        /// </summary>
-        public bool Contains(FieldType field) => List.Contains(field ?? throw new ArgumentNullException(nameof(field)));
-
-        /// <summary>
-        /// Determines if the specified field type is in the list.
-        /// </summary>
-        public bool Contains(IFieldType field) => List.Contains((FieldType)field ?? throw new ArgumentNullException(nameof(field)));
-
-        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<FieldType> GetEnumerator() => List.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        if (!List.Contains(field))
+            List.Add(field);
     }
+
+    /// <summary>
+    /// Searches the list for a field specified by its name and returns it.
+    /// </summary>
+    public FieldType? Find(string name)
+    {
+        foreach (var field in List)
+        {
+            if (field.Name == name)
+                return field;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Searches the list for a field specified by its name and returns it.
+    /// </summary>
+    public FieldType? Find(ROM name)
+    {
+        foreach (var field in List)
+        {
+            if (field.Name == name)
+                return field;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determines if the specified field type is in the list.
+    /// </summary>
+    public bool Contains(FieldType field) => List.Contains(field ?? throw new ArgumentNullException(nameof(field)));
+
+    /// <summary>
+    /// Determines if the specified field type is in the list.
+    /// </summary>
+    public bool Contains(IFieldType field) => List.Contains((FieldType)field ?? throw new ArgumentNullException(nameof(field)));
+
+    /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+    public IEnumerator<FieldType> GetEnumerator() => List.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -3,362 +3,361 @@ using System.Linq.Expressions;
 using System.Reflection;
 using GraphQL.Resolvers;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Helper methods for auto-registering graph types, <see cref="Builders.FieldBuilder{TSourceType, TReturnType}.ResolveDelegate(Delegate?)">Resolve</see>,
+/// schema builder method builders, and <see cref="NameFieldResolver"/>.
+/// </summary>
+public static class AutoRegisteringHelper
 {
     /// <summary>
-    /// Helper methods for auto-registering graph types, <see cref="Builders.FieldBuilder{TSourceType, TReturnType}.ResolveDelegate(Delegate?)">Resolve</see>,
-    /// schema builder method builders, and <see cref="NameFieldResolver"/>.
+    /// Constructs a field resolver for the specified field, property or method with the specified instance expression.
+    /// Does not build accompanying query arguments for detected method parameters.
+    /// Does not allow overriding build behavior.
+    /// <br/><br/>
+    /// An example of an instance expression would be as follows:
+    /// <code>context =&gt; (TSourceType)context.Source</code>
     /// </summary>
-    public static class AutoRegisteringHelper
+    public static IFieldResolver BuildFieldResolver(MemberInfo memberInfo, Type? sourceType, FieldType? fieldType, LambdaExpression instanceExpression)
     {
-        /// <summary>
-        /// Constructs a field resolver for the specified field, property or method with the specified instance expression.
-        /// Does not build accompanying query arguments for detected method parameters.
-        /// Does not allow overriding build behavior.
-        /// <br/><br/>
-        /// An example of an instance expression would be as follows:
-        /// <code>context =&gt; (TSourceType)context.Source</code>
-        /// </summary>
-        public static IFieldResolver BuildFieldResolver(MemberInfo memberInfo, Type? sourceType, FieldType? fieldType, LambdaExpression instanceExpression)
+        // this entire method is a simplification of AutoRegisteringObjectGraphType.BuildFieldType
+        // but it does not provide the ability to override any behavior, and it does not return or
+        // build query arguments
+        if (memberInfo is FieldInfo fieldInfo)
         {
-            // this entire method is a simplification of AutoRegisteringObjectGraphType.BuildFieldType
-            // but it does not provide the ability to override any behavior, and it does not return or
-            // build query arguments
-            if (memberInfo is FieldInfo fieldInfo)
-            {
-                return new MemberResolver(fieldInfo, instanceExpression);
-            }
-            else if (memberInfo is PropertyInfo propertyInfo)
-            {
-                return new MemberResolver(propertyInfo, instanceExpression);
-            }
-            else if (memberInfo is MethodInfo methodInfo)
-            {
-                var arguments = BuildFieldResolver_BuildMethodArguments(methodInfo, sourceType, fieldType);
-                return new MemberResolver(methodInfo, instanceExpression, arguments);
-            }
-
-            throw new ArgumentOutOfRangeException(nameof(memberInfo), "Member must be a field, property or method.");
+            return new MemberResolver(fieldInfo, instanceExpression);
         }
-
-        /// <summary>
-        /// Constructs an event stream resolver for the specified method with the specified instance expression.
-        /// Does not build accompanying query arguments for detected method parameters.
-        /// Does not allow overriding build behavior.
-        /// <br/><br/>
-        /// An example of an instance expression would be as follows:
-        /// <code>context =&gt; (TSourceType)context.Source</code>
-        /// </summary>
-        public static ISourceStreamResolver BuildSourceStreamResolver(MethodInfo methodInfo, Type? sourceType, FieldType? fieldType, LambdaExpression instanceExpression)
+        else if (memberInfo is PropertyInfo propertyInfo)
+        {
+            return new MemberResolver(propertyInfo, instanceExpression);
+        }
+        else if (memberInfo is MethodInfo methodInfo)
         {
             var arguments = BuildFieldResolver_BuildMethodArguments(methodInfo, sourceType, fieldType);
-            return new SourceStreamMethodResolver(methodInfo, instanceExpression, arguments);
+            return new MemberResolver(methodInfo, instanceExpression, arguments);
         }
 
-        private static IList<LambdaExpression> BuildFieldResolver_BuildMethodArguments(MethodInfo methodInfo, Type? sourceType, FieldType? fieldType)
-        {
-            List<LambdaExpression> expressions = new();
-            foreach (var parameterInfo in methodInfo.GetParameters())
-            {
-                var typeInformation = new TypeInformation(parameterInfo);
-                typeInformation.ApplyAttributes(); // typically this is unnecessary, since this is primarily used to control the graph type of generated query arguments
-                var argumentInfo = new ArgumentInformation(parameterInfo, sourceType, fieldType, typeInformation);
-                argumentInfo.ApplyAttributes(); // necessary to allow [FromSource], [FromServices] and similar attributes to work
-                var (queryArgument, expression) = argumentInfo.ConstructQueryArgument();
-                if (queryArgument != null)
-                {
-                    // even though the query argument is not used, it is necessary to apply attributes to the generated argument in case the name is overridden,
-                    // as the generated query argument's name is used within the expression for the call to GetArgument
-                    var attributes = parameterInfo.GetGraphQLAttributes();
-                    foreach (var attr in attributes)
-                        attr.Modify(queryArgument);
-                }
-                expression ??= GetParameterExpression(
-                    parameterInfo.ParameterType,
-                    queryArgument ?? throw new InvalidOperationException("Invalid response from ConstructQueryArgument: queryArgument and expression cannot both be null"));
-                expressions.Add(expression);
-            }
-            return expressions;
-        }
+        throw new ArgumentOutOfRangeException(nameof(memberInfo), "Member must be a field, property or method.");
+    }
 
-        /// <summary>
-        /// Builds the following instance expression:
-        /// <code>context =&gt; context.Source as TSourceType ?? (context.RequestServices ?? serviceProvider).GetService(sourceType) ?? throw new InvalidOperationException(...)</code>
-        /// </summary>
-        internal static LambdaExpression BuildInstanceExpressionForSchemaBuilder(Type sourceType, IServiceProvider serviceProvider)
-        {
-            // exception cannot occur here, so don't worry catching TargetInvokeException
-            return (LambdaExpression)_buildSourceExpressionForSchemaBuilderInternalMethodInfo
-                .MakeGenericMethod(sourceType)
-                .Invoke(null, new object[] { serviceProvider })!;
-        }
+    /// <summary>
+    /// Constructs an event stream resolver for the specified method with the specified instance expression.
+    /// Does not build accompanying query arguments for detected method parameters.
+    /// Does not allow overriding build behavior.
+    /// <br/><br/>
+    /// An example of an instance expression would be as follows:
+    /// <code>context =&gt; (TSourceType)context.Source</code>
+    /// </summary>
+    public static ISourceStreamResolver BuildSourceStreamResolver(MethodInfo methodInfo, Type? sourceType, FieldType? fieldType, LambdaExpression instanceExpression)
+    {
+        var arguments = BuildFieldResolver_BuildMethodArguments(methodInfo, sourceType, fieldType);
+        return new SourceStreamMethodResolver(methodInfo, instanceExpression, arguments);
+    }
 
-        private static readonly MethodInfo _buildSourceExpressionForSchemaBuilderInternalMethodInfo = typeof(AutoRegisteringHelper).GetMethod(nameof(BuildSourceExpressionForSchemaBuilderInternal), BindingFlags.Static | BindingFlags.NonPublic)!;
-        private static Expression<Func<IResolveFieldContext, T>> BuildSourceExpressionForSchemaBuilderInternal<T>(IServiceProvider serviceProvider)
-            => context => BuildSourceExpressionForSchemaBuilderInternal_GetSource<T>(context, serviceProvider);
-        private static T BuildSourceExpressionForSchemaBuilderInternal_GetSource<T>(IResolveFieldContext context, IServiceProvider serviceProvider)
-        {
-            var source = context.Source;
-
-            var target = typeof(T).IsInstanceOfType(source)
-                ? (T)source!
-                : (T?)(context.RequestServices ?? serviceProvider).GetService(typeof(T));
-
-            if (target == null)
-            {
-                var parentType = context.ParentType != null ? $"{context.ParentType.Name}." : null;
-                throw new InvalidOperationException($"Could not resolve an instance of {typeof(T).Name} to execute {parentType}{context.FieldAst.Name}");
-            }
-
-            return target;
-        }
-
-        /// <summary>
-        /// Scans a specific CLR type for <see cref="GraphQLAttribute"/> attributes and applies
-        /// them to the specified <see cref="IGraphType"/>.
-        /// Also scans the CLR type's owning module and assembly for globally-applied attributes.
-        /// </summary>
-        internal static void ApplyGraphQLAttributes<TSourceType>(IGraphType graphType)
-        {
-            // Description and deprecation reason are already set in ComplexGraphType<TSourceType> constructor
-
-            // Apply derivatives of GraphQLAttribute
-            var attributes = typeof(TSourceType).GetGraphQLAttributes();
-            foreach (var attr in attributes)
-            {
-                attr.Modify(graphType);
-            }
-        }
-
-        /// <summary>
-        /// Filters an enumeration of <see cref="PropertyInfo"/> values to exclude specified properties.
-        /// </summary>
-        internal static IEnumerable<PropertyInfo> ExcludeProperties<TSourceType>(IEnumerable<PropertyInfo> properties, params Expression<Func<TSourceType, object?>>[]? excludedProperties)
-            => excludedProperties == null || excludedProperties.Length == 0
-                ? properties
-                : properties.Where(propertyInfo => !excludedProperties!.Any(p => GetPropertyName(p) == propertyInfo.Name));
-
-        /// <summary>
-        /// Creates a <see cref="FieldType"/> for the specified <see cref="MemberInfo"/>.
-        /// </summary>
-        internal static FieldType CreateField(MemberInfo memberInfo, Func<MemberInfo, TypeInformation> getTypeInformation, Action<FieldType, MemberInfo>? buildFieldType, bool isInputType)
-        {
-            var typeInformation = getTypeInformation(memberInfo);
-            var graphType = typeInformation.ConstructGraphType();
-            var fieldType = CreateField(memberInfo, graphType, isInputType);
-            // set resolver, if applicable
-            buildFieldType?.Invoke(fieldType, memberInfo);
-            // apply field attributes after resolver has been set
-            ApplyFieldAttributes(memberInfo, fieldType, isInputType);
-            return fieldType;
-        }
-
-        /// <summary>
-        /// Creates a <see cref="FieldType"/> for the specified <see cref="MemberInfo"/>.
-        /// </summary>
-        internal static FieldType CreateField(MemberInfo memberInfo, Type graphType, bool isInputType)
-        {
-            var fieldType = new FieldType()
-            {
-                Name = memberInfo.Name,
-                Description = memberInfo.Description(),
-                DeprecationReason = memberInfo.ObsoleteMessage(),
-                Type = graphType,
-                DefaultValue = isInputType ? memberInfo.DefaultValue() : null,
-            };
-            if (isInputType)
-            {
-                fieldType.WithMetadata(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME, memberInfo.Name);
-                var memberType = memberInfo is PropertyInfo propertyInfo ? propertyInfo.PropertyType : ((FieldInfo)memberInfo).FieldType;
-                fieldType.Parser = value => memberType.IsInstanceOfType(value) ? value : value.GetPropertyValue(memberType, fieldType.ResolvedType!)!;
-            }
-            if (!isInputType &&
-                memberInfo is MethodInfo methodInfo &&
-                fieldType.Name.EndsWith("Async") &&
-                methodInfo.ReturnType.IsGenericType &&
-                methodInfo.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
-            {
-                fieldType.Name = fieldType.Name.Substring(0, fieldType.Name.Length - 5);
-            }
-
-            return fieldType;
-        }
-
-        /// <summary>
-        /// Applies <see cref="GraphQLAttribute"/>s defined on <paramref name="memberInfo"/> to <paramref name="fieldType"/>.
-        /// Also scans the member's owning module and assembly for globally-applied attributes.
-        /// </summary>
-        internal static void ApplyFieldAttributes(MemberInfo memberInfo, FieldType fieldType, bool isInputType)
-        {
-            // Apply derivatives of GraphQLAttribute
-            var attributes = memberInfo.GetGraphQLAttributes();
-            foreach (var attr in attributes)
-            {
-                attr.Modify(fieldType, isInputType);
-            }
-        }
-
-        private static string GetPropertyName<TSourceType>(Expression<Func<TSourceType, object?>> expression)
-        {
-            if (expression.Body is MemberExpression m1)
-                return m1.Member.Name;
-
-            if (expression.Body is UnaryExpression u && u.Operand is MemberExpression m2)
-                return m2.Member.Name;
-
-            throw new NotSupportedException($"Unsupported type of expression: {expression.GetType().Name}");
-        }
-
-        /// <summary>
-        /// Constructs a lambda expression for a field resolver to return the specified query argument
-        /// from the resolve context. The returned lambda is similar to the following:
-        /// <code>context =&gt; context.GetArgument&lt;T&gt;(queryArgument.Name, queryArgument.DefaultValue)</code>
-        /// </summary>
-        internal static LambdaExpression GetParameterExpression(Type parameterType, QueryArgument queryArgument)
-        {
-            //construct a typed call to AutoRegisteringHelper.GetArgumentInternal, passing in queryArgument
-            var getArgumentMethodTyped = _getArgumentMethod.MakeGenericMethod(parameterType);
-            var resolveFieldContextParameter = Expression.Parameter(typeof(IResolveFieldContext), "context");
-            var queryArgumentExpression = Expression.Constant(queryArgument, typeof(QueryArgument));
-            //e.g. Func<IResolveFieldContext, int> = (context) => AutoRegisteringHelper.GetArgumentInternal<int>(context, queryArgument);
-            var expr = Expression.Call(getArgumentMethodTyped, resolveFieldContextParameter, queryArgumentExpression);
-            return Expression.Lambda(expr, resolveFieldContextParameter);
-        }
-
-        private static readonly MethodInfo _getArgumentMethod = typeof(AutoRegisteringHelper).GetMethod(nameof(GetArgumentInternal), BindingFlags.NonPublic | BindingFlags.Static)!;
-        /// <summary>
-        /// Returns the value for the specified query argument, or <c>default(T)</c> if the argument
-        /// was not specified and the argument is not configured with a default value.
-        /// </summary>
-        private static T? GetArgumentInternal<T>(IResolveFieldContext context, QueryArgument queryArgument)
-        {
-            // note: if the query argument has a default value, TryGetArgumentExact will always return true
-            return context.TryGetArgumentExact(typeof(T), queryArgument.Name, out var value)
-                ? (T?)value
-                : default;
-        }
-
-        /// <summary>
-        /// Returns a list of <see cref="FieldType"/> instances representing the fields ready to be
-        /// added to the graph type.
-        /// </summary>
-        internal static IEnumerable<FieldType> ProvideFields(IEnumerable<MemberInfo> members, Func<MemberInfo, FieldType?> createField, bool isInputType)
-        {
-            foreach (var memberInfo in members)
-            {
-                bool include = true;
-                foreach (var attr in memberInfo.GetGraphQLAttributes())
-                {
-                    include = attr.ShouldInclude(memberInfo, isInputType);
-                    if (!include)
-                        break;
-                }
-                if (!include)
-                    continue;
-                var fieldType = createField(memberInfo);
-                if (fieldType != null)
-                    yield return fieldType;
-            }
-        }
-
-        /// <summary>
-        /// Analyzes a member and returns an instance of <see cref="TypeInformation"/>
-        /// containing information necessary to select a graph type. Nullable reference annotations
-        /// are read, if they exist, as well as the <see cref="RequiredAttribute"/> attribute.
-        /// Then any <see cref="GraphQLAttribute"/> attributes marked on the property are applied.
-        /// <br/><br/>
-        /// Override this method to enforce specific graph types for specific CLR types, or to implement custom
-        /// attributes to change graph type selection behavior.
-        /// </summary>
-        internal static TypeInformation GetTypeInformation(MemberInfo memberInfo, bool isInputType)
-        {
-            var typeInformation = memberInfo switch
-            {
-                PropertyInfo propertyInfo => new TypeInformation(propertyInfo, isInputType),
-                MethodInfo methodInfo when !isInputType => new TypeInformation(methodInfo),
-                FieldInfo fieldInfo => new TypeInformation(fieldInfo, isInputType),
-                _ => isInputType
-                    ? throw new ArgumentOutOfRangeException(nameof(memberInfo), "Only properties and fields are supported.")
-                    : throw new ArgumentOutOfRangeException(nameof(memberInfo), "Only properties, methods and fields are supported."),
-            };
-            typeInformation.ApplyAttributes();
-            return typeInformation;
-        }
-
-        /// <summary>
-        /// Analyzes a method argument and returns an instance of <see cref="TypeInformation"/>
-        /// containing information necessary to select a graph type. Nullable reference annotations
-        /// are read, if they exist, as well as the <see cref="RequiredAttribute"/> attribute.
-        /// Then any <see cref="GraphQLAttribute"/> attributes marked on the property are applied.
-        /// <br/><br/>
-        /// Override this method to enforce specific graph types for specific CLR types, or to implement custom
-        /// attributes to change graph type selection behavior.
-        /// </summary>
-        internal static TypeInformation GetTypeInformation(ParameterInfo parameterInfo)
+    private static IList<LambdaExpression> BuildFieldResolver_BuildMethodArguments(MethodInfo methodInfo, Type? sourceType, FieldType? fieldType)
+    {
+        List<LambdaExpression> expressions = new();
+        foreach (var parameterInfo in methodInfo.GetParameters())
         {
             var typeInformation = new TypeInformation(parameterInfo);
-            typeInformation.ApplyAttributes();
-            return typeInformation;
-        }
-
-        /// <summary>
-        /// Identifies the constructor to use when constructing instances of <typeparamref name="TSourceType"/>.
-        /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
-        /// parameterless constructor, or the only public contructor, or returns <see langword="null"/> otherwise.
-        /// </summary>
-        internal static ConstructorInfo? GetConstructorOrDefault<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSourceType>()
-            => GetConstructorOrDefault(typeof(TSourceType));
-
-        /// <summary>
-        /// Identifies the constructor to use when constructing instances of <paramref name="sourceType"/>.
-        /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
-        /// parameterless constructor, or the only public contructor, or returns <see langword="null"/> otherwise.
-        /// </summary>
-        internal static ConstructorInfo? GetConstructorOrDefault([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type sourceType)
-        {
-            var constructors = sourceType.GetConstructors();
-            // if there are no public constructors, return null
-            if (constructors == null || constructors.Length == 0)
-                return null;
-            // if there is only one public constructor, return it
-            if (constructors.Length == 1)
-                return constructors[0];
-            // if there are multiple public constructors, return the one marked with GraphQLConstructorAttribute, or the parameterless constructor, or null
-            ConstructorInfo? match = null;
-            ConstructorInfo? parameterless = null;
-            foreach (var constructor in constructors)
+            typeInformation.ApplyAttributes(); // typically this is unnecessary, since this is primarily used to control the graph type of generated query arguments
+            var argumentInfo = new ArgumentInformation(parameterInfo, sourceType, fieldType, typeInformation);
+            argumentInfo.ApplyAttributes(); // necessary to allow [FromSource], [FromServices] and similar attributes to work
+            var (queryArgument, expression) = argumentInfo.ConstructQueryArgument();
+            if (queryArgument != null)
             {
-                if (constructor.GetCustomAttribute<GraphQLConstructorAttribute>() != null)
-                {
-                    if (match != null)
-                        throw new InvalidOperationException($"Multiple constructors marked with {nameof(GraphQLConstructorAttribute)} found on type '{sourceType.GetFriendlyName()}'.");
-                    match = constructor;
-                }
-                if (constructor.GetParameters().Length == 0)
-                {
-                    parameterless = constructor;
-                }
+                // even though the query argument is not used, it is necessary to apply attributes to the generated argument in case the name is overridden,
+                // as the generated query argument's name is used within the expression for the call to GetArgument
+                var attributes = parameterInfo.GetGraphQLAttributes();
+                foreach (var attr in attributes)
+                    attr.Modify(queryArgument);
             }
-            return match ?? parameterless;
+            expression ??= GetParameterExpression(
+                parameterInfo.ParameterType,
+                queryArgument ?? throw new InvalidOperationException("Invalid response from ConstructQueryArgument: queryArgument and expression cannot both be null"));
+            expressions.Add(expression);
+        }
+        return expressions;
+    }
+
+    /// <summary>
+    /// Builds the following instance expression:
+    /// <code>context =&gt; context.Source as TSourceType ?? (context.RequestServices ?? serviceProvider).GetService(sourceType) ?? throw new InvalidOperationException(...)</code>
+    /// </summary>
+    internal static LambdaExpression BuildInstanceExpressionForSchemaBuilder(Type sourceType, IServiceProvider serviceProvider)
+    {
+        // exception cannot occur here, so don't worry catching TargetInvokeException
+        return (LambdaExpression)_buildSourceExpressionForSchemaBuilderInternalMethodInfo
+            .MakeGenericMethod(sourceType)
+            .Invoke(null, new object[] { serviceProvider })!;
+    }
+
+    private static readonly MethodInfo _buildSourceExpressionForSchemaBuilderInternalMethodInfo = typeof(AutoRegisteringHelper).GetMethod(nameof(BuildSourceExpressionForSchemaBuilderInternal), BindingFlags.Static | BindingFlags.NonPublic)!;
+    private static Expression<Func<IResolveFieldContext, T>> BuildSourceExpressionForSchemaBuilderInternal<T>(IServiceProvider serviceProvider)
+        => context => BuildSourceExpressionForSchemaBuilderInternal_GetSource<T>(context, serviceProvider);
+    private static T BuildSourceExpressionForSchemaBuilderInternal_GetSource<T>(IResolveFieldContext context, IServiceProvider serviceProvider)
+    {
+        var source = context.Source;
+
+        var target = typeof(T).IsInstanceOfType(source)
+            ? (T)source!
+            : (T?)(context.RequestServices ?? serviceProvider).GetService(typeof(T));
+
+        if (target == null)
+        {
+            var parentType = context.ParentType != null ? $"{context.ParentType.Name}." : null;
+            throw new InvalidOperationException($"Could not resolve an instance of {typeof(T).Name} to execute {parentType}{context.FieldAst.Name}");
         }
 
-        /// <summary>
-        /// Identifies the constructor to use when constructing instances of <paramref name="sourceType"/>.
-        /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
-        /// parameterless constructor, or the only public contructor, or throws an exception otherwise.
-        /// </summary>
-        internal static ConstructorInfo GetConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type sourceType)
+        return target;
+    }
+
+    /// <summary>
+    /// Scans a specific CLR type for <see cref="GraphQLAttribute"/> attributes and applies
+    /// them to the specified <see cref="IGraphType"/>.
+    /// Also scans the CLR type's owning module and assembly for globally-applied attributes.
+    /// </summary>
+    internal static void ApplyGraphQLAttributes<TSourceType>(IGraphType graphType)
+    {
+        // Description and deprecation reason are already set in ComplexGraphType<TSourceType> constructor
+
+        // Apply derivatives of GraphQLAttribute
+        var attributes = typeof(TSourceType).GetGraphQLAttributes();
+        foreach (var attr in attributes)
         {
-            var ret = GetConstructorOrDefault(sourceType);
-            // if there are no valid constructors, throw the proper exception
-            if (ret == null)
-            {
-                if (sourceType.GetConstructors().Length == 0)
-                    throw new InvalidOperationException($"No public constructors found on CLR type '{sourceType.GetFriendlyName()}'.");
-                else
-                    throw new InvalidOperationException($"CLR type '{sourceType.GetFriendlyName()}' must have a public parameterless constructor, a single constructor, or a public constructor marked with " + nameof(GraphQLConstructorAttribute) + ".");
-            }
-            return ret;
+            attr.Modify(graphType);
         }
+    }
+
+    /// <summary>
+    /// Filters an enumeration of <see cref="PropertyInfo"/> values to exclude specified properties.
+    /// </summary>
+    internal static IEnumerable<PropertyInfo> ExcludeProperties<TSourceType>(IEnumerable<PropertyInfo> properties, params Expression<Func<TSourceType, object?>>[]? excludedProperties)
+        => excludedProperties == null || excludedProperties.Length == 0
+            ? properties
+            : properties.Where(propertyInfo => !excludedProperties!.Any(p => GetPropertyName(p) == propertyInfo.Name));
+
+    /// <summary>
+    /// Creates a <see cref="FieldType"/> for the specified <see cref="MemberInfo"/>.
+    /// </summary>
+    internal static FieldType CreateField(MemberInfo memberInfo, Func<MemberInfo, TypeInformation> getTypeInformation, Action<FieldType, MemberInfo>? buildFieldType, bool isInputType)
+    {
+        var typeInformation = getTypeInformation(memberInfo);
+        var graphType = typeInformation.ConstructGraphType();
+        var fieldType = CreateField(memberInfo, graphType, isInputType);
+        // set resolver, if applicable
+        buildFieldType?.Invoke(fieldType, memberInfo);
+        // apply field attributes after resolver has been set
+        ApplyFieldAttributes(memberInfo, fieldType, isInputType);
+        return fieldType;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="FieldType"/> for the specified <see cref="MemberInfo"/>.
+    /// </summary>
+    internal static FieldType CreateField(MemberInfo memberInfo, Type graphType, bool isInputType)
+    {
+        var fieldType = new FieldType()
+        {
+            Name = memberInfo.Name,
+            Description = memberInfo.Description(),
+            DeprecationReason = memberInfo.ObsoleteMessage(),
+            Type = graphType,
+            DefaultValue = isInputType ? memberInfo.DefaultValue() : null,
+        };
+        if (isInputType)
+        {
+            fieldType.WithMetadata(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME, memberInfo.Name);
+            var memberType = memberInfo is PropertyInfo propertyInfo ? propertyInfo.PropertyType : ((FieldInfo)memberInfo).FieldType;
+            fieldType.Parser = value => memberType.IsInstanceOfType(value) ? value : value.GetPropertyValue(memberType, fieldType.ResolvedType!)!;
+        }
+        if (!isInputType &&
+            memberInfo is MethodInfo methodInfo &&
+            fieldType.Name.EndsWith("Async") &&
+            methodInfo.ReturnType.IsGenericType &&
+            methodInfo.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
+        {
+            fieldType.Name = fieldType.Name.Substring(0, fieldType.Name.Length - 5);
+        }
+
+        return fieldType;
+    }
+
+    /// <summary>
+    /// Applies <see cref="GraphQLAttribute"/>s defined on <paramref name="memberInfo"/> to <paramref name="fieldType"/>.
+    /// Also scans the member's owning module and assembly for globally-applied attributes.
+    /// </summary>
+    internal static void ApplyFieldAttributes(MemberInfo memberInfo, FieldType fieldType, bool isInputType)
+    {
+        // Apply derivatives of GraphQLAttribute
+        var attributes = memberInfo.GetGraphQLAttributes();
+        foreach (var attr in attributes)
+        {
+            attr.Modify(fieldType, isInputType);
+        }
+    }
+
+    private static string GetPropertyName<TSourceType>(Expression<Func<TSourceType, object?>> expression)
+    {
+        if (expression.Body is MemberExpression m1)
+            return m1.Member.Name;
+
+        if (expression.Body is UnaryExpression u && u.Operand is MemberExpression m2)
+            return m2.Member.Name;
+
+        throw new NotSupportedException($"Unsupported type of expression: {expression.GetType().Name}");
+    }
+
+    /// <summary>
+    /// Constructs a lambda expression for a field resolver to return the specified query argument
+    /// from the resolve context. The returned lambda is similar to the following:
+    /// <code>context =&gt; context.GetArgument&lt;T&gt;(queryArgument.Name, queryArgument.DefaultValue)</code>
+    /// </summary>
+    internal static LambdaExpression GetParameterExpression(Type parameterType, QueryArgument queryArgument)
+    {
+        //construct a typed call to AutoRegisteringHelper.GetArgumentInternal, passing in queryArgument
+        var getArgumentMethodTyped = _getArgumentMethod.MakeGenericMethod(parameterType);
+        var resolveFieldContextParameter = Expression.Parameter(typeof(IResolveFieldContext), "context");
+        var queryArgumentExpression = Expression.Constant(queryArgument, typeof(QueryArgument));
+        //e.g. Func<IResolveFieldContext, int> = (context) => AutoRegisteringHelper.GetArgumentInternal<int>(context, queryArgument);
+        var expr = Expression.Call(getArgumentMethodTyped, resolveFieldContextParameter, queryArgumentExpression);
+        return Expression.Lambda(expr, resolveFieldContextParameter);
+    }
+
+    private static readonly MethodInfo _getArgumentMethod = typeof(AutoRegisteringHelper).GetMethod(nameof(GetArgumentInternal), BindingFlags.NonPublic | BindingFlags.Static)!;
+    /// <summary>
+    /// Returns the value for the specified query argument, or <c>default(T)</c> if the argument
+    /// was not specified and the argument is not configured with a default value.
+    /// </summary>
+    private static T? GetArgumentInternal<T>(IResolveFieldContext context, QueryArgument queryArgument)
+    {
+        // note: if the query argument has a default value, TryGetArgumentExact will always return true
+        return context.TryGetArgumentExact(typeof(T), queryArgument.Name, out var value)
+            ? (T?)value
+            : default;
+    }
+
+    /// <summary>
+    /// Returns a list of <see cref="FieldType"/> instances representing the fields ready to be
+    /// added to the graph type.
+    /// </summary>
+    internal static IEnumerable<FieldType> ProvideFields(IEnumerable<MemberInfo> members, Func<MemberInfo, FieldType?> createField, bool isInputType)
+    {
+        foreach (var memberInfo in members)
+        {
+            bool include = true;
+            foreach (var attr in memberInfo.GetGraphQLAttributes())
+            {
+                include = attr.ShouldInclude(memberInfo, isInputType);
+                if (!include)
+                    break;
+            }
+            if (!include)
+                continue;
+            var fieldType = createField(memberInfo);
+            if (fieldType != null)
+                yield return fieldType;
+        }
+    }
+
+    /// <summary>
+    /// Analyzes a member and returns an instance of <see cref="TypeInformation"/>
+    /// containing information necessary to select a graph type. Nullable reference annotations
+    /// are read, if they exist, as well as the <see cref="RequiredAttribute"/> attribute.
+    /// Then any <see cref="GraphQLAttribute"/> attributes marked on the property are applied.
+    /// <br/><br/>
+    /// Override this method to enforce specific graph types for specific CLR types, or to implement custom
+    /// attributes to change graph type selection behavior.
+    /// </summary>
+    internal static TypeInformation GetTypeInformation(MemberInfo memberInfo, bool isInputType)
+    {
+        var typeInformation = memberInfo switch
+        {
+            PropertyInfo propertyInfo => new TypeInformation(propertyInfo, isInputType),
+            MethodInfo methodInfo when !isInputType => new TypeInformation(methodInfo),
+            FieldInfo fieldInfo => new TypeInformation(fieldInfo, isInputType),
+            _ => isInputType
+                ? throw new ArgumentOutOfRangeException(nameof(memberInfo), "Only properties and fields are supported.")
+                : throw new ArgumentOutOfRangeException(nameof(memberInfo), "Only properties, methods and fields are supported."),
+        };
+        typeInformation.ApplyAttributes();
+        return typeInformation;
+    }
+
+    /// <summary>
+    /// Analyzes a method argument and returns an instance of <see cref="TypeInformation"/>
+    /// containing information necessary to select a graph type. Nullable reference annotations
+    /// are read, if they exist, as well as the <see cref="RequiredAttribute"/> attribute.
+    /// Then any <see cref="GraphQLAttribute"/> attributes marked on the property are applied.
+    /// <br/><br/>
+    /// Override this method to enforce specific graph types for specific CLR types, or to implement custom
+    /// attributes to change graph type selection behavior.
+    /// </summary>
+    internal static TypeInformation GetTypeInformation(ParameterInfo parameterInfo)
+    {
+        var typeInformation = new TypeInformation(parameterInfo);
+        typeInformation.ApplyAttributes();
+        return typeInformation;
+    }
+
+    /// <summary>
+    /// Identifies the constructor to use when constructing instances of <typeparamref name="TSourceType"/>.
+    /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
+    /// parameterless constructor, or the only public contructor, or returns <see langword="null"/> otherwise.
+    /// </summary>
+    internal static ConstructorInfo? GetConstructorOrDefault<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSourceType>()
+        => GetConstructorOrDefault(typeof(TSourceType));
+
+    /// <summary>
+    /// Identifies the constructor to use when constructing instances of <paramref name="sourceType"/>.
+    /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
+    /// parameterless constructor, or the only public contructor, or returns <see langword="null"/> otherwise.
+    /// </summary>
+    internal static ConstructorInfo? GetConstructorOrDefault([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type sourceType)
+    {
+        var constructors = sourceType.GetConstructors();
+        // if there are no public constructors, return null
+        if (constructors == null || constructors.Length == 0)
+            return null;
+        // if there is only one public constructor, return it
+        if (constructors.Length == 1)
+            return constructors[0];
+        // if there are multiple public constructors, return the one marked with GraphQLConstructorAttribute, or the parameterless constructor, or null
+        ConstructorInfo? match = null;
+        ConstructorInfo? parameterless = null;
+        foreach (var constructor in constructors)
+        {
+            if (constructor.GetCustomAttribute<GraphQLConstructorAttribute>() != null)
+            {
+                if (match != null)
+                    throw new InvalidOperationException($"Multiple constructors marked with {nameof(GraphQLConstructorAttribute)} found on type '{sourceType.GetFriendlyName()}'.");
+                match = constructor;
+            }
+            if (constructor.GetParameters().Length == 0)
+            {
+                parameterless = constructor;
+            }
+        }
+        return match ?? parameterless;
+    }
+
+    /// <summary>
+    /// Identifies the constructor to use when constructing instances of <paramref name="sourceType"/>.
+    /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
+    /// parameterless constructor, or the only public contructor, or throws an exception otherwise.
+    /// </summary>
+    internal static ConstructorInfo GetConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type sourceType)
+    {
+        var ret = GetConstructorOrDefault(sourceType);
+        // if there are no valid constructors, throw the proper exception
+        if (ret == null)
+        {
+            if (sourceType.GetConstructors().Length == 0)
+                throw new InvalidOperationException($"No public constructors found on CLR type '{sourceType.GetFriendlyName()}'.");
+            else
+                throw new InvalidOperationException($"CLR type '{sourceType.GetFriendlyName()}' must have a public parameterless constructor, a single constructor, or a public constructor marked with " + nameof(GraphQLConstructorAttribute) + ".");
+        }
+        return ret;
     }
 }

--- a/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
@@ -4,126 +4,125 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+internal static class AutoRegisteringInputObjectGraphType
 {
-    internal static class AutoRegisteringInputObjectGraphType
+    public static ConcurrentDictionary<Type, IInputObjectGraphType> ReflectionCache { get; } = new();
+}
+
+/// <summary>
+/// Allows you to automatically register the necessary fields for the specified input type.
+/// Supports <see cref="DescriptionAttribute"/>, <see cref="ObsoleteAttribute"/>, <see cref="DefaultValueAttribute"/> and <see cref="RequiredAttribute"/>.
+/// Also it can get descriptions for fields from the XML comments.
+/// Note that now __InputValue has no isDeprecated and deprecationReason fields but in the future they may appear - https://github.com/graphql/graphql-spec/pull/525
+/// </summary>
+public class AutoRegisteringInputObjectGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)][NotAGraphType] TSourceType> : InputObjectGraphType<TSourceType>
+{
+    private readonly Expression<Func<TSourceType, object?>>[]? _excludedProperties;
+
+    /// <summary>
+    /// Creates a GraphQL type from <typeparamref name="TSourceType"/>.
+    /// <br/><br/>
+    /// When <see cref="GlobalSwitches.EnableReflectionCaching"/> is enabled (typically for scoped schemas),
+    /// be sure to place any custom initialization code within <see cref="ConfigureGraph"/> or <see cref="ProvideFields"/>
+    /// so that the instance will be cached with the customizations.
+    /// </summary>
+    public AutoRegisteringInputObjectGraphType() : this(null) { }
+
+    /// <summary>
+    /// Creates a GraphQL type from <typeparamref name="TSourceType"/> by specifying fields to exclude from registration.
+    /// </summary>
+    /// <param name="excludedProperties">Expressions for excluding fields, for example 'o => o.Age'.</param>
+    public AutoRegisteringInputObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
+        : this(
+            GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringInputObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry)
+                ? (AutoRegisteringInputObjectGraphType<TSourceType>?)cacheEntry
+                : null,
+            excludedProperties,
+            GlobalSwitches.EnableReflectionCaching)
     {
-        public static ConcurrentDictionary<Type, IInputObjectGraphType> ReflectionCache { get; } = new();
+    }
+
+    internal AutoRegisteringInputObjectGraphType(AutoRegisteringInputObjectGraphType<TSourceType>? cloneFrom, Expression<Func<TSourceType, object?>>[]? excludedProperties, bool cache)
+        : base(cloneFrom)
+    {
+        // if copying a cached instance, just return the instance
+        if (cloneFrom != null)
+            return;
+
+        _excludedProperties = excludedProperties;
+        Name = typeof(TSourceType).GraphQLName();
+        ConfigureGraph();
+        foreach (var fieldType in ProvideFields())
+        {
+            _ = AddField(fieldType);
+        }
+
+        // cache the instance if reflection caching is enabled
+        if (cache && excludedProperties == null)
+        {
+            foreach (var f in Fields.List)
+            {
+                if (f.ResolvedType != null)
+                    cache = false;
+            }
+
+            // cache the constructed object
+            if (cache)
+                AutoRegisteringInputObjectGraphType.ReflectionCache[typeof(TSourceType)] = new AutoRegisteringInputObjectGraphType<TSourceType>(this, null, false);
+        }
     }
 
     /// <summary>
-    /// Allows you to automatically register the necessary fields for the specified input type.
-    /// Supports <see cref="DescriptionAttribute"/>, <see cref="ObsoleteAttribute"/>, <see cref="DefaultValueAttribute"/> and <see cref="RequiredAttribute"/>.
-    /// Also it can get descriptions for fields from the XML comments.
-    /// Note that now __InputValue has no isDeprecated and deprecationReason fields but in the future they may appear - https://github.com/graphql/graphql-spec/pull/525
+    /// Applies default configuration settings to this graph type along with any <see cref="GraphQLAttribute"/> attributes marked on <typeparamref name="TSourceType"/>.
+    /// Allows the ability to override the default naming convention used by this class without affecting attributes applied directly to <typeparamref name="TSourceType"/>.
     /// </summary>
-    public class AutoRegisteringInputObjectGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)][NotAGraphType] TSourceType> : InputObjectGraphType<TSourceType>
+    protected virtual void ConfigureGraph()
     {
-        private readonly Expression<Func<TSourceType, object?>>[]? _excludedProperties;
-
-        /// <summary>
-        /// Creates a GraphQL type from <typeparamref name="TSourceType"/>.
-        /// <br/><br/>
-        /// When <see cref="GlobalSwitches.EnableReflectionCaching"/> is enabled (typically for scoped schemas),
-        /// be sure to place any custom initialization code within <see cref="ConfigureGraph"/> or <see cref="ProvideFields"/>
-        /// so that the instance will be cached with the customizations.
-        /// </summary>
-        public AutoRegisteringInputObjectGraphType() : this(null) { }
-
-        /// <summary>
-        /// Creates a GraphQL type from <typeparamref name="TSourceType"/> by specifying fields to exclude from registration.
-        /// </summary>
-        /// <param name="excludedProperties">Expressions for excluding fields, for example 'o => o.Age'.</param>
-        public AutoRegisteringInputObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
-            : this(
-                GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringInputObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry)
-                    ? (AutoRegisteringInputObjectGraphType<TSourceType>?)cacheEntry
-                    : null,
-                excludedProperties,
-                GlobalSwitches.EnableReflectionCaching)
-        {
-        }
-
-        internal AutoRegisteringInputObjectGraphType(AutoRegisteringInputObjectGraphType<TSourceType>? cloneFrom, Expression<Func<TSourceType, object?>>[]? excludedProperties, bool cache)
-            : base(cloneFrom)
-        {
-            // if copying a cached instance, just return the instance
-            if (cloneFrom != null)
-                return;
-
-            _excludedProperties = excludedProperties;
-            Name = typeof(TSourceType).GraphQLName();
-            ConfigureGraph();
-            foreach (var fieldType in ProvideFields())
-            {
-                _ = AddField(fieldType);
-            }
-
-            // cache the instance if reflection caching is enabled
-            if (cache && excludedProperties == null)
-            {
-                foreach (var f in Fields.List)
-                {
-                    if (f.ResolvedType != null)
-                        cache = false;
-                }
-
-                // cache the constructed object
-                if (cache)
-                    AutoRegisteringInputObjectGraphType.ReflectionCache[typeof(TSourceType)] = new AutoRegisteringInputObjectGraphType<TSourceType>(this, null, false);
-            }
-        }
-
-        /// <summary>
-        /// Applies default configuration settings to this graph type along with any <see cref="GraphQLAttribute"/> attributes marked on <typeparamref name="TSourceType"/>.
-        /// Allows the ability to override the default naming convention used by this class without affecting attributes applied directly to <typeparamref name="TSourceType"/>.
-        /// </summary>
-        protected virtual void ConfigureGraph()
-        {
-            AutoRegisteringHelper.ApplyGraphQLAttributes<TSourceType>(this);
-        }
-
-        /// <inheritdoc cref="AutoRegisteringHelper.ProvideFields(IEnumerable{MemberInfo}, Func{MemberInfo, FieldType?}, bool)"/>
-        protected virtual IEnumerable<FieldType> ProvideFields()
-            => AutoRegisteringHelper.ProvideFields(GetRegisteredMembers(), CreateField, true);
-
-        /// <summary>
-        /// Processes the specified property or field and returns a <see cref="FieldType"/>.
-        /// May return <see langword="null"/> to skip a property.
-        /// </summary>
-        protected virtual FieldType? CreateField(MemberInfo memberInfo)
-            => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, null, true);
-
-        /// <summary>
-        /// Returns a list of properties or fields that should have fields created for them.
-        /// Unless overridden, returns a list of public instance writable properties,
-        /// including properties on inherited classes.
-        /// </summary>
-        protected virtual IEnumerable<MemberInfo> GetRegisteredMembers()
-        {
-            // determine which constructor will be used to create the object, or null if unknown (perhaps due to overriding ParseDictionary)
-            var constructor = AutoRegisteringHelper.GetConstructorOrDefault<TSourceType>();
-            // get constructor's parameters
-            var constructorParameters = constructor?.GetParameters();
-            // get constructor's parameter names
-            var parameters = constructorParameters == null || constructorParameters.Length == 0 ? null : constructorParameters.Select(x => x.Name).ToArray();
-            // define PropertyInfo predicate based on whether the constructor has any parameters
-            Func<PropertyInfo, bool> predicate = parameters == null
-                // any writable property
-                ? static x => x.SetMethod?.IsPublic ?? false
-                // any writable property, or any read-only property that has a constructor parameter
-                : x => (x.SetMethod?.IsPublic ?? false) || parameters.Contains(x.Name, StringComparer.InvariantCultureIgnoreCase);
-            // return the list of properties, excluding ones specifically specified in the AutoRegisteringInputGraphType constructor
-            return AutoRegisteringHelper.ExcludeProperties(
-                typeof(TSourceType).GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(predicate),
-                _excludedProperties);
-        }
-
-        /// <inheritdoc cref="AutoRegisteringHelper.GetTypeInformation(MemberInfo, bool)"/>
-        /// <remarks>
-        /// Only properties and fields are supported.
-        /// </remarks>
-        protected virtual TypeInformation GetTypeInformation(MemberInfo memberInfo)
-            => AutoRegisteringHelper.GetTypeInformation(memberInfo, true);
+        AutoRegisteringHelper.ApplyGraphQLAttributes<TSourceType>(this);
     }
+
+    /// <inheritdoc cref="AutoRegisteringHelper.ProvideFields(IEnumerable{MemberInfo}, Func{MemberInfo, FieldType?}, bool)"/>
+    protected virtual IEnumerable<FieldType> ProvideFields()
+        => AutoRegisteringHelper.ProvideFields(GetRegisteredMembers(), CreateField, true);
+
+    /// <summary>
+    /// Processes the specified property or field and returns a <see cref="FieldType"/>.
+    /// May return <see langword="null"/> to skip a property.
+    /// </summary>
+    protected virtual FieldType? CreateField(MemberInfo memberInfo)
+        => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, null, true);
+
+    /// <summary>
+    /// Returns a list of properties or fields that should have fields created for them.
+    /// Unless overridden, returns a list of public instance writable properties,
+    /// including properties on inherited classes.
+    /// </summary>
+    protected virtual IEnumerable<MemberInfo> GetRegisteredMembers()
+    {
+        // determine which constructor will be used to create the object, or null if unknown (perhaps due to overriding ParseDictionary)
+        var constructor = AutoRegisteringHelper.GetConstructorOrDefault<TSourceType>();
+        // get constructor's parameters
+        var constructorParameters = constructor?.GetParameters();
+        // get constructor's parameter names
+        var parameters = constructorParameters == null || constructorParameters.Length == 0 ? null : constructorParameters.Select(x => x.Name).ToArray();
+        // define PropertyInfo predicate based on whether the constructor has any parameters
+        Func<PropertyInfo, bool> predicate = parameters == null
+            // any writable property
+            ? static x => x.SetMethod?.IsPublic ?? false
+            // any writable property, or any read-only property that has a constructor parameter
+            : x => (x.SetMethod?.IsPublic ?? false) || parameters.Contains(x.Name, StringComparer.InvariantCultureIgnoreCase);
+        // return the list of properties, excluding ones specifically specified in the AutoRegisteringInputGraphType constructor
+        return AutoRegisteringHelper.ExcludeProperties(
+            typeof(TSourceType).GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(predicate),
+            _excludedProperties);
+    }
+
+    /// <inheritdoc cref="AutoRegisteringHelper.GetTypeInformation(MemberInfo, bool)"/>
+    /// <remarks>
+    /// Only properties and fields are supported.
+    /// </remarks>
+    protected virtual TypeInformation GetTypeInformation(MemberInfo memberInfo)
+        => AutoRegisteringHelper.GetTypeInformation(memberInfo, true);
 }

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -4,166 +4,165 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+internal static class AutoRegisteringObjectGraphType
 {
-    internal static class AutoRegisteringObjectGraphType
+    public static ConcurrentDictionary<Type, IObjectGraphType> ReflectionCache { get; } = new();
+}
+
+/// <summary>
+/// Allows you to automatically register the necessary fields for the specified type.
+/// Supports <see cref="DescriptionAttribute"/>, <see cref="ObsoleteAttribute"/>, <see cref="DefaultValueAttribute"/> and <see cref="RequiredAttribute"/>.
+/// Also it can get descriptions for fields from the XML comments.
+/// </summary>
+public class AutoRegisteringObjectGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)][NotAGraphType] TSourceType> : ObjectGraphType<TSourceType>
+{
+    private readonly Expression<Func<TSourceType, object?>>[]? _excludedProperties;
+
+    /// <summary>
+    /// Creates a GraphQL type from <typeparamref name="TSourceType"/>.
+    /// <br/><br/>
+    /// When <see cref="GlobalSwitches.EnableReflectionCaching"/> is enabled (typically for scoped schemas),
+    /// be sure to place any custom initialization code within <see cref="ConfigureGraph"/> or <see cref="ProvideFields"/>
+    /// so that the instance will be cached with the customizations. Also note that <see cref="ObjectGraphType{TSourceType}.Interfaces"/>
+    /// will reference a shared instance of <see cref="Interfaces"/> when restored from the cache and must not be modified further.
+    /// </summary>
+    public AutoRegisteringObjectGraphType() : this(null) { }
+
+    /// <summary>
+    /// Creates a GraphQL type from <typeparamref name="TSourceType"/> by specifying fields to exclude from registration.
+    /// </summary>
+    /// <param name="excludedProperties">Expressions for excluding fields, for example 'o => o.Age'.</param>
+    public AutoRegisteringObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
+        : this(
+            GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry)
+                ? (AutoRegisteringObjectGraphType<TSourceType>?)cacheEntry
+                : null,
+            excludedProperties,
+            GlobalSwitches.EnableReflectionCaching)
     {
-        public static ConcurrentDictionary<Type, IObjectGraphType> ReflectionCache { get; } = new();
+    }
+
+    internal AutoRegisteringObjectGraphType(AutoRegisteringObjectGraphType<TSourceType>? cloneFrom, Expression<Func<TSourceType, object?>>[]? excludedProperties, bool cache)
+        : base(cloneFrom)
+    {
+        // if copying a cached instance, just return the instance
+        if (cloneFrom != null)
+            return;
+
+        _excludedProperties = excludedProperties;
+        Name = typeof(TSourceType).GraphQLName();
+        ConfigureGraph();
+        foreach (var fieldType in ProvideFields())
+        {
+            _ = AddField(fieldType);
+        }
+
+        // cache the instance if reflection caching is enabled
+        if (cache &&
+            excludedProperties == null &&
+            ResolvedInterfaces.Count == 0)
+        {
+            foreach (var f in Fields.List)
+            {
+                if (f.ResolvedType != null)
+                    cache = false;
+
+                if (f.Arguments?.List != null)
+                {
+                    foreach (var a in f.Arguments.List)
+                    {
+                        if (a.ResolvedType != null || a.Type == null)
+                            cache = false;
+                    }
+                }
+            }
+
+            // cache the constructed object
+            if (cache)
+                AutoRegisteringObjectGraphType.ReflectionCache[typeof(TSourceType)] = new AutoRegisteringObjectGraphType<TSourceType>(this, null, false);
+        }
     }
 
     /// <summary>
-    /// Allows you to automatically register the necessary fields for the specified type.
-    /// Supports <see cref="DescriptionAttribute"/>, <see cref="ObsoleteAttribute"/>, <see cref="DefaultValueAttribute"/> and <see cref="RequiredAttribute"/>.
-    /// Also it can get descriptions for fields from the XML comments.
+    /// Applies default configuration settings to this graph type along with any <see cref="GraphQLAttribute"/> attributes marked on <typeparamref name="TSourceType"/>.
+    /// Allows the ability to override the default naming convention used by this class without affecting attributes applied directly to <typeparamref name="TSourceType"/>.
     /// </summary>
-    public class AutoRegisteringObjectGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)][NotAGraphType] TSourceType> : ObjectGraphType<TSourceType>
+    protected virtual void ConfigureGraph()
     {
-        private readonly Expression<Func<TSourceType, object?>>[]? _excludedProperties;
-
-        /// <summary>
-        /// Creates a GraphQL type from <typeparamref name="TSourceType"/>.
-        /// <br/><br/>
-        /// When <see cref="GlobalSwitches.EnableReflectionCaching"/> is enabled (typically for scoped schemas),
-        /// be sure to place any custom initialization code within <see cref="ConfigureGraph"/> or <see cref="ProvideFields"/>
-        /// so that the instance will be cached with the customizations. Also note that <see cref="ObjectGraphType{TSourceType}.Interfaces"/>
-        /// will reference a shared instance of <see cref="Interfaces"/> when restored from the cache and must not be modified further.
-        /// </summary>
-        public AutoRegisteringObjectGraphType() : this(null) { }
-
-        /// <summary>
-        /// Creates a GraphQL type from <typeparamref name="TSourceType"/> by specifying fields to exclude from registration.
-        /// </summary>
-        /// <param name="excludedProperties">Expressions for excluding fields, for example 'o => o.Age'.</param>
-        public AutoRegisteringObjectGraphType(params Expression<Func<TSourceType, object?>>[]? excludedProperties)
-            : this(
-                GlobalSwitches.EnableReflectionCaching && excludedProperties == null && AutoRegisteringObjectGraphType.ReflectionCache.TryGetValue(typeof(TSourceType), out var cacheEntry)
-                    ? (AutoRegisteringObjectGraphType<TSourceType>?)cacheEntry
-                    : null,
-                excludedProperties,
-                GlobalSwitches.EnableReflectionCaching)
-        {
-        }
-
-        internal AutoRegisteringObjectGraphType(AutoRegisteringObjectGraphType<TSourceType>? cloneFrom, Expression<Func<TSourceType, object?>>[]? excludedProperties, bool cache)
-            : base(cloneFrom)
-        {
-            // if copying a cached instance, just return the instance
-            if (cloneFrom != null)
-                return;
-
-            _excludedProperties = excludedProperties;
-            Name = typeof(TSourceType).GraphQLName();
-            ConfigureGraph();
-            foreach (var fieldType in ProvideFields())
-            {
-                _ = AddField(fieldType);
-            }
-
-            // cache the instance if reflection caching is enabled
-            if (cache &&
-                excludedProperties == null &&
-                ResolvedInterfaces.Count == 0)
-            {
-                foreach (var f in Fields.List)
-                {
-                    if (f.ResolvedType != null)
-                        cache = false;
-
-                    if (f.Arguments?.List != null)
-                    {
-                        foreach (var a in f.Arguments.List)
-                        {
-                            if (a.ResolvedType != null || a.Type == null)
-                                cache = false;
-                        }
-                    }
-                }
-
-                // cache the constructed object
-                if (cache)
-                    AutoRegisteringObjectGraphType.ReflectionCache[typeof(TSourceType)] = new AutoRegisteringObjectGraphType<TSourceType>(this, null, false);
-            }
-        }
-
-        /// <summary>
-        /// Applies default configuration settings to this graph type along with any <see cref="GraphQLAttribute"/> attributes marked on <typeparamref name="TSourceType"/>.
-        /// Allows the ability to override the default naming convention used by this class without affecting attributes applied directly to <typeparamref name="TSourceType"/>.
-        /// </summary>
-        protected virtual void ConfigureGraph()
-        {
-            AutoRegisteringHelper.ApplyGraphQLAttributes<TSourceType>(this);
-        }
-
-        /// <inheritdoc cref="AutoRegisteringHelper.ProvideFields(IEnumerable{MemberInfo}, Func{MemberInfo, FieldType?}, bool)"/>
-        protected virtual IEnumerable<FieldType> ProvideFields()
-            => AutoRegisteringHelper.ProvideFields(GetRegisteredMembers(), CreateField, false);
-
-        /// <summary>
-        /// Processes the specified member and returns a <see cref="FieldType"/>.
-        /// May return <see langword="null"/> to skip a member.
-        /// </summary>
-        protected virtual FieldType? CreateField(MemberInfo memberInfo)
-            => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, BuildFieldType, false);
-
-        /// <inheritdoc cref="AutoRegisteringOutputHelper.BuildFieldType(MemberInfo, FieldType, Func{MemberInfo, LambdaExpression}, Func{Type, Func{FieldType, ParameterInfo, ArgumentInformation}}, Action{ParameterInfo, QueryArgument})"/>
-        protected void BuildFieldType(FieldType fieldType, MemberInfo memberInfo)
-        {
-            Func<Type, Func<FieldType, ParameterInfo, ArgumentInformation>> getTypedArgumentInfoMethod =
-                parameterType =>
-                {
-                    var getArgumentInfoMethodInfo = _getArgumentInformationInternalMethodInfo.MakeGenericMethod(parameterType);
-                    return (Func<FieldType, ParameterInfo, ArgumentInformation>)getArgumentInfoMethodInfo.CreateDelegate(typeof(Func<FieldType, ParameterInfo, ArgumentInformation>), this);
-                };
-
-            AutoRegisteringOutputHelper.BuildFieldType(
-                memberInfo,
-                fieldType,
-                BuildMemberInstanceExpression,
-                getTypedArgumentInfoMethod,
-                ApplyArgumentAttributes);
-        }
-
-        /// <summary>
-        /// Returns a lambda expression that will be used by the field resolver to access the member.
-        /// <br/><br/>
-        /// Typically this is a lambda expression of type <see cref="Func{T, TResult}">Func</see>&lt;<see cref="IResolveFieldContext"/>, <typeparamref name="TSourceType"/>&gt;.
-        /// <br/><br/>
-        /// By default this returns the <see cref="IResolveFieldContext.Source"/> property.
-        /// </summary>
-        /// <param name="memberInfo">The member being called or accessed.</param>
-        protected virtual LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo)
-            => _sourceExpression;
-
-        private static readonly Expression<Func<IResolveFieldContext, TSourceType>> _sourceExpression
-            = context => (TSourceType)(context.Source ?? ThrowSourceNullException());
-
-        private static object ThrowSourceNullException()
-        {
-            throw new InvalidOperationException("IResolveFieldContext.Source is null; please use static methods when using an AutoRegisteringObjectGraphType as a root graph type or provide a root value.");
-        }
-
-        private static readonly MethodInfo _getArgumentInformationInternalMethodInfo = typeof(AutoRegisteringObjectGraphType<TSourceType>).GetMethod(nameof(GetArgumentInformationInternal), BindingFlags.NonPublic | BindingFlags.Instance)!;
-        private ArgumentInformation GetArgumentInformationInternal<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)
-            => GetArgumentInformation<TParameterType>(fieldType, parameterInfo);
-
-        /// <inheritdoc cref="AutoRegisteringOutputHelper.ApplyArgumentAttributes(ParameterInfo, QueryArgument)"/>
-        protected virtual void ApplyArgumentAttributes(ParameterInfo parameterInfo, QueryArgument queryArgument)
-            => AutoRegisteringOutputHelper.ApplyArgumentAttributes(parameterInfo, queryArgument);
-
-        /// <inheritdoc cref="AutoRegisteringOutputHelper.GetArgumentInformation{TSourceType}(TypeInformation, FieldType, ParameterInfo)"/>
-        protected virtual ArgumentInformation GetArgumentInformation<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)
-            => AutoRegisteringOutputHelper.GetArgumentInformation<TSourceType>(GetTypeInformation(parameterInfo), fieldType, parameterInfo);
-
-        /// <inheritdoc cref="AutoRegisteringOutputHelper.GetRegisteredMembers{TSourceType}(Expression{Func{TSourceType, object?}}[])"/>
-        protected virtual IEnumerable<MemberInfo> GetRegisteredMembers()
-            => AutoRegisteringOutputHelper.GetRegisteredMembers(_excludedProperties);
-
-        /// <inheritdoc cref="AutoRegisteringHelper.GetTypeInformation(MemberInfo, bool)"/>
-        protected virtual TypeInformation GetTypeInformation(MemberInfo memberInfo)
-            => AutoRegisteringHelper.GetTypeInformation(memberInfo, false);
-
-        /// <inheritdoc cref="AutoRegisteringHelper.GetTypeInformation(ParameterInfo)"/>
-        protected virtual TypeInformation GetTypeInformation(ParameterInfo parameterInfo)
-            => AutoRegisteringHelper.GetTypeInformation(parameterInfo);
+        AutoRegisteringHelper.ApplyGraphQLAttributes<TSourceType>(this);
     }
+
+    /// <inheritdoc cref="AutoRegisteringHelper.ProvideFields(IEnumerable{MemberInfo}, Func{MemberInfo, FieldType?}, bool)"/>
+    protected virtual IEnumerable<FieldType> ProvideFields()
+        => AutoRegisteringHelper.ProvideFields(GetRegisteredMembers(), CreateField, false);
+
+    /// <summary>
+    /// Processes the specified member and returns a <see cref="FieldType"/>.
+    /// May return <see langword="null"/> to skip a member.
+    /// </summary>
+    protected virtual FieldType? CreateField(MemberInfo memberInfo)
+        => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, BuildFieldType, false);
+
+    /// <inheritdoc cref="AutoRegisteringOutputHelper.BuildFieldType(MemberInfo, FieldType, Func{MemberInfo, LambdaExpression}, Func{Type, Func{FieldType, ParameterInfo, ArgumentInformation}}, Action{ParameterInfo, QueryArgument})"/>
+    protected void BuildFieldType(FieldType fieldType, MemberInfo memberInfo)
+    {
+        Func<Type, Func<FieldType, ParameterInfo, ArgumentInformation>> getTypedArgumentInfoMethod =
+            parameterType =>
+            {
+                var getArgumentInfoMethodInfo = _getArgumentInformationInternalMethodInfo.MakeGenericMethod(parameterType);
+                return (Func<FieldType, ParameterInfo, ArgumentInformation>)getArgumentInfoMethodInfo.CreateDelegate(typeof(Func<FieldType, ParameterInfo, ArgumentInformation>), this);
+            };
+
+        AutoRegisteringOutputHelper.BuildFieldType(
+            memberInfo,
+            fieldType,
+            BuildMemberInstanceExpression,
+            getTypedArgumentInfoMethod,
+            ApplyArgumentAttributes);
+    }
+
+    /// <summary>
+    /// Returns a lambda expression that will be used by the field resolver to access the member.
+    /// <br/><br/>
+    /// Typically this is a lambda expression of type <see cref="Func{T, TResult}">Func</see>&lt;<see cref="IResolveFieldContext"/>, <typeparamref name="TSourceType"/>&gt;.
+    /// <br/><br/>
+    /// By default this returns the <see cref="IResolveFieldContext.Source"/> property.
+    /// </summary>
+    /// <param name="memberInfo">The member being called or accessed.</param>
+    protected virtual LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo)
+        => _sourceExpression;
+
+    private static readonly Expression<Func<IResolveFieldContext, TSourceType>> _sourceExpression
+        = context => (TSourceType)(context.Source ?? ThrowSourceNullException());
+
+    private static object ThrowSourceNullException()
+    {
+        throw new InvalidOperationException("IResolveFieldContext.Source is null; please use static methods when using an AutoRegisteringObjectGraphType as a root graph type or provide a root value.");
+    }
+
+    private static readonly MethodInfo _getArgumentInformationInternalMethodInfo = typeof(AutoRegisteringObjectGraphType<TSourceType>).GetMethod(nameof(GetArgumentInformationInternal), BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private ArgumentInformation GetArgumentInformationInternal<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)
+        => GetArgumentInformation<TParameterType>(fieldType, parameterInfo);
+
+    /// <inheritdoc cref="AutoRegisteringOutputHelper.ApplyArgumentAttributes(ParameterInfo, QueryArgument)"/>
+    protected virtual void ApplyArgumentAttributes(ParameterInfo parameterInfo, QueryArgument queryArgument)
+        => AutoRegisteringOutputHelper.ApplyArgumentAttributes(parameterInfo, queryArgument);
+
+    /// <inheritdoc cref="AutoRegisteringOutputHelper.GetArgumentInformation{TSourceType}(TypeInformation, FieldType, ParameterInfo)"/>
+    protected virtual ArgumentInformation GetArgumentInformation<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)
+        => AutoRegisteringOutputHelper.GetArgumentInformation<TSourceType>(GetTypeInformation(parameterInfo), fieldType, parameterInfo);
+
+    /// <inheritdoc cref="AutoRegisteringOutputHelper.GetRegisteredMembers{TSourceType}(Expression{Func{TSourceType, object?}}[])"/>
+    protected virtual IEnumerable<MemberInfo> GetRegisteredMembers()
+        => AutoRegisteringOutputHelper.GetRegisteredMembers(_excludedProperties);
+
+    /// <inheritdoc cref="AutoRegisteringHelper.GetTypeInformation(MemberInfo, bool)"/>
+    protected virtual TypeInformation GetTypeInformation(MemberInfo memberInfo)
+        => AutoRegisteringHelper.GetTypeInformation(memberInfo, false);
+
+    /// <inheritdoc cref="AutoRegisteringHelper.GetTypeInformation(ParameterInfo)"/>
+    protected virtual TypeInformation GetTypeInformation(ParameterInfo parameterInfo)
+        => AutoRegisteringHelper.GetTypeInformation(parameterInfo);
 }

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -5,689 +5,688 @@ using GraphQL.Types.Relay;
 using GraphQL.Utilities;
 using GraphQLParser;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a default base class for all complex (that is, having their own properties) input and output graph types.
+/// </summary>
+public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType, IComplexGraphType
 {
-    /// <summary>
-    /// Represents a default base class for all complex (that is, having their own properties) input and output graph types.
-    /// </summary>
-    public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType, IComplexGraphType
+    internal const string ORIGINAL_EXPRESSION_PROPERTY_NAME = nameof(ORIGINAL_EXPRESSION_PROPERTY_NAME);
+
+    /// <inheritdoc/>
+    protected ComplexGraphType()
+        : this(null)
     {
-        internal const string ORIGINAL_EXPRESSION_PROPERTY_NAME = nameof(ORIGINAL_EXPRESSION_PROPERTY_NAME);
+    }
 
-        /// <inheritdoc/>
-        protected ComplexGraphType()
-            : this(null)
+    internal ComplexGraphType(ComplexGraphType<TSourceType>? cloneFrom)
+        : base(cloneFrom)
+    {
+        if (cloneFrom == null)
         {
+            if (typeof(IGraphType).IsAssignableFrom(typeof(TSourceType)) && GetType() != typeof(Introspection.__Type))
+                throw new InvalidOperationException($"Cannot use graph type '{typeof(TSourceType).Name}' as a model for graph type '{GetType().Name}'. Please use a model rather than a graph type for {nameof(TSourceType)}.");
+
+            Description ??= typeof(TSourceType).Description();
+            DeprecationReason ??= typeof(TSourceType).ObsoleteMessage();
+            return;
         }
 
-        internal ComplexGraphType(ComplexGraphType<TSourceType>? cloneFrom)
-            : base(cloneFrom)
+        Description = cloneFrom.Description;
+        DeprecationReason = cloneFrom.DeprecationReason;
+
+        foreach (var f in cloneFrom.Fields.List)
         {
-            if (cloneFrom == null)
+            var field = new FieldType()
             {
-                if (typeof(IGraphType).IsAssignableFrom(typeof(TSourceType)) && GetType() != typeof(Introspection.__Type))
-                    throw new InvalidOperationException($"Cannot use graph type '{typeof(TSourceType).Name}' as a model for graph type '{GetType().Name}'. Please use a model rather than a graph type for {nameof(TSourceType)}.");
+                Name = f.Name,
+                DeprecationReason = f.DeprecationReason,
+                DefaultValue = f.DefaultValue,
+                Description = f.Description,
+                Resolver = f.Resolver,
+                StreamResolver = f.StreamResolver,
+                Type = f.Type,
+            };
+            f.CopyMetadataTo(field);
+            if (f.ResolvedType != null)
+                throw new InvalidOperationException("Cannot clone field when ResolvedType is set.");
 
-                Description ??= typeof(TSourceType).Description();
-                DeprecationReason ??= typeof(TSourceType).ObsoleteMessage();
-                return;
-            }
-
-            Description = cloneFrom.Description;
-            DeprecationReason = cloneFrom.DeprecationReason;
-
-            foreach (var f in cloneFrom.Fields.List)
+            if (f.Arguments?.List != null && f.Arguments.List.Count > 0)
             {
-                var field = new FieldType()
+                var args = new QueryArguments();
+                foreach (var a in f.Arguments.List)
                 {
-                    Name = f.Name,
-                    DeprecationReason = f.DeprecationReason,
-                    DefaultValue = f.DefaultValue,
-                    Description = f.Description,
-                    Resolver = f.Resolver,
-                    StreamResolver = f.StreamResolver,
-                    Type = f.Type,
-                };
-                f.CopyMetadataTo(field);
-                if (f.ResolvedType != null)
-                    throw new InvalidOperationException("Cannot clone field when ResolvedType is set.");
-
-                if (f.Arguments?.List != null && f.Arguments.List.Count > 0)
-                {
-                    var args = new QueryArguments();
-                    foreach (var a in f.Arguments.List)
+                    var arg = new QueryArgument(a.Type!)
                     {
-                        var arg = new QueryArgument(a.Type!)
-                        {
-                            Name = a.Name,
-                            Description = a.Description,
-                            DefaultValue = a.DefaultValue,
-                            DeprecationReason = a.DeprecationReason,
-                        };
-                        a.CopyMetadataTo(arg);
-                        args.Add(arg);
-                    }
-                    field.Arguments = args;
+                        Name = a.Name,
+                        Description = a.Description,
+                        DefaultValue = a.DefaultValue,
+                        DeprecationReason = a.DeprecationReason,
+                    };
+                    a.CopyMetadataTo(arg);
+                    args.Add(arg);
                 }
-
-                Fields.Add(field);
+                field.Arguments = args;
             }
+
+            Fields.Add(field);
         }
+    }
 
-        /// <inheritdoc/>
-        public TypeFields Fields { get; } = new();
+    /// <inheritdoc/>
+    public TypeFields Fields { get; } = new();
 
-        /// <inheritdoc/>
-        public bool HasField(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-                return false;
-
-            // DO NOT USE LINQ ON HOT PATH
-            foreach (var field in Fields.List)
-            {
-                if (string.Equals(field.Name, name, StringComparison.Ordinal))
-                    return true;
-            }
-
+    /// <inheritdoc/>
+    public bool HasField(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
             return false;
+
+        // DO NOT USE LINQ ON HOT PATH
+        foreach (var field in Fields.List)
+        {
+            if (string.Equals(field.Name, name, StringComparison.Ordinal))
+                return true;
         }
 
-        /// <inheritdoc/>
-        public FieldType? GetField(ROM name)
-        {
-            // DO NOT USE LINQ ON HOT PATH
-            foreach (var field in Fields.List)
-            {
-                if (field.Name == name)
-                    return field;
-            }
+        return false;
+    }
 
-            return null;
+    /// <inheritdoc/>
+    public FieldType? GetField(ROM name)
+    {
+        // DO NOT USE LINQ ON HOT PATH
+        foreach (var field in Fields.List)
+        {
+            if (field.Name == name)
+                return field;
         }
 
-        /// <inheritdoc/>
-        public virtual FieldType AddField(FieldType fieldType)
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public virtual FieldType AddField(FieldType fieldType)
+    {
+        if (fieldType == null)
+            throw new ArgumentNullException(nameof(fieldType));
+
+        NameValidator.ValidateNameNotNull(fieldType.Name, NamedElement.Field);
+
+        if (!fieldType.ResolvedType.IsGraphQLTypeReference())
         {
-            if (fieldType == null)
-                throw new ArgumentNullException(nameof(fieldType));
-
-            NameValidator.ValidateNameNotNull(fieldType.Name, NamedElement.Field);
-
-            if (!fieldType.ResolvedType.IsGraphQLTypeReference())
-            {
-                if (this is IInputObjectGraphType)
-                {
-                    if (fieldType.ResolvedType != null ? fieldType.ResolvedType.IsInputType() == false : fieldType.Type?.IsInputType() == false)
-                        throw new ArgumentOutOfRangeException(nameof(fieldType),
-                            $"Input type '{Name ?? GetType().GetFriendlyName()}' can have fields only of input types: ScalarGraphType, EnumerationGraphType or IInputObjectGraphType. Field '{fieldType.Name}' has an output type.");
-                }
-                else
-                {
-                    if (fieldType.ResolvedType != null ? fieldType.ResolvedType.IsOutputType() == false : fieldType.Type?.IsOutputType() == false)
-                        throw new ArgumentOutOfRangeException(nameof(fieldType),
-                            $"Output type '{Name ?? GetType().GetFriendlyName()}' can have fields only of output types: ScalarGraphType, ObjectGraphType, InterfaceGraphType, UnionGraphType or EnumerationGraphType. Field '{fieldType.Name}' has an input type.");
-                }
-            }
-
-            if (HasField(fieldType.Name))
-            {
-                throw new ArgumentOutOfRangeException(nameof(fieldType),
-                    $"A field with the name '{fieldType.Name}' is already registered for GraphType '{Name ?? GetType().Name}'");
-            }
-
-            if (fieldType.ResolvedType == null)
-            {
-                if (fieldType.Type == null)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(fieldType),
-                        $"The declared field '{fieldType.Name ?? fieldType.GetType().GetFriendlyName()}' on '{Name ?? GetType().GetFriendlyName()}' requires a field '{nameof(fieldType.Type)}' when no '{nameof(fieldType.ResolvedType)}' is provided.");
-                }
-                else if (!fieldType.Type.IsGraphType())
-                {
-                    throw new ArgumentOutOfRangeException(nameof(fieldType),
-                        $"The declared Field type '{fieldType.Type.Name}' should derive from GraphType.");
-                }
-            }
-
-            Fields.Add(fieldType);
-
-            return fieldType;
-        }
-
-        /// <summary>
-        /// Creates a field builder used by Field() methods.
-        /// </summary>
-        [Obsolete("Please use the overload that accepts the name as the first argument.")]
-        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
-        {
-            return FieldBuilder<TSourceType, TReturnType>.Create(type);
-        }
-
-        /// <summary>
-        /// Creates a field builder used by Field() methods.
-        /// </summary>
-        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
-        {
-            return FieldBuilder<TSourceType, TReturnType>.Create(name, type);
-        }
-
-        /// <summary>
-        /// Creates a field builder used by Field() methods.
-        /// </summary>
-        [Obsolete("Please use the overload that accepts the name as the first argument.")]
-        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>(IGraphType type)
-        {
-            return FieldBuilder<TSourceType, TReturnType>.Create(type);
-        }
-
-        /// <summary>
-        /// Creates a field builder used by Field() methods.
-        /// </summary>
-        protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>(string name, IGraphType type)
-        {
-            return FieldBuilder<TSourceType, TReturnType>.Create(name, type);
-        }
-
-        /// <summary>
-        /// Adds a field with the specified properties to this graph type.
-        /// </summary>
-        /// <param name="type">The .NET type of the graph type of this field.</param>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="description">The description of the field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
-        /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
-        public FieldType Field(
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
-            string name,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, object?>? resolve = null,
-            string? deprecationReason = null)
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = type,
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, object>(resolve)
-                    : null
-            });
-        }
-
-        /// <summary>
-        /// Adds a field with the specified properties to this graph type.
-        /// </summary>
-        /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="description">The description of the field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
-        /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
-        public FieldType Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
-            string name,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, object?>? resolve = null,
-            string? deprecationReason = null)
-            where TGraphType : IGraphType
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = typeof(TGraphType),
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, object>(resolve)
-                    : null
-            });
-        }
-
-        /// <summary>
-        /// Adds a field with the specified properties to this graph type.
-        /// </summary>
-        /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="description">The description of the field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
-        /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
-        public FieldType FieldDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
-            string name,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Delegate? resolve = null,
-            string? deprecationReason = null)
-            where TGraphType : IGraphType
-        {
-            IFieldResolver? resolver = null;
-
-            if (resolve != null)
-            {
-                // create an instance expression that points to the instance represented by the delegate
-                // for instance, if the delegate represents obj.MyMethod,
-                // then the lambda would be: _ => obj
-                var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
-                var body = Expression.Constant(resolve.Target, resolve.Method.DeclaringType!);
-                var lambda = Expression.Lambda(body, param);
-                resolver = AutoRegisteringHelper.BuildFieldResolver(resolve.Method, null, null, lambda);
-            }
-
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = typeof(TGraphType),
-                Arguments = arguments,
-                Resolver = resolver,
-            });
-        }
-
-        /// <summary>
-        /// Adds a field with the specified properties to this graph type.
-        /// </summary>
-        /// <param name="type">The .NET type of the graph type of this field.</param>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="description">The description of the field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
-        /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
-        public FieldType FieldAsync(
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
-            string name,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, Task<object?>>? resolve = null,
-            string? deprecationReason = null)
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = type,
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, object>(context => new ValueTask<object?>(resolve(context)))
-                    : null
-            });
-        }
-
-        /// <summary>
-        /// Adds a field with the specified properties to this graph type.
-        /// </summary>
-        /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="description">The description of the field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
-        /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
-        public FieldType FieldAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
-            string name,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, Task<object?>>? resolve = null,
-            string? deprecationReason = null)
-            where TGraphType : IGraphType
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = typeof(TGraphType),
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, object>(context => new ValueTask<object?>(resolve(context)))
-                    : null
-            });
-        }
-
-        /// <summary>
-        /// Adds a field with the specified properties to this graph type.
-        /// </summary>
-        /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
-        /// <typeparam name="TReturnType">The type of the return value of the field resolver delegate.</typeparam>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="description">The description of the field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
-        /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
-        public FieldType FieldAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType, [NotAGraphType] TReturnType>(
-            string name,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, Task<TReturnType?>>? resolve = null,
-            string? deprecationReason = null)
-            where TGraphType : IGraphType
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = typeof(TGraphType),
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, TReturnType>(context => new ValueTask<TReturnType?>(resolve(context)))
-                    : null
-            });
-        }
-
-        /// <summary>
-        /// Adds a subscription field with the specified properties to this graph type.
-        /// </summary>
-        /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="description">The description of this field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. Data from an event stream is processed by this field resolver as the source before being passed to the field's children as the source. Typically this would be <c>context => context.Source</c>.</param>
-        /// <param name="subscribe">A source stream resolver delegate.</param>
-        /// <param name="deprecationReason">The deprecation reason for the field.</param>
-        /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
-        public FieldType FieldSubscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
-            string name,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, object?>? resolve = null, // TODO: remove?
-            Func<IResolveFieldContext, IObservable<object?>>? subscribe = null,
-            string? deprecationReason = null)
-            where TGraphType : IGraphType
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = typeof(TGraphType),
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, object>(resolve)
-                    : null,
-                StreamResolver = subscribe != null
-                    ? new SourceStreamResolver<object>(subscribe)
-                    : null
-            });
-        }
-
-        /// <summary>
-        /// Adds a subscription field with the specified properties to this graph type.
-        /// </summary>
-        /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="description">The description of this field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. Data from an event stream is processed by this field resolver as the source before being passed to the field's children as the source. Typically this would be <c>context => context.Source</c>.</param>
-        /// <param name="subscribeAsync">A source stream resolver delegate.</param>
-        /// <param name="deprecationReason">The deprecation reason for the field.</param>
-        /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
-        public FieldType FieldSubscribeAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
-            string name,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext<TSourceType>, object?>? resolve = null, // TODO: remove?
-            Func<IResolveFieldContext, Task<IObservable<object?>>>? subscribeAsync = null,
-            string? deprecationReason = null)
-            where TGraphType : IGraphType
-        {
-            return AddField(new FieldType
-            {
-                Name = name,
-                Description = description,
-                DeprecationReason = deprecationReason,
-                Type = typeof(TGraphType),
-                Arguments = arguments,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<TSourceType, object>(resolve)
-                    : null,
-                StreamResolver = subscribeAsync != null
-                    ? new SourceStreamResolver<object>(context => new ValueTask<IObservable<object?>>(subscribeAsync(context)))
-                    : null
-            });
-        }
-
-        /// <summary>
-        /// Adds a new field to the complex graph type and returns a builder for this newly added field.
-        /// </summary>
-        /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
-        /// <typeparam name="TReturnType">The return type of the field resolver.</typeparam>
-        /// <param name="name">The name of the field.</param>
-        public virtual FieldBuilder<TSourceType, TReturnType> Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType, [NotAGraphType] TReturnType>(string name)
-            where TGraphType : IGraphType
-        {
-            var builder = CreateBuilder<TReturnType>(name, typeof(TGraphType));
-            AddField(builder.FieldType);
-            return builder;
-        }
-
-        /// <inheritdoc cref="Field{TGraphType, TReturnType}(string)"/>
-        [Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
-        public virtual FieldBuilder<TSourceType, TReturnType> Field<TGraphType, [NotAGraphType] TReturnType>()
-            where TGraphType : IGraphType
-            => Field<TGraphType, TReturnType>("default");
-
-        /// <inheritdoc cref="Field{TGraphType}(string)"/>
-        [Obsolete("Please call Field<TGraphType>(string name) instead.")]
-        public virtual FieldBuilder<TSourceType, object> Field<TGraphType>()
-            where TGraphType : IGraphType
-            => Field<TGraphType, object>("default");
-
-        /// <summary>
-        /// Adds a new field to the complex graph type and returns a builder for this newly added field.
-        /// </summary>
-        /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
-        /// <param name="name">The name of the field.</param>
-        public virtual FieldBuilder<TSourceType, object> Field<TGraphType>(string name)
-            where TGraphType : IGraphType
-            => Field<TGraphType, object>(name);
-
-        /// <summary>
-        /// Adds a new field to the complex graph type and returns a builder for this newly added field.
-        /// </summary>
-        public virtual FieldBuilder<TSourceType, TReturnType> Field<[NotAGraphType] TReturnType>(string name, bool nullable = false)
-        {
-            Type type;
-
-            try
-            {
-                type = typeof(TReturnType).GetGraphTypeFromType(nullable, this is IInputObjectGraphType ? TypeMappingMode.InputType : TypeMappingMode.OutputType);
-            }
-            catch (ArgumentOutOfRangeException exp)
-            {
-                throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from type '{typeof(TReturnType).Name}'. " + exp.Message, exp);
-            }
-
-            var builder = CreateBuilder<TReturnType>(name, type);
-
-            AddField(builder.FieldType);
-            return builder;
-        }
-
-        /// <summary>
-        /// Adds a new field to the complex graph type and returns a builder for this newly added field.
-        /// </summary>
-        /// <param name="type">The .NET type of the graph type of this field.</param>
-        /// <param name="name">The name of the field.</param>
-        public virtual FieldBuilder<TSourceType, object> Field(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
-        {
-            var builder = CreateBuilder<object>(name, type);
-            AddField(builder.FieldType);
-            return builder;
-        }
-
-        /// <summary>
-        /// Adds a new field to the complex graph type and returns a builder for this newly added field.
-        /// </summary>
-        /// <param name="type">The graph type of this field.</param>
-        /// <param name="name">The name of the field.</param>
-        public virtual FieldBuilder<TSourceType, object> Field(string name, IGraphType type)
-        {
-            var builder = CreateBuilder<object>(name, type);
-            AddField(builder.FieldType);
-            return builder;
-        }
-
-        /// <summary>
-        /// Adds a new field to the complex graph type and returns a builder for this newly added field that is linked to a property of the source object.
-        /// <br/><br/>
-        /// Note: this method uses dynamic compilation and therefore allocates a relatively large amount of
-        /// memory in managed heap, ~1KB. Do not use this method in cases with limited memory requirements.
-        /// </summary>
-        /// <typeparam name="TProperty">The return type of the field.</typeparam>
-        /// <param name="name">The name of this field.</param>
-        /// <param name="expression">The property of the source object represented within an expression.</param>
-        /// <param name="nullable">Indicates if this field should be nullable or not. Ignored when <paramref name="type"/> is specified.</param>
-        /// <param name="type">The graph type of the field; if <see langword="null"/> then will be inferred from the specified expression via registered schema mappings.</param>
-        public virtual FieldBuilder<TSourceType, TProperty> Field<TProperty>(
-            string name,
-            Expression<Func<TSourceType, TProperty>> expression,
-            bool nullable = false,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null)
-        {
-            try
-            {
-                if (type == null)
-                    type = typeof(TProperty).GetGraphTypeFromType(nullable, this is IInputObjectGraphType ? TypeMappingMode.InputType : TypeMappingMode.OutputType);
-            }
-            catch (ArgumentOutOfRangeException exp)
-            {
-                throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from expression '{expression}'. " + exp.Message, exp);
-            }
-
-            var builder = CreateBuilder<TProperty>(name, type)
-                .Description(expression.DescriptionOf())
-                .DeprecationReason(expression.DeprecationReasonOf())
-                .DefaultValue(expression.DefaultValueOf());
-
             if (this is IInputObjectGraphType)
             {
-                builder.ParseValue(value => value is TProperty ? value : value.GetPropertyValue(typeof(TProperty), builder.FieldType.ResolvedType!)!);
+                if (fieldType.ResolvedType != null ? fieldType.ResolvedType.IsInputType() == false : fieldType.Type?.IsInputType() == false)
+                    throw new ArgumentOutOfRangeException(nameof(fieldType),
+                        $"Input type '{Name ?? GetType().GetFriendlyName()}' can have fields only of input types: ScalarGraphType, EnumerationGraphType or IInputObjectGraphType. Field '{fieldType.Name}' has an output type.");
             }
-
-            if (this is IObjectGraphType)
-                builder.Resolve(new ExpressionFieldResolver<TSourceType, TProperty>(expression));
-
-            if (expression.Body is MemberExpression expr)
+            else
             {
-                builder.FieldType.Metadata[ORIGINAL_EXPRESSION_PROPERTY_NAME] = expr.Member.Name;
+                if (fieldType.ResolvedType != null ? fieldType.ResolvedType.IsOutputType() == false : fieldType.Type?.IsOutputType() == false)
+                    throw new ArgumentOutOfRangeException(nameof(fieldType),
+                        $"Output type '{Name ?? GetType().GetFriendlyName()}' can have fields only of output types: ScalarGraphType, ObjectGraphType, InterfaceGraphType, UnionGraphType or EnumerationGraphType. Field '{fieldType.Name}' has an input type.");
             }
-
-            AddField(builder.FieldType);
-            return builder;
         }
 
-        /// <summary>
-        /// Adds a new field to the complex graph type and returns a builder for this newly added field that is linked to a property of the source object.
-        /// The default name of this field is inferred by the property represented within the expression.
-        /// <br/><br/>
-        /// Note: this method uses dynamic compilation and therefore allocates a relatively large amount of
-        /// memory in managed heap, ~1KB. Do not use this method in cases with limited memory requirements.
-        /// </summary>
-        /// <typeparam name="TProperty">The return type of the field.</typeparam>
-        /// <param name="expression">The property of the source object represented within an expression.</param>
-        /// <param name="nullable">Indicates if this field should be nullable or not. Ignored when <paramref name="type"/> is specified.</param>
-        /// <param name="type">The graph type of the field; if <see langword="null"/> then will be inferred from the specified expression via registered schema mappings.</param>
-        public virtual FieldBuilder<TSourceType, TProperty> Field<TProperty>(
-            Expression<Func<TSourceType, TProperty>> expression,
-            bool nullable = false,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null)
+        if (HasField(fieldType.Name))
         {
-            string name;
-            try
+            throw new ArgumentOutOfRangeException(nameof(fieldType),
+                $"A field with the name '{fieldType.Name}' is already registered for GraphType '{Name ?? GetType().Name}'");
+        }
+
+        if (fieldType.ResolvedType == null)
+        {
+            if (fieldType.Type == null)
             {
-                name = expression.NameOf();
+                throw new ArgumentOutOfRangeException(nameof(fieldType),
+                    $"The declared field '{fieldType.Name ?? fieldType.GetType().GetFriendlyName()}' on '{Name ?? GetType().GetFriendlyName()}' requires a field '{nameof(fieldType.Type)}' when no '{nameof(fieldType.ResolvedType)}' is provided.");
             }
-            catch
+            else if (!fieldType.Type.IsGraphType())
             {
-                throw new ArgumentException(
-                    $"Cannot infer a Field name from the expression: '{expression.Body}' " +
-                    $"on parent GraphQL type: '{Name ?? GetType().Name}'.");
+                throw new ArgumentOutOfRangeException(nameof(fieldType),
+                    $"The declared Field type '{fieldType.Type.Name}' should derive from GraphType.");
             }
-            return Field(name, expression, nullable, type);
         }
 
-        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType}(string)"/>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public ConnectionBuilder<TSourceType> Connection<TNodeType>()
-            where TNodeType : IGraphType
+        Fields.Add(fieldType);
+
+        return fieldType;
+    }
+
+    /// <summary>
+    /// Creates a field builder used by Field() methods.
+    /// </summary>
+    [Obsolete("Please use the overload that accepts the name as the first argument.")]
+    protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
+    {
+        return FieldBuilder<TSourceType, TReturnType>.Create(type);
+    }
+
+    /// <summary>
+    /// Creates a field builder used by Field() methods.
+    /// </summary>
+    protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
+    {
+        return FieldBuilder<TSourceType, TReturnType>.Create(name, type);
+    }
+
+    /// <summary>
+    /// Creates a field builder used by Field() methods.
+    /// </summary>
+    [Obsolete("Please use the overload that accepts the name as the first argument.")]
+    protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>(IGraphType type)
+    {
+        return FieldBuilder<TSourceType, TReturnType>.Create(type);
+    }
+
+    /// <summary>
+    /// Creates a field builder used by Field() methods.
+    /// </summary>
+    protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>(string name, IGraphType type)
+    {
+        return FieldBuilder<TSourceType, TReturnType>.Create(name, type);
+    }
+
+    /// <summary>
+    /// Adds a field with the specified properties to this graph type.
+    /// </summary>
+    /// <param name="type">The .NET type of the graph type of this field.</param>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="description">The description of the field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
+    /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
+    /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    public FieldType Field(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
+        string name,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext<TSourceType>, object?>? resolve = null,
+        string? deprecationReason = null)
+    {
+        return AddField(new FieldType
         {
-            var builder = ConnectionBuilder.Create<TNodeType, TSourceType>();
-            AddField(builder.FieldType);
-            return builder;
+            Name = name,
+            Description = description,
+            DeprecationReason = deprecationReason,
+            Type = type,
+            Arguments = arguments,
+            Resolver = resolve != null
+                ? new FuncFieldResolver<TSourceType, object>(resolve)
+                : null
+        });
+    }
+
+    /// <summary>
+    /// Adds a field with the specified properties to this graph type.
+    /// </summary>
+    /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="description">The description of the field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
+    /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
+    /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    public FieldType Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
+        string name,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext<TSourceType>, object?>? resolve = null,
+        string? deprecationReason = null)
+        where TGraphType : IGraphType
+    {
+        return AddField(new FieldType
+        {
+            Name = name,
+            Description = description,
+            DeprecationReason = deprecationReason,
+            Type = typeof(TGraphType),
+            Arguments = arguments,
+            Resolver = resolve != null
+                ? new FuncFieldResolver<TSourceType, object>(resolve)
+                : null
+        });
+    }
+
+    /// <summary>
+    /// Adds a field with the specified properties to this graph type.
+    /// </summary>
+    /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="description">The description of the field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
+    /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
+    /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    public FieldType FieldDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
+        string name,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Delegate? resolve = null,
+        string? deprecationReason = null)
+        where TGraphType : IGraphType
+    {
+        IFieldResolver? resolver = null;
+
+        if (resolve != null)
+        {
+            // create an instance expression that points to the instance represented by the delegate
+            // for instance, if the delegate represents obj.MyMethod,
+            // then the lambda would be: _ => obj
+            var param = Expression.Parameter(typeof(IResolveFieldContext), "context");
+            var body = Expression.Constant(resolve.Target, resolve.Method.DeclaringType!);
+            var lambda = Expression.Lambda(body, param);
+            resolver = AutoRegisteringHelper.BuildFieldResolver(resolve.Method, null, null, lambda);
         }
 
-        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType}(string)"/>
-        public ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
-            where TNodeType : IGraphType
+        return AddField(new FieldType
         {
-            var builder = ConnectionBuilder.Create<TNodeType, TSourceType>(name);
-            AddField(builder.FieldType);
-            return builder;
+            Name = name,
+            Description = description,
+            DeprecationReason = deprecationReason,
+            Type = typeof(TGraphType),
+            Arguments = arguments,
+            Resolver = resolver,
+        });
+    }
+
+    /// <summary>
+    /// Adds a field with the specified properties to this graph type.
+    /// </summary>
+    /// <param name="type">The .NET type of the graph type of this field.</param>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="description">The description of the field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
+    /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
+    /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    public FieldType FieldAsync(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
+        string name,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext<TSourceType>, Task<object?>>? resolve = null,
+        string? deprecationReason = null)
+    {
+        return AddField(new FieldType
+        {
+            Name = name,
+            Description = description,
+            DeprecationReason = deprecationReason,
+            Type = type,
+            Arguments = arguments,
+            Resolver = resolve != null
+                ? new FuncFieldResolver<TSourceType, object>(context => new ValueTask<object?>(resolve(context)))
+                : null
+        });
+    }
+
+    /// <summary>
+    /// Adds a field with the specified properties to this graph type.
+    /// </summary>
+    /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="description">The description of the field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
+    /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
+    /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    public FieldType FieldAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
+        string name,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext<TSourceType>, Task<object?>>? resolve = null,
+        string? deprecationReason = null)
+        where TGraphType : IGraphType
+    {
+        return AddField(new FieldType
+        {
+            Name = name,
+            Description = description,
+            DeprecationReason = deprecationReason,
+            Type = typeof(TGraphType),
+            Arguments = arguments,
+            Resolver = resolve != null
+                ? new FuncFieldResolver<TSourceType, object>(context => new ValueTask<object?>(resolve(context)))
+                : null
+        });
+    }
+
+    /// <summary>
+    /// Adds a field with the specified properties to this graph type.
+    /// </summary>
+    /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
+    /// <typeparam name="TReturnType">The type of the return value of the field resolver delegate.</typeparam>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="description">The description of the field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
+    /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
+    /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    public FieldType FieldAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType, [NotAGraphType] TReturnType>(
+        string name,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext<TSourceType>, Task<TReturnType?>>? resolve = null,
+        string? deprecationReason = null)
+        where TGraphType : IGraphType
+    {
+        return AddField(new FieldType
+        {
+            Name = name,
+            Description = description,
+            DeprecationReason = deprecationReason,
+            Type = typeof(TGraphType),
+            Arguments = arguments,
+            Resolver = resolve != null
+                ? new FuncFieldResolver<TSourceType, TReturnType>(context => new ValueTask<TReturnType?>(resolve(context)))
+                : null
+        });
+    }
+
+    /// <summary>
+    /// Adds a subscription field with the specified properties to this graph type.
+    /// </summary>
+    /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="description">The description of this field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. Data from an event stream is processed by this field resolver as the source before being passed to the field's children as the source. Typically this would be <c>context => context.Source</c>.</param>
+    /// <param name="subscribe">A source stream resolver delegate.</param>
+    /// <param name="deprecationReason">The deprecation reason for the field.</param>
+    /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    public FieldType FieldSubscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
+        string name,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext<TSourceType>, object?>? resolve = null, // TODO: remove?
+        Func<IResolveFieldContext, IObservable<object?>>? subscribe = null,
+        string? deprecationReason = null)
+        where TGraphType : IGraphType
+    {
+        return AddField(new FieldType
+        {
+            Name = name,
+            Description = description,
+            DeprecationReason = deprecationReason,
+            Type = typeof(TGraphType),
+            Arguments = arguments,
+            Resolver = resolve != null
+                ? new FuncFieldResolver<TSourceType, object>(resolve)
+                : null,
+            StreamResolver = subscribe != null
+                ? new SourceStreamResolver<object>(subscribe)
+                : null
+        });
+    }
+
+    /// <summary>
+    /// Adds a subscription field with the specified properties to this graph type.
+    /// </summary>
+    /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="description">The description of this field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. Data from an event stream is processed by this field resolver as the source before being passed to the field's children as the source. Typically this would be <c>context => context.Source</c>.</param>
+    /// <param name="subscribeAsync">A source stream resolver delegate.</param>
+    /// <param name="deprecationReason">The deprecation reason for the field.</param>
+    /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    public FieldType FieldSubscribeAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
+        string name,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext<TSourceType>, object?>? resolve = null, // TODO: remove?
+        Func<IResolveFieldContext, Task<IObservable<object?>>>? subscribeAsync = null,
+        string? deprecationReason = null)
+        where TGraphType : IGraphType
+    {
+        return AddField(new FieldType
+        {
+            Name = name,
+            Description = description,
+            DeprecationReason = deprecationReason,
+            Type = typeof(TGraphType),
+            Arguments = arguments,
+            Resolver = resolve != null
+                ? new FuncFieldResolver<TSourceType, object>(resolve)
+                : null,
+            StreamResolver = subscribeAsync != null
+                ? new SourceStreamResolver<object>(context => new ValueTask<IObservable<object?>>(subscribeAsync(context)))
+                : null
+        });
+    }
+
+    /// <summary>
+    /// Adds a new field to the complex graph type and returns a builder for this newly added field.
+    /// </summary>
+    /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
+    /// <typeparam name="TReturnType">The return type of the field resolver.</typeparam>
+    /// <param name="name">The name of the field.</param>
+    public virtual FieldBuilder<TSourceType, TReturnType> Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType, [NotAGraphType] TReturnType>(string name)
+        where TGraphType : IGraphType
+    {
+        var builder = CreateBuilder<TReturnType>(name, typeof(TGraphType));
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <inheritdoc cref="Field{TGraphType, TReturnType}(string)"/>
+    [Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
+    public virtual FieldBuilder<TSourceType, TReturnType> Field<TGraphType, [NotAGraphType] TReturnType>()
+        where TGraphType : IGraphType
+        => Field<TGraphType, TReturnType>("default");
+
+    /// <inheritdoc cref="Field{TGraphType}(string)"/>
+    [Obsolete("Please call Field<TGraphType>(string name) instead.")]
+    public virtual FieldBuilder<TSourceType, object> Field<TGraphType>()
+        where TGraphType : IGraphType
+        => Field<TGraphType, object>("default");
+
+    /// <summary>
+    /// Adds a new field to the complex graph type and returns a builder for this newly added field.
+    /// </summary>
+    /// <typeparam name="TGraphType">The .NET type of the graph type of this field.</typeparam>
+    /// <param name="name">The name of the field.</param>
+    public virtual FieldBuilder<TSourceType, object> Field<TGraphType>(string name)
+        where TGraphType : IGraphType
+        => Field<TGraphType, object>(name);
+
+    /// <summary>
+    /// Adds a new field to the complex graph type and returns a builder for this newly added field.
+    /// </summary>
+    public virtual FieldBuilder<TSourceType, TReturnType> Field<[NotAGraphType] TReturnType>(string name, bool nullable = false)
+    {
+        Type type;
+
+        try
+        {
+            type = typeof(TReturnType).GetGraphTypeFromType(nullable, this is IInputObjectGraphType ? TypeMappingMode.InputType : TypeMappingMode.OutputType);
+        }
+        catch (ArgumentOutOfRangeException exp)
+        {
+            throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from type '{typeof(TReturnType).Name}'. " + exp.Message, exp);
         }
 
-        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType}(string)"/>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
+        var builder = CreateBuilder<TReturnType>(name, type);
+
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a new field to the complex graph type and returns a builder for this newly added field.
+    /// </summary>
+    /// <param name="type">The .NET type of the graph type of this field.</param>
+    /// <param name="name">The name of the field.</param>
+    public virtual FieldBuilder<TSourceType, object> Field(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
+    {
+        var builder = CreateBuilder<object>(name, type);
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a new field to the complex graph type and returns a builder for this newly added field.
+    /// </summary>
+    /// <param name="type">The graph type of this field.</param>
+    /// <param name="name">The name of the field.</param>
+    public virtual FieldBuilder<TSourceType, object> Field(string name, IGraphType type)
+    {
+        var builder = CreateBuilder<object>(name, type);
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a new field to the complex graph type and returns a builder for this newly added field that is linked to a property of the source object.
+    /// <br/><br/>
+    /// Note: this method uses dynamic compilation and therefore allocates a relatively large amount of
+    /// memory in managed heap, ~1KB. Do not use this method in cases with limited memory requirements.
+    /// </summary>
+    /// <typeparam name="TProperty">The return type of the field.</typeparam>
+    /// <param name="name">The name of this field.</param>
+    /// <param name="expression">The property of the source object represented within an expression.</param>
+    /// <param name="nullable">Indicates if this field should be nullable or not. Ignored when <paramref name="type"/> is specified.</param>
+    /// <param name="type">The graph type of the field; if <see langword="null"/> then will be inferred from the specified expression via registered schema mappings.</param>
+    public virtual FieldBuilder<TSourceType, TProperty> Field<TProperty>(
+        string name,
+        Expression<Func<TSourceType, TProperty>> expression,
+        bool nullable = false,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null)
+    {
+        try
         {
-            var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TSourceType>();
-            AddField(builder.FieldType);
-            return builder;
+            if (type == null)
+                type = typeof(TProperty).GetGraphTypeFromType(nullable, this is IInputObjectGraphType ? TypeMappingMode.InputType : TypeMappingMode.OutputType);
+        }
+        catch (ArgumentOutOfRangeException exp)
+        {
+            throw new ArgumentException($"The GraphQL type for field '{Name ?? GetType().Name}.{name}' could not be derived implicitly from expression '{expression}'. " + exp.Message, exp);
         }
 
-        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType}(string)"/>
-        public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
+        var builder = CreateBuilder<TProperty>(name, type)
+            .Description(expression.DescriptionOf())
+            .DeprecationReason(expression.DeprecationReasonOf())
+            .DefaultValue(expression.DefaultValueOf());
+
+        if (this is IInputObjectGraphType)
         {
-            var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TSourceType>(name);
-            AddField(builder.FieldType);
-            return builder;
+            builder.ParseValue(value => value is TProperty ? value : value.GetPropertyValue(typeof(TProperty), builder.FieldType.ResolvedType!)!);
         }
 
-        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType, TConnectionType}(string)"/>
-        [Obsolete("Please use the overload that accepts the mandatory name argument.")]
-        public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+        if (this is IObjectGraphType)
+            builder.Resolve(new ExpressionFieldResolver<TSourceType, TProperty>(expression));
+
+        if (expression.Body is MemberExpression expr)
         {
-            var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TConnectionType, TSourceType>();
-            AddField(builder.FieldType);
-            return builder;
+            builder.FieldType.Metadata[ORIGINAL_EXPRESSION_PROPERTY_NAME] = expr.Member.Name;
         }
 
-        /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType, TConnectionType}(string)"/>
-        public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>(string name)
-            where TNodeType : IGraphType
-            where TEdgeType : EdgeType<TNodeType>
-            where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a new field to the complex graph type and returns a builder for this newly added field that is linked to a property of the source object.
+    /// The default name of this field is inferred by the property represented within the expression.
+    /// <br/><br/>
+    /// Note: this method uses dynamic compilation and therefore allocates a relatively large amount of
+    /// memory in managed heap, ~1KB. Do not use this method in cases with limited memory requirements.
+    /// </summary>
+    /// <typeparam name="TProperty">The return type of the field.</typeparam>
+    /// <param name="expression">The property of the source object represented within an expression.</param>
+    /// <param name="nullable">Indicates if this field should be nullable or not. Ignored when <paramref name="type"/> is specified.</param>
+    /// <param name="type">The graph type of the field; if <see langword="null"/> then will be inferred from the specified expression via registered schema mappings.</param>
+    public virtual FieldBuilder<TSourceType, TProperty> Field<TProperty>(
+        Expression<Func<TSourceType, TProperty>> expression,
+        bool nullable = false,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null)
+    {
+        string name;
+        try
         {
-            var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TConnectionType, TSourceType>(name);
-            AddField(builder.FieldType);
-            return builder;
+            name = expression.NameOf();
         }
+        catch
+        {
+            throw new ArgumentException(
+                $"Cannot infer a Field name from the expression: '{expression.Body}' " +
+                $"on parent GraphQL type: '{Name ?? GetType().Name}'.");
+        }
+        return Field(name, expression, nullable, type);
+    }
+
+    /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType}(string)"/>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public ConnectionBuilder<TSourceType> Connection<TNodeType>()
+        where TNodeType : IGraphType
+    {
+        var builder = ConnectionBuilder.Create<TNodeType, TSourceType>();
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType}(string)"/>
+    public ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
+        where TNodeType : IGraphType
+    {
+        var builder = ConnectionBuilder.Create<TNodeType, TSourceType>(name);
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType}(string)"/>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+    {
+        var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TSourceType>();
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType}(string)"/>
+    public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+    {
+        var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TSourceType>(name);
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType, TConnectionType}(string)"/>
+    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+    {
+        var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TConnectionType, TSourceType>();
+        AddField(builder.FieldType);
+        return builder;
+    }
+
+    /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType, TConnectionType}(string)"/>
+    public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>(string name)
+        where TNodeType : IGraphType
+        where TEdgeType : EdgeType<TNodeType>
+        where TConnectionType : ConnectionType<TNodeType, TEdgeType>
+    {
+        var builder = ConnectionBuilder.Create<TNodeType, TEdgeType, TConnectionType, TSourceType>(name);
+        AddField(builder.FieldType);
+        return builder;
     }
 }

--- a/src/GraphQL/Types/Composite/IAbstractGraphType.cs
+++ b/src/GraphQL/Types/Composite/IAbstractGraphType.cs
@@ -1,73 +1,72 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// An interface for such graph types that do not represent concrete graph types, that is, for interfaces and unions.
+/// </summary>
+public interface IAbstractGraphType : IGraphType
 {
     /// <summary>
-    /// An interface for such graph types that do not represent concrete graph types, that is, for interfaces and unions.
+    /// Gets or sets a delegate that can be used to determine the proper graph type for the specified object value. See
+    /// <see cref="AbstractGraphTypeExtensions.GetObjectType(IAbstractGraphType, object, ISchema)"/> for more details.
     /// </summary>
-    public interface IAbstractGraphType : IGraphType
+    Func<object, IObjectGraphType?>? ResolveType { get; set; }
+
+    /// <summary>
+    /// Returns a set of possible types for this abstract graph type.
+    /// </summary>
+    PossibleTypes PossibleTypes { get; }
+
+    /// <summary>
+    /// Adds the specified graph type to a list of possible graph types for this abstract graph type.
+    /// </summary>
+    void AddPossibleType(IObjectGraphType type);
+}
+
+/// <summary>
+/// Provides extension methods for <see cref="IAbstractGraphType"/> instances.
+/// </summary>
+public static class AbstractGraphTypeExtensions
+{
+    /// <summary>
+    /// Returns true if the specified graph type is one of the possible graph types for this abstract graph type.
+    /// </summary>
+    public static bool IsPossibleType(this IAbstractGraphType abstractType, IGraphType type)
     {
-        /// <summary>
-        /// Gets or sets a delegate that can be used to determine the proper graph type for the specified object value. See
-        /// <see cref="AbstractGraphTypeExtensions.GetObjectType(IAbstractGraphType, object, ISchema)"/> for more details.
-        /// </summary>
-        Func<object, IObjectGraphType?>? ResolveType { get; set; }
+        foreach (var possible in abstractType.PossibleTypes.List)
+        {
+            if (possible.Equals(type))
+                return true;
+        }
 
-        /// <summary>
-        /// Returns a set of possible types for this abstract graph type.
-        /// </summary>
-        PossibleTypes PossibleTypes { get; }
-
-        /// <summary>
-        /// Adds the specified graph type to a list of possible graph types for this abstract graph type.
-        /// </summary>
-        void AddPossibleType(IObjectGraphType type);
+        return false;
     }
 
     /// <summary>
-    /// Provides extension methods for <see cref="IAbstractGraphType"/> instances.
+    /// Returns the proper graph type for the specified object for this abstract graph type. If the abstract
+    /// graph type implements <see cref="IAbstractGraphType.ResolveType"/>, then this method is called to determine
+    /// the best graph type to use. Otherwise, <see cref="IObjectGraphType.IsTypeOf"/> is called on each possible
+    /// graph type supported by the abstract graph type to determine if a match can be found.
     /// </summary>
-    public static class AbstractGraphTypeExtensions
+    public static IObjectGraphType? GetObjectType(this IAbstractGraphType abstractType, object value, ISchema schema)
     {
-        /// <summary>
-        /// Returns true if the specified graph type is one of the possible graph types for this abstract graph type.
-        /// </summary>
-        public static bool IsPossibleType(this IAbstractGraphType abstractType, IGraphType type)
+        var result = abstractType.ResolveType != null
+            ? abstractType.ResolveType(value)
+            : GetTypeOf(abstractType, value);
+
+        if (result is GraphQLTypeReference reference)
+            result = schema.AllTypes[reference.TypeName] as IObjectGraphType;
+
+        return result;
+
+        static IObjectGraphType? GetTypeOf(IAbstractGraphType abstractType, object value)
         {
             foreach (var possible in abstractType.PossibleTypes.List)
             {
-                if (possible.Equals(type))
-                    return true;
+                if (possible.IsTypeOf != null && possible.IsTypeOf(value))
+                    return possible;
             }
 
-            return false;
-        }
-
-        /// <summary>
-        /// Returns the proper graph type for the specified object for this abstract graph type. If the abstract
-        /// graph type implements <see cref="IAbstractGraphType.ResolveType"/>, then this method is called to determine
-        /// the best graph type to use. Otherwise, <see cref="IObjectGraphType.IsTypeOf"/> is called on each possible
-        /// graph type supported by the abstract graph type to determine if a match can be found.
-        /// </summary>
-        public static IObjectGraphType? GetObjectType(this IAbstractGraphType abstractType, object value, ISchema schema)
-        {
-            var result = abstractType.ResolveType != null
-                ? abstractType.ResolveType(value)
-                : GetTypeOf(abstractType, value);
-
-            if (result is GraphQLTypeReference reference)
-                result = schema.AllTypes[reference.TypeName] as IObjectGraphType;
-
-            return result;
-
-            static IObjectGraphType? GetTypeOf(IAbstractGraphType abstractType, object value)
-            {
-                foreach (var possible in abstractType.PossibleTypes.List)
-                {
-                    if (possible.IsTypeOf != null && possible.IsTypeOf(value))
-                        return possible;
-                }
-
-                return null;
-            }
+            return null;
         }
     }
 }

--- a/src/GraphQL/Types/Composite/InputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/InputObjectGraphType.cs
@@ -1,195 +1,194 @@
 using System.Reflection;
 using GraphQLParser.AST;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents an input object graph type.
+/// </summary>
+public interface IInputObjectGraphType : IComplexGraphType
 {
     /// <summary>
-    /// Represents an input object graph type.
+    /// Converts a supplied dictionary of keys and values to an object.
+    /// Overriding this method allows for customizing the deserialization process of input objects,
+    /// much like a field resolver does for output objects. For example, you can set some 'computed'
+    /// properties for your input object which were not passed in the GraphQL request.
     /// </summary>
-    public interface IInputObjectGraphType : IComplexGraphType
+    object ParseDictionary(IDictionary<string, object?> value);
+
+    /// <summary>
+    /// Returns a boolean indicating if the provided value is valid as a default value for a
+    /// field or argument of this type.
+    /// </summary>
+    bool IsValidDefault(object value);
+
+    /// <summary>
+    /// Converts a value to an AST representation. This is necessary for introspection queries
+    /// to return the default value for fields of this scalar type. This method may throw an exception
+    /// or return <see langword="null"/> for a failed conversion.
+    /// </summary>
+    GraphQLValue ToAST(object value);
+}
+
+/// <inheritdoc/>
+public class InputObjectGraphType : InputObjectGraphType<object>
+{
+}
+
+/// <inheritdoc cref="IInputObjectGraphType"/>
+public class InputObjectGraphType<[NotAGraphType][DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] TSourceType> : ComplexGraphType<TSourceType>, IInputObjectGraphType
+{
+    private Func<IDictionary<string, object?>, object>? _parseDictionary;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    public InputObjectGraphType()
+        : this(null)
     {
-        /// <summary>
-        /// Converts a supplied dictionary of keys and values to an object.
-        /// Overriding this method allows for customizing the deserialization process of input objects,
-        /// much like a field resolver does for output objects. For example, you can set some 'computed'
-        /// properties for your input object which were not passed in the GraphQL request.
-        /// </summary>
-        object ParseDictionary(IDictionary<string, object?> value);
+    }
 
-        /// <summary>
-        /// Returns a boolean indicating if the provided value is valid as a default value for a
-        /// field or argument of this type.
-        /// </summary>
-        bool IsValidDefault(object value);
+    internal InputObjectGraphType(InputObjectGraphType<TSourceType>? cloneFrom)
+        : base(cloneFrom)
+    {
+        // if (cloneFrom == null) { /* initialization logic */ }
 
-        /// <summary>
-        /// Converts a value to an AST representation. This is necessary for introspection queries
-        /// to return the default value for fields of this scalar type. This method may throw an exception
-        /// or return <see langword="null"/> for a failed conversion.
-        /// </summary>
-        GraphQLValue ToAST(object value);
+        if (typeof(TSourceType) == typeof(object))
+        {
+            // for InputObjectGraphType just return the dictionary
+            _parseDictionary = static x => x;
+        }
     }
 
     /// <inheritdoc/>
-    public class InputObjectGraphType : InputObjectGraphType<object>
+    public override void Initialize(ISchema schema)
     {
-    }
+        base.Initialize(schema);
 
-    /// <inheritdoc cref="IInputObjectGraphType"/>
-    public class InputObjectGraphType<[NotAGraphType][DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] TSourceType> : ComplexGraphType<TSourceType>, IInputObjectGraphType
-    {
-        private Func<IDictionary<string, object?>, object>? _parseDictionary;
-
-        /// <summary>
-        /// Initializes a new instance.
-        /// </summary>
-        public InputObjectGraphType()
-            : this(null)
+        if (_parseDictionary == null) // when typeof(TSourceType) != typeof(object)
         {
-        }
-
-        internal InputObjectGraphType(InputObjectGraphType<TSourceType>? cloneFrom)
-            : base(cloneFrom)
-        {
-            // if (cloneFrom == null) { /* initialization logic */ }
-
-            if (typeof(TSourceType) == typeof(object))
+            // check the value converter for a conversion from dictionary to this object type
+            var conv = ValueConverter.GetConversion(typeof(IDictionary<string, object?>), typeof(TSourceType));
+            if (conv != null)
             {
-                // for InputObjectGraphType just return the dictionary
-                _parseDictionary = static x => x;
+                _parseDictionary = conv;
             }
-        }
-
-        /// <inheritdoc/>
-        public override void Initialize(ISchema schema)
-        {
-            base.Initialize(schema);
-
-            if (_parseDictionary == null) // when typeof(TSourceType) != typeof(object)
+            else if (GlobalSwitches.DynamicallyCompileToObject)
             {
-                // check the value converter for a conversion from dictionary to this object type
-                var conv = ValueConverter.GetConversion(typeof(IDictionary<string, object?>), typeof(TSourceType));
-                if (conv != null)
+                // check if the user has overridden ParseDictionary
+                if (GetType().GetMethod(nameof(ParseDictionary), [typeof(IDictionary<string, object?>)])!.DeclaringType == typeof(InputObjectGraphType<TSourceType>))
                 {
-                    _parseDictionary = conv;
-                }
-                else if (GlobalSwitches.DynamicallyCompileToObject)
-                {
-                    // check if the user has overridden ParseDictionary
-                    if (GetType().GetMethod(nameof(ParseDictionary), [typeof(IDictionary<string, object?>)])!.DeclaringType == typeof(InputObjectGraphType<TSourceType>))
-                    {
-                        // if the user has not, validate and compile the conversion from dictionary to object immediately
-                        _parseDictionary = ObjectExtensions.CompileToObject(typeof(TSourceType), this);
-                    }
-                    else
-                    {
-                        // if they have, validate and compile upon first use (if any)
-                        _parseDictionary = data => (_parseDictionary = ObjectExtensions.CompileToObject(typeof(TSourceType), this))(data);
-                    }
+                    // if the user has not, validate and compile the conversion from dictionary to object immediately
+                    _parseDictionary = ObjectExtensions.CompileToObject(typeof(TSourceType), this);
                 }
                 else
                 {
-                    // use reflection to convert the dictionary to object
-                    _parseDictionary = ParseDictionaryViaReflection;
+                    // if they have, validate and compile upon first use (if any)
+                    _parseDictionary = data => (_parseDictionary = ObjectExtensions.CompileToObject(typeof(TSourceType), this))(data);
                 }
             }
+            else
+            {
+                // use reflection to convert the dictionary to object
+                _parseDictionary = ParseDictionaryViaReflection;
+            }
         }
+    }
 
-        /// <summary>
-        /// Converts a supplied dictionary of keys and values to an object.
-        /// The default implementation uses <see cref="ObjectExtensions.ToObject(IDictionary{string, object?}, Type, IGraphType)"/> to convert the
-        /// supplied field values into an object of type <typeparamref name="TSourceType"/>.
-        /// When <see cref="GlobalSwitches.DynamicallyCompileToObject"/> is <see langword="true"/>, this method is compiled to a delegate
-        /// during <see cref="Initialize"/> and the compiled delegate is used for all subsequent calls.
-        /// Overriding this method allows for customizing the deserialization process of input objects,
-        /// much like a field resolver does for output objects. For example, you can set some 'computed'
-        /// properties for your input object which were not passed in the GraphQL request.
-        /// </summary>
-        public virtual object ParseDictionary(IDictionary<string, object?> value)
+    /// <summary>
+    /// Converts a supplied dictionary of keys and values to an object.
+    /// The default implementation uses <see cref="ObjectExtensions.ToObject(IDictionary{string, object?}, Type, IGraphType)"/> to convert the
+    /// supplied field values into an object of type <typeparamref name="TSourceType"/>.
+    /// When <see cref="GlobalSwitches.DynamicallyCompileToObject"/> is <see langword="true"/>, this method is compiled to a delegate
+    /// during <see cref="Initialize"/> and the compiled delegate is used for all subsequent calls.
+    /// Overriding this method allows for customizing the deserialization process of input objects,
+    /// much like a field resolver does for output objects. For example, you can set some 'computed'
+    /// properties for your input object which were not passed in the GraphQL request.
+    /// </summary>
+    public virtual object ParseDictionary(IDictionary<string, object?> value)
+    {
+        if (value == null)
+            return null!;
+
+        if (_parseDictionary != null)
+            return _parseDictionary(value);
+
+        // remainder of this method should not occur unless the user has overridden Initialize
+        return ParseDictionaryViaReflection(value);
+    }
+
+    private object ParseDictionaryViaReflection(IDictionary<string, object?> value)
+        => value.ToObject(typeof(TSourceType), this);
+
+    /// <inheritdoc/>
+    public virtual bool IsValidDefault(object value)
+    {
+        if (value is not TSourceType)
+            return false;
+
+        foreach (var field in Fields)
         {
-            if (value == null)
-                return null!;
-
-            if (_parseDictionary != null)
-                return _parseDictionary(value);
-
-            // remainder of this method should not occur unless the user has overridden Initialize
-            return ParseDictionaryViaReflection(value);
-        }
-
-        private object ParseDictionaryViaReflection(IDictionary<string, object?> value)
-            => value.ToObject(typeof(TSourceType), this);
-
-        /// <inheritdoc/>
-        public virtual bool IsValidDefault(object value)
-        {
-            if (value is not TSourceType)
+            if (!field.ResolvedType!.IsValidDefault(GetFieldValue(field, value)))
                 return false;
-
-            foreach (var field in Fields)
-            {
-                if (!field.ResolvedType!.IsValidDefault(GetFieldValue(field, value)))
-                    return false;
-            }
-
-            return true;
         }
 
-        /// <summary>
-        /// Converts a value to an AST representation. This is necessary for introspection queries
-        /// to return the default value for fields of this input object type. Also AST representation
-        /// is used while printing schema as SDL.
-        /// <br/>
-        /// This method may throw an exception or return <see langword="null"/> for a failed conversion.
-        /// <br/><br/>
-        /// The default implementation returns <see cref="GraphQLNullValue"/> if <paramref name="value"/>
-        /// is <see langword="null"/> and <see cref="GraphQLObjectValue"/> filled with the values
-        /// for all input fields except ones returning <see cref="GraphQLNullValue"/>.
-        /// <br/><br/>
-        /// Note that you may need to override this method if you have already overrided <see cref="ParseDictionary"/>.
-        /// </summary>
-        public virtual GraphQLValue ToAST(object? value)
+        return true;
+    }
+
+    /// <summary>
+    /// Converts a value to an AST representation. This is necessary for introspection queries
+    /// to return the default value for fields of this input object type. Also AST representation
+    /// is used while printing schema as SDL.
+    /// <br/>
+    /// This method may throw an exception or return <see langword="null"/> for a failed conversion.
+    /// <br/><br/>
+    /// The default implementation returns <see cref="GraphQLNullValue"/> if <paramref name="value"/>
+    /// is <see langword="null"/> and <see cref="GraphQLObjectValue"/> filled with the values
+    /// for all input fields except ones returning <see cref="GraphQLNullValue"/>.
+    /// <br/><br/>
+    /// Note that you may need to override this method if you have already overrided <see cref="ParseDictionary"/>.
+    /// </summary>
+    public virtual GraphQLValue ToAST(object? value)
+    {
+        if (value == null)
+            return GraphQLValuesCache.Null;
+
+        var objectValue = new GraphQLObjectValue
         {
-            if (value == null)
-                return GraphQLValuesCache.Null;
+            Fields = new List<GraphQLObjectField>(Fields.Count)
+        };
 
-            var objectValue = new GraphQLObjectValue
-            {
-                Fields = new List<GraphQLObjectField>(Fields.Count)
-            };
-
-            foreach (var field in Fields)
-            {
-                var fieldValue = field.ResolvedType!.ToAST(GetFieldValue(field, value));
-                if (fieldValue is not GraphQLNullValue)
-                {
-                    objectValue.Fields.Add(new GraphQLObjectField(new GraphQLName(field.Name), fieldValue));
-                }
-            }
-
-            return objectValue;
-        }
-
-        private static object? GetFieldValue(FieldType field, object? value)
+        foreach (var field in Fields)
         {
-            if (value == null)
-                return null;
-
-            // Given Field("FirstName", x => x.FName) and key == "FirstName" returns "FName"
-            string propertyName = field.GetMetadata(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME, field.Name) ?? field.Name;
-            PropertyInfo? propertyInfo;
-            try
+            var fieldValue = field.ResolvedType!.ToAST(GetFieldValue(field, value));
+            if (fieldValue is not GraphQLNullValue)
             {
-                propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                objectValue.Fields.Add(new GraphQLObjectField(new GraphQLName(field.Name), fieldValue));
             }
-            catch (AmbiguousMatchException)
-            {
-                propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-            }
-
-            return propertyInfo?.CanRead == true
-                ? propertyInfo.GetValue(value)
-                : null;
         }
+
+        return objectValue;
+    }
+
+    private static object? GetFieldValue(FieldType field, object? value)
+    {
+        if (value == null)
+            return null;
+
+        // Given Field("FirstName", x => x.FName) and key == "FirstName" returns "FName"
+        string propertyName = field.GetMetadata(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME, field.Name) ?? field.Name;
+        PropertyInfo? propertyInfo;
+        try
+        {
+            propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+        }
+        catch (AmbiguousMatchException)
+        {
+            propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        }
+
+        return propertyInfo?.CanRead == true
+            ? propertyInfo.GetValue(value)
+            : null;
     }
 }

--- a/src/GraphQL/Types/Composite/InterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/InterfaceGraphType.cs
@@ -1,55 +1,54 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a GraphQL interface graph type.
+/// </summary>
+public interface IInterfaceGraphType : IAbstractGraphType, IComplexGraphType
+{
+}
+
+/// <inheritdoc cref="InterfaceGraphType"/>
+public class InterfaceGraphType<[NotAGraphType] TSource> : ComplexGraphType<TSource>, IInterfaceGraphType
 {
     /// <summary>
-    /// Represents a GraphQL interface graph type.
+    /// Initializes a new instance.
     /// </summary>
-    public interface IInterfaceGraphType : IAbstractGraphType, IComplexGraphType
+    public InterfaceGraphType()
+        : this(null)
     {
     }
 
-    /// <inheritdoc cref="InterfaceGraphType"/>
-    public class InterfaceGraphType<[NotAGraphType] TSource> : ComplexGraphType<TSource>, IInterfaceGraphType
+    internal InterfaceGraphType(InterfaceGraphType<TSource>? copyFrom)
+        : base(copyFrom)
     {
-        /// <summary>
-        /// Initializes a new instance.
-        /// </summary>
-        public InterfaceGraphType()
-            : this(null)
+        if (copyFrom != null)
         {
+            if (copyFrom.PossibleTypes.Count != 0)
+                throw new InvalidOperationException("Cannot clone interface containing possible types.");
+            if (copyFrom.ResolveType != null)
+                throw new InvalidOperationException("Cannot clone interface with configured ResolveType property.");
         }
-
-        internal InterfaceGraphType(InterfaceGraphType<TSource>? copyFrom)
-            : base(copyFrom)
-        {
-            if (copyFrom != null)
-            {
-                if (copyFrom.PossibleTypes.Count != 0)
-                    throw new InvalidOperationException("Cannot clone interface containing possible types.");
-                if (copyFrom.ResolveType != null)
-                    throw new InvalidOperationException("Cannot clone interface with configured ResolveType property.");
-            }
-            // else { /* initialization logic */ }
-        }
-
-        /// <inheritdoc/>
-        public PossibleTypes PossibleTypes { get; } = new PossibleTypes();
-
-        /// <inheritdoc/>
-        public Func<object, IObjectGraphType?>? ResolveType { get; set; }
-
-        /// <inheritdoc/>
-        public void AddPossibleType(IObjectGraphType type)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            this.IsValidInterfaceFor(type, throwError: true);
-            PossibleTypes.Add(type);
-        }
+        // else { /* initialization logic */ }
     }
 
-    /// <inheritdoc cref="IInterfaceGraphType"/>
-    public class InterfaceGraphType : InterfaceGraphType<object>
+    /// <inheritdoc/>
+    public PossibleTypes PossibleTypes { get; } = new PossibleTypes();
+
+    /// <inheritdoc/>
+    public Func<object, IObjectGraphType?>? ResolveType { get; set; }
+
+    /// <inheritdoc/>
+    public void AddPossibleType(IObjectGraphType type)
     {
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+
+        this.IsValidInterfaceFor(type, throwError: true);
+        PossibleTypes.Add(type);
     }
+}
+
+/// <inheritdoc cref="IInterfaceGraphType"/>
+public class InterfaceGraphType : InterfaceGraphType<object>
+{
 }

--- a/src/GraphQL/Types/Composite/ListGraphType.cs
+++ b/src/GraphQL/Types/Composite/ListGraphType.cs
@@ -1,61 +1,60 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a list of objects. A GraphQL schema may describe that a field represents a list of another type.
+/// The List type is provided for this reason, and wraps another type.
+/// </summary>
+public class ListGraphType : GraphType, IProvideResolvedType
 {
     /// <summary>
-    /// Represents a list of objects. A GraphQL schema may describe that a field represents a list of another type.
-    /// The List type is provided for this reason, and wraps another type.
+    /// Initializes a new instance for the specified inner graph type.
     /// </summary>
-    public class ListGraphType : GraphType, IProvideResolvedType
+    public ListGraphType(IGraphType? type)
     {
-        /// <summary>
-        /// Initializes a new instance for the specified inner graph type.
-        /// </summary>
-        public ListGraphType(IGraphType? type)
-        {
-            ResolvedType = type;
-        }
-
-        /// <summary>
-        /// Returns the .NET type of the inner (wrapped) graph type.
-        /// </summary>
-        public virtual Type? Type => null;
-
-        private IGraphType? _resolvedType;
-
-        /// <summary>
-        /// Gets or sets the instance of the inner (wrapped) graph type.
-        /// </summary>
-        public IGraphType? ResolvedType
-        {
-            get => _resolvedType;
-            set
-            {
-                if (value != null && Type != null && !Type.IsAssignableFrom(value.GetType()))
-                    throw new ArgumentOutOfRangeException("ResolvedType", $"Type '{Type.Name}' should be assignable from ResolvedType '{value.GetType().Name}'.");
-
-                _resolvedType = value;
-                _cachedString = null;
-            }
-        }
-
-        private string? _cachedString; // note, than Name always null for type wrappers
-
-        /// <inheritdoc/>
-        public override string ToString() => _cachedString ??= $"[{ResolvedType}]";
+        ResolvedType = type;
     }
 
-    /// <inheritdoc cref="ListGraphType"/>
-    public sealed class ListGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T> : ListGraphType
-        where T : IGraphType
-    {
-        /// <summary>
-        /// Initializes a new instance for the specified inner graph type.
-        /// </summary>
-        public ListGraphType()
-            : base(null)
-        {
-        }
+    /// <summary>
+    /// Returns the .NET type of the inner (wrapped) graph type.
+    /// </summary>
+    public virtual Type? Type => null;
 
-        /// <inheritdoc/>
-        public override Type Type => typeof(T);
+    private IGraphType? _resolvedType;
+
+    /// <summary>
+    /// Gets or sets the instance of the inner (wrapped) graph type.
+    /// </summary>
+    public IGraphType? ResolvedType
+    {
+        get => _resolvedType;
+        set
+        {
+            if (value != null && Type != null && !Type.IsAssignableFrom(value.GetType()))
+                throw new ArgumentOutOfRangeException("ResolvedType", $"Type '{Type.Name}' should be assignable from ResolvedType '{value.GetType().Name}'.");
+
+            _resolvedType = value;
+            _cachedString = null;
+        }
     }
+
+    private string? _cachedString; // note, than Name always null for type wrappers
+
+    /// <inheritdoc/>
+    public override string ToString() => _cachedString ??= $"[{ResolvedType}]";
+}
+
+/// <inheritdoc cref="ListGraphType"/>
+public sealed class ListGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T> : ListGraphType
+    where T : IGraphType
+{
+    /// <summary>
+    /// Initializes a new instance for the specified inner graph type.
+    /// </summary>
+    public ListGraphType()
+        : base(null)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override Type Type => typeof(T);
 }

--- a/src/GraphQL/Types/Composite/NonNullGraphType.cs
+++ b/src/GraphQL/Types/Composite/NonNullGraphType.cs
@@ -1,71 +1,70 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a graph type that, for output graphs, is never <see langword="null"/>, or for input graphs, is not optional.
+/// In other words the NonNull type wraps another type, and denotes that the resulting value will never be <see langword="null"/>.
+/// </summary>
+public class NonNullGraphType : GraphType, IProvideResolvedType
 {
     /// <summary>
-    /// Represents a graph type that, for output graphs, is never <see langword="null"/>, or for input graphs, is not optional.
-    /// In other words the NonNull type wraps another type, and denotes that the resulting value will never be <see langword="null"/>.
+    /// Initializes a new instance for the specified inner graph type.
     /// </summary>
-    public class NonNullGraphType : GraphType, IProvideResolvedType
+    public NonNullGraphType(IGraphType? type)
     {
-        /// <summary>
-        /// Initializes a new instance for the specified inner graph type.
-        /// </summary>
-        public NonNullGraphType(IGraphType? type)
-        {
-            ResolvedType = type;
-        }
-
-        /// <summary>
-        /// Returns the .NET type of the inner (wrapped) graph type.
-        /// </summary>
-        public virtual Type? Type => null;
-
-        private IGraphType? _resolvedType;
-
-        /// <summary>
-        /// Gets or sets the instance of the inner (wrapped) graph type.
-        /// </summary>
-        public IGraphType? ResolvedType
-        {
-            get => _resolvedType;
-            set
-            {
-                if (value is NonNullGraphType) //TODO: null check here or in ctor
-                {
-                    // https://spec.graphql.org/October2021/#sec-Non-Null.Type-Validation
-                    throw new ArgumentOutOfRangeException("ResolvedType", "Cannot nest NonNull inside NonNull.");
-                }
-
-                if (value != null && Type != null && !Type.IsAssignableFrom(value.GetType()))
-                    throw new ArgumentOutOfRangeException("ResolvedType", $"Type '{Type.Name}' should be assignable from ResolvedType '{value.GetType().Name}'.");
-
-                _resolvedType = value;
-                _cachedString = null;
-            }
-        }
-
-        private string? _cachedString; // note, than Name always null for type wrappers
-
-        /// <inheritdoc/>
-        public override string ToString() => _cachedString ??= $"{ResolvedType}!";
+        ResolvedType = type;
     }
 
-    /// <inheritdoc cref="NonNullGraphType"/>
-    public sealed class NonNullGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T> : NonNullGraphType
-        where T : IGraphType
-    {
-        /// <summary>
-        /// Initializes a new instance for the specified inner graph type.
-        /// </summary>
-        public NonNullGraphType()
-            : base(null)
-        {
-            if (typeof(NonNullGraphType).IsAssignableFrom(typeof(T)))
-            {
-                throw new ArgumentOutOfRangeException("type", "Cannot nest NonNull inside NonNull.");
-            }
-        }
+    /// <summary>
+    /// Returns the .NET type of the inner (wrapped) graph type.
+    /// </summary>
+    public virtual Type? Type => null;
 
-        /// <inheritdoc/>
-        public override Type Type => typeof(T);
+    private IGraphType? _resolvedType;
+
+    /// <summary>
+    /// Gets or sets the instance of the inner (wrapped) graph type.
+    /// </summary>
+    public IGraphType? ResolvedType
+    {
+        get => _resolvedType;
+        set
+        {
+            if (value is NonNullGraphType) //TODO: null check here or in ctor
+            {
+                // https://spec.graphql.org/October2021/#sec-Non-Null.Type-Validation
+                throw new ArgumentOutOfRangeException("ResolvedType", "Cannot nest NonNull inside NonNull.");
+            }
+
+            if (value != null && Type != null && !Type.IsAssignableFrom(value.GetType()))
+                throw new ArgumentOutOfRangeException("ResolvedType", $"Type '{Type.Name}' should be assignable from ResolvedType '{value.GetType().Name}'.");
+
+            _resolvedType = value;
+            _cachedString = null;
+        }
     }
+
+    private string? _cachedString; // note, than Name always null for type wrappers
+
+    /// <inheritdoc/>
+    public override string ToString() => _cachedString ??= $"{ResolvedType}!";
+}
+
+/// <inheritdoc cref="NonNullGraphType"/>
+public sealed class NonNullGraphType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T> : NonNullGraphType
+    where T : IGraphType
+{
+    /// <summary>
+    /// Initializes a new instance for the specified inner graph type.
+    /// </summary>
+    public NonNullGraphType()
+        : base(null)
+    {
+        if (typeof(NonNullGraphType).IsAssignableFrom(typeof(T)))
+        {
+            throw new ArgumentOutOfRangeException("type", "Cannot nest NonNull inside NonNull.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override Type Type => typeof(T);
 }

--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -1,85 +1,84 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents an interface for all object (that is, having their own properties) output graph types.
+/// </summary>
+public interface IObjectGraphType : IComplexGraphType, IImplementInterfaces
 {
     /// <summary>
-    /// Represents an interface for all object (that is, having their own properties) output graph types.
+    /// Gets or sets a delegate that determines if the specified object is valid for this graph type.
     /// </summary>
-    public interface IObjectGraphType : IComplexGraphType, IImplementInterfaces
-    {
-        /// <summary>
-        /// Gets or sets a delegate that determines if the specified object is valid for this graph type.
-        /// </summary>
-        Func<object, bool>? IsTypeOf { get; set; }
-
-        /// <summary>
-        /// Adds an instance of <see cref="IInterfaceGraphType"/> to the list of interface instances supported by this object graph type.
-        /// </summary>
-        void AddResolvedInterface(IInterfaceGraphType graphType);
-    }
+    Func<object, bool>? IsTypeOf { get; set; }
 
     /// <summary>
-    /// Represents a default base class for all object (that is, having their own properties) output graph types.
+    /// Adds an instance of <see cref="IInterfaceGraphType"/> to the list of interface instances supported by this object graph type.
     /// </summary>
-    /// <typeparam name="TSourceType">Typically the type of the object that this graph represents. More specifically, the .NET type of the source property within field resolvers for this graph.</typeparam>
-    public class ObjectGraphType<[NotAGraphType] TSourceType> : ComplexGraphType<TSourceType>, IObjectGraphType
+    void AddResolvedInterface(IInterfaceGraphType graphType);
+}
+
+/// <summary>
+/// Represents a default base class for all object (that is, having their own properties) output graph types.
+/// </summary>
+/// <typeparam name="TSourceType">Typically the type of the object that this graph represents. More specifically, the .NET type of the source property within field resolvers for this graph.</typeparam>
+public class ObjectGraphType<[NotAGraphType] TSourceType> : ComplexGraphType<TSourceType>, IObjectGraphType
+{
+    /// <inheritdoc/>
+    public Func<object, bool>? IsTypeOf { get; set; }
+
+    /// <inheritdoc/>
+    public ObjectGraphType()
+        : this(null)
     {
-        /// <inheritdoc/>
-        public Func<object, bool>? IsTypeOf { get; set; }
-
-        /// <inheritdoc/>
-        public ObjectGraphType()
-            : this(null)
-        {
-        }
-
-        internal ObjectGraphType(ObjectGraphType<TSourceType>? cloneFrom)
-            : base(cloneFrom)
-        {
-            if (cloneFrom == null)
-            {
-                if (typeof(TSourceType) != typeof(object))
-                    IsTypeOf = instance => instance is TSourceType;
-                Interfaces = new Interfaces();
-                return;
-            }
-            IsTypeOf = cloneFrom.IsTypeOf;
-            Interfaces = cloneFrom.Interfaces;
-            if (cloneFrom.ResolvedInterfaces.Count > 0)
-                throw new InvalidOperationException("Cannot clone ObjectGraphType when ResolvedInterfaces contains items.");
-        }
-
-        /// <inheritdoc/>
-        public void AddResolvedInterface(IInterfaceGraphType graphType)
-        {
-            if (graphType == null)
-                throw new ArgumentNullException(nameof(graphType));
-
-            _ = graphType.IsValidInterfaceFor(this, throwError: true);
-            ResolvedInterfaces.Add(graphType);
-        }
-
-        /// <inheritdoc/>
-        public Interfaces Interfaces { get; }
-
-        /// <inheritdoc/>
-        public ResolvedInterfaces ResolvedInterfaces { get; } = new ResolvedInterfaces();
-
-        /// <summary>
-        /// Adds a GraphQL interface graph type to the list of GraphQL interfaces implemented by this graph type.
-        /// </summary>
-        public void Interface<TInterface>()
-            where TInterface : IInterfaceGraphType
-            => Interfaces.Add<TInterface>();
-
-        /// <summary>
-        /// Adds a GraphQL interface graph type to the list of GraphQL interfaces implemented by this graph type.
-        /// </summary>
-        public void Interface(Type type) => Interfaces.Add(type);
     }
+
+    internal ObjectGraphType(ObjectGraphType<TSourceType>? cloneFrom)
+        : base(cloneFrom)
+    {
+        if (cloneFrom == null)
+        {
+            if (typeof(TSourceType) != typeof(object))
+                IsTypeOf = instance => instance is TSourceType;
+            Interfaces = new Interfaces();
+            return;
+        }
+        IsTypeOf = cloneFrom.IsTypeOf;
+        Interfaces = cloneFrom.Interfaces;
+        if (cloneFrom.ResolvedInterfaces.Count > 0)
+            throw new InvalidOperationException("Cannot clone ObjectGraphType when ResolvedInterfaces contains items.");
+    }
+
+    /// <inheritdoc/>
+    public void AddResolvedInterface(IInterfaceGraphType graphType)
+    {
+        if (graphType == null)
+            throw new ArgumentNullException(nameof(graphType));
+
+        _ = graphType.IsValidInterfaceFor(this, throwError: true);
+        ResolvedInterfaces.Add(graphType);
+    }
+
+    /// <inheritdoc/>
+    public Interfaces Interfaces { get; }
+
+    /// <inheritdoc/>
+    public ResolvedInterfaces ResolvedInterfaces { get; } = new ResolvedInterfaces();
 
     /// <summary>
-    /// Represents a default base class for all object (that is, having their own properties) output graph types.
+    /// Adds a GraphQL interface graph type to the list of GraphQL interfaces implemented by this graph type.
     /// </summary>
-    public class ObjectGraphType : ObjectGraphType<object?>
-    {
-    }
+    public void Interface<TInterface>()
+        where TInterface : IInterfaceGraphType
+        => Interfaces.Add<TInterface>();
+
+    /// <summary>
+    /// Adds a GraphQL interface graph type to the list of GraphQL interfaces implemented by this graph type.
+    /// </summary>
+    public void Interface(Type type) => Interfaces.Add(type);
+}
+
+/// <summary>
+/// Represents a default base class for all object (that is, having their own properties) output graph types.
+/// </summary>
+public class ObjectGraphType : ObjectGraphType<object?>
+{
 }

--- a/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
@@ -1,71 +1,70 @@
 using GraphQL.Resolvers;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Provides methods to add fields to output graph types.
+/// </summary>
+[Obsolete("This class will be removed in v8.")]
+public static class ObjectGraphTypeExtensions
 {
     /// <summary>
-    /// Provides methods to add fields to output graph types.
+    /// Adds a field with the specified properties to a specified output graph type.
     /// </summary>
-    [Obsolete("This class will be removed in v8.")]
-    public static class ObjectGraphTypeExtensions
+    /// <param name="obj">The graph type to add a field to.</param>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="type">The graph type of this field.</param>
+    /// <param name="description">The description of the field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
+    public static void Field(
+        this IObjectGraphType obj,
+        string name,
+        IGraphType type,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext, object?>? resolve = null)
     {
-        /// <summary>
-        /// Adds a field with the specified properties to a specified output graph type.
-        /// </summary>
-        /// <param name="obj">The graph type to add a field to.</param>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="type">The graph type of this field.</param>
-        /// <param name="description">The description of the field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
-        public static void Field(
-            this IObjectGraphType obj,
-            string name,
-            IGraphType type,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext, object?>? resolve = null)
+        var field = new FieldType
         {
-            var field = new FieldType
-            {
-                Name = name,
-                Description = description,
-                Arguments = arguments,
-                ResolvedType = type,
-                Resolver = resolve != null ? new FuncFieldResolver<object>(resolve) : null
-            };
-            obj.AddField(field);
-        }
+            Name = name,
+            Description = description,
+            Arguments = arguments,
+            ResolvedType = type,
+            Resolver = resolve != null ? new FuncFieldResolver<object>(resolve) : null
+        };
+        obj.AddField(field);
+    }
 
-        /// <summary>
-        /// Adds a field with the specified properties to a specified output graph type.
-        /// </summary>
-        /// <param name="obj">The graph type to add a field to.</param>
-        /// <param name="name">The name of the field.</param>
-        /// <param name="type">The graph type of this field.</param>
-        /// <param name="description">The description of the field.</param>
-        /// <param name="arguments">A list of arguments for the field.</param>
-        /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
-        public static void FieldAsync(
-            this IObjectGraphType obj,
-            string name,
-            IGraphType type,
-            string? description = null,
-            QueryArguments? arguments = null,
-            Func<IResolveFieldContext, Task<object?>>? resolve = null)
+    /// <summary>
+    /// Adds a field with the specified properties to a specified output graph type.
+    /// </summary>
+    /// <param name="obj">The graph type to add a field to.</param>
+    /// <param name="name">The name of the field.</param>
+    /// <param name="type">The graph type of this field.</param>
+    /// <param name="description">The description of the field.</param>
+    /// <param name="arguments">A list of arguments for the field.</param>
+    /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
+    public static void FieldAsync(
+        this IObjectGraphType obj,
+        string name,
+        IGraphType type,
+        string? description = null,
+        QueryArguments? arguments = null,
+        Func<IResolveFieldContext, Task<object?>>? resolve = null)
+    {
+        var field = new FieldType
         {
-            var field = new FieldType
-            {
-                Name = name,
-                Description = description,
-                Arguments = arguments,
-                ResolvedType = type,
-                Resolver = resolve != null
-                    ? new FuncFieldResolver<object>(context => new ValueTask<object?>(resolve(context)))
-                    : null
-            };
-            obj.AddField(field);
-        }
+            Name = name,
+            Description = description,
+            Arguments = arguments,
+            ResolvedType = type,
+            Resolver = resolve != null
+                ? new FuncFieldResolver<object>(context => new ValueTask<object?>(resolve(context)))
+                : null
+        };
+        obj.AddField(field);
     }
 }

--- a/src/GraphQL/Types/Composite/UnionGraphType.cs
+++ b/src/GraphQL/Types/Composite/UnionGraphType.cs
@@ -1,68 +1,67 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a GraphQL union graph type.
+/// </summary>
+public class UnionGraphType : GraphType, IAbstractGraphType
 {
-    /// <summary>
-    /// Represents a GraphQL union graph type.
-    /// </summary>
-    public class UnionGraphType : GraphType, IAbstractGraphType
+    private List<Type>? _types;
+
+    /// <inheritdoc/>
+    public PossibleTypes PossibleTypes { get; } = new PossibleTypes();
+
+    /// <inheritdoc/>
+    public Func<object, IObjectGraphType?>? ResolveType { get; set; }
+
+    /// <inheritdoc/>
+    public void AddPossibleType(IObjectGraphType type)
     {
-        private List<Type>? _types;
-
-        /// <inheritdoc/>
-        public PossibleTypes PossibleTypes { get; } = new PossibleTypes();
-
-        /// <inheritdoc/>
-        public Func<object, IObjectGraphType?>? ResolveType { get; set; }
-
-        /// <inheritdoc/>
-        public void AddPossibleType(IObjectGraphType type)
-        {
-            PossibleTypes.Add(type);
-        }
-
-        /// <summary>
-        /// Gets or sets a list of graph types that this union represents.
-        /// </summary>
-        public IEnumerable<Type> Types
-        {
-            get => _types ?? Enumerable.Empty<Type>();
-            set
-            {
-                EnsureTypes();
-
-                _types!.Clear();
-                _types.AddRange(value);
-            }
-        }
-
-        /// <summary>
-        /// Adds a graph type to the list of graph types that this union represents.
-        /// </summary>
-        public void Type<TType>()
-            where TType : IObjectGraphType
-        {
-            EnsureTypes();
-
-            if (!_types!.Contains(typeof(TType)))
-                _types.Add(typeof(TType));
-        }
-
-        /// <inheritdoc cref="Type{TType}"/>
-        public void Type(Type type)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            if (!typeof(IObjectGraphType).IsAssignableFrom(type))
-            {
-                throw new ArgumentException($"Added union type '{type.Name}' must implement {nameof(IObjectGraphType)}", nameof(type));
-            }
-
-            EnsureTypes();
-
-            if (!_types!.Contains(type))
-                _types.Add(type);
-        }
-
-        private void EnsureTypes() => _types ??= new();
+        PossibleTypes.Add(type);
     }
+
+    /// <summary>
+    /// Gets or sets a list of graph types that this union represents.
+    /// </summary>
+    public IEnumerable<Type> Types
+    {
+        get => _types ?? Enumerable.Empty<Type>();
+        set
+        {
+            EnsureTypes();
+
+            _types!.Clear();
+            _types.AddRange(value);
+        }
+    }
+
+    /// <summary>
+    /// Adds a graph type to the list of graph types that this union represents.
+    /// </summary>
+    public void Type<TType>()
+        where TType : IObjectGraphType
+    {
+        EnsureTypes();
+
+        if (!_types!.Contains(typeof(TType)))
+            _types.Add(typeof(TType));
+    }
+
+    /// <inheritdoc cref="Type{TType}"/>
+    public void Type(Type type)
+    {
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (!typeof(IObjectGraphType).IsAssignableFrom(type))
+        {
+            throw new ArgumentException($"Added union type '{type.Name}' must implement {nameof(IObjectGraphType)}", nameof(type));
+        }
+
+        EnsureTypes();
+
+        if (!_types!.Contains(type))
+            _types.Add(type);
+    }
+
+    private void EnsureTypes() => _types ??= new();
 }

--- a/src/GraphQL/Types/Directives/AppliedDirective.cs
+++ b/src/GraphQL/Types/Directives/AppliedDirective.cs
@@ -1,78 +1,77 @@
 using System.Collections;
 using GraphQL.Utilities;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a directive applied to a schema element - type, field, argument, etc.
+/// </summary>
+public class AppliedDirective : IEnumerable<DirectiveArgument>
 {
+    private string _name = null!;
+
+    internal List<DirectiveArgument>? List { get; private set; }
+
     /// <summary>
-    /// Represents a directive applied to a schema element - type, field, argument, etc.
+    /// Creates directive.
     /// </summary>
-    public class AppliedDirective : IEnumerable<DirectiveArgument>
+    /// <param name="name">Directive name.</param>
+    public AppliedDirective(string name)
     {
-        private string _name = null!;
-
-        internal List<DirectiveArgument>? List { get; private set; }
-
-        /// <summary>
-        /// Creates directive.
-        /// </summary>
-        /// <param name="name">Directive name.</param>
-        public AppliedDirective(string name)
-        {
-            Name = name;
-        }
-
-        /// <summary>
-        /// Directive name.
-        /// </summary>
-        public string Name
-        {
-            get => _name;
-            set
-            {
-                NameValidator.ValidateName(value, NamedElement.Directive);
-                _name = value;
-            }
-        }
-
-        /// <summary>
-        /// Returns the number of directive arguments.
-        /// </summary>
-        public int ArgumentsCount => List?.Count ?? 0;
-
-        /// <summary>
-        /// Adds an argument to the directive.
-        /// </summary>
-        public AppliedDirective AddArgument(DirectiveArgument argument)
-        {
-            if (argument == null)
-                throw new ArgumentNullException(nameof(argument));
-
-            (List ??= new()).Add(argument);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Searches the directive arguments for an argument specified by its name and returns it.
-        /// </summary>
-        /// <param name="argumentName">Argument name.</param>
-        public DirectiveArgument? FindArgument(string argumentName)
-        {
-            if (List != null)
-            {
-                foreach (var arg in List)
-                {
-                    if (arg.Name == argumentName)
-                        return arg;
-                }
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
-        public IEnumerator<DirectiveArgument> GetEnumerator() => (List ?? System.Linq.Enumerable.Empty<DirectiveArgument>()).GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        Name = name;
     }
+
+    /// <summary>
+    /// Directive name.
+    /// </summary>
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            NameValidator.ValidateName(value, NamedElement.Directive);
+            _name = value;
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of directive arguments.
+    /// </summary>
+    public int ArgumentsCount => List?.Count ?? 0;
+
+    /// <summary>
+    /// Adds an argument to the directive.
+    /// </summary>
+    public AppliedDirective AddArgument(DirectiveArgument argument)
+    {
+        if (argument == null)
+            throw new ArgumentNullException(nameof(argument));
+
+        (List ??= new()).Add(argument);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Searches the directive arguments for an argument specified by its name and returns it.
+    /// </summary>
+    /// <param name="argumentName">Argument name.</param>
+    public DirectiveArgument? FindArgument(string argumentName)
+    {
+        if (List != null)
+        {
+            foreach (var arg in List)
+            {
+                if (arg.Name == argumentName)
+                    return arg;
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+    public IEnumerator<DirectiveArgument> GetEnumerator() => (List ?? System.Linq.Enumerable.Empty<DirectiveArgument>()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/GraphQL/Types/Directives/Built-in/DeprecatedDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/DeprecatedDirective.cs
@@ -1,31 +1,30 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Types
-{
-    /// <summary>
-    /// Used to declare element of a GraphQL schema as deprecated.
-    /// </summary>
-    public class DeprecatedDirective : Directive
-    {
-        /// <inheritdoc/>
-        public override bool? Introspectable => true;
+namespace GraphQL.Types;
 
-        /// <summary>
-        /// Initializes a new instance of the 'deprecated' directive.
-        /// </summary>
-        public DeprecatedDirective()
-            : base("deprecated", DirectiveLocation.FieldDefinition, DirectiveLocation.EnumValue)
+/// <summary>
+/// Used to declare element of a GraphQL schema as deprecated.
+/// </summary>
+public class DeprecatedDirective : Directive
+{
+    /// <inheritdoc/>
+    public override bool? Introspectable => true;
+
+    /// <summary>
+    /// Initializes a new instance of the 'deprecated' directive.
+    /// </summary>
+    public DeprecatedDirective()
+        : base("deprecated", DirectiveLocation.FieldDefinition, DirectiveLocation.EnumValue)
+    {
+        Description = "Marks an element of a GraphQL schema as no longer supported.";
+        Arguments = new QueryArguments(new QueryArgument<StringGraphType>
         {
-            Description = "Marks an element of a GraphQL schema as no longer supported.";
-            Arguments = new QueryArguments(new QueryArgument<StringGraphType>
-            {
-                Name = "reason",
-                Description =
-                    "Explains why this element was deprecated, usually also including a " +
-                    "suggestion for how to access supported similar data. Formatted " +
-                    "in [Markdown](https://daringfireball.net/projects/markdown/).",
-                DefaultValue = "No longer supported"
-            });
-        }
+            Name = "reason",
+            Description =
+                "Explains why this element was deprecated, usually also including a " +
+                "suggestion for how to access supported similar data. Formatted " +
+                "in [Markdown](https://daringfireball.net/projects/markdown/).",
+            DefaultValue = "No longer supported"
+        });
     }
 }

--- a/src/GraphQL/Types/Directives/Built-in/IncludeDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/IncludeDirective.cs
@@ -1,24 +1,23 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Used to conditionally include fields or fragments.
+/// </summary>
+public class IncludeDirective : Directive
 {
     /// <summary>
-    /// Used to conditionally include fields or fragments.
+    /// Initializes a new instance of the 'include' directive.
     /// </summary>
-    public class IncludeDirective : Directive
+    public IncludeDirective()
+        : base("include", DirectiveLocation.Field, DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment)
     {
-        /// <summary>
-        /// Initializes a new instance of the 'include' directive.
-        /// </summary>
-        public IncludeDirective()
-            : base("include", DirectiveLocation.Field, DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment)
+        Description = "Directs the executor to include this field or fragment only when the 'if' argument is true.";
+        Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>>
         {
-            Description = "Directs the executor to include this field or fragment only when the 'if' argument is true.";
-            Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>>
-            {
-                Name = "if",
-                Description = "Included when true."
-            });
-        }
+            Name = "if",
+            Description = "Included when true."
+        });
     }
 }

--- a/src/GraphQL/Types/Directives/Built-in/SkipDirective.cs
+++ b/src/GraphQL/Types/Directives/Built-in/SkipDirective.cs
@@ -1,24 +1,23 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Used to conditionally skip (exclude) fields or fragments.
+/// </summary>
+public class SkipDirective : Directive
 {
     /// <summary>
-    /// Used to conditionally skip (exclude) fields or fragments.
+    /// Initializes a new instance of the 'skip' directive.
     /// </summary>
-    public class SkipDirective : Directive
+    public SkipDirective()
+        : base("skip", DirectiveLocation.Field, DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment)
     {
-        /// <summary>
-        /// Initializes a new instance of the 'skip' directive.
-        /// </summary>
-        public SkipDirective()
-            : base("skip", DirectiveLocation.Field, DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment)
+        Description = "Directs the executor to skip this field or fragment when the 'if' argument is true.";
+        Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>>
         {
-            Description = "Directs the executor to skip this field or fragment when the 'if' argument is true.";
-            Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>>
-            {
-                Name = "if",
-                Description = "Skipped when true."
-            });
-        }
+            Name = "if",
+            Description = "Skipped when true."
+        });
     }
 }

--- a/src/GraphQL/Types/Directives/Custom/LengthDirective.cs
+++ b/src/GraphQL/Types/Directives/Custom/LengthDirective.cs
@@ -1,60 +1,59 @@
 using GraphQL.Validation.Rules;
 using GraphQLParser.AST;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Used to specify the minimum and/or maximum length for an input field or argument.
+/// <br/><br/>
+/// When applied to argument or input field, this directive itself does not check anything. It only
+/// declares the necessary requirements and these requirements will be visible in introspection if
+/// <see cref="ExperimentalFeatures.AppliedDirectives">ExperimentalFeatures.AppliedDirectives</see>
+/// feature is enabled on schema. Use <see cref="InputFieldsAndArgumentsOfCorrectLength"/> validation
+/// rule if you want to enable checking for the length of arguments and input fields.
+/// </summary>
+public class LengthDirective : Directive
 {
+    /// <inheritdoc/>
+    public override bool? Introspectable => true;
+
     /// <summary>
-    /// Used to specify the minimum and/or maximum length for an input field or argument.
-    /// <br/><br/>
-    /// When applied to argument or input field, this directive itself does not check anything. It only
-    /// declares the necessary requirements and these requirements will be visible in introspection if
-    /// <see cref="ExperimentalFeatures.AppliedDirectives">ExperimentalFeatures.AppliedDirectives</see>
-    /// feature is enabled on schema. Use <see cref="InputFieldsAndArgumentsOfCorrectLength"/> validation
-    /// rule if you want to enable checking for the length of arguments and input fields.
+    /// Initializes a new instance of the 'length' directive.
     /// </summary>
-    public class LengthDirective : Directive
+    public LengthDirective()
+        : base("length", DirectiveLocation.InputFieldDefinition, DirectiveLocation.ArgumentDefinition)
     {
-        /// <inheritdoc/>
-        public override bool? Introspectable => true;
+        Description = "Used to specify the minimum and/or maximum length for an input field or argument.";
+        Arguments = new QueryArguments(
+            new QueryArgument<IntGraphType>
+            {
+                Name = "min",
+                Description = "If specified, specifies the minimum length that the input field or argument must have."
+            },
+            new QueryArgument<IntGraphType>
+            {
+                Name = "max",
+                Description = "If specified, specifies the maximum length that the input field or argument must have."
+            }
+        );
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the 'length' directive.
-        /// </summary>
-        public LengthDirective()
-            : base("length", DirectiveLocation.InputFieldDefinition, DirectiveLocation.ArgumentDefinition)
-        {
-            Description = "Used to specify the minimum and/or maximum length for an input field or argument.";
-            Arguments = new QueryArguments(
-                new QueryArgument<IntGraphType>
-                {
-                    Name = "min",
-                    Description = "If specified, specifies the minimum length that the input field or argument must have."
-                },
-                new QueryArgument<IntGraphType>
-                {
-                    Name = "max",
-                    Description = "If specified, specifies the maximum length that the input field or argument must have."
-                }
-            );
-        }
+    /// <inheritdoc/>
+    public override void Validate(AppliedDirective applied)
+    {
+        var min = applied.FindArgument("min")?.Value;
+        var max = applied.FindArgument("max")?.Value;
 
-        /// <inheritdoc/>
-        public override void Validate(AppliedDirective applied)
-        {
-            var min = applied.FindArgument("min")?.Value;
-            var max = applied.FindArgument("max")?.Value;
+        if (min == null && max == null)
+            throw new ArgumentException("Either 'min' or 'max' argument must be specified for @length directive.");
 
-            if (min == null && max == null)
-                throw new ArgumentException("Either 'min' or 'max' argument must be specified for @length directive.");
+        if (min != null && (min is not int minV || minV < 0))
+            throw new ArgumentOutOfRangeException("min", $"Argument 'min' for @length directive must be of type int and greater or equal 0. Current: {min}, {min.GetType().Name}");
 
-            if (min != null && (min is not int minV || minV < 0))
-                throw new ArgumentOutOfRangeException("min", $"Argument 'min' for @length directive must be of type int and greater or equal 0. Current: {min}, {min.GetType().Name}");
+        if (max != null && (max is not int maxV || maxV < 0))
+            throw new ArgumentOutOfRangeException("max", $"Argument 'max' for @length directive must be of type int and greater or equal 0. Current: {max}, {max.GetType().Name}");
 
-            if (max != null && (max is not int maxV || maxV < 0))
-                throw new ArgumentOutOfRangeException("max", $"Argument 'max' for @length directive must be of type int and greater or equal 0. Current: {max}, {max.GetType().Name}");
-
-            if (min != null && max != null && (int)min > (int)max)
-                throw new ArgumentOutOfRangeException($"Argument 'max' must be equal or greater than 'min' argument for @length directive; min={min}, max={max}");
-        }
+        if (min != null && max != null && (int)min > (int)max)
+            throw new ArgumentOutOfRangeException($"Argument 'max' must be equal or greater than 'min' argument for @length directive; min={min}, max={max}");
     }
 }

--- a/src/GraphQL/Types/Directives/Directive.cs
+++ b/src/GraphQL/Types/Directives/Directive.cs
@@ -1,99 +1,98 @@
 using GraphQL.Utilities;
 using GraphQLParser.AST;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Directives are used by the GraphQL runtime as a way of modifying execution
+/// behavior. Type system creators will usually not create these directly.
+/// </summary>
+public class Directive : MetadataProvider, INamedType, IProvideDescription
 {
     /// <summary>
-    /// Directives are used by the GraphQL runtime as a way of modifying execution
-    /// behavior. Type system creators will usually not create these directly.
+    /// Initializes a new instance with the specified name.
     /// </summary>
-    public class Directive : MetadataProvider, INamedType, IProvideDescription
+    /// <param name="name">The directive name within the GraphQL schema.</param>
+    internal Directive(string name)
     {
-        /// <summary>
-        /// Initializes a new instance with the specified name.
-        /// </summary>
-        /// <param name="name">The directive name within the GraphQL schema.</param>
-        internal Directive(string name)
-        {
-            Name = name;
-        }
+        Name = name;
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified parameters.
-        /// </summary>
-        /// <param name="name">The directive name within the GraphQL schema.</param>
-        /// <param name="locations">A list of locations where the directive can be applied.</param>
-        public Directive(string name, IEnumerable<DirectiveLocation> locations)
-        {
-            if (locations == null)
-                throw new ArgumentNullException(nameof(locations));
+    /// <summary>
+    /// Initializes a new instance with the specified parameters.
+    /// </summary>
+    /// <param name="name">The directive name within the GraphQL schema.</param>
+    /// <param name="locations">A list of locations where the directive can be applied.</param>
+    public Directive(string name, IEnumerable<DirectiveLocation> locations)
+    {
+        if (locations == null)
+            throw new ArgumentNullException(nameof(locations));
 
-            Name = name;
-            Locations.AddRange(locations);
+        Name = name;
+        Locations.AddRange(locations);
 
-            if (Locations.Count == 0)
-                throw new ArgumentException("Directive must have locations", nameof(locations));
-        }
+        if (Locations.Count == 0)
+            throw new ArgumentException("Directive must have locations", nameof(locations));
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified parameters.
-        /// </summary>
-        /// <param name="name">The directive name within the GraphQL schema.</param>
-        /// <param name="locations">A list of locations where the directive can be applied.</param>
-        public Directive(string name, params DirectiveLocation[] locations)
-        {
-            if (locations == null)
-                throw new ArgumentNullException(nameof(locations));
-            if (locations.Length == 0)
-                throw new ArgumentException("Directive must have locations", nameof(locations));
+    /// <summary>
+    /// Initializes a new instance with the specified parameters.
+    /// </summary>
+    /// <param name="name">The directive name within the GraphQL schema.</param>
+    /// <param name="locations">A list of locations where the directive can be applied.</param>
+    public Directive(string name, params DirectiveLocation[] locations)
+    {
+        if (locations == null)
+            throw new ArgumentNullException(nameof(locations));
+        if (locations.Length == 0)
+            throw new ArgumentException("Directive must have locations", nameof(locations));
 
-            Name = name;
-            Locations.AddRange(locations);
-        }
+        Name = name;
+        Locations.AddRange(locations);
+    }
 
-        /// <inheritdoc/>
-        public string Name { get; set; }
+    /// <inheritdoc/>
+    public string Name { get; set; }
 
-        /// <inheritdoc />
-        public override string ToString() => Name;
+    /// <inheritdoc />
+    public override string ToString() => Name;
 
-        /// <summary>
-        /// Gets or sets the description of the directive.
-        /// </summary>
-        public string? Description { get; set; }
+    /// <summary>
+    /// Gets or sets the description of the directive.
+    /// </summary>
+    public string? Description { get; set; }
 
-        /// <summary>
-        /// Indicates whether the directive and its usages for schema elements should return in response
-        /// to an introspection request. By default (null) if the directive has all its locations of
-        /// type ExecutableDirectiveLocation, only then it will be present in the introspection response.
-        /// </summary>
-        public virtual bool? Introspectable => null;
+    /// <summary>
+    /// Indicates whether the directive and its usages for schema elements should return in response
+    /// to an introspection request. By default (null) if the directive has all its locations of
+    /// type ExecutableDirectiveLocation, only then it will be present in the introspection response.
+    /// </summary>
+    public virtual bool? Introspectable => null;
 
-        /// <summary>
-        /// Indicates if the directive may be used repeatedly at a single location.
-        /// <br/><br/>
-        /// Repeatable directives are often useful when the same directive
-        /// should be used with different arguments at a single location,
-        /// especially in cases where additional information needs to be
-        /// provided to a type or schema extension via a directive
-        /// </summary>
-        public bool Repeatable { get; set; }
+    /// <summary>
+    /// Indicates if the directive may be used repeatedly at a single location.
+    /// <br/><br/>
+    /// Repeatable directives are often useful when the same directive
+    /// should be used with different arguments at a single location,
+    /// especially in cases where additional information needs to be
+    /// provided to a type or schema extension via a directive
+    /// </summary>
+    public bool Repeatable { get; set; }
 
-        /// <summary>
-        /// Gets or sets a list of arguments for the directive.
-        /// </summary>
-        public QueryArguments? Arguments { get; set; }
+    /// <summary>
+    /// Gets or sets a list of arguments for the directive.
+    /// </summary>
+    public QueryArguments? Arguments { get; set; }
 
-        /// <summary>
-        /// Returns a list of locations where the directive can be applied.
-        /// </summary>
-        public List<DirectiveLocation> Locations { get; } = new List<DirectiveLocation>();
+    /// <summary>
+    /// Returns a list of locations where the directive can be applied.
+    /// </summary>
+    public List<DirectiveLocation> Locations { get; } = new List<DirectiveLocation>();
 
-        /// <summary>
-        /// Validates given <paramref name="applied"/> directive against this directive graph type.
-        /// </summary>
-        public virtual void Validate(AppliedDirective applied)
-        {
-        }
+    /// <summary>
+    /// Validates given <paramref name="applied"/> directive against this directive graph type.
+    /// </summary>
+    public virtual void Validate(AppliedDirective applied)
+    {
     }
 }

--- a/src/GraphQL/Types/Directives/DirectiveArgument.cs
+++ b/src/GraphQL/Types/Directives/DirectiveArgument.cs
@@ -1,39 +1,38 @@
 using GraphQL.Utilities;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents an argument of a directive applied to a schema element - type, field, argument, etc.
+/// </summary>
+public class DirectiveArgument
 {
     /// <summary>
-    /// Represents an argument of a directive applied to a schema element - type, field, argument, etc.
+    /// Creates argument.
     /// </summary>
-    public class DirectiveArgument
+    /// <param name="name">Argument name.</param>
+    public DirectiveArgument(string name)
     {
-        /// <summary>
-        /// Creates argument.
-        /// </summary>
-        /// <param name="name">Argument name.</param>
-        public DirectiveArgument(string name)
-        {
-            Name = name;
-        }
-
-        private string _name = null!;
-
-        /// <summary>
-        /// Argument name.
-        /// </summary>
-        public string Name
-        {
-            get => _name;
-            set
-            {
-                NameValidator.ValidateName(value, NamedElement.Argument);
-                _name = value;
-            }
-        }
-
-        /// <summary>
-        /// Argument value.
-        /// </summary>
-        public object? Value { get; set; }
+        Name = name;
     }
+
+    private string _name = null!;
+
+    /// <summary>
+    /// Argument name.
+    /// </summary>
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            NameValidator.ValidateName(value, NamedElement.Argument);
+            _name = value;
+        }
+    }
+
+    /// <summary>
+    /// Argument value.
+    /// </summary>
+    public object? Value { get; set; }
 }

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -3,109 +3,108 @@ using GraphQL.Execution;
 using GraphQL.Resolvers;
 using GraphQL.Utilities;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a field of a graph type.
+/// </summary>
+[DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
+public class FieldType : MetadataProvider, IFieldType
 {
-    /// <summary>
-    /// Represents a field of a graph type.
-    /// </summary>
-    [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
-    public class FieldType : MetadataProvider, IFieldType
+    private string? _name;
+    /// <inheritdoc/>
+    public string Name
     {
-        private string? _name;
-        /// <inheritdoc/>
-        public string Name
-        {
-            get => _name!;
-            set => SetName(value, validate: true);
-        }
-
-        internal void SetName(string name, bool validate)
-        {
-            if (_name != name)
-            {
-                if (validate)
-                {
-                    NameValidator.ValidateName(name, NamedElement.Field);
-                }
-
-                _name = name;
-            }
-        }
-
-        /// <inheritdoc/>
-        public string? Description { get; set; }
-
-        /// <inheritdoc/>
-        public string? DeprecationReason
-        {
-            get => this.GetDeprecationReason();
-            set => this.SetDeprecationReason(value);
-        }
-
-        /// <summary>
-        /// Gets or sets the default value of the field. Only applies to fields of input object graph types.
-        /// </summary>
-        public object? DefaultValue { get; set; }
-
-        private Type? _type;
-        /// <summary>
-        /// Gets or sets the graph type of this field.
-        /// </summary>
-        public Type? Type
-        {
-            get => _type;
-            set
-            {
-                if (value != null && !value.IsGraphType())
-                    throw new ArgumentOutOfRangeException(nameof(value), $"Type '{value}' is not a graph type.");
-                if (value != null && value.IsGenericTypeDefinition)
-                    throw new ArgumentOutOfRangeException(nameof(value), $"Type '{value}' should not be an open generic type definition.");
-                _type = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the graph type of this field.
-        /// </summary>
-        public IGraphType? ResolvedType { get; set; }
-
-        /// <inheritdoc/>
-        public QueryArguments? Arguments { get; set; }
-
-        /// <summary>
-        /// This property contains the argument values supplied to the field resolver if no arguments
-        /// to the field were supplied within the request. This property serves as an optimization in
-        /// <see cref="ReadonlyResolveFieldContext.Arguments"/>. So basically, we are optimizing for
-        /// the idea that much of the time there are no field arguments specified, and simply the
-        /// default set needs to be returned.
-        /// Note that this value is automatically initialized during schema initialization.
-        /// </summary>
-        internal IDictionary<string, ArgumentValue>? DefaultArgumentValues { get; set; }
-
-        /// <summary>
-        /// Gets or sets a field resolver for the field. Only applicable to fields of output graph types.
-        /// </summary>
-        public IFieldResolver? Resolver { get; set; }
-
-        /// <summary>
-        /// Gets or sets a subscription resolver for the field. Only applicable to the root fields of subscription.
-        /// </summary>
-        public ISourceStreamResolver? StreamResolver { get; set; }
-
-        /// <summary>
-        /// Parses the value received from the client when the value is not <see langword="null"/>.
-        /// Occurs during validation prior to <see cref="Validator"/>.
-        /// Throw an exception if necessary to indicate a problem.
-        /// Only applicable to fields of input graph types.
-        /// </summary>
-        public Func<object, object>? Parser { get; set; }
-
-        /// <summary>
-        /// Validates the value received from the client when the value is not <see langword="null"/>.
-        /// Occurs during validation after <see cref="Parser"/> has parsed the value.
-        /// Throw an exception if necessary to indicate a problem.
-        /// Only applicable to fields of input graph types.
-        /// </summary>
-        public Action<object>? Validator { get; set; }
+        get => _name!;
+        set => SetName(value, validate: true);
     }
+
+    internal void SetName(string name, bool validate)
+    {
+        if (_name != name)
+        {
+            if (validate)
+            {
+                NameValidator.ValidateName(name, NamedElement.Field);
+            }
+
+            _name = name;
+        }
+    }
+
+    /// <inheritdoc/>
+    public string? Description { get; set; }
+
+    /// <inheritdoc/>
+    public string? DeprecationReason
+    {
+        get => this.GetDeprecationReason();
+        set => this.SetDeprecationReason(value);
+    }
+
+    /// <summary>
+    /// Gets or sets the default value of the field. Only applies to fields of input object graph types.
+    /// </summary>
+    public object? DefaultValue { get; set; }
+
+    private Type? _type;
+    /// <summary>
+    /// Gets or sets the graph type of this field.
+    /// </summary>
+    public Type? Type
+    {
+        get => _type;
+        set
+        {
+            if (value != null && !value.IsGraphType())
+                throw new ArgumentOutOfRangeException(nameof(value), $"Type '{value}' is not a graph type.");
+            if (value != null && value.IsGenericTypeDefinition)
+                throw new ArgumentOutOfRangeException(nameof(value), $"Type '{value}' should not be an open generic type definition.");
+            _type = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the graph type of this field.
+    /// </summary>
+    public IGraphType? ResolvedType { get; set; }
+
+    /// <inheritdoc/>
+    public QueryArguments? Arguments { get; set; }
+
+    /// <summary>
+    /// This property contains the argument values supplied to the field resolver if no arguments
+    /// to the field were supplied within the request. This property serves as an optimization in
+    /// <see cref="ReadonlyResolveFieldContext.Arguments"/>. So basically, we are optimizing for
+    /// the idea that much of the time there are no field arguments specified, and simply the
+    /// default set needs to be returned.
+    /// Note that this value is automatically initialized during schema initialization.
+    /// </summary>
+    internal IDictionary<string, ArgumentValue>? DefaultArgumentValues { get; set; }
+
+    /// <summary>
+    /// Gets or sets a field resolver for the field. Only applicable to fields of output graph types.
+    /// </summary>
+    public IFieldResolver? Resolver { get; set; }
+
+    /// <summary>
+    /// Gets or sets a subscription resolver for the field. Only applicable to the root fields of subscription.
+    /// </summary>
+    public ISourceStreamResolver? StreamResolver { get; set; }
+
+    /// <summary>
+    /// Parses the value received from the client when the value is not <see langword="null"/>.
+    /// Occurs during validation prior to <see cref="Validator"/>.
+    /// Throw an exception if necessary to indicate a problem.
+    /// Only applicable to fields of input graph types.
+    /// </summary>
+    public Func<object, object>? Parser { get; set; }
+
+    /// <summary>
+    /// Validates the value received from the client when the value is not <see langword="null"/>.
+    /// Occurs during validation after <see cref="Parser"/> has parsed the value.
+    /// Throw an exception if necessary to indicate a problem.
+    /// Only applicable to fields of input graph types.
+    /// </summary>
+    public Action<object>? Validator { get; set; }
 }

--- a/src/GraphQL/Types/Fields/IFieldType.cs
+++ b/src/GraphQL/Types/Fields/IFieldType.cs
@@ -1,18 +1,17 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a field of a graph type.
+/// </summary>
+public interface IFieldType : IHaveDefaultValue, IMetadataReader, IMetadataWriter, IProvideDescription, IProvideDeprecationReason
 {
     /// <summary>
-    /// Represents a field of a graph type.
+    /// Gets or sets the name of the field.
     /// </summary>
-    public interface IFieldType : IHaveDefaultValue, IMetadataReader, IMetadataWriter, IProvideDescription, IProvideDeprecationReason
-    {
-        /// <summary>
-        /// Gets or sets the name of the field.
-        /// </summary>
-        string Name { get; set; }
+    string Name { get; set; }
 
-        /// <summary>
-        /// Gets or sets a list of arguments for the field.
-        /// </summary>
-        QueryArguments? Arguments { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets a list of arguments for the field.
+    /// </summary>
+    QueryArguments? Arguments { get; set; }
 }

--- a/src/GraphQL/Types/GraphQLTypeReference.cs
+++ b/src/GraphQL/Types/GraphQLTypeReference.cs
@@ -1,85 +1,84 @@
 using System.Diagnostics;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents a placeholder for another GraphQL type, referenced by name. Must be replaced with a
+/// reference to the actual GraphQL type before using the reference.
+/// </summary>
+[DebuggerDisplay("ref {TypeName,nq}")]
+public sealed class GraphQLTypeReference : InterfaceGraphType, IObjectGraphType
 {
     /// <summary>
-    /// Represents a placeholder for another GraphQL type, referenced by name. Must be replaced with a
-    /// reference to the actual GraphQL type before using the reference.
+    /// Initializes a new instance for the specified graph type name.
     /// </summary>
-    [DebuggerDisplay("ref {TypeName,nq}")]
-    public sealed class GraphQLTypeReference : InterfaceGraphType, IObjectGraphType
+    public GraphQLTypeReference(string typeName)
     {
-        /// <summary>
-        /// Initializes a new instance for the specified graph type name.
-        /// </summary>
-        public GraphQLTypeReference(string typeName)
-        {
-            SetName("__GraphQLTypeReference", validate: false);
-            TypeName = typeName;
-        }
-
-        /// <summary>
-        /// Returns the GraphQL type name that this reference is a placeholder for.
-        /// </summary>
-        public string TypeName { get; private set; }
-
-        /// <inheritdoc/>
-        public Func<object, bool>? IsTypeOf
-        {
-            get => throw Invalid();
-            set => throw Invalid();
-        }
-
-        /// <inheritdoc/>
-        public void AddResolvedInterface(IInterfaceGraphType graphType) => throw Invalid();
-
-        /// <inheritdoc/>
-        public Interfaces Interfaces => throw Invalid();
-
-        /// <inheritdoc/>
-        public ResolvedInterfaces ResolvedInterfaces => throw Invalid();
-
-        private InvalidOperationException Invalid() => new($"This is just a reference to '{TypeName}'. Resolve the real type first.");
-
-        /// <inheritdoc/>
-        public override bool Equals(object? obj)
-        {
-            return obj is GraphQLTypeReference other
-                ? TypeName == other.TypeName
-                : base.Equals(obj);
-        }
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => TypeName?.GetHashCode() ?? 0;
+        SetName("__GraphQLTypeReference", validate: false);
+        TypeName = typeName;
     }
 
     /// <summary>
-    /// Represents a placeholder for another GraphQL Output type, referenced by CLR type. Must be replaced with a
-    /// reference to the actual GraphQL type before using the reference.
+    /// Returns the GraphQL type name that this reference is a placeholder for.
     /// </summary>
-    public sealed class GraphQLClrOutputTypeReference<[NotAGraphType] T> : InterfaceGraphType, IObjectGraphType
+    public string TypeName { get; private set; }
+
+    /// <inheritdoc/>
+    public Func<object, bool>? IsTypeOf
     {
-        private GraphQLClrOutputTypeReference()
-        {
-        }
-
-        Func<object, bool>? IObjectGraphType.IsTypeOf { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        Interfaces IImplementInterfaces.Interfaces => throw new NotImplementedException();
-
-        ResolvedInterfaces IImplementInterfaces.ResolvedInterfaces => throw new NotImplementedException();
-
-        void IObjectGraphType.AddResolvedInterface(IInterfaceGraphType graphType) => throw new NotImplementedException();
+        get => throw Invalid();
+        set => throw Invalid();
     }
 
-    /// <summary>
-    /// Represents a placeholder for another GraphQL Input type, referenced by CLR type. Must be replaced with a
-    /// reference to the actual GraphQL type before using the reference.
-    /// </summary>
-    public sealed class GraphQLClrInputTypeReference<[NotAGraphType] T> : InputObjectGraphType
+    /// <inheritdoc/>
+    public void AddResolvedInterface(IInterfaceGraphType graphType) => throw Invalid();
+
+    /// <inheritdoc/>
+    public Interfaces Interfaces => throw Invalid();
+
+    /// <inheritdoc/>
+    public ResolvedInterfaces ResolvedInterfaces => throw Invalid();
+
+    private InvalidOperationException Invalid() => new($"This is just a reference to '{TypeName}'. Resolve the real type first.");
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
     {
-        private GraphQLClrInputTypeReference()
-        {
-        }
+        return obj is GraphQLTypeReference other
+            ? TypeName == other.TypeName
+            : base.Equals(obj);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => TypeName?.GetHashCode() ?? 0;
+}
+
+/// <summary>
+/// Represents a placeholder for another GraphQL Output type, referenced by CLR type. Must be replaced with a
+/// reference to the actual GraphQL type before using the reference.
+/// </summary>
+public sealed class GraphQLClrOutputTypeReference<[NotAGraphType] T> : InterfaceGraphType, IObjectGraphType
+{
+    private GraphQLClrOutputTypeReference()
+    {
+    }
+
+    Func<object, bool>? IObjectGraphType.IsTypeOf { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    Interfaces IImplementInterfaces.Interfaces => throw new NotImplementedException();
+
+    ResolvedInterfaces IImplementInterfaces.ResolvedInterfaces => throw new NotImplementedException();
+
+    void IObjectGraphType.AddResolvedInterface(IInterfaceGraphType graphType) => throw new NotImplementedException();
+}
+
+/// <summary>
+/// Represents a placeholder for another GraphQL Input type, referenced by CLR type. Must be replaced with a
+/// reference to the actual GraphQL type before using the reference.
+/// </summary>
+public sealed class GraphQLClrInputTypeReference<[NotAGraphType] T> : InputObjectGraphType
+{
+    private GraphQLClrInputTypeReference()
+    {
     }
 }

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -1,138 +1,137 @@
 using GraphQL.Utilities;
 
-namespace GraphQL.Types
-{
-    /// <summary>
-    /// Represents a graph type.
-    /// </summary>
-    public abstract class GraphType : MetadataProvider, IGraphType
-    {
-        private string _name;
-        private bool _initialized;
+namespace GraphQL.Types;
 
-        /// <summary>
-        /// Initializes a new instance of the graph type.
-        /// </summary>
-        protected GraphType()
-            : this(null)
-        {
-        }
+/// <summary>
+/// Represents a graph type.
+/// </summary>
+public abstract class GraphType : MetadataProvider, IGraphType
+{
+    private string _name;
+    private bool _initialized;
+
+    /// <summary>
+    /// Initializes a new instance of the graph type.
+    /// </summary>
+    protected GraphType()
+        : this(null)
+    {
+    }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal GraphType(GraphType? cloneFrom)
+    internal GraphType(GraphType? cloneFrom)
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    {
+        if (cloneFrom == null)
         {
-            if (cloneFrom == null)
+            if (!IsTypeModifier) // specification requires name must be null for these types
             {
-                if (!IsTypeModifier) // specification requires name must be null for these types
-                {
-                    // GraphType must always have a valid name so set it to default name in constructor
-                    // and skip validation only for well-known types including introspection.
-                    // This name can be always changed later to any valid value.
-                    SetName(GetDefaultName(), validate: GetType().Assembly != typeof(GraphType).Assembly);
-                }
-                return;
+                // GraphType must always have a valid name so set it to default name in constructor
+                // and skip validation only for well-known types including introspection.
+                // This name can be always changed later to any valid value.
+                SetName(GetDefaultName(), validate: GetType().Assembly != typeof(GraphType).Assembly);
             }
-            _name = cloneFrom._name;
-            cloneFrom.CopyMetadataTo(this);
+            return;
         }
+        _name = cloneFrom._name;
+        cloneFrom.CopyMetadataTo(this);
+    }
 
-        /// <inheritdoc/>
-        public virtual void Initialize(ISchema schema)
-        {
-            if (_initialized)
-                throw new InvalidOperationException($"This graph type '{GetType().GetFriendlyName()}' with name '{Name}' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.");
-            _initialized = true;
-        }
+    /// <inheritdoc/>
+    public virtual void Initialize(ISchema schema)
+    {
+        if (_initialized)
+            throw new InvalidOperationException($"This graph type '{GetType().GetFriendlyName()}' with name '{Name}' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.");
+        _initialized = true;
+    }
 
-        private bool IsTypeModifier => this is ListGraphType || this is NonNullGraphType; // lgtm [cs/type-test-of-this]
+    private bool IsTypeModifier => this is ListGraphType || this is NonNullGraphType; // lgtm [cs/type-test-of-this]
 
-        private string GetDefaultName()
-        {
-            var type = GetType();
+    private string GetDefaultName()
+    {
+        var type = GetType();
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            if (!GlobalSwitches.UseLegacyTypeNaming)
+        if (!GlobalSwitches.UseLegacyTypeNaming)
 #pragma warning restore CS0618 // Type or member is obsolete
-                return type.GraphQLName();
+            return type.GraphQLName();
 
-            string name = type.Name;
-            if (GlobalSwitches.UseDeclaringTypeNames)
-            {
-                var parent = type.DeclaringType;
-                while (parent != null)
-                {
-                    name = parent.Name + "_" + name;
-                    parent = parent.DeclaringType;
-                }
-            }
-
-            name = name.Replace('`', '_')
-                       .Replace('@', '_'); // https://github.com/graphql-dotnet/graphql-dotnet/issues/3472
-            if (name.EndsWith(nameof(GraphType), StringComparison.InvariantCulture))
-                name = name.Substring(0, name.Length - nameof(GraphType).Length);
-
-            return name;
-        }
-
-        internal void SetName(string name, bool validate)
+        string name = type.Name;
+        if (GlobalSwitches.UseDeclaringTypeNames)
         {
-            if (_name != name)
+            var parent = type.DeclaringType;
+            while (parent != null)
             {
-                if (validate)
-                {
-                    NameValidator.ValidateName(name, NamedElement.Type);
-
-                    if (IsTypeModifier)
-                        throw new ArgumentOutOfRangeException(nameof(name), "A type modifier (List, NonNull) name must be null");
-                }
-
-                _name = name;
+                name = parent.Name + "_" + name;
+                parent = parent.DeclaringType;
             }
         }
 
-        /// <inheritdoc/>
-        public string Name
-        {
-            get => _name;
-            set => SetName(value, validate: true);
-        }
+        name = name.Replace('`', '_')
+                   .Replace('@', '_'); // https://github.com/graphql-dotnet/graphql-dotnet/issues/3472
+        if (name.EndsWith(nameof(GraphType), StringComparison.InvariantCulture))
+            name = name.Substring(0, name.Length - nameof(GraphType).Length);
 
-        /// <inheritdoc/>
-        public string? Description { get; set; }
-
-        /// <inheritdoc/>
-        public string? DeprecationReason
-        {
-            get => this.GetDeprecationReason();
-            set => this.SetDeprecationReason(value);
-        }
-
-        /// <inheritdoc />
-        public override string ToString() => Name;
-
-        /// <summary>
-        /// Determines if the name of the specified graph type is equal to the name of this graph type.
-        /// </summary>
-        protected bool Equals(IGraphType other) => string.Equals(Name, other.Name, StringComparison.InvariantCulture);
-
-        /// <summary>
-        /// Determines if the graph type is equal to the specified object,
-        /// or if the name of the specified graph type is equal to the name of this graph type.
-        /// </summary>
-        public override bool Equals(object? obj)
-        {
-            if (obj is null)
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-
-            return Equals((IGraphType)obj);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
+        return name;
     }
+
+    internal void SetName(string name, bool validate)
+    {
+        if (_name != name)
+        {
+            if (validate)
+            {
+                NameValidator.ValidateName(name, NamedElement.Type);
+
+                if (IsTypeModifier)
+                    throw new ArgumentOutOfRangeException(nameof(name), "A type modifier (List, NonNull) name must be null");
+            }
+
+            _name = name;
+        }
+    }
+
+    /// <inheritdoc/>
+    public string Name
+    {
+        get => _name;
+        set => SetName(value, validate: true);
+    }
+
+    /// <inheritdoc/>
+    public string? Description { get; set; }
+
+    /// <inheritdoc/>
+    public string? DeprecationReason
+    {
+        get => this.GetDeprecationReason();
+        set => this.SetDeprecationReason(value);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Determines if the name of the specified graph type is equal to the name of this graph type.
+    /// </summary>
+    protected bool Equals(IGraphType other) => string.Equals(Name, other.Name, StringComparison.InvariantCulture);
+
+    /// <summary>
+    /// Determines if the graph type is equal to the specified object,
+    /// or if the name of the specified graph type is equal to the name of this graph type.
+    /// </summary>
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj.GetType() != GetType())
+            return false;
+
+        return Equals((IGraphType)obj);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode() => Name?.GetHashCode() ?? 0;
 }

--- a/src/GraphQL/Types/IGraphType.cs
+++ b/src/GraphQL/Types/IGraphType.cs
@@ -1,50 +1,49 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// A type that has a name within the GraphQL schema.
+/// </summary>
+public interface INamedType
 {
     /// <summary>
-    /// A type that has a name within the GraphQL schema.
+    /// Gets or sets a type name within the GraphQL schema. Type names are case sensitive and
+    /// consist of alphanumeric characters and underscores only. Type names cannot start with
+    /// a digit. For List and NonNull type modifiers returns <see langword="null"/>.
     /// </summary>
-    public interface INamedType
-    {
-        /// <summary>
-        /// Gets or sets a type name within the GraphQL schema. Type names are case sensitive and
-        /// consist of alphanumeric characters and underscores only. Type names cannot start with
-        /// a digit. For List and NonNull type modifiers returns <see langword="null"/>.
-        /// </summary>
-        string Name { get; set; }
-    }
+    string Name { get; set; }
+}
 
+/// <summary>
+/// A schema element that can have description.
+/// </summary>
+public interface IProvideDescription
+{
     /// <summary>
-    /// A schema element that can have description.
+    /// Gets or sets the element description.
     /// </summary>
-    public interface IProvideDescription
-    {
-        /// <summary>
-        /// Gets or sets the element description.
-        /// </summary>
-        string? Description { get; set; }
-    }
+    string? Description { get; set; }
+}
 
+/// <summary>
+/// A schema element that can be deprecated. Now implemented by <see cref="IFieldType"/>,
+/// <see cref="QueryArgument"/> and <see cref="EnumValueDefinition"/>.
+/// </summary>
+public interface IProvideDeprecationReason
+{
     /// <summary>
-    /// A schema element that can be deprecated. Now implemented by <see cref="IFieldType"/>,
-    /// <see cref="QueryArgument"/> and <see cref="EnumValueDefinition"/>.
+    /// Gets or sets the reason this element has been deprecated;
+    /// <see langword="null"/> if this element has not been deprecated.
     /// </summary>
-    public interface IProvideDeprecationReason
-    {
-        /// <summary>
-        /// Gets or sets the reason this element has been deprecated;
-        /// <see langword="null"/> if this element has not been deprecated.
-        /// </summary>
-        string? DeprecationReason { get; set; }
-    }
+    string? DeprecationReason { get; set; }
+}
 
+/// <summary>
+/// Represents a graph type within the GraphQL schema.
+/// </summary>
+public interface IGraphType : IMetadataReader, IMetadataWriter, IProvideDescription, IProvideDeprecationReason, INamedType
+{
     /// <summary>
-    /// Represents a graph type within the GraphQL schema.
+    /// Initializes the graph type.
     /// </summary>
-    public interface IGraphType : IMetadataReader, IMetadataWriter, IProvideDescription, IProvideDeprecationReason, INamedType
-    {
-        /// <summary>
-        /// Initializes the graph type.
-        /// </summary>
-        void Initialize(ISchema schema);
-    }
+    void Initialize(ISchema schema);
 }

--- a/src/GraphQL/Types/IHaveDefaultValue.cs
+++ b/src/GraphQL/Types/IHaveDefaultValue.cs
@@ -1,13 +1,12 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Provides a default value for arguments of fields or input object graph types.
+/// </summary>
+public interface IHaveDefaultValue : IProvideResolvedType
 {
     /// <summary>
-    /// Provides a default value for arguments of fields or input object graph types.
+    /// Returns the default value of this argument or field.
     /// </summary>
-    public interface IHaveDefaultValue : IProvideResolvedType
-    {
-        /// <summary>
-        /// Returns the default value of this argument or field.
-        /// </summary>
-        object? DefaultValue { get; }
-    }
+    object? DefaultValue { get; }
 }

--- a/src/GraphQL/Types/IImplementInterfaces.cs
+++ b/src/GraphQL/Types/IImplementInterfaces.cs
@@ -1,18 +1,17 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Provides properties for enumerating supported GraphQL interface types for an output graph type.
+/// </summary>
+public interface IImplementInterfaces
 {
     /// <summary>
-    /// Provides properties for enumerating supported GraphQL interface types for an output graph type.
+    /// Gets or sets a list of .NET types of supported GraphQL interface types.
     /// </summary>
-    public interface IImplementInterfaces
-    {
-        /// <summary>
-        /// Gets or sets a list of .NET types of supported GraphQL interface types.
-        /// </summary>
-        Interfaces Interfaces { get; }
+    Interfaces Interfaces { get; }
 
-        /// <summary>
-        /// Gets or sets a list of instances of supported GraphQL interface types.
-        /// </summary>
-        ResolvedInterfaces ResolvedInterfaces { get; }
-    }
+    /// <summary>
+    /// Gets or sets a list of instances of supported GraphQL interface types.
+    /// </summary>
+    ResolvedInterfaces ResolvedInterfaces { get; }
 }

--- a/src/GraphQL/Types/IProvideMetadata.cs
+++ b/src/GraphQL/Types/IProvideMetadata.cs
@@ -1,40 +1,39 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Provides basic capabilities for getting and setting arbitrary meta information.
+/// This interface is implemented by numerous descendants like <see cref="GraphType"/>,
+/// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+/// </summary>
+public interface IProvideMetadata
 {
     /// <summary>
-    /// Provides basic capabilities for getting and setting arbitrary meta information.
-    /// This interface is implemented by numerous descendants like <see cref="GraphType"/>,
-    /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+    /// Provides all meta information as a key-value dictionary.
     /// </summary>
-    public interface IProvideMetadata
-    {
-        /// <summary>
-        /// Provides all meta information as a key-value dictionary.
-        /// </summary>
-        Dictionary<string, object?> Metadata { get; }
+    Dictionary<string, object?> Metadata { get; }
 
-        /// <summary>
-        /// Gets a value by a given key. If there is no value for the given key, returns <paramref name="defaultValue"/>.
-        /// </summary>
-        /// <typeparam name="TType">Type of the value.</typeparam>
-        /// <param name="key">String key.</param>
-        /// <param name="defaultValue">It is used if there is no value for the given key.</param>
-        /// <returns>Value of the specified type.</returns>
-        TType GetMetadata<TType>(string key, TType defaultValue = default!);
+    /// <summary>
+    /// Gets a value by a given key. If there is no value for the given key, returns <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <typeparam name="TType">Type of the value.</typeparam>
+    /// <param name="key">String key.</param>
+    /// <param name="defaultValue">It is used if there is no value for the given key.</param>
+    /// <returns>Value of the specified type.</returns>
+    TType GetMetadata<TType>(string key, TType defaultValue = default!);
 
-        /// <summary>
-        /// Gets a value by a given key. If there is no value for the given key, returns value obtained from <paramref name="defaultValueFactory"/>.
-        /// </summary>
-        /// <typeparam name="TType">Type of the value.</typeparam>
-        /// <param name="key">String key.</param>
-        /// <param name="defaultValueFactory">It is used if there is no value for the given key.</param>
-        /// <returns>Value of the specified type.</returns>
-        TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory);
+    /// <summary>
+    /// Gets a value by a given key. If there is no value for the given key, returns value obtained from <paramref name="defaultValueFactory"/>.
+    /// </summary>
+    /// <typeparam name="TType">Type of the value.</typeparam>
+    /// <param name="key">String key.</param>
+    /// <param name="defaultValueFactory">It is used if there is no value for the given key.</param>
+    /// <returns>Value of the specified type.</returns>
+    TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory);
 
-        /// <summary>
-        /// Indicates whether there is meta information with the given key.
-        /// </summary>
-        /// <param name="key">String key.</param>
-        /// <returns><see langword="true"/> if value for such key exists, otherwise <see langword="false"/>.</returns>
-        bool HasMetadata(string key);
-    }
+    /// <summary>
+    /// Indicates whether there is meta information with the given key.
+    /// </summary>
+    /// <param name="key">String key.</param>
+    /// <returns><see langword="true"/> if value for such key exists, otherwise <see langword="false"/>.</returns>
+    bool HasMetadata(string key);
 }

--- a/src/GraphQL/Types/IProvideResolvedType.cs
+++ b/src/GraphQL/Types/IProvideResolvedType.cs
@@ -1,14 +1,13 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Provides properties for returning the graph type for the argument or field. Also used for <see cref="ListGraphType"/> and <see cref="NonNullGraphType"/>.
+/// </summary>
+public interface IProvideResolvedType
 {
     /// <summary>
-    /// Provides properties for returning the graph type for the argument or field. Also used for <see cref="ListGraphType"/> and <see cref="NonNullGraphType"/>.
+    /// Returns the graph type of this argument or field.
+    /// In case of <see cref="ListGraphType"/> or <see cref="NonNullGraphType"/>, returns an instance of the inner (wrapped) graph type.
     /// </summary>
-    public interface IProvideResolvedType
-    {
-        /// <summary>
-        /// Returns the graph type of this argument or field.
-        /// In case of <see cref="ListGraphType"/> or <see cref="NonNullGraphType"/>, returns an instance of the inner (wrapped) graph type.
-        /// </summary>
-        IGraphType? ResolvedType { get; set; }
-    }
+    IGraphType? ResolvedType { get; set; }
 }

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -3,165 +3,164 @@ using GraphQL.Instrumentation;
 using GraphQL.Introspection;
 using GraphQL.Utilities;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// The schema for the GraphQL request. Contains references to the 'query', 'mutation', and 'subscription' base graph types.
+/// <br/><br/>
+/// Also allows for adding custom directives, additional graph types, and custom value converters.
+/// <br/><br/>
+/// <see cref="Schema"/> only requires the <see cref="Schema.Query">Query</see> property to be set; although commonly the <see cref="Schema.Mutation">Mutation</see> and/or <see cref="Schema.Subscription">Subscription</see> properties are also set.
+/// </summary>
+public interface ISchema : IMetadataReader, IProvideDescription
 {
+    /// <inheritdoc cref="ExperimentalFeatures"/>
+    ExperimentalFeatures Features { get; set; }
+
     /// <summary>
-    /// The schema for the GraphQL request. Contains references to the 'query', 'mutation', and 'subscription' base graph types.
-    /// <br/><br/>
-    /// Also allows for adding custom directives, additional graph types, and custom value converters.
-    /// <br/><br/>
-    /// <see cref="Schema"/> only requires the <see cref="Schema.Query">Query</see> property to be set; although commonly the <see cref="Schema.Mutation">Mutation</see> and/or <see cref="Schema.Subscription">Subscription</see> properties are also set.
+    /// Returns <see langword="true"/> once the schema has been initialized.
     /// </summary>
-    public interface ISchema : IMetadataReader, IProvideDescription
-    {
-        /// <inheritdoc cref="ExperimentalFeatures"/>
-        ExperimentalFeatures Features { get; set; }
+    bool Initialized { get; }
 
-        /// <summary>
-        /// Returns <see langword="true"/> once the schema has been initialized.
-        /// </summary>
-        bool Initialized { get; }
+    /// <summary>
+    /// Initializes the schema. Called by <see cref="IDocumentExecuter"/> before validating or executing the request.
+    /// <br/><br/>
+    /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="FieldMiddleware"/>.
+    /// <br/><br/>
+    /// This method should be safe to be called from multiple threads simultaneously.
+    /// </summary>
+    void Initialize();
 
-        /// <summary>
-        /// Initializes the schema. Called by <see cref="IDocumentExecuter"/> before validating or executing the request.
-        /// <br/><br/>
-        /// Note that middleware cannot be applied once the schema has been initialized. See <see cref="FieldMiddleware"/>.
-        /// <br/><br/>
-        /// This method should be safe to be called from multiple threads simultaneously.
-        /// </summary>
-        void Initialize();
+    /// <summary>
+    /// Field and argument names are sanitized by the provided <see cref="INameConverter"/>; defaults to <see cref="CamelCaseNameConverter"/>
+    /// </summary>
+    INameConverter NameConverter { get; }
 
-        /// <summary>
-        /// Field and argument names are sanitized by the provided <see cref="INameConverter"/>; defaults to <see cref="CamelCaseNameConverter"/>
-        /// </summary>
-        INameConverter NameConverter { get; }
+    /// <summary>
+    /// Note that field middlewares from this property apply only to an uninitialized schema. If the schema is initialized
+    /// then adding additional middleware through the builder does nothing. The schema is initialized (if not yet)
+    /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)">ExecuteAsync</see>.
+    /// However, you can also apply middlewares at any time in runtime using SchemaTypes.ApplyMiddleware method.
+    /// </summary>
+    IFieldMiddlewareBuilder FieldMiddleware { get; }
 
-        /// <summary>
-        /// Note that field middlewares from this property apply only to an uninitialized schema. If the schema is initialized
-        /// then adding additional middleware through the builder does nothing. The schema is initialized (if not yet)
-        /// at the beginning of the first call to <see cref="DocumentExecuter"/>.<see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)">ExecuteAsync</see>.
-        /// However, you can also apply middlewares at any time in runtime using SchemaTypes.ApplyMiddleware method.
-        /// </summary>
-        IFieldMiddlewareBuilder FieldMiddleware { get; }
+    /// <summary>
+    /// The 'query' base graph type; required.
+    /// </summary>
+    IObjectGraphType Query { get; set; }
 
-        /// <summary>
-        /// The 'query' base graph type; required.
-        /// </summary>
-        IObjectGraphType Query { get; set; }
+    /// <summary>
+    /// The 'mutation' base graph type; optional.
+    /// </summary>
+    IObjectGraphType? Mutation { get; set; }
 
-        /// <summary>
-        /// The 'mutation' base graph type; optional.
-        /// </summary>
-        IObjectGraphType? Mutation { get; set; }
+    /// <summary>
+    /// The 'subscription' base graph type; optional.
+    /// </summary>
+    IObjectGraphType? Subscription { get; set; }
 
-        /// <summary>
-        /// The 'subscription' base graph type; optional.
-        /// </summary>
-        IObjectGraphType? Subscription { get; set; }
+    /// <summary>
+    /// Returns a list of directives supported by the schema.
+    /// <br/><br/>
+    /// Directives are used by the GraphQL runtime as a way of modifying execution
+    /// behavior. Type system creators do not usually create them directly.
+    /// <br/><br/>
+    /// <see cref="Schema"/> initializes the list to include <see cref="SchemaDirectives.Include"/>, <see cref="SchemaDirectives.Skip"/> and <see cref="SchemaDirectives.Deprecated"/> by default.
+    /// </summary>
+    SchemaDirectives Directives { get; }
 
-        /// <summary>
-        /// Returns a list of directives supported by the schema.
-        /// <br/><br/>
-        /// Directives are used by the GraphQL runtime as a way of modifying execution
-        /// behavior. Type system creators do not usually create them directly.
-        /// <br/><br/>
-        /// <see cref="Schema"/> initializes the list to include <see cref="SchemaDirectives.Include"/>, <see cref="SchemaDirectives.Skip"/> and <see cref="SchemaDirectives.Deprecated"/> by default.
-        /// </summary>
-        SchemaDirectives Directives { get; }
+    /// <summary>
+    /// Returns a list of all the graph types utilized by this schema.
+    /// </summary>
+    SchemaTypes AllTypes { get; }
 
-        /// <summary>
-        /// Returns a list of all the graph types utilized by this schema.
-        /// </summary>
-        SchemaTypes AllTypes { get; }
+    /// <summary>
+    /// A list of additional graph types manually added to the schema by a <see cref="RegisterType(Type)"/> call.
+    /// </summary>
+    IEnumerable<Type> AdditionalTypes { get; }
 
-        /// <summary>
-        /// A list of additional graph types manually added to the schema by a <see cref="RegisterType(Type)"/> call.
-        /// </summary>
-        IEnumerable<Type> AdditionalTypes { get; }
+    /// <summary>
+    /// A list of additional graph type instances manually added to the schema by a <see cref="RegisterType(IGraphType)"/> call.
+    /// </summary>
+    IEnumerable<IGraphType> AdditionalTypeInstances { get; }
 
-        /// <summary>
-        /// A list of additional graph type instances manually added to the schema by a <see cref="RegisterType(IGraphType)"/> call.
-        /// </summary>
-        IEnumerable<IGraphType> AdditionalTypeInstances { get; }
+    /// <summary>
+    /// Adds the specified instance of an <see cref="ISchemaNodeVisitor"/> to the schema.
+    /// When initializing a schema, all registered visitors will be executed on each
+    /// schema element when it is traversed.
+    /// </summary>
+    void RegisterVisitor(ISchemaNodeVisitor visitor);
 
-        /// <summary>
-        /// Adds the specified instance of an <see cref="ISchemaNodeVisitor"/> to the schema.
-        /// When initializing a schema, all registered visitors will be executed on each
-        /// schema element when it is traversed.
-        /// </summary>
-        void RegisterVisitor(ISchemaNodeVisitor visitor);
+    /// <summary>
+    /// Adds the specified visitor type to the schema. When initializing a schema, all
+    /// registered visitors will be executed on each schema element when it is traversed.
+    /// </summary>
+    void RegisterVisitor(Type type);
 
-        /// <summary>
-        /// Adds the specified visitor type to the schema. When initializing a schema, all
-        /// registered visitors will be executed on each schema element when it is traversed.
-        /// </summary>
-        void RegisterVisitor(Type type);
+    /// <summary>
+    /// Adds the specified specific instance of an <see cref="IGraphType"/> to the schema.
+    /// <br/><br/>
+    /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+    /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+    /// </summary>
+    void RegisterType(IGraphType type);
 
-        /// <summary>
-        /// Adds the specified specific instance of an <see cref="IGraphType"/> to the schema.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
-        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        void RegisterType(IGraphType type);
+    /// <summary>
+    /// Adds the specified graph type to the schema. Type must implement <see cref="IGraphType"/>.
+    /// <br/><br/>
+    /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
+    /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
+    /// </summary>
+    void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
 
-        /// <summary>
-        /// Adds the specified graph type to the schema. Type must implement <see cref="IGraphType"/>.
-        /// <br/><br/>
-        /// Not typically required as schema initialization will scan the <see cref="Query"/>, <see cref="Mutation"/> and <see cref="Subscription"/> graphs,
-        /// creating instances of <see cref="IGraphType"/>s referenced therein as necessary.
-        /// </summary>
-        void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
+    /// <summary>
+    /// Registers type mapping from CLR type to GraphType.
+    /// <br/>
+    /// These mappings are used for type inference when constructing fields using expressions:
+    /// <br/>
+    /// <c>
+    /// Field(x => x.Filters);
+    /// </c>
+    /// </summary>
+    /// <param name="clrType">The CLR property type from which to infer the GraphType.</param>
+    /// <param name="graphType">Inferred GraphType.</param>
+    void RegisterTypeMapping(Type clrType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type graphType);
 
-        /// <summary>
-        /// Registers type mapping from CLR type to GraphType.
-        /// <br/>
-        /// These mappings are used for type inference when constructing fields using expressions:
-        /// <br/>
-        /// <c>
-        /// Field(x => x.Filters);
-        /// </c>
-        /// </summary>
-        /// <param name="clrType">The CLR property type from which to infer the GraphType.</param>
-        /// <param name="graphType">Inferred GraphType.</param>
-        void RegisterTypeMapping(Type clrType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type graphType);
+    /// <summary>
+    /// Returns all registered by <see cref="RegisterTypeMapping"/> type mappings.
+    /// </summary>
+    IEnumerable<(Type clrType, Type graphType)> TypeMappings { get; }
 
-        /// <summary>
-        /// Returns all registered by <see cref="RegisterTypeMapping"/> type mappings.
-        /// </summary>
-        IEnumerable<(Type clrType, Type graphType)> TypeMappings { get; }
+    /// <summary>
+    /// Returns all built-in type mappings for scalars.
+    /// </summary>
+    IEnumerable<(Type clrType, Type graphType)> BuiltInTypeMappings { get; }
 
-        /// <summary>
-        /// Returns all built-in type mappings for scalars.
-        /// </summary>
-        IEnumerable<(Type clrType, Type graphType)> BuiltInTypeMappings { get; }
+    /// <summary>
+    /// Provides the ability to filter the schema upon introspection to hide types, fields, arguments, enum values, directives.
+    /// By default nothing is hidden. Note that this filter in fact does not prohibit the execution of queries that contain
+    /// hidden types/fields. To limit access to the particular fields, you should use some authorization logic.
+    /// </summary>
+    ISchemaFilter Filter { get; set; }
 
-        /// <summary>
-        /// Provides the ability to filter the schema upon introspection to hide types, fields, arguments, enum values, directives.
-        /// By default nothing is hidden. Note that this filter in fact does not prohibit the execution of queries that contain
-        /// hidden types/fields. To limit access to the particular fields, you should use some authorization logic.
-        /// </summary>
-        ISchemaFilter Filter { get; set; }
+    /// <summary>
+    /// Provides the ability to order the schema elements upon introspection.
+    /// By default all elements are returned as is, no sorting is applied.
+    /// </summary>
+    ISchemaComparer Comparer { get; set; }
 
-        /// <summary>
-        /// Provides the ability to order the schema elements upon introspection.
-        /// By default all elements are returned as is, no sorting is applied.
-        /// </summary>
-        ISchemaComparer Comparer { get; set; }
+    /// <summary>
+    /// Returns a reference to the __schema introspection field available on the query graph type.
+    /// </summary>
+    FieldType SchemaMetaFieldType { get; }
 
-        /// <summary>
-        /// Returns a reference to the __schema introspection field available on the query graph type.
-        /// </summary>
-        FieldType SchemaMetaFieldType { get; }
+    /// <summary>
+    /// Returns a reference to the __type introspection field available on the query graph type.
+    /// </summary>
+    FieldType TypeMetaFieldType { get; }
 
-        /// <summary>
-        /// Returns a reference to the __type introspection field available on the query graph type.
-        /// </summary>
-        FieldType TypeMetaFieldType { get; }
-
-        /// <summary>
-        /// Returns a reference to the __typename introspection field available on any object, interface, or union graph type.
-        /// </summary>
-        FieldType TypeNameMetaFieldType { get; }
-    }
+    /// <summary>
+    /// Returns a reference to the __typename introspection field available on any object, interface, or union graph type.
+    /// </summary>
+    FieldType TypeNameMetaFieldType { get; }
 }

--- a/src/GraphQL/Types/QueryArgument.cs
+++ b/src/GraphQL/Types/QueryArgument.cs
@@ -1,139 +1,138 @@
 using System.Diagnostics;
 using GraphQL.Utilities;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Represents an argument to a field or directive.
+/// </summary>
+/// <typeparam name="TType">The graph type of the argument.</typeparam>
+public class QueryArgument<TType> : QueryArgument
+    where TType : IGraphType
 {
     /// <summary>
-    /// Represents an argument to a field or directive.
+    /// Initializes a new instance of the argument.
     /// </summary>
-    /// <typeparam name="TType">The graph type of the argument.</typeparam>
-    public class QueryArgument<TType> : QueryArgument
-        where TType : IGraphType
+    public QueryArgument()
+        : base(typeof(TType))
     {
-        /// <summary>
-        /// Initializes a new instance of the argument.
-        /// </summary>
-        public QueryArgument()
-            : base(typeof(TType))
+    }
+}
+
+/// <summary>
+/// Represents an argument to a field or directive.
+/// </summary>
+[DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
+public class QueryArgument : MetadataProvider, IHaveDefaultValue, IProvideDescription, IProvideDeprecationReason
+{
+    private Type? _type;
+    private IGraphType? _resolvedType;
+
+    /// <summary>
+    /// Initializes a new instance of the argument.
+    /// </summary>
+    /// <param name="type">The graph type of the argument.</param>
+    public QueryArgument(IGraphType type)
+    {
+        ResolvedType = type ?? throw new ArgumentOutOfRangeException(nameof(type), "QueryArgument type is required");
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the argument.
+    /// </summary>
+    /// <param name="type">The graph type of the argument.</param>
+    public QueryArgument(Type type)
+    {
+        if (type == null || !typeof(IGraphType).IsAssignableFrom(type))
         {
+            throw new ArgumentOutOfRangeException(nameof(type), "QueryArgument type is required and must derive from IGraphType.");
+        }
+
+        Type = type;
+    }
+
+    private string? _name;
+    /// <summary>
+    /// Gets or sets the name of the argument.
+    /// </summary>
+    public string Name
+    {
+        get => _name!;
+        set
+        {
+            if (_name != value)
+            {
+                NameValidator.ValidateName(value, NamedElement.Argument);
+                _name = value;
+            }
         }
     }
 
     /// <summary>
-    /// Represents an argument to a field or directive.
+    /// Gets or sets the description of the argument.
     /// </summary>
-    [DebuggerDisplay("{Name,nq}: {ResolvedType,nq}")]
-    public class QueryArgument : MetadataProvider, IHaveDefaultValue, IProvideDescription, IProvideDeprecationReason
+    public string? Description { get; set; }
+
+    /// <inheritdoc/>
+    public string? DeprecationReason
     {
-        private Type? _type;
-        private IGraphType? _resolvedType;
-
-        /// <summary>
-        /// Initializes a new instance of the argument.
-        /// </summary>
-        /// <param name="type">The graph type of the argument.</param>
-        public QueryArgument(IGraphType type)
-        {
-            ResolvedType = type ?? throw new ArgumentOutOfRangeException(nameof(type), "QueryArgument type is required");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the argument.
-        /// </summary>
-        /// <param name="type">The graph type of the argument.</param>
-        public QueryArgument(Type type)
-        {
-            if (type == null || !typeof(IGraphType).IsAssignableFrom(type))
-            {
-                throw new ArgumentOutOfRangeException(nameof(type), "QueryArgument type is required and must derive from IGraphType.");
-            }
-
-            Type = type;
-        }
-
-        private string? _name;
-        /// <summary>
-        /// Gets or sets the name of the argument.
-        /// </summary>
-        public string Name
-        {
-            get => _name!;
-            set
-            {
-                if (_name != value)
-                {
-                    NameValidator.ValidateName(value, NamedElement.Argument);
-                    _name = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the description of the argument.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <inheritdoc/>
-        public string? DeprecationReason
-        {
-            get => this.GetDeprecationReason();
-            set => this.SetDeprecationReason(value);
-        }
-
-        /// <summary>
-        /// Gets or sets the default value of the argument.
-        /// </summary>
-        public object? DefaultValue { get; set; }
-
-        /// <summary>
-        /// Returns the graph type of this argument.
-        /// </summary>
-        public IGraphType? ResolvedType
-        {
-            get => _resolvedType;
-            set => _resolvedType = CheckResolvedType(value);
-        }
-
-        /// <inheritdoc/>
-        public Type? Type
-        {
-            get => _type;
-            internal set => _type = CheckType(value);
-        }
-
-        private Type? CheckType(Type? type)
-        {
-            if (type?.IsInputType() == false)
-                throw Create(nameof(Type), type);
-
-            return type;
-        }
-
-        private IGraphType? CheckResolvedType(IGraphType? type)
-        {
-            if (type != null && !type.IsGraphQLTypeReference() && !type.IsInputType())
-                throw Create(nameof(ResolvedType), type.GetType());
-
-            return type;
-        }
-
-        /// <summary>
-        /// Parses the value received from the client when the value is not <see langword="null"/>.
-        /// Occurs during validation prior to <see cref="Validator"/>.
-        /// Throw an exception if necessary to indicate a problem.
-        /// Only applicable to fields of input graph types.
-        /// </summary>
-        public Func<object, object>? Parser { get; set; }
-
-        /// <summary>
-        /// Validates the value received from the client when the value is not <see langword="null"/>.
-        /// Occurs during validation after <see cref="Parser"/> has parsed the value.
-        /// Throw an exception if necessary to indicate a problem.
-        /// Only applicable to fields of input graph types.
-        /// </summary>
-        public Action<object>? Validator { get; set; }
-
-        private ArgumentOutOfRangeException Create(string paramName, Type value) => new(paramName,
-            $"'{value.GetFriendlyName()}' is not a valid input type. QueryArgument must be one of the input types: ScalarGraphType, EnumerationGraphType or IInputObjectGraphType.");
+        get => this.GetDeprecationReason();
+        set => this.SetDeprecationReason(value);
     }
+
+    /// <summary>
+    /// Gets or sets the default value of the argument.
+    /// </summary>
+    public object? DefaultValue { get; set; }
+
+    /// <summary>
+    /// Returns the graph type of this argument.
+    /// </summary>
+    public IGraphType? ResolvedType
+    {
+        get => _resolvedType;
+        set => _resolvedType = CheckResolvedType(value);
+    }
+
+    /// <inheritdoc/>
+    public Type? Type
+    {
+        get => _type;
+        internal set => _type = CheckType(value);
+    }
+
+    private Type? CheckType(Type? type)
+    {
+        if (type?.IsInputType() == false)
+            throw Create(nameof(Type), type);
+
+        return type;
+    }
+
+    private IGraphType? CheckResolvedType(IGraphType? type)
+    {
+        if (type != null && !type.IsGraphQLTypeReference() && !type.IsInputType())
+            throw Create(nameof(ResolvedType), type.GetType());
+
+        return type;
+    }
+
+    /// <summary>
+    /// Parses the value received from the client when the value is not <see langword="null"/>.
+    /// Occurs during validation prior to <see cref="Validator"/>.
+    /// Throw an exception if necessary to indicate a problem.
+    /// Only applicable to fields of input graph types.
+    /// </summary>
+    public Func<object, object>? Parser { get; set; }
+
+    /// <summary>
+    /// Validates the value received from the client when the value is not <see langword="null"/>.
+    /// Occurs during validation after <see cref="Parser"/> has parsed the value.
+    /// Throw an exception if necessary to indicate a problem.
+    /// Only applicable to fields of input graph types.
+    /// </summary>
+    public Action<object>? Validator { get; set; }
+
+    private ArgumentOutOfRangeException Create(string paramName, Type value) => new(paramName,
+        $"'{value.GetFriendlyName()}' is not a valid input type. QueryArgument must be one of the input types: ScalarGraphType, EnumerationGraphType or IInputObjectGraphType.");
 }

--- a/src/GraphQL/Types/Relay/ConnectionType.cs
+++ b/src/GraphQL/Types/Relay/ConnectionType.cs
@@ -1,58 +1,57 @@
-namespace GraphQL.Types.Relay
+namespace GraphQL.Types.Relay;
+
+/// <summary>
+/// A connection graph type for the specified node graph type. The GraphQL type name
+/// defaults to {NodeType}Connection where {NodeType} is the GraphQL type name of
+/// the node graph type. This graph type assumes that the source (the result of
+/// the parent field's resolver) is <see cref="ConnectionType{TNodeType, TEdgeType}"/>
+/// or <see cref="ConnectionType{TNodeType}"/> or has the same members.
+/// </summary>
+/// <typeparam name="TNodeType">The graph type of the result data set's data type.</typeparam>
+/// <typeparam name="TEdgeType">The edge graph type of node, typically <see cref="EdgeType{TNodeType}"/>.</typeparam>
+public class ConnectionType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType> : ObjectGraphType<object>
+    where TNodeType : IGraphType
+    where TEdgeType : EdgeType<TNodeType>
 {
-    /// <summary>
-    /// A connection graph type for the specified node graph type. The GraphQL type name
-    /// defaults to {NodeType}Connection where {NodeType} is the GraphQL type name of
-    /// the node graph type. This graph type assumes that the source (the result of
-    /// the parent field's resolver) is <see cref="ConnectionType{TNodeType, TEdgeType}"/>
-    /// or <see cref="ConnectionType{TNodeType}"/> or has the same members.
-    /// </summary>
-    /// <typeparam name="TNodeType">The graph type of the result data set's data type.</typeparam>
-    /// <typeparam name="TEdgeType">The edge graph type of node, typically <see cref="EdgeType{TNodeType}"/>.</typeparam>
-    public class ConnectionType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TEdgeType> : ObjectGraphType<object>
-        where TNodeType : IGraphType
-        where TEdgeType : EdgeType<TNodeType>
+    /// <inheritdoc/>
+    public ConnectionType()
     {
-        /// <inheritdoc/>
-        public ConnectionType()
-        {
-            string graphQLTypeName = typeof(TNodeType).GraphQLName();
-            Name = $"{graphQLTypeName}Connection";
-            Description =
-                $"A connection from an object to a list of objects of type `{graphQLTypeName}`.";
+        string graphQLTypeName = typeof(TNodeType).GraphQLName();
+        Name = $"{graphQLTypeName}Connection";
+        Description =
+            $"A connection from an object to a list of objects of type `{graphQLTypeName}`.";
 
-            Field<IntGraphType>("totalCount")
-                .Description(
-                    "A count of the total number of objects in this connection, ignoring pagination. " +
-                    "This allows a client to fetch the first five objects by passing \"5\" as the argument " +
-                    "to `first`, then fetch the total count so it could display \"5 of 83\", for example. " +
-                    "In cases where we employ infinite scrolling or don't have an exact count of entries, " +
-                    "this field will return `null`.");
+        Field<IntGraphType>("totalCount")
+            .Description(
+                "A count of the total number of objects in this connection, ignoring pagination. " +
+                "This allows a client to fetch the first five objects by passing \"5\" as the argument " +
+                "to `first`, then fetch the total count so it could display \"5 of 83\", for example. " +
+                "In cases where we employ infinite scrolling or don't have an exact count of entries, " +
+                "this field will return `null`.");
 
-            Field<NonNullGraphType<PageInfoType>>("pageInfo")
-                .Description("Information to aid in pagination.");
+        Field<NonNullGraphType<PageInfoType>>("pageInfo")
+            .Description("Information to aid in pagination.");
 
-            Field<ListGraphType<TEdgeType>>("edges")
-                .Description("A list of all of the edges returned in the connection.");
+        Field<ListGraphType<TEdgeType>>("edges")
+            .Description("A list of all of the edges returned in the connection.");
 
-            Field<ListGraphType<TNodeType>>("items")
-                .Description(
-                    "A list of all of the objects returned in the connection. This is a convenience field provided " +
-                    "for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data " +
-                    "is needed, this field can be used instead. Note that when clients like Relay need to fetch " +
-                    "the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, " +
-                    "and the full \"{ edges { node } } \" version should be used instead.");
-        }
+        Field<ListGraphType<TNodeType>>("items")
+            .Description(
+                "A list of all of the objects returned in the connection. This is a convenience field provided " +
+                "for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data " +
+                "is needed, this field can be used instead. Note that when clients like Relay need to fetch " +
+                "the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, " +
+                "and the full \"{ edges { node } } \" version should be used instead.");
     }
+}
 
-    /// <summary>
-    /// A connection graph type for the specified node type. The GraphQL type name
-    /// defaults to {NodeType}Connection where {NodeType} is the GraphQL type name of
-    /// the node graph type. The edge graph type used is <see cref="EdgeType{TNodeType}"/>.
-    /// </summary>
-    /// <typeparam name="TNodeType">The graph type of the result data set's data type.</typeparam>
-    public class ConnectionType<TNodeType> : ConnectionType<TNodeType, EdgeType<TNodeType>>
-        where TNodeType : IGraphType
-    {
-    }
+/// <summary>
+/// A connection graph type for the specified node type. The GraphQL type name
+/// defaults to {NodeType}Connection where {NodeType} is the GraphQL type name of
+/// the node graph type. The edge graph type used is <see cref="EdgeType{TNodeType}"/>.
+/// </summary>
+/// <typeparam name="TNodeType">The graph type of the result data set's data type.</typeparam>
+public class ConnectionType<TNodeType> : ConnectionType<TNodeType, EdgeType<TNodeType>>
+    where TNodeType : IGraphType
+{
 }

--- a/src/GraphQL/Types/Relay/DataObjects/Connection.cs
+++ b/src/GraphQL/Types/Relay/DataObjects/Connection.cs
@@ -1,40 +1,39 @@
-namespace GraphQL.Types.Relay.DataObjects
+namespace GraphQL.Types.Relay.DataObjects;
+
+/// <summary>
+/// Represents a connection result containing nodes and pagination information.
+/// </summary>
+/// <typeparam name="TNode">The data type.</typeparam>
+/// <typeparam name="TEdge">The edge type, typically <see cref="Edge{TNode}"/>.</typeparam>
+public class Connection<TNode, TEdge>
+    where TEdge : Edge<TNode>
 {
     /// <summary>
-    /// Represents a connection result containing nodes and pagination information.
+    /// The total number of records available. Returns <see langword="null"/> if the total number is unknown.
     /// </summary>
-    /// <typeparam name="TNode">The data type.</typeparam>
-    /// <typeparam name="TEdge">The edge type, typically <see cref="Edge{TNode}"/>.</typeparam>
-    public class Connection<TNode, TEdge>
-        where TEdge : Edge<TNode>
-    {
-        /// <summary>
-        /// The total number of records available. Returns <see langword="null"/> if the total number is unknown.
-        /// </summary>
-        public int? TotalCount { get; set; }
-
-        /// <summary>
-        /// Additional pagination information for this result data set.
-        /// </summary>
-        public PageInfo? PageInfo { get; set; }
-
-        /// <summary>
-        /// The result data set, stored as a list of edges containing a node (the data) and a cursor (a unique identifier for the data).
-        /// </summary>
-        public List<TEdge>? Edges { get; set; }
-
-        /// <summary>
-        /// The result data set.
-        /// </summary>
-        public List<TNode?>? Items => Edges?.Select(edge => edge.Node).ToList();
-    }
+    public int? TotalCount { get; set; }
 
     /// <summary>
-    /// Represents a connection result containing nodes and pagination information, with an
-    /// edge type of <see cref="Edge{TNode}"/>.
+    /// Additional pagination information for this result data set.
     /// </summary>
-    /// <typeparam name="TNode">The data type.</typeparam>
-    public class Connection<TNode> : Connection<TNode, Edge<TNode>>
-    {
-    }
+    public PageInfo? PageInfo { get; set; }
+
+    /// <summary>
+    /// The result data set, stored as a list of edges containing a node (the data) and a cursor (a unique identifier for the data).
+    /// </summary>
+    public List<TEdge>? Edges { get; set; }
+
+    /// <summary>
+    /// The result data set.
+    /// </summary>
+    public List<TNode?>? Items => Edges?.Select(edge => edge.Node).ToList();
+}
+
+/// <summary>
+/// Represents a connection result containing nodes and pagination information, with an
+/// edge type of <see cref="Edge{TNode}"/>.
+/// </summary>
+/// <typeparam name="TNode">The data type.</typeparam>
+public class Connection<TNode> : Connection<TNode, Edge<TNode>>
+{
 }

--- a/src/GraphQL/Types/Relay/DataObjects/Edge.cs
+++ b/src/GraphQL/Types/Relay/DataObjects/Edge.cs
@@ -1,19 +1,18 @@
-namespace GraphQL.Types.Relay.DataObjects
+namespace GraphQL.Types.Relay.DataObjects;
+
+/// <summary>
+/// Represents an edge of a connection containing a node (a row of data) and cursor (a unique identifier for the row of data).
+/// </summary>
+/// <typeparam name="TNode">The data type.</typeparam>
+public class Edge<TNode>
 {
     /// <summary>
-    /// Represents an edge of a connection containing a node (a row of data) and cursor (a unique identifier for the row of data).
+    /// The cursor of this edge's node. A cursor is a string representation of a unique identifier of this node.
     /// </summary>
-    /// <typeparam name="TNode">The data type.</typeparam>
-    public class Edge<TNode>
-    {
-        /// <summary>
-        /// The cursor of this edge's node. A cursor is a string representation of a unique identifier of this node.
-        /// </summary>
-        public string? Cursor { get; set; }
+    public string? Cursor { get; set; }
 
-        /// <summary>
-        /// The node. A node is a single row of data within the result data set.
-        /// </summary>
-        public TNode? Node { get; set; }
-    }
+    /// <summary>
+    /// The node. A node is a single row of data within the result data set.
+    /// </summary>
+    public TNode? Node { get; set; }
 }

--- a/src/GraphQL/Types/Relay/DataObjects/PageInfo.cs
+++ b/src/GraphQL/Types/Relay/DataObjects/PageInfo.cs
@@ -1,28 +1,27 @@
-namespace GraphQL.Types.Relay.DataObjects
+namespace GraphQL.Types.Relay.DataObjects;
+
+/// <summary>
+/// Contains pagination information relating to the result data set.
+/// </summary>
+public class PageInfo
 {
     /// <summary>
-    /// Contains pagination information relating to the result data set.
+    /// Indicates if there are additional pages of data that can be returned.
     /// </summary>
-    public class PageInfo
-    {
-        /// <summary>
-        /// Indicates if there are additional pages of data that can be returned.
-        /// </summary>
-        public bool HasNextPage { get; set; }
+    public bool HasNextPage { get; set; }
 
-        /// <summary>
-        /// Indicates if there are prior pages of data that can be returned.
-        /// </summary>
-        public bool HasPreviousPage { get; set; }
+    /// <summary>
+    /// Indicates if there are prior pages of data that can be returned.
+    /// </summary>
+    public bool HasPreviousPage { get; set; }
 
-        /// <summary>
-        /// The cursor of the first node in the result data set.
-        /// </summary>
-        public string? StartCursor { get; set; }
+    /// <summary>
+    /// The cursor of the first node in the result data set.
+    /// </summary>
+    public string? StartCursor { get; set; }
 
-        /// <summary>
-        /// The cursor of the last node in the result data set.
-        /// </summary>
-        public string? EndCursor { get; set; }
-    }
+    /// <summary>
+    /// The cursor of the last node in the result data set.
+    /// </summary>
+    public string? EndCursor { get; set; }
 }

--- a/src/GraphQL/Types/Relay/EdgeType.cs
+++ b/src/GraphQL/Types/Relay/EdgeType.cs
@@ -1,29 +1,28 @@
-namespace GraphQL.Types.Relay
+namespace GraphQL.Types.Relay;
+
+/// <summary>
+/// An edge graph type for the specified node graph type. The GraphQL type name
+/// defaults to {NodeType}Edge where {NodeType} is the GraphQL type name of
+/// the node graph type. This graph type assumes that the source (the result of
+/// the parent field's resolver) is <see cref="EdgeType{TNodeType}"/>
+/// or has the same members.
+/// </summary>
+/// <typeparam name="TNodeType">The graph type of the result data set's data type.</typeparam>
+public class EdgeType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType> : ObjectGraphType<object>
+    where TNodeType : IGraphType
 {
-    /// <summary>
-    /// An edge graph type for the specified node graph type. The GraphQL type name
-    /// defaults to {NodeType}Edge where {NodeType} is the GraphQL type name of
-    /// the node graph type. This graph type assumes that the source (the result of
-    /// the parent field's resolver) is <see cref="EdgeType{TNodeType}"/>
-    /// or has the same members.
-    /// </summary>
-    /// <typeparam name="TNodeType">The graph type of the result data set's data type.</typeparam>
-    public class EdgeType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNodeType> : ObjectGraphType<object>
-        where TNodeType : IGraphType
+    /// <inheritdoc/>
+    public EdgeType()
     {
-        /// <inheritdoc/>
-        public EdgeType()
-        {
-            string graphQLTypeName = typeof(TNodeType).GraphQLName();
-            Name = $"{graphQLTypeName}Edge";
-            Description =
-                $"An edge in a connection from an object to another object of type `{graphQLTypeName}`.";
+        string graphQLTypeName = typeof(TNodeType).GraphQLName();
+        Name = $"{graphQLTypeName}Edge";
+        Description =
+            $"An edge in a connection from an object to another object of type `{graphQLTypeName}`.";
 
-            Field<NonNullGraphType<StringGraphType>>("cursor")
-                .Description("A cursor for use in pagination");
+        Field<NonNullGraphType<StringGraphType>>("cursor")
+            .Description("A cursor for use in pagination");
 
-            Field<TNodeType>("node")
-                .Description("The item at the end of the edge");
-        }
+        Field<TNodeType>("node")
+            .Description("The item at the end of the edge");
     }
 }

--- a/src/GraphQL/Types/Relay/PageInfoType.cs
+++ b/src/GraphQL/Types/Relay/PageInfoType.cs
@@ -1,20 +1,19 @@
-namespace GraphQL.Types.Relay
-{
-    /// <summary>
-    /// A graph type that represents pagination information relating to the result data set.
-    /// </summary>
-    public class PageInfoType : ObjectGraphType<object>
-    {
-        /// <inheritdoc/>
-        public PageInfoType()
-        {
-            Name = "PageInfo";
-            Description = "Information about pagination in a connection.";
+namespace GraphQL.Types.Relay;
 
-            Field<NonNullGraphType<BooleanGraphType>>("hasNextPage").Description("When paginating forwards, are there more items?");
-            Field<NonNullGraphType<BooleanGraphType>>("hasPreviousPage").Description("When paginating backwards, are there more items?");
-            Field<StringGraphType>("startCursor").Description("When paginating backwards, the cursor to continue.");
-            Field<StringGraphType>("endCursor").Description("When paginating forwards, the cursor to continue.");
-        }
+/// <summary>
+/// A graph type that represents pagination information relating to the result data set.
+/// </summary>
+public class PageInfoType : ObjectGraphType<object>
+{
+    /// <inheritdoc/>
+    public PageInfoType()
+    {
+        Name = "PageInfo";
+        Description = "Information about pagination in a connection.";
+
+        Field<NonNullGraphType<BooleanGraphType>>("hasNextPage").Description("When paginating forwards, are there more items?");
+        Field<NonNullGraphType<BooleanGraphType>>("hasPreviousPage").Description("When paginating backwards, are there more items?");
+        Field<StringGraphType>("startCursor").Description("When paginating backwards, the cursor to continue.");
+        Field<StringGraphType>("endCursor").Description("When paginating forwards, the cursor to continue.");
     }
 }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -7,524 +7,523 @@ using GraphQL.Introspection;
 using GraphQL.Utilities;
 using GraphQLParser.AST;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <inheritdoc cref="ISchema"/>
+[DebuggerTypeProxy(typeof(SchemaDebugView))]
+public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
 {
-    /// <inheritdoc cref="ISchema"/>
-    [DebuggerTypeProxy(typeof(SchemaDebugView))]
-    public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
+    private sealed class SchemaDebugView
     {
-        private sealed class SchemaDebugView
+        private readonly Schema _schema;
+
+        public SchemaDebugView(Schema schema)
         {
-            private readonly Schema _schema;
-
-            public SchemaDebugView(Schema schema)
-            {
-                _schema = schema;
-            }
-
-            public Dictionary<string, object?> Metadata => _schema.Metadata;
-
-            public ExperimentalFeatures Features => _schema.Features;
-
-            public INameConverter NameConverter => _schema.NameConverter;
-
-            public IFieldMiddlewareBuilder FieldMiddleware => _schema.FieldMiddleware;
-
-            public bool Initialized => _schema.Initialized;
-
-            public string? Description => _schema.Description;
-
-            public IObjectGraphType Query => _schema.Query;
-
-            public IObjectGraphType? Mutation => _schema.Mutation;
-
-            public IObjectGraphType? Subscription => _schema.Subscription;
-
-            public ISchemaFilter Filter => _schema.Filter;
-
-            /// <inheritdoc/>
-            public ISchemaComparer Comparer => _schema.Comparer;
-
-            /// <inheritdoc/>
-            public SchemaDirectives Directives => _schema.Directives;
-
-            /// <inheritdoc/>
-            public SchemaTypes? AllTypes => _schema._allTypes;
-
-            public string AllTypesMessage => _schema._allTypes == null ? "AllTypes property too early initialization was suppressed to prevent unforeseen consequences. You may click Raw View in debugger window to evaluate all properties." : string.Empty;
-
-            public IEnumerable<Type> AdditionalTypes => _schema.AdditionalTypes;
-
-            public IEnumerable<IGraphType> AdditionalTypeInstances => _schema.AdditionalTypeInstances;
-
-            /// <inheritdoc/>
-            public FieldType? SchemaMetaFieldType => AllTypes?.SchemaMetaFieldType;
-
-            /// <inheritdoc/>
-            public FieldType? TypeMetaFieldType => AllTypes?.TypeMetaFieldType;
-
-            /// <inheritdoc/>
-            public FieldType? TypeNameMetaFieldType => AllTypes?.TypeNameMetaFieldType;
-
-            public IEnumerable<(Type clrType, Type graphType)> TypeMappings => _schema.TypeMappings;
-
-            /// <inheritdoc/>
-            public IEnumerable<(Type clrType, Type graphType)> BuiltInTypeMappings => _schema.BuiltInTypeMappings;
+            _schema = schema;
         }
 
-        private bool _disposed;
-        private IServiceProvider _services;
-        private SchemaTypes? _allTypes;
-        private ExceptionDispatchInfo? _initializationException;
-        private readonly object _allTypesInitializationLock = new();
+        public Dictionary<string, object?> Metadata => _schema.Metadata;
 
-        private List<Type>? _additionalTypes;
-        private List<IGraphType>? _additionalInstances;
+        public ExperimentalFeatures Features => _schema.Features;
 
-        private List<Type>? _visitorTypes;
-        private List<ISchemaNodeVisitor>? _visitors;
+        public INameConverter NameConverter => _schema.NameConverter;
 
-        /// <summary>
-        /// Create an instance of <see cref="Schema"/> with the <see cref="DefaultServiceProvider"/>, which
-        /// uses <see cref="Activator.CreateInstance(Type)"/> to create required objects.
-        /// </summary>
-        public Schema()
-            : this(new DefaultServiceProvider())
-        {
-        }
+        public IFieldMiddlewareBuilder FieldMiddleware => _schema.FieldMiddleware;
 
-        /// <summary>
-        /// Create an instance of <see cref="Schema"/> with a specified <see cref="IServiceProvider"/>, used
-        /// to create required objects.
-        /// Pulls registered <see cref="IConfigureSchema"/> instances from <paramref name="services"/> and
-        /// executes them.
-        /// </summary>
-        public Schema(IServiceProvider services)
-            : this(services, true)
-        {
-        }
+        public bool Initialized => _schema.Initialized;
 
-        /// <summary>
-        /// Create an instance of <see cref="Schema"/> with a specified <see cref="IServiceProvider"/>, used
-        /// to create required objects.
-        /// If <paramref name="runConfigurations"/> is <see langword="true"/>, pulls registered
-        /// <see cref="IConfigureSchema"/> instances from <paramref name="services"/> and executes them.
-        /// </summary>
-        public Schema(IServiceProvider services, bool runConfigurations = true)
-            : this(services, (runConfigurations ? services.GetService(typeof(IEnumerable<IConfigureSchema>)) as IEnumerable<IConfigureSchema> : null)!)
-        {
-        }
+        public string? Description => _schema.Description;
 
-        /// <summary>
-        /// Create an instance of <see cref="Schema"/> with a specified <see cref="IServiceProvider"/>, used
-        /// to create required objects.
-        /// Executes the specified <see cref="IConfigureSchema"/> instances on the schema, if any.
-        /// </summary>
-        public Schema(IServiceProvider services, IEnumerable<IConfigureSchema> configurations)
-        {
-            _services = services;
+        public IObjectGraphType Query => _schema.Query;
 
-            Directives = new SchemaDirectives();
-            Directives.Register(Directives.Include, Directives.Skip, Directives.Deprecated);
+        public IObjectGraphType? Mutation => _schema.Mutation;
 
-            foreach (var configuration in configurations ?? Array.Empty<IConfigureSchema>())
-            {
-                configuration.Configure(this, services);
-            }
-        }
+        public IObjectGraphType? Subscription => _schema.Subscription;
 
-        /// <summary>
-        /// Builds schema from the specified string and configuration delegate.
-        /// </summary>
-        /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
-        /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
-        /// <returns>Created schema.</returns>
-        public static Schema For(string typeDefinitions, Action<SchemaBuilder>? configure = null)
-            => For<SchemaBuilder>(typeDefinitions, configure);
-
-        /// <summary>
-        /// Builds schema from the specified string and configuration delegate.
-        /// </summary>
-        /// <typeparam name="TSchemaBuilder">The type of <see cref="SchemaBuilder"/> that will create the schema.</typeparam>
-        /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
-        /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
-        /// <returns>Created schema.</returns>
-        public static Schema For<TSchemaBuilder>(string typeDefinitions, Action<TSchemaBuilder>? configure = null)
-            where TSchemaBuilder : SchemaBuilder, new()
-        {
-            var builder = new TSchemaBuilder();
-            configure?.Invoke(builder);
-            return builder.Build(typeDefinitions);
-        }
+        public ISchemaFilter Filter => _schema.Filter;
 
         /// <inheritdoc/>
-        public ExperimentalFeatures Features { get; set; } = new ExperimentalFeatures();
+        public ISchemaComparer Comparer => _schema.Comparer;
 
         /// <inheritdoc/>
-        public INameConverter NameConverter { get; set; } = CamelCaseNameConverter.Instance;
+        public SchemaDirectives Directives => _schema.Directives;
 
         /// <inheritdoc/>
-        public IFieldMiddlewareBuilder FieldMiddleware { get; internal set; } = new FieldMiddlewareBuilder();
+        public SchemaTypes? AllTypes => _schema._allTypes;
+
+        public string AllTypesMessage => _schema._allTypes == null ? "AllTypes property too early initialization was suppressed to prevent unforeseen consequences. You may click Raw View in debugger window to evaluate all properties." : string.Empty;
+
+        public IEnumerable<Type> AdditionalTypes => _schema.AdditionalTypes;
+
+        public IEnumerable<IGraphType> AdditionalTypeInstances => _schema.AdditionalTypeInstances;
 
         /// <inheritdoc/>
-        public bool Initialized { get; private set; }
+        public FieldType? SchemaMetaFieldType => AllTypes?.SchemaMetaFieldType;
 
-        // TODO: It would be worthwhile to think at all about how to redo the design so that such a situation does not arise.
-        private void CheckInitialized([System.Runtime.CompilerServices.CallerMemberName] string name = "")
+        /// <inheritdoc/>
+        public FieldType? TypeMetaFieldType => AllTypes?.TypeMetaFieldType;
+
+        /// <inheritdoc/>
+        public FieldType? TypeNameMetaFieldType => AllTypes?.TypeNameMetaFieldType;
+
+        public IEnumerable<(Type clrType, Type graphType)> TypeMappings => _schema.TypeMappings;
+
+        /// <inheritdoc/>
+        public IEnumerable<(Type clrType, Type graphType)> BuiltInTypeMappings => _schema.BuiltInTypeMappings;
+    }
+
+    private bool _disposed;
+    private IServiceProvider _services;
+    private SchemaTypes? _allTypes;
+    private ExceptionDispatchInfo? _initializationException;
+    private readonly object _allTypesInitializationLock = new();
+
+    private List<Type>? _additionalTypes;
+    private List<IGraphType>? _additionalInstances;
+
+    private List<Type>? _visitorTypes;
+    private List<ISchemaNodeVisitor>? _visitors;
+
+    /// <summary>
+    /// Create an instance of <see cref="Schema"/> with the <see cref="DefaultServiceProvider"/>, which
+    /// uses <see cref="Activator.CreateInstance(Type)"/> to create required objects.
+    /// </summary>
+    public Schema()
+        : this(new DefaultServiceProvider())
+    {
+    }
+
+    /// <summary>
+    /// Create an instance of <see cref="Schema"/> with a specified <see cref="IServiceProvider"/>, used
+    /// to create required objects.
+    /// Pulls registered <see cref="IConfigureSchema"/> instances from <paramref name="services"/> and
+    /// executes them.
+    /// </summary>
+    public Schema(IServiceProvider services)
+        : this(services, true)
+    {
+    }
+
+    /// <summary>
+    /// Create an instance of <see cref="Schema"/> with a specified <see cref="IServiceProvider"/>, used
+    /// to create required objects.
+    /// If <paramref name="runConfigurations"/> is <see langword="true"/>, pulls registered
+    /// <see cref="IConfigureSchema"/> instances from <paramref name="services"/> and executes them.
+    /// </summary>
+    public Schema(IServiceProvider services, bool runConfigurations = true)
+        : this(services, (runConfigurations ? services.GetService(typeof(IEnumerable<IConfigureSchema>)) as IEnumerable<IConfigureSchema> : null)!)
+    {
+    }
+
+    /// <summary>
+    /// Create an instance of <see cref="Schema"/> with a specified <see cref="IServiceProvider"/>, used
+    /// to create required objects.
+    /// Executes the specified <see cref="IConfigureSchema"/> instances on the schema, if any.
+    /// </summary>
+    public Schema(IServiceProvider services, IEnumerable<IConfigureSchema> configurations)
+    {
+        _services = services;
+
+        Directives = new SchemaDirectives();
+        Directives.Register(Directives.Include, Directives.Skip, Directives.Deprecated);
+
+        foreach (var configuration in configurations ?? Array.Empty<IConfigureSchema>())
         {
-            if (Initialized)
-                throw new InvalidOperationException($"Schema is already initialized and sealed for modifications. You should call '{name}' only when Schema.Initialized = false.");
+            configuration.Configure(this, services);
         }
+    }
 
-        /// <inheritdoc/>
-        public void Initialize()
+    /// <summary>
+    /// Builds schema from the specified string and configuration delegate.
+    /// </summary>
+    /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
+    /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
+    /// <returns>Created schema.</returns>
+    public static Schema For(string typeDefinitions, Action<SchemaBuilder>? configure = null)
+        => For<SchemaBuilder>(typeDefinitions, configure);
+
+    /// <summary>
+    /// Builds schema from the specified string and configuration delegate.
+    /// </summary>
+    /// <typeparam name="TSchemaBuilder">The type of <see cref="SchemaBuilder"/> that will create the schema.</typeparam>
+    /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
+    /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
+    /// <returns>Created schema.</returns>
+    public static Schema For<TSchemaBuilder>(string typeDefinitions, Action<TSchemaBuilder>? configure = null)
+        where TSchemaBuilder : SchemaBuilder, new()
+    {
+        var builder = new TSchemaBuilder();
+        configure?.Invoke(builder);
+        return builder.Build(typeDefinitions);
+    }
+
+    /// <inheritdoc/>
+    public ExperimentalFeatures Features { get; set; } = new ExperimentalFeatures();
+
+    /// <inheritdoc/>
+    public INameConverter NameConverter { get; set; } = CamelCaseNameConverter.Instance;
+
+    /// <inheritdoc/>
+    public IFieldMiddlewareBuilder FieldMiddleware { get; internal set; } = new FieldMiddlewareBuilder();
+
+    /// <inheritdoc/>
+    public bool Initialized { get; private set; }
+
+    // TODO: It would be worthwhile to think at all about how to redo the design so that such a situation does not arise.
+    private void CheckInitialized([System.Runtime.CompilerServices.CallerMemberName] string name = "")
+    {
+        if (Initialized)
+            throw new InvalidOperationException($"Schema is already initialized and sealed for modifications. You should call '{name}' only when Schema.Initialized = false.");
+    }
+
+    /// <inheritdoc/>
+    public void Initialize()
+    {
+        CheckDisposed();
+
+        if (Initialized)
+            return;
+
+        lock (_allTypesInitializationLock)
         {
-            CheckDisposed();
-
             if (Initialized)
                 return;
 
-            lock (_allTypesInitializationLock)
-            {
-                if (Initialized)
-                    return;
-
-                _initializationException?.Throw();
-
-                try
-                {
-                    CreateAndInitializeSchemaTypes();
-
-                    Initialized = true;
-                }
-                catch (Exception ex)
-                {
-                    _initializationException = ExceptionDispatchInfo.Capture(ex);
-                    throw;
-                }
-            }
-        }
-
-        /// <inheritdoc/>
-        public string? Description { get; set; }
-
-        /// <inheritdoc/>
-        public IObjectGraphType Query { get; set; } = null!;
-
-        /// <inheritdoc/>
-        public IObjectGraphType? Mutation { get; set; }
-
-        /// <inheritdoc/>
-        public IObjectGraphType? Subscription { get; set; }
-
-        /// <summary>
-        /// Gets the service object of the specified type. Schema itself acts as a service provider used to
-        /// create objects, such as graph types, requested by the schema.
-        /// <br/><br/>
-        /// Note that most objects are created during schema initialization, which then have the same lifetime
-        /// as the schema's lifetime.
-        /// <br/><br/>
-        /// Other types created by the service provider may include directive visitors, middlewares, validation
-        /// rules, and name converters, among others.
-        /// <br/><br/>
-        /// Explicit implementation of the <see cref="IServiceProvider.GetService"/> method makes this method
-        /// less visible to the calling code, which reduces the likelihood of using it as so called ServiceLocator
-        /// anti-pattern. However, in some advanced scenarios this may be necessary.
-        /// </summary>
-        /// <param name="serviceType">An object that specifies the type of service object to get.</param>
-        /// <returns>
-        /// A service object of type <paramref name="serviceType"/> or <see langword="null"/> if there is no service
-        /// object of type serviceType.
-        /// </returns>
-        object? IServiceProvider.GetService(Type serviceType) => _services.GetService(serviceType);
-
-        /// <inheritdoc/>
-        public ISchemaFilter Filter { get; set; } = new DefaultSchemaFilter();
-
-        /// <inheritdoc/>
-        public ISchemaComparer Comparer { get; set; } = new DefaultSchemaComparer();
-
-        /// <inheritdoc/>
-        public SchemaDirectives Directives { get; }
-
-        /// <inheritdoc/>
-        public SchemaTypes AllTypes
-        {
-            get
-            {
-                if (_allTypes == null)
-                    Initialize();
-
-                return _allTypes!;
-            }
-        }
-
-        /// <inheritdoc/>
-        public IEnumerable<Type> AdditionalTypes => _additionalTypes ?? Enumerable.Empty<Type>();
-
-        /// <inheritdoc/>
-        public IEnumerable<IGraphType> AdditionalTypeInstances => _additionalInstances ?? Enumerable.Empty<IGraphType>();
-
-        /// <inheritdoc/>
-        public FieldType SchemaMetaFieldType => AllTypes.SchemaMetaFieldType;
-
-        /// <inheritdoc/>
-        public FieldType TypeMetaFieldType => AllTypes.TypeMetaFieldType;
-
-        /// <inheritdoc/>
-        public FieldType TypeNameMetaFieldType => AllTypes.TypeNameMetaFieldType;
-
-        /// <inheritdoc/>
-        public void RegisterVisitor(ISchemaNodeVisitor visitor)
-        {
-            CheckDisposed();
-            CheckInitialized();
-
-            (_visitors ??= new()).Add(visitor ?? throw new ArgumentNullException(nameof(visitor)));
-        }
-
-        /// <inheritdoc/>
-        public void RegisterVisitor(Type type)
-        {
-            CheckDisposed();
-            CheckInitialized();
-
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            if (!typeof(ISchemaNodeVisitor).IsAssignableFrom(type))
-            {
-                throw new ArgumentOutOfRangeException(nameof(type), $"Type must be of {nameof(ISchemaNodeVisitor)}.");
-            }
-
-            if (!(_visitorTypes ??= new()).Contains(type))
-                _visitorTypes.Add(type);
-        }
-
-        /// <inheritdoc/>
-        public void RegisterType(IGraphType type)
-        {
-            CheckDisposed();
-            CheckInitialized();
-
-            (_additionalInstances ??= new()).Add(type ?? throw new ArgumentNullException(nameof(type)));
-        }
-
-        /// <inheritdoc/>
-        public void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
-        {
-            CheckDisposed();
-            CheckInitialized();
-
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            if (!typeof(IGraphType).IsAssignableFrom(type))
-            {
-                throw new ArgumentOutOfRangeException(nameof(type), "Type must be of IGraphType.");
-            }
-
-            _additionalTypes ??= new();
-
-            if (!_additionalTypes.Contains(type))
-                _additionalTypes.Add(type);
-        }
-
-        /// <inheritdoc/>
-        public void RegisterTypes(params Type[] types)
-        {
-            CheckDisposed();
-            CheckInitialized();
-
-            if (types == null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
-
-            foreach (var type in types)
-            {
-                RegisterType(type);
-            }
-        }
-
-        private List<(Type clrType, Type graphType)>? _clrToGraphTypeMappings;
-
-        /// <inheritdoc/>
-        public void RegisterTypeMapping(
-            Type clrType,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            Type graphType)
-        {
-            (_clrToGraphTypeMappings ??= new()).Add((
-                CheckClrType(clrType ?? throw new ArgumentNullException(nameof(clrType))),
-                CheckGraphType(graphType ?? throw new ArgumentNullException(nameof(graphType)))
-            ));
-
-            Type CheckClrType(Type clrType)
-            {
-                return typeof(IGraphType).IsAssignableFrom(clrType)
-                    ? throw new ArgumentOutOfRangeException(nameof(clrType), $"{clrType.FullName}' is already a GraphType (i.e. not CLR type like System.DateTime or System.String). You must specify CLR type instead of GraphType.")
-                    : clrType;
-            }
-
-            Type CheckGraphType(Type graphType)
-            {
-                return typeof(IGraphType).IsAssignableFrom(graphType)
-                    ? graphType
-                    : throw new ArgumentOutOfRangeException(nameof(graphType), $"{graphType.FullName}' must be a GraphType (i.e. not CLR type like System.DateTime or System.String). You must specify GraphType type instead of CLR type.");
-            }
-        }
-
-        /// <inheritdoc/>
-        public IEnumerable<(Type clrType, Type graphType)> TypeMappings => _clrToGraphTypeMappings ?? Enumerable.Empty<(Type, Type)>();
-
-        /// <inheritdoc/>
-        public IEnumerable<(Type clrType, Type graphType)> BuiltInTypeMappings
-        {
-            get
-            {
-                foreach (var pair in SchemaTypes.BuiltInScalarMappings)
-                    yield return (pair.Key, pair.Value);
-            }
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <inheritdoc/>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (!_disposed)
-                {
-                    _services = null!;
-                    Query = null!;
-                    Mutation = null;
-                    Subscription = null;
-                    Filter = null!;
-
-                    _additionalInstances?.Clear();
-                    _additionalTypes?.Clear();
-                    Directives.List.Clear();
-                    _visitors?.Clear();
-                    _visitorTypes?.Clear();
-
-                    _allTypes?.Dictionary.Clear();
-                    _allTypes = null;
-
-                    _disposed = true;
-                }
-            }
-        }
-
-        private void CheckDisposed()
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(Schema));
-        }
-
-        private void CreateAndInitializeSchemaTypes()
-        {
-            IEnumerable<ISchemaNodeVisitor> GetVisitors()
-            {
-                if (_visitors != null)
-                {
-                    foreach (var visitor in _visitors)
-                        yield return visitor;
-                }
-
-                if (_visitorTypes != null)
-                {
-                    foreach (var type in _visitorTypes)
-                        yield return (ISchemaNodeVisitor)_services.GetRequiredService(type);
-                }
-            }
-
-            _allTypes = CreateSchemaTypes();
+            _initializationException?.Throw();
 
             try
             {
-                // At this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete.
-                // However, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock.
-                _allTypes.ApplyMiddleware(FieldMiddleware);
+                CreateAndInitializeSchemaTypes();
 
-                foreach (var visitor in GetVisitors())
-                    visitor.Run(this);
-
-                Validate();
+                Initialized = true;
             }
-            catch
+            catch (Exception ex)
             {
-                _allTypes = null;
+                _initializationException = ExceptionDispatchInfo.Capture(ex);
                 throw;
             }
         }
+    }
 
-        /// <summary>
-        /// Creates and returns a new instance of <see cref="SchemaTypes"/> for this schema.
-        /// Does not apply middleware, apply schema visitors, or validate the schema.
-        /// </summary>
-        /// <remarks>
-        /// This executes within a lock in <see cref="Initialize"/>.
-        /// </remarks>
-        protected virtual SchemaTypes CreateSchemaTypes()
+    /// <inheritdoc/>
+    public string? Description { get; set; }
+
+    /// <inheritdoc/>
+    public IObjectGraphType Query { get; set; } = null!;
+
+    /// <inheritdoc/>
+    public IObjectGraphType? Mutation { get; set; }
+
+    /// <inheritdoc/>
+    public IObjectGraphType? Subscription { get; set; }
+
+    /// <summary>
+    /// Gets the service object of the specified type. Schema itself acts as a service provider used to
+    /// create objects, such as graph types, requested by the schema.
+    /// <br/><br/>
+    /// Note that most objects are created during schema initialization, which then have the same lifetime
+    /// as the schema's lifetime.
+    /// <br/><br/>
+    /// Other types created by the service provider may include directive visitors, middlewares, validation
+    /// rules, and name converters, among others.
+    /// <br/><br/>
+    /// Explicit implementation of the <see cref="IServiceProvider.GetService"/> method makes this method
+    /// less visible to the calling code, which reduces the likelihood of using it as so called ServiceLocator
+    /// anti-pattern. However, in some advanced scenarios this may be necessary.
+    /// </summary>
+    /// <param name="serviceType">An object that specifies the type of service object to get.</param>
+    /// <returns>
+    /// A service object of type <paramref name="serviceType"/> or <see langword="null"/> if there is no service
+    /// object of type serviceType.
+    /// </returns>
+    object? IServiceProvider.GetService(Type serviceType) => _services.GetService(serviceType);
+
+    /// <inheritdoc/>
+    public ISchemaFilter Filter { get; set; } = new DefaultSchemaFilter();
+
+    /// <inheritdoc/>
+    public ISchemaComparer Comparer { get; set; } = new DefaultSchemaComparer();
+
+    /// <inheritdoc/>
+    public SchemaDirectives Directives { get; }
+
+    /// <inheritdoc/>
+    public SchemaTypes AllTypes
+    {
+        get
         {
-            return new SchemaTypes(this, _services);
+            if (_allTypes == null)
+                Initialize();
+
+            return _allTypes!;
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<Type> AdditionalTypes => _additionalTypes ?? Enumerable.Empty<Type>();
+
+    /// <inheritdoc/>
+    public IEnumerable<IGraphType> AdditionalTypeInstances => _additionalInstances ?? Enumerable.Empty<IGraphType>();
+
+    /// <inheritdoc/>
+    public FieldType SchemaMetaFieldType => AllTypes.SchemaMetaFieldType;
+
+    /// <inheritdoc/>
+    public FieldType TypeMetaFieldType => AllTypes.TypeMetaFieldType;
+
+    /// <inheritdoc/>
+    public FieldType TypeNameMetaFieldType => AllTypes.TypeNameMetaFieldType;
+
+    /// <inheritdoc/>
+    public void RegisterVisitor(ISchemaNodeVisitor visitor)
+    {
+        CheckDisposed();
+        CheckInitialized();
+
+        (_visitors ??= new()).Add(visitor ?? throw new ArgumentNullException(nameof(visitor)));
+    }
+
+    /// <inheritdoc/>
+    public void RegisterVisitor(Type type)
+    {
+        CheckDisposed();
+        CheckInitialized();
+
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (!typeof(ISchemaNodeVisitor).IsAssignableFrom(type))
+        {
+            throw new ArgumentOutOfRangeException(nameof(type), $"Type must be of {nameof(ISchemaNodeVisitor)}.");
         }
 
-        /// <summary>
-        /// Validates correctness of the created schema. This method is called only once - during schema initialization.
-        /// </summary>
-        protected virtual void Validate()
+        if (!(_visitorTypes ??= new()).Contains(type))
+            _visitorTypes.Add(type);
+    }
+
+    /// <inheritdoc/>
+    public void RegisterType(IGraphType type)
+    {
+        CheckDisposed();
+        CheckInitialized();
+
+        (_additionalInstances ??= new()).Add(type ?? throw new ArgumentNullException(nameof(type)));
+    }
+
+    /// <inheritdoc/>
+    public void RegisterType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
+    {
+        CheckDisposed();
+        CheckInitialized();
+
+        if (type == null)
+            throw new ArgumentNullException(nameof(type));
+
+        if (!typeof(IGraphType).IsAssignableFrom(type))
         {
-            //TODO: add different validations, also see SchemaBuilder.Validate
-            //TODO: checks for parsed SDL may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653
-            // Do not change the order of these validations.
-            CoerceInputTypeDefaultValues();
-            SchemaValidationVisitor.Instance.Run(this);
-            AppliedDirectivesValidationVisitor.Instance.Run(this);
-            FieldTypeDefaultArgumentsVisitor.Instance.Run(this);
+            throw new ArgumentOutOfRangeException(nameof(type), "Type must be of IGraphType.");
         }
 
-        /// <summary>
-        /// Coerces input types' default values when those values are <see cref="GraphQLValue"/> nodes.
-        /// This is applicable when the <see cref="SchemaBuilder"/> is used to build the schema.
-        /// </summary>
-        protected virtual void CoerceInputTypeDefaultValues()
+        _additionalTypes ??= new();
+
+        if (!_additionalTypes.Contains(type))
+            _additionalTypes.Add(type);
+    }
+
+    /// <inheritdoc/>
+    public void RegisterTypes(params Type[] types)
+    {
+        CheckDisposed();
+        CheckInitialized();
+
+        if (types == null)
         {
-            var completed = new HashSet<IInputObjectGraphType>();
-            var inProcess = new Stack<IInputObjectGraphType>();
-            foreach (var type in AllTypes.Dictionary.Values)
+            throw new ArgumentNullException(nameof(types));
+        }
+
+        foreach (var type in types)
+        {
+            RegisterType(type);
+        }
+    }
+
+    private List<(Type clrType, Type graphType)>? _clrToGraphTypeMappings;
+
+    /// <inheritdoc/>
+    public void RegisterTypeMapping(
+        Type clrType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        Type graphType)
+    {
+        (_clrToGraphTypeMappings ??= new()).Add((
+            CheckClrType(clrType ?? throw new ArgumentNullException(nameof(clrType))),
+            CheckGraphType(graphType ?? throw new ArgumentNullException(nameof(graphType)))
+        ));
+
+        Type CheckClrType(Type clrType)
+        {
+            return typeof(IGraphType).IsAssignableFrom(clrType)
+                ? throw new ArgumentOutOfRangeException(nameof(clrType), $"{clrType.FullName}' is already a GraphType (i.e. not CLR type like System.DateTime or System.String). You must specify CLR type instead of GraphType.")
+                : clrType;
+        }
+
+        Type CheckGraphType(Type graphType)
+        {
+            return typeof(IGraphType).IsAssignableFrom(graphType)
+                ? graphType
+                : throw new ArgumentOutOfRangeException(nameof(graphType), $"{graphType.FullName}' must be a GraphType (i.e. not CLR type like System.DateTime or System.String). You must specify GraphType type instead of CLR type.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<(Type clrType, Type graphType)> TypeMappings => _clrToGraphTypeMappings ?? Enumerable.Empty<(Type, Type)>();
+
+    /// <inheritdoc/>
+    public IEnumerable<(Type clrType, Type graphType)> BuiltInTypeMappings
+    {
+        get
+        {
+            foreach (var pair in SchemaTypes.BuiltInScalarMappings)
+                yield return (pair.Key, pair.Value);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc/>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (!_disposed)
             {
-                if (type is IInputObjectGraphType inputType)
-                    ExamineType(inputType, completed, inProcess);
+                _services = null!;
+                Query = null!;
+                Mutation = null;
+                Subscription = null;
+                Filter = null!;
+
+                _additionalInstances?.Clear();
+                _additionalTypes?.Clear();
+                Directives.List.Clear();
+                _visitors?.Clear();
+                _visitorTypes?.Clear();
+
+                _allTypes?.Dictionary.Clear();
+                _allTypes = null;
+
+                _disposed = true;
+            }
+        }
+    }
+
+    private void CheckDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(Schema));
+    }
+
+    private void CreateAndInitializeSchemaTypes()
+    {
+        IEnumerable<ISchemaNodeVisitor> GetVisitors()
+        {
+            if (_visitors != null)
+            {
+                foreach (var visitor in _visitors)
+                    yield return visitor;
             }
 
-            static void ExamineType(IInputObjectGraphType inputType, HashSet<IInputObjectGraphType> completed, Stack<IInputObjectGraphType> inProcess)
+            if (_visitorTypes != null)
             {
-                if (completed.Contains(inputType))
-                    return;
-                if (inProcess.Contains(inputType))
-                    throw new InvalidOperationException($"Default values in input types cannot contain a circular dependency loop. Please resolve dependency loop between the following types: {string.Join(", ", inProcess.Select(x => $"'{x.Name}'"))}.");
-                inProcess.Push(inputType);
-                foreach (var field in inputType.Fields)
+                foreach (var type in _visitorTypes)
+                    yield return (ISchemaNodeVisitor)_services.GetRequiredService(type);
+            }
+        }
+
+        _allTypes = CreateSchemaTypes();
+
+        try
+        {
+            // At this point, Initialized will return false, and Initialize will still lock while waiting for initialization to complete.
+            // However, AllTypes and similar properties will return a reference to SchemaTypes without waiting for a lock.
+            _allTypes.ApplyMiddleware(FieldMiddleware);
+
+            foreach (var visitor in GetVisitors())
+                visitor.Run(this);
+
+            Validate();
+        }
+        catch
+        {
+            _allTypes = null;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Creates and returns a new instance of <see cref="SchemaTypes"/> for this schema.
+    /// Does not apply middleware, apply schema visitors, or validate the schema.
+    /// </summary>
+    /// <remarks>
+    /// This executes within a lock in <see cref="Initialize"/>.
+    /// </remarks>
+    protected virtual SchemaTypes CreateSchemaTypes()
+    {
+        return new SchemaTypes(this, _services);
+    }
+
+    /// <summary>
+    /// Validates correctness of the created schema. This method is called only once - during schema initialization.
+    /// </summary>
+    protected virtual void Validate()
+    {
+        //TODO: add different validations, also see SchemaBuilder.Validate
+        //TODO: checks for parsed SDL may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653
+        // Do not change the order of these validations.
+        CoerceInputTypeDefaultValues();
+        SchemaValidationVisitor.Instance.Run(this);
+        AppliedDirectivesValidationVisitor.Instance.Run(this);
+        FieldTypeDefaultArgumentsVisitor.Instance.Run(this);
+    }
+
+    /// <summary>
+    /// Coerces input types' default values when those values are <see cref="GraphQLValue"/> nodes.
+    /// This is applicable when the <see cref="SchemaBuilder"/> is used to build the schema.
+    /// </summary>
+    protected virtual void CoerceInputTypeDefaultValues()
+    {
+        var completed = new HashSet<IInputObjectGraphType>();
+        var inProcess = new Stack<IInputObjectGraphType>();
+        foreach (var type in AllTypes.Dictionary.Values)
+        {
+            if (type is IInputObjectGraphType inputType)
+                ExamineType(inputType, completed, inProcess);
+        }
+
+        static void ExamineType(IInputObjectGraphType inputType, HashSet<IInputObjectGraphType> completed, Stack<IInputObjectGraphType> inProcess)
+        {
+            if (completed.Contains(inputType))
+                return;
+            if (inProcess.Contains(inputType))
+                throw new InvalidOperationException($"Default values in input types cannot contain a circular dependency loop. Please resolve dependency loop between the following types: {string.Join(", ", inProcess.Select(x => $"'{x.Name}'"))}.");
+            inProcess.Push(inputType);
+            foreach (var field in inputType.Fields)
+            {
+                if (field.DefaultValue is GraphQLValue value)
                 {
-                    if (field.DefaultValue is GraphQLValue value)
-                    {
-                        var baseType = field.ResolvedType!.GetNamedType();
-                        if (baseType is IInputObjectGraphType inputFieldType)
-                            ExamineType(inputFieldType, completed, inProcess);
-                        field.DefaultValue = Execution.ExecutionHelper.CoerceValue(field.ResolvedType!, value).Value;
-                    }
+                    var baseType = field.ResolvedType!.GetNamedType();
+                    if (baseType is IInputObjectGraphType inputFieldType)
+                        ExamineType(inputFieldType, completed, inProcess);
+                    field.DefaultValue = Execution.ExecutionHelper.CoerceValue(field.ResolvedType!, value).Value;
                 }
-                inProcess.Pop();
-                completed.Add(inputType);
             }
+            inProcess.Pop();
+            completed.Add(inputType);
         }
     }
 }

--- a/src/GraphQL/Types/TypeCollectionContext.cs
+++ b/src/GraphQL/Types/TypeCollectionContext.cs
@@ -1,80 +1,79 @@
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Provides a mechanism to resolve graph type instances from their .NET types,
+/// and also to register new graph type instances with their name in the graph type lookup table.
+/// (See <see cref="SchemaTypes"/>.)
+/// </summary>
+internal sealed class TypeCollectionContext
 {
     /// <summary>
-    /// Provides a mechanism to resolve graph type instances from their .NET types,
-    /// and also to register new graph type instances with their name in the graph type lookup table.
-    /// (See <see cref="SchemaTypes"/>.)
+    /// Initializes a new instance with the specified parameters.
     /// </summary>
-    internal sealed class TypeCollectionContext
+    /// <param name="resolver">A delegate which returns an instance of a graph type from its .NET type.</param>
+    /// <param name="addType">A delegate which adds a graph type instance to the list of named graph types for the schema.</param>
+    /// <param name="typeMappings">CLR-GraphType type mappings.</param>
+    /// <param name="schema">The schema.</param>
+    internal TypeCollectionContext(Func<Type, IGraphType> resolver, Action<string, IGraphType, TypeCollectionContext> addType, IEnumerable<IGraphTypeMappingProvider>? typeMappings, ISchema schema)
     {
-        /// <summary>
-        /// Initializes a new instance with the specified parameters.
-        /// </summary>
-        /// <param name="resolver">A delegate which returns an instance of a graph type from its .NET type.</param>
-        /// <param name="addType">A delegate which adds a graph type instance to the list of named graph types for the schema.</param>
-        /// <param name="typeMappings">CLR-GraphType type mappings.</param>
-        /// <param name="schema">The schema.</param>
-        internal TypeCollectionContext(Func<Type, IGraphType> resolver, Action<string, IGraphType, TypeCollectionContext> addType, IEnumerable<IGraphTypeMappingProvider>? typeMappings, ISchema schema)
-        {
-            ResolveType = resolver;
-            AddType = addType;
-            ClrToGraphTypeMappings = typeMappings;
-            Schema = schema;
-            if (GlobalSwitches.TrackGraphTypeInitialization)
-                InitializationTrace = new();
-        }
-
-        /// <summary>
-        /// Returns a delegate which returns an instance of a graph type from its .NET type.
-        /// </summary>
-        internal Func<Type, IGraphType> ResolveType { get; }
-
-        /// <summary>
-        /// Returns a delegate which adds a graph type instance to the list of named graph types for the schema.
-        /// </summary>
-        internal Action<string, IGraphType, TypeCollectionContext> AddType { get; }
-
-        internal IEnumerable<IGraphTypeMappingProvider>? ClrToGraphTypeMappings { get; }
-
-        internal Stack<Type> InFlightRegisteredTypes { get; } = new();
-
-        internal ISchema Schema { get; }
-
-        internal List<string>? InitializationTrace { get; set; }
-
-        internal TypeCollectionContextInitializationTrace Trace(string traceElement) =>
-            InitializationTrace == null
-                ? default
-                : new(this, traceElement);
-
-        internal TypeCollectionContextInitializationTrace Trace(string traceElement, object? arg1)
-        {
-            return InitializationTrace == null
-                ? default
-                : new(this, string.Format(traceElement, arg1));
-        }
-
-        internal TypeCollectionContextInitializationTrace Trace(string traceElement, object? arg1, object? arg2)
-        {
-            return InitializationTrace == null
-                ? default
-                : new(this, string.Format(traceElement, arg1, arg2));
-        }
+        ResolveType = resolver;
+        AddType = addType;
+        ClrToGraphTypeMappings = typeMappings;
+        Schema = schema;
+        if (GlobalSwitches.TrackGraphTypeInitialization)
+            InitializationTrace = new();
     }
 
-    internal readonly struct TypeCollectionContextInitializationTrace : IDisposable
+    /// <summary>
+    /// Returns a delegate which returns an instance of a graph type from its .NET type.
+    /// </summary>
+    internal Func<Type, IGraphType> ResolveType { get; }
+
+    /// <summary>
+    /// Returns a delegate which adds a graph type instance to the list of named graph types for the schema.
+    /// </summary>
+    internal Action<string, IGraphType, TypeCollectionContext> AddType { get; }
+
+    internal IEnumerable<IGraphTypeMappingProvider>? ClrToGraphTypeMappings { get; }
+
+    internal Stack<Type> InFlightRegisteredTypes { get; } = new();
+
+    internal ISchema Schema { get; }
+
+    internal List<string>? InitializationTrace { get; set; }
+
+    internal TypeCollectionContextInitializationTrace Trace(string traceElement) =>
+        InitializationTrace == null
+            ? default
+            : new(this, traceElement);
+
+    internal TypeCollectionContextInitializationTrace Trace(string traceElement, object? arg1)
     {
-        private readonly TypeCollectionContext? _context;
+        return InitializationTrace == null
+            ? default
+            : new(this, string.Format(traceElement, arg1));
+    }
 
-        public TypeCollectionContextInitializationTrace(TypeCollectionContext context, string traceElement)
-        {
-            _context = context;
-            context.InitializationTrace?.Add(traceElement);
-        }
+    internal TypeCollectionContextInitializationTrace Trace(string traceElement, object? arg1, object? arg2)
+    {
+        return InitializationTrace == null
+            ? default
+            : new(this, string.Format(traceElement, arg1, arg2));
+    }
+}
 
-        public void Dispose()
-        {
-            _context?.InitializationTrace?.RemoveAt(_context.InitializationTrace.Count - 1);
-        }
+internal readonly struct TypeCollectionContextInitializationTrace : IDisposable
+{
+    private readonly TypeCollectionContext? _context;
+
+    public TypeCollectionContextInitializationTrace(TypeCollectionContext context, string traceElement)
+    {
+        _context = context;
+        context.InitializationTrace?.Add(traceElement);
+    }
+
+    public void Dispose()
+    {
+        _context?.InitializationTrace?.RemoveAt(_context.InitializationTrace.Count - 1);
     }
 }

--- a/src/GraphQL/Types/TypeExtensions.cs
+++ b/src/GraphQL/Types/TypeExtensions.cs
@@ -1,78 +1,77 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Provides helper methods for locating a graph type within a schema from the AST type.
+/// </summary>
+public static class TypeExtensions
 {
     /// <summary>
-    /// Provides helper methods for locating a graph type within a schema from the AST type.
+    /// Searches a schema for a graph type specified by an AST type after unwrapping any
+    /// <see cref="GraphQLNonNullType"/> or <see cref="GraphQLListType"/> layers. If the type cannot be
+    /// found, returns <see langword="null"/>.
     /// </summary>
-    public static class TypeExtensions
+    /// <param name="type">The AST type to search for.</param>
+    /// <param name="schema">The schema to search within.</param>
+    public static IGraphType? NamedGraphTypeFromType(this GraphQLType type, ISchema schema) => type switch
     {
-        /// <summary>
-        /// Searches a schema for a graph type specified by an AST type after unwrapping any
-        /// <see cref="GraphQLNonNullType"/> or <see cref="GraphQLListType"/> layers. If the type cannot be
-        /// found, returns <see langword="null"/>.
-        /// </summary>
-        /// <param name="type">The AST type to search for.</param>
-        /// <param name="schema">The schema to search within.</param>
-        public static IGraphType? NamedGraphTypeFromType(this GraphQLType type, ISchema schema) => type switch
+        GraphQLNonNullType nonnull => NamedGraphTypeFromType(nonnull.Type, schema),
+        GraphQLListType list => NamedGraphTypeFromType(list.Type, schema),
+        GraphQLNamedType named => schema.AllTypes[named.Name],
+        _ => null
+    };
+
+    /// <summary>
+    /// Searches a schema for a graph type specified by an AST type. If the type
+    /// cannot be found, returns <see langword="null"/>.
+    /// </summary>
+    /// <param name="type">The AST type to search for.</param>
+    /// <param name="schema">The schema to search within.</param>
+    public static IGraphType? GraphTypeFromType(this GraphQLType type, ISchema schema)
+    {
+        if (type is GraphQLNonNullType nonnull)
         {
-            GraphQLNonNullType nonnull => NamedGraphTypeFromType(nonnull.Type, schema),
-            GraphQLListType list => NamedGraphTypeFromType(list.Type, schema),
-            GraphQLNamedType named => schema.AllTypes[named.Name],
-            _ => null
-        };
-
-        /// <summary>
-        /// Searches a schema for a graph type specified by an AST type. If the type
-        /// cannot be found, returns <see langword="null"/>.
-        /// </summary>
-        /// <param name="type">The AST type to search for.</param>
-        /// <param name="schema">The schema to search within.</param>
-        public static IGraphType? GraphTypeFromType(this GraphQLType type, ISchema schema)
-        {
-            if (type is GraphQLNonNullType nonnull)
-            {
-                var ofType = GraphTypeFromType(nonnull.Type, schema);
-                return ofType == null
-                    ? null
-                    : new NonNullGraphType(ofType);
-            }
-
-            if (type is GraphQLListType list)
-            {
-                var ofType = GraphTypeFromType(list.Type, schema);
-                return ofType == null
-                    ? null
-                    : new ListGraphType(ofType);
-            }
-
-            return type is GraphQLNamedType named
-                ? schema.AllTypes[named.Name]
-                : null;
+            var ofType = GraphTypeFromType(nonnull.Type, schema);
+            return ofType == null
+                ? null
+                : new NonNullGraphType(ofType);
         }
 
-        /// <summary>
-        /// Returns the name of an AST type after unwrapping any <see cref="GraphQLNonNullType"/> or <see cref="GraphQLListType"/> layers.
-        /// </summary>
-        public static string Name(this GraphQLType type) => type switch
+        if (type is GraphQLListType list)
         {
-            GraphQLNonNullType nonnull => Name(nonnull.Type),
-            GraphQLListType list => Name(list.Type),
-            GraphQLNamedType named => named.Name.StringValue, //ISSUE:allocation but used only on error paths
-            _ => throw new NotSupportedException($"Unknown type {type}")
-        };
+            var ofType = GraphTypeFromType(list.Type, schema);
+            return ofType == null
+                ? null
+                : new ListGraphType(ofType);
+        }
 
-        /// <summary>
-        /// Returns the formatted GraphQL type name of the AST type,
-        /// using brackets and exclamation points as necessary to
-        /// indicate lists or non-null types, respectively.
-        /// </summary>
-        public static string FullName(this GraphQLType type) => type switch
-        {
-            GraphQLNonNullType nonnull => $"{FullName(nonnull.Type)}!",
-            GraphQLListType list => $"[{FullName(list.Type)}]",
-            GraphQLNamedType named => named.Name.StringValue, //ISSUE:allocation
-            _ => throw new NotSupportedException($"Unknown type {type}")
-        };
+        return type is GraphQLNamedType named
+            ? schema.AllTypes[named.Name]
+            : null;
     }
+
+    /// <summary>
+    /// Returns the name of an AST type after unwrapping any <see cref="GraphQLNonNullType"/> or <see cref="GraphQLListType"/> layers.
+    /// </summary>
+    public static string Name(this GraphQLType type) => type switch
+    {
+        GraphQLNonNullType nonnull => Name(nonnull.Type),
+        GraphQLListType list => Name(list.Type),
+        GraphQLNamedType named => named.Name.StringValue, //ISSUE:allocation but used only on error paths
+        _ => throw new NotSupportedException($"Unknown type {type}")
+    };
+
+    /// <summary>
+    /// Returns the formatted GraphQL type name of the AST type,
+    /// using brackets and exclamation points as necessary to
+    /// indicate lists or non-null types, respectively.
+    /// </summary>
+    public static string FullName(this GraphQLType type) => type switch
+    {
+        GraphQLNonNullType nonnull => $"{FullName(nonnull.Type)}!",
+        GraphQLListType list => $"[{FullName(list.Type)}]",
+        GraphQLNamedType named => named.Name.StringValue, //ISSUE:allocation
+        _ => throw new NotSupportedException($"Unknown type {type}")
+    };
 }

--- a/src/GraphQL/Types/TypeInformation.cs
+++ b/src/GraphQL/Types/TypeInformation.cs
@@ -2,352 +2,351 @@ using System.Collections;
 using System.Reflection;
 using GraphQL.DataLoader;
 
-namespace GraphQL.Types
+namespace GraphQL.Types;
+
+/// <summary>
+/// Parses a <see cref="System.Type"/> along with nullability information into its constituent parts
+/// in preparation for creating a graph type that represents such a type.
+/// </summary>
+public class TypeInformation
 {
     /// <summary>
-    /// Parses a <see cref="System.Type"/> along with nullability information into its constituent parts
-    /// in preparation for creating a graph type that represents such a type.
+    /// The member being inspected. This is a <see cref="MethodInfo"/>, <see cref="PropertyInfo"/> or <see cref="FieldInfo"/> instance.
     /// </summary>
-    public class TypeInformation
+    public MemberInfo MemberInfo { get; }
+
+    /// <summary>
+    /// The parameter being inspected. Only applicable when <see cref="MemberInfo"/> is a <see cref="MethodInfo"/>.
+    /// </summary>
+    public ParameterInfo? ParameterInfo { get; }
+
+    /// <summary>
+    /// Indicates that this is an input type (an argument or input field); false for output types.
+    /// </summary>
+    public bool IsInputType { get; }
+
+    /// <summary>
+    /// The underlying CLR type represented. This might be the underlying type of a <see cref="Nullable{T}"/>
+    /// or the underlying type of a <see cref="IEnumerable{T}"/>.
+    /// </summary>
+    public Type Type { get; set; }
+
+    /// <summary>
+    /// Indicates if the underlying type is nullable.
+    /// </summary>
+    public bool IsNullable { get; set; }
+
+    /// <summary>
+    /// Indicates that this represents a list of elements.
+    /// </summary>
+    public bool IsList { get; set; }
+
+    /// <summary>
+    /// Indicates if the list is nullable.
+    /// </summary>
+    public bool ListIsNullable { get; set; }
+
+    private Type? _graphType;
+    /// <summary>
+    /// The graph type of the underlying CLR type or <see langword="null"/> to detect the graph type automatically.
+    /// </summary>
+    public Type? GraphType
     {
-        /// <summary>
-        /// The member being inspected. This is a <see cref="MethodInfo"/>, <see cref="PropertyInfo"/> or <see cref="FieldInfo"/> instance.
-        /// </summary>
-        public MemberInfo MemberInfo { get; }
-
-        /// <summary>
-        /// The parameter being inspected. Only applicable when <see cref="MemberInfo"/> is a <see cref="MethodInfo"/>.
-        /// </summary>
-        public ParameterInfo? ParameterInfo { get; }
-
-        /// <summary>
-        /// Indicates that this is an input type (an argument or input field); false for output types.
-        /// </summary>
-        public bool IsInputType { get; }
-
-        /// <summary>
-        /// The underlying CLR type represented. This might be the underlying type of a <see cref="Nullable{T}"/>
-        /// or the underlying type of a <see cref="IEnumerable{T}"/>.
-        /// </summary>
-        public Type Type { get; set; }
-
-        /// <summary>
-        /// Indicates if the underlying type is nullable.
-        /// </summary>
-        public bool IsNullable { get; set; }
-
-        /// <summary>
-        /// Indicates that this represents a list of elements.
-        /// </summary>
-        public bool IsList { get; set; }
-
-        /// <summary>
-        /// Indicates if the list is nullable.
-        /// </summary>
-        public bool ListIsNullable { get; set; }
-
-        private Type? _graphType;
-        /// <summary>
-        /// The graph type of the underlying CLR type or <see langword="null"/> to detect the graph type automatically.
-        /// </summary>
-        public Type? GraphType
+        get => _graphType;
+        set
         {
-            get => _graphType;
-            set
+            if (value == null)
             {
-                if (value == null)
-                {
-                    _graphType = null;
-                    return;
-                }
-                if (IsInputType)
-                {
-                    if (!value.IsInputType())
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(value), "Value can only be an input graph type.");
-                    }
-                }
-                else if (!value.IsOutputType())
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value), "Value can only be an output graph type.");
-                }
-                if (!value.IsNamedType())
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value), "Value must be a named graph type.");
-                }
-                _graphType = value;
+                _graphType = null;
+                return;
             }
-        }
-
-        /// <summary>
-        /// Initializes an instance with the specified properties.
-        /// </summary>
-        /// <param name="memberInfo">The member being inspected.</param>
-        /// <param name="isInputType">Indicates that this is an input type (an argument or input field); false for output types.</param>
-        /// <param name="type">The underlying type.</param>
-        /// <param name="isNullable">Indicates that the underlying type is nullable.</param>
-        /// <param name="isList">Indicates that this member represents a list of elements.</param>
-        /// <param name="listIsNullable">Indicates that the list is nullable.</param>
-        /// <param name="graphType">The graph type of the underlying CLR type; null to be generated by <see cref="GraphQL.TypeExtensions.GetGraphTypeFromType(System.Type, bool, TypeMappingMode)"/>.</param>
-        public TypeInformation(MemberInfo memberInfo, bool isInputType, Type type, bool isNullable, bool isList, bool listIsNullable, Type? graphType)
-        {
-            MemberInfo = memberInfo ?? throw new ArgumentNullException(nameof(memberInfo));
-            IsInputType = isInputType;
-            Type = type ?? throw new ArgumentNullException(nameof(type));
-            IsNullable = isNullable;
-            IsList = isList;
-            ListIsNullable = listIsNullable;
-            GraphType = graphType;
-        }
-
-        /// <summary>
-        /// Initializes an instance with the specified properties.
-        /// </summary>
-        /// <param name="parameterInfo">The parameter being inspected.</param>
-        /// <param name="type">The underlying type.</param>
-        /// <param name="isNullable">Indicates that the underlying type is nullable.</param>
-        /// <param name="isList">Indicates that this member represents a list of elements.</param>
-        /// <param name="listIsNullable">Indicates that the list is nullable.</param>
-        /// <param name="graphType">The graph type of the underlying CLR type; null to be generated by <see cref="GraphQL.TypeExtensions.GetGraphTypeFromType(System.Type, bool, TypeMappingMode)"/>.</param>
-        public TypeInformation(ParameterInfo parameterInfo, Type type, bool isNullable, bool isList, bool listIsNullable, Type? graphType)
-            : this(parameterInfo.Member, true, type, isNullable, isList, listIsNullable, graphType)
-        {
-            ParameterInfo = parameterInfo;
-        }
-
-        /// <summary>
-        /// Initializes an instance containing type information necessary to select a graph type.
-        /// The instance is populated based on inspecting the type and NRT annotations on the specified property.
-        /// </summary>
-        public TypeInformation(PropertyInfo propertyInfo, bool isInput)
-            : this(propertyInfo, isInput, propertyInfo.PropertyType, false, false, false, null)
-        {
-            // for the purposes of processing the nullability information, if the property is
-            // read-only, read the nullability information as if it were an output type (so read the getter)
-            var treatAsInput = isInput && propertyInfo.CanWrite;
-            var typeTree = Interpret(new NullabilityInfoContext().Create(propertyInfo), treatAsInput);
-
-            ProcessTypeTree(typeTree, isInput);
-        }
-
-        /// <summary>
-        /// Initializes an instance containing type information necessary to select a graph type.
-        /// The instance is populated based on inspecting the type and NRT annotations on the specified field.
-        /// </summary>
-        public TypeInformation(FieldInfo fieldInfo, bool isInput)
-            : this(fieldInfo, isInput, fieldInfo.FieldType, false, false, false, null)
-        {
-            var typeTree = Interpret(new NullabilityInfoContext().Create(fieldInfo), isInput);
-
-            ProcessTypeTree(typeTree, isInput);
-        }
-
-        /// <summary>
-        /// Initializes an instance containing type information necessary to select a graph type.
-        /// The instance is populated based on inspecting the type and NRT annotations on the specified method.
-        /// </summary>
-        public TypeInformation(MethodInfo methodInfo)
-            : this(methodInfo, false, methodInfo.ReturnType, false, false, false, null)
-        {
-            var typeTree = Interpret(new NullabilityInfoContext().Create(methodInfo.ReturnParameter), false);
-
-            ProcessTypeTree(typeTree, false);
-        }
-
-        /// <summary>
-        /// Initializes an instance containing type information necessary to select a graph type.
-        /// The instance is populated based on inspecting the type and NRT annotations on the specified parameter.
-        /// </summary>
-        public TypeInformation(ParameterInfo parameterInfo)
-            : this(parameterInfo, parameterInfo.ParameterType, false, false, false, null)
-        {
-            var typeTree = Interpret(new NullabilityInfoContext().Create(parameterInfo), true);
-
-            ProcessTypeTree(typeTree, true);
-        }
-
-        /// <summary>
-        /// Populates the <see cref="Type"/>, <see cref="IsNullable"/>, <see cref="IsList"/> and <see cref="ListIsNullable"/>
-        /// properties of this instance from a provided <paramref name="typeTree"/>.
-        /// </summary>
-        private void ProcessTypeTree(List<(Type Type, NullabilityState Nullable)> typeTree, bool isInput)
-        {
-            foreach (var type in typeTree)
+            if (IsInputType)
             {
-                //detect list types, but not lists of lists
-                if (!IsList)
+                if (!value.IsInputType())
                 {
-                    if (type.Type.IsArray)
+                    throw new ArgumentOutOfRangeException(nameof(value), "Value can only be an input graph type.");
+                }
+            }
+            else if (!value.IsOutputType())
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "Value can only be an output graph type.");
+            }
+            if (!value.IsNamedType())
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "Value must be a named graph type.");
+            }
+            _graphType = value;
+        }
+    }
+
+    /// <summary>
+    /// Initializes an instance with the specified properties.
+    /// </summary>
+    /// <param name="memberInfo">The member being inspected.</param>
+    /// <param name="isInputType">Indicates that this is an input type (an argument or input field); false for output types.</param>
+    /// <param name="type">The underlying type.</param>
+    /// <param name="isNullable">Indicates that the underlying type is nullable.</param>
+    /// <param name="isList">Indicates that this member represents a list of elements.</param>
+    /// <param name="listIsNullable">Indicates that the list is nullable.</param>
+    /// <param name="graphType">The graph type of the underlying CLR type; null to be generated by <see cref="GraphQL.TypeExtensions.GetGraphTypeFromType(System.Type, bool, TypeMappingMode)"/>.</param>
+    public TypeInformation(MemberInfo memberInfo, bool isInputType, Type type, bool isNullable, bool isList, bool listIsNullable, Type? graphType)
+    {
+        MemberInfo = memberInfo ?? throw new ArgumentNullException(nameof(memberInfo));
+        IsInputType = isInputType;
+        Type = type ?? throw new ArgumentNullException(nameof(type));
+        IsNullable = isNullable;
+        IsList = isList;
+        ListIsNullable = listIsNullable;
+        GraphType = graphType;
+    }
+
+    /// <summary>
+    /// Initializes an instance with the specified properties.
+    /// </summary>
+    /// <param name="parameterInfo">The parameter being inspected.</param>
+    /// <param name="type">The underlying type.</param>
+    /// <param name="isNullable">Indicates that the underlying type is nullable.</param>
+    /// <param name="isList">Indicates that this member represents a list of elements.</param>
+    /// <param name="listIsNullable">Indicates that the list is nullable.</param>
+    /// <param name="graphType">The graph type of the underlying CLR type; null to be generated by <see cref="GraphQL.TypeExtensions.GetGraphTypeFromType(System.Type, bool, TypeMappingMode)"/>.</param>
+    public TypeInformation(ParameterInfo parameterInfo, Type type, bool isNullable, bool isList, bool listIsNullable, Type? graphType)
+        : this(parameterInfo.Member, true, type, isNullable, isList, listIsNullable, graphType)
+    {
+        ParameterInfo = parameterInfo;
+    }
+
+    /// <summary>
+    /// Initializes an instance containing type information necessary to select a graph type.
+    /// The instance is populated based on inspecting the type and NRT annotations on the specified property.
+    /// </summary>
+    public TypeInformation(PropertyInfo propertyInfo, bool isInput)
+        : this(propertyInfo, isInput, propertyInfo.PropertyType, false, false, false, null)
+    {
+        // for the purposes of processing the nullability information, if the property is
+        // read-only, read the nullability information as if it were an output type (so read the getter)
+        var treatAsInput = isInput && propertyInfo.CanWrite;
+        var typeTree = Interpret(new NullabilityInfoContext().Create(propertyInfo), treatAsInput);
+
+        ProcessTypeTree(typeTree, isInput);
+    }
+
+    /// <summary>
+    /// Initializes an instance containing type information necessary to select a graph type.
+    /// The instance is populated based on inspecting the type and NRT annotations on the specified field.
+    /// </summary>
+    public TypeInformation(FieldInfo fieldInfo, bool isInput)
+        : this(fieldInfo, isInput, fieldInfo.FieldType, false, false, false, null)
+    {
+        var typeTree = Interpret(new NullabilityInfoContext().Create(fieldInfo), isInput);
+
+        ProcessTypeTree(typeTree, isInput);
+    }
+
+    /// <summary>
+    /// Initializes an instance containing type information necessary to select a graph type.
+    /// The instance is populated based on inspecting the type and NRT annotations on the specified method.
+    /// </summary>
+    public TypeInformation(MethodInfo methodInfo)
+        : this(methodInfo, false, methodInfo.ReturnType, false, false, false, null)
+    {
+        var typeTree = Interpret(new NullabilityInfoContext().Create(methodInfo.ReturnParameter), false);
+
+        ProcessTypeTree(typeTree, false);
+    }
+
+    /// <summary>
+    /// Initializes an instance containing type information necessary to select a graph type.
+    /// The instance is populated based on inspecting the type and NRT annotations on the specified parameter.
+    /// </summary>
+    public TypeInformation(ParameterInfo parameterInfo)
+        : this(parameterInfo, parameterInfo.ParameterType, false, false, false, null)
+    {
+        var typeTree = Interpret(new NullabilityInfoContext().Create(parameterInfo), true);
+
+        ProcessTypeTree(typeTree, true);
+    }
+
+    /// <summary>
+    /// Populates the <see cref="Type"/>, <see cref="IsNullable"/>, <see cref="IsList"/> and <see cref="ListIsNullable"/>
+    /// properties of this instance from a provided <paramref name="typeTree"/>.
+    /// </summary>
+    private void ProcessTypeTree(List<(Type Type, NullabilityState Nullable)> typeTree, bool isInput)
+    {
+        foreach (var type in typeTree)
+        {
+            //detect list types, but not lists of lists
+            if (!IsList)
+            {
+                if (type.Type.IsArray)
+                {
+                    //unwrap type and mark as list
+                    IsList = true;
+                    ListIsNullable = IsNullable || type.Nullable != NullabilityState.NotNull;
+                    continue;
+                }
+                if (type.Type.IsGenericType)
+                {
+                    if (IsRecognizedListType(type.Type))
                     {
                         //unwrap type and mark as list
                         IsList = true;
                         ListIsNullable = IsNullable || type.Nullable != NullabilityState.NotNull;
+                        IsNullable = false;
                         continue;
                     }
-                    if (type.Type.IsGenericType)
-                    {
-                        if (IsRecognizedListType(type.Type))
-                        {
-                            //unwrap type and mark as list
-                            IsList = true;
-                            ListIsNullable = IsNullable || type.Nullable != NullabilityState.NotNull;
-                            IsNullable = false;
-                            continue;
-                        }
-                    }
-                    if (type.Type == typeof(IEnumerable) || type.Type == typeof(ICollection))
-                    {
-                        //assume list of nullable object
-                        IsList = true;
-                        ListIsNullable = IsNullable || type.Nullable != NullabilityState.NotNull;
-                        IsNullable = false;
-                        break;
-                    }
                 }
-                if (!isInput)
+                if (type.Type == typeof(IEnumerable) || type.Type == typeof(ICollection))
                 {
-                    if (type.Type.IsGenericType)
-                    {
-                        var genericType = type.Type.GetGenericTypeDefinition();
-                        if (genericType == typeof(Task<>) || genericType == typeof(ValueTask<>)
-                            || genericType == typeof(IAsyncEnumerable<>)
-                            || genericType == typeof(IDataLoaderResult<>) || genericType == typeof(IObservable<>))
-                        {
-                            //unwrap type
-                            IsNullable |= type.Nullable != NullabilityState.NotNull;
-                            continue;
-                        }
-                    }
-                    if (type.Type == typeof(IDataLoaderResult))
-                    {
-                        //assume nullable object
-                        break;
-                    }
-                }
-                //found match
-                IsNullable |= type.Nullable != NullabilityState.NotNull;
-                Type = type.Type;
-                return;
-            }
-            //unknown type
-            IsNullable = true;
-            Type = typeof(object);
-        }
-
-        /// <summary>
-        /// Flattens a complex <see cref="NullabilityInfo"/> structure into a list of types and nullability flags.
-        /// <see cref="Nullable{T}"/> structs return their underlying type rather than <see cref="Nullable{T}"/>.
-        /// </summary>
-        private static List<(Type Type, NullabilityState Nullable)> Interpret(NullabilityInfo info, bool isInput)
-        {
-            var list = new List<(Type, NullabilityState)>(info.GenericTypeArguments.Length + 1);
-            RecursiveLoop(info);
-            return list;
-
-            void RecursiveLoop(NullabilityInfo info)
-            {
-                if (info.Type.IsGenericType)
-                {
-                    var nullableType = Nullable.GetUnderlyingType(info.Type);
-                    if (nullableType != null)
-                    {
-                        list.Add((nullableType, NullabilityState.Nullable));
-                    }
-                    else
-                    {
-                        list.Add((info.Type, isInput ? info.WriteState : info.ReadState));
-                    }
-                    foreach (var t in info.GenericTypeArguments)
-                    {
-                        RecursiveLoop(t);
-                    }
-                }
-                else if (info.ElementType != null)
-                {
-                    list.Add((info.Type, isInput ? info.WriteState : info.ReadState));
-                    RecursiveLoop(info.ElementType);
-                }
-                else
-                {
-                    list.Add((info.Type, isInput ? info.WriteState : info.ReadState));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Applies <see cref="GraphQLAttribute"/> attributes for the specified member to this instance.
-        /// Also scans the member's owning module and assembly for globally-applied attributes,
-        /// and applies attributes defined within <see cref="GlobalSwitches.GlobalAttributes"/>.
-        /// </summary>
-        public virtual void ApplyAttributes()
-        {
-            var memberOrParameter = (ICustomAttributeProvider?)ParameterInfo ?? MemberInfo;
-            if (memberOrParameter.IsDefined(typeof(System.ComponentModel.DataAnnotations.RequiredAttribute), false))
-            {
-                if (IsList)
-                {
-                    ListIsNullable = false;
-                }
-                else
-                {
+                    //assume list of nullable object
+                    IsList = true;
+                    ListIsNullable = IsNullable || type.Nullable != NullabilityState.NotNull;
                     IsNullable = false;
+                    break;
                 }
             }
-
-            var attributes = ParameterInfo != null
-                ? ParameterInfo.GetGraphQLAttributes()
-                : MemberInfo.GetGraphQLAttributes();
-            foreach (var attr in attributes)
+            if (!isInput)
             {
-                attr.Modify(this);
+                if (type.Type.IsGenericType)
+                {
+                    var genericType = type.Type.GetGenericTypeDefinition();
+                    if (genericType == typeof(Task<>) || genericType == typeof(ValueTask<>)
+                        || genericType == typeof(IAsyncEnumerable<>)
+                        || genericType == typeof(IDataLoaderResult<>) || genericType == typeof(IObservable<>))
+                    {
+                        //unwrap type
+                        IsNullable |= type.Nullable != NullabilityState.NotNull;
+                        continue;
+                    }
+                }
+                if (type.Type == typeof(IDataLoaderResult))
+                {
+                    //assume nullable object
+                    break;
+                }
             }
+            //found match
+            IsNullable |= type.Nullable != NullabilityState.NotNull;
+            Type = type.Type;
+            return;
         }
+        //unknown type
+        IsNullable = true;
+        Type = typeof(object);
+    }
 
-        /// <summary>
-        /// Returns a graph type constructed based on the properties set within this instance.
-        /// If <see cref="GraphType"/> is <see langword="null"/>, the graph type is generated via
-        /// <see cref="GraphQL.TypeExtensions.GetGraphTypeFromType(System.Type, bool, TypeMappingMode)"/>.
-        /// The graph type is then wrapped with <see cref="NonNullGraphType{T}"/> and/or
-        /// <see cref="ListGraphType{T}"/> as appropriate.
-        /// </summary>
-        public virtual Type ConstructGraphType()
+    /// <summary>
+    /// Flattens a complex <see cref="NullabilityInfo"/> structure into a list of types and nullability flags.
+    /// <see cref="Nullable{T}"/> structs return their underlying type rather than <see cref="Nullable{T}"/>.
+    /// </summary>
+    private static List<(Type Type, NullabilityState Nullable)> Interpret(NullabilityInfo info, bool isInput)
+    {
+        var list = new List<(Type, NullabilityState)>(info.GenericTypeArguments.Length + 1);
+        RecursiveLoop(info);
+        return list;
+
+        void RecursiveLoop(NullabilityInfo info)
         {
-            var type = GraphType;
-            if (type != null)
+            if (info.Type.IsGenericType)
             {
-                if (!IsNullable)
-                    type = typeof(NonNullGraphType<>).MakeGenericType(type);
+                var nullableType = Nullable.GetUnderlyingType(info.Type);
+                if (nullableType != null)
+                {
+                    list.Add((nullableType, NullabilityState.Nullable));
+                }
+                else
+                {
+                    list.Add((info.Type, isInput ? info.WriteState : info.ReadState));
+                }
+                foreach (var t in info.GenericTypeArguments)
+                {
+                    RecursiveLoop(t);
+                }
+            }
+            else if (info.ElementType != null)
+            {
+                list.Add((info.Type, isInput ? info.WriteState : info.ReadState));
+                RecursiveLoop(info.ElementType);
             }
             else
             {
-                type = Type.GetGraphTypeFromType(IsNullable, IsInputType ? TypeMappingMode.InputType : TypeMappingMode.OutputType);
+                list.Add((info.Type, isInput ? info.WriteState : info.ReadState));
             }
+        }
+    }
+
+    /// <summary>
+    /// Applies <see cref="GraphQLAttribute"/> attributes for the specified member to this instance.
+    /// Also scans the member's owning module and assembly for globally-applied attributes,
+    /// and applies attributes defined within <see cref="GlobalSwitches.GlobalAttributes"/>.
+    /// </summary>
+    public virtual void ApplyAttributes()
+    {
+        var memberOrParameter = (ICustomAttributeProvider?)ParameterInfo ?? MemberInfo;
+        if (memberOrParameter.IsDefined(typeof(System.ComponentModel.DataAnnotations.RequiredAttribute), false))
+        {
             if (IsList)
             {
-                type = typeof(ListGraphType<>).MakeGenericType(type);
-                if (!ListIsNullable)
-                    type = typeof(NonNullGraphType<>).MakeGenericType(type);
+                ListIsNullable = false;
             }
-            return type;
+            else
+            {
+                IsNullable = false;
+            }
         }
 
-        internal static readonly Type[] EnumerableListTypes = new Type[] {
-            typeof(IEnumerable<>),
-            typeof(IList<>),
-            typeof(List<>),
-            typeof(ICollection<>),
-            typeof(IReadOnlyCollection<>),
-            typeof(IReadOnlyList<>),
-            typeof(HashSet<>),
-            typeof(ISet<>),
-        };
-
-        /// <summary>
-        /// Determines if the specified type is one of a certain set of recognized generic list types.
-        /// Does not match for <see cref="string"/> or <see cref="IDictionary{TKey, TValue}"/> or other
-        /// types which may also be able to be cast to <see cref="IEnumerable{T}"/>.
-        /// </summary>
-        private bool IsRecognizedListType(Type type)
-            => Array.IndexOf(EnumerableListTypes, type.GetGenericTypeDefinition()) >= 0;
+        var attributes = ParameterInfo != null
+            ? ParameterInfo.GetGraphQLAttributes()
+            : MemberInfo.GetGraphQLAttributes();
+        foreach (var attr in attributes)
+        {
+            attr.Modify(this);
+        }
     }
+
+    /// <summary>
+    /// Returns a graph type constructed based on the properties set within this instance.
+    /// If <see cref="GraphType"/> is <see langword="null"/>, the graph type is generated via
+    /// <see cref="GraphQL.TypeExtensions.GetGraphTypeFromType(System.Type, bool, TypeMappingMode)"/>.
+    /// The graph type is then wrapped with <see cref="NonNullGraphType{T}"/> and/or
+    /// <see cref="ListGraphType{T}"/> as appropriate.
+    /// </summary>
+    public virtual Type ConstructGraphType()
+    {
+        var type = GraphType;
+        if (type != null)
+        {
+            if (!IsNullable)
+                type = typeof(NonNullGraphType<>).MakeGenericType(type);
+        }
+        else
+        {
+            type = Type.GetGraphTypeFromType(IsNullable, IsInputType ? TypeMappingMode.InputType : TypeMappingMode.OutputType);
+        }
+        if (IsList)
+        {
+            type = typeof(ListGraphType<>).MakeGenericType(type);
+            if (!ListIsNullable)
+                type = typeof(NonNullGraphType<>).MakeGenericType(type);
+        }
+        return type;
+    }
+
+    internal static readonly Type[] EnumerableListTypes = new Type[] {
+        typeof(IEnumerable<>),
+        typeof(IList<>),
+        typeof(List<>),
+        typeof(ICollection<>),
+        typeof(IReadOnlyCollection<>),
+        typeof(IReadOnlyList<>),
+        typeof(HashSet<>),
+        typeof(ISet<>),
+    };
+
+    /// <summary>
+    /// Determines if the specified type is one of a certain set of recognized generic list types.
+    /// Does not match for <see cref="string"/> or <see cref="IDictionary{TKey, TValue}"/> or other
+    /// types which may also be able to be cast to <see cref="IEnumerable{T}"/>.
+    /// </summary>
+    private bool IsRecognizedListType(Type type)
+        => Array.IndexOf(EnumerableListTypes, type.GetGenericTypeDefinition()) >= 0;
 }

--- a/src/GraphQL/Utilities/ArgumentConfig.cs
+++ b/src/GraphQL/Utilities/ArgumentConfig.cs
@@ -1,32 +1,31 @@
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Provides configuration for specific field argument when building schema via <see cref="SchemaBuilder"/>.
+/// </summary>
+public class ArgumentConfig : MetadataProvider
 {
     /// <summary>
-    /// Provides configuration for specific field argument when building schema via <see cref="SchemaBuilder"/>.
+    /// Creates an instance of <see cref="ArgumentConfig"/> with the specified name.
     /// </summary>
-    public class ArgumentConfig : MetadataProvider
+    /// <param name="name">Field argument name.</param>
+    public ArgumentConfig(string name)
     {
-        /// <summary>
-        /// Creates an instance of <see cref="ArgumentConfig"/> with the specified name.
-        /// </summary>
-        /// <param name="name">Field argument name.</param>
-        public ArgumentConfig(string name)
-        {
-            Name = name;
-        }
-
-        /// <summary>
-        /// Gets the name of the argument.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Gets or sets the argument description.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Gets or sets the default value of the field argument.
-        /// </summary>
-        public object? DefaultValue { get; set; }
+        Name = name;
     }
+
+    /// <summary>
+    /// Gets the name of the argument.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets or sets the argument description.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default value of the field argument.
+    /// </summary>
+    public object? DefaultValue { get; set; }
 }

--- a/src/GraphQL/Utilities/Federation/AnyScalarGraphType.cs
+++ b/src/GraphQL/Utilities/Federation/AnyScalarGraphType.cs
@@ -1,18 +1,17 @@
 using GraphQL.Types;
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation;
+
+/// <summary>
+/// Represents a type unknown within this portion of the federated schema.
+/// </summary>
+public class AnyScalarGraphType : ComplexScalarGraphType
 {
     /// <summary>
-    /// Represents a type unknown within this portion of the federated schema.
+    /// Initializes a new instance of this class.
     /// </summary>
-    public class AnyScalarGraphType : ComplexScalarGraphType
+    public AnyScalarGraphType()
     {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        public AnyScalarGraphType()
-        {
-            Name = "_Any";
-        }
+        Name = "_Any";
     }
 }

--- a/src/GraphQL/Utilities/Federation/FederatedResolveContext.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedResolveContext.cs
@@ -1,10 +1,9 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation;
+
+public class FederatedResolveContext
 {
-    public class FederatedResolveContext
-    {
-        public IResolveFieldContext ParentFieldContext { get; set; } = null!;
-        public Dictionary<string, object?> Arguments { get; set; } = null!;
-    }
+    public IResolveFieldContext ParentFieldContext { get; set; } = null!;
+    public Dictionary<string, object?> Arguments { get; set; } = null!;
 }

--- a/src/GraphQL/Utilities/Federation/FederatedSchema.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchema.cs
@@ -1,35 +1,34 @@
 using GraphQL.Types;
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation;
+
+/// <summary>
+/// A schema builder for GraphQL federation
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1102:Make class static.", Justification = "TODO: rewrite")]
+public class FederatedSchema
 {
     /// <summary>
-    /// A schema builder for GraphQL federation
+    /// Builds schema from the specified string and configuration delegate.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1102:Make class static.", Justification = "TODO: rewrite")]
-    public class FederatedSchema
-    {
-        /// <summary>
-        /// Builds schema from the specified string and configuration delegate.
-        /// </summary>
-        /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
-        /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
-        /// <returns>Created schema.</returns>
-        public static Schema For(string typeDefinitions, Action<FederatedSchemaBuilder>? configure = null)
-            => For<FederatedSchemaBuilder>(typeDefinitions, configure);
+    /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
+    /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
+    /// <returns>Created schema.</returns>
+    public static Schema For(string typeDefinitions, Action<FederatedSchemaBuilder>? configure = null)
+        => For<FederatedSchemaBuilder>(typeDefinitions, configure);
 
-        /// <summary>
-        /// Builds schema from the specified string and configuration delegate.
-        /// </summary>
-        /// <typeparam name="TFederatedSchemaBuilder">The type of <see cref="FederatedSchemaBuilder"/> that will create the schema.</typeparam>
-        /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
-        /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
-        /// <returns>Created schema.</returns>
-        public static Schema For<TFederatedSchemaBuilder>(string typeDefinitions, Action<TFederatedSchemaBuilder>? configure = null)
-            where TFederatedSchemaBuilder : FederatedSchemaBuilder, new()
-        {
-            var builder = new TFederatedSchemaBuilder();
-            configure?.Invoke(builder);
-            return builder.Build(typeDefinitions);
-        }
+    /// <summary>
+    /// Builds schema from the specified string and configuration delegate.
+    /// </summary>
+    /// <typeparam name="TFederatedSchemaBuilder">The type of <see cref="FederatedSchemaBuilder"/> that will create the schema.</typeparam>
+    /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
+    /// <param name="configure">Optional configuration delegate to setup <see cref="SchemaBuilder"/>.</param>
+    /// <returns>Created schema.</returns>
+    public static Schema For<TFederatedSchemaBuilder>(string typeDefinitions, Action<TFederatedSchemaBuilder>? configure = null)
+        where TFederatedSchemaBuilder : FederatedSchemaBuilder, new()
+    {
+        var builder = new TFederatedSchemaBuilder();
+        configure?.Invoke(builder);
+        return builder.Build(typeDefinitions);
     }
 }

--- a/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
+++ b/src/GraphQL/Utilities/Federation/FederatedSchemaPrinter.cs
@@ -3,134 +3,133 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation;
+
+[Obsolete("Please use the schema.Print() extension method instead. This class will be removed in v9.")]
+public class FederatedSchemaPrinter : SchemaPrinter //TODO:should be completely rewritten
 {
-    [Obsolete("Please use the schema.Print() extension method instead. This class will be removed in v9.")]
-    public class FederatedSchemaPrinter : SchemaPrinter //TODO:should be completely rewritten
+    private readonly List<string> _federatedDirectives = new()
     {
-        private readonly List<string> _federatedDirectives = new()
-        {
-            "external",
-            "provides",
-            "requires",
-            "key",
-            "extends"
-        };
+        "external",
+        "provides",
+        "requires",
+        "key",
+        "extends"
+    };
 
-        private readonly List<string> _federatedTypes = new()
-        {
-            "_Service",
-            "_Entity",
-            "_Any"
-        };
+    private readonly List<string> _federatedTypes = new()
+    {
+        "_Service",
+        "_Entity",
+        "_Any"
+    };
 
-        public FederatedSchemaPrinter(ISchema schema, SchemaPrinterOptions? options = null)
-            : base(schema, options)
-        {
-        }
+    public FederatedSchemaPrinter(ISchema schema, SchemaPrinterOptions? options = null)
+        : base(schema, options)
+    {
+    }
 
-        public string PrintFederatedDirectives(IGraphType type)
-        {
-            Schema?.Initialize();
+    public string PrintFederatedDirectives(IGraphType type)
+    {
+        Schema?.Initialize();
 
-            return type.IsInputObjectType() ? "" : PrintFederatedDirectivesFromAst(type);
-        }
+        return type.IsInputObjectType() ? "" : PrintFederatedDirectivesFromAst(type);
+    }
 
-        public string PrintFederatedDirectivesFromAst(IMetadataReader type)
-        {
-            Schema?.Initialize();
+    public string PrintFederatedDirectivesFromAst(IMetadataReader type)
+    {
+        Schema?.Initialize();
 
-            var astDirectives = type.GetAstType<IHasDirectivesNode>()?.Directives ?? type.GetExtensionDirectives<GraphQLDirective>();
-            if (astDirectives == null)
-                return "";
+        var astDirectives = type.GetAstType<IHasDirectivesNode>()?.Directives ?? type.GetExtensionDirectives<GraphQLDirective>();
+        if (astDirectives == null)
+            return "";
 
-            var dirs = string.Join(
-                " ",
-                astDirectives
-                    .Where(x => IsFederatedDirective((string)x.Name)) //TODO:alloc
-                    .Select(PrintAstDirective)
-            );
+        var dirs = string.Join(
+            " ",
+            astDirectives
+                .Where(x => IsFederatedDirective((string)x.Name)) //TODO:alloc
+                .Select(PrintAstDirective)
+        );
 
-            return string.IsNullOrWhiteSpace(dirs) ? "" : $" {dirs}";
-        }
+        return string.IsNullOrWhiteSpace(dirs) ? "" : $" {dirs}";
+    }
 
-        public string PrintAstDirective(GraphQLDirective directive)
-        {
-            Schema?.Initialize();
+    public string PrintAstDirective(GraphQLDirective directive)
+    {
+        Schema?.Initialize();
 
-            return directive.Print();
-        }
+        return directive.Print();
+    }
 
-        public override string PrintObject(IObjectGraphType type)
-        {
-            Schema?.Initialize();
+    public override string PrintObject(IObjectGraphType type)
+    {
+        Schema?.Initialize();
 
-            var isExtension = type!.IsExtensionType();
+        var isExtension = type!.IsExtensionType();
 
-            var interfaces = type!.ResolvedInterfaces.List.Select(x => x.Name).ToList();
-            var delimiter = " & ";
-            var implementedInterfaces = interfaces.Count > 0
-                ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
-                : "";
+        var interfaces = type!.ResolvedInterfaces.List.Select(x => x.Name).ToList();
+        var delimiter = " & ";
+        var implementedInterfaces = interfaces.Count > 0
+            ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
+            : "";
 
-            var federatedDirectives = PrintFederatedDirectives(type);
+        var federatedDirectives = PrintFederatedDirectives(type);
 
-            var extended = isExtension ? "extend " : "";
+        var extended = isExtension ? "extend " : "";
 
-            if (type.Fields.Any(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name)))
-                return FormatDescription(type.Description) + "{1}type {2}{3}{4} {{{0}{5}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, implementedInterfaces, federatedDirectives, PrintFields(type));
-            else
-                return FormatDescription(type.Description) + "{0}type {1}{2}{3}".ToFormat(extended, type.Name, implementedInterfaces, federatedDirectives);
-        }
+        if (type.Fields.Any(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name)))
+            return FormatDescription(type.Description) + "{1}type {2}{3}{4} {{{0}{5}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, implementedInterfaces, federatedDirectives, PrintFields(type));
+        else
+            return FormatDescription(type.Description) + "{0}type {1}{2}{3}".ToFormat(extended, type.Name, implementedInterfaces, federatedDirectives);
+    }
 
-        public override string PrintInterface(IInterfaceGraphType type)
-        {
-            Schema?.Initialize();
+    public override string PrintInterface(IInterfaceGraphType type)
+    {
+        Schema?.Initialize();
 
-            var isExtension = type.IsExtensionType();
-            var extended = isExtension ? "extend " : "";
+        var isExtension = type.IsExtensionType();
+        var extended = isExtension ? "extend " : "";
 
-            return FormatDescription(type.Description) + "{1}interface {2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, PrintFields(type));
-        }
+        return FormatDescription(type.Description) + "{1}interface {2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, extended, type.Name, PrintFields(type));
+    }
 
-        public override string PrintFields(IComplexGraphType type)
-        {
-            Schema?.Initialize();
+    public override string PrintFields(IComplexGraphType type)
+    {
+        Schema?.Initialize();
 
-            var fields = type?.Fields
-                .Where(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name))
-                .Select(x =>
-                new
-                {
-                    x.Name,
-                    Type = x.ResolvedType,
-                    Args = PrintArgs(x),
-                    Description = FormatDescription(x.Description, "  "),
-                    Deprecation = Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : string.Empty,
-                    FederatedDirectives = PrintFederatedDirectivesFromAst(x)
-                }).ToList();
+        var fields = type?.Fields
+            .Where(x => !IsFederatedType(x.ResolvedType!.GetNamedType().Name))
+            .Select(x =>
+            new
+            {
+                x.Name,
+                Type = x.ResolvedType,
+                Args = PrintArgs(x),
+                Description = FormatDescription(x.Description, "  "),
+                Deprecation = Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : string.Empty,
+                FederatedDirectives = PrintFederatedDirectivesFromAst(x)
+            }).ToList();
 
-            return fields == null ? "" : string.Join(Environment.NewLine, fields.Select(
-                f => "{3}  {0}{1}: {2}{4}{5}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation, f.FederatedDirectives)));
-        }
+        return fields == null ? "" : string.Join(Environment.NewLine, fields.Select(
+            f => "{3}  {0}{1}: {2}{4}{5}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation, f.FederatedDirectives)));
+    }
 
-        public string PrintFederatedSchema()
-        {
-            Schema?.Initialize();
+    public string PrintFederatedSchema()
+    {
+        Schema?.Initialize();
 
-            return PrintFilteredSchema(
-                directiveName => !IsBuiltInDirective(directiveName) && !IsFederatedDirective(directiveName),
-                typeName => !IsFederatedType(typeName) && IsDefinedType(typeName));
-        }
+        return PrintFilteredSchema(
+            directiveName => !IsBuiltInDirective(directiveName) && !IsFederatedDirective(directiveName),
+            typeName => !IsFederatedType(typeName) && IsDefinedType(typeName));
+    }
 
-        public bool IsFederatedDirective(string directiveName)
-        {
-            return _federatedDirectives.Contains(directiveName);
-        }
+    public bool IsFederatedDirective(string directiveName)
+    {
+        return _federatedDirectives.Contains(directiveName);
+    }
 
-        public bool IsFederatedType(string typeName)
-        {
-            return _federatedTypes.Contains(typeName);
-        }
+    public bool IsFederatedType(string typeName)
+    {
+        return _federatedTypes.Contains(typeName);
     }
 }

--- a/src/GraphQL/Utilities/Federation/FuncFederatedResolver.cs
+++ b/src/GraphQL/Utilities/Federation/FuncFederatedResolver.cs
@@ -1,19 +1,18 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation;
+
+public class FuncFederatedResolver<T> : IFederatedResolver
 {
-    public class FuncFederatedResolver<T> : IFederatedResolver
+    private readonly Func<FederatedResolveContext, Task<T?>> _resolver;
+
+    public FuncFederatedResolver(Func<FederatedResolveContext, Task<T?>> func)
     {
-        private readonly Func<FederatedResolveContext, Task<T?>> _resolver;
+        _resolver = func;
+    }
 
-        public FuncFederatedResolver(Func<FederatedResolveContext, Task<T?>> func)
-        {
-            _resolver = func;
-        }
-
-        public async Task<object?> Resolve(FederatedResolveContext context)
-        {
-            return await _resolver(context).ConfigureAwait(false);
-        }
+    public async Task<object?> Resolve(FederatedResolveContext context)
+    {
+        return await _resolver(context).ConfigureAwait(false);
     }
 }

--- a/src/GraphQL/Utilities/Federation/IFederatedResolver.cs
+++ b/src/GraphQL/Utilities/Federation/IFederatedResolver.cs
@@ -1,9 +1,8 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-namespace GraphQL.Utilities.Federation
+namespace GraphQL.Utilities.Federation;
+
+public interface IFederatedResolver
 {
-    public interface IFederatedResolver
-    {
-        Task<object?> Resolve(FederatedResolveContext context);
-    }
+    Task<object?> Resolve(FederatedResolveContext context);
 }

--- a/src/GraphQL/Utilities/Federation/ServiceGraphType.cs
+++ b/src/GraphQL/Utilities/Federation/ServiceGraphType.cs
@@ -2,19 +2,18 @@
 
 using GraphQL.Types;
 
-namespace GraphQL.Utilities.Federation
-{
-    public class ServiceGraphType : ObjectGraphType
-    {
-        public ServiceGraphType()
-        {
-            Name = "_Service";
+namespace GraphQL.Utilities.Federation;
 
-            var options = new PrintOptions
-            {
-                IncludeFederationTypes = false, // for federation v1 support
-            };
-            Field<StringGraphType>("sdl").Resolve(context => context.Schema.Print(options));
-        }
+public class ServiceGraphType : ObjectGraphType
+{
+    public ServiceGraphType()
+    {
+        Name = "_Service";
+
+        var options = new PrintOptions
+        {
+            IncludeFederationTypes = false, // for federation v1 support
+        };
+        Field<StringGraphType>("sdl").Resolve(context => context.Schema.Print(options));
     }
 }

--- a/src/GraphQL/Utilities/Federation/TypeConfigExtensions.cs
+++ b/src/GraphQL/Utilities/Federation/TypeConfigExtensions.cs
@@ -1,17 +1,16 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-namespace GraphQL.Utilities.Federation
-{
-    public static class TypeConfigExtensions
-    {
-        public static void ResolveReferenceAsync<T>(this TypeConfig config, Func<FederatedResolveContext, Task<T?>> resolver)
-        {
-            ResolveReferenceAsync(config, new FuncFederatedResolver<T>(resolver));
-        }
+namespace GraphQL.Utilities.Federation;
 
-        public static void ResolveReferenceAsync(this TypeConfig config, IFederatedResolver resolver)
-        {
-            config.Metadata[FederatedSchemaBuilder.RESOLVER_METADATA_FIELD] = resolver;
-        }
+public static class TypeConfigExtensions
+{
+    public static void ResolveReferenceAsync<T>(this TypeConfig config, Func<FederatedResolveContext, Task<T?>> resolver)
+    {
+        ResolveReferenceAsync(config, new FuncFederatedResolver<T>(resolver));
+    }
+
+    public static void ResolveReferenceAsync(this TypeConfig config, IFederatedResolver resolver)
+    {
+        config.Metadata[FederatedSchemaBuilder.RESOLVER_METADATA_FIELD] = resolver;
     }
 }

--- a/src/GraphQL/Utilities/FieldConfig.cs
+++ b/src/GraphQL/Utilities/FieldConfig.cs
@@ -1,73 +1,72 @@
 using GraphQL.Reflection;
 using GraphQL.Resolvers;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Provides configuration for specific field of GraphType when building schema via <see cref="SchemaBuilder"/>.
+/// </summary>
+public class FieldConfig : MetadataProvider
 {
+    private readonly LightweightCache<string, ArgumentConfig> _arguments =
+       new(f => new ArgumentConfig(f));
+
     /// <summary>
-    /// Provides configuration for specific field of GraphType when building schema via <see cref="SchemaBuilder"/>.
+    /// Creates an instance of <see cref="FieldConfig"/> with the specified name.
     /// </summary>
-    public class FieldConfig : MetadataProvider
+    /// <param name="name">Field argument name.</param>
+    public FieldConfig(string name)
     {
-        private readonly LightweightCache<string, ArgumentConfig> _arguments =
-           new(f => new ArgumentConfig(f));
-
-        /// <summary>
-        /// Creates an instance of <see cref="FieldConfig"/> with the specified name.
-        /// </summary>
-        /// <param name="name">Field argument name.</param>
-        public FieldConfig(string name)
-        {
-            Name = name;
-        }
-
-        /// <summary>
-        /// Gets the name of the field.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Gets or sets the field description.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Gets or sets the reason this field has been deprecated;
-        /// <see langword="null"/> if this element has not been deprecated.
-        /// Only applies to fields of output graph types.
-        /// </summary>
-        public string? DeprecationReason { get; set; }
-
-        /// <summary>
-        /// Gets or sets the default value of the field. Only applies to fields of input object graph types.
-        /// </summary>
-        public object? DefaultValue { get; set; }
-
-        /// <summary>
-        /// Gets or sets the field resolver.
-        /// </summary>
-        public IFieldResolver? Resolver { get; set; }
-
-        /// <summary>
-        /// Gets or sets the event stream resolver.
-        /// </summary>
-        public ISourceStreamResolver? StreamResolver { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IAccessor"/> representing the class member
-        /// to be executed for the field resolver.
-        /// </summary>
-        public IAccessor? ResolverAccessor { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IAccessor"/> representing the class member
-        /// to be executed for the subscription field's event stream resolver.
-        /// </summary>
-        public IAccessor? StreamResolverAccessor { get; set; }
-
-        /// <summary>
-        /// Gets configuration for specific field argument by argument name.
-        /// </summary>
-        /// <param name="argumentName">Name of the field argument.</param>
-        public ArgumentConfig ArgumentFor(string argumentName) => _arguments[argumentName];
+        Name = name;
     }
+
+    /// <summary>
+    /// Gets the name of the field.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets or sets the field description.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reason this field has been deprecated;
+    /// <see langword="null"/> if this element has not been deprecated.
+    /// Only applies to fields of output graph types.
+    /// </summary>
+    public string? DeprecationReason { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default value of the field. Only applies to fields of input object graph types.
+    /// </summary>
+    public object? DefaultValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the field resolver.
+    /// </summary>
+    public IFieldResolver? Resolver { get; set; }
+
+    /// <summary>
+    /// Gets or sets the event stream resolver.
+    /// </summary>
+    public ISourceStreamResolver? StreamResolver { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="IAccessor"/> representing the class member
+    /// to be executed for the field resolver.
+    /// </summary>
+    public IAccessor? ResolverAccessor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="IAccessor"/> representing the class member
+    /// to be executed for the subscription field's event stream resolver.
+    /// </summary>
+    public IAccessor? StreamResolverAccessor { get; set; }
+
+    /// <summary>
+    /// Gets configuration for specific field argument by argument name.
+    /// </summary>
+    /// <param name="argumentName">Name of the field argument.</param>
+    public ArgumentConfig ArgumentFor(string argumentName) => _arguments[argumentName];
 }

--- a/src/GraphQL/Utilities/MetadataProvider.cs
+++ b/src/GraphQL/Utilities/MetadataProvider.cs
@@ -1,52 +1,51 @@
 using GraphQL.Types;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Default implementation of <see cref="IProvideMetadata"/>. This is the base class for numerous
+/// descendants like <see cref="GraphType"/>, <see cref="FieldType"/>, <see cref="Schema"/> and others.
+/// Provides access to metadata reading and writing extension methods through <see cref="IMetadataReader"/>
+/// and <see cref="IMetadataWriter"/>.
+/// </summary>
+public class MetadataProvider : IMetadataReader, IMetadataWriter
 {
-    /// <summary>
-    /// Default implementation of <see cref="IProvideMetadata"/>. This is the base class for numerous
-    /// descendants like <see cref="GraphType"/>, <see cref="FieldType"/>, <see cref="Schema"/> and others.
-    /// Provides access to metadata reading and writing extension methods through <see cref="IMetadataReader"/>
-    /// and <see cref="IMetadataWriter"/>.
-    /// </summary>
-    public class MetadataProvider : IMetadataReader, IMetadataWriter
+    private Dictionary<string, object?>? _metadata;
+
+    /// <inheritdoc />
+    public Dictionary<string, object?> Metadata => _metadata ??= new();
+
+    IMetadataReader IMetadataWriter.MetadataReader => this;
+
+    /// <inheritdoc />
+    public TType GetMetadata<TType>(string key, TType defaultValue = default!)
     {
-        private Dictionary<string, object?>? _metadata;
+        var local = _metadata;
+        return local != null && local.TryGetValue(key, out object? item) ? (TType)item! : defaultValue;
+    }
 
-        /// <inheritdoc />
-        public Dictionary<string, object?> Metadata => _metadata ??= new();
+    /// <inheritdoc />
+    public TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory)
+    {
+        var local = _metadata;
+        return local != null && local.TryGetValue(key, out object? item) ? (TType)item! : defaultValueFactory();
+    }
 
-        IMetadataReader IMetadataWriter.MetadataReader => this;
+    /// <inheritdoc />
+    public bool HasMetadata(string key) => _metadata?.ContainsKey(key) ?? false;
 
-        /// <inheritdoc />
-        public TType GetMetadata<TType>(string key, TType defaultValue = default!)
+    /// <summary>
+    /// Copies metadata to the specified target.
+    /// </summary>
+    /// <param name="target">Target for copying metadata.</param>
+    public void CopyMetadataTo(IMetadataWriter target)
+    {
+        var local = _metadata;
+        if (local?.Count > 0)
         {
-            var local = _metadata;
-            return local != null && local.TryGetValue(key, out object? item) ? (TType)item! : defaultValue;
-        }
-
-        /// <inheritdoc />
-        public TType GetMetadata<TType>(string key, Func<TType> defaultValueFactory)
-        {
-            var local = _metadata;
-            return local != null && local.TryGetValue(key, out object? item) ? (TType)item! : defaultValueFactory();
-        }
-
-        /// <inheritdoc />
-        public bool HasMetadata(string key) => _metadata?.ContainsKey(key) ?? false;
-
-        /// <summary>
-        /// Copies metadata to the specified target.
-        /// </summary>
-        /// <param name="target">Target for copying metadata.</param>
-        public void CopyMetadataTo(IMetadataWriter target)
-        {
-            var local = _metadata;
-            if (local?.Count > 0)
-            {
-                var to = target.Metadata;
-                foreach (var kv in local)
-                    to[kv.Key] = kv.Value;
-            }
+            var to = target.Metadata;
+            foreach (var kv in local)
+                to[kv.Key] = kv.Value;
         }
     }
 }

--- a/src/GraphQL/Utilities/NameValidator.cs
+++ b/src/GraphQL/Utilities/NameValidator.cs
@@ -1,65 +1,64 @@
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Validator for GraphQL names.
+/// </summary>
+public static class NameValidator
 {
     /// <summary>
-    /// Validator for GraphQL names.
+    /// Validates a specified name.
     /// </summary>
-    public static class NameValidator
+    /// <param name="name">GraphQL name.</param>
+    /// <param name="type">Type of element: field, type, argument, enum.</param>
+    public static void ValidateName(string name, NamedElement type) => GlobalSwitches.NameValidation(name, type);
+
+    /// <summary>
+    /// Validates a specified name during schema initialization.
+    /// </summary>
+    /// <param name="name">GraphQL name.</param>
+    /// <param name="type">Type of element: field, type, argument, enum.</param>
+    internal static void ValidateNameOnSchemaInitialize(string name, NamedElement type) => ValidateDefault(name, type);
+
+    /// <summary>
+    /// Validates a specified name according to the GraphQL <see href="https://spec.graphql.org/October2021/#sec-Names">specification</see>.
+    /// </summary>
+    /// <param name="name">GraphQL name.</param>
+    /// <param name="type">Type of element: field, type, argument, enum or directive.</param>
+    public static void ValidateDefault(string name, NamedElement type)
     {
-        /// <summary>
-        /// Validates a specified name.
-        /// </summary>
-        /// <param name="name">GraphQL name.</param>
-        /// <param name="type">Type of element: field, type, argument, enum.</param>
-        public static void ValidateName(string name, NamedElement type) => GlobalSwitches.NameValidation(name, type);
+        ValidateNameNotNull(name, type);
 
-        /// <summary>
-        /// Validates a specified name during schema initialization.
-        /// </summary>
-        /// <param name="name">GraphQL name.</param>
-        /// <param name="type">Type of element: field, type, argument, enum.</param>
-        internal static void ValidateNameOnSchemaInitialize(string name, NamedElement type) => ValidateDefault(name, type);
-
-        /// <summary>
-        /// Validates a specified name according to the GraphQL <see href="https://spec.graphql.org/October2021/#sec-Names">specification</see>.
-        /// </summary>
-        /// <param name="name">GraphQL name.</param>
-        /// <param name="type">Type of element: field, type, argument, enum or directive.</param>
-        public static void ValidateDefault(string name, NamedElement type)
+        if (name.Length > 1 && name[0] == '_' && name[1] == '_')
         {
-            ValidateNameNotNull(name, type);
-
-            if (name.Length > 1 && name[0] == '_' && name[1] == '_')
-            {
-                throw new ArgumentOutOfRangeException(nameof(name),
-                    $"A {type.ToString().ToLower()} name: '{name}' must not begin with __, which is reserved by GraphQL introspection.");
-            }
-
-            var c = name[0];
-            if ((c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && c != '_')
-                ThrowMatchError();
-
-            for (int i = 1; i < name.Length; ++i)
-            {
-                c = name[i];
-                if ((c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_')
-                    ThrowMatchError();
-            }
-
-            void ThrowMatchError()
-            {
-                throw new ArgumentOutOfRangeException(nameof(name),
-                    $"A {type.ToString().ToLower()} name must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but '{name}' does not.");
-            }
+            throw new ArgumentOutOfRangeException(nameof(name),
+                $"A {type.ToString().ToLower()} name: '{name}' must not begin with __, which is reserved by GraphQL introspection.");
         }
 
-        //TODO: maybe remove after
-        internal static void ValidateNameNotNull(string name, NamedElement type)
+        var c = name[0];
+        if ((c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && c != '_')
+            ThrowMatchError();
+
+        for (int i = 1; i < name.Length; ++i)
         {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                throw new ArgumentOutOfRangeException(nameof(name),
-                    $"A {type.ToString().ToLower()} name can not be null or empty.");
-            }
+            c = name[i];
+            if ((c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_')
+                ThrowMatchError();
+        }
+
+        void ThrowMatchError()
+        {
+            throw new ArgumentOutOfRangeException(nameof(name),
+                $"A {type.ToString().ToLower()} name must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but '{name}' does not.");
+        }
+    }
+
+    //TODO: maybe remove after
+    internal static void ValidateNameNotNull(string name, NamedElement type)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentOutOfRangeException(nameof(name),
+                $"A {type.ToString().ToLower()} name can not be null or empty.");
         }
     }
 }

--- a/src/GraphQL/Utilities/NamedElement.cs
+++ b/src/GraphQL/Utilities/NamedElement.cs
@@ -1,33 +1,32 @@
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Indicates a field, type, argument, enum or directive.
+/// </summary>
+public enum NamedElement
 {
     /// <summary>
-    /// Indicates a field, type, argument, enum or directive.
+    /// A field
     /// </summary>
-    public enum NamedElement
-    {
-        /// <summary>
-        /// A field
-        /// </summary>
-        Field,
+    Field,
 
-        /// <summary>
-        /// A type
-        /// </summary>
-        Type,
+    /// <summary>
+    /// A type
+    /// </summary>
+    Type,
 
-        /// <summary>
-        /// An argument
-        /// </summary>
-        Argument,
+    /// <summary>
+    /// An argument
+    /// </summary>
+    Argument,
 
-        /// <summary>
-        /// An enum value
-        /// </summary>
-        EnumValue,
+    /// <summary>
+    /// An enum value
+    /// </summary>
+    EnumValue,
 
-        /// <summary>
-        /// A directive
-        /// </summary>
-        Directive,
-    }
+    /// <summary>
+    /// A directive
+    /// </summary>
+    Directive,
 }

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -5,672 +5,671 @@ using GraphQL.Types;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Builds schema from string.
+/// </summary>
+public class SchemaBuilder
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    protected readonly Dictionary<string, IGraphType> _types = new();
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+    private GraphQLSchemaDefinition? _schemaDef;
+
+    private IgnoreOptions CreateIgnoreOptions()
+    {
+        var options = IgnoreOptions.None;
+        if (IgnoreComments)
+            options |= IgnoreOptions.Comments;
+        if (IgnoreLocations)
+            options |= IgnoreOptions.Locations;
+        return options;
+    }
+
+    /// <summary>
+    /// This <see cref="IServiceProvider"/> is used to create required objects during building schema.
+    /// <br/><br/>
+    /// By default equals to <see cref="DefaultServiceProvider"/>.
+    /// </summary>
+    public IServiceProvider ServiceProvider { get; set; } = new DefaultServiceProvider();
+
+    /// <summary>
+    /// Specifies whether to ignore comments when parsing GraphQL document.
+    /// By default, all comments are ignored.
+    /// </summary>
+    public bool IgnoreComments { get; set; } = true;
+
+    /// <summary>
+    /// Specifies whether to ignore token locations when parsing GraphQL document.
+    /// By default, all token locations are taken into account.
+    /// </summary>
+    public bool IgnoreLocations { get; set; }
+
+    /// <summary>
+    /// Allows to successfully build the schema even if types are found that are not registered int <see cref="Types"/>.
+    /// <br/>
+    /// By default <see langword="true"/>.
+    /// </summary>
+    public bool AllowUnknownTypes { get; set; } = true;
+
+    /// <summary>
+    /// Allows to successfully build the schema even if fields are found that have no resolvers.
+    /// <br/>
+    /// By default <see langword="true"/>.
+    /// </summary>
+    public bool AllowUnknownFields { get; set; } = true;
+
+    /// <inheritdoc cref="TypeSettings" />
+    public TypeSettings Types { get; } = new TypeSettings();
+
+    /// <summary>
+    /// If <see langword="true"/>, pulls registered <see cref="IConfigureSchema"/>
+    /// instances from <see cref="ServiceProvider"/> and executes them.
+    /// </summary>
+    public bool RunConfigurations { get; set; } = true;
+
     /// <summary>
     /// Builds schema from string.
     /// </summary>
-    public class SchemaBuilder
+    /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
+    /// <returns>Created schema.</returns>
+    public virtual Schema Build(string typeDefinitions)
     {
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-        protected readonly Dictionary<string, IGraphType> _types = new();
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-        private GraphQLSchemaDefinition? _schemaDef;
+        var document = Parser.Parse(typeDefinitions, new ParserOptions { Ignore = CreateIgnoreOptions() });
+        Validate(document);
+        return BuildSchemaFrom(document);
+    }
 
-        private IgnoreOptions CreateIgnoreOptions()
+    /// <summary>
+    /// Validate the specified SDL.
+    /// </summary>
+    protected virtual void Validate(GraphQLDocument document)
+    {
+        var definitionsByName = document.Definitions.OfType<GraphQLTypeDefinition>().ToLookup(def => def.Name!.Value);
+        var duplicates = definitionsByName.Where(grouping => grouping.Count() > 1).ToArray();
+        if (duplicates.Length > 0)
         {
-            var options = IgnoreOptions.None;
-            if (IgnoreComments)
-                options |= IgnoreOptions.Comments;
-            if (IgnoreLocations)
-                options |= IgnoreOptions.Locations;
-            return options;
-        }
-
-        /// <summary>
-        /// This <see cref="IServiceProvider"/> is used to create required objects during building schema.
-        /// <br/><br/>
-        /// By default equals to <see cref="DefaultServiceProvider"/>.
-        /// </summary>
-        public IServiceProvider ServiceProvider { get; set; } = new DefaultServiceProvider();
-
-        /// <summary>
-        /// Specifies whether to ignore comments when parsing GraphQL document.
-        /// By default, all comments are ignored.
-        /// </summary>
-        public bool IgnoreComments { get; set; } = true;
-
-        /// <summary>
-        /// Specifies whether to ignore token locations when parsing GraphQL document.
-        /// By default, all token locations are taken into account.
-        /// </summary>
-        public bool IgnoreLocations { get; set; }
-
-        /// <summary>
-        /// Allows to successfully build the schema even if types are found that are not registered int <see cref="Types"/>.
-        /// <br/>
-        /// By default <see langword="true"/>.
-        /// </summary>
-        public bool AllowUnknownTypes { get; set; } = true;
-
-        /// <summary>
-        /// Allows to successfully build the schema even if fields are found that have no resolvers.
-        /// <br/>
-        /// By default <see langword="true"/>.
-        /// </summary>
-        public bool AllowUnknownFields { get; set; } = true;
-
-        /// <inheritdoc cref="TypeSettings" />
-        public TypeSettings Types { get; } = new TypeSettings();
-
-        /// <summary>
-        /// If <see langword="true"/>, pulls registered <see cref="IConfigureSchema"/>
-        /// instances from <see cref="ServiceProvider"/> and executes them.
-        /// </summary>
-        public bool RunConfigurations { get; set; } = true;
-
-        /// <summary>
-        /// Builds schema from string.
-        /// </summary>
-        /// <param name="typeDefinitions">A textual description of the schema in SDL (Schema Definition Language) format.</param>
-        /// <returns>Created schema.</returns>
-        public virtual Schema Build(string typeDefinitions)
-        {
-            var document = Parser.Parse(typeDefinitions, new ParserOptions { Ignore = CreateIgnoreOptions() });
-            Validate(document);
-            return BuildSchemaFrom(document);
-        }
-
-        /// <summary>
-        /// Validate the specified SDL.
-        /// </summary>
-        protected virtual void Validate(GraphQLDocument document)
-        {
-            var definitionsByName = document.Definitions.OfType<GraphQLTypeDefinition>().ToLookup(def => def.Name!.Value);
-            var duplicates = definitionsByName.Where(grouping => grouping.Count() > 1).ToArray();
-            if (duplicates.Length > 0)
-            {
-                throw new ArgumentException(@$"All types within a GraphQL schema must have unique names. No two provided types may have the same name.
+            throw new ArgumentException(@$"All types within a GraphQL schema must have unique names. No two provided types may have the same name.
 Schema contains a redefinition of these types: {string.Join(", ", duplicates.Select(item => item.Key))}", nameof(document));
-            }
-
-            //TODO: checks for parsed SDL may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653
-            // Also see Schema.Validate
         }
 
-        /// <summary>
-        /// Returns a new <see cref="Schema"/> instance.
-        /// </summary>
-        protected virtual Schema CreateSchema() => new(ServiceProvider, runConfigurations: RunConfigurations);
+        //TODO: checks for parsed SDL may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653
+        // Also see Schema.Validate
+    }
 
-        private Schema BuildSchemaFrom(GraphQLDocument document)
+    /// <summary>
+    /// Returns a new <see cref="Schema"/> instance.
+    /// </summary>
+    protected virtual Schema CreateSchema() => new(ServiceProvider, runConfigurations: RunConfigurations);
+
+    private Schema BuildSchemaFrom(GraphQLDocument document)
+    {
+        var schema = CreateSchema();
+
+        PreConfigure(schema);
+
+        var directives = new List<Directive>();
+
+        // process the schema definition first
+        foreach (var def in document.Definitions)
         {
-            var schema = CreateSchema();
-
-            PreConfigure(schema);
-
-            var directives = new List<Directive>();
-
-            // process the schema definition first
-            foreach (var def in document.Definitions)
+            if (def is GraphQLSchemaDefinition schemaDef)
             {
-                if (def is GraphQLSchemaDefinition schemaDef)
-                {
-                    _schemaDef = schemaDef;
-                    schema.SetAstType(schemaDef);
-                }
+                _schemaDef = schemaDef;
+                schema.SetAstType(schemaDef);
             }
-
-            foreach (var def in document.Definitions)
-            {
-                if (def is GraphQLObjectTypeDefinition objDef)
-                {
-                    var type = ToObjectGraphType(objDef);
-                    _types[type.Name] = type;
-                }
-                else if (def is GraphQLObjectTypeExtension ext)
-                {
-                    //TODO: rewrite and add support for other extensions
-                    var typeDef = new GraphQLObjectTypeDefinition(ext.Name)
-                    {
-                        Comments = ext.Comments,
-                        Description = null,
-                        Directives = ext.Directives,
-                        Fields = ext.Fields,
-                        Interfaces = ext.Interfaces,
-                        Location = ext.Location,
-                    };
-                    var type = ToObjectGraphType(typeDef, true);
-                    _types[type.Name] = type;
-                }
-                else if (def is GraphQLInterfaceTypeDefinition ifaceDef)
-                {
-                    var type = ToInterfaceType(ifaceDef);
-                    _types[type.Name] = type;
-                }
-                else if (def is GraphQLEnumTypeDefinition enumDef)
-                {
-                    var type = ToEnumerationType(enumDef);
-                    _types[type.Name] = type;
-                }
-                else if (def is GraphQLUnionTypeDefinition unionDef)
-                {
-                    var type = ToUnionType(unionDef);
-                    _types[type.Name] = type;
-                }
-                else if (def is GraphQLInputObjectTypeDefinition inputDef)
-                {
-                    var type = ToInputObjectType(inputDef);
-                    _types[type.Name] = type;
-                }
-                else if (def is GraphQLDirectiveDefinition directiveDef)
-                {
-                    var directive = ToDirective(directiveDef);
-                    directives.Add(directive);
-                }
-            }
-
-            if (_schemaDef != null)
-            {
-                schema.Description = _schemaDef.Description?.Value.ToString() ?? _schemaDef.MergeComments();
-
-                foreach (var operationTypeDef in _schemaDef.OperationTypes!)
-                {
-                    var typeName = (string)operationTypeDef.Type!.Name; //TODO:alloc
-                    var type = GetType(typeName) as IObjectGraphType;
-
-                    switch (operationTypeDef.Operation)
-                    {
-                        case OperationType.Query:
-                            schema.Query = type!;
-                            break;
-
-                        case OperationType.Mutation:
-                            schema.Mutation = type;
-                            break;
-
-                        case OperationType.Subscription:
-                            schema.Subscription = type;
-                            break;
-
-                        default:
-                            throw new ArgumentOutOfRangeException($"Unknown operation type {operationTypeDef.Operation}");
-                    }
-                }
-            }
-            else
-            {
-                schema.Query = (GetType("Query") as IObjectGraphType)!;
-                schema.Mutation = GetType("Mutation") as IObjectGraphType;
-                schema.Subscription = GetType("Subscription") as IObjectGraphType;
-            }
-
-            foreach (var type in _types)
-                schema.RegisterType(type.Value);
-
-            foreach (var directive in directives)
-                schema.Directives.Register(directive);
-
-            Debug.Assert(schema.Initialized == false);
-            return schema;
         }
 
-        /// <summary>
-        /// Configures the <paramref name="schema"/> prior to adding any types.
-        /// </summary>
-        protected virtual void PreConfigure(Schema schema)
+        foreach (var def in document.Definitions)
         {
-        }
-
-        /// <summary>
-        /// Returns the graph type built for the specified graph type name.
-        /// </summary>
-        protected virtual IGraphType? GetType(string name)
-        {
-            return _types.TryGetValue(name, out var type) ? type : null;
-        }
-
-        private bool IsSubscriptionType(ObjectGraphType type)
-        {
-            var operationDefinition = _schemaDef?.OperationTypes?.FirstOrDefault(o => o.Operation == OperationType.Subscription);
-            return operationDefinition == null
-                ? type.Name == "Subscription"
-                : type.Name == operationDefinition.Type!.Name;
-        }
-
-        private void AssertKnownType(TypeConfig typeConfig)
-        {
-            if (typeConfig.Type == null && !AllowUnknownTypes)
-                throw new InvalidOperationException($"Unknown type '{typeConfig.Name}'. Verify that you have configured SchemaBuilder correctly.");
-        }
-
-        private void AssertKnownField(FieldConfig fieldConfig, TypeConfig typeConfig)
-        {
-            if (fieldConfig.Resolver == null && !AllowUnknownFields)
-                throw new InvalidOperationException($"Unknown field '{typeConfig.Name}.{fieldConfig.Name}' has no resolver. Verify that you have configured SchemaBuilder correctly.");
-        }
-
-        private void OverrideDeprecationReason(IProvideDeprecationReason element, string? reason)
-        {
-            if (reason != null)
-                element.DeprecationReason = reason;
-        }
-
-        /// <summary>
-        /// Returns an <see cref="IObjectGraphType"/> from the specified <see cref="GraphQLObjectTypeDefinition"/>.
-        /// </summary>
-        protected virtual IObjectGraphType ToObjectGraphType(GraphQLObjectTypeDefinition astType, bool isExtensionType = false)
-        {
-            var name = (string)astType.Name; //TODO:alloc
-            var typeConfig = Types.For(name);
-
-            AssertKnownType(typeConfig);
-
-            var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<ObjectGraphType>)) as IGraphTypeFactory<ObjectGraphType>;
-            var type = _types.TryGetValue(name, out var t)
-                ? t as ObjectGraphType ?? throw new InvalidOperationException($"Type '{name} should be ObjectGraphType")
-                : typeFactory?.Create() ?? new ObjectGraphType();
-
-            type.Name = name;
-
-            if (!isExtensionType)
+            if (def is GraphQLObjectTypeDefinition objDef)
             {
-                type.Description = typeConfig.Description ?? astType.Description?.Value.ToString() ?? astType.MergeComments();
-                type.IsTypeOf = typeConfig.IsTypeOfFunc;
+                var type = ToObjectGraphType(objDef);
+                _types[type.Name] = type;
             }
-
-            typeConfig.CopyMetadataTo(type);
-
-            Func<string, GraphQLFieldDefinition, FieldType> constructFieldType = IsSubscriptionType(type)
-                ? ToSubscriptionFieldType
-                : ToFieldType;
-
-            if (astType.Fields != null)
+            else if (def is GraphQLObjectTypeExtension ext)
             {
-                foreach (var f in astType.Fields)
-                    type.AddField(constructFieldType(type.Name, f));
-            }
-
-            if (astType.Interfaces != null)
-            {
-                foreach (var i in astType.Interfaces)
-                    type.AddResolvedInterface(new GraphQLTypeReference((string)i.Name)); //TODO:alloc
-            }
-
-            if (isExtensionType)
-            {
-                type.AddExtensionAstType(astType);
-            }
-            else
-            {
-                type.SetAstType(astType);
-                OverrideDeprecationReason(type, typeConfig.DeprecationReason);
-            }
-
-            return type;
-        }
-
-        private void InitializeField(FieldConfig config, Type? parentType)
-        {
-            config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);
-
-            if (config.ResolverAccessor != null)
-            {
-                config.Resolver = AutoRegisteringHelper.BuildFieldResolver(
-                    config.ResolverAccessor.MethodInfo,
-                    null, // unknown source type
-                    null, // unknown FieldType
-                    AutoRegisteringHelper.BuildInstanceExpressionForSchemaBuilder(config.ResolverAccessor.DeclaringType, ServiceProvider));
-
-                var attrs = config.ResolverAccessor.GetAttributes<GraphQLAttribute>();
-                if (attrs != null)
+                //TODO: rewrite and add support for other extensions
+                var typeDef = new GraphQLObjectTypeDefinition(ext.Name)
                 {
-                    foreach (var a in attrs)
-                        a.Modify(config);
+                    Comments = ext.Comments,
+                    Description = null,
+                    Directives = ext.Directives,
+                    Fields = ext.Fields,
+                    Interfaces = ext.Interfaces,
+                    Location = ext.Location,
+                };
+                var type = ToObjectGraphType(typeDef, true);
+                _types[type.Name] = type;
+            }
+            else if (def is GraphQLInterfaceTypeDefinition ifaceDef)
+            {
+                var type = ToInterfaceType(ifaceDef);
+                _types[type.Name] = type;
+            }
+            else if (def is GraphQLEnumTypeDefinition enumDef)
+            {
+                var type = ToEnumerationType(enumDef);
+                _types[type.Name] = type;
+            }
+            else if (def is GraphQLUnionTypeDefinition unionDef)
+            {
+                var type = ToUnionType(unionDef);
+                _types[type.Name] = type;
+            }
+            else if (def is GraphQLInputObjectTypeDefinition inputDef)
+            {
+                var type = ToInputObjectType(inputDef);
+                _types[type.Name] = type;
+            }
+            else if (def is GraphQLDirectiveDefinition directiveDef)
+            {
+                var directive = ToDirective(directiveDef);
+                directives.Add(directive);
+            }
+        }
+
+        if (_schemaDef != null)
+        {
+            schema.Description = _schemaDef.Description?.Value.ToString() ?? _schemaDef.MergeComments();
+
+            foreach (var operationTypeDef in _schemaDef.OperationTypes!)
+            {
+                var typeName = (string)operationTypeDef.Type!.Name; //TODO:alloc
+                var type = GetType(typeName) as IObjectGraphType;
+
+                switch (operationTypeDef.Operation)
+                {
+                    case OperationType.Query:
+                        schema.Query = type!;
+                        break;
+
+                    case OperationType.Mutation:
+                        schema.Mutation = type;
+                        break;
+
+                    case OperationType.Subscription:
+                        schema.Subscription = type;
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException($"Unknown operation type {operationTypeDef.Operation}");
                 }
             }
         }
-
-        private void InitializeSubscriptionField(FieldConfig config, Type? parentType)
+        else
         {
-            config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);
-            config.StreamResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.StreamResolver);
-
-            if (config.ResolverAccessor != null && config.StreamResolverAccessor != null)
-            {
-                config.Resolver = AutoRegisteringHelper.BuildFieldResolver(
-                    config.ResolverAccessor.MethodInfo,
-                    null, // unknown source type
-                    null, // unknown FieldType
-                    AutoRegisteringHelper.BuildInstanceExpressionForSchemaBuilder(config.ResolverAccessor.DeclaringType, ServiceProvider));
-
-                var attrs = config.ResolverAccessor.GetAttributes<GraphQLAttribute>();
-                if (attrs != null)
-                {
-                    foreach (var a in attrs)
-                        a.Modify(config);
-                }
-
-                config.StreamResolver = AutoRegisteringHelper.BuildSourceStreamResolver(
-                    config.StreamResolverAccessor.MethodInfo,
-                    null, // unknown source type
-                    null, // unknown FieldType
-                    AutoRegisteringHelper.BuildInstanceExpressionForSchemaBuilder(config.ResolverAccessor.DeclaringType, ServiceProvider));
-            }
+            schema.Query = (GetType("Query") as IObjectGraphType)!;
+            schema.Mutation = GetType("Mutation") as IObjectGraphType;
+            schema.Subscription = GetType("Subscription") as IObjectGraphType;
         }
 
-        /// <summary>
-        /// Returns a <see cref="FieldType"/> from the specified <see cref="GraphQLFieldDefinition"/>.
-        /// </summary>
-        protected virtual FieldType ToFieldType(string parentTypeName, GraphQLFieldDefinition fieldDef)
+        foreach (var type in _types)
+            schema.RegisterType(type.Value);
+
+        foreach (var directive in directives)
+            schema.Directives.Register(directive);
+
+        Debug.Assert(schema.Initialized == false);
+        return schema;
+    }
+
+    /// <summary>
+    /// Configures the <paramref name="schema"/> prior to adding any types.
+    /// </summary>
+    protected virtual void PreConfigure(Schema schema)
+    {
+    }
+
+    /// <summary>
+    /// Returns the graph type built for the specified graph type name.
+    /// </summary>
+    protected virtual IGraphType? GetType(string name)
+    {
+        return _types.TryGetValue(name, out var type) ? type : null;
+    }
+
+    private bool IsSubscriptionType(ObjectGraphType type)
+    {
+        var operationDefinition = _schemaDef?.OperationTypes?.FirstOrDefault(o => o.Operation == OperationType.Subscription);
+        return operationDefinition == null
+            ? type.Name == "Subscription"
+            : type.Name == operationDefinition.Type!.Name;
+    }
+
+    private void AssertKnownType(TypeConfig typeConfig)
+    {
+        if (typeConfig.Type == null && !AllowUnknownTypes)
+            throw new InvalidOperationException($"Unknown type '{typeConfig.Name}'. Verify that you have configured SchemaBuilder correctly.");
+    }
+
+    private void AssertKnownField(FieldConfig fieldConfig, TypeConfig typeConfig)
+    {
+        if (fieldConfig.Resolver == null && !AllowUnknownFields)
+            throw new InvalidOperationException($"Unknown field '{typeConfig.Name}.{fieldConfig.Name}' has no resolver. Verify that you have configured SchemaBuilder correctly.");
+    }
+
+    private void OverrideDeprecationReason(IProvideDeprecationReason element, string? reason)
+    {
+        if (reason != null)
+            element.DeprecationReason = reason;
+    }
+
+    /// <summary>
+    /// Returns an <see cref="IObjectGraphType"/> from the specified <see cref="GraphQLObjectTypeDefinition"/>.
+    /// </summary>
+    protected virtual IObjectGraphType ToObjectGraphType(GraphQLObjectTypeDefinition astType, bool isExtensionType = false)
+    {
+        var name = (string)astType.Name; //TODO:alloc
+        var typeConfig = Types.For(name);
+
+        AssertKnownType(typeConfig);
+
+        var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<ObjectGraphType>)) as IGraphTypeFactory<ObjectGraphType>;
+        var type = _types.TryGetValue(name, out var t)
+            ? t as ObjectGraphType ?? throw new InvalidOperationException($"Type '{name} should be ObjectGraphType")
+            : typeFactory?.Create() ?? new ObjectGraphType();
+
+        type.Name = name;
+
+        if (!isExtensionType)
         {
-            var typeConfig = Types.For(parentTypeName);
-
-            AssertKnownType(typeConfig);
-
-            var fieldConfig = typeConfig.FieldFor((string)fieldDef.Name); //TODO:alloc
-            InitializeField(fieldConfig, typeConfig.Type);
-
-            AssertKnownField(fieldConfig, typeConfig);
-
-            var field = new FieldType
-            {
-                Name = fieldConfig.Name,
-                Description = fieldConfig.Description ?? fieldDef.Description?.Value.ToString() ?? fieldDef.MergeComments(),
-                ResolvedType = ToGraphType(fieldDef.Type),
-                Resolver = fieldConfig.Resolver
-            };
-
-            fieldConfig.CopyMetadataTo(field);
-
-            field.Arguments = ToQueryArguments(fieldConfig, fieldDef.Arguments?.Items);
-
-            field.SetAstType(fieldDef);
-            OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
-
-            return field;
+            type.Description = typeConfig.Description ?? astType.Description?.Value.ToString() ?? astType.MergeComments();
+            type.IsTypeOf = typeConfig.IsTypeOfFunc;
         }
 
-        /// <summary>
-        /// Returns a subscription <see cref="FieldType"/> from the specified <see cref="GraphQLFieldDefinition"/>.
-        /// </summary>
-        protected virtual FieldType ToSubscriptionFieldType(string parentTypeName, GraphQLFieldDefinition fieldDef)
+        typeConfig.CopyMetadataTo(type);
+
+        Func<string, GraphQLFieldDefinition, FieldType> constructFieldType = IsSubscriptionType(type)
+            ? ToSubscriptionFieldType
+            : ToFieldType;
+
+        if (astType.Fields != null)
         {
-            var typeConfig = Types.For(parentTypeName);
-
-            AssertKnownType(typeConfig);
-
-            var fieldConfig = typeConfig.FieldFor((string)fieldDef.Name); //TODO:alloc
-            InitializeSubscriptionField(fieldConfig, typeConfig.Type);
-
-            AssertKnownField(fieldConfig, typeConfig);
-
-            var field = new FieldType
-            {
-                Name = fieldConfig.Name,
-                Description = fieldConfig.Description ?? fieldDef.Description?.Value.ToString() ?? fieldDef.MergeComments(),
-                ResolvedType = ToGraphType(fieldDef.Type),
-                Resolver = fieldConfig.Resolver,
-                StreamResolver = fieldConfig.StreamResolver
-            };
-
-            fieldConfig.CopyMetadataTo(field);
-
-            field.Arguments = ToQueryArguments(fieldConfig, fieldDef.Arguments?.Items);
-
-            field.SetAstType(fieldDef);
-            OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
-
-            return field;
+            foreach (var f in astType.Fields)
+                type.AddField(constructFieldType(type.Name, f));
         }
 
-        /// <summary>
-        /// Returns a <see cref="FieldType"/> from the specified <see cref="GraphQLInputValueDefinition"/>.
-        /// </summary>
-        protected virtual FieldType ToFieldType(string parentTypeName, GraphQLInputValueDefinition inputDef)
+        if (astType.Interfaces != null)
         {
-            var typeConfig = Types.For(parentTypeName);
-
-            AssertKnownType(typeConfig);
-
-            var fieldConfig = typeConfig.FieldFor((string)inputDef.Name); //TODO:alloc
-            InitializeField(fieldConfig, typeConfig.Type);
-
-            AssertKnownField(fieldConfig, typeConfig);
-
-            var field = new FieldType
-            {
-                Name = fieldConfig.Name,
-                Description = fieldConfig.Description ?? inputDef.Description?.Value.ToString() ?? inputDef.MergeComments(),
-                ResolvedType = ToGraphType(inputDef.Type),
-                DefaultValue = fieldConfig.DefaultValue ?? inputDef.DefaultValue
-            };
-
-            field.SetAstType(inputDef);
-
-            OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
-
-            return field;
+            foreach (var i in astType.Interfaces)
+                type.AddResolvedInterface(new GraphQLTypeReference((string)i.Name)); //TODO:alloc
         }
 
-        /// <summary>
-        /// Returns a <see cref="InterfaceGraphType"/> from the specified <see cref="GraphQLInterfaceTypeDefinition"/>.
-        /// </summary>
-        protected virtual InterfaceGraphType ToInterfaceType(GraphQLInterfaceTypeDefinition interfaceDef)
+        if (isExtensionType)
         {
-            var name = (string)interfaceDef.Name; //TODO:alloc
-            var typeConfig = Types.For(name);
-
-            AssertKnownType(typeConfig);
-
-            var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<InterfaceGraphType>)) as IGraphTypeFactory<InterfaceGraphType>;
-            var type = typeFactory?.Create() ?? new InterfaceGraphType();
-
-            type.Name = name;
-            type.Description = typeConfig.Description ?? interfaceDef.Description?.Value.ToString() ?? interfaceDef.MergeComments();
-            type.ResolveType = typeConfig.ResolveType;
-            type.SetAstType(interfaceDef);
-
+            type.AddExtensionAstType(astType);
+        }
+        else
+        {
+            type.SetAstType(astType);
             OverrideDeprecationReason(type, typeConfig.DeprecationReason);
+        }
 
-            typeConfig.CopyMetadataTo(type);
+        return type;
+    }
 
-            if (interfaceDef.Fields != null)
+    private void InitializeField(FieldConfig config, Type? parentType)
+    {
+        config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);
+
+        if (config.ResolverAccessor != null)
+        {
+            config.Resolver = AutoRegisteringHelper.BuildFieldResolver(
+                config.ResolverAccessor.MethodInfo,
+                null, // unknown source type
+                null, // unknown FieldType
+                AutoRegisteringHelper.BuildInstanceExpressionForSchemaBuilder(config.ResolverAccessor.DeclaringType, ServiceProvider));
+
+            var attrs = config.ResolverAccessor.GetAttributes<GraphQLAttribute>();
+            if (attrs != null)
             {
-                foreach (var f in interfaceDef.Fields)
-                {
-                    type.AddField(ToFieldType(type.Name, f));
-                }
+                foreach (var a in attrs)
+                    a.Modify(config);
+            }
+        }
+    }
+
+    private void InitializeSubscriptionField(FieldConfig config, Type? parentType)
+    {
+        config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);
+        config.StreamResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.StreamResolver);
+
+        if (config.ResolverAccessor != null && config.StreamResolverAccessor != null)
+        {
+            config.Resolver = AutoRegisteringHelper.BuildFieldResolver(
+                config.ResolverAccessor.MethodInfo,
+                null, // unknown source type
+                null, // unknown FieldType
+                AutoRegisteringHelper.BuildInstanceExpressionForSchemaBuilder(config.ResolverAccessor.DeclaringType, ServiceProvider));
+
+            var attrs = config.ResolverAccessor.GetAttributes<GraphQLAttribute>();
+            if (attrs != null)
+            {
+                foreach (var a in attrs)
+                    a.Modify(config);
             }
 
-            return type;
+            config.StreamResolver = AutoRegisteringHelper.BuildSourceStreamResolver(
+                config.StreamResolverAccessor.MethodInfo,
+                null, // unknown source type
+                null, // unknown FieldType
+                AutoRegisteringHelper.BuildInstanceExpressionForSchemaBuilder(config.ResolverAccessor.DeclaringType, ServiceProvider));
         }
+    }
 
-        /// <summary>
-        /// Returns a <see cref="UnionGraphType"/> from the specified <see cref="GraphQLUnionTypeDefinition"/>.
-        /// </summary>
-        protected virtual UnionGraphType ToUnionType(GraphQLUnionTypeDefinition unionDef)
+    /// <summary>
+    /// Returns a <see cref="FieldType"/> from the specified <see cref="GraphQLFieldDefinition"/>.
+    /// </summary>
+    protected virtual FieldType ToFieldType(string parentTypeName, GraphQLFieldDefinition fieldDef)
+    {
+        var typeConfig = Types.For(parentTypeName);
+
+        AssertKnownType(typeConfig);
+
+        var fieldConfig = typeConfig.FieldFor((string)fieldDef.Name); //TODO:alloc
+        InitializeField(fieldConfig, typeConfig.Type);
+
+        AssertKnownField(fieldConfig, typeConfig);
+
+        var field = new FieldType
         {
-            var name = (string)unionDef.Name; //TODO:alloc
-            var typeConfig = Types.For(name);
+            Name = fieldConfig.Name,
+            Description = fieldConfig.Description ?? fieldDef.Description?.Value.ToString() ?? fieldDef.MergeComments(),
+            ResolvedType = ToGraphType(fieldDef.Type),
+            Resolver = fieldConfig.Resolver
+        };
 
-            AssertKnownType(typeConfig);
+        fieldConfig.CopyMetadataTo(field);
 
-            var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<UnionGraphType>)) as IGraphTypeFactory<UnionGraphType>;
-            var type = typeFactory?.Create() ?? new UnionGraphType();
+        field.Arguments = ToQueryArguments(fieldConfig, fieldDef.Arguments?.Items);
 
-            type.Name = name;
-            type.Description = typeConfig.Description ?? unionDef.Description?.Value.ToString() ?? unionDef.MergeComments();
-            type.ResolveType = typeConfig.ResolveType;
-            type.SetAstType(unionDef);
+        field.SetAstType(fieldDef);
+        OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
 
-            OverrideDeprecationReason(type, typeConfig.DeprecationReason);
+        return field;
+    }
 
-            typeConfig.CopyMetadataTo(type);
+    /// <summary>
+    /// Returns a subscription <see cref="FieldType"/> from the specified <see cref="GraphQLFieldDefinition"/>.
+    /// </summary>
+    protected virtual FieldType ToSubscriptionFieldType(string parentTypeName, GraphQLFieldDefinition fieldDef)
+    {
+        var typeConfig = Types.For(parentTypeName);
 
-            if (unionDef.Types?.Count > 0) // just in case
-            {
-                foreach (var x in unionDef.Types)
-                {
-                    string n = (string)x.Name; //TODO:alloc
-                    type.AddPossibleType(((GetType(n) ?? new GraphQLTypeReference(n)) as IObjectGraphType)!);
-                }
-            }
+        AssertKnownType(typeConfig);
 
-            return type;
-        }
+        var fieldConfig = typeConfig.FieldFor((string)fieldDef.Name); //TODO:alloc
+        InitializeSubscriptionField(fieldConfig, typeConfig.Type);
 
-        /// <summary>
-        /// Returns an <see cref="InputObjectGraphType"/> from the specified <see cref="GraphQLInputObjectTypeDefinition"/>.
-        /// </summary>
-        protected virtual InputObjectGraphType ToInputObjectType(GraphQLInputObjectTypeDefinition inputDef)
+        AssertKnownField(fieldConfig, typeConfig);
+
+        var field = new FieldType
         {
-            var name = (string)inputDef.Name; //TODO:alloc
-            var typeConfig = Types.For(name);
+            Name = fieldConfig.Name,
+            Description = fieldConfig.Description ?? fieldDef.Description?.Value.ToString() ?? fieldDef.MergeComments(),
+            ResolvedType = ToGraphType(fieldDef.Type),
+            Resolver = fieldConfig.Resolver,
+            StreamResolver = fieldConfig.StreamResolver
+        };
 
-            AssertKnownType(typeConfig);
+        fieldConfig.CopyMetadataTo(field);
 
-            var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<InputObjectGraphType>)) as IGraphTypeFactory<InputObjectGraphType>;
-            var type = typeFactory?.Create() ?? new InputObjectGraphType();
+        field.Arguments = ToQueryArguments(fieldConfig, fieldDef.Arguments?.Items);
 
-            type.Name = name;
-            type.Description = typeConfig.Description ?? inputDef.Description?.Value.ToString() ?? inputDef.MergeComments();
-            type.SetAstType(inputDef);
+        field.SetAstType(fieldDef);
+        OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
 
-            OverrideDeprecationReason(type, typeConfig.DeprecationReason);
+        return field;
+    }
 
-            typeConfig.CopyMetadataTo(type);
+    /// <summary>
+    /// Returns a <see cref="FieldType"/> from the specified <see cref="GraphQLInputValueDefinition"/>.
+    /// </summary>
+    protected virtual FieldType ToFieldType(string parentTypeName, GraphQLInputValueDefinition inputDef)
+    {
+        var typeConfig = Types.For(parentTypeName);
 
-            if (inputDef.Fields != null)
-            {
-                foreach (var f in inputDef.Fields)
-                {
-                    type.AddField(ToFieldType(type.Name, f));
-                }
-            }
+        AssertKnownType(typeConfig);
 
-            return type;
-        }
+        var fieldConfig = typeConfig.FieldFor((string)inputDef.Name); //TODO:alloc
+        InitializeField(fieldConfig, typeConfig.Type);
 
-        /// <summary>
-        /// Returns an <see cref="EnumerationGraphType"/> from the specified <see cref="GraphQLEnumTypeDefinition"/>.
-        /// </summary>
-        protected virtual EnumerationGraphType ToEnumerationType(GraphQLEnumTypeDefinition enumDef)
+        AssertKnownField(fieldConfig, typeConfig);
+
+        var field = new FieldType
         {
-            var name = (string)enumDef.Name; //TODO:alloc
-            var typeConfig = Types.For(name);
+            Name = fieldConfig.Name,
+            Description = fieldConfig.Description ?? inputDef.Description?.Value.ToString() ?? inputDef.MergeComments(),
+            ResolvedType = ToGraphType(inputDef.Type),
+            DefaultValue = fieldConfig.DefaultValue ?? inputDef.DefaultValue
+        };
 
-            AssertKnownType(typeConfig);
+        field.SetAstType(inputDef);
 
-            var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<EnumerationGraphType>)) as IGraphTypeFactory<EnumerationGraphType>;
-            var type = typeFactory?.Create() ?? new EnumerationGraphType();
+        OverrideDeprecationReason(field, fieldConfig.DeprecationReason);
 
-            type.Name = name;
-            type.Description = typeConfig.Description ?? enumDef.Description?.Value.ToString() ?? enumDef.MergeComments();
-            type.SetAstType(enumDef);
+        return field;
+    }
 
-            OverrideDeprecationReason(type, typeConfig.DeprecationReason);
+    /// <summary>
+    /// Returns a <see cref="InterfaceGraphType"/> from the specified <see cref="GraphQLInterfaceTypeDefinition"/>.
+    /// </summary>
+    protected virtual InterfaceGraphType ToInterfaceType(GraphQLInterfaceTypeDefinition interfaceDef)
+    {
+        var name = (string)interfaceDef.Name; //TODO:alloc
+        var typeConfig = Types.For(name);
 
-            if (enumDef.Values?.Count > 0) // just in case
-            {
-                foreach (var value in enumDef.Values)
-                {
-                    type.Add(ToEnumValue(value, typeConfig.Type));
-                }
-            }
+        AssertKnownType(typeConfig);
 
-            return type;
-        }
+        var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<InterfaceGraphType>)) as IGraphTypeFactory<InterfaceGraphType>;
+        var type = typeFactory?.Create() ?? new InterfaceGraphType();
 
-        /// <summary>
-        /// Returns a <see cref="Directive"/> from the specified <see cref="GraphQLDirectiveDefinition"/>.
-        /// </summary>
-        protected virtual Directive ToDirective(GraphQLDirectiveDefinition directiveDef)
+        type.Name = name;
+        type.Description = typeConfig.Description ?? interfaceDef.Description?.Value.ToString() ?? interfaceDef.MergeComments();
+        type.ResolveType = typeConfig.ResolveType;
+        type.SetAstType(interfaceDef);
+
+        OverrideDeprecationReason(type, typeConfig.DeprecationReason);
+
+        typeConfig.CopyMetadataTo(type);
+
+        if (interfaceDef.Fields != null)
         {
-            var result = new Directive(directiveDef.Name.StringValue) //ISSUE:allocation
+            foreach (var f in interfaceDef.Fields)
             {
-                Description = directiveDef.Description?.Value.ToString() ?? directiveDef.MergeComments(),
-                Repeatable = directiveDef.Repeatable,
-                Arguments = ToQueryArguments(directiveDef.Arguments?.Items)
-            };
-
-            if (directiveDef.Locations.Items.Count > 0) // just in case
-            {
-                foreach (var location in directiveDef.Locations.Items)
-                {
-                    result.Locations.Add(location);
-                }
-            }
-
-            return result;
-        }
-
-        private EnumValueDefinition ToEnumValue(GraphQLEnumValueDefinition valDef, Type? enumType)
-        {
-            var name = (string)valDef.Name; //TODO:alloc
-            return new EnumValueDefinition(name, enumType == null ? name : Enum.Parse(enumType, name, true))
-            {
-                Description = valDef.Description?.Value.ToString() ?? valDef.MergeComments()
-                // TODO: SchemaFirst configuration (TypeConfig/FieldConfig) does not allow to specify DeprecationReason for enum values
-                //DeprecationReason = ???
-            }.SetAstType(valDef);
-        }
-
-        /// <summary>
-        /// Returns a <see cref="QueryArgument"/> from the specified <see cref="GraphQLInputValueDefinition"/>.
-        /// </summary>
-        protected virtual QueryArgument ToArgument(ArgumentConfig argumentConfig, GraphQLInputValueDefinition inputDef)
-        {
-            var argument = new QueryArgument(ToGraphType(inputDef.Type!))
-            {
-                Name = argumentConfig.Name,
-                DefaultValue = argumentConfig.DefaultValue ?? inputDef.DefaultValue,
-                Description = argumentConfig.Description ?? inputDef.Description?.Value.ToString() ?? inputDef.MergeComments()
-            }.SetAstType(inputDef);
-
-            argumentConfig.CopyMetadataTo(argument);
-
-            return argument;
-        }
-
-        private IGraphType ToGraphType(GraphQLType astType)
-        {
-            switch (astType.Kind)
-            {
-                case ASTNodeKind.NonNullType:
-                {
-                    var type = ToGraphType(((GraphQLNonNullType)astType).Type!);
-                    return new NonNullGraphType(type);
-                }
-
-                case ASTNodeKind.ListType:
-                {
-                    var type = ToGraphType(((GraphQLListType)astType).Type!);
-                    return new ListGraphType(type);
-                }
-
-                case ASTNodeKind.NamedType:
-                {
-                    var namedType = (GraphQLNamedType)astType;
-                    var name = (string)namedType.Name; //TODO:alloc
-                    var type = GetType(name);
-                    return type ?? new GraphQLTypeReference(name);
-                }
-
-                default:
-                    throw new ArgumentOutOfRangeException($"Unknown GraphQL type {astType.Kind}");
+                type.AddField(ToFieldType(type.Name, f));
             }
         }
 
-        //TODO: add support for directive arguments
-        private QueryArguments ToQueryArguments(List<GraphQLInputValueDefinition>? arguments)
+        return type;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="UnionGraphType"/> from the specified <see cref="GraphQLUnionTypeDefinition"/>.
+    /// </summary>
+    protected virtual UnionGraphType ToUnionType(GraphQLUnionTypeDefinition unionDef)
+    {
+        var name = (string)unionDef.Name; //TODO:alloc
+        var typeConfig = Types.For(name);
+
+        AssertKnownType(typeConfig);
+
+        var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<UnionGraphType>)) as IGraphTypeFactory<UnionGraphType>;
+        var type = typeFactory?.Create() ?? new UnionGraphType();
+
+        type.Name = name;
+        type.Description = typeConfig.Description ?? unionDef.Description?.Value.ToString() ?? unionDef.MergeComments();
+        type.ResolveType = typeConfig.ResolveType;
+        type.SetAstType(unionDef);
+
+        OverrideDeprecationReason(type, typeConfig.DeprecationReason);
+
+        typeConfig.CopyMetadataTo(type);
+
+        if (unionDef.Types?.Count > 0) // just in case
         {
-            return arguments == null ? new QueryArguments() : new QueryArguments(arguments.Select(a => ToArgument(new ArgumentConfig((string)a.Name), a))); //TODO:alloc
+            foreach (var x in unionDef.Types)
+            {
+                string n = (string)x.Name; //TODO:alloc
+                type.AddPossibleType(((GetType(n) ?? new GraphQLTypeReference(n)) as IObjectGraphType)!);
+            }
         }
 
-        private QueryArguments ToQueryArguments(FieldConfig fieldConfig, List<GraphQLInputValueDefinition>? arguments)
+        return type;
+    }
+
+    /// <summary>
+    /// Returns an <see cref="InputObjectGraphType"/> from the specified <see cref="GraphQLInputObjectTypeDefinition"/>.
+    /// </summary>
+    protected virtual InputObjectGraphType ToInputObjectType(GraphQLInputObjectTypeDefinition inputDef)
+    {
+        var name = (string)inputDef.Name; //TODO:alloc
+        var typeConfig = Types.For(name);
+
+        AssertKnownType(typeConfig);
+
+        var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<InputObjectGraphType>)) as IGraphTypeFactory<InputObjectGraphType>;
+        var type = typeFactory?.Create() ?? new InputObjectGraphType();
+
+        type.Name = name;
+        type.Description = typeConfig.Description ?? inputDef.Description?.Value.ToString() ?? inputDef.MergeComments();
+        type.SetAstType(inputDef);
+
+        OverrideDeprecationReason(type, typeConfig.DeprecationReason);
+
+        typeConfig.CopyMetadataTo(type);
+
+        if (inputDef.Fields != null)
         {
-            return arguments == null ? new QueryArguments() : new QueryArguments(arguments.Select(a => ToArgument(fieldConfig.ArgumentFor((string)a.Name), a))); //TODO:alloc
+            foreach (var f in inputDef.Fields)
+            {
+                type.AddField(ToFieldType(type.Name, f));
+            }
         }
+
+        return type;
+    }
+
+    /// <summary>
+    /// Returns an <see cref="EnumerationGraphType"/> from the specified <see cref="GraphQLEnumTypeDefinition"/>.
+    /// </summary>
+    protected virtual EnumerationGraphType ToEnumerationType(GraphQLEnumTypeDefinition enumDef)
+    {
+        var name = (string)enumDef.Name; //TODO:alloc
+        var typeConfig = Types.For(name);
+
+        AssertKnownType(typeConfig);
+
+        var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<EnumerationGraphType>)) as IGraphTypeFactory<EnumerationGraphType>;
+        var type = typeFactory?.Create() ?? new EnumerationGraphType();
+
+        type.Name = name;
+        type.Description = typeConfig.Description ?? enumDef.Description?.Value.ToString() ?? enumDef.MergeComments();
+        type.SetAstType(enumDef);
+
+        OverrideDeprecationReason(type, typeConfig.DeprecationReason);
+
+        if (enumDef.Values?.Count > 0) // just in case
+        {
+            foreach (var value in enumDef.Values)
+            {
+                type.Add(ToEnumValue(value, typeConfig.Type));
+            }
+        }
+
+        return type;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Directive"/> from the specified <see cref="GraphQLDirectiveDefinition"/>.
+    /// </summary>
+    protected virtual Directive ToDirective(GraphQLDirectiveDefinition directiveDef)
+    {
+        var result = new Directive(directiveDef.Name.StringValue) //ISSUE:allocation
+        {
+            Description = directiveDef.Description?.Value.ToString() ?? directiveDef.MergeComments(),
+            Repeatable = directiveDef.Repeatable,
+            Arguments = ToQueryArguments(directiveDef.Arguments?.Items)
+        };
+
+        if (directiveDef.Locations.Items.Count > 0) // just in case
+        {
+            foreach (var location in directiveDef.Locations.Items)
+            {
+                result.Locations.Add(location);
+            }
+        }
+
+        return result;
+    }
+
+    private EnumValueDefinition ToEnumValue(GraphQLEnumValueDefinition valDef, Type? enumType)
+    {
+        var name = (string)valDef.Name; //TODO:alloc
+        return new EnumValueDefinition(name, enumType == null ? name : Enum.Parse(enumType, name, true))
+        {
+            Description = valDef.Description?.Value.ToString() ?? valDef.MergeComments()
+            // TODO: SchemaFirst configuration (TypeConfig/FieldConfig) does not allow to specify DeprecationReason for enum values
+            //DeprecationReason = ???
+        }.SetAstType(valDef);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="QueryArgument"/> from the specified <see cref="GraphQLInputValueDefinition"/>.
+    /// </summary>
+    protected virtual QueryArgument ToArgument(ArgumentConfig argumentConfig, GraphQLInputValueDefinition inputDef)
+    {
+        var argument = new QueryArgument(ToGraphType(inputDef.Type!))
+        {
+            Name = argumentConfig.Name,
+            DefaultValue = argumentConfig.DefaultValue ?? inputDef.DefaultValue,
+            Description = argumentConfig.Description ?? inputDef.Description?.Value.ToString() ?? inputDef.MergeComments()
+        }.SetAstType(inputDef);
+
+        argumentConfig.CopyMetadataTo(argument);
+
+        return argument;
+    }
+
+    private IGraphType ToGraphType(GraphQLType astType)
+    {
+        switch (astType.Kind)
+        {
+            case ASTNodeKind.NonNullType:
+            {
+                var type = ToGraphType(((GraphQLNonNullType)astType).Type!);
+                return new NonNullGraphType(type);
+            }
+
+            case ASTNodeKind.ListType:
+            {
+                var type = ToGraphType(((GraphQLListType)astType).Type!);
+                return new ListGraphType(type);
+            }
+
+            case ASTNodeKind.NamedType:
+            {
+                var namedType = (GraphQLNamedType)astType;
+                var name = (string)namedType.Name; //TODO:alloc
+                var type = GetType(name);
+                return type ?? new GraphQLTypeReference(name);
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException($"Unknown GraphQL type {astType.Kind}");
+        }
+    }
+
+    //TODO: add support for directive arguments
+    private QueryArguments ToQueryArguments(List<GraphQLInputValueDefinition>? arguments)
+    {
+        return arguments == null ? new QueryArguments() : new QueryArguments(arguments.Select(a => ToArgument(new ArgumentConfig((string)a.Name), a))); //TODO:alloc
+    }
+
+    private QueryArguments ToQueryArguments(FieldConfig fieldConfig, List<GraphQLInputValueDefinition>? arguments)
+    {
+        return arguments == null ? new QueryArguments() : new QueryArguments(arguments.Select(a => ToArgument(fieldConfig.ArgumentFor((string)a.Name), a))); //TODO:alloc
     }
 }

--- a/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
+++ b/src/GraphQL/Utilities/SchemaBuilderExtensions.cs
@@ -1,90 +1,89 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+internal static class SchemaBuilderExtensions
 {
-    internal static class SchemaBuilderExtensions
+    private const string AST_METAFIELD = "__AST_MetaField__"; // TODO: possible remove
+    private const string EXTENSION_AST_METAFIELD = "__EXTENSION_AST_MetaField__"; // TODO: possible remove
+
+    public static bool IsExtensionType(this IMetadataReader type)
     {
-        private const string AST_METAFIELD = "__AST_MetaField__"; // TODO: possible remove
-        private const string EXTENSION_AST_METAFIELD = "__EXTENSION_AST_MetaField__"; // TODO: possible remove
+        return type.HasExtensionAstTypes()
+            && !type.AstTypeHasFields();
+    }
 
-        public static bool IsExtensionType(this IMetadataReader type)
+    public static bool AstTypeHasFields(this IMetadataReader type)
+    {
+        return GetAstType<ASTNode>(type) switch
         {
-            return type.HasExtensionAstTypes()
-                && !type.AstTypeHasFields();
-        }
+            GraphQLObjectTypeDefinition otd => otd.Fields?.Any() ?? false,
+            GraphQLInterfaceTypeDefinition itd => itd.Fields?.Any() ?? false,
+            _ => false
+        };
+    }
 
-        public static bool AstTypeHasFields(this IMetadataReader type)
+    public static T? GetAstType<T>(this IMetadataReader type) where T : class // TODO: possible remove
+    {
+        return type.GetMetadata<T>(AST_METAFIELD);
+    }
+
+    public static TMetadataProvider SetAstType<TMetadataProvider>(this TMetadataProvider provider, ASTNode node) // TODO: possible remove
+        where TMetadataProvider : IMetadataWriter
+
+    {
+        provider.WithMetadata(AST_METAFIELD, node); //TODO: remove?
+
+        if (node is IHasDirectivesNode ast)
+            provider.CopyDirectivesFrom(ast);
+
+        return provider;
+    }
+
+    public static TMetadataProvider CopyDirectivesFrom<TMetadataProvider>(this TMetadataProvider provider, IHasDirectivesNode node)
+        where TMetadataProvider : IMetadataWriter
+    {
+        if (node.Directives?.Count > 0)
         {
-            return GetAstType<ASTNode>(type) switch
+            foreach (var directive in node.Directives)
             {
-                GraphQLObjectTypeDefinition otd => otd.Fields?.Any() ?? false,
-                GraphQLInterfaceTypeDefinition itd => itd.Fields?.Any() ?? false,
-                _ => false
-            };
-        }
-
-        public static T? GetAstType<T>(this IMetadataReader type) where T : class // TODO: possible remove
-        {
-            return type.GetMetadata<T>(AST_METAFIELD);
-        }
-
-        public static TMetadataProvider SetAstType<TMetadataProvider>(this TMetadataProvider provider, ASTNode node) // TODO: possible remove
-            where TMetadataProvider : IMetadataWriter
-
-        {
-            provider.WithMetadata(AST_METAFIELD, node); //TODO: remove?
-
-            if (node is IHasDirectivesNode ast)
-                provider.CopyDirectivesFrom(ast);
-
-            return provider;
-        }
-
-        public static TMetadataProvider CopyDirectivesFrom<TMetadataProvider>(this TMetadataProvider provider, IHasDirectivesNode node)
-            where TMetadataProvider : IMetadataWriter
-        {
-            if (node.Directives?.Count > 0)
-            {
-                foreach (var directive in node.Directives)
+                provider.ApplyDirective(directive!.Name.StringValue, d => //ISSUE:allocation
                 {
-                    provider.ApplyDirective(directive!.Name.StringValue, d => //ISSUE:allocation
+                    if (directive.Arguments?.Count > 0)
                     {
-                        if (directive.Arguments?.Count > 0)
-                        {
-                            foreach (var arg in directive.Arguments)
-                                d.AddArgument(new DirectiveArgument(arg.Name.StringValue) { Value = arg.Value.ParseAnyLiteral() }); //ISSUE:allocation
-                        }
-                    });
-                }
+                        foreach (var arg in directive.Arguments)
+                            d.AddArgument(new DirectiveArgument(arg.Name.StringValue) { Value = arg.Value.ParseAnyLiteral() }); //ISSUE:allocation
+                    }
+                });
             }
-            return provider;
         }
+        return provider;
+    }
 
-        public static bool HasExtensionAstTypes(this IMetadataReader type)
-        {
-            return type.HasMetadata(EXTENSION_AST_METAFIELD) && GetExtensionAstTypes(type).Count > 0;
-        }
+    public static bool HasExtensionAstTypes(this IMetadataReader type)
+    {
+        return type.HasMetadata(EXTENSION_AST_METAFIELD) && GetExtensionAstTypes(type).Count > 0;
+    }
 
-        public static void AddExtensionAstType<T>(this IMetadataWriter type, T astType) where T : ASTNode
-        {
-            var types = GetExtensionAstTypes(type.MetadataReader);
-            types.Add(astType);
-            type.Metadata[EXTENSION_AST_METAFIELD] = types;
+    public static void AddExtensionAstType<T>(this IMetadataWriter type, T astType) where T : ASTNode
+    {
+        var types = GetExtensionAstTypes(type.MetadataReader);
+        types.Add(astType);
+        type.Metadata[EXTENSION_AST_METAFIELD] = types;
 
-            if (astType is IHasDirectivesNode ast)
-                type.CopyDirectivesFrom(ast);
-        }
+        if (astType is IHasDirectivesNode ast)
+            type.CopyDirectivesFrom(ast);
+    }
 
-        public static List<ASTNode> GetExtensionAstTypes(this IMetadataReader type)
-        {
-            return type.GetMetadata(EXTENSION_AST_METAFIELD, () => new List<ASTNode>())!;
-        }
+    public static List<ASTNode> GetExtensionAstTypes(this IMetadataReader type)
+    {
+        return type.GetMetadata(EXTENSION_AST_METAFIELD, () => new List<ASTNode>())!;
+    }
 
-        public static IEnumerable<GraphQLDirective> GetExtensionDirectives<T>(this IMetadataReader type) where T : ASTNode
-        {
-            var types = type.GetExtensionAstTypes().OfType<IHasDirectivesNode>().Where(n => n.Directives != null);
-            return types.SelectMany(x => x.Directives!);
-        }
+    public static IEnumerable<GraphQLDirective> GetExtensionDirectives<T>(this IMetadataReader type) where T : ASTNode
+    {
+        var types = type.GetExtensionAstTypes().OfType<IHasDirectivesNode>().Where(n => n.Directives != null);
+        return types.SelectMany(x => x.Directives!);
     }
 }

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -10,524 +10,523 @@ using GraphQLParser.AST;
 
 //TODO:should be completely rewritten
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+internal static class SchemaPrinterExtensions
 {
-    internal static class SchemaPrinterExtensions
+    public static IEnumerable<T> OrderBy<T>(this IEnumerable<T> list, IComparer<T>? comparer)
+        => comparer == null ? list : list.OrderBy(x => x, comparer);
+}
+
+/// <summary>
+/// Enables printing schema as SDL (Schema Definition Language) document.
+/// <br/>
+/// See <see href="https://spec.graphql.org/October2021/#sec-Type-System"/> for more information.
+/// </summary>
+[Obsolete("Please use the schema.Print() extension method instead. This class will be removed in v9.")]
+public class SchemaPrinter //TODO: rewrite string concatenations to use buffer ?
+{
+    private static readonly List<string> _builtInScalars = new()
     {
-        public static IEnumerable<T> OrderBy<T>(this IEnumerable<T> list, IComparer<T>? comparer)
-            => comparer == null ? list : list.OrderBy(x => x, comparer);
+        "String",
+        "Boolean",
+        "Int",
+        "Float",
+        "ID"
+    };
+
+    private static readonly List<string> _builtInDirectives = new()
+    {
+        "skip",
+        "include",
+        "deprecated"
+    };
+
+    /// <summary>
+    /// Creates printer with the specified options.
+    /// </summary>
+    /// <param name="schema">Schema to print.</param>
+    /// <param name="options">Printer options.</param>
+    public SchemaPrinter(ISchema schema, SchemaPrinterOptions? options = null)
+    {
+        Schema = schema;
+        Options = options ?? new SchemaPrinterOptions();
+    }
+
+    protected static bool IsIntrospectionType(string typeName) => typeName.StartsWith("__", StringComparison.InvariantCulture);
+
+    protected static bool IsBuiltInScalar(string typeName) => _builtInScalars.Contains(typeName);
+
+    protected static bool IsBuiltInDirective(string directiveName) => _builtInDirectives.Contains(directiveName);
+
+    protected ISchema Schema { get; set; }
+
+    protected SchemaPrinterOptions Options { get; }
+
+    /// <summary>
+    /// Prints only 'defined' types and directives.
+    /// <br/>
+    /// See <see cref="IsDefinedType(string)"/> and <see cref="IsDefinedDirective(string)"/> for more information about what 'defined' means.
+    /// </summary>
+    /// <returns>SDL document.</returns>
+    public string Print() => PrintFilteredSchema(IsDefinedDirective, IsDefinedType);
+
+    /// <summary>
+    /// Prints only introspection types.
+    /// </summary>
+    /// <returns>SDL document.</returns>
+    public string PrintIntrospectionSchema() => PrintFilteredSchema(IsBuiltInDirective, IsIntrospectionType);
+
+    /// <summary>
+    /// Prints schema according to the specified filters.
+    /// </summary>
+    /// <param name="directiveFilter">Filter for directives.</param>
+    /// <param name="typeFilter">Filter for types.</param>
+    /// <returns>SDL document.</returns>
+    public string PrintFilteredSchema(Func<string, bool> directiveFilter, Func<string, bool> typeFilter)
+    {
+        if (Schema == null)
+            return "";
+
+        Schema.Initialize();
+
+        var directives = Schema.Directives.Where(d => directiveFilter(d.Name)).OrderBy(d => d.Name, StringComparer.Ordinal).ToList();
+        var types = Schema.AllTypes
+            .Dictionary
+            .Values
+            .Where(t => typeFilter(t.Name))
+            .OrderBy(x => x.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var result = new[]
+        {
+            PrintSchemaDefinition(Schema),
+        }
+        .Concat(directives.OrderBy(Options.Comparer?.DirectiveComparer).Select(PrintDirective))
+        .Concat(types.OrderBy(Options.Comparer?.TypeComparer).Select(PrintType))
+        .Where(x => x != null)
+        .ToList();
+
+        return string.Join(Environment.NewLine + Environment.NewLine, result) + Environment.NewLine;
     }
 
     /// <summary>
-    /// Enables printing schema as SDL (Schema Definition Language) document.
-    /// <br/>
-    /// See <see href="https://spec.graphql.org/October2021/#sec-Type-System"/> for more information.
+    /// Determines that the specified directive is defined in the schema and should be printed.
+    /// By default, all directives are defined (printed) except for built-in directives.
     /// </summary>
-    [Obsolete("Please use the schema.Print() extension method instead. This class will be removed in v9.")]
-    public class SchemaPrinter //TODO: rewrite string concatenations to use buffer ?
+    protected virtual bool IsDefinedDirective(string directiveName) => !IsBuiltInDirective(directiveName);
+
+    /// <summary>
+    /// Determines that the specified type is defined in the schema and should be printed.
+    /// By default, all types are defined (printed) except for introspection types and built-in scalars.
+    /// </summary>
+    protected virtual bool IsDefinedType(string typeName) => !IsIntrospectionType(typeName) && !IsBuiltInScalar(typeName);
+
+    public string? PrintSchemaDefinition(ISchema schema)
     {
-        private static readonly List<string> _builtInScalars = new()
+        schema?.Initialize();
+
+        if (schema == null || IsSchemaOfCommonNames(schema))
+            return null;
+
+        var operationTypes = new List<string>();
+
+        if (schema.Query != null)
         {
-            "String",
-            "Boolean",
-            "Int",
-            "Float",
-            "ID"
+            operationTypes.Add($"  query: {schema.Query}");
+        }
+
+        if (schema.Mutation != null)
+        {
+            operationTypes.Add($"  mutation: {schema.Mutation}");
+        }
+
+        if (schema.Subscription != null)
+        {
+            operationTypes.Add($"  subscription: {schema.Subscription}");
+        }
+
+        return $"schema {{{Environment.NewLine}{string.Join(Environment.NewLine, operationTypes)}{Environment.NewLine}}}";
+    }
+
+    /**
+     * GraphQL schema define root types for each type of operation. These types are
+     * the same as any other type and can be named in any manner, however there is
+     * a common naming convention:
+     *
+     *   schema {
+     *     query: Query
+     *     mutation: Mutation
+     *     subscription: Subscription
+     *   }
+     *
+     * When using this naming convention, the schema description can be omitted.
+     */
+    public bool IsSchemaOfCommonNames(ISchema schema)
+    {
+        Schema?.Initialize();
+
+        if (schema.Query != null && schema.Query.Name != "Query")
+        {
+            return false;
+        }
+
+        if (schema.Mutation != null && schema.Mutation.Name != "Mutation")
+        {
+            return false;
+        }
+
+        if (schema.Subscription != null && schema.Subscription.Name != "Subscription")
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public string PrintType(IGraphType type)
+    {
+        Schema?.Initialize();
+
+        return type switch
+        {
+            EnumerationGraphType graphType => PrintEnum(graphType),
+            ScalarGraphType scalarGraphType => PrintScalar(scalarGraphType),
+            IObjectGraphType objectGraphType => PrintObject(objectGraphType),
+            IInterfaceGraphType interfaceGraphType => PrintInterface(interfaceGraphType),
+            UnionGraphType unionGraphType => PrintUnion(unionGraphType),
+            Directive directiveGraphType => PrintDirective(directiveGraphType),  //TODO: DirectiveGraphType does not inherit IGraphType
+            IInputObjectGraphType input => PrintInputObject(input),
+            _ => throw new InvalidOperationException($"Unknown GraphType '{type.GetType().Name}' with name '{type.Name}'")
         };
+    }
 
-        private static readonly List<string> _builtInDirectives = new()
+    public virtual string PrintScalar(ScalarGraphType type)
+    {
+        Schema?.Initialize();
+
+        return $"{FormatDescription(type.Description)}scalar {type.Name}";
+    }
+
+    public virtual string PrintObject(IObjectGraphType type)
+    {
+        Schema?.Initialize();
+
+        var interfaces = type.ResolvedInterfaces.List.Select(x => x.Name).ToList();
+        var delimiter = " & ";
+        var implementedInterfaces = interfaces.Count > 0
+            ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
+            : "";
+
+        if (type.Fields.Count > 0)
+            return FormatDescription(type.Description) + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));
+        else
+            return FormatDescription(type.Description) + "type {0}{1}".ToFormat(type.Name, implementedInterfaces);
+    }
+
+    public virtual string PrintInterface(IInterfaceGraphType type)
+    {
+        Schema?.Initialize();
+
+        return FormatDescription(type.Description) + "interface {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, PrintFields(type));
+    }
+
+    public virtual string PrintUnion(UnionGraphType type)
+    {
+        Schema?.Initialize();
+
+        var possibleTypes = string.Join(" | ", type.PossibleTypes.Select(x => x.Name));
+        return FormatDescription(type.Description) + "union {0} = {1}".ToFormat(type.Name, possibleTypes);
+    }
+
+    public virtual string PrintEnum(EnumerationGraphType type)
+    {
+        Schema?.Initialize();
+
+        var values = string.Join(Environment.NewLine, type.Values.OrderBy(Options.Comparer?.EnumValueComparer(type)).Select(x => FormatDescription(x.Description, "  ") + "  " + x.Name + (Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : "")));
+        return FormatDescription(type.Description) + "enum {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, values);
+    }
+
+    public virtual string PrintInputObject(IInputObjectGraphType type)
+    {
+        Schema?.Initialize();
+
+        var fields = type.Fields.OrderBy<FieldType>(Options.Comparer?.FieldComparer(type)).Select(x => PrintInputValue(x));
+        return FormatDescription(type.Description) + "input {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, string.Join(Environment.NewLine, fields));
+    }
+
+    public virtual string PrintFields(IComplexGraphType type)
+    {
+        Schema?.Initialize();
+
+        var fields = type?.Fields
+            .OrderBy<FieldType>(Options.Comparer?.FieldComparer(type))
+            .Select(x =>
+            new
+            {
+                x.Name,
+                Type = x.ResolvedType,
+                Args = PrintArgs(x),
+                Description = FormatDescription(x.Description, "  "),
+                Deprecation = Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : "",
+            }).ToList();
+
+        return fields == null
+            ? ""
+            : string.Join(Environment.NewLine, fields.Select(
+                f => "{3}  {0}{1}: {2}{4}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation)));
+    }
+
+    public virtual string PrintArgs(FieldType field)
+    {
+        Schema?.Initialize();
+
+        if (field.Arguments == null || field.Arguments.Count == 0)
         {
-            "skip",
-            "include",
-            "deprecated"
+            return string.Empty;
+        }
+
+        return "({0})".ToFormat(string.Join(", ", field.Arguments.OrderBy(Options.Comparer?.ArgumentComparer(field)).Select(PrintInputValue))); //TODO: iterator allocation
+    }
+
+    public string PrintInputValue(FieldType field)
+    {
+        Schema?.Initialize();
+
+        var argumentType = field.ResolvedType!;
+        var description = $"{FormatDescription(field.Description, "  ")}  {field.Name}: {argumentType}";
+
+        if (field.DefaultValue != null)
+        {
+            description += " = {0}".ToFormat(FormatDefaultValue(field.DefaultValue, argumentType));
+        }
+
+        return description;
+    }
+
+    public string PrintInputValue(QueryArgument argument)
+    {
+        Schema?.Initialize();
+
+        var argumentType = argument.ResolvedType!;
+        var desc = "{0}: {1}".ToFormat(argument.Name, argumentType);
+
+        if (argument.DefaultValue != null)
+        {
+            desc += " = {0}".ToFormat(FormatDefaultValue(argument.DefaultValue, argumentType));
+        }
+
+        return desc;
+    }
+
+    public string PrintDirective(Directive directive)
+    {
+        Schema?.Initialize();
+
+        var builder = new StringBuilder();
+        builder.Append(FormatDescription(directive.Description));
+        builder.Append($"directive @{directive.Name}");
+
+        if (directive.Arguments?.Count > 0)
+        {
+            builder.AppendLine("(");
+            builder.AppendLine(FormatDirectiveArguments(directive.Arguments));
+            builder.Append(')');
+        }
+
+        if (directive.Repeatable)
+            builder.Append(" repeatable");
+
+        builder.Append($" on {FormatDirectiveLocationList(directive.Locations)}");
+        return builder.ToString().TrimStart();
+    }
+
+    private string? FormatDirectiveArguments(QueryArguments arguments)
+    {
+        if (arguments == null || arguments.Count == 0)
+            return null;
+        //v5 todo: sort directive arguments list via Options.Comparer -- needs ArgumentComparer(DirectiveGraphType directive)
+        return string.Join(Environment.NewLine, arguments.Select(arg => $"  {PrintInputValue(arg)}"));
+    }
+
+    private string FormatDirectiveLocationList(IEnumerable<DirectiveLocation> locations)
+    {
+        //v5 todo: sort DirectiveLocation list via Options.Comparer -- needs DirectiveLocationComparer(DirectiveGraphType directive)
+        return string.Join(" | ", locations.Select(x => __DirectiveLocation.Instance.Serialize(x))); //TODO: remove allocations
+    }
+
+    protected string FormatDescription(string? description, string indentation = "")
+    {
+        return Options.IncludeDescriptions
+            ? PrintDescription(description, indentation)
+            : "";
+    }
+
+    public string FormatDefaultValue(object? value, IGraphType graphType)
+    {
+        Schema?.Initialize();
+
+        if (value == null)
+            return "null";
+
+        return graphType switch
+        {
+            NonNullGraphType nonNull => FormatDefaultValue(value, nonNull.ResolvedType!),
+            ListGraphType list => "[{0}]".ToFormat(string.Join(", ", ((IEnumerable)value).Cast<object>().Select(i => FormatDefaultValue(i, list.ResolvedType!)))),
+            IInputObjectGraphType input => FormatInputObjectValue(value, input),
+            EnumerationGraphType enumeration => (enumeration.ToAST(value) ?? throw new ArgumentOutOfRangeException(nameof(value), $"Unable to convert '{value}' to AST for enumeration type '{enumeration.Name}'.")).Print(),
+            ScalarGraphType scalar => (scalar.ToAST(value) ?? throw new ArgumentOutOfRangeException(nameof(value), $"Unable to convert '{value}' to AST for scalar type '{scalar.Name}'.")).Print(),
+            _ => throw new NotSupportedException($"Unsupported graph type '{graphType}'")
         };
+    }
 
-        /// <summary>
-        /// Creates printer with the specified options.
-        /// </summary>
-        /// <param name="schema">Schema to print.</param>
-        /// <param name="options">Printer options.</param>
-        public SchemaPrinter(ISchema schema, SchemaPrinterOptions? options = null)
+    private string FormatInputObjectValue(object value, IInputObjectGraphType input)
+    {
+        var sb = new StringBuilder();
+        sb.Append("{ ");
+
+        foreach (var field in input.Fields.OrderBy(Options.Comparer?.FieldComparer(input)))
         {
-            Schema = schema;
-            Options = options ?? new SchemaPrinterOptions();
-        }
+            string propertyName = field.GetMetadata<string>(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME) ?? field.Name;
 
-        protected static bool IsIntrospectionType(string typeName) => typeName.StartsWith("__", StringComparison.InvariantCulture);
-
-        protected static bool IsBuiltInScalar(string typeName) => _builtInScalars.Contains(typeName);
-
-        protected static bool IsBuiltInDirective(string directiveName) => _builtInDirectives.Contains(directiveName);
-
-        protected ISchema Schema { get; set; }
-
-        protected SchemaPrinterOptions Options { get; }
-
-        /// <summary>
-        /// Prints only 'defined' types and directives.
-        /// <br/>
-        /// See <see cref="IsDefinedType(string)"/> and <see cref="IsDefinedDirective(string)"/> for more information about what 'defined' means.
-        /// </summary>
-        /// <returns>SDL document.</returns>
-        public string Print() => PrintFilteredSchema(IsDefinedDirective, IsDefinedType);
-
-        /// <summary>
-        /// Prints only introspection types.
-        /// </summary>
-        /// <returns>SDL document.</returns>
-        public string PrintIntrospectionSchema() => PrintFilteredSchema(IsBuiltInDirective, IsIntrospectionType);
-
-        /// <summary>
-        /// Prints schema according to the specified filters.
-        /// </summary>
-        /// <param name="directiveFilter">Filter for directives.</param>
-        /// <param name="typeFilter">Filter for types.</param>
-        /// <returns>SDL document.</returns>
-        public string PrintFilteredSchema(Func<string, bool> directiveFilter, Func<string, bool> typeFilter)
-        {
-            if (Schema == null)
-                return "";
-
-            Schema.Initialize();
-
-            var directives = Schema.Directives.Where(d => directiveFilter(d.Name)).OrderBy(d => d.Name, StringComparer.Ordinal).ToList();
-            var types = Schema.AllTypes
-                .Dictionary
-                .Values
-                .Where(t => typeFilter(t.Name))
-                .OrderBy(x => x.Name, StringComparer.Ordinal)
-                .ToList();
-
-            var result = new[]
+            // if 'value' is stored as a dictionary of key/value pairs, pull the field value from the dictionary by the property name
+            object? propertyValue;
+            if (value is IDictionary<string, object?> dic)
             {
-                PrintSchemaDefinition(Schema),
+                // note: per spec, unspecified properties may not exist within the dictionary
+                if (!dic.TryGetValue(propertyName, out propertyValue))
+                    continue;
             }
-            .Concat(directives.OrderBy(Options.Comparer?.DirectiveComparer).Select(PrintDirective))
-            .Concat(types.OrderBy(Options.Comparer?.TypeComparer).Select(PrintType))
-            .Where(x => x != null)
-            .ToList();
-
-            return string.Join(Environment.NewLine + Environment.NewLine, result) + Environment.NewLine;
-        }
-
-        /// <summary>
-        /// Determines that the specified directive is defined in the schema and should be printed.
-        /// By default, all directives are defined (printed) except for built-in directives.
-        /// </summary>
-        protected virtual bool IsDefinedDirective(string directiveName) => !IsBuiltInDirective(directiveName);
-
-        /// <summary>
-        /// Determines that the specified type is defined in the schema and should be printed.
-        /// By default, all types are defined (printed) except for introspection types and built-in scalars.
-        /// </summary>
-        protected virtual bool IsDefinedType(string typeName) => !IsIntrospectionType(typeName) && !IsBuiltInScalar(typeName);
-
-        public string? PrintSchemaDefinition(ISchema schema)
-        {
-            schema?.Initialize();
-
-            if (schema == null || IsSchemaOfCommonNames(schema))
-                return null;
-
-            var operationTypes = new List<string>();
-
-            if (schema.Query != null)
-            {
-                operationTypes.Add($"  query: {schema.Query}");
-            }
-
-            if (schema.Mutation != null)
-            {
-                operationTypes.Add($"  mutation: {schema.Mutation}");
-            }
-
-            if (schema.Subscription != null)
-            {
-                operationTypes.Add($"  subscription: {schema.Subscription}");
-            }
-
-            return $"schema {{{Environment.NewLine}{string.Join(Environment.NewLine, operationTypes)}{Environment.NewLine}}}";
-        }
-
-        /**
-         * GraphQL schema define root types for each type of operation. These types are
-         * the same as any other type and can be named in any manner, however there is
-         * a common naming convention:
-         *
-         *   schema {
-         *     query: Query
-         *     mutation: Mutation
-         *     subscription: Subscription
-         *   }
-         *
-         * When using this naming convention, the schema description can be omitted.
-         */
-        public bool IsSchemaOfCommonNames(ISchema schema)
-        {
-            Schema?.Initialize();
-
-            if (schema.Query != null && schema.Query.Name != "Query")
-            {
-                return false;
-            }
-
-            if (schema.Mutation != null && schema.Mutation.Name != "Mutation")
-            {
-                return false;
-            }
-
-            if (schema.Subscription != null && schema.Subscription.Name != "Subscription")
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        public string PrintType(IGraphType type)
-        {
-            Schema?.Initialize();
-
-            return type switch
-            {
-                EnumerationGraphType graphType => PrintEnum(graphType),
-                ScalarGraphType scalarGraphType => PrintScalar(scalarGraphType),
-                IObjectGraphType objectGraphType => PrintObject(objectGraphType),
-                IInterfaceGraphType interfaceGraphType => PrintInterface(interfaceGraphType),
-                UnionGraphType unionGraphType => PrintUnion(unionGraphType),
-                Directive directiveGraphType => PrintDirective(directiveGraphType),  //TODO: DirectiveGraphType does not inherit IGraphType
-                IInputObjectGraphType input => PrintInputObject(input),
-                _ => throw new InvalidOperationException($"Unknown GraphType '{type.GetType().Name}' with name '{type.Name}'")
-            };
-        }
-
-        public virtual string PrintScalar(ScalarGraphType type)
-        {
-            Schema?.Initialize();
-
-            return $"{FormatDescription(type.Description)}scalar {type.Name}";
-        }
-
-        public virtual string PrintObject(IObjectGraphType type)
-        {
-            Schema?.Initialize();
-
-            var interfaces = type.ResolvedInterfaces.List.Select(x => x.Name).ToList();
-            var delimiter = " & ";
-            var implementedInterfaces = interfaces.Count > 0
-                ? " implements {0}".ToFormat(string.Join(delimiter, interfaces))
-                : "";
-
-            if (type.Fields.Count > 0)
-                return FormatDescription(type.Description) + "type {1}{2} {{{0}{3}{0}}}".ToFormat(Environment.NewLine, type.Name, implementedInterfaces, PrintFields(type));
+            // if 'value' is stored as an object -- e.g. new MyObject { Value = "Test" } -- then pull from the property directly
             else
-                return FormatDescription(type.Description) + "type {0}{1}".ToFormat(type.Name, implementedInterfaces);
-        }
-
-        public virtual string PrintInterface(IInterfaceGraphType type)
-        {
-            Schema?.Initialize();
-
-            return FormatDescription(type.Description) + "interface {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, PrintFields(type));
-        }
-
-        public virtual string PrintUnion(UnionGraphType type)
-        {
-            Schema?.Initialize();
-
-            var possibleTypes = string.Join(" | ", type.PossibleTypes.Select(x => x.Name));
-            return FormatDescription(type.Description) + "union {0} = {1}".ToFormat(type.Name, possibleTypes);
-        }
-
-        public virtual string PrintEnum(EnumerationGraphType type)
-        {
-            Schema?.Initialize();
-
-            var values = string.Join(Environment.NewLine, type.Values.OrderBy(Options.Comparer?.EnumValueComparer(type)).Select(x => FormatDescription(x.Description, "  ") + "  " + x.Name + (Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : "")));
-            return FormatDescription(type.Description) + "enum {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, values);
-        }
-
-        public virtual string PrintInputObject(IInputObjectGraphType type)
-        {
-            Schema?.Initialize();
-
-            var fields = type.Fields.OrderBy<FieldType>(Options.Comparer?.FieldComparer(type)).Select(x => PrintInputValue(x));
-            return FormatDescription(type.Description) + "input {1} {{{0}{2}{0}}}".ToFormat(Environment.NewLine, type.Name, string.Join(Environment.NewLine, fields));
-        }
-
-        public virtual string PrintFields(IComplexGraphType type)
-        {
-            Schema?.Initialize();
-
-            var fields = type?.Fields
-                .OrderBy<FieldType>(Options.Comparer?.FieldComparer(type))
-                .Select(x =>
-                new
+            {
+                PropertyInfo propertyInfo;
+                try
                 {
-                    x.Name,
-                    Type = x.ResolvedType,
-                    Args = PrintArgs(x),
-                    Description = FormatDescription(x.Description, "  "),
-                    Deprecation = Options.IncludeDeprecationReasons ? PrintDeprecation(x.DeprecationReason) : "",
-                }).ToList();
-
-            return fields == null
-                ? ""
-                : string.Join(Environment.NewLine, fields.Select(
-                    f => "{3}  {0}{1}: {2}{4}".ToFormat(f.Name, f.Args, f.Type, f.Description, f.Deprecation)));
-        }
-
-        public virtual string PrintArgs(FieldType field)
-        {
-            Schema?.Initialize();
-
-            if (field.Arguments == null || field.Arguments.Count == 0)
-            {
-                return string.Empty;
-            }
-
-            return "({0})".ToFormat(string.Join(", ", field.Arguments.OrderBy(Options.Comparer?.ArgumentComparer(field)).Select(PrintInputValue))); //TODO: iterator allocation
-        }
-
-        public string PrintInputValue(FieldType field)
-        {
-            Schema?.Initialize();
-
-            var argumentType = field.ResolvedType!;
-            var description = $"{FormatDescription(field.Description, "  ")}  {field.Name}: {argumentType}";
-
-            if (field.DefaultValue != null)
-            {
-                description += " = {0}".ToFormat(FormatDefaultValue(field.DefaultValue, argumentType));
-            }
-
-            return description;
-        }
-
-        public string PrintInputValue(QueryArgument argument)
-        {
-            Schema?.Initialize();
-
-            var argumentType = argument.ResolvedType!;
-            var desc = "{0}: {1}".ToFormat(argument.Name, argumentType);
-
-            if (argument.DefaultValue != null)
-            {
-                desc += " = {0}".ToFormat(FormatDefaultValue(argument.DefaultValue, argumentType));
-            }
-
-            return desc;
-        }
-
-        public string PrintDirective(Directive directive)
-        {
-            Schema?.Initialize();
-
-            var builder = new StringBuilder();
-            builder.Append(FormatDescription(directive.Description));
-            builder.Append($"directive @{directive.Name}");
-
-            if (directive.Arguments?.Count > 0)
-            {
-                builder.AppendLine("(");
-                builder.AppendLine(FormatDirectiveArguments(directive.Arguments));
-                builder.Append(')');
-            }
-
-            if (directive.Repeatable)
-                builder.Append(" repeatable");
-
-            builder.Append($" on {FormatDirectiveLocationList(directive.Locations)}");
-            return builder.ToString().TrimStart();
-        }
-
-        private string? FormatDirectiveArguments(QueryArguments arguments)
-        {
-            if (arguments == null || arguments.Count == 0)
-                return null;
-            //v5 todo: sort directive arguments list via Options.Comparer -- needs ArgumentComparer(DirectiveGraphType directive)
-            return string.Join(Environment.NewLine, arguments.Select(arg => $"  {PrintInputValue(arg)}"));
-        }
-
-        private string FormatDirectiveLocationList(IEnumerable<DirectiveLocation> locations)
-        {
-            //v5 todo: sort DirectiveLocation list via Options.Comparer -- needs DirectiveLocationComparer(DirectiveGraphType directive)
-            return string.Join(" | ", locations.Select(x => __DirectiveLocation.Instance.Serialize(x))); //TODO: remove allocations
-        }
-
-        protected string FormatDescription(string? description, string indentation = "")
-        {
-            return Options.IncludeDescriptions
-                ? PrintDescription(description, indentation)
-                : "";
-        }
-
-        public string FormatDefaultValue(object? value, IGraphType graphType)
-        {
-            Schema?.Initialize();
-
-            if (value == null)
-                return "null";
-
-            return graphType switch
-            {
-                NonNullGraphType nonNull => FormatDefaultValue(value, nonNull.ResolvedType!),
-                ListGraphType list => "[{0}]".ToFormat(string.Join(", ", ((IEnumerable)value).Cast<object>().Select(i => FormatDefaultValue(i, list.ResolvedType!)))),
-                IInputObjectGraphType input => FormatInputObjectValue(value, input),
-                EnumerationGraphType enumeration => (enumeration.ToAST(value) ?? throw new ArgumentOutOfRangeException(nameof(value), $"Unable to convert '{value}' to AST for enumeration type '{enumeration.Name}'.")).Print(),
-                ScalarGraphType scalar => (scalar.ToAST(value) ?? throw new ArgumentOutOfRangeException(nameof(value), $"Unable to convert '{value}' to AST for scalar type '{scalar.Name}'.")).Print(),
-                _ => throw new NotSupportedException($"Unsupported graph type '{graphType}'")
-            };
-        }
-
-        private string FormatInputObjectValue(object value, IInputObjectGraphType input)
-        {
-            var sb = new StringBuilder();
-            sb.Append("{ ");
-
-            foreach (var field in input.Fields.OrderBy(Options.Comparer?.FieldComparer(input)))
-            {
-                string propertyName = field.GetMetadata<string>(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME) ?? field.Name;
-
-                // if 'value' is stored as a dictionary of key/value pairs, pull the field value from the dictionary by the property name
-                object? propertyValue;
-                if (value is IDictionary<string, object?> dic)
-                {
-                    // note: per spec, unspecified properties may not exist within the dictionary
-                    if (!dic.TryGetValue(propertyName, out propertyValue))
-                        continue;
+                    propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance)!;
                 }
-                // if 'value' is stored as an object -- e.g. new MyObject { Value = "Test" } -- then pull from the property directly
-                else
+                catch (AmbiguousMatchException)
                 {
-                    PropertyInfo propertyInfo;
-                    try
-                    {
-                        propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance)!;
-                    }
-                    catch (AmbiguousMatchException)
-                    {
-                        propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)!;
-                    }
-
-                    propertyValue = propertyInfo.GetValue(value);
+                    propertyInfo = value.GetType().GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)!;
                 }
 
-                sb.Append(field.Name)
-                   .Append(": ")
-                   .Append(FormatDefaultValue(propertyValue, field.ResolvedType!))
-                   .Append(", ");
+                propertyValue = propertyInfo.GetValue(value);
             }
 
-            sb.Length -= 2;
-            sb.Append(" }");
-            return sb.ToString();
+            sb.Append(field.Name)
+               .Append(": ")
+               .Append(FormatDefaultValue(propertyValue, field.ResolvedType!))
+               .Append(", ");
         }
 
-        public virtual string PrintComment(string? comment, string indentation = "", bool firstInBlock = true)
+        sb.Length -= 2;
+        sb.Append(" }");
+        return sb.ToString();
+    }
+
+    public virtual string PrintComment(string? comment, string indentation = "", bool firstInBlock = true)
+    {
+        if (string.IsNullOrWhiteSpace(comment))
+            return "";
+
+        indentation ??= "";
+
+        // normalize newlines
+        comment = comment!.Replace("\r", "");
+
+        var lines = comment.Split('\n');
+
+        var desc = !string.IsNullOrWhiteSpace(indentation) && !firstInBlock ? Environment.NewLine : "";
+
+        foreach (var line in lines)
         {
-            if (string.IsNullOrWhiteSpace(comment))
-                return "";
-
-            indentation ??= "";
-
-            // normalize newlines
-            comment = comment!.Replace("\r", "");
-
-            var lines = comment.Split('\n');
-
-            var desc = !string.IsNullOrWhiteSpace(indentation) && !firstInBlock ? Environment.NewLine : "";
-
-            foreach (var line in lines)
+            if (line == "")
             {
-                if (line == "")
-                {
-                    desc += indentation + $"#{Environment.NewLine}";
-                }
-                else
-                {
-                    // For > 120 character long lines, cut at space boundaries into sublines
-                    // of ~80 chars.
-                    var sublines = BreakLine(line, 120 - indentation.Length);
-                    foreach (string sub in sublines)
-                        desc += $"{indentation}# {sub}{Environment.NewLine}";
-                }
+                desc += indentation + $"#{Environment.NewLine}";
             }
-
-            return desc;
+            else
+            {
+                // For > 120 character long lines, cut at space boundaries into sublines
+                // of ~80 chars.
+                var sublines = BreakLine(line, 120 - indentation.Length);
+                foreach (string sub in sublines)
+                    desc += $"{indentation}# {sub}{Environment.NewLine}";
+            }
         }
 
-        public string PrintDescription(string? description, string indentation = "", bool firstInBlock = true)
+        return desc;
+    }
+
+    public string PrintDescription(string? description, string indentation = "", bool firstInBlock = true)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return "";
+
+        indentation ??= "";
+
+        // escape """ with \"""
+        description = description!.Replace("\"\"\"", "\\\"\"\"");
+
+        // normalize newlines
+        description = description.Replace("\r", "");
+
+        // remove control characters besides newline and tab
+        if (description.Any(c => c < ' ' && c != '\t' & c != '\n'))
         {
-            if (string.IsNullOrWhiteSpace(description))
-                return "";
-
-            indentation ??= "";
-
-            // escape """ with \"""
-            description = description!.Replace("\"\"\"", "\\\"\"\"");
-
-            // normalize newlines
-            description = description.Replace("\r", "");
-
-            // remove control characters besides newline and tab
-            if (description.Any(c => c < ' ' && c != '\t' & c != '\n'))
-            {
-                description = new string(description.Where(c => c >= ' ' || c == '\t' || c == '\n').ToArray());
-            }
-
-            var lines = description.Split('\n');
-
-            var desc = !string.IsNullOrWhiteSpace(indentation) && !firstInBlock ? Environment.NewLine : "";
-
-            desc += indentation + "\"\"\"\n";
-
-            foreach (var line in lines)
-            {
-                if (string.IsNullOrWhiteSpace(line))
-                {
-                    desc += Environment.NewLine;
-                }
-                else
-                {
-                    desc += indentation + line + Environment.NewLine;
-                }
-            }
-
-            desc += indentation + "\"\"\"\n";
-
-            return desc;
+            description = new string(description.Where(c => c >= ' ' || c == '\t' || c == '\n').ToArray());
         }
 
-        public string PrintDeprecation(string? reason)
+        var lines = description.Split('\n');
+
+        var desc = !string.IsNullOrWhiteSpace(indentation) && !firstInBlock ? Environment.NewLine : "";
+
+        desc += indentation + "\"\"\"\n";
+
+        foreach (var line in lines)
         {
-            if (string.IsNullOrWhiteSpace(reason))
+            if (string.IsNullOrWhiteSpace(line))
             {
-                return string.Empty;
+                desc += Environment.NewLine;
             }
-            return $" @deprecated(reason: {new GraphQLStringValue(reason!).Print()})";
+            else
+            {
+                desc += indentation + line + Environment.NewLine;
+            }
         }
 
-        public string[] BreakLine(string line, int len)
+        desc += indentation + "\"\"\"\n";
+
+        return desc;
+    }
+
+    public string PrintDeprecation(string? reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
         {
-            if (line.Length < len + 5)
-            {
-                return new[] { line };
-            }
-            var parts = Regex.Split(line, $"((?: |^).{{15,{len - 40}}}(?= |$))");
-            if (parts.Length < 4)
-            {
-                return new[] { line };
-            }
-            var sublines = new List<string>
-            {
-                parts[0] + parts[1] + parts[2]
-            };
-            for (var i = 3; i < parts.Length; i += 2)
-            {
-                sublines.Add(parts[i].Substring(1) + parts[i + 1]);
-            }
-            return sublines.ToArray();
+            return string.Empty;
         }
+        return $" @deprecated(reason: {new GraphQLStringValue(reason!).Print()})";
+    }
+
+    public string[] BreakLine(string line, int len)
+    {
+        if (line.Length < len + 5)
+        {
+            return new[] { line };
+        }
+        var parts = Regex.Split(line, $"((?: |^).{{15,{len - 40}}}(?= |$))");
+        if (parts.Length < 4)
+        {
+            return new[] { line };
+        }
+        var sublines = new List<string>
+        {
+            parts[0] + parts[1] + parts[2]
+        };
+        for (var i = 3; i < parts.Length; i += 2)
+        {
+            sublines.Add(parts[i].Substring(1) + parts[i + 1]);
+        }
+        return sublines.ToArray();
     }
 }

--- a/src/GraphQL/Utilities/SchemaPrinterOptions.cs
+++ b/src/GraphQL/Utilities/SchemaPrinterOptions.cs
@@ -1,26 +1,25 @@
 using GraphQL.Introspection;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Options for schema printing when using <see cref="SchemaPrinter.Print"/>.
+/// </summary>
+public class SchemaPrinterOptions
 {
     /// <summary>
-    /// Options for schema printing when using <see cref="SchemaPrinter.Print"/>.
+    /// Indicates whether to print a description for types, fields, directives, arguments and other schema elements.
     /// </summary>
-    public class SchemaPrinterOptions
-    {
-        /// <summary>
-        /// Indicates whether to print a description for types, fields, directives, arguments and other schema elements.
-        /// </summary>
-        public bool IncludeDescriptions { get; set; }
+    public bool IncludeDescriptions { get; set; }
 
-        /// <summary>
-        /// Indicates whether to print a deprecation reason for fields and enum values.
-        /// </summary>
-        public bool IncludeDeprecationReasons { get; set; }
+    /// <summary>
+    /// Indicates whether to print a deprecation reason for fields and enum values.
+    /// </summary>
+    public bool IncludeDeprecationReasons { get; set; }
 
-        /// <summary>
-        /// Provides the ability to order the schema elements upon printing.
-        /// By default all elements are returned as-is; no sorting is applied.
-        /// </summary>
-        public ISchemaComparer? Comparer { get; set; }
-    }
+    /// <summary>
+    /// Provides the ability to order the schema elements upon printing.
+    /// By default all elements are returned as-is; no sorting is applied.
+    /// </summary>
+    public ISchemaComparer? Comparer { get; set; }
 }

--- a/src/GraphQL/Utilities/ServiceProviderExtensions.cs
+++ b/src/GraphQL/Utilities/ServiceProviderExtensions.cs
@@ -1,31 +1,30 @@
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+internal static class ServiceProviderExtensions
 {
-    internal static class ServiceProviderExtensions
+    /// <summary>
+    /// Get service of type <typeparamref name="T"/> from the <see cref="IServiceProvider"/>.
+    /// This method has exactly the same behavior as ServiceProviderServiceExtensions.GetRequiredService.
+    /// It is added so as not to be dependent on the Microsoft.Extensions.DependencyInjection.Abstractions package.
+    /// https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderserviceextensions.getrequiredservice
+    /// </summary>
+    public static T GetRequiredService<T>(this IServiceProvider provider) => (T)GetRequiredService(provider, typeof(T));
+
+    /// <summary>
+    /// Get service of type <paramref name="serviceType"/> from the <see cref="IServiceProvider"/>.
+    /// This method has exactly the same behavior as ServiceProviderServiceExtensions.GetRequiredService.
+    /// It is added so as not to be dependent on the Microsoft.Extensions.DependencyInjection.Abstractions package.
+    /// https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderserviceextensions.getrequiredservice
+    /// </summary>
+    public static object GetRequiredService(this IServiceProvider provider, Type serviceType)
     {
-        /// <summary>
-        /// Get service of type <typeparamref name="T"/> from the <see cref="IServiceProvider"/>.
-        /// This method has exactly the same behavior as ServiceProviderServiceExtensions.GetRequiredService.
-        /// It is added so as not to be dependent on the Microsoft.Extensions.DependencyInjection.Abstractions package.
-        /// https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderserviceextensions.getrequiredservice
-        /// </summary>
-        public static T GetRequiredService<T>(this IServiceProvider provider) => (T)GetRequiredService(provider, typeof(T));
+        if (provider == null)
+            throw new ArgumentNullException(nameof(provider));
 
-        /// <summary>
-        /// Get service of type <paramref name="serviceType"/> from the <see cref="IServiceProvider"/>.
-        /// This method has exactly the same behavior as ServiceProviderServiceExtensions.GetRequiredService.
-        /// It is added so as not to be dependent on the Microsoft.Extensions.DependencyInjection.Abstractions package.
-        /// https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderserviceextensions.getrequiredservice
-        /// </summary>
-        public static object GetRequiredService(this IServiceProvider provider, Type serviceType)
-        {
-            if (provider == null)
-                throw new ArgumentNullException(nameof(provider));
+        if (serviceType == null)
+            throw new ArgumentNullException(nameof(serviceType));
 
-            if (serviceType == null)
-                throw new ArgumentNullException(nameof(serviceType));
-
-            object? service = provider.GetService(serviceType);
-            return service ?? throw new InvalidOperationException($"No service for type '{serviceType.GetFriendlyName()}' has been registered.");
-        }
+        object? service = provider.GetService(serviceType);
+        return service ?? throw new InvalidOperationException($"No service for type '{serviceType.GetFriendlyName()}' has been registered.");
     }
 }

--- a/src/GraphQL/Utilities/StringUtils.cs
+++ b/src/GraphQL/Utilities/StringUtils.cs
@@ -1,139 +1,138 @@
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Provides utility methods for strings.
+/// </summary>
+public static class StringUtils
 {
     /// <summary>
-    /// Provides utility methods for strings.
+    /// Given array of strings [ "A", "B", "C" ] return one string "'A', 'B' or 'C'".
     /// </summary>
-    public static class StringUtils
+    public static string QuotedOrList(IEnumerable<string> items, int maxLength = 5) //TODO: make internal in v5 and change items type
     {
-        /// <summary>
-        /// Given array of strings [ "A", "B", "C" ] return one string "'A', 'B' or 'C'".
-        /// </summary>
-        public static string QuotedOrList(IEnumerable<string> items, int maxLength = 5) //TODO: make internal in v5 and change items type
+        string[] itemsArray = items.Take(maxLength).ToArray();
+        int index = 0;
+        return itemsArray
+            .Select(x => $"'{x}'")
+            .Aggregate((list, quoted) =>
+                list +
+                (itemsArray.Length > 2 ? ", " : " ") +
+                (++index == itemsArray.Length - 1 ? "or " : "") +
+                quoted);
+    }
+
+    /// <summary>
+    /// Given an invalid input string and a list of valid options, returns a filtered
+    /// list of valid options sorted based on their similarity with the input.
+    /// </summary>
+    public static string[] SuggestionList(string input, IEnumerable<string>? options)
+    {
+        if (options == null)
         {
-            string[] itemsArray = items.Take(maxLength).ToArray();
-            int index = 0;
-            return itemsArray
-                .Select(x => $"'{x}'")
-                .Aggregate((list, quoted) =>
-                    list +
-                    (itemsArray.Length > 2 ? ", " : " ") +
-                    (++index == itemsArray.Length - 1 ? "or " : "") +
-                    quoted);
+            return Array.Empty<string>();
         }
 
-        /// <summary>
-        /// Given an invalid input string and a list of valid options, returns a filtered
-        /// list of valid options sorted based on their similarity with the input.
-        /// </summary>
-        public static string[] SuggestionList(string input, IEnumerable<string>? options)
+        var optionsByDistance = new Dictionary<string, int>();
+        var inputThreshold = input.Length / 2;
+        foreach (string t in options)
         {
-            if (options == null)
+            var distance = DamerauLevenshteinDistance(input, t, inputThreshold);
+            var threshold = Math.Max(inputThreshold, Math.Max(t.Length / 2, 1));
+            if (distance <= threshold)
             {
-                return Array.Empty<string>();
+                optionsByDistance[t] = distance;
             }
-
-            var optionsByDistance = new Dictionary<string, int>();
-            var inputThreshold = input.Length / 2;
-            foreach (string t in options)
-            {
-                var distance = DamerauLevenshteinDistance(input, t, inputThreshold);
-                var threshold = Math.Max(inputThreshold, Math.Max(t.Length / 2, 1));
-                if (distance <= threshold)
-                {
-                    optionsByDistance[t] = distance;
-                }
-            }
-
-            return optionsByDistance.OrderBy(x => x.Value).Select(x => x.Key).ToArray();
         }
 
-        /// <summary>
-        /// Computes the Damerau-Levenshtein Distance between two strings, represented as arrays of
-        /// integers, where each integer represents the code point of a character in the source string.
-        /// Includes an optional threshold which can be used to indicate the maximum allowable distance.
-        /// http://stackoverflow.com/a/9454016/279764
-        /// </summary>
-        /// <param name="source">An array of the code points of the first string</param>
-        /// <param name="target">An array of the code points of the second string</param>
-        /// <param name="threshold">Maximum allowable distance</param>
-        /// <returns>Int.MaxValue if threshold exceeded; otherwise the Damerau-Levenshtein distance between the strings</returns>
-        public static int DamerauLevenshteinDistance(string source, string target, int threshold)
-        {
-            int length1 = source.Length;
-            int length2 = target.Length;
+        return optionsByDistance.OrderBy(x => x.Value).Select(x => x.Key).ToArray();
+    }
 
-            // Return trivial case - difference in string lengths exceeds threshold
-            if (Math.Abs(length1 - length2) > threshold)
+    /// <summary>
+    /// Computes the Damerau-Levenshtein Distance between two strings, represented as arrays of
+    /// integers, where each integer represents the code point of a character in the source string.
+    /// Includes an optional threshold which can be used to indicate the maximum allowable distance.
+    /// http://stackoverflow.com/a/9454016/279764
+    /// </summary>
+    /// <param name="source">An array of the code points of the first string</param>
+    /// <param name="target">An array of the code points of the second string</param>
+    /// <param name="threshold">Maximum allowable distance</param>
+    /// <returns>Int.MaxValue if threshold exceeded; otherwise the Damerau-Levenshtein distance between the strings</returns>
+    public static int DamerauLevenshteinDistance(string source, string target, int threshold)
+    {
+        int length1 = source.Length;
+        int length2 = target.Length;
+
+        // Return trivial case - difference in string lengths exceeds threshold
+        if (Math.Abs(length1 - length2) > threshold)
+            return int.MaxValue;
+
+        // Ensure arrays [i] / length1 use shorter length
+        if (length1 > length2)
+        {
+            Swap(ref target, ref source);
+            Swap(ref length1, ref length2);
+        }
+
+        int maxi = length1;
+        int maxj = length2;
+
+        int[] dCurrent = new int[maxi + 1];
+        int[] dMinus1 = new int[maxi + 1];
+        int[] dMinus2 = new int[maxi + 1];
+        int[] dSwap;
+
+        for (int i = 0; i <= maxi; i++)
+            dCurrent[i] = i;
+
+        int jm1 = 0, im1, im2;
+
+        for (int j = 1; j <= maxj; j++)
+        {
+            // Rotate
+            dSwap = dMinus2;
+            dMinus2 = dMinus1;
+            dMinus1 = dCurrent;
+            dCurrent = dSwap;
+
+            // Initialize
+            int minDistance = int.MaxValue;
+            dCurrent[0] = j;
+            im1 = 0;
+            im2 = -1;
+
+            for (int i = 1; i <= maxi; i++)
+            {
+                int cost = source[im1] == target[jm1] ? 0 : 1;
+
+                int del = dCurrent[im1] + 1;
+                int ins = dMinus1[i] + 1;
+                int sub = dMinus1[im1] + cost;
+
+                //Fastest execution for min value of 3 integers
+                int min = (del > ins) ? (ins > sub ? sub : ins) : (del > sub ? sub : del);
+
+                if (i > 1 && j > 1 && source[im2] == target[jm1] && source[im1] == target[j - 2])
+                    min = Math.Min(min, dMinus2[im2] + cost);
+
+                dCurrent[i] = min;
+                if (min < minDistance)
+                    minDistance = min;
+                im1++;
+                im2++;
+            }
+            jm1++;
+            if (minDistance > threshold)
                 return int.MaxValue;
+        }
 
-            // Ensure arrays [i] / length1 use shorter length
-            if (length1 > length2)
-            {
-                Swap(ref target, ref source);
-                Swap(ref length1, ref length2);
-            }
+        int result = dCurrent[maxi];
+        return result > threshold ? int.MaxValue : result;
 
-            int maxi = length1;
-            int maxj = length2;
-
-            int[] dCurrent = new int[maxi + 1];
-            int[] dMinus1 = new int[maxi + 1];
-            int[] dMinus2 = new int[maxi + 1];
-            int[] dSwap;
-
-            for (int i = 0; i <= maxi; i++)
-                dCurrent[i] = i;
-
-            int jm1 = 0, im1, im2;
-
-            for (int j = 1; j <= maxj; j++)
-            {
-                // Rotate
-                dSwap = dMinus2;
-                dMinus2 = dMinus1;
-                dMinus1 = dCurrent;
-                dCurrent = dSwap;
-
-                // Initialize
-                int minDistance = int.MaxValue;
-                dCurrent[0] = j;
-                im1 = 0;
-                im2 = -1;
-
-                for (int i = 1; i <= maxi; i++)
-                {
-                    int cost = source[im1] == target[jm1] ? 0 : 1;
-
-                    int del = dCurrent[im1] + 1;
-                    int ins = dMinus1[i] + 1;
-                    int sub = dMinus1[im1] + cost;
-
-                    //Fastest execution for min value of 3 integers
-                    int min = (del > ins) ? (ins > sub ? sub : ins) : (del > sub ? sub : del);
-
-                    if (i > 1 && j > 1 && source[im2] == target[jm1] && source[im1] == target[j - 2])
-                        min = Math.Min(min, dMinus2[im2] + cost);
-
-                    dCurrent[i] = min;
-                    if (min < minDistance)
-                        minDistance = min;
-                    im1++;
-                    im2++;
-                }
-                jm1++;
-                if (minDistance > threshold)
-                    return int.MaxValue;
-            }
-
-            int result = dCurrent[maxi];
-            return result > threshold ? int.MaxValue : result;
-
-            static void Swap<T>(ref T arg1, ref T arg2)
-            {
-                T temp = arg1;
-                arg1 = arg2;
-                arg2 = temp;
-            }
+        static void Swap<T>(ref T arg1, ref T arg2)
+        {
+            T temp = arg1;
+            arg1 = arg2;
+            arg2 = temp;
         }
     }
 }

--- a/src/GraphQL/Utilities/TypeConfig.cs
+++ b/src/GraphQL/Utilities/TypeConfig.cs
@@ -1,88 +1,87 @@
 using GraphQL.Types;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Provides configuration for specific GraphType when building schema via <see cref="SchemaBuilder"/>.
+/// </summary>
+public class TypeConfig : MetadataProvider
 {
+    private readonly LightweightCache<string, FieldConfig> _fields =
+        new(f => new FieldConfig(f));
+
+    private Type? _type;
+
     /// <summary>
-    /// Provides configuration for specific GraphType when building schema via <see cref="SchemaBuilder"/>.
+    /// Creates an instance of <see cref="TypeConfig"/> with the specified name.
     /// </summary>
-    public class TypeConfig : MetadataProvider
+    /// <param name="name">Field argument name.</param>
+    public TypeConfig(string name)
     {
-        private readonly LightweightCache<string, FieldConfig> _fields =
-            new(f => new FieldConfig(f));
+        Name = name;
+    }
 
-        private Type? _type;
-
-        /// <summary>
-        /// Creates an instance of <see cref="TypeConfig"/> with the specified name.
-        /// </summary>
-        /// <param name="name">Field argument name.</param>
-        public TypeConfig(string name)
+    /// <summary>
+    /// Gets or sets the CLR type of the GraphQL type configured by this instance.
+    /// </summary>
+    public Type? Type
+    {
+        get => _type;
+        set
         {
-            Name = name;
+            _type = value;
+            ApplyMetadata(value);
         }
+    }
 
-        /// <summary>
-        /// Gets or sets the CLR type of the GraphQL type configured by this instance.
-        /// </summary>
-        public Type? Type
+    /// <summary>
+    /// Gets the name of the GraphType.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets or sets the description of the GraphType.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reason this GraphType has been deprecated;
+    /// <see langword="null"/> if this element has not been deprecated.
+    /// </summary>
+    public string? DeprecationReason { get; set; }
+
+    /// <inheritdoc cref="IAbstractGraphType.ResolveType"/>
+    public Func<object, IObjectGraphType>? ResolveType { get; set; }
+
+    /// <inheritdoc cref="IObjectGraphType.IsTypeOf"/>
+    public Func<object, bool>? IsTypeOfFunc { get; set; }
+
+    /// <summary>
+    /// Sets the <see cref="IsTypeOfFunc"/> property to a delegate
+    /// that returns <see langword="true"/> when the object is a type
+    /// that can be cast to <typeparamref name="T"/>.
+    /// </summary>
+    public void IsTypeOf<T>()
+    {
+        IsTypeOfFunc = obj => obj?.GetType().IsAssignableFrom(typeof(T)) ?? false;
+    }
+
+    /// <summary>
+    /// Gets configuration for specific field of GraphType by field name.
+    /// </summary>
+    /// <param name="fieldName">Name of the field.</param>
+    public FieldConfig FieldFor(string fieldName) => _fields[fieldName];
+
+    private void ApplyMetadata(Type? type)
+    {
+        var attributes = type?.GetGraphQLAttributes();
+
+        if (attributes == null)
+            return;
+
+        foreach (var a in attributes)
         {
-            get => _type;
-            set
-            {
-                _type = value;
-                ApplyMetadata(value);
-            }
-        }
-
-        /// <summary>
-        /// Gets the name of the GraphType.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Gets or sets the description of the GraphType.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Gets or sets the reason this GraphType has been deprecated;
-        /// <see langword="null"/> if this element has not been deprecated.
-        /// </summary>
-        public string? DeprecationReason { get; set; }
-
-        /// <inheritdoc cref="IAbstractGraphType.ResolveType"/>
-        public Func<object, IObjectGraphType>? ResolveType { get; set; }
-
-        /// <inheritdoc cref="IObjectGraphType.IsTypeOf"/>
-        public Func<object, bool>? IsTypeOfFunc { get; set; }
-
-        /// <summary>
-        /// Sets the <see cref="IsTypeOfFunc"/> property to a delegate
-        /// that returns <see langword="true"/> when the object is a type
-        /// that can be cast to <typeparamref name="T"/>.
-        /// </summary>
-        public void IsTypeOf<T>()
-        {
-            IsTypeOfFunc = obj => obj?.GetType().IsAssignableFrom(typeof(T)) ?? false;
-        }
-
-        /// <summary>
-        /// Gets configuration for specific field of GraphType by field name.
-        /// </summary>
-        /// <param name="fieldName">Name of the field.</param>
-        public FieldConfig FieldFor(string fieldName) => _fields[fieldName];
-
-        private void ApplyMetadata(Type? type)
-        {
-            var attributes = type?.GetGraphQLAttributes();
-
-            if (attributes == null)
-                return;
-
-            foreach (var a in attributes)
-            {
-                a.Modify(this);
-            }
+            a.Modify(this);
         }
     }
 }

--- a/src/GraphQL/Utilities/TypeSettings.cs
+++ b/src/GraphQL/Utilities/TypeSettings.cs
@@ -1,121 +1,120 @@
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Provides configuration for GraphTypes and their fields and arguments when building schema via <see cref="SchemaBuilder"/>.
+/// </summary>
+public class TypeSettings
 {
+    private readonly LightweightCache<string, TypeConfig> _typeConfigurations;
+    private readonly List<Action<TypeConfig>> _forAllTypesConfigurationDelegates;
+
     /// <summary>
-    /// Provides configuration for GraphTypes and their fields and arguments when building schema via <see cref="SchemaBuilder"/>.
+    /// Initializes a new instance.
     /// </summary>
-    public class TypeSettings
+    public TypeSettings()
     {
-        private readonly LightweightCache<string, TypeConfig> _typeConfigurations;
-        private readonly List<Action<TypeConfig>> _forAllTypesConfigurationDelegates;
+        _typeConfigurations = new LightweightCache<string, TypeConfig>(name => new TypeConfig(name));
+        _forAllTypesConfigurationDelegates = new List<Action<TypeConfig>>();
+    }
 
-        /// <summary>
-        /// Initializes a new instance.
-        /// </summary>
-        public TypeSettings()
+    /// <summary>
+    /// Gets configuration for specific GraphType by its name.
+    /// Executes configured configuration delegates for the type cofiguration.
+    /// </summary>
+    /// <param name="typeName">Name of the GraphType.</param>
+    public TypeConfig For(string typeName)
+    {
+        var exists = _typeConfigurations.Has(typeName);
+        var typeConfig = _typeConfigurations[typeName];
+        if (!exists)
         {
-            _typeConfigurations = new LightweightCache<string, TypeConfig>(name => new TypeConfig(name));
-            _forAllTypesConfigurationDelegates = new List<Action<TypeConfig>>();
+            foreach (var a in _forAllTypesConfigurationDelegates)
+                a.Invoke(typeConfig);
         }
 
-        /// <summary>
-        /// Gets configuration for specific GraphType by its name.
-        /// Executes configured configuration delegates for the type cofiguration.
-        /// </summary>
-        /// <param name="typeName">Name of the GraphType.</param>
-        public TypeConfig For(string typeName)
-        {
-            var exists = _typeConfigurations.Has(typeName);
-            var typeConfig = _typeConfigurations[typeName];
-            if (!exists)
-            {
-                foreach (var a in _forAllTypesConfigurationDelegates)
-                    a.Invoke(typeConfig);
-            }
+        return typeConfig;
+    }
 
-            return typeConfig;
-        }
+    /// <summary>
+    /// Adds a configuration delegate that executes for all types.
+    /// </summary>
+    public TypeSettings ForAll(Action<TypeConfig> configure)
+    {
+        _forAllTypesConfigurationDelegates.Add(configure ?? throw new ArgumentNullException(nameof(configure)));
+        return this;
+    }
 
-        /// <summary>
-        /// Adds a configuration delegate that executes for all types.
-        /// </summary>
-        public TypeSettings ForAll(Action<TypeConfig> configure)
-        {
-            _forAllTypesConfigurationDelegates.Add(configure ?? throw new ArgumentNullException(nameof(configure)));
-            return this;
-        }
+    /// <summary>
+    /// Adds a configuration for the specified CLR type.
+    /// </summary>
+    public void Include<TType>()
+    {
+        Include(typeof(TType));
+    }
 
-        /// <summary>
-        /// Adds a configuration for the specified CLR type.
-        /// </summary>
-        public void Include<TType>()
-        {
-            Include(typeof(TType));
-        }
+    /// <summary>
+    /// Adds a configuration for the specified CLR type, as the specified graph type name.
+    /// </summary>
+    public void Include<TType>(string name)
+    {
+        Include(name, typeof(TType));
+    }
 
-        /// <summary>
-        /// Adds a configuration for the specified CLR type, as the specified graph type name.
-        /// </summary>
-        public void Include<TType>(string name)
-        {
-            Include(name, typeof(TType));
-        }
+    /// <summary>
+    /// Adds a configuration for the specified CLR type.
+    /// </summary>
+    public void Include(Type type)
+    {
+        var name = type.GraphQLName();
+        Include(name, type);
+    }
 
-        /// <summary>
-        /// Adds a configuration for the specified CLR type.
-        /// </summary>
-        public void Include(Type type)
-        {
-            var name = type.GraphQLName();
-            Include(name, type);
-        }
+    /// <summary>
+    /// Adds a configuration for the specified CLR type, as the specified graph type name.
+    /// </summary>
+    public void Include(string name, Type type)
+    {
+        For(name).Type = type;
+    }
 
-        /// <summary>
-        /// Adds a configuration for the specified CLR type, as the specified graph type name.
-        /// </summary>
-        public void Include(string name, Type type)
-        {
-            For(name).Type = type;
-        }
+    /// <summary>
+    /// Adds a configuration for the specified CLR source type <typeparamref name="TTypeOfType"/>,
+    /// which executes field resolvers on the specified CLR type <typeparamref name="TType"/>.
+    /// </summary>
+    public void Include<TType, TTypeOfType>()
+    {
+        Include(typeof(TType), typeof(TTypeOfType));
+    }
 
-        /// <summary>
-        /// Adds a configuration for the specified CLR source type <typeparamref name="TTypeOfType"/>,
-        /// which executes field resolvers on the specified CLR type <typeparamref name="TType"/>.
-        /// </summary>
-        public void Include<TType, TTypeOfType>()
-        {
-            Include(typeof(TType), typeof(TTypeOfType));
-        }
+    /// <summary>
+    /// Adds a configuration for the specified CLR source type <typeparamref name="TTypeOfType"/>,
+    /// which executes field resolvers on the specified CLR type <typeparamref name="TType"/>,
+    /// with the specified graph type name.
+    /// </summary>
+    public void Include<TType, TTypeOfType>(string name)
+    {
+        Include(name, typeof(TType), typeof(TTypeOfType));
+    }
 
-        /// <summary>
-        /// Adds a configuration for the specified CLR source type <typeparamref name="TTypeOfType"/>,
-        /// which executes field resolvers on the specified CLR type <typeparamref name="TType"/>,
-        /// with the specified graph type name.
-        /// </summary>
-        public void Include<TType, TTypeOfType>(string name)
-        {
-            Include(name, typeof(TType), typeof(TTypeOfType));
-        }
+    /// <summary>
+    /// Adds a configuration for the specified CLR source type <paramref name="typeOfType"/>,
+    /// which executes field resolvers on the specified CLR type <paramref name="type"/>.
+    /// </summary>
+    public void Include(Type type, Type typeOfType)
+    {
+        var name = (type ?? throw new ArgumentNullException(nameof(type))).GraphQLName();
+        Include(name, type, typeOfType);
+    }
 
-        /// <summary>
-        /// Adds a configuration for the specified CLR source type <paramref name="typeOfType"/>,
-        /// which executes field resolvers on the specified CLR type <paramref name="type"/>.
-        /// </summary>
-        public void Include(Type type, Type typeOfType)
-        {
-            var name = (type ?? throw new ArgumentNullException(nameof(type))).GraphQLName();
-            Include(name, type, typeOfType);
-        }
-
-        /// <summary>
-        /// Adds a configuration for the specified CLR source type <paramref name="typeOfType"/>,
-        /// which executes field resolvers on the specified CLR type <paramref name="type"/>,
-        /// with the specified graph type name.
-        /// </summary>
-        public void Include(string name, Type type, Type typeOfType)
-        {
-            var config = For(name);
-            config.Type = type;
-            config.IsTypeOfFunc = obj => obj?.GetType().IsAssignableFrom(typeOfType) ?? false;
-        }
+    /// <summary>
+    /// Adds a configuration for the specified CLR source type <paramref name="typeOfType"/>,
+    /// which executes field resolvers on the specified CLR type <paramref name="type"/>,
+    /// with the specified graph type name.
+    /// </summary>
+    public void Include(string name, Type type, Type typeOfType)
+    {
+        var config = For(name);
+        config.Type = type;
+        config.IsTypeOfFunc = obj => obj?.GetType().IsAssignableFrom(typeOfType) ?? false;
     }
 }

--- a/src/GraphQL/Utilities/Visitors/AppliedDirectivesValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/AppliedDirectivesValidationVisitor.cs
@@ -1,143 +1,142 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// This visitor verifies the correct application of directives to the schema elements.
+/// </summary>
+public sealed class AppliedDirectivesValidationVisitor : ISchemaNodeVisitor
 {
     /// <summary>
-    /// This visitor verifies the correct application of directives to the schema elements.
+    /// Returns a static instance of the <see cref="AppliedDirectivesValidationVisitor"/> class.
     /// </summary>
-    public sealed class AppliedDirectivesValidationVisitor : ISchemaNodeVisitor
+    public static readonly AppliedDirectivesValidationVisitor Instance = new();
+
+    private AppliedDirectivesValidationVisitor()
     {
-        /// <summary>
-        /// Returns a static instance of the <see cref="AppliedDirectivesValidationVisitor"/> class.
-        /// </summary>
-        public static readonly AppliedDirectivesValidationVisitor Instance = new();
+    }
 
-        private AppliedDirectivesValidationVisitor()
+    /// <inheritdoc/>
+    public void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(argument, field, type, schema, DirectiveLocation.ArgumentDefinition);
+
+    /// <inheritdoc/>
+    public void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema) => ValidateAppliedDirectives(argument, field, type, schema, DirectiveLocation.ArgumentDefinition);
+
+    /// <inheritdoc/>
+    public void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema) => ValidateAppliedDirectives(argument, directive, null, schema, DirectiveLocation.ArgumentDefinition);
+
+    /// <inheritdoc/>
+    public void VisitEnum(EnumerationGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Enum);
+
+    /// <inheritdoc/>
+    public void VisitDirective(Directive directive, ISchema schema) => ValidateAppliedDirectives(directive, null, null, schema, null); // no location for directives (yet), see https://github.com/graphql/graphql-spec/issues/818
+
+    /// <inheritdoc/>
+    public void VisitEnumValue(EnumValueDefinition value, EnumerationGraphType type, ISchema schema) => ValidateAppliedDirectives(value, type, null, schema, DirectiveLocation.EnumValue);
+
+    /// <inheritdoc/>
+    public void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(field, type, null, schema, DirectiveLocation.FieldDefinition);
+
+    /// <inheritdoc/>
+    public void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema) => ValidateAppliedDirectives(field, type, null, schema, DirectiveLocation.FieldDefinition);
+
+    /// <inheritdoc/>
+    public void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(field, type, null, schema, DirectiveLocation.InputFieldDefinition);
+
+    /// <inheritdoc/>
+    public void VisitInputObject(IInputObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.InputObject);
+
+    /// <inheritdoc/>
+    public void VisitInterface(IInterfaceGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Interface);
+
+    /// <inheritdoc/>
+    public void VisitObject(IObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Object);
+
+    /// <inheritdoc/>
+    public void VisitScalar(ScalarGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Scalar);
+
+    /// <inheritdoc/>
+    public void VisitSchema(ISchema schema) => ValidateAppliedDirectives(schema, null, null, schema, DirectiveLocation.Schema);
+
+    /// <inheritdoc/>
+    public void VisitUnion(UnionGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Union);
+
+    /// <inheritdoc/>
+    private void ValidateAppliedDirectives(IMetadataReader provider, object? parent1, object? parent2, ISchema schema, DirectiveLocation? location)
+    {
+        //TODO: switch to the schema coordinates?
+        string GetElementDescription() => (provider, parent1, parent2) switch
         {
-        }
+            (QueryArgument arg, FieldType field, INamedType type) => $"field argument '{type.Name}.{field.Name}:{arg.Name}'",
+            (QueryArgument arg, Directive dir, _) => $"directive argument '{dir.Name}:{arg.Name}'",
+            (EnumerationGraphType en, _, _) => $"enumeration '{en.Name}'",
+            (EnumValueDefinition enVal, EnumerationGraphType type, _) => $"enumeration value '{type.Name}.{enVal.Name}'",
+            (ScalarGraphType scalar, _, _) => $"scalar '{scalar.Name}'",
+            (Directive dir, _, _) => $"directive '{dir.Name}'",
+            (FieldType field, INamedType type, _) => $"field '{type.Name}.{field.Name}'",
+            (IInputObjectGraphType input, _, _) => $"input '{input.Name}'",
+            (IInterfaceGraphType iface, _, _) => $"interface '{iface.Name}'",
+            (IObjectGraphType obj, _, _) => $"object '{obj.Name}'",
+            (ISchema _, _, _) => "schema",
+            _ => throw new NotSupportedException(provider.GetType().Name),
+        };
 
-        /// <inheritdoc/>
-        public void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(argument, field, type, schema, DirectiveLocation.ArgumentDefinition);
-
-        /// <inheritdoc/>
-        public void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema) => ValidateAppliedDirectives(argument, field, type, schema, DirectiveLocation.ArgumentDefinition);
-
-        /// <inheritdoc/>
-        public void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema) => ValidateAppliedDirectives(argument, directive, null, schema, DirectiveLocation.ArgumentDefinition);
-
-        /// <inheritdoc/>
-        public void VisitEnum(EnumerationGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Enum);
-
-        /// <inheritdoc/>
-        public void VisitDirective(Directive directive, ISchema schema) => ValidateAppliedDirectives(directive, null, null, schema, null); // no location for directives (yet), see https://github.com/graphql/graphql-spec/issues/818
-
-        /// <inheritdoc/>
-        public void VisitEnumValue(EnumValueDefinition value, EnumerationGraphType type, ISchema schema) => ValidateAppliedDirectives(value, type, null, schema, DirectiveLocation.EnumValue);
-
-        /// <inheritdoc/>
-        public void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(field, type, null, schema, DirectiveLocation.FieldDefinition);
-
-        /// <inheritdoc/>
-        public void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema) => ValidateAppliedDirectives(field, type, null, schema, DirectiveLocation.FieldDefinition);
-
-        /// <inheritdoc/>
-        public void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(field, type, null, schema, DirectiveLocation.InputFieldDefinition);
-
-        /// <inheritdoc/>
-        public void VisitInputObject(IInputObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.InputObject);
-
-        /// <inheritdoc/>
-        public void VisitInterface(IInterfaceGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Interface);
-
-        /// <inheritdoc/>
-        public void VisitObject(IObjectGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Object);
-
-        /// <inheritdoc/>
-        public void VisitScalar(ScalarGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Scalar);
-
-        /// <inheritdoc/>
-        public void VisitSchema(ISchema schema) => ValidateAppliedDirectives(schema, null, null, schema, DirectiveLocation.Schema);
-
-        /// <inheritdoc/>
-        public void VisitUnion(UnionGraphType type, ISchema schema) => ValidateAppliedDirectives(type, null, null, schema, DirectiveLocation.Union);
-
-        /// <inheritdoc/>
-        private void ValidateAppliedDirectives(IMetadataReader provider, object? parent1, object? parent2, ISchema schema, DirectiveLocation? location)
+        if (provider.HasAppliedDirectives())
         {
-            //TODO: switch to the schema coordinates?
-            string GetElementDescription() => (provider, parent1, parent2) switch
-            {
-                (QueryArgument arg, FieldType field, INamedType type) => $"field argument '{type.Name}.{field.Name}:{arg.Name}'",
-                (QueryArgument arg, Directive dir, _) => $"directive argument '{dir.Name}:{arg.Name}'",
-                (EnumerationGraphType en, _, _) => $"enumeration '{en.Name}'",
-                (EnumValueDefinition enVal, EnumerationGraphType type, _) => $"enumeration value '{type.Name}.{enVal.Name}'",
-                (ScalarGraphType scalar, _, _) => $"scalar '{scalar.Name}'",
-                (Directive dir, _, _) => $"directive '{dir.Name}'",
-                (FieldType field, INamedType type, _) => $"field '{type.Name}.{field.Name}'",
-                (IInputObjectGraphType input, _, _) => $"input '{input.Name}'",
-                (IInterfaceGraphType iface, _, _) => $"interface '{iface.Name}'",
-                (IObjectGraphType obj, _, _) => $"object '{obj.Name}'",
-                (ISchema _, _, _) => "schema",
-                _ => throw new NotSupportedException(provider.GetType().Name),
-            };
+            var appliedDirectives = provider.GetAppliedDirectives()!.List!;
 
-            if (provider.HasAppliedDirectives())
+            foreach (var directive in schema.Directives.List)
             {
-                var appliedDirectives = provider.GetAppliedDirectives()!.List!;
+                if (!directive.Repeatable && appliedDirectives.Count(applied => applied.Name == directive.Name) > 1)
+                    throw new InvalidOperationException($"Non-repeatable directive '{directive.Name}' is applied to {GetElementDescription()} more than one time.");
+            }
 
-                foreach (var directive in schema.Directives.List)
+            foreach (var appliedDirective in appliedDirectives)
+            {
+                var schemaDirective = schema.Directives.Find(appliedDirective.Name)
+                    ?? throw new InvalidOperationException($"Unknown directive '{appliedDirective.Name}' applied to {GetElementDescription()}.");
+
+                if (location != null && !schemaDirective.Locations.Contains(location.Value))
                 {
-                    if (!directive.Repeatable && appliedDirectives.Count(applied => applied.Name == directive.Name) > 1)
-                        throw new InvalidOperationException($"Non-repeatable directive '{directive.Name}' is applied to {GetElementDescription()} more than one time.");
+                    // TODO: think about strict check; needs to rewrite some tests (5)
+                    // This is a temporary solution for @deprecated directive that we actually allow to more schema elements.
+                    if (schemaDirective.Name != "deprecated")
+                        throw new InvalidOperationException($"Directive '{schemaDirective.Name}' is applied in the wrong location '{location.Value}' to {GetElementDescription()}. Allowed locations: {string.Join(", ", schemaDirective.Locations)}");
                 }
 
-                foreach (var appliedDirective in appliedDirectives)
+                if (schemaDirective.Arguments?.Count > 0)
                 {
-                    var schemaDirective = schema.Directives.Find(appliedDirective.Name)
-                        ?? throw new InvalidOperationException($"Unknown directive '{appliedDirective.Name}' applied to {GetElementDescription()}.");
-
-                    if (location != null && !schemaDirective.Locations.Contains(location.Value))
+                    foreach (var definedArg in schemaDirective.Arguments!.List!)
                     {
-                        // TODO: think about strict check; needs to rewrite some tests (5)
-                        // This is a temporary solution for @deprecated directive that we actually allow to more schema elements.
-                        if (schemaDirective.Name != "deprecated")
-                            throw new InvalidOperationException($"Directive '{schemaDirective.Name}' is applied in the wrong location '{location.Value}' to {GetElementDescription()}. Allowed locations: {string.Join(", ", schemaDirective.Locations)}");
-                    }
-
-                    if (schemaDirective.Arguments?.Count > 0)
-                    {
-                        foreach (var definedArg in schemaDirective.Arguments!.List!)
+                        var appliedArg = appliedDirective.FindArgument(definedArg.Name);
+                        if (appliedArg == null)
                         {
-                            var appliedArg = appliedDirective.FindArgument(definedArg.Name);
-                            if (appliedArg == null)
-                            {
-                                // definedArg.DefaultValue has been already validated in SchemaValidationVisitor.VisitDirectiveArgumentDefinition
-                                if (definedArg.ResolvedType is NonNullGraphType && definedArg.DefaultValue == null)
-                                    throw new InvalidOperationException($"Directive '{appliedDirective.Name}' applied to {GetElementDescription()} does not specify required argument '{definedArg.Name}' that has no default value.");
-                            }
-                            else
-                            {
-                                if (definedArg.ResolvedType is NonNullGraphType && appliedArg.Value == null)
-                                    throw new InvalidOperationException($"Directive '{appliedDirective.Name}' applied to {GetElementDescription()} explicitly specifies 'null' value for required argument '{definedArg.Name}'. The value must be non-null.");
-                            }
-
-                            //TODO: add check for applied directive argument value type
-                            //appliedArg.Value should be of definedArg.ResolvedType / definedArg.Type
+                            // definedArg.DefaultValue has been already validated in SchemaValidationVisitor.VisitDirectiveArgumentDefinition
+                            if (definedArg.ResolvedType is NonNullGraphType && definedArg.DefaultValue == null)
+                                throw new InvalidOperationException($"Directive '{appliedDirective.Name}' applied to {GetElementDescription()} does not specify required argument '{definedArg.Name}' that has no default value.");
                         }
-                    }
-
-                    if (appliedDirective.ArgumentsCount > 0)
-                    {
-                        foreach (var arg in appliedDirective.List!)
+                        else
                         {
-                            if (schemaDirective.Arguments?.Find(arg.Name) == null)
-                                throw new InvalidOperationException($"Unknown directive argument '{arg.Name}' for directive '{appliedDirective.Name}' applied to {GetElementDescription()}.");
+                            if (definedArg.ResolvedType is NonNullGraphType && appliedArg.Value == null)
+                                throw new InvalidOperationException($"Directive '{appliedDirective.Name}' applied to {GetElementDescription()} explicitly specifies 'null' value for required argument '{definedArg.Name}'. The value must be non-null.");
                         }
-                    }
 
-                    schemaDirective.Validate(appliedDirective);
+                        //TODO: add check for applied directive argument value type
+                        //appliedArg.Value should be of definedArg.ResolvedType / definedArg.Type
+                    }
                 }
+
+                if (appliedDirective.ArgumentsCount > 0)
+                {
+                    foreach (var arg in appliedDirective.List!)
+                    {
+                        if (schemaDirective.Arguments?.Find(arg.Name) == null)
+                            throw new InvalidOperationException($"Unknown directive argument '{arg.Name}' for directive '{appliedDirective.Name}' applied to {GetElementDescription()}.");
+                    }
+                }
+
+                schemaDirective.Validate(appliedDirective);
             }
         }
     }

--- a/src/GraphQL/Utilities/Visitors/BaseSchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/BaseSchemaNodeVisitor.cs
@@ -1,86 +1,85 @@
 using GraphQL.Types;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Base class implementing <see cref="ISchemaNodeVisitor"/>. Does nothing.
+/// Inherit from it if you need to override only some of the methods.
+/// </summary>
+public abstract class BaseSchemaNodeVisitor : ISchemaNodeVisitor
 {
-    /// <summary>
-    /// Base class implementing <see cref="ISchemaNodeVisitor"/>. Does nothing.
-    /// Inherit from it if you need to override only some of the methods.
-    /// </summary>
-    public abstract class BaseSchemaNodeVisitor : ISchemaNodeVisitor
+    /// <inheritdoc />
+    public virtual void VisitSchema(ISchema schema)
     {
-        /// <inheritdoc />
-        public virtual void VisitSchema(ISchema schema)
-        {
-        }
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitDirective(Directive directive, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitDirective(Directive directive, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitScalar(ScalarGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitScalar(ScalarGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitObject(IObjectGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitObject(IObjectGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitInputObject(IInputObjectGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitInputObject(IInputObjectGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitInterface(IInterfaceGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitInterface(IInterfaceGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitUnion(UnionGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitUnion(UnionGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitEnum(EnumerationGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitEnum(EnumerationGraphType type, ISchema schema)
+    {
+    }
 
-        /// <inheritdoc />
-        public virtual void VisitEnumValue(EnumValueDefinition value, EnumerationGraphType type, ISchema schema)
-        {
-        }
+    /// <inheritdoc />
+    public virtual void VisitEnumValue(EnumValueDefinition value, EnumerationGraphType type, ISchema schema)
+    {
     }
 }

--- a/src/GraphQL/Utilities/Visitors/FieldTypeDefaultArgumentsVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/FieldTypeDefaultArgumentsVisitor.cs
@@ -1,38 +1,37 @@
 using GraphQL.Execution;
 using GraphQL.Types;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Sets <see cref="FieldType.DefaultArgumentValues"/> for each <see cref="FieldType"/>.
+/// </summary>
+public sealed class FieldTypeDefaultArgumentsVisitor : BaseSchemaNodeVisitor
 {
     /// <summary>
-    /// Sets <see cref="FieldType.DefaultArgumentValues"/> for each <see cref="FieldType"/>.
+    /// Returns a static instance of the <see cref="FieldTypeDefaultArgumentsVisitor"/> class.
     /// </summary>
-    public sealed class FieldTypeDefaultArgumentsVisitor : BaseSchemaNodeVisitor
+    public static readonly FieldTypeDefaultArgumentsVisitor Instance = new();
+
+    private FieldTypeDefaultArgumentsVisitor()
     {
-        /// <summary>
-        /// Returns a static instance of the <see cref="FieldTypeDefaultArgumentsVisitor"/> class.
-        /// </summary>
-        public static readonly FieldTypeDefaultArgumentsVisitor Instance = new();
+    }
 
-        private FieldTypeDefaultArgumentsVisitor()
+    /// <inheritdoc/>
+    public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
+    {
+        if (field.Arguments?.Count > 0)
         {
+            field.DefaultArgumentValues = field.Arguments.ToDictionary(arg => arg.Name, arg => new ArgumentValue(arg.DefaultValue, ArgumentSource.FieldDefault));
         }
+    }
 
-        /// <inheritdoc/>
-        public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
+    /// <inheritdoc/>
+    public override void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema)
+    {
+        if (field.Arguments?.Count > 0)
         {
-            if (field.Arguments?.Count > 0)
-            {
-                field.DefaultArgumentValues = field.Arguments.ToDictionary(arg => arg.Name, arg => new ArgumentValue(arg.DefaultValue, ArgumentSource.FieldDefault));
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema)
-        {
-            if (field.Arguments?.Count > 0)
-            {
-                field.DefaultArgumentValues = field.Arguments.ToDictionary(arg => arg.Name, arg => new ArgumentValue(arg.DefaultValue, ArgumentSource.FieldDefault));
-            }
+            field.DefaultArgumentValues = field.Arguments.ToDictionary(arg => arg.Name, arg => new ArgumentValue(arg.DefaultValue, ArgumentSource.FieldDefault));
         }
     }
 }

--- a/src/GraphQL/Utilities/Visitors/ISchemaNodeVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/ISchemaNodeVisitor.cs
@@ -1,89 +1,88 @@
 using GraphQL.Types;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Visitor which methods are called when traversing the schema. This happens either explicitly, i.e. when calling
+/// <see cref="SchemaExtensions.Run(ISchemaNodeVisitor, ISchema)"/> method directly or during schema creation when
+/// this method is executed on all schema visitors registered on the schema.
+/// <br/>
+/// Also see <see href="https://www.apollographql.com/docs/graphql-tools/schema-directives/#implementing-schema-directives"/>
+/// </summary>
+public interface ISchemaNodeVisitor
 {
     /// <summary>
-    /// Visitor which methods are called when traversing the schema. This happens either explicitly, i.e. when calling
-    /// <see cref="SchemaExtensions.Run(ISchemaNodeVisitor, ISchema)"/> method directly or during schema creation when
-    /// this method is executed on all schema visitors registered on the schema.
-    /// <br/>
-    /// Also see <see href="https://www.apollographql.com/docs/graphql-tools/schema-directives/#implementing-schema-directives"/>
+    /// Visits <see cref="Schema"/>.
     /// </summary>
-    public interface ISchemaNodeVisitor
-    {
-        /// <summary>
-        /// Visits <see cref="Schema"/>.
-        /// </summary>
-        void VisitSchema(ISchema schema);
+    void VisitSchema(ISchema schema);
 
-        /// <summary>
-        /// Visits registered within the schema <see cref="Directive"/>.
-        /// </summary>
-        void VisitDirective(Directive directive, ISchema schema);
+    /// <summary>
+    /// Visits registered within the schema <see cref="Directive"/>.
+    /// </summary>
+    void VisitDirective(Directive directive, ISchema schema);
 
-        /// <summary>
-        /// Visits registered within the schema <see cref="ScalarGraphType"/>.
-        /// </summary>
-        void VisitScalar(ScalarGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits registered within the schema <see cref="ScalarGraphType"/>.
+    /// </summary>
+    void VisitScalar(ScalarGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits registered within the schema object graph type.
-        /// </summary>
-        void VisitObject(IObjectGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits registered within the schema object graph type.
+    /// </summary>
+    void VisitObject(IObjectGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits registered within the schema input object graph type.
-        /// </summary>
-        void VisitInputObject(IInputObjectGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits registered within the schema input object graph type.
+    /// </summary>
+    void VisitInputObject(IInputObjectGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits field of registered within the schema object graph type.
-        /// </summary>
-        void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits field of registered within the schema object graph type.
+    /// </summary>
+    void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits field of registered within the schema interface graph type.
-        /// </summary>
-        void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits field of registered within the schema interface graph type.
+    /// </summary>
+    void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits field of registered within the schema input object graph type.
-        /// </summary>
-        void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits field of registered within the schema input object graph type.
+    /// </summary>
+    void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits field argument of registered within the schema object graph type.
-        /// </summary>
-        void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits field argument of registered within the schema object graph type.
+    /// </summary>
+    void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits field argument of registered within the schema interface graph type.
-        /// </summary>
-        void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits field argument of registered within the schema interface graph type.
+    /// </summary>
+    void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits directive argument.
-        /// </summary>
-        void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema);
+    /// <summary>
+    /// Visits directive argument.
+    /// </summary>
+    void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema);
 
-        /// <summary>
-        /// Visits registered within the schema <see cref="IInterfaceGraphType"/>.
-        /// </summary>
-        void VisitInterface(IInterfaceGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits registered within the schema <see cref="IInterfaceGraphType"/>.
+    /// </summary>
+    void VisitInterface(IInterfaceGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits registered within the schema <see cref="UnionGraphType"/>.
-        /// </summary>
-        void VisitUnion(UnionGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits registered within the schema <see cref="UnionGraphType"/>.
+    /// </summary>
+    void VisitUnion(UnionGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits registered within the schema <see cref="EnumerationGraphType"/>.
-        /// </summary>
-        void VisitEnum(EnumerationGraphType type, ISchema schema);
+    /// <summary>
+    /// Visits registered within the schema <see cref="EnumerationGraphType"/>.
+    /// </summary>
+    void VisitEnum(EnumerationGraphType type, ISchema schema);
 
-        /// <summary>
-        /// Visits value of registered within the schema <see cref="EnumerationGraphType"/>.
-        /// </summary>
-        void VisitEnumValue(EnumValueDefinition value, EnumerationGraphType type, ISchema schema);
-    }
+    /// <summary>
+    /// Visits value of registered within the schema <see cref="EnumerationGraphType"/>.
+    /// </summary>
+    void VisitEnumValue(EnumValueDefinition value, EnumerationGraphType type, ISchema schema);
 }

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -1,385 +1,384 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Validates the schema as required by the official specification. Also looks for
+/// default values within arguments and inputs fields which are stored in AST nodes
+/// and coerces them to their internally represented values.
+/// </summary>
+public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
 {
     /// <summary>
-    /// Validates the schema as required by the official specification. Also looks for
-    /// default values within arguments and inputs fields which are stored in AST nodes
-    /// and coerces them to their internally represented values.
+    /// Returns a static instance of the <see cref="SchemaValidationVisitor"/> class.
     /// </summary>
-    public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
+    public static readonly SchemaValidationVisitor Instance = new();
+
+    private SchemaValidationVisitor()
     {
-        /// <summary>
-        /// Returns a static instance of the <see cref="SchemaValidationVisitor"/> class.
-        /// </summary>
-        public static readonly SchemaValidationVisitor Instance = new();
+    }
 
-        private SchemaValidationVisitor()
+    #region Object
+
+    // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Objects
+    // Object types have the potential to be invalid if incorrectly defined.
+    // This set of rules must be adhered to by every Object type in a GraphQL schema.
+    /// <inheritdoc/>
+    public override void VisitObject(IObjectGraphType type, ISchema schema)
+    {
+        // 1
+        if (type.Fields.Count == 0)
+            throw new InvalidOperationException($"An Object type '{type.Name}' must define one or more fields.");
+
+        // 2.1
+        foreach (var item in type.Fields.List.ToLookup(f => f.Name))
         {
+            if (item.Count() > 1)
+                throw new InvalidOperationException($"The field '{item.Key}' must have a unique name within Object type '{type.Name}'; no two fields may share the same name.");
         }
 
-        #region Object
+        // 3
+        // TODO: ? An object type may declare that it implements one or more unique interfaces.
 
-        // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Objects
-        // Object types have the potential to be invalid if incorrectly defined.
-        // This set of rules must be adhered to by every Object type in a GraphQL schema.
-        /// <inheritdoc/>
-        public override void VisitObject(IObjectGraphType type, ISchema schema)
+        // 4
+        // TODO: An object type must be a super‐set of all interfaces it implements
+    }
+
+    /// <inheritdoc/>
+    public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
+    {
+        // 2.2
+        if (field.Name.StartsWith("__"))
+            throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have a name which begins with the __ (two underscores).");
+
+        if (!HasFullSpecifiedResolvedType(field))
+            throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
+
+        if (field.ResolvedType is GraphQLTypeReference)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
+
+        // 2.3
+        if (!field.ResolvedType!.IsOutputType())
+            throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must be an output type.");
+
+        ValidateFieldArgumentsUniqueness(field, type);
+
+        if (field.StreamResolver != null && type != schema.Subscription)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+
+        if (field.Parser != null)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have Parser set. You should set Parser only for fields of input object types.");
+
+        if (field.Validator != null)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have Validator set. You should set Validator only for fields of input object types.");
+    }
+
+    /// <inheritdoc/>
+    public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema)
+    {
+        // 2.4.1
+        if (argument.Name.StartsWith("__"))
+            throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must not have a name which begins with the __ (two underscores).");
+
+        if (!HasFullSpecifiedResolvedType(argument))
+            throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
+
+        if (argument.ResolvedType is GraphQLTypeReference)
+            throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
+
+        // 2.4.2
+        if (!argument.ResolvedType!.IsInputType())
+            throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must be an input type.");
+
+        // validate default value
+        ValidateQueryArgumentDefaultValue(argument, field, type);
+
+        // 2.4.3
+        if (argument.ResolvedType is NonNullGraphType && argument.DefaultValue is null && argument.DeprecationReason is not null)
+            throw new InvalidOperationException($"The required argument '{argument.Name}' of field '{type.Name}.{field.Name}' has no default value so `@deprecated` directive must not be applied to this argument. To deprecate a required argument, it must first be made optional by either changing the type to nullable or adding a default value.");
+    }
+
+    #endregion
+
+    #region Interface
+
+    // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Interfaces
+    // Interface types have the potential to be invalid if incorrectly defined.
+    /// <inheritdoc/>
+    public override void VisitInterface(IInterfaceGraphType type, ISchema schema)
+    {
+        // 1
+        if (type.Fields.Count == 0)
+            throw new InvalidOperationException($"An Interface type '{type.Name}' must define one or more fields.");
+
+        // 2.1
+        foreach (var item in type.Fields.List.ToLookup(f => f.Name))
         {
-            // 1
-            if (type.Fields.Count == 0)
-                throw new InvalidOperationException($"An Object type '{type.Name}' must define one or more fields.");
+            if (item.Count() > 1)
+                throw new InvalidOperationException($"The field '{item.Key}' must have a unique name within Interface type '{type.Name}'; no two fields may share the same name.");
+        }
+    }
 
-            // 2.1
-            foreach (var item in type.Fields.List.ToLookup(f => f.Name))
+    /// <inheritdoc/>
+    public override void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema)
+    {
+        // 2.2
+        if (field.Name.StartsWith("__"))
+            throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have a name which begins with the __ (two underscores).");
+
+        if (!HasFullSpecifiedResolvedType(field))
+            throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
+
+        if (field.ResolvedType is GraphQLTypeReference)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
+
+        // 2.3
+        if (!field.ResolvedType!.IsOutputType())
+            throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must be an output type.");
+
+        ValidateFieldArgumentsUniqueness(field, type);
+
+        if (field.StreamResolver != null && type != schema.Subscription)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+
+        if (field.Resolver != null)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have Resolver set. Each interface is translated to a concrete type during request execution. You should set Resolver only for fields of object output types.");
+
+        if (field.Parser != null)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have Parser set. Each interface is translated to a concrete type during request execution. You should set Parser only for fields of input object types.");
+
+        if (field.Validator != null)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have Validator set. Each interface is translated to a concrete type during request execution. You should set Validator only for fields of input object types.");
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema)
+    {
+        // 2.4.1
+        if (argument.Name.StartsWith("__"))
+            throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must not have a name which begins with the __ (two underscores).");
+
+        if (!HasFullSpecifiedResolvedType(argument))
+            throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
+
+        if (argument.ResolvedType is GraphQLTypeReference)
+            throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
+
+        // 2.4.2
+        if (!argument.ResolvedType!.IsInputType())
+            throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must be an input type.");
+
+        // validate default value
+        ValidateQueryArgumentDefaultValue(argument, field, type);
+
+        // 2.4.3
+        if (argument.ResolvedType is NonNullGraphType && argument.DefaultValue is null && argument.DeprecationReason is not null)
+            throw new InvalidOperationException($"The required argument '{argument.Name}' of field '{type.Name}.{field.Name}' has no default value so `@deprecated` directive must not be applied to this argument. To deprecate a required argument, it must first be made optional by either changing the type to nullable or adding a default value.");
+    }
+
+    #endregion
+
+    #region Input Object
+
+    // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Input-Objects
+    // Input Object types have the potential to be invalid if incorrectly defined.
+    /// <inheritdoc/>
+    public override void VisitInputObject(IInputObjectGraphType type, ISchema schema)
+    {
+        // 1
+        if (type.Fields.Count == 0)
+            throw new InvalidOperationException($"An Input Object type '{type.Name}' must define one or more input fields.");
+
+        // 2.1
+        foreach (var item in type.Fields.List.ToLookup(f => f.Name))
+        {
+            if (item.Count() > 1)
+                throw new InvalidOperationException($"The input field '{item.Key}' must have a unique name within Input Object type '{type.Name}'; no two fields may share the same name.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema)
+    {
+        // 2.2
+        if (field.Name.StartsWith("__"))
+            throw new InvalidOperationException($"The input field '{field.Name}' of an Input Object '{type.Name}' must not have a name which begins with the __ (two underscores).");
+
+        if (!HasFullSpecifiedResolvedType(field))
+            throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
+
+        if (field.ResolvedType is GraphQLTypeReference)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
+
+        // 2.3
+        if (!field.ResolvedType!.IsInputType())
+            throw new InvalidOperationException($"The input field '{field.Name}' of an Input Object '{type.Name}' must be an input type.");
+
+        // validate default value
+        if (field.DefaultValue is GraphQLValue value)
+        {
+            field.DefaultValue = Execution.ExecutionHelper.CoerceValue(field.ResolvedType!, value).Value;
+        }
+        else if (field.DefaultValue != null && !field.ResolvedType!.IsValidDefault(field.DefaultValue))
+        {
+            throw new InvalidOperationException($"The default value of Input Object type field '{type.Name}.{field.Name}' is invalid.");
+        }
+
+        if (field.Arguments?.Count > 0)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have any arguments specified.");
+
+        // 2.4
+        if (field.ResolvedType is NonNullGraphType && field.DefaultValue is null && field.DeprecationReason is not null)
+            throw new InvalidOperationException($"The required input field '{field.Name}' of an Input Object '{type.Name}' has no default value so `@deprecated` directive must not be applied to this input field. To deprecate an input field, it must first be made optional by either changing the type to nullable or adding a default value.");
+
+        if (field.StreamResolver != null)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+
+        if (field.Resolver != null)
+            throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have Resolver set. You should set Resolver only for fields of object output types.");
+    }
+
+    #endregion
+
+    // See https://spec.graphql.org/October2021/#sec-Root-Operation-Types
+    /// <inheritdoc/>
+    public override void VisitSchema(ISchema schema)
+    {
+        var n1 = schema.Query?.Name;
+        var n2 = schema.Mutation?.Name;
+        var n3 = schema.Subscription?.Name;
+        if (n1 == n2 && n1 != null || n1 == n3 && n1 != null || n2 == n3 && n2 != null)
+            throw new InvalidOperationException("The query, mutation, and subscription root types must all be different types if provided.");
+        if (schema.Subscription != null)
+        {
+            foreach (var field in schema.Subscription.Fields.List)
+            {
+                if (field.StreamResolver == null)
+                    throw new InvalidOperationException($"The field '{field.Name}' of the subscription root type '{schema.Subscription.Name}' must have StreamResolver set.");
+            }
+        }
+    }
+
+    // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Unions
+    // Union types have the potential to be invalid if incorrectly defined.
+    /// <inheritdoc/>
+    public override void VisitUnion(UnionGraphType type, ISchema schema)
+    {
+        // 1
+        if (type.PossibleTypes.Count == 0)
+            throw new InvalidOperationException($"A Union type '{type.Name}' must include one or more unique member types.");
+
+        // 2 [requirement met by design]
+        // The member types of a Union type must all be Object base types;
+        // Scalar, Interface and Union types must not be member types of a Union.
+        // Similarly, wrapping types must not be member types of a Union.
+    }
+
+    // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Enums
+    // Enum types have the potential to be invalid if incorrectly defined.
+    /// <inheritdoc/>
+    public override void VisitEnum(EnumerationGraphType type, ISchema schema)
+    {
+        // 1
+        if (type.Values.Count == 0)
+            throw new InvalidOperationException($"An Enum type '{type.Name}' must define one or more unique enum values.");
+    }
+
+    // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Type-System.Directives
+    // Directive types have the potential to be invalid if incorrectly defined.
+    /// <inheritdoc/>
+    public override void VisitDirective(Directive directive, ISchema schema)
+    {
+        if (directive.Locations.Count == 0)
+            throw new InvalidOperationException($"Directive '{directive.Name}' must have locations");
+
+        // 1. A directive definition must not contain the use of a directive which references itself directly.
+        // TODO:
+
+        // 2. A directive definition must not contain the use of a directive which references itself indirectly
+        // by referencing a Type or Directive which transitively includes a reference to this directive.
+        // TODO:
+
+        // 3
+        if (directive.Name.StartsWith("__"))
+            throw new InvalidOperationException($"The directive '{directive.Name}' must not have a name which begins with the __ (two underscores).");
+
+        ValidateDirectiveArgumentsUniqueness(directive);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema)
+    {
+        // 4.1
+        if (argument.Name.StartsWith("__"))
+            throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must not have a name which begins with the __ (two underscores).");
+
+        if (!HasFullSpecifiedResolvedType(argument))
+            throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
+
+        if (argument.ResolvedType is GraphQLTypeReference)
+            throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
+
+        // 4.2
+        if (!argument.ResolvedType!.IsInputType())
+            throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must be an input type.");
+
+        // validate default
+        if (argument.DefaultValue is GraphQLValue value)
+        {
+            argument.DefaultValue = Execution.ExecutionHelper.CoerceValue(argument.ResolvedType!, value).Value;
+        }
+        else if (argument.DefaultValue != null && !argument.ResolvedType!.IsValidDefault(argument.DefaultValue))
+        {
+            throw new InvalidOperationException($"The default value of argument '{argument.Name}' of directive '{directive.Name}' is invalid.");
+        }
+    }
+
+    private void ValidateQueryArgumentDefaultValue(QueryArgument argument, FieldType field, INamedType type)
+    {
+        if (argument.DefaultValue is GraphQLValue value)
+        {
+            argument.DefaultValue = Execution.ExecutionHelper.CoerceValue(argument.ResolvedType!, value).Value;
+        }
+        else if (argument.DefaultValue != null && !argument.ResolvedType!.IsValidDefault(argument.DefaultValue))
+        {
+            throw new InvalidOperationException($"The default value of argument '{argument.Name}' of field '{type.Name}.{field.Name}' is invalid.");
+        }
+    }
+
+    private void ValidateFieldArgumentsUniqueness(FieldType field, INamedType type)
+    {
+        if (field.Arguments?.Count > 0)
+        {
+            foreach (var item in field.Arguments.List!.ToLookup(f => f.Name))
             {
                 if (item.Count() > 1)
-                    throw new InvalidOperationException($"The field '{item.Key}' must have a unique name within Object type '{type.Name}'; no two fields may share the same name.");
+                    throw new InvalidOperationException($"The argument '{item.Key}' must have a unique name within field '{type.Name}.{field.Name}'; no two field arguments may share the same name.");
             }
-
-            // 3
-            // TODO: ? An object type may declare that it implements one or more unique interfaces.
-
-            // 4
-            // TODO: An object type must be a super‐set of all interfaces it implements
         }
+    }
 
-        /// <inheritdoc/>
-        public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
+    private void ValidateDirectiveArgumentsUniqueness(Directive directive)
+    {
+        if (directive.Arguments?.Count > 0)
         {
-            // 2.2
-            if (field.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have a name which begins with the __ (two underscores).");
-
-            if (!HasFullSpecifiedResolvedType(field))
-                throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
-
-            if (field.ResolvedType is GraphQLTypeReference)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
-
-            // 2.3
-            if (!field.ResolvedType!.IsOutputType())
-                throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must be an output type.");
-
-            ValidateFieldArgumentsUniqueness(field, type);
-
-            if (field.StreamResolver != null && type != schema.Subscription)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
-
-            if (field.Parser != null)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have Parser set. You should set Parser only for fields of input object types.");
-
-            if (field.Validator != null)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Object type '{type.Name}' must not have Validator set. You should set Validator only for fields of input object types.");
-        }
-
-        /// <inheritdoc/>
-        public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema)
-        {
-            // 2.4.1
-            if (argument.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must not have a name which begins with the __ (two underscores).");
-
-            if (!HasFullSpecifiedResolvedType(argument))
-                throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
-
-            if (argument.ResolvedType is GraphQLTypeReference)
-                throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
-
-            // 2.4.2
-            if (!argument.ResolvedType!.IsInputType())
-                throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must be an input type.");
-
-            // validate default value
-            ValidateQueryArgumentDefaultValue(argument, field, type);
-
-            // 2.4.3
-            if (argument.ResolvedType is NonNullGraphType && argument.DefaultValue is null && argument.DeprecationReason is not null)
-                throw new InvalidOperationException($"The required argument '{argument.Name}' of field '{type.Name}.{field.Name}' has no default value so `@deprecated` directive must not be applied to this argument. To deprecate a required argument, it must first be made optional by either changing the type to nullable or adding a default value.");
-        }
-
-        #endregion
-
-        #region Interface
-
-        // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Interfaces
-        // Interface types have the potential to be invalid if incorrectly defined.
-        /// <inheritdoc/>
-        public override void VisitInterface(IInterfaceGraphType type, ISchema schema)
-        {
-            // 1
-            if (type.Fields.Count == 0)
-                throw new InvalidOperationException($"An Interface type '{type.Name}' must define one or more fields.");
-
-            // 2.1
-            foreach (var item in type.Fields.List.ToLookup(f => f.Name))
+            foreach (var item in directive.Arguments.List!.ToLookup(f => f.Name))
             {
                 if (item.Count() > 1)
-                    throw new InvalidOperationException($"The field '{item.Key}' must have a unique name within Interface type '{type.Name}'; no two fields may share the same name.");
+                    throw new InvalidOperationException($"The argument '{item.Key}' must have a unique name within directive '{directive.Name}'; no two directive arguments may share the same name.");
             }
         }
+    }
 
-        /// <inheritdoc/>
-        public override void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema)
+    private static bool HasFullSpecifiedResolvedType(IProvideResolvedType type)
+    {
+        return type.ResolvedType switch
         {
-            // 2.2
-            if (field.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have a name which begins with the __ (two underscores).");
-
-            if (!HasFullSpecifiedResolvedType(field))
-                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
-
-            if (field.ResolvedType is GraphQLTypeReference)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
-
-            // 2.3
-            if (!field.ResolvedType!.IsOutputType())
-                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must be an output type.");
-
-            ValidateFieldArgumentsUniqueness(field, type);
-
-            if (field.StreamResolver != null && type != schema.Subscription)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
-
-            if (field.Resolver != null)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have Resolver set. Each interface is translated to a concrete type during request execution. You should set Resolver only for fields of object output types.");
-
-            if (field.Parser != null)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have Parser set. Each interface is translated to a concrete type during request execution. You should set Parser only for fields of input object types.");
-
-            if (field.Validator != null)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have Validator set. Each interface is translated to a concrete type during request execution. You should set Validator only for fields of input object types.");
-        }
-
-        /// <inheritdoc/>
-        public override void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema)
-        {
-            // 2.4.1
-            if (argument.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must not have a name which begins with the __ (two underscores).");
-
-            if (!HasFullSpecifiedResolvedType(argument))
-                throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
-
-            if (argument.ResolvedType is GraphQLTypeReference)
-                throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
-
-            // 2.4.2
-            if (!argument.ResolvedType!.IsInputType())
-                throw new InvalidOperationException($"The argument '{argument.Name}' of field '{type.Name}.{field.Name}' must be an input type.");
-
-            // validate default value
-            ValidateQueryArgumentDefaultValue(argument, field, type);
-
-            // 2.4.3
-            if (argument.ResolvedType is NonNullGraphType && argument.DefaultValue is null && argument.DeprecationReason is not null)
-                throw new InvalidOperationException($"The required argument '{argument.Name}' of field '{type.Name}.{field.Name}' has no default value so `@deprecated` directive must not be applied to this argument. To deprecate a required argument, it must first be made optional by either changing the type to nullable or adding a default value.");
-        }
-
-        #endregion
-
-        #region Input Object
-
-        // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Input-Objects
-        // Input Object types have the potential to be invalid if incorrectly defined.
-        /// <inheritdoc/>
-        public override void VisitInputObject(IInputObjectGraphType type, ISchema schema)
-        {
-            // 1
-            if (type.Fields.Count == 0)
-                throw new InvalidOperationException($"An Input Object type '{type.Name}' must define one or more input fields.");
-
-            // 2.1
-            foreach (var item in type.Fields.List.ToLookup(f => f.Name))
-            {
-                if (item.Count() > 1)
-                    throw new InvalidOperationException($"The input field '{item.Key}' must have a unique name within Input Object type '{type.Name}'; no two fields may share the same name.");
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema)
-        {
-            // 2.2
-            if (field.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The input field '{field.Name}' of an Input Object '{type.Name}' must not have a name which begins with the __ (two underscores).");
-
-            if (!HasFullSpecifiedResolvedType(field))
-                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
-
-            if (field.ResolvedType is GraphQLTypeReference)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
-
-            // 2.3
-            if (!field.ResolvedType!.IsInputType())
-                throw new InvalidOperationException($"The input field '{field.Name}' of an Input Object '{type.Name}' must be an input type.");
-
-            // validate default value
-            if (field.DefaultValue is GraphQLValue value)
-            {
-                field.DefaultValue = Execution.ExecutionHelper.CoerceValue(field.ResolvedType!, value).Value;
-            }
-            else if (field.DefaultValue != null && !field.ResolvedType!.IsValidDefault(field.DefaultValue))
-            {
-                throw new InvalidOperationException($"The default value of Input Object type field '{type.Name}.{field.Name}' is invalid.");
-            }
-
-            if (field.Arguments?.Count > 0)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have any arguments specified.");
-
-            // 2.4
-            if (field.ResolvedType is NonNullGraphType && field.DefaultValue is null && field.DeprecationReason is not null)
-                throw new InvalidOperationException($"The required input field '{field.Name}' of an Input Object '{type.Name}' has no default value so `@deprecated` directive must not be applied to this input field. To deprecate an input field, it must first be made optional by either changing the type to nullable or adding a default value.");
-
-            if (field.StreamResolver != null)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
-
-            if (field.Resolver != null)
-                throw new InvalidOperationException($"The field '{field.Name}' of an Input Object type '{type.Name}' must not have Resolver set. You should set Resolver only for fields of object output types.");
-        }
-
-        #endregion
-
-        // See https://spec.graphql.org/October2021/#sec-Root-Operation-Types
-        /// <inheritdoc/>
-        public override void VisitSchema(ISchema schema)
-        {
-            var n1 = schema.Query?.Name;
-            var n2 = schema.Mutation?.Name;
-            var n3 = schema.Subscription?.Name;
-            if (n1 == n2 && n1 != null || n1 == n3 && n1 != null || n2 == n3 && n2 != null)
-                throw new InvalidOperationException("The query, mutation, and subscription root types must all be different types if provided.");
-            if (schema.Subscription != null)
-            {
-                foreach (var field in schema.Subscription.Fields.List)
-                {
-                    if (field.StreamResolver == null)
-                        throw new InvalidOperationException($"The field '{field.Name}' of the subscription root type '{schema.Subscription.Name}' must have StreamResolver set.");
-                }
-            }
-        }
-
-        // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Unions
-        // Union types have the potential to be invalid if incorrectly defined.
-        /// <inheritdoc/>
-        public override void VisitUnion(UnionGraphType type, ISchema schema)
-        {
-            // 1
-            if (type.PossibleTypes.Count == 0)
-                throw new InvalidOperationException($"A Union type '{type.Name}' must include one or more unique member types.");
-
-            // 2 [requirement met by design]
-            // The member types of a Union type must all be Object base types;
-            // Scalar, Interface and Union types must not be member types of a Union.
-            // Similarly, wrapping types must not be member types of a Union.
-        }
-
-        // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Enums
-        // Enum types have the potential to be invalid if incorrectly defined.
-        /// <inheritdoc/>
-        public override void VisitEnum(EnumerationGraphType type, ISchema schema)
-        {
-            // 1
-            if (type.Values.Count == 0)
-                throw new InvalidOperationException($"An Enum type '{type.Name}' must define one or more unique enum values.");
-        }
-
-        // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Type-System.Directives
-        // Directive types have the potential to be invalid if incorrectly defined.
-        /// <inheritdoc/>
-        public override void VisitDirective(Directive directive, ISchema schema)
-        {
-            if (directive.Locations.Count == 0)
-                throw new InvalidOperationException($"Directive '{directive.Name}' must have locations");
-
-            // 1. A directive definition must not contain the use of a directive which references itself directly.
-            // TODO:
-
-            // 2. A directive definition must not contain the use of a directive which references itself indirectly
-            // by referencing a Type or Directive which transitively includes a reference to this directive.
-            // TODO:
-
-            // 3
-            if (directive.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The directive '{directive.Name}' must not have a name which begins with the __ (two underscores).");
-
-            ValidateDirectiveArgumentsUniqueness(directive);
-        }
-
-        /// <inheritdoc/>
-        public override void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema)
-        {
-            // 4.1
-            if (argument.Name.StartsWith("__"))
-                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must not have a name which begins with the __ (two underscores).");
-
-            if (!HasFullSpecifiedResolvedType(argument))
-                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must have non-null '{nameof(IFieldType.ResolvedType)}' property for all types in the chain.");
-
-            if (argument.ResolvedType is GraphQLTypeReference)
-                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' has '{nameof(GraphQLTypeReference)}' type. This type must be replaced with a reference to the actual GraphQL type before using the reference.");
-
-            // 4.2
-            if (!argument.ResolvedType!.IsInputType())
-                throw new InvalidOperationException($"The argument '{argument.Name}' of directive '{directive.Name}' must be an input type.");
-
-            // validate default
-            if (argument.DefaultValue is GraphQLValue value)
-            {
-                argument.DefaultValue = Execution.ExecutionHelper.CoerceValue(argument.ResolvedType!, value).Value;
-            }
-            else if (argument.DefaultValue != null && !argument.ResolvedType!.IsValidDefault(argument.DefaultValue))
-            {
-                throw new InvalidOperationException($"The default value of argument '{argument.Name}' of directive '{directive.Name}' is invalid.");
-            }
-        }
-
-        private void ValidateQueryArgumentDefaultValue(QueryArgument argument, FieldType field, INamedType type)
-        {
-            if (argument.DefaultValue is GraphQLValue value)
-            {
-                argument.DefaultValue = Execution.ExecutionHelper.CoerceValue(argument.ResolvedType!, value).Value;
-            }
-            else if (argument.DefaultValue != null && !argument.ResolvedType!.IsValidDefault(argument.DefaultValue))
-            {
-                throw new InvalidOperationException($"The default value of argument '{argument.Name}' of field '{type.Name}.{field.Name}' is invalid.");
-            }
-        }
-
-        private void ValidateFieldArgumentsUniqueness(FieldType field, INamedType type)
-        {
-            if (field.Arguments?.Count > 0)
-            {
-                foreach (var item in field.Arguments.List!.ToLookup(f => f.Name))
-                {
-                    if (item.Count() > 1)
-                        throw new InvalidOperationException($"The argument '{item.Key}' must have a unique name within field '{type.Name}.{field.Name}'; no two field arguments may share the same name.");
-                }
-            }
-        }
-
-        private void ValidateDirectiveArgumentsUniqueness(Directive directive)
-        {
-            if (directive.Arguments?.Count > 0)
-            {
-                foreach (var item in directive.Arguments.List!.ToLookup(f => f.Name))
-                {
-                    if (item.Count() > 1)
-                        throw new InvalidOperationException($"The argument '{item.Key}' must have a unique name within directive '{directive.Name}'; no two directive arguments may share the same name.");
-                }
-            }
-        }
-
-        private static bool HasFullSpecifiedResolvedType(IProvideResolvedType type)
-        {
-            return type.ResolvedType switch
-            {
-                null => false,
-                ListGraphType list => HasFullSpecifiedResolvedType(list),
-                NonNullGraphType nonNull => HasFullSpecifiedResolvedType(nonNull),
-                _ => true, // not null
-            };
-        }
+            null => false,
+            ListGraphType list => HasFullSpecifiedResolvedType(list),
+            NonNullGraphType nonNull => HasFullSpecifiedResolvedType(nonNull),
+            _ => true, // not null
+        };
     }
 }

--- a/src/GraphQL/Utilities/XmlDocumentationExtensions.cs
+++ b/src/GraphQL/Utilities/XmlDocumentationExtensions.cs
@@ -3,168 +3,167 @@ using System.Reflection;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
-namespace GraphQL.Utilities
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Provides extension methods for reading XML comments from reflected members.
+/// </summary>
+internal static class XmlDocumentationExtensions
 {
-    /// <summary>
-    /// Provides extension methods for reading XML comments from reflected members.
-    /// </summary>
-    internal static class XmlDocumentationExtensions
+    private static readonly ConcurrentDictionary<string, XDocument?> _cachedXml = new(StringComparer.OrdinalIgnoreCase);
+
+    private static string GetParameterName(this ParameterInfo parameter) => GetTypeName(parameter.ParameterType);
+
+    private static string? NullIfEmpty(this string? text) => text == string.Empty ? null : text;
+
+    private static string GetTypeName(Type type)
     {
-        private static readonly ConcurrentDictionary<string, XDocument?> _cachedXml = new(StringComparer.OrdinalIgnoreCase);
-
-        private static string GetParameterName(this ParameterInfo parameter) => GetTypeName(parameter.ParameterType);
-
-        private static string? NullIfEmpty(this string? text) => text == string.Empty ? null : text;
-
-        private static string GetTypeName(Type type)
+        if (type.IsGenericType)
         {
-            if (type.IsGenericType)
-            {
-                string baseName = type.GetGenericTypeDefinition().ToString();
-                baseName = baseName.Substring(0, baseName.IndexOf('`'));
-                return $"{baseName}{{{string.Join(",", type.GetGenericArguments().Select(GetTypeName))}}}";
-            }
-
-            return type.FullName!;
+            string baseName = type.GetGenericTypeDefinition().ToString();
+            baseName = baseName.Substring(0, baseName.IndexOf('`'));
+            return $"{baseName}{{{string.Join(",", type.GetGenericArguments().Select(GetTypeName))}}}";
         }
 
-        /// <summary>
-        /// Returns the expected name for a member element in the XML documentation file.
-        /// </summary>
-        /// <param name="member">The reflected member.</param>
-        /// <returns>The name of the member element.</returns>
-        private static string GetMemberElementName(MemberInfo member)
+        return type.FullName!;
+    }
+
+    /// <summary>
+    /// Returns the expected name for a member element in the XML documentation file.
+    /// </summary>
+    /// <param name="member">The reflected member.</param>
+    /// <returns>The name of the member element.</returns>
+    private static string GetMemberElementName(MemberInfo member)
+    {
+        char prefixCode;
+        string memberName = member is Type t
+            ? t.FullName! // member is a Type
+            : member.DeclaringType!.FullName + "." + member.Name;  // member belongs to a Type
+        memberName = memberName.Replace('+', '.');
+
+        switch (member.MemberType)
         {
-            char prefixCode;
-            string memberName = member is Type t
-                ? t.FullName! // member is a Type
-                : member.DeclaringType!.FullName + "." + member.Name;  // member belongs to a Type
-            memberName = memberName.Replace('+', '.');
+            case MemberTypes.Constructor:
+                // XML documentation uses slightly different constructor names
+                memberName = memberName.Replace(".ctor", "#ctor");
+                goto case MemberTypes.Method;
 
-            switch (member.MemberType)
-            {
-                case MemberTypes.Constructor:
-                    // XML documentation uses slightly different constructor names
-                    memberName = memberName.Replace(".ctor", "#ctor");
-                    goto case MemberTypes.Method;
+            case MemberTypes.Method:
+                prefixCode = 'M';
+                // parameters are listed according to their type, not their name
+                string paramTypesList = string.Join(",", ((MethodBase)member).GetParameters().Select(x => x.GetParameterName()).ToArray());
+                if (!string.IsNullOrEmpty(paramTypesList))
+                    memberName += "(" + paramTypesList + ")";
+                break;
 
-                case MemberTypes.Method:
-                    prefixCode = 'M';
-                    // parameters are listed according to their type, not their name
-                    string paramTypesList = string.Join(",", ((MethodBase)member).GetParameters().Select(x => x.GetParameterName()).ToArray());
-                    if (!string.IsNullOrEmpty(paramTypesList))
-                        memberName += "(" + paramTypesList + ")";
-                    break;
+            case MemberTypes.Event:
+                prefixCode = 'E';
+                break;
 
-                case MemberTypes.Event:
-                    prefixCode = 'E';
-                    break;
+            case MemberTypes.Field:
+                prefixCode = 'F';
+                break;
 
-                case MemberTypes.Field:
-                    prefixCode = 'F';
-                    break;
+            case MemberTypes.NestedType:
+                // XML documentation uses slightly different nested type names
+                goto case MemberTypes.TypeInfo;
 
-                case MemberTypes.NestedType:
-                    // XML documentation uses slightly different nested type names
-                    goto case MemberTypes.TypeInfo;
+            case MemberTypes.TypeInfo:
+                prefixCode = 'T';
+                break;
 
-                case MemberTypes.TypeInfo:
-                    prefixCode = 'T';
-                    break;
+            case MemberTypes.Property:
+                prefixCode = 'P';
+                break;
 
-                case MemberTypes.Property:
-                    prefixCode = 'P';
-                    break;
-
-                default:
-                    throw new ArgumentException("Unknown member type", nameof(member));
-            }
-
-            // elements are of the form "M:Namespace.Class.Method"
-            return $"{prefixCode}:{memberName}";
+            default:
+                throw new ArgumentException("Unknown member type", nameof(member));
         }
 
-        private static XDocument? GetDocument(Assembly asm, string pathToXmlFile)
+        // elements are of the form "M:Namespace.Class.Method"
+        return $"{prefixCode}:{memberName}";
+    }
+
+    private static XDocument? GetDocument(Assembly asm, string pathToXmlFile)
+    {
+        string assemblyName = asm.GetName().FullName;
+        XDocument? doc = null;
+
+        return _cachedXml.GetOrAdd(assemblyName, key =>
         {
-            string assemblyName = asm.GetName().FullName;
-            XDocument? doc = null;
 
-            return _cachedXml.GetOrAdd(assemblyName, key =>
+            try
             {
+                if (File.Exists(pathToXmlFile))
+                    doc = XDocument.Load(pathToXmlFile);
 
-                try
+                if (doc == null)
                 {
-                    if (File.Exists(pathToXmlFile))
-                        doc = XDocument.Load(pathToXmlFile);
-
-                    if (doc == null)
-                    {
-                        string relativePath = Path.Combine(Path.GetDirectoryName(asm.Location)!, pathToXmlFile);
-                        if (File.Exists(relativePath))
-                            doc = XDocument.Load(relativePath);
-                    }
+                    string relativePath = Path.Combine(Path.GetDirectoryName(asm.Location)!, pathToXmlFile);
+                    if (File.Exists(relativePath))
+                        doc = XDocument.Load(relativePath);
                 }
+            }
 #pragma warning disable RCS1075 // Avoid empty catch clause that catches System.Exception.
-                catch (Exception)
-                {
-                    // No logging is needed
-                }
+            catch (Exception)
+            {
+                // No logging is needed
+            }
 #pragma warning restore RCS1075 // Avoid empty catch clause that catches System.Exception.
 
-                return doc;
-            });
-        }
-
-        /// <summary>
-        /// Returns the XML documentation (summary tag) for the specified member.
-        /// </summary>
-        /// <param name="member">The reflected member.</param>
-        /// <returns>The contents of the summary tag for the member.</returns>
-        public static string? GetXmlDocumentation(this MemberInfo member) => GetXmlDocumentation(member, member.Module.Assembly.GetName().Name + ".xml");
-
-        /// <summary>
-        /// Returns the XML documentation (summary tag) for the specified member.
-        /// </summary>
-        /// <param name="member">The reflected member.</param>
-        /// <param name="pathToXmlFile">Path to the XML documentation file.</param>
-        /// <returns>The contents of the summary tag for the member.</returns>
-        public static string? GetXmlDocumentation(this MemberInfo member, string pathToXmlFile) => GetXmlDocumentation(member, GetDocument(member.Module.Assembly, pathToXmlFile));
-
-        /// <summary>
-        /// Returns the XML documentation (summary tag) for the specified member.
-        /// </summary>
-        /// <param name="member">The reflected member.</param>
-        /// <param name="xml">XML documentation.</param>
-        /// <returns>The contents of the summary tag for the member.</returns>
-        public static string? GetXmlDocumentation(this MemberInfo member, XDocument? xml) => xml?.XPathEvaluate(
-            $"string(/doc/members/member[@name='{GetMemberElementName(member)}']/summary)").ToString()!.Trim().NullIfEmpty();
-
-        /// <summary>
-        /// Returns the XML documentation (returns/param tag) for the specified parameter.
-        /// </summary>
-        /// <param name="parameter">The reflected parameter (or return value).</param>
-        /// <returns>The contents of the returns/param tag for the parameter.</returns>
-        public static string? GetXmlDocumentation(this ParameterInfo parameter) => GetXmlDocumentation(parameter, parameter.Member.Module.Assembly.GetName().Name + ".xml");
-
-        /// <summary>
-        /// Returns the XML documentation (returns/param tag) for the specified parameter.
-        /// </summary>
-        /// <param name="parameter">The reflected parameter (or return value).</param>
-        /// <param name="pathToXmlFile">Path to the XML documentation file.</param>
-        /// <returns>The contents of the returns/param tag for the parameter.</returns>
-        public static string? GetXmlDocumentation(this ParameterInfo parameter, string pathToXmlFile) => GetXmlDocumentation(parameter, GetDocument(parameter.Member.Module.Assembly, pathToXmlFile));
-
-        /// <summary>
-        /// Returns the XML documentation (returns/param tag) for the specified parameter.
-        /// </summary>
-        /// <param name="parameter">The reflected parameter (or return value).</param>
-        /// <param name="xml">XML documentation.</param>
-        /// <returns>The contents of the returns/param tag for the parameter.</returns>
-        public static string? GetXmlDocumentation(this ParameterInfo parameter, XDocument? xml) =>
-            parameter.IsRetval || string.IsNullOrEmpty(parameter.Name)
-                ? xml?.XPathEvaluate(
-                    $"string(/doc/members/member[@name='{GetMemberElementName(parameter.Member)}']/returns)").ToString()!.Trim().NullIfEmpty()
-                : xml?.XPathEvaluate(
-                    $"string(/doc/members/member[@name='{GetMemberElementName(parameter.Member)}']/param[@name='{parameter.Name}'])").ToString()!.Trim().NullIfEmpty();
+            return doc;
+        });
     }
+
+    /// <summary>
+    /// Returns the XML documentation (summary tag) for the specified member.
+    /// </summary>
+    /// <param name="member">The reflected member.</param>
+    /// <returns>The contents of the summary tag for the member.</returns>
+    public static string? GetXmlDocumentation(this MemberInfo member) => GetXmlDocumentation(member, member.Module.Assembly.GetName().Name + ".xml");
+
+    /// <summary>
+    /// Returns the XML documentation (summary tag) for the specified member.
+    /// </summary>
+    /// <param name="member">The reflected member.</param>
+    /// <param name="pathToXmlFile">Path to the XML documentation file.</param>
+    /// <returns>The contents of the summary tag for the member.</returns>
+    public static string? GetXmlDocumentation(this MemberInfo member, string pathToXmlFile) => GetXmlDocumentation(member, GetDocument(member.Module.Assembly, pathToXmlFile));
+
+    /// <summary>
+    /// Returns the XML documentation (summary tag) for the specified member.
+    /// </summary>
+    /// <param name="member">The reflected member.</param>
+    /// <param name="xml">XML documentation.</param>
+    /// <returns>The contents of the summary tag for the member.</returns>
+    public static string? GetXmlDocumentation(this MemberInfo member, XDocument? xml) => xml?.XPathEvaluate(
+        $"string(/doc/members/member[@name='{GetMemberElementName(member)}']/summary)").ToString()!.Trim().NullIfEmpty();
+
+    /// <summary>
+    /// Returns the XML documentation (returns/param tag) for the specified parameter.
+    /// </summary>
+    /// <param name="parameter">The reflected parameter (or return value).</param>
+    /// <returns>The contents of the returns/param tag for the parameter.</returns>
+    public static string? GetXmlDocumentation(this ParameterInfo parameter) => GetXmlDocumentation(parameter, parameter.Member.Module.Assembly.GetName().Name + ".xml");
+
+    /// <summary>
+    /// Returns the XML documentation (returns/param tag) for the specified parameter.
+    /// </summary>
+    /// <param name="parameter">The reflected parameter (or return value).</param>
+    /// <param name="pathToXmlFile">Path to the XML documentation file.</param>
+    /// <returns>The contents of the returns/param tag for the parameter.</returns>
+    public static string? GetXmlDocumentation(this ParameterInfo parameter, string pathToXmlFile) => GetXmlDocumentation(parameter, GetDocument(parameter.Member.Module.Assembly, pathToXmlFile));
+
+    /// <summary>
+    /// Returns the XML documentation (returns/param tag) for the specified parameter.
+    /// </summary>
+    /// <param name="parameter">The reflected parameter (or return value).</param>
+    /// <param name="xml">XML documentation.</param>
+    /// <returns>The contents of the returns/param tag for the parameter.</returns>
+    public static string? GetXmlDocumentation(this ParameterInfo parameter, XDocument? xml) =>
+        parameter.IsRetval || string.IsNullOrEmpty(parameter.Name)
+            ? xml?.XPathEvaluate(
+                $"string(/doc/members/member[@name='{GetMemberElementName(parameter.Member)}']/returns)").ToString()!.Trim().NullIfEmpty()
+            : xml?.XPathEvaluate(
+                $"string(/doc/members/member[@name='{GetMemberElementName(parameter.Member)}']/param[@name='{parameter.Name}'])").ToString()!.Trim().NullIfEmpty();
 }

--- a/src/GraphQL/Validation/BaseVariableVisitor.cs
+++ b/src/GraphQL/Validation/BaseVariableVisitor.cs
@@ -1,28 +1,27 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Base class implementing <see cref="IVariableVisitor"/>. Does nothing.
+/// Inherit from it if you need to override only some of the methods.
+/// </summary>
+public class BaseVariableVisitor : IVariableVisitor
 {
-    /// <summary>
-    /// Base class implementing <see cref="IVariableVisitor"/>. Does nothing.
-    /// Inherit from it if you need to override only some of the methods.
-    /// </summary>
-    public class BaseVariableVisitor : IVariableVisitor
-    {
-        /// <inheritdoc/>
-        public virtual ValueTask VisitFieldAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, FieldType field, object? variableValue, object? parsedValue)
-            => default;
+    /// <inheritdoc/>
+    public virtual ValueTask VisitFieldAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, FieldType field, object? variableValue, object? parsedValue)
+        => default;
 
-        /// <inheritdoc/>
-        public virtual ValueTask VisitListAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ListGraphType type, object? variableValue, IList<object?>? parsedValue)
-            => default;
+    /// <inheritdoc/>
+    public virtual ValueTask VisitListAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ListGraphType type, object? variableValue, IList<object?>? parsedValue)
+        => default;
 
-        /// <inheritdoc/>
-        public virtual ValueTask VisitObjectAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, object? variableValue, object? parsedValue)
-            => default;
+    /// <inheritdoc/>
+    public virtual ValueTask VisitObjectAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, object? variableValue, object? parsedValue)
+        => default;
 
-        /// <inheritdoc/>
-        public virtual ValueTask VisitScalarAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ScalarGraphType type, object? variableValue, object? parsedValue)
-            => default;
-    }
+    /// <inheritdoc/>
+    public virtual ValueTask VisitScalarAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ScalarGraphType type, object? variableValue, object? parsedValue)
+        => default;
 }

--- a/src/GraphQL/Validation/BasicVisitor.cs
+++ b/src/GraphQL/Validation/BasicVisitor.cs
@@ -1,66 +1,65 @@
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Walks an AST node tree executing <see cref="INodeVisitor.EnterAsync(ASTNode, ValidationContext)"/>
+/// and <see cref="INodeVisitor.LeaveAsync(ASTNode, ValidationContext)"/> methods for each node.
+/// </summary>
+public class BasicVisitor : ASTVisitor<BasicVisitor.State>
 {
+    private readonly IList<INodeVisitor> _visitors;
+
     /// <summary>
-    /// Walks an AST node tree executing <see cref="INodeVisitor.EnterAsync(ASTNode, ValidationContext)"/>
-    /// and <see cref="INodeVisitor.LeaveAsync(ASTNode, ValidationContext)"/> methods for each node.
+    /// Returns a new instance configured for the specified list of <see cref="INodeVisitor"/>.
     /// </summary>
-    public class BasicVisitor : ASTVisitor<BasicVisitor.State>
+    public BasicVisitor(params INodeVisitor[] visitors)
     {
-        private readonly IList<INodeVisitor> _visitors;
+        _visitors = visitors;
+    }
+
+    /// <inheritdoc cref="BasicVisitor(INodeVisitor[])"/>
+    public BasicVisitor(IList<INodeVisitor> visitors)
+    {
+        _visitors = visitors;
+    }
+
+    /// <summary>
+    /// Walks the specified <see cref="ASTNode"/>, executing <see cref="INodeVisitor.EnterAsync(ASTNode, ValidationContext)"/> and
+    /// <see cref="INodeVisitor.LeaveAsync(ASTNode, ValidationContext)"/> methods for each node.
+    /// </summary>
+    public override async ValueTask VisitAsync(ASTNode? node, State context)
+    {
+        if (node != null)
+        {
+            for (int i = 0; i < _visitors.Count; ++i)
+                await _visitors[i].EnterAsync(node, context.Context).ConfigureAwait(false);
+
+            await base.VisitAsync(node, context).ConfigureAwait(false);
+
+            for (int i = _visitors.Count - 1; i >= 0; --i)
+                await _visitors[i].LeaveAsync(node, context.Context).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc cref="IASTVisitorContext"/>
+    public readonly struct State : IASTVisitorContext
+    {
+        /// <summary>
+        /// Initializes a new instance with the specified validation context.
+        /// </summary>
+        public State(ValidationContext context)
+        {
+            Context = context;
+        }
 
         /// <summary>
-        /// Returns a new instance configured for the specified list of <see cref="INodeVisitor"/>.
+        /// Returns the validation context.
         /// </summary>
-        public BasicVisitor(params INodeVisitor[] visitors)
-        {
-            _visitors = visitors;
-        }
+        public ValidationContext Context { get; }
 
-        /// <inheritdoc cref="BasicVisitor(INodeVisitor[])"/>
-        public BasicVisitor(IList<INodeVisitor> visitors)
-        {
-            _visitors = visitors;
-        }
-
-        /// <summary>
-        /// Walks the specified <see cref="ASTNode"/>, executing <see cref="INodeVisitor.EnterAsync(ASTNode, ValidationContext)"/> and
-        /// <see cref="INodeVisitor.LeaveAsync(ASTNode, ValidationContext)"/> methods for each node.
-        /// </summary>
-        public override async ValueTask VisitAsync(ASTNode? node, State context)
-        {
-            if (node != null)
-            {
-                for (int i = 0; i < _visitors.Count; ++i)
-                    await _visitors[i].EnterAsync(node, context.Context).ConfigureAwait(false);
-
-                await base.VisitAsync(node, context).ConfigureAwait(false);
-
-                for (int i = _visitors.Count - 1; i >= 0; --i)
-                    await _visitors[i].LeaveAsync(node, context.Context).ConfigureAwait(false);
-            }
-        }
-
-        /// <inheritdoc cref="IASTVisitorContext"/>
-        public readonly struct State : IASTVisitorContext
-        {
-            /// <summary>
-            /// Initializes a new instance with the specified validation context.
-            /// </summary>
-            public State(ValidationContext context)
-            {
-                Context = context;
-            }
-
-            /// <summary>
-            /// Returns the validation context.
-            /// </summary>
-            public ValidationContext Context { get; }
-
-            /// <inheritdoc/>
-            public CancellationToken CancellationToken => Context.CancellationToken;
-        }
+        /// <inheritdoc/>
+        public CancellationToken CancellationToken => Context.CancellationToken;
     }
 }

--- a/src/GraphQL/Validation/Complexity/AnalysisContext.cs
+++ b/src/GraphQL/Validation/Complexity/AnalysisContext.cs
@@ -1,84 +1,83 @@
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
 
-namespace GraphQL.Validation.Complexity
+namespace GraphQL.Validation.Complexity;
+
+internal sealed class AnalysisContext : IASTVisitorContext
 {
-    internal sealed class AnalysisContext : IASTVisitorContext
+    public double AvgImpact { get; set; }
+
+    public double? CurrentSubSelectionImpact { get; set; }
+
+    public double CurrentEndNodeImpact { get; set; }
+
+    public FragmentComplexity CurrentFragmentComplexity { get; set; } = null!;
+
+    public ComplexityResult Result { get; } = new ComplexityResult();
+
+    public int LoopCounter { get; set; }
+
+    public int MaxRecursionCount { get; set; }
+
+    public bool FragmentMapAlreadyBuilt { get; set; }
+
+    public Dictionary<string, FragmentComplexity> FragmentMap { get; } = new Dictionary<string, FragmentComplexity>();
+
+    public CancellationToken CancellationToken => default;
+
+    public void AssertRecursion()
     {
-        public double AvgImpact { get; set; }
-
-        public double? CurrentSubSelectionImpact { get; set; }
-
-        public double CurrentEndNodeImpact { get; set; }
-
-        public FragmentComplexity CurrentFragmentComplexity { get; set; } = null!;
-
-        public ComplexityResult Result { get; } = new ComplexityResult();
-
-        public int LoopCounter { get; set; }
-
-        public int MaxRecursionCount { get; set; }
-
-        public bool FragmentMapAlreadyBuilt { get; set; }
-
-        public Dictionary<string, FragmentComplexity> FragmentMap { get; } = new Dictionary<string, FragmentComplexity>();
-
-        public CancellationToken CancellationToken => default;
-
-        public void AssertRecursion()
+        if (LoopCounter++ > MaxRecursionCount)
         {
-            if (LoopCounter++ > MaxRecursionCount)
-            {
-                throw new InvalidOperationException("Query is too complex to validate.");
-            }
+            throw new InvalidOperationException("Query is too complex to validate.");
         }
+    }
 
-        public static double? GetImpactFromArgs(GraphQLField node) //TODO: variables support
+    public static double? GetImpactFromArgs(GraphQLField node) //TODO: variables support
+    {
+        double? newImpact = null;
+
+        if (node.Arguments != null)
         {
-            double? newImpact = null;
-
-            if (node.Arguments != null)
+            if (node.Arguments.ValueFor("id") != null)
             {
-                if (node.Arguments.ValueFor("id") != null)
+                newImpact = 1;
+            }
+            else
+            {
+                if (node.Arguments.ValueFor("first") is GraphQLIntValue firstValue)
                 {
-                    newImpact = 1;
+                    newImpact = Int.Parse(firstValue.Value);
                 }
                 else
                 {
-                    if (node.Arguments.ValueFor("first") is GraphQLIntValue firstValue)
-                    {
-                        newImpact = Int.Parse(firstValue.Value);
-                    }
-                    else
-                    {
-                        if (node.Arguments.ValueFor("last") is GraphQLIntValue lastValue)
-                            newImpact = Int.Parse(lastValue.Value);
-                    }
+                    if (node.Arguments.ValueFor("last") is GraphQLIntValue lastValue)
+                        newImpact = Int.Parse(lastValue.Value);
                 }
             }
-
-            return newImpact;
         }
 
-        /// <summary>
-        /// Takes into account the complexity of the specified node.
-        /// <br/>
-        /// Available nodes:
-        /// <list type="number">
-        /// <item><see cref="GraphQLField"/></item>
-        /// <item><see cref="GraphQLFragmentSpread"/></item>
-        /// </list>
-        /// </summary>
-        /// <param name="node">The node for which the complexity is added.</param>
-        /// <param name="impact">Added complexity.</param>
-        public void RecordFieldComplexity(ASTNode node, double impact)
-        {
-            Result.Complexity += impact;
+        return newImpact;
+    }
 
-            if (Result.ComplexityMap.ContainsKey(node))
-                Result.ComplexityMap[node] += impact;
-            else
-                Result.ComplexityMap.Add(node, impact);
-        }
+    /// <summary>
+    /// Takes into account the complexity of the specified node.
+    /// <br/>
+    /// Available nodes:
+    /// <list type="number">
+    /// <item><see cref="GraphQLField"/></item>
+    /// <item><see cref="GraphQLFragmentSpread"/></item>
+    /// </list>
+    /// </summary>
+    /// <param name="node">The node for which the complexity is added.</param>
+    /// <param name="impact">Added complexity.</param>
+    public void RecordFieldComplexity(ASTNode node, double impact)
+    {
+        Result.Complexity += impact;
+
+        if (Result.ComplexityMap.ContainsKey(node))
+            Result.ComplexityMap[node] += impact;
+        else
+            Result.ComplexityMap.Add(node, impact);
     }
 }

--- a/src/GraphQL/Validation/Complexity/ComplexityConfiguration.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityConfiguration.cs
@@ -1,31 +1,30 @@
-namespace GraphQL.Validation.Complexity
+namespace GraphQL.Validation.Complexity;
+
+/// <summary>
+/// Configuration parameters for a complexity analyzer.
+/// </summary>
+public class ComplexityConfiguration
 {
     /// <summary>
-    /// Configuration parameters for a complexity analyzer.
+    /// Gets or sets the allowed maximum depth of the query.
+    /// <see langword="null"/> if the depth does not need to be limited.
     /// </summary>
-    public class ComplexityConfiguration
-    {
-        /// <summary>
-        /// Gets or sets the allowed maximum depth of the query.
-        /// <see langword="null"/> if the depth does not need to be limited.
-        /// </summary>
-        public int? MaxDepth { get; set; }
+    public int? MaxDepth { get; set; }
 
-        /// <summary>
-        /// Gets or sets the maximum calculated document complexity factor.
-        /// <see langword="null"/> if the complexity does not need to be limited.
-        /// </summary>
-        public int? MaxComplexity { get; set; }
+    /// <summary>
+    /// Gets or sets the maximum calculated document complexity factor.
+    /// <see langword="null"/> if the complexity does not need to be limited.
+    /// </summary>
+    public int? MaxComplexity { get; set; }
 
-        /// <summary>
-        /// Hardcoded maximum number of objects returned by each field.
-        /// If there is no hardcoded maximum then use the average number of rows/objects returned by each field.
-        /// </summary>
-        public double? FieldImpact { get; set; }
+    /// <summary>
+    /// Hardcoded maximum number of objects returned by each field.
+    /// If there is no hardcoded maximum then use the average number of rows/objects returned by each field.
+    /// </summary>
+    public double? FieldImpact { get; set; }
 
-        /// <summary>
-        /// Max number of times to traverse tree nodes. GraphiQL queries take ~95 iterations, adjust as needed.
-        /// </summary>
-        public int MaxRecursionCount { get; set; } = 250;
-    }
+    /// <summary>
+    /// Max number of times to traverse tree nodes. GraphiQL queries take ~95 iterations, adjust as needed.
+    /// </summary>
+    public int MaxRecursionCount { get; set; } = 250;
 }

--- a/src/GraphQL/Validation/Complexity/ComplexityResult.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityResult.cs
@@ -1,25 +1,24 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Complexity
+namespace GraphQL.Validation.Complexity;
+
+/// <summary>
+/// Contains the result of a complexity analysis.
+/// </summary>
+public class ComplexityResult
 {
     /// <summary>
-    /// Contains the result of a complexity analysis.
+    /// Returns a dictionary of nodes and their complexity factors.
     /// </summary>
-    public class ComplexityResult
-    {
-        /// <summary>
-        /// Returns a dictionary of nodes and their complexity factors.
-        /// </summary>
-        public Dictionary<ASTNode, double> ComplexityMap { get; } = new();
+    public Dictionary<ASTNode, double> ComplexityMap { get; } = new();
 
-        /// <summary>
-        /// Returns the total calculated document complexity factor over all executed nodes.
-        /// </summary>
-        public double Complexity { get; set; }
+    /// <summary>
+    /// Returns the total calculated document complexity factor over all executed nodes.
+    /// </summary>
+    public double Complexity { get; set; }
 
-        /// <summary>
-        /// Returns the total query depth.
-        /// </summary>
-        public int TotalQueryDepth { get; set; }
-    }
+    /// <summary>
+    /// Returns the total query depth.
+    /// </summary>
+    public int TotalQueryDepth { get; set; }
 }

--- a/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityVisitor.cs
@@ -3,125 +3,124 @@ using GraphQL.Validation.Rules.Custom;
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
 
-namespace GraphQL.Validation.Complexity
+namespace GraphQL.Validation.Complexity;
+
+/// <summary>
+/// Two-phase complexity visitor. See <see cref="ComplexityValidationRule.Analyze(GraphQLDocument, double, int, ISchema?)"/>.
+/// Phase 1. Calculate complexity of all fragments defined in GraphQL document; <see cref="AnalysisContext.FragmentMapAlreadyBuilt"/> is false.
+/// Phase 2. Calculate complexity of executed operation; <see cref="AnalysisContext.FragmentMapAlreadyBuilt"/> is true.
+/// </summary>
+internal class ComplexityVisitor : ASTVisitor<AnalysisContext>
 {
-    /// <summary>
-    /// Two-phase complexity visitor. See <see cref="ComplexityValidationRule.Analyze(GraphQLDocument, double, int, ISchema?)"/>.
-    /// Phase 1. Calculate complexity of all fragments defined in GraphQL document; <see cref="AnalysisContext.FragmentMapAlreadyBuilt"/> is false.
-    /// Phase 2. Calculate complexity of executed operation; <see cref="AnalysisContext.FragmentMapAlreadyBuilt"/> is true.
-    /// </summary>
-    internal class ComplexityVisitor : ASTVisitor<AnalysisContext>
+    private readonly TypeInfo? _visitor;
+
+    public ComplexityVisitor()
     {
-        private readonly TypeInfo? _visitor;
+    }
 
-        public ComplexityVisitor()
+    public ComplexityVisitor(ISchema schema)
+    {
+        _visitor = new TypeInfo(schema);
+    }
+
+    public override async ValueTask VisitAsync(ASTNode? node, AnalysisContext context)
+    {
+        if (node != null)
         {
+            if (_visitor != null)
+                await _visitor.EnterAsync(node, null!).ConfigureAwait(false);
+
+            await base.VisitAsync(node, context).ConfigureAwait(false);
+
+            if (_visitor != null)
+                await _visitor.LeaveAsync(node, null!).ConfigureAwait(false);
         }
+    }
 
-        public ComplexityVisitor(ISchema schema)
+    protected override async ValueTask VisitFragmentDefinitionAsync(GraphQLFragmentDefinition fragmentDefinition, AnalysisContext context)
+    {
+        if (!context.FragmentMapAlreadyBuilt)
         {
-            _visitor = new TypeInfo(schema);
+            context.FragmentMap[fragmentDefinition.FragmentName.Name.StringValue] = context.CurrentFragmentComplexity = new FragmentComplexity();
+
+            await base.VisitFragmentDefinitionAsync(fragmentDefinition, context).ConfigureAwait(false);
+
+            context.CurrentFragmentComplexity = null!;
         }
+    }
 
-        public override async ValueTask VisitAsync(ASTNode? node, AnalysisContext context)
+    protected override async ValueTask VisitFieldAsync(GraphQLField field, AnalysisContext context)
+    {
+        context.AssertRecursion();
+
+        var prevCurrentSubSelectionImpact = context.CurrentSubSelectionImpact;
+        var prevCurrentEndNodeImpact = context.CurrentEndNodeImpact;
+
+        var fieldImpact = _visitor?.GetFieldDef()?.GetComplexityImpact() ?? context.AvgImpact;
+        var zeroImpact = fieldImpact == 0;
+        context.CurrentSubSelectionImpact ??= (zeroImpact ? context.AvgImpact : fieldImpact);
+
+        if (context.FragmentMapAlreadyBuilt)
         {
-            if (node != null)
+            if (field.SelectionSet == null) // leaf field
             {
-                if (_visitor != null)
-                    await _visitor.EnterAsync(node, null!).ConfigureAwait(false);
-
-                await base.VisitAsync(node, context).ConfigureAwait(false);
-
-                if (_visitor != null)
-                    await _visitor.LeaveAsync(node, null!).ConfigureAwait(false);
-            }
-        }
-
-        protected override async ValueTask VisitFragmentDefinitionAsync(GraphQLFragmentDefinition fragmentDefinition, AnalysisContext context)
-        {
-            if (!context.FragmentMapAlreadyBuilt)
-            {
-                context.FragmentMap[fragmentDefinition.FragmentName.Name.StringValue] = context.CurrentFragmentComplexity = new FragmentComplexity();
-
-                await base.VisitFragmentDefinitionAsync(fragmentDefinition, context).ConfigureAwait(false);
-
-                context.CurrentFragmentComplexity = null!;
-            }
-        }
-
-        protected override async ValueTask VisitFieldAsync(GraphQLField field, AnalysisContext context)
-        {
-            context.AssertRecursion();
-
-            var prevCurrentSubSelectionImpact = context.CurrentSubSelectionImpact;
-            var prevCurrentEndNodeImpact = context.CurrentEndNodeImpact;
-
-            var fieldImpact = _visitor?.GetFieldDef()?.GetComplexityImpact() ?? context.AvgImpact;
-            var zeroImpact = fieldImpact == 0;
-            context.CurrentSubSelectionImpact ??= (zeroImpact ? context.AvgImpact : fieldImpact);
-
-            if (context.FragmentMapAlreadyBuilt)
-            {
-                if (field.SelectionSet == null) // leaf field
-                {
-                    context.RecordFieldComplexity(field, zeroImpact ? 0 : context.CurrentEndNodeImpact);
-                }
-                else
-                {
-                    context.Result.TotalQueryDepth++;
-
-                    double? impactFromArgs = AnalysisContext.GetImpactFromArgs(field);
-                    context.CurrentEndNodeImpact = impactFromArgs == null
-                        ? context.CurrentSubSelectionImpact.Value
-                        : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
-
-                    context.RecordFieldComplexity(field, zeroImpact ? 0 : context.CurrentEndNodeImpact);
-                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (zeroImpact ? context.AvgImpact : fieldImpact);
-                }
+                context.RecordFieldComplexity(field, zeroImpact ? 0 : context.CurrentEndNodeImpact);
             }
             else
             {
-                if (field.SelectionSet == null) // leaf field
-                {
-                    context.CurrentFragmentComplexity.Complexity += zeroImpact ? 0 : context.CurrentEndNodeImpact;
-                }
-                else
-                {
-                    context.CurrentFragmentComplexity.Depth++;
+                context.Result.TotalQueryDepth++;
 
-                    double? impactFromArgs = AnalysisContext.GetImpactFromArgs(field);
-                    context.CurrentEndNodeImpact = impactFromArgs == null
-                        ? context.CurrentSubSelectionImpact.Value
-                        : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
+                double? impactFromArgs = AnalysisContext.GetImpactFromArgs(field);
+                context.CurrentEndNodeImpact = impactFromArgs == null
+                    ? context.CurrentSubSelectionImpact.Value
+                    : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
 
-                    context.CurrentFragmentComplexity.Complexity += zeroImpact ? 0 : context.CurrentEndNodeImpact;
-                    context.CurrentSubSelectionImpact *= impactFromArgs ?? (zeroImpact ? context.AvgImpact : fieldImpact);
-                }
+                context.RecordFieldComplexity(field, zeroImpact ? 0 : context.CurrentEndNodeImpact);
+                context.CurrentSubSelectionImpact *= impactFromArgs ?? (zeroImpact ? context.AvgImpact : fieldImpact);
             }
-
-            await base.VisitFieldAsync(field, context).ConfigureAwait(false);
-
-            context.CurrentSubSelectionImpact = prevCurrentSubSelectionImpact;
-            context.CurrentEndNodeImpact = prevCurrentEndNodeImpact;
         }
-
-        protected override async ValueTask VisitFragmentSpreadAsync(GraphQLFragmentSpread fragmentSpread, AnalysisContext context)
+        else
         {
-            var fragmentComplexity = context.FragmentMap[fragmentSpread.FragmentName.Name.StringValue];
-
-            var complexity = (context.CurrentSubSelectionImpact ?? context.AvgImpact) / context.AvgImpact * fragmentComplexity.Complexity;
-            if (context.FragmentMapAlreadyBuilt)
+            if (field.SelectionSet == null) // leaf field
             {
-                context.RecordFieldComplexity(fragmentSpread, complexity);
-                context.Result.TotalQueryDepth += fragmentComplexity.Depth;
+                context.CurrentFragmentComplexity.Complexity += zeroImpact ? 0 : context.CurrentEndNodeImpact;
             }
             else
             {
-                context.CurrentFragmentComplexity.Complexity += complexity;
-                context.CurrentFragmentComplexity.Depth += fragmentComplexity.Depth;
-            }
+                context.CurrentFragmentComplexity.Depth++;
 
-            await base.VisitFragmentSpreadAsync(fragmentSpread, context).ConfigureAwait(false);
+                double? impactFromArgs = AnalysisContext.GetImpactFromArgs(field);
+                context.CurrentEndNodeImpact = impactFromArgs == null
+                    ? context.CurrentSubSelectionImpact.Value
+                    : impactFromArgs.Value / context.AvgImpact * context.CurrentSubSelectionImpact.Value;
+
+                context.CurrentFragmentComplexity.Complexity += zeroImpact ? 0 : context.CurrentEndNodeImpact;
+                context.CurrentSubSelectionImpact *= impactFromArgs ?? (zeroImpact ? context.AvgImpact : fieldImpact);
+            }
         }
+
+        await base.VisitFieldAsync(field, context).ConfigureAwait(false);
+
+        context.CurrentSubSelectionImpact = prevCurrentSubSelectionImpact;
+        context.CurrentEndNodeImpact = prevCurrentEndNodeImpact;
+    }
+
+    protected override async ValueTask VisitFragmentSpreadAsync(GraphQLFragmentSpread fragmentSpread, AnalysisContext context)
+    {
+        var fragmentComplexity = context.FragmentMap[fragmentSpread.FragmentName.Name.StringValue];
+
+        var complexity = (context.CurrentSubSelectionImpact ?? context.AvgImpact) / context.AvgImpact * fragmentComplexity.Complexity;
+        if (context.FragmentMapAlreadyBuilt)
+        {
+            context.RecordFieldComplexity(fragmentSpread, complexity);
+            context.Result.TotalQueryDepth += fragmentComplexity.Depth;
+        }
+        else
+        {
+            context.CurrentFragmentComplexity.Complexity += complexity;
+            context.CurrentFragmentComplexity.Depth += fragmentComplexity.Depth;
+        }
+
+        await base.VisitFragmentSpreadAsync(fragmentSpread, context).ConfigureAwait(false);
     }
 }

--- a/src/GraphQL/Validation/Complexity/FragmentComplexity.cs
+++ b/src/GraphQL/Validation/Complexity/FragmentComplexity.cs
@@ -1,24 +1,23 @@
-namespace GraphQL.Validation.Complexity
+namespace GraphQL.Validation.Complexity;
+
+/// <summary>
+/// Class to track complexity of fragment defined in GraphQL document.
+/// </summary>
+internal sealed class FragmentComplexity
 {
     /// <summary>
-    /// Class to track complexity of fragment defined in GraphQL document.
+    /// Depth of fragment.
+    /// <br/><br/>
+    /// Depth 0: fragment frag1 on Type { f }
+    /// <br/>
+    /// Depth 1: fragment frag1 on Type { f { ff } }
+    /// <br/>
+    /// Depth 2: fragment frag1 on Type { f { ff { fff } } }
     /// </summary>
-    internal sealed class FragmentComplexity
-    {
-        /// <summary>
-        /// Depth of fragment.
-        /// <br/><br/>
-        /// Depth 0: fragment frag1 on Type { f }
-        /// <br/>
-        /// Depth 1: fragment frag1 on Type { f { ff } }
-        /// <br/>
-        /// Depth 2: fragment frag1 on Type { f { ff { fff } } }
-        /// </summary>
-        public int Depth { get; set; }
+    public int Depth { get; set; }
 
-        /// <summary>
-        /// Complexity of fragment.
-        /// </summary>
-        public double Complexity { get; set; }
-    }
+    /// <summary>
+    /// Complexity of fragment.
+    /// </summary>
+    public double Complexity { get; set; }
 }

--- a/src/GraphQL/Validation/CompositeVariableVisitor.cs
+++ b/src/GraphQL/Validation/CompositeVariableVisitor.cs
@@ -1,39 +1,38 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+internal sealed class CompositeVariableVisitor : IVariableVisitor
 {
-    internal sealed class CompositeVariableVisitor : IVariableVisitor
+    private readonly List<IVariableVisitor> _visitors;
+
+    public CompositeVariableVisitor(List<IVariableVisitor> visitors)
     {
-        private readonly List<IVariableVisitor> _visitors;
+        _visitors = visitors;
+    }
 
-        public CompositeVariableVisitor(List<IVariableVisitor> visitors)
-        {
-            _visitors = visitors;
-        }
+    public async ValueTask VisitFieldAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, FieldType field, object? variableValue, object? parsedValue)
+    {
+        foreach (var visitor in _visitors)
+            await visitor.VisitFieldAsync(context, variable, variableName, type, field, variableValue, parsedValue).ConfigureAwait(false);
+    }
 
-        public async ValueTask VisitFieldAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, FieldType field, object? variableValue, object? parsedValue)
-        {
-            foreach (var visitor in _visitors)
-                await visitor.VisitFieldAsync(context, variable, variableName, type, field, variableValue, parsedValue).ConfigureAwait(false);
-        }
+    public async ValueTask VisitListAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ListGraphType type, object? variableValue, IList<object?>? parsedValue)
+    {
+        foreach (var visitor in _visitors)
+            await visitor.VisitListAsync(context, variable, variableName, type, variableValue, parsedValue).ConfigureAwait(false);
+    }
 
-        public async ValueTask VisitListAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ListGraphType type, object? variableValue, IList<object?>? parsedValue)
-        {
-            foreach (var visitor in _visitors)
-                await visitor.VisitListAsync(context, variable, variableName, type, variableValue, parsedValue).ConfigureAwait(false);
-        }
+    public async ValueTask VisitObjectAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, object? variableValue, object? parsedValue)
+    {
+        foreach (var visitor in _visitors)
+            await visitor.VisitObjectAsync(context, variable, variableName, type, variableValue, parsedValue).ConfigureAwait(false);
+    }
 
-        public async ValueTask VisitObjectAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, object? variableValue, object? parsedValue)
-        {
-            foreach (var visitor in _visitors)
-                await visitor.VisitObjectAsync(context, variable, variableName, type, variableValue, parsedValue).ConfigureAwait(false);
-        }
-
-        public async ValueTask VisitScalarAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ScalarGraphType type, object? variableValue, object? parsedValue)
-        {
-            foreach (var visitor in _visitors)
-                await visitor.VisitScalarAsync(context, variable, variableName, type, variableValue, parsedValue).ConfigureAwait(false);
-        }
+    public async ValueTask VisitScalarAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ScalarGraphType type, object? variableValue, object? parsedValue)
+    {
+        foreach (var visitor in _visitors)
+            await visitor.VisitScalarAsync(context, variable, variableName, type, variableValue, parsedValue).ConfigureAwait(false);
     }
 }

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -1,170 +1,136 @@
 using GraphQL.Validation.Rules;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Validates a document against a set of validation rules and returns a list of the errors found.
+/// If the document passes validation, also returns the set of parsed variables and argument values for fields and applied directives.
+/// </summary>
+public interface IDocumentValidator
 {
+    /// <inheritdoc cref="IDocumentValidator"/>
+    Task<IValidationResult> ValidateAsync(in ValidationOptions options);
+}
+
+/// <inheritdoc/>
+public partial class DocumentValidator : IDocumentValidator
+{
+    // frequently reused objects
+    private ValidationContext? _reusableValidationContext;
+
     /// <summary>
-    /// Validates a document against a set of validation rules and returns a list of the errors found.
-    /// If the document passes validation, also returns the set of parsed variables and argument values for fields and applied directives.
+    /// Returns the default set of validation rules.
     /// </summary>
-    public interface IDocumentValidator
+    public static readonly IEnumerable<IValidationRule> CoreRules = new List<IValidationRule>
     {
-        /// <inheritdoc cref="IDocumentValidator"/>
-        Task<IValidationResult> ValidateAsync(in ValidationOptions options);
-    }
+        UniqueOperationNames.Instance,
+        LoneAnonymousOperation.Instance,
+        SingleRootFieldSubscriptions.Instance,
+        KnownTypeNames.Instance,
+        FragmentsOnCompositeTypes.Instance,
+        VariablesAreInputTypes.Instance,
+        ScalarLeafs.Instance,
+        FieldsOnCorrectType.Instance,
+        UniqueFragmentNames.Instance,
+        KnownFragmentNames.Instance,
+        NoUnusedFragments.Instance,
+        PossibleFragmentSpreads.Instance,
+        NoFragmentCycles.Instance,
+        NoUndefinedVariables.Instance,
+        NoUnusedVariables.Instance,
+        UniqueVariableNames.Instance,
+        KnownDirectivesInAllowedLocations.Instance,
+        UniqueDirectivesPerLocation.Instance,
+        KnownArgumentNames.Instance,
+        UniqueArgumentNames.Instance,
+        ArgumentsOfCorrectType.Instance,
+        ProvidedNonNullArguments.Instance,
+        DefaultValuesOfCorrectType.Instance,
+        VariablesInAllowedPosition.Instance,
+        UniqueInputFieldNames.Instance,
+        OverlappingFieldsCanBeMerged.Instance,
+    };
 
     /// <inheritdoc/>
-    public partial class DocumentValidator : IDocumentValidator
+    public Task<IValidationResult> ValidateAsync(in ValidationOptions options)
     {
-        // frequently reused objects
-        private ValidationContext? _reusableValidationContext;
+        options.Schema.Initialize();
 
-        /// <summary>
-        /// Returns the default set of validation rules.
-        /// </summary>
-        public static readonly IEnumerable<IValidationRule> CoreRules = new List<IValidationRule>
+        var context = Interlocked.Exchange(ref _reusableValidationContext, null) ?? new ValidationContext();
+        context.TypeInfo = new TypeInfo(options.Schema);
+        context.Schema = options.Schema;
+        context.Document = options.Document;
+        context.UserContext = options.UserContext;
+        context.Variables = options.Variables;
+        context.Extensions = options.Extensions;
+        context.Operation = options.Operation;
+        context.Metrics = options.Metrics;
+        context.RequestServices = options.RequestServices;
+        context.User = options.User;
+        context.CancellationToken = options.CancellationToken;
+
+        return ValidateAsyncCoreAsync(context, options.Rules ?? CoreRules);
+    }
+
+    private async Task<IValidationResult> ValidateAsyncCoreAsync(ValidationContext context, IEnumerable<IValidationRule> rules)
+    {
+        try
         {
-            UniqueOperationNames.Instance,
-            LoneAnonymousOperation.Instance,
-            SingleRootFieldSubscriptions.Instance,
-            KnownTypeNames.Instance,
-            FragmentsOnCompositeTypes.Instance,
-            VariablesAreInputTypes.Instance,
-            ScalarLeafs.Instance,
-            FieldsOnCorrectType.Instance,
-            UniqueFragmentNames.Instance,
-            KnownFragmentNames.Instance,
-            NoUnusedFragments.Instance,
-            PossibleFragmentSpreads.Instance,
-            NoFragmentCycles.Instance,
-            NoUndefinedVariables.Instance,
-            NoUnusedVariables.Instance,
-            UniqueVariableNames.Instance,
-            KnownDirectivesInAllowedLocations.Instance,
-            UniqueDirectivesPerLocation.Instance,
-            KnownArgumentNames.Instance,
-            UniqueArgumentNames.Instance,
-            ArgumentsOfCorrectType.Instance,
-            ProvidedNonNullArguments.Instance,
-            DefaultValuesOfCorrectType.Instance,
-            VariablesInAllowedPosition.Instance,
-            UniqueInputFieldNames.Instance,
-            OverlappingFieldsCanBeMerged.Instance,
-        };
+            Variables? variables = null;
+            List<IVariableVisitor>? variableVisitors = null;
 
-        /// <inheritdoc/>
-        public Task<IValidationResult> ValidateAsync(in ValidationOptions options)
-        {
-            options.Schema.Initialize();
-
-            var context = Interlocked.Exchange(ref _reusableValidationContext, null) ?? new ValidationContext();
-            context.TypeInfo = new TypeInfo(options.Schema);
-            context.Schema = options.Schema;
-            context.Document = options.Document;
-            context.UserContext = options.UserContext;
-            context.Variables = options.Variables;
-            context.Extensions = options.Extensions;
-            context.Operation = options.Operation;
-            context.Metrics = options.Metrics;
-            context.RequestServices = options.RequestServices;
-            context.User = options.User;
-            context.CancellationToken = options.CancellationToken;
-
-            return ValidateAsyncCoreAsync(context, options.Rules ?? CoreRules);
-        }
-
-        private async Task<IValidationResult> ValidateAsyncCoreAsync(ValidationContext context, IEnumerable<IValidationRule> rules)
-        {
-            try
+            if (rules.Any())
             {
-                Variables? variables = null;
-                List<IVariableVisitor>? variableVisitors = null;
-
-                if (rules.Any())
+                var visitors = new List<INodeVisitor>
                 {
-                    var visitors = new List<INodeVisitor>
-                    {
-                        context.TypeInfo
-                    };
+                    context.TypeInfo
+                };
 
-                    foreach (var rule in rules)
-                    {
-                        var visitor = await rule.GetPreNodeVisitorAsync(context).ConfigureAwait(false);
-                        if (visitor != null)
-                            visitors.Add(visitor);
+                foreach (var rule in rules)
+                {
+                    var visitor = await rule.GetPreNodeVisitorAsync(context).ConfigureAwait(false);
+                    if (visitor != null)
+                        visitors.Add(visitor);
 
-                        var variableVisitor = await rule.GetVariableVisitorAsync(context).ConfigureAwait(false);
-                        if (variableVisitor != null)
-                            (variableVisitors ??= new()).Add(variableVisitor);
-                    }
-
-                    await new BasicVisitor(visitors).VisitAsync(context.Document, new BasicVisitor.State(context)).ConfigureAwait(false);
+                    var variableVisitor = await rule.GetVariableVisitorAsync(context).ConfigureAwait(false);
+                    if (variableVisitor != null)
+                        (variableVisitors ??= new()).Add(variableVisitor);
                 }
 
-                if (context.HasErrors)
-                {
-                    return new ValidationResult(context.Errors);
-                }
+                await new BasicVisitor(visitors).VisitAsync(context.Document, new BasicVisitor.State(context)).ConfigureAwait(false);
+            }
 
-                // can report errors even without rules enabled
-                (variables, var errors) = await context.GetVariablesValuesAsync(variableVisitors == null
-                    ? null
-                    : variableVisitors.Count == 1
-                        ? variableVisitors[0]
-                        : new CompositeVariableVisitor(variableVisitors)).ConfigureAwait(false);
+            if (context.HasErrors)
+            {
+                return new ValidationResult(context.Errors);
+            }
 
-                if (errors != null)
-                {
-                    foreach (var error in errors)
-                        context.ReportError(error);
-                }
+            // can report errors even without rules enabled
+            (variables, var errors) = await context.GetVariablesValuesAsync(variableVisitors == null
+                ? null
+                : variableVisitors.Count == 1
+                    ? variableVisitors[0]
+                    : new CompositeVariableVisitor(variableVisitors)).ConfigureAwait(false);
 
-                if (context.HasErrors)
-                {
-                    return new ValidationResult(context.Errors) { Variables = variables };
-                }
+            if (errors != null)
+            {
+                foreach (var error in errors)
+                    context.ReportError(error);
+            }
 
-                // parse all field arguments
-                using var parseArgumentVisitorContext = new ParseArgumentVisitor.Context(context, variables);
-                await ParseArgumentVisitor.Instance.VisitAsync(context.Document, parseArgumentVisitorContext).ConfigureAwait(false);
-                context.ArgumentValues = parseArgumentVisitorContext.ArgumentValues;
-                context.DirectiveValues = parseArgumentVisitorContext.DirectiveValues;
+            if (context.HasErrors)
+            {
+                return new ValidationResult(context.Errors) { Variables = variables };
+            }
 
-                if (context.HasErrors)
-                {
-                    return new ValidationResult(context.Errors)
-                    {
-                        Variables = variables,
-                        ArgumentValues = context.ArgumentValues,
-                        DirectiveValues = context.DirectiveValues,
-                    };
-                }
+            // parse all field arguments
+            using var parseArgumentVisitorContext = new ParseArgumentVisitor.Context(context, variables);
+            await ParseArgumentVisitor.Instance.VisitAsync(context.Document, parseArgumentVisitorContext).ConfigureAwait(false);
+            context.ArgumentValues = parseArgumentVisitorContext.ArgumentValues;
+            context.DirectiveValues = parseArgumentVisitorContext.DirectiveValues;
 
-                if (rules.Any())
-                {
-                    List<INodeVisitor>? visitors = null;
-
-                    foreach (var rule in rules)
-                    {
-                        var visitor = await rule.GetPostNodeVisitorAsync(context).ConfigureAwait(false);
-                        if (visitor != null)
-                        {
-                            visitors ??= [context.TypeInfo];
-                            visitors.Add(visitor);
-                        }
-                    }
-
-                    if (visitors != null)
-                    {
-                        // clear state of TypeInfo structure to be sure that it is not polluted by previous validation
-                        context.TypeInfo.Clear();
-
-                        await new BasicVisitor(visitors).VisitAsync(context.Document, new BasicVisitor.State(context)).ConfigureAwait(false);
-                    }
-                }
-
-                if (!context.HasErrors && variables == Variables.None && context.ArgumentValues == null && context.DirectiveValues == null)
-                    return SuccessfullyValidatedResult.Instance;
-
+            if (context.HasErrors)
+            {
                 return new ValidationResult(context.Errors)
                 {
                     Variables = variables,
@@ -172,13 +138,46 @@ namespace GraphQL.Validation
                     DirectiveValues = context.DirectiveValues,
                 };
             }
-            finally
+
+            if (rules.Any())
             {
-                if (!context.HasErrors)
+                List<INodeVisitor>? visitors = null;
+
+                foreach (var rule in rules)
                 {
-                    context.Reset();
-                    _ = Interlocked.CompareExchange(ref _reusableValidationContext, context, null);
+                    var visitor = await rule.GetPostNodeVisitorAsync(context).ConfigureAwait(false);
+                    if (visitor != null)
+                    {
+                        visitors ??= [context.TypeInfo];
+                        visitors.Add(visitor);
+                    }
                 }
+
+                if (visitors != null)
+                {
+                    // clear state of TypeInfo structure to be sure that it is not polluted by previous validation
+                    context.TypeInfo.Clear();
+
+                    await new BasicVisitor(visitors).VisitAsync(context.Document, new BasicVisitor.State(context)).ConfigureAwait(false);
+                }
+            }
+
+            if (!context.HasErrors && variables == Variables.None && context.ArgumentValues == null && context.DirectiveValues == null)
+                return SuccessfullyValidatedResult.Instance;
+
+            return new ValidationResult(context.Errors)
+            {
+                Variables = variables,
+                ArgumentValues = context.ArgumentValues,
+                DirectiveValues = context.DirectiveValues,
+            };
+        }
+        finally
+        {
+            if (!context.HasErrors)
+            {
+                context.Reset();
+                _ = Interlocked.CompareExchange(ref _reusableValidationContext, context, null);
             }
         }
     }

--- a/src/GraphQL/Validation/Errors.Custom/InputFieldsAndArgumentsOfCorrectLengthError.cs
+++ b/src/GraphQL/Validation/Errors.Custom/InputFieldsAndArgumentsOfCorrectLengthError.cs
@@ -1,43 +1,42 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.InputFieldsAndArgumentsOfCorrectLength"/>
+[Serializable]
+public class InputFieldsAndArgumentsOfCorrectLengthError : ValidationError
 {
-    /// <inheritdoc cref="Rules.InputFieldsAndArgumentsOfCorrectLength"/>
-    [Serializable]
-    public class InputFieldsAndArgumentsOfCorrectLengthError : ValidationError
+    private const string NUMBER = "5.6.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public InputFieldsAndArgumentsOfCorrectLengthError(ValidationContext context, ASTNode node, int? length, int? min, int? max)
+        : base(context.Document.Source, NUMBER, BadValueMessage(node, length, min, max), node)
     {
-        private const string NUMBER = "5.6.1";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public InputFieldsAndArgumentsOfCorrectLengthError(ValidationContext context, ASTNode node, int? length, int? min, int? max)
-            : base(context.Document.Source, NUMBER, BadValueMessage(node, length, min, max), node)
-        {
-        }
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public InputFieldsAndArgumentsOfCorrectLengthError(ValidationContext context, GraphQLVariableDefinition node, VariableName variableName, int? length, int? min, int? max)
+        : base(context.Document.Source, NUMBER, BadValueMessage(variableName, length, min, max), node)
+    {
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public InputFieldsAndArgumentsOfCorrectLengthError(ValidationContext context, GraphQLVariableDefinition node, VariableName variableName, int? length, int? min, int? max)
-            : base(context.Document.Source, NUMBER, BadValueMessage(variableName, length, min, max), node)
-        {
-        }
+    private static string BadValueMessage(ASTNode node, int? length, int? minLength, int? maxLength)
+    {
+        string len = length.HasValue ? length.ToString()! : "null";
+        string min = (minLength ?? 0).ToString();
+        string max = maxLength.HasValue ? maxLength.ToString()! : "unrestricted";
+        return $"{node.Kind} '{((INamedNode)node).Name}' has invalid length ({len}). Length must be in range [{min}, {max}].";
+    }
 
-        private static string BadValueMessage(ASTNode node, int? length, int? minLength, int? maxLength)
-        {
-            string len = length.HasValue ? length.ToString()! : "null";
-            string min = (minLength ?? 0).ToString();
-            string max = maxLength.HasValue ? maxLength.ToString()! : "unrestricted";
-            return $"{node.Kind} '{((INamedNode)node).Name}' has invalid length ({len}). Length must be in range [{min}, {max}].";
-        }
-
-        private static string BadValueMessage(VariableName variableName, int? length, int? minLength, int? maxLength)
-        {
-            string len = length.HasValue ? length.ToString()! : "null";
-            string min = (minLength ?? 0).ToString();
-            string max = maxLength.HasValue ? maxLength.ToString()! : "unrestricted";
-            return $"Variable '{variableName}' has invalid length ({len}). Length must be in range [{min}, {max}].";
-        }
+    private static string BadValueMessage(VariableName variableName, int? length, int? minLength, int? maxLength)
+    {
+        string len = length.HasValue ? length.ToString()! : "null";
+        string min = (minLength ?? 0).ToString();
+        string max = maxLength.HasValue ? maxLength.ToString()! : "unrestricted";
+        return $"Variable '{variableName}' has invalid length ({len}). Length must be in range [{min}, {max}].";
     }
 }

--- a/src/GraphQL/Validation/Errors.Custom/InvalidVariableError.cs
+++ b/src/GraphQL/Validation/Errors.Custom/InvalidVariableError.cs
@@ -1,33 +1,32 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Represents an error triggered by an invalid variable passed with the associated document.
+/// </summary>
+[Serializable]
+public class InvalidVariableError : ValidationError
 {
+    // The specification does not contain rules for validating the actual variables values, so the number of the entire section of the specification is used.
+    private const string NUMBER = "5.8";
+
     /// <summary>
-    /// Represents an error triggered by an invalid variable passed with the associated document.
+    /// Initializes a new instance of the <see cref="InvalidVariableError"/> class for a specified variable and error message.
     /// </summary>
-    [Serializable]
-    public class InvalidVariableError : ValidationError
+    public InvalidVariableError(ValidationContext context, GraphQLVariableDefinition node, VariableName variableName, string message)
+        : base(context.Document.Source, NUMBER, $"Variable '${variableName}' is invalid. {message}", node)
     {
-        // The specification does not contain rules for validating the actual variables values, so the number of the entire section of the specification is used.
-        private const string NUMBER = "5.8";
+        Code = "INVALID_VALUE";
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidVariableError"/> class for a specified variable and error message.
-        /// </summary>
-        public InvalidVariableError(ValidationContext context, GraphQLVariableDefinition node, VariableName variableName, string message)
-            : base(context.Document.Source, NUMBER, $"Variable '${variableName}' is invalid. {message}", node)
-        {
-            Code = "INVALID_VALUE";
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidVariableError"/> class for a specified variable
-        /// and error message. Loads any exception data from the inner exception into this instance.
-        /// </summary>
-        public InvalidVariableError(ValidationContext context, GraphQLVariableDefinition node, VariableName variableName, string message, Exception innerException)
-            : base(context.Document.Source, NUMBER, $"Variable '${variableName}' is invalid. {message}", innerException, node)
-        {
-            Code = "INVALID_VALUE";
-        }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidVariableError"/> class for a specified variable
+    /// and error message. Loads any exception data from the inner exception into this instance.
+    /// </summary>
+    public InvalidVariableError(ValidationContext context, GraphQLVariableDefinition node, VariableName variableName, string message, Exception innerException)
+        : base(context.Document.Source, NUMBER, $"Variable '${variableName}' is invalid. {message}", innerException, node)
+    {
+        Code = "INVALID_VALUE";
     }
 }

--- a/src/GraphQL/Validation/Errors/ArgumentsOfCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/ArgumentsOfCorrectTypeError.cs
@@ -1,26 +1,25 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.ArgumentsOfCorrectType"/>
+[Serializable]
+public class ArgumentsOfCorrectTypeError : ValidationError
 {
-    /// <inheritdoc cref="Rules.ArgumentsOfCorrectType"/>
-    [Serializable]
-    public class ArgumentsOfCorrectTypeError : ValidationError
+    internal const string NUMBER = "5.6.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public ArgumentsOfCorrectTypeError(ValidationContext context, GraphQLArgument node, string verboseErrors)
+        : base(context.Document.Source, NUMBER, BadValueMessage(node.Name.StringValue, verboseErrors), node)
     {
-        internal const string NUMBER = "5.6.1";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public ArgumentsOfCorrectTypeError(ValidationContext context, GraphQLArgument node, string verboseErrors)
-            : base(context.Document.Source, NUMBER, BadValueMessage(node.Name.StringValue, verboseErrors), node)
-        {
-        }
-
-        internal static string BadValueMessage(string argName, string verboseErrors)
-        {
-            return string.IsNullOrEmpty(verboseErrors)
-                ? $"Argument '{argName}' has invalid value."
-                : $"Argument '{argName}' has invalid value. {verboseErrors}";
-        }
+    internal static string BadValueMessage(string argName, string verboseErrors)
+    {
+        return string.IsNullOrEmpty(verboseErrors)
+            ? $"Argument '{argName}' has invalid value."
+            : $"Argument '{argName}' has invalid value. {verboseErrors}";
     }
 }

--- a/src/GraphQL/Validation/Errors/DefaultValuesOfCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/DefaultValuesOfCorrectTypeError.cs
@@ -1,27 +1,26 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.DefaultValuesOfCorrectType"/>
+[Serializable]
+public class DefaultValuesOfCorrectTypeError : ValidationError
 {
-    /// <inheritdoc cref="Rules.DefaultValuesOfCorrectType"/>
-    [Serializable]
-    public class DefaultValuesOfCorrectTypeError : ValidationError
+    internal const string NUMBER = "5.6.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public DefaultValuesOfCorrectTypeError(ValidationContext context, GraphQLVariableDefinition varDefAst, IGraphType inputType, string verboseErrors)
+        : base(context.Document.Source, NUMBER, BadValueForDefaultArgMessage(varDefAst.Variable.Name.StringValue, inputType.ToString()!, varDefAst.DefaultValue!.Print(), verboseErrors), varDefAst.DefaultValue!)
     {
-        internal const string NUMBER = "5.6.1";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public DefaultValuesOfCorrectTypeError(ValidationContext context, GraphQLVariableDefinition varDefAst, IGraphType inputType, string verboseErrors)
-            : base(context.Document.Source, NUMBER, BadValueForDefaultArgMessage(varDefAst.Variable.Name.StringValue, inputType.ToString()!, varDefAst.DefaultValue!.Print(), verboseErrors), varDefAst.DefaultValue!)
-        {
-        }
-
-        internal static string BadValueForDefaultArgMessage(string varName, string type, string value, string verboseErrors)
-        {
-            return string.IsNullOrEmpty(verboseErrors)
-                ? $"Variable '{varName}' of type '{type}' has invalid default value '{value}'."
-                : $"Variable '{varName}' of type '{type}' has invalid default value '{value}'. {verboseErrors}";
-        }
+    internal static string BadValueForDefaultArgMessage(string varName, string type, string value, string verboseErrors)
+    {
+        return string.IsNullOrEmpty(verboseErrors)
+            ? $"Variable '{varName}' of type '{type}' has invalid default value '{value}'."
+            : $"Variable '{varName}' of type '{type}' has invalid default value '{value}'. {verboseErrors}";
     }
 }

--- a/src/GraphQL/Validation/Errors/DirectivesInAllowedLocationsError.cs
+++ b/src/GraphQL/Validation/Errors/DirectivesInAllowedLocationsError.cs
@@ -1,17 +1,16 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.KnownDirectivesInAllowedLocations"/>
+[Serializable]
+public class DirectivesInAllowedLocationsError : ValidationError
 {
-    /// <inheritdoc cref="Rules.KnownDirectivesInAllowedLocations"/>
-    [Serializable]
-    public class DirectivesInAllowedLocationsError : ValidationError
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public DirectivesInAllowedLocationsError(ValidationContext context, GraphQLDirective node, DirectiveLocation candidateLocation)
+        : base(context.Document.Source, "5.7.2", $"Directive '{node.Name}' may not be used on {candidateLocation}.", node)
     {
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public DirectivesInAllowedLocationsError(ValidationContext context, GraphQLDirective node, DirectiveLocation candidateLocation)
-            : base(context.Document.Source, "5.7.2", $"Directive '{node.Name}' may not be used on {candidateLocation}.", node)
-        {
-        }
     }
 }

--- a/src/GraphQL/Validation/Errors/FieldsOnCorrectTypeError.cs
+++ b/src/GraphQL/Validation/Errors/FieldsOnCorrectTypeError.cs
@@ -2,51 +2,50 @@ using GraphQL.Types;
 using GraphQL.Utilities;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.FieldsOnCorrectType"/>
+[Serializable]
+public class FieldsOnCorrectTypeError : ValidationError
 {
-    /// <inheritdoc cref="Rules.FieldsOnCorrectType"/>
-    [Serializable]
-    public class FieldsOnCorrectTypeError : ValidationError
+    internal const string NUMBER = "5.3.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public FieldsOnCorrectTypeError(ValidationContext context, GraphQLField node, IGraphType type, IEnumerable<string> suggestedTypeNames, IEnumerable<string> suggestedFieldNames)
+        : base(context.Document.Source, NUMBER, UndefinedFieldMessage(node.Name.StringValue, type.Name, suggestedTypeNames, suggestedFieldNames), node)
     {
-        internal const string NUMBER = "5.3.1";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public FieldsOnCorrectTypeError(ValidationContext context, GraphQLField node, IGraphType type, IEnumerable<string> suggestedTypeNames, IEnumerable<string> suggestedFieldNames)
-            : base(context.Document.Source, NUMBER, UndefinedFieldMessage(node.Name.StringValue, type.Name, suggestedTypeNames, suggestedFieldNames), node)
+    internal static string UndefinedFieldMessage(
+        string fieldName,
+        string type,
+        IEnumerable<string> suggestedTypeNames,
+        IEnumerable<string> suggestedFieldNames)
+    {
+        var message = $"Cannot query field '{fieldName}' on type '{type}'.";
+
+        if (suggestedTypeNames != null)
         {
+            var suggestedTypeNamesList = suggestedTypeNames.ToList();
+            if (suggestedTypeNamesList.Count > 0)
+            {
+                var suggestions = StringUtils.QuotedOrList(suggestedTypeNamesList);
+                message += $" Did you mean to use an inline fragment on {suggestions}?";
+                return message;
+            }
         }
 
-        internal static string UndefinedFieldMessage(
-            string fieldName,
-            string type,
-            IEnumerable<string> suggestedTypeNames,
-            IEnumerable<string> suggestedFieldNames)
+        if (suggestedFieldNames != null)
         {
-            var message = $"Cannot query field '{fieldName}' on type '{type}'.";
-
-            if (suggestedTypeNames != null)
+            var suggestedFieldNamesList = suggestedFieldNames.ToList();
+            if (suggestedFieldNamesList.Count > 0)
             {
-                var suggestedTypeNamesList = suggestedTypeNames.ToList();
-                if (suggestedTypeNamesList.Count > 0)
-                {
-                    var suggestions = StringUtils.QuotedOrList(suggestedTypeNamesList);
-                    message += $" Did you mean to use an inline fragment on {suggestions}?";
-                    return message;
-                }
+                message += $" Did you mean {StringUtils.QuotedOrList(suggestedFieldNamesList)}?";
             }
-
-            if (suggestedFieldNames != null)
-            {
-                var suggestedFieldNamesList = suggestedFieldNames.ToList();
-                if (suggestedFieldNamesList.Count > 0)
-                {
-                    message += $" Did you mean {StringUtils.QuotedOrList(suggestedFieldNamesList)}?";
-                }
-            }
-
-            return message;
         }
+
+        return message;
     }
 }

--- a/src/GraphQL/Validation/Errors/FragmentsOnCompositeTypesError.cs
+++ b/src/GraphQL/Validation/Errors/FragmentsOnCompositeTypesError.cs
@@ -1,33 +1,32 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.FragmentsOnCompositeTypes"/>
+[Serializable]
+public class FragmentsOnCompositeTypesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.FragmentsOnCompositeTypes"/>
-    [Serializable]
-    public class FragmentsOnCompositeTypesError : ValidationError
+    internal const string NUMBER = "5.5.1.3";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public FragmentsOnCompositeTypesError(ValidationContext context, GraphQLInlineFragment node)
+        : base(context.Document.Source, NUMBER, InlineFragmentOnNonCompositeErrorMessage(node.TypeCondition!.Type.Print()), node.TypeCondition!.Type)
     {
-        internal const string NUMBER = "5.5.1.3";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public FragmentsOnCompositeTypesError(ValidationContext context, GraphQLInlineFragment node)
-            : base(context.Document.Source, NUMBER, InlineFragmentOnNonCompositeErrorMessage(node.TypeCondition!.Type.Print()), node.TypeCondition!.Type)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public FragmentsOnCompositeTypesError(ValidationContext context, GraphQLFragmentDefinition node)
-            : base(context.Document.Source, NUMBER, FragmentOnNonCompositeErrorMessage(node.FragmentName.Name.StringValue, node.TypeCondition.Type.Print()), node.TypeCondition.Type)
-        {
-        }
-
-        internal static string InlineFragmentOnNonCompositeErrorMessage(string type)
-            => $"Fragment cannot condition on non composite type '{type}'.";
-
-        internal static string FragmentOnNonCompositeErrorMessage(string fragName, string type)
-            => $"Fragment '{fragName}' cannot condition on non composite type '{type}'.";
     }
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public FragmentsOnCompositeTypesError(ValidationContext context, GraphQLFragmentDefinition node)
+        : base(context.Document.Source, NUMBER, FragmentOnNonCompositeErrorMessage(node.FragmentName.Name.StringValue, node.TypeCondition.Type.Print()), node.TypeCondition.Type)
+    {
+    }
+
+    internal static string InlineFragmentOnNonCompositeErrorMessage(string type)
+        => $"Fragment cannot condition on non composite type '{type}'.";
+
+    internal static string FragmentOnNonCompositeErrorMessage(string fragName, string type)
+        => $"Fragment '{fragName}' cannot condition on non composite type '{type}'.";
 }

--- a/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownArgumentNamesError.cs
@@ -2,59 +2,58 @@ using GraphQL.Types;
 using GraphQL.Utilities;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.KnownArgumentNames"/>
+[Serializable]
+public class KnownArgumentNamesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.KnownArgumentNames"/>
-    [Serializable]
-    public class KnownArgumentNamesError : ValidationError
+    internal const string NUMBER = "5.4.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public KnownArgumentNamesError(ValidationContext context, GraphQLArgument node, FieldType fieldDef, IGraphType parentType)
+        : base(context.Document.Source, NUMBER,
+            UnknownArgMessage(
+                node.Name.StringValue,
+                fieldDef.Name,
+                parentType.ToString()!,
+                StringUtils.SuggestionList(node.Name.StringValue, fieldDef.Arguments?.List?.Select(q => q.Name))), //ISSUE:allocation
+            node)
     {
-        internal const string NUMBER = "5.4.1";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public KnownArgumentNamesError(ValidationContext context, GraphQLArgument node, FieldType fieldDef, IGraphType parentType)
-            : base(context.Document.Source, NUMBER,
-                UnknownArgMessage(
-                    node.Name.StringValue,
-                    fieldDef.Name,
-                    parentType.ToString()!,
-                    StringUtils.SuggestionList(node.Name.StringValue, fieldDef.Arguments?.List?.Select(q => q.Name))), //ISSUE:allocation
-                node)
-        {
-        }
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public KnownArgumentNamesError(ValidationContext context, GraphQLArgument node, Directive directive)
+        : base(context.Document.Source, NUMBER,
+            UnknownDirectiveArgMessage(
+                node.Name.StringValue,
+                directive.Name,
+                StringUtils.SuggestionList(node.Name.StringValue, directive.Arguments?.Select(q => q.Name))), //ISSUE:allocation
+            node)
+    {
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public KnownArgumentNamesError(ValidationContext context, GraphQLArgument node, Directive directive)
-            : base(context.Document.Source, NUMBER,
-                UnknownDirectiveArgMessage(
-                    node.Name.StringValue,
-                    directive.Name,
-                    StringUtils.SuggestionList(node.Name.StringValue, directive.Arguments?.Select(q => q.Name))), //ISSUE:allocation
-                node)
+    internal static string UnknownArgMessage(string argName, string fieldName, string type, params string[] suggestedArgs)
+    {
+        var message = $"Unknown argument '{argName}' on field '{fieldName}' of type '{type}'.";
+        if (suggestedArgs != null && suggestedArgs.Length > 0)
         {
+            message += $" Did you mean {StringUtils.QuotedOrList(suggestedArgs)}";
         }
+        return message;
+    }
 
-        internal static string UnknownArgMessage(string argName, string fieldName, string type, params string[] suggestedArgs)
+    internal static string UnknownDirectiveArgMessage(string argName, string directiveName, params string[] suggestedArgs)
+    {
+        var message = $"Unknown argument '{argName}' on directive '{directiveName}'.";
+        if (suggestedArgs != null && suggestedArgs.Length > 0)
         {
-            var message = $"Unknown argument '{argName}' on field '{fieldName}' of type '{type}'.";
-            if (suggestedArgs != null && suggestedArgs.Length > 0)
-            {
-                message += $" Did you mean {StringUtils.QuotedOrList(suggestedArgs)}";
-            }
-            return message;
+            message += $" Did you mean {StringUtils.QuotedOrList(suggestedArgs)}";
         }
-
-        internal static string UnknownDirectiveArgMessage(string argName, string directiveName, params string[] suggestedArgs)
-        {
-            var message = $"Unknown argument '{argName}' on directive '{directiveName}'.";
-            if (suggestedArgs != null && suggestedArgs.Length > 0)
-            {
-                message += $" Did you mean {StringUtils.QuotedOrList(suggestedArgs)}";
-            }
-            return message;
-        }
+        return message;
     }
 }

--- a/src/GraphQL/Validation/Errors/KnownDirectivesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownDirectivesError.cs
@@ -1,19 +1,18 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
-{
-    /// <inheritdoc cref="Rules.KnownDirectivesInAllowedLocations"/>
-    [Serializable]
-    public class KnownDirectivesError : ValidationError
-    {
-        internal const string NUMBER = "5.7.1";
+namespace GraphQL.Validation.Errors;
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public KnownDirectivesError(ValidationContext context, GraphQLDirective node)
-            : base(context.Document.Source, NUMBER, $"Unknown directive '{node.Name}'.", node)
-        {
-        }
+/// <inheritdoc cref="Rules.KnownDirectivesInAllowedLocations"/>
+[Serializable]
+public class KnownDirectivesError : ValidationError
+{
+    internal const string NUMBER = "5.7.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public KnownDirectivesError(ValidationContext context, GraphQLDirective node)
+        : base(context.Document.Source, NUMBER, $"Unknown directive '{node.Name}'.", node)
+    {
     }
 }

--- a/src/GraphQL/Validation/Errors/KnownFragmentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownFragmentNamesError.cs
@@ -1,22 +1,21 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.KnownFragmentNames"/>
+[Serializable]
+public class KnownFragmentNamesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.KnownFragmentNames"/>
-    [Serializable]
-    public class KnownFragmentNamesError : ValidationError
+    internal const string NUMBER = "5.5.2.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public KnownFragmentNamesError(ValidationContext context, GraphQLFragmentSpread node, string fragmentName)
+        : base(context.Document.Source, NUMBER, UnknownFragmentMessage(fragmentName), node)
     {
-        internal const string NUMBER = "5.5.2.1";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public KnownFragmentNamesError(ValidationContext context, GraphQLFragmentSpread node, string fragmentName)
-            : base(context.Document.Source, NUMBER, UnknownFragmentMessage(fragmentName), node)
-        {
-        }
-
-        internal static string UnknownFragmentMessage(string fragName)
-            => $"Unknown fragment '{fragName}'.";
     }
+
+    internal static string UnknownFragmentMessage(string fragName)
+        => $"Unknown fragment '{fragName}'.";
 }

--- a/src/GraphQL/Validation/Errors/KnownTypeNamesError.cs
+++ b/src/GraphQL/Validation/Errors/KnownTypeNamesError.cs
@@ -1,30 +1,29 @@
 using GraphQL.Utilities;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.KnownTypeNames"/>
+[Serializable]
+public class KnownTypeNamesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.KnownTypeNames"/>
-    [Serializable]
-    public class KnownTypeNamesError : ValidationError
+    internal const string NUMBER = "5.5.1.2";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public KnownTypeNamesError(ValidationContext context, GraphQLNamedType node, string[] suggestedTypes)
+        : base(context.Document.Source, NUMBER, UnknownTypeMessage(node.Name.StringValue, suggestedTypes), node)
     {
-        internal const string NUMBER = "5.5.1.2";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public KnownTypeNamesError(ValidationContext context, GraphQLNamedType node, string[] suggestedTypes)
-            : base(context.Document.Source, NUMBER, UnknownTypeMessage(node.Name.StringValue, suggestedTypes), node)
+    internal static string UnknownTypeMessage(string type, params string[] suggestedTypes)
+    {
+        var message = $"Unknown type {type}.";
+        if (suggestedTypes != null && suggestedTypes.Length > 0)
         {
+            message += $" Did you mean {StringUtils.QuotedOrList(suggestedTypes)}?";
         }
-
-        internal static string UnknownTypeMessage(string type, params string[] suggestedTypes)
-        {
-            var message = $"Unknown type {type}.";
-            if (suggestedTypes != null && suggestedTypes.Length > 0)
-            {
-                message += $" Did you mean {StringUtils.QuotedOrList(suggestedTypes)}?";
-            }
-            return message;
-        }
+        return message;
     }
 }

--- a/src/GraphQL/Validation/Errors/LoneAnonymousOperationError.cs
+++ b/src/GraphQL/Validation/Errors/LoneAnonymousOperationError.cs
@@ -1,22 +1,21 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.LoneAnonymousOperation"/>
+[Serializable]
+public class LoneAnonymousOperationError : ValidationError
 {
-    /// <inheritdoc cref="Rules.LoneAnonymousOperation"/>
-    [Serializable]
-    public class LoneAnonymousOperationError : ValidationError
+    internal const string NUMBER = "5.2.2.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public LoneAnonymousOperationError(ValidationContext context, GraphQLOperationDefinition node)
+        : base(context.Document.Source, NUMBER, AnonOperationNotAloneMessage(), node)
     {
-        internal const string NUMBER = "5.2.2.1";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public LoneAnonymousOperationError(ValidationContext context, GraphQLOperationDefinition node)
-            : base(context.Document.Source, NUMBER, AnonOperationNotAloneMessage(), node)
-        {
-        }
-
-        internal static string AnonOperationNotAloneMessage()
-            => "This anonymous operation must be the only defined operation.";
     }
+
+    internal static string AnonOperationNotAloneMessage()
+        => "This anonymous operation must be the only defined operation.";
 }

--- a/src/GraphQL/Validation/Errors/NoFragmentCyclesError.cs
+++ b/src/GraphQL/Validation/Errors/NoFragmentCyclesError.cs
@@ -1,25 +1,24 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.NoFragmentCycles"/>
+[Serializable]
+public class NoFragmentCyclesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.NoFragmentCycles"/>
-    [Serializable]
-    public class NoFragmentCyclesError : ValidationError
+    internal const string NUMBER = "5.5.2.2";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public NoFragmentCyclesError(ValidationContext context, string fragName, string[] spreadNames, params ASTNode[] nodes)
+        : base(context.Document.Source, NUMBER, CycleErrorMessage(fragName, spreadNames), nodes)
     {
-        internal const string NUMBER = "5.5.2.2";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public NoFragmentCyclesError(ValidationContext context, string fragName, string[] spreadNames, params ASTNode[] nodes)
-            : base(context.Document.Source, NUMBER, CycleErrorMessage(fragName, spreadNames), nodes)
-        {
-        }
-
-        internal static string CycleErrorMessage(string fragName, string[] spreadNames)
-        {
-            var via = spreadNames.Length > 0 ? " via " + string.Join(", ", spreadNames) : "";
-            return $"Cannot spread fragment '{fragName}' within itself{via}.";
-        }
+    internal static string CycleErrorMessage(string fragName, string[] spreadNames)
+    {
+        var via = spreadNames.Length > 0 ? " via " + string.Join(", ", spreadNames) : "";
+        return $"Cannot spread fragment '{fragName}' within itself{via}.";
     }
 }

--- a/src/GraphQL/Validation/Errors/NoUndefinedVariablesError.cs
+++ b/src/GraphQL/Validation/Errors/NoUndefinedVariablesError.cs
@@ -1,26 +1,25 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.NoUndefinedVariables"/>
+[Serializable]
+public class NoUndefinedVariablesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.NoUndefinedVariables"/>
-    [Serializable]
-    public class NoUndefinedVariablesError : ValidationError
+    internal const string NUMBER = "5.8.3";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public NoUndefinedVariablesError(ValidationContext context, GraphQLOperationDefinition node, GraphQLVariable variableReference)
+        : base(context.Document.Source, NUMBER, UndefinedVarMessage(variableReference.Name.StringValue, node.Name?.StringValue), variableReference, node)
     {
-        internal const string NUMBER = "5.8.3";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public NoUndefinedVariablesError(ValidationContext context, GraphQLOperationDefinition node, GraphQLVariable variableReference)
-            : base(context.Document.Source, NUMBER, UndefinedVarMessage(variableReference.Name.StringValue, node.Name?.StringValue), variableReference, node)
-        {
-        }
-
-        internal static string UndefinedVarMessage(string varName, string? opName)
-        {
-            return string.IsNullOrEmpty(opName)
-                ? $"Variable '${varName}' is not defined."
-                : $"Variable '${varName}' is not defined by operation '{opName}'.";
-        }
+    internal static string UndefinedVarMessage(string varName, string? opName)
+    {
+        return string.IsNullOrEmpty(opName)
+            ? $"Variable '${varName}' is not defined."
+            : $"Variable '${varName}' is not defined by operation '{opName}'.";
     }
 }

--- a/src/GraphQL/Validation/Errors/NoUnusedFragmentsError.cs
+++ b/src/GraphQL/Validation/Errors/NoUnusedFragmentsError.cs
@@ -1,22 +1,21 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.NoUnusedFragments"/>
+[Serializable]
+public class NoUnusedFragmentsError : ValidationError
 {
-    /// <inheritdoc cref="Rules.NoUnusedFragments"/>
-    [Serializable]
-    public class NoUnusedFragmentsError : ValidationError
+    internal const string NUMBER = "5.5.1.4";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public NoUnusedFragmentsError(ValidationContext context, GraphQLFragmentDefinition node)
+        : base(context.Document.Source, NUMBER, UnusedFragMessage(node.FragmentName.Name.StringValue), node)
     {
-        internal const string NUMBER = "5.5.1.4";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public NoUnusedFragmentsError(ValidationContext context, GraphQLFragmentDefinition node)
-            : base(context.Document.Source, NUMBER, UnusedFragMessage(node.FragmentName.Name.StringValue), node)
-        {
-        }
-
-        internal static string UnusedFragMessage(string fragName)
-            => $"Fragment '{fragName}' is never used.";
     }
+
+    internal static string UnusedFragMessage(string fragName)
+        => $"Fragment '{fragName}' is never used.";
 }

--- a/src/GraphQL/Validation/Errors/NoUnusedVariablesError.cs
+++ b/src/GraphQL/Validation/Errors/NoUnusedVariablesError.cs
@@ -1,26 +1,25 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.NoUnusedVariables"/>
+[Serializable]
+public class NoUnusedVariablesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.NoUnusedVariables"/>
-    [Serializable]
-    public class NoUnusedVariablesError : ValidationError
+    internal const string NUMBER = "5.8.4";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public NoUnusedVariablesError(ValidationContext context, GraphQLVariableDefinition node, GraphQLOperationDefinition op)
+        : base(context.Document.Source, NUMBER, UnusedVariableMessage(node.Variable.Name.StringValue, op.Name?.StringValue), node)
     {
-        internal const string NUMBER = "5.8.4";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public NoUnusedVariablesError(ValidationContext context, GraphQLVariableDefinition node, GraphQLOperationDefinition op)
-            : base(context.Document.Source, NUMBER, UnusedVariableMessage(node.Variable.Name.StringValue, op.Name?.StringValue), node)
-        {
-        }
-
-        internal static string UnusedVariableMessage(string varName, string? opName)
-        {
-            return string.IsNullOrEmpty(opName)
-                ? $"Variable '${varName}' is never used."
-                : $"Variable '${varName}' is never used in operation '${opName}'.";
-        }
+    internal static string UnusedVariableMessage(string varName, string? opName)
+    {
+        return string.IsNullOrEmpty(opName)
+            ? $"Variable '${varName}' is never used."
+            : $"Variable '${varName}' is never used in operation '${opName}'.";
     }
 }

--- a/src/GraphQL/Validation/Errors/OverlappingFieldsCanBeMergedError.cs
+++ b/src/GraphQL/Validation/Errors/OverlappingFieldsCanBeMergedError.cs
@@ -1,40 +1,39 @@
 using GraphQLParser.AST;
 using static GraphQL.Validation.Rules.OverlappingFieldsCanBeMerged;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.OverlappingFieldsCanBeMerged"/>
+[Serializable]
+public class OverlappingFieldsCanBeMergedError : ValidationError
 {
-    /// <inheritdoc cref="Rules.OverlappingFieldsCanBeMerged"/>
-    [Serializable]
-    public class OverlappingFieldsCanBeMergedError : ValidationError
+    internal const string NUMBER = "5.3.2";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public OverlappingFieldsCanBeMergedError(ValidationContext context, Conflict conflict)
+        : base(context.Document.Source, NUMBER, FieldsConflictMessage(conflict.Reason.Name, conflict.Reason),
+              conflict.FieldsLeft.Concat(conflict.FieldsRight).Cast<ASTNode>().ToArray())
     {
-        internal const string NUMBER = "5.3.2";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public OverlappingFieldsCanBeMergedError(ValidationContext context, Conflict conflict)
-            : base(context.Document.Source, NUMBER, FieldsConflictMessage(conflict.Reason.Name, conflict.Reason),
-                  conflict.FieldsLeft.Concat(conflict.FieldsRight).Cast<ASTNode>().ToArray())
+    internal static string FieldsConflictMessage(string responseName, ConflictReason reason) =>
+        $"Fields {responseName} conflicts because {ReasonMessage(reason.Message)}. " +
+        "Use different aliases on the fields to fetch both if this was intentional.";
+
+    private static string ReasonMessage(Message reasonMessage)
+    {
+        if (reasonMessage.Msgs?.Count > 0)
         {
+            return string.Join(
+                " and ",
+                reasonMessage.Msgs.Select(x => $"subfields '{x.Name}' conflict because {ReasonMessage(x.Message)}").ToArray()
+            );
         }
-
-        internal static string FieldsConflictMessage(string responseName, ConflictReason reason) =>
-            $"Fields {responseName} conflicts because {ReasonMessage(reason.Message)}. " +
-            "Use different aliases on the fields to fetch both if this was intentional.";
-
-        private static string ReasonMessage(Message reasonMessage)
+        else
         {
-            if (reasonMessage.Msgs?.Count > 0)
-            {
-                return string.Join(
-                    " and ",
-                    reasonMessage.Msgs.Select(x => $"subfields '{x.Name}' conflict because {ReasonMessage(x.Message)}").ToArray()
-                );
-            }
-            else
-            {
-                return reasonMessage.Msg!;
-            }
+            return reasonMessage.Msg!;
         }
     }
 }

--- a/src/GraphQL/Validation/Errors/PossibleFragmentSpreadsError.cs
+++ b/src/GraphQL/Validation/Errors/PossibleFragmentSpreadsError.cs
@@ -1,34 +1,33 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.PossibleFragmentSpreads"/>
+[Serializable]
+public class PossibleFragmentSpreadsError : ValidationError
 {
-    /// <inheritdoc cref="Rules.PossibleFragmentSpreads"/>
-    [Serializable]
-    public class PossibleFragmentSpreadsError : ValidationError
+    internal const string NUMBER = "5.5.2.3";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public PossibleFragmentSpreadsError(ValidationContext context, GraphQLInlineFragment node, IGraphType parentType, IGraphType fragType)
+        : base(context.Document.Source, NUMBER, TypeIncompatibleAnonSpreadMessage(parentType.ToString()!, fragType.ToString()!), node)
     {
-        internal const string NUMBER = "5.5.2.3";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public PossibleFragmentSpreadsError(ValidationContext context, GraphQLInlineFragment node, IGraphType parentType, IGraphType fragType)
-            : base(context.Document.Source, NUMBER, TypeIncompatibleAnonSpreadMessage(parentType.ToString()!, fragType.ToString()!), node)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public PossibleFragmentSpreadsError(ValidationContext context, GraphQLFragmentSpread node, IGraphType parentType, IGraphType fragType)
-            : base(context.Document.Source, NUMBER, TypeIncompatibleSpreadMessage(node.FragmentName.Name.StringValue, parentType.ToString()!, fragType.ToString()!), node)
-        {
-        }
-
-        internal static string TypeIncompatibleSpreadMessage(string fragName, string parentType, string fragType)
-            => $"Fragment '{fragName}' cannot be spread here as objects of type '{parentType}' can never be of type '{fragType}'.";
-
-        internal static string TypeIncompatibleAnonSpreadMessage(string parentType, string fragType)
-            => $"Fragment cannot be spread here as objects of type '{parentType}' can never be of type '{fragType}'.";
     }
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public PossibleFragmentSpreadsError(ValidationContext context, GraphQLFragmentSpread node, IGraphType parentType, IGraphType fragType)
+        : base(context.Document.Source, NUMBER, TypeIncompatibleSpreadMessage(node.FragmentName.Name.StringValue, parentType.ToString()!, fragType.ToString()!), node)
+    {
+    }
+
+    internal static string TypeIncompatibleSpreadMessage(string fragName, string parentType, string fragType)
+        => $"Fragment '{fragName}' cannot be spread here as objects of type '{parentType}' can never be of type '{fragType}'.";
+
+    internal static string TypeIncompatibleAnonSpreadMessage(string parentType, string fragType)
+        => $"Fragment cannot be spread here as objects of type '{parentType}' can never be of type '{fragType}'.";
 }

--- a/src/GraphQL/Validation/Errors/ProvidedNonNullArgumentsError.cs
+++ b/src/GraphQL/Validation/Errors/ProvidedNonNullArgumentsError.cs
@@ -1,34 +1,33 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.ProvidedNonNullArguments"/>
+[Serializable]
+public class ProvidedNonNullArgumentsError : ValidationError
 {
-    /// <inheritdoc cref="Rules.ProvidedNonNullArguments"/>
-    [Serializable]
-    public class ProvidedNonNullArgumentsError : ValidationError
+    internal const string NUMBER = "5.4.2.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public ProvidedNonNullArgumentsError(ValidationContext context, GraphQLField node, QueryArgument arg)
+        : base(context.Document.Source, NUMBER, MissingFieldArgMessage(node.Name.StringValue, arg.Name, arg.ResolvedType!.ToString()!), node)
     {
-        internal const string NUMBER = "5.4.2.1";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public ProvidedNonNullArgumentsError(ValidationContext context, GraphQLField node, QueryArgument arg)
-            : base(context.Document.Source, NUMBER, MissingFieldArgMessage(node.Name.StringValue, arg.Name, arg.ResolvedType!.ToString()!), node)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public ProvidedNonNullArgumentsError(ValidationContext context, GraphQLDirective node, QueryArgument arg)
-            : base(context.Document.Source, NUMBER, MissingDirectiveArgMessage(node.Name.StringValue, arg.Name, arg.ResolvedType!.ToString()!), node)
-        {
-        }
-
-        internal static string MissingFieldArgMessage(string fieldName, string argName, string type)
-            => $"Argument '{argName}' of type '{type}' is required for field '{fieldName}' but not provided.";
-
-        internal static string MissingDirectiveArgMessage(string directiveName, string argName, string type)
-            => $"Argument '{argName}' of type '{type}' is required for directive '{directiveName}' but not provided.";
     }
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public ProvidedNonNullArgumentsError(ValidationContext context, GraphQLDirective node, QueryArgument arg)
+        : base(context.Document.Source, NUMBER, MissingDirectiveArgMessage(node.Name.StringValue, arg.Name, arg.ResolvedType!.ToString()!), node)
+    {
+    }
+
+    internal static string MissingFieldArgMessage(string fieldName, string argName, string type)
+        => $"Argument '{argName}' of type '{type}' is required for field '{fieldName}' but not provided.";
+
+    internal static string MissingDirectiveArgMessage(string directiveName, string argName, string type)
+        => $"Argument '{argName}' of type '{type}' is required for directive '{directiveName}' but not provided.";
 }

--- a/src/GraphQL/Validation/Errors/ScalarLeafsError.cs
+++ b/src/GraphQL/Validation/Errors/ScalarLeafsError.cs
@@ -1,34 +1,33 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.ScalarLeafs"/>
+[Serializable]
+public class ScalarLeafsError : ValidationError
 {
-    /// <inheritdoc cref="Rules.ScalarLeafs"/>
-    [Serializable]
-    public class ScalarLeafsError : ValidationError
+    internal const string NUMBER = "5.3.3";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public ScalarLeafsError(ValidationContext context, GraphQLSelectionSet node, GraphQLField field, IGraphType type)
+        : base(context.Document.Source, NUMBER, NoSubselectionAllowedMessage(field.Name.StringValue, type.ToString()!), node)
     {
-        internal const string NUMBER = "5.3.3";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public ScalarLeafsError(ValidationContext context, GraphQLSelectionSet node, GraphQLField field, IGraphType type)
-            : base(context.Document.Source, NUMBER, NoSubselectionAllowedMessage(field.Name.StringValue, type.ToString()!), node)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public ScalarLeafsError(ValidationContext context, GraphQLField node, IGraphType type)
-            : base(context.Document.Source, NUMBER, RequiredSubselectionMessage(node.Name.StringValue, type.ToString()!), node)
-        {
-        }
-
-        internal static string NoSubselectionAllowedMessage(string field, string type)
-            => $"Field {field} of type {type} must not have a sub selection";
-
-        internal static string RequiredSubselectionMessage(string field, string type)
-            => $"Field {field} of type {type} must have a sub selection";
     }
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public ScalarLeafsError(ValidationContext context, GraphQLField node, IGraphType type)
+        : base(context.Document.Source, NUMBER, RequiredSubselectionMessage(node.Name.StringValue, type.ToString()!), node)
+    {
+    }
+
+    internal static string NoSubselectionAllowedMessage(string field, string type)
+        => $"Field {field} of type {type} must not have a sub selection";
+
+    internal static string RequiredSubselectionMessage(string field, string type)
+        => $"Field {field} of type {type} must have a sub selection";
 }

--- a/src/GraphQL/Validation/Errors/SingleRootFieldSubscriptionsError.cs
+++ b/src/GraphQL/Validation/Errors/SingleRootFieldSubscriptionsError.cs
@@ -1,25 +1,24 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.SingleRootFieldSubscriptions"/>
+[Serializable]
+public class SingleRootFieldSubscriptionsError : ValidationError
 {
-    /// <inheritdoc cref="Rules.SingleRootFieldSubscriptions"/>
-    [Serializable]
-    public class SingleRootFieldSubscriptionsError : ValidationError
+    internal const string NUMBER = "5.2.3.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public SingleRootFieldSubscriptionsError(ValidationContext context, GraphQLOperationDefinition operation, params ASTNode[] nodes)
+        : base(context.Document.Source, NUMBER, InvalidNumberOfRootFieldMessage(operation.Name), nodes)
     {
-        internal const string NUMBER = "5.2.3.1";
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public SingleRootFieldSubscriptionsError(ValidationContext context, GraphQLOperationDefinition operation, params ASTNode[] nodes)
-            : base(context.Document.Source, NUMBER, InvalidNumberOfRootFieldMessage(operation.Name), nodes)
-        {
-        }
-
-        internal static string InvalidNumberOfRootFieldMessage(GraphQLName? name)
-        {
-            string prefix = name is null ? "Anonymous Subscription" : $"Subscription '{name}'";
-            return $"{prefix} must have exactly one root field and that field must not be an introspection field.";
-        }
+    internal static string InvalidNumberOfRootFieldMessage(GraphQLName? name)
+    {
+        string prefix = name is null ? "Anonymous Subscription" : $"Subscription '{name}'";
+        return $"{prefix} must have exactly one root field and that field must not be an introspection field.";
     }
 }

--- a/src/GraphQL/Validation/Errors/UniqueArgumentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueArgumentNamesError.cs
@@ -1,22 +1,21 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.UniqueArgumentNames"/>
+[Serializable]
+public class UniqueArgumentNamesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.UniqueArgumentNames"/>
-    [Serializable]
-    public class UniqueArgumentNamesError : ValidationError
+    internal const string NUMBER = "5.4.2";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public UniqueArgumentNamesError(ValidationContext context, GraphQLArgument node, GraphQLArgument otherNode)
+        : base(context.Document.Source, NUMBER, DuplicateArgMessage(node.Name.StringValue), node, otherNode)
     {
-        internal const string NUMBER = "5.4.2";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public UniqueArgumentNamesError(ValidationContext context, GraphQLArgument node, GraphQLArgument otherNode)
-            : base(context.Document.Source, NUMBER, DuplicateArgMessage(node.Name.StringValue), node, otherNode)
-        {
-        }
-
-        internal static string DuplicateArgMessage(string argName)
-            => $"There can be only one argument named '{argName}'.";
     }
+
+    internal static string DuplicateArgMessage(string argName)
+        => $"There can be only one argument named '{argName}'.";
 }

--- a/src/GraphQL/Validation/Errors/UniqueDirectivesPerLocationError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueDirectivesPerLocationError.cs
@@ -1,19 +1,18 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
-{
-    /// <inheritdoc cref="Rules.UniqueDirectivesPerLocation"/>
-    [Serializable]
-    public class UniqueDirectivesPerLocationError : ValidationError
-    {
-        internal const string NUMBER = "5.7.3";
+namespace GraphQL.Validation.Errors;
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public UniqueDirectivesPerLocationError(ValidationContext context, GraphQLDirective node)
-            : base(context.Document.Source, NUMBER, $"The directive '{node.Name}' can only be used once at this location.", node)
-        {
-        }
+/// <inheritdoc cref="Rules.UniqueDirectivesPerLocation"/>
+[Serializable]
+public class UniqueDirectivesPerLocationError : ValidationError
+{
+    internal const string NUMBER = "5.7.3";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public UniqueDirectivesPerLocationError(ValidationContext context, GraphQLDirective node)
+        : base(context.Document.Source, NUMBER, $"The directive '{node.Name}' can only be used once at this location.", node)
+    {
     }
 }

--- a/src/GraphQL/Validation/Errors/UniqueFragmentNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueFragmentNamesError.cs
@@ -1,22 +1,21 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.UniqueFragmentNames"/>
+[Serializable]
+public class UniqueFragmentNamesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.UniqueFragmentNames"/>
-    [Serializable]
-    public class UniqueFragmentNamesError : ValidationError
+    internal const string NUMBER = "5.5.1.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public UniqueFragmentNamesError(ValidationContext context, GraphQLFragmentDefinition node, GraphQLFragmentDefinition altNode)
+        : base(context.Document.Source, NUMBER, DuplicateFragmentNameMessage(node.FragmentName.Name.StringValue), node, altNode)
     {
-        internal const string NUMBER = "5.5.1.1";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public UniqueFragmentNamesError(ValidationContext context, GraphQLFragmentDefinition node, GraphQLFragmentDefinition altNode)
-            : base(context.Document.Source, NUMBER, DuplicateFragmentNameMessage(node.FragmentName.Name.StringValue), node, altNode)
-        {
-        }
-
-        internal static string DuplicateFragmentNameMessage(string fragName)
-            => $"There can only be one fragment named '{fragName}'";
     }
+
+    internal static string DuplicateFragmentNameMessage(string fragName)
+        => $"There can only be one fragment named '{fragName}'";
 }

--- a/src/GraphQL/Validation/Errors/UniqueInputFieldNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueInputFieldNamesError.cs
@@ -1,22 +1,21 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.UniqueInputFieldNames"/>
+[Serializable]
+public class UniqueInputFieldNamesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.UniqueInputFieldNames"/>
-    [Serializable]
-    public class UniqueInputFieldNamesError : ValidationError
+    internal const string NUMBER = "5.6.3";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public UniqueInputFieldNamesError(ValidationContext context, GraphQLValue node, GraphQLObjectField altNode)
+        : base(context.Document.Source, NUMBER, DuplicateInputField(altNode.Name.StringValue), node, altNode.Value)
     {
-        internal const string NUMBER = "5.6.3";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public UniqueInputFieldNamesError(ValidationContext context, GraphQLValue node, GraphQLObjectField altNode)
-            : base(context.Document.Source, NUMBER, DuplicateInputField(altNode.Name.StringValue), node, altNode.Value)
-        {
-        }
-
-        internal static string DuplicateInputField(string fieldName)
-            => $"There can be only one input field named {fieldName}.";
     }
+
+    internal static string DuplicateInputField(string fieldName)
+        => $"There can be only one input field named {fieldName}.";
 }

--- a/src/GraphQL/Validation/Errors/UniqueOperationNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueOperationNamesError.cs
@@ -1,22 +1,21 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.UniqueOperationNames"/>
+[Serializable]
+public class UniqueOperationNamesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.UniqueOperationNames"/>
-    [Serializable]
-    public class UniqueOperationNamesError : ValidationError
+    internal const string NUMBER = "5.2.1.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public UniqueOperationNamesError(ValidationContext context, GraphQLOperationDefinition node)
+        : base(context.Document.Source, NUMBER, DuplicateOperationNameMessage(node.Name!.StringValue), node)
     {
-        internal const string NUMBER = "5.2.1.1";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public UniqueOperationNamesError(ValidationContext context, GraphQLOperationDefinition node)
-            : base(context.Document.Source, NUMBER, DuplicateOperationNameMessage(node.Name!.StringValue), node)
-        {
-        }
-
-        internal static string DuplicateOperationNameMessage(string opName)
-            => $"There can only be one operation named {opName}.";
     }
+
+    internal static string DuplicateOperationNameMessage(string opName)
+        => $"There can only be one operation named {opName}.";
 }

--- a/src/GraphQL/Validation/Errors/UniqueVariableNamesError.cs
+++ b/src/GraphQL/Validation/Errors/UniqueVariableNamesError.cs
@@ -1,22 +1,21 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.UniqueVariableNames"/>
+[Serializable]
+public class UniqueVariableNamesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.UniqueVariableNames"/>
-    [Serializable]
-    public class UniqueVariableNamesError : ValidationError
+    internal const string NUMBER = "5.8.1";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public UniqueVariableNamesError(ValidationContext context, GraphQLVariableDefinition node, GraphQLVariableDefinition altNode)
+        : base(context.Document.Source, NUMBER, DuplicateVariableMessage(node.Variable.Name.StringValue), node, altNode)
     {
-        internal const string NUMBER = "5.8.1";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public UniqueVariableNamesError(ValidationContext context, GraphQLVariableDefinition node, GraphQLVariableDefinition altNode)
-            : base(context.Document.Source, NUMBER, DuplicateVariableMessage(node.Variable.Name.StringValue), node, altNode)
-        {
-        }
-
-        internal static string DuplicateVariableMessage(string variableName)
-            => $"There can be only one variable named '{variableName}'";
     }
+
+    internal static string DuplicateVariableMessage(string variableName)
+        => $"There can be only one variable named '{variableName}'";
 }

--- a/src/GraphQL/Validation/Errors/VariablesAreInputTypesError.cs
+++ b/src/GraphQL/Validation/Errors/VariablesAreInputTypesError.cs
@@ -1,23 +1,22 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.VariablesAreInputTypes"/>
+[Serializable]
+public class VariablesAreInputTypesError : ValidationError
 {
-    /// <inheritdoc cref="Rules.VariablesAreInputTypes"/>
-    [Serializable]
-    public class VariablesAreInputTypesError : ValidationError
+    internal const string NUMBER = "5.8.2";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public VariablesAreInputTypesError(ValidationContext context, GraphQLVariableDefinition node, IGraphType type)
+        : base(context.Document.Source, NUMBER, UndefinedVarMessage(node.Variable.Name.StringValue, type?.ToString() ?? node.Type.Name()), node)
     {
-        internal const string NUMBER = "5.8.2";
-
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public VariablesAreInputTypesError(ValidationContext context, GraphQLVariableDefinition node, IGraphType type)
-            : base(context.Document.Source, NUMBER, UndefinedVarMessage(node.Variable.Name.StringValue, type?.ToString() ?? node.Type.Name()), node)
-        {
-        }
-
-        internal static string UndefinedVarMessage(string variableName, string typeName)
-            => $"Variable '{variableName}' cannot be non-input type '{typeName}'.";
     }
+
+    internal static string UndefinedVarMessage(string variableName, string typeName)
+        => $"Variable '{variableName}' cannot be non-input type '{typeName}'.";
 }

--- a/src/GraphQL/Validation/Errors/VariablesInAllowedPositionError.cs
+++ b/src/GraphQL/Validation/Errors/VariablesInAllowedPositionError.cs
@@ -2,28 +2,27 @@ using GraphQL.Types;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Errors
+namespace GraphQL.Validation.Errors;
+
+/// <inheritdoc cref="Rules.VariablesInAllowedPosition"/>
+[Serializable]
+public class VariablesInAllowedPositionError : ValidationError
 {
-    /// <inheritdoc cref="Rules.VariablesInAllowedPosition"/>
-    [Serializable]
-    public class VariablesInAllowedPositionError : ValidationError
+    internal const string NUMBER = "5.8.5";
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public VariablesInAllowedPositionError(ValidationContext context, GraphQLVariableDefinition varDef, IGraphType varType, VariableUsage usage)
+        : base(context.Document.Source, NUMBER, BadVarPosMessage(usage.Node.Name.StringValue, varType.ToString()!, usage.Type.ToString()!))
     {
-        internal const string NUMBER = "5.8.5";
+        var varDefLoc = Location.FromLinearPosition(context.Document.Source, varDef.Location.Start);
+        var usageLoc = Location.FromLinearPosition(context.Document.Source, usage.Node.Location.Start);
 
-        /// <summary>
-        /// Initializes a new instance with the specified properties.
-        /// </summary>
-        public VariablesInAllowedPositionError(ValidationContext context, GraphQLVariableDefinition varDef, IGraphType varType, VariableUsage usage)
-            : base(context.Document.Source, NUMBER, BadVarPosMessage(usage.Node.Name.StringValue, varType.ToString()!, usage.Type.ToString()!))
-        {
-            var varDefLoc = Location.FromLinearPosition(context.Document.Source, varDef.Location.Start);
-            var usageLoc = Location.FromLinearPosition(context.Document.Source, usage.Node.Location.Start);
-
-            AddLocation(varDefLoc);
-            AddLocation(usageLoc);
-        }
-
-        internal static string BadVarPosMessage(string varName, string varType, string expectedType)
-            => $"Variable '${varName}' of type '{varType}' used in position expecting type '{expectedType}'.";
+        AddLocation(varDefLoc);
+        AddLocation(usageLoc);
     }
+
+    internal static string BadVarPosMessage(string varName, string varType, string expectedType)
+        => $"Variable '${varName}' of type '{varType}' used in position expecting type '{expectedType}'.";
 }

--- a/src/GraphQL/Validation/INodeVisitor.cs
+++ b/src/GraphQL/Validation/INodeVisitor.cs
@@ -1,20 +1,19 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// An interface to handle events raised by a node walker such as <see cref="BasicVisitor"/>.
+/// </summary>
+public interface INodeVisitor
 {
     /// <summary>
-    /// An interface to handle events raised by a node walker such as <see cref="BasicVisitor"/>.
+    /// Called when the node walker is entering a node.
     /// </summary>
-    public interface INodeVisitor
-    {
-        /// <summary>
-        /// Called when the node walker is entering a node.
-        /// </summary>
-        ValueTask EnterAsync(ASTNode node, ValidationContext context);
+    ValueTask EnterAsync(ASTNode node, ValidationContext context);
 
-        /// <summary>
-        /// Called when the node walker is leaving a node.
-        /// </summary>
-        ValueTask LeaveAsync(ASTNode node, ValidationContext context);
-    }
+    /// <summary>
+    /// Called when the node walker is leaving a node.
+    /// </summary>
+    ValueTask LeaveAsync(ASTNode node, ValidationContext context);
 }

--- a/src/GraphQL/Validation/IValidationResult.cs
+++ b/src/GraphQL/Validation/IValidationResult.cs
@@ -1,43 +1,42 @@
 using GraphQL.Execution;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Contains a list of the validation errors found after validating a document against a set of validation rules.
+/// If the document passes validation, this will also contain the set of parsed variables and argument values for fields and applied directives.
+/// </summary>
+public interface IValidationResult
 {
     /// <summary>
-    /// Contains a list of the validation errors found after validating a document against a set of validation rules.
-    /// If the document passes validation, this will also contain the set of parsed variables and argument values for fields and applied directives.
+    /// Returns <see langword="true"/> if no errors were found during the validation of a document.
     /// </summary>
-    public interface IValidationResult
-    {
-        /// <summary>
-        /// Returns <see langword="true"/> if no errors were found during the validation of a document.
-        /// </summary>
-        bool IsValid { get; }
+    bool IsValid { get; }
 
-        /// <summary>
-        /// Returns a list of the errors found during validation of a document.
-        /// </summary>
-        ExecutionErrors Errors { get; }
+    /// <summary>
+    /// Returns a list of the errors found during validation of a document.
+    /// </summary>
+    ExecutionErrors Errors { get; }
 
-        /// <summary>
-        /// Returns the set of variables parsed from the inputs.
-        /// If the document did not pass validation, this value will be <see langword="null"/>.
-        /// If the document passed validation but contained no variables, this value will be <see cref="Variables.None"/>.
-        /// </summary>
-        Variables? Variables { get; }
+    /// <summary>
+    /// Returns the set of variables parsed from the inputs.
+    /// If the document did not pass validation, this value will be <see langword="null"/>.
+    /// If the document passed validation but contained no variables, this value will be <see cref="Variables.None"/>.
+    /// </summary>
+    Variables? Variables { get; }
 
-        /// <summary>
-        /// Returns a dictionary of fields, and for each field, a dictionary of arguments defined for the field with their values.
-        /// If the document did not pass validation, or if no field arguments were found, this value will be <see langword="null"/>.
-        /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
-        /// </summary>
-        IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; }
+    /// <summary>
+    /// Returns a dictionary of fields, and for each field, a dictionary of arguments defined for the field with their values.
+    /// If the document did not pass validation, or if no field arguments were found, this value will be <see langword="null"/>.
+    /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
+    /// </summary>
+    IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; }
 
-        /// <summary>
-        /// Returns a dictionary of fields, and for each field, a dictionary of directives defined for the field with argument
-        /// values for each directive.
-        /// If the document did not pass validation, or if no directives were found, this value will be <see langword="null"/>.
-        /// </summary>
-        IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; }
-    }
+    /// <summary>
+    /// Returns a dictionary of fields, and for each field, a dictionary of directives defined for the field with argument
+    /// values for each directive.
+    /// If the document did not pass validation, or if no directives were found, this value will be <see langword="null"/>.
+    /// </summary>
+    IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; }
 }

--- a/src/GraphQL/Validation/IValidationRule.cs
+++ b/src/GraphQL/Validation/IValidationRule.cs
@@ -1,28 +1,27 @@
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Represents a validation rule for a document.
+/// </summary>
+public interface IValidationRule
 {
     /// <summary>
-    /// Represents a validation rule for a document.
+    /// Prepares and returns a node visitor to be used to validate a document (via a node walker) against this
+    /// validation rule before the document has parsed any arguments. Validation failures are added then by this
+    /// visitor to a list stored within <see cref="ValidationContext.Errors"/>.
     /// </summary>
-    public interface IValidationRule
-    {
-        /// <summary>
-        /// Prepares and returns a node visitor to be used to validate a document (via a node walker) against this
-        /// validation rule before the document has parsed any arguments. Validation failures are added then by this
-        /// visitor to a list stored within <see cref="ValidationContext.Errors"/>.
-        /// </summary>
-        ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context);
+    ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context);
 
-        /// <summary>
-        /// Prepares and returns a visitor which methods are called when parsing the inputs into variables in
-        /// <see cref="ValidationContext.GetVariablesValuesAsync(IVariableVisitor?)"/>.
-        /// </summary>
-        ValueTask<IVariableVisitor?> GetVariableVisitorAsync(ValidationContext context);
+    /// <summary>
+    /// Prepares and returns a visitor which methods are called when parsing the inputs into variables in
+    /// <see cref="ValidationContext.GetVariablesValuesAsync(IVariableVisitor?)"/>.
+    /// </summary>
+    ValueTask<IVariableVisitor?> GetVariableVisitorAsync(ValidationContext context);
 
-        /// <summary>
-        /// Prepares and returns a node visitor to be used to validate a document (via a node walker) against this
-        /// validation rule after the document has parsed all arguments. Validation failures are added then by this
-        /// visitor to a list stored within <see cref="ValidationContext.Errors"/>.
-        /// </summary>
-        ValueTask<INodeVisitor?> GetPostNodeVisitorAsync(ValidationContext context);
-    }
+    /// <summary>
+    /// Prepares and returns a node visitor to be used to validate a document (via a node walker) against this
+    /// validation rule after the document has parsed all arguments. Validation failures are added then by this
+    /// visitor to a list stored within <see cref="ValidationContext.Errors"/>.
+    /// </summary>
+    ValueTask<INodeVisitor?> GetPostNodeVisitorAsync(ValidationContext context);
 }

--- a/src/GraphQL/Validation/IVariableVisitor.cs
+++ b/src/GraphQL/Validation/IVariableVisitor.cs
@@ -1,31 +1,30 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Visitor whose methods are called when parsing the inputs into variables in <see cref="ValidationContext.GetVariablesValuesAsync(IVariableVisitor?)"/>.
+/// </summary>
+public interface IVariableVisitor
 {
     /// <summary>
-    /// Visitor whose methods are called when parsing the inputs into variables in <see cref="ValidationContext.GetVariablesValuesAsync(IVariableVisitor?)"/>.
+    /// Visits parsed scalar value.
     /// </summary>
-    public interface IVariableVisitor
-    {
-        /// <summary>
-        /// Visits parsed scalar value.
-        /// </summary>
-        ValueTask VisitScalarAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ScalarGraphType type, object? variableValue, object? parsedValue);
+    ValueTask VisitScalarAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ScalarGraphType type, object? variableValue, object? parsedValue);
 
-        /// <summary>
-        /// Visits parsed list value.
-        /// </summary>
-        ValueTask VisitListAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ListGraphType type, object? variableValue, IList<object?>? parsedValue);
+    /// <summary>
+    /// Visits parsed list value.
+    /// </summary>
+    ValueTask VisitListAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, ListGraphType type, object? variableValue, IList<object?>? parsedValue);
 
-        /// <summary>
-        /// Visits parsed input object value.
-        /// </summary>
-        ValueTask VisitObjectAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, object? variableValue, object? parsedValue);
+    /// <summary>
+    /// Visits parsed input object value.
+    /// </summary>
+    ValueTask VisitObjectAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, object? variableValue, object? parsedValue);
 
-        /// <summary>
-        /// Visits parsed value of input object field.
-        /// </summary>
-        ValueTask VisitFieldAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, FieldType field, object? variableValue, object? parsedValue);
-    }
+    /// <summary>
+    /// Visits parsed value of input object field.
+    /// </summary>
+    ValueTask VisitFieldAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, FieldType field, object? variableValue, object? parsedValue);
 }

--- a/src/GraphQL/Validation/MatchingNodeVisitor.cs
+++ b/src/GraphQL/Validation/MatchingNodeVisitor.cs
@@ -1,112 +1,111 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// A node listener which runs configured delegates only when the node entered/left matches the specified node type.
+/// </summary>
+/// <typeparam name="TNode">A specified AST node type.</typeparam>
+public class MatchingNodeVisitor<TNode> : INodeVisitor
+    where TNode : ASTNode
 {
+    private readonly Func<TNode, ValidationContext, ValueTask>? _enter;
+    private readonly Func<TNode, ValidationContext, ValueTask>? _leave;
+
     /// <summary>
-    /// A node listener which runs configured delegates only when the node entered/left matches the specified node type.
+    /// Returns a new instance configured with the specified enter/leave delegates.
     /// </summary>
-    /// <typeparam name="TNode">A specified AST node type.</typeparam>
-    public class MatchingNodeVisitor<TNode> : INodeVisitor
-        where TNode : ASTNode
+    public MatchingNodeVisitor(Action<TNode, ValidationContext>? enter = null, Action<TNode, ValidationContext>? leave = null)
+        : this(FromAction(enter), FromAction(leave))
     {
-        private readonly Func<TNode, ValidationContext, ValueTask>? _enter;
-        private readonly Func<TNode, ValidationContext, ValueTask>? _leave;
-
-        /// <summary>
-        /// Returns a new instance configured with the specified enter/leave delegates.
-        /// </summary>
-        public MatchingNodeVisitor(Action<TNode, ValidationContext>? enter = null, Action<TNode, ValidationContext>? leave = null)
-            : this(FromAction(enter), FromAction(leave))
-        {
-        }
-
-        private static Func<TNode, ValidationContext, ValueTask>? FromAction(Action<TNode, ValidationContext>? action)
-        {
-            if (action == null)
-            {
-                return null;
-            }
-            return (node, context) =>
-            {
-                action(node, context);
-                return default;
-            };
-        }
-
-        /// <inheritdoc cref="MatchingNodeVisitor{TNode}(Action{TNode, ValidationContext}?, Action{TNode, ValidationContext}?)"/>
-        public MatchingNodeVisitor(Func<TNode, ValidationContext, ValueTask>? enter = null, Func<TNode, ValidationContext, ValueTask>? leave = null)
-        {
-            if (enter == null && leave == null)
-            {
-                throw new ArgumentException("Must provide an enter or leave function.");
-            }
-
-            _enter = enter;
-            _leave = leave;
-        }
-
-        ValueTask INodeVisitor.EnterAsync(ASTNode node, ValidationContext context)
-        {
-            if (_enter != null && node is TNode n)
-            {
-                return _enter(n, context);
-            }
-            return default;
-        }
-
-        ValueTask INodeVisitor.LeaveAsync(ASTNode node, ValidationContext context)
-        {
-            if (_leave != null && node is TNode n)
-            {
-                return _leave(n, context);
-            }
-            return default;
-        }
     }
 
-    /// <summary>
-    /// A node listener which runs configured delegates only when the node entered/left matches the specified node type.
-    /// </summary>
-    /// <typeparam name="TNode">A specified AST node type.</typeparam>
-    /// <typeparam name="TState">Type of the provided state.</typeparam>
-    public class MatchingNodeVisitor<TNode, TState> : INodeVisitor
-        where TNode : ASTNode
+    private static Func<TNode, ValidationContext, ValueTask>? FromAction(Action<TNode, ValidationContext>? action)
     {
-        private readonly Action<TNode, ValidationContext, TState?>? _enter;
-        private readonly Action<TNode, ValidationContext, TState?>? _leave;
-        private readonly TState? _state;
-
-        /// <summary>
-        /// Returns a new instance configured with the specified enter/leave delegates and arbitrary state.
-        /// </summary>
-        public MatchingNodeVisitor(TState? state, Action<TNode, ValidationContext, TState?>? enter = null, Action<TNode, ValidationContext, TState?>? leave = null)
+        if (action == null)
         {
-            if (enter == null && leave == null)
-            {
-                throw new ArgumentException("Must provide an enter or leave function.");
-            }
-
-            _enter = enter;
-            _leave = leave;
-            _state = state;
+            return null;
         }
-
-        ValueTask INodeVisitor.EnterAsync(ASTNode node, ValidationContext context)
+        return (node, context) =>
         {
-            if (_enter != null && node is TNode n)
-            {
-                _enter(n, context, _state);
-            }
+            action(node, context);
             return default;
+        };
+    }
+
+    /// <inheritdoc cref="MatchingNodeVisitor{TNode}(Action{TNode, ValidationContext}?, Action{TNode, ValidationContext}?)"/>
+    public MatchingNodeVisitor(Func<TNode, ValidationContext, ValueTask>? enter = null, Func<TNode, ValidationContext, ValueTask>? leave = null)
+    {
+        if (enter == null && leave == null)
+        {
+            throw new ArgumentException("Must provide an enter or leave function.");
         }
 
-        ValueTask INodeVisitor.LeaveAsync(ASTNode node, ValidationContext context)
+        _enter = enter;
+        _leave = leave;
+    }
+
+    ValueTask INodeVisitor.EnterAsync(ASTNode node, ValidationContext context)
+    {
+        if (_enter != null && node is TNode n)
         {
-            if (_leave != null && node is TNode n)
-            {
-                _leave(n, context, _state);
-            }
-            return default;
+            return _enter(n, context);
         }
+        return default;
+    }
+
+    ValueTask INodeVisitor.LeaveAsync(ASTNode node, ValidationContext context)
+    {
+        if (_leave != null && node is TNode n)
+        {
+            return _leave(n, context);
+        }
+        return default;
+    }
+}
+
+/// <summary>
+/// A node listener which runs configured delegates only when the node entered/left matches the specified node type.
+/// </summary>
+/// <typeparam name="TNode">A specified AST node type.</typeparam>
+/// <typeparam name="TState">Type of the provided state.</typeparam>
+public class MatchingNodeVisitor<TNode, TState> : INodeVisitor
+    where TNode : ASTNode
+{
+    private readonly Action<TNode, ValidationContext, TState?>? _enter;
+    private readonly Action<TNode, ValidationContext, TState?>? _leave;
+    private readonly TState? _state;
+
+    /// <summary>
+    /// Returns a new instance configured with the specified enter/leave delegates and arbitrary state.
+    /// </summary>
+    public MatchingNodeVisitor(TState? state, Action<TNode, ValidationContext, TState?>? enter = null, Action<TNode, ValidationContext, TState?>? leave = null)
+    {
+        if (enter == null && leave == null)
+        {
+            throw new ArgumentException("Must provide an enter or leave function.");
+        }
+
+        _enter = enter;
+        _leave = leave;
+        _state = state;
+    }
+
+    ValueTask INodeVisitor.EnterAsync(ASTNode node, ValidationContext context)
+    {
+        if (_enter != null && node is TNode n)
+        {
+            _enter(n, context, _state);
+        }
+        return default;
+    }
+
+    ValueTask INodeVisitor.LeaveAsync(ASTNode node, ValidationContext context)
+    {
+        if (_leave != null && node is TNode n)
+        {
+            _leave(n, context, _state);
+        }
+        return default;
     }
 }

--- a/src/GraphQL/Validation/NodeVisitors.cs
+++ b/src/GraphQL/Validation/NodeVisitors.cs
@@ -1,33 +1,32 @@
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Represents a set of <see cref="INodeVisitor"/> instances that each runs upon entering or leaving a node.
+/// Be aware that all <see cref="INodeVisitor"/> instances are called in the order supplied; not in reverse order upon leaving a node.
+/// </summary>
+public sealed class NodeVisitors : INodeVisitor
 {
+    private readonly INodeVisitor[] _nodeVisitors;
+
     /// <summary>
-    /// Represents a set of <see cref="INodeVisitor"/> instances that each runs upon entering or leaving a node.
-    /// Be aware that all <see cref="INodeVisitor"/> instances are called in the order supplied; not in reverse order upon leaving a node.
+    /// Initializes a new instance with the specified <see cref="INodeVisitor"/>s.
     /// </summary>
-    public sealed class NodeVisitors : INodeVisitor
+    public NodeVisitors(params INodeVisitor[] nodeVisitors)
     {
-        private readonly INodeVisitor[] _nodeVisitors;
+        _nodeVisitors = nodeVisitors ?? throw new ArgumentNullException(nameof(nodeVisitors));
+    }
 
-        /// <summary>
-        /// Initializes a new instance with the specified <see cref="INodeVisitor"/>s.
-        /// </summary>
-        public NodeVisitors(params INodeVisitor[] nodeVisitors)
-        {
-            _nodeVisitors = nodeVisitors ?? throw new ArgumentNullException(nameof(nodeVisitors));
-        }
+    async ValueTask INodeVisitor.EnterAsync(ASTNode node, ValidationContext context)
+    {
+        foreach (var n in _nodeVisitors)
+            await n.EnterAsync(node, context).ConfigureAwait(false);
+    }
 
-        async ValueTask INodeVisitor.EnterAsync(ASTNode node, ValidationContext context)
-        {
-            foreach (var n in _nodeVisitors)
-                await n.EnterAsync(node, context).ConfigureAwait(false);
-        }
-
-        async ValueTask INodeVisitor.LeaveAsync(ASTNode node, ValidationContext context)
-        {
-            foreach (var n in _nodeVisitors)
-                await n.LeaveAsync(node, context).ConfigureAwait(false);
-        }
+    async ValueTask INodeVisitor.LeaveAsync(ASTNode node, ValidationContext context)
+    {
+        foreach (var n in _nodeVisitors)
+            await n.LeaveAsync(node, context).ConfigureAwait(false);
     }
 }

--- a/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
+++ b/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
@@ -3,103 +3,102 @@ using GraphQL.Utilities.Visitors;
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Validation rule that checks minimum and maximum length of provided values for input fields and
+/// arguments that marked with <see cref="LengthDirective"/> directive. Doesn't check default values.
+/// <br/><br/>
+/// This is not a standard validation rule that is not in the official specification. Note that this
+/// rule will be required to run on cached queries also since it works with request variables, so
+/// <see cref="ExecutionOptions.CachedDocumentValidationRules">ExecutionOptions.CachedDocumentValidationRules</see>
+/// needs to be set as well (if using caching).
+/// </summary>
+/// <remarks>
+/// Please copy the newer <see cref="PatternMatchingDirective"/> and <see cref="PatternMatchingVisitor"/>
+/// when designing new custom directives that can be used to validate input fields and arguments.
+/// </remarks>
+public class InputFieldsAndArgumentsOfCorrectLength : ValidationRuleBase
 {
-    /// <summary>
-    /// Validation rule that checks minimum and maximum length of provided values for input fields and
-    /// arguments that marked with <see cref="LengthDirective"/> directive. Doesn't check default values.
-    /// <br/><br/>
-    /// This is not a standard validation rule that is not in the official specification. Note that this
-    /// rule will be required to run on cached queries also since it works with request variables, so
-    /// <see cref="ExecutionOptions.CachedDocumentValidationRules">ExecutionOptions.CachedDocumentValidationRules</see>
-    /// needs to be set as well (if using caching).
-    /// </summary>
-    /// <remarks>
-    /// Please copy the newer <see cref="PatternMatchingDirective"/> and <see cref="PatternMatchingVisitor"/>
-    /// when designing new custom directives that can be used to validate input fields and arguments.
-    /// </remarks>
-    public class InputFieldsAndArgumentsOfCorrectLength : ValidationRuleBase
+    private sealed class FieldVisitor : BaseVariableVisitor
     {
-        private sealed class FieldVisitor : BaseVariableVisitor
+        public static readonly FieldVisitor Instance = new();
+
+        public override ValueTask VisitFieldAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, FieldType field, object? variableValue, object? parsedValue)
         {
-            public static readonly FieldVisitor Instance = new();
-
-            public override ValueTask VisitFieldAsync(ValidationContext context, GraphQLVariableDefinition variable, VariableName variableName, IInputObjectGraphType type, FieldType field, object? variableValue, object? parsedValue)
-            {
-                var lengthDirective = field.FindAppliedDirective("length");
-                if (lengthDirective == null)
-                    return default;
-
-                var min = lengthDirective.FindArgument("min")?.Value;
-                var max = lengthDirective.FindArgument("max")?.Value;
-
-                if (parsedValue == null)
-                {
-                    if (min != null)
-                        context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, variable, variableName, null, (int?)min, (int?)max));
-                }
-                else if (parsedValue is string str)
-                {
-                    if (min != null && str.Length < (int)min || max != null && str.Length > (int)max)
-                        context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, variable, variableName, str.Length, (int?)min, (int?)max));
-                }
-
-                return default;
-            }
-        }
-
-        /// <inheritdoc/>
-        public override ValueTask<IVariableVisitor?> GetVariableVisitorAsync(ValidationContext context) => new(FieldVisitor.Instance);
-
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly InputFieldsAndArgumentsOfCorrectLength Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="InputFieldsAndArgumentsOfCorrectLengthError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLArgument>((arg, context) => CheckLength(arg, arg.Value, context.TypeInfo.GetArgument(), context)),
-            new MatchingNodeVisitor<GraphQLObjectField>((field, context) =>
-            {
-                if (context.TypeInfo.GetInputType(1)?.GetNamedType() is IInputObjectGraphType input)
-                    CheckLength(field, field.Value, input.GetField(field.Name), context);
-            })
-        );
-
-        private static void CheckLength(ASTNode node, GraphQLValue value, IMetadataReader? provider, ValidationContext context)
-        {
-            var lengthDirective = provider?.FindAppliedDirective("length");
+            var lengthDirective = field.FindAppliedDirective("length");
             if (lengthDirective == null)
-                return;
+                return default;
 
             var min = lengthDirective.FindArgument("min")?.Value;
             var max = lengthDirective.FindArgument("max")?.Value;
 
-            if (value is GraphQLNullValue)
+            if (parsedValue == null)
             {
                 if (min != null)
-                    context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, node, null, (int?)min, (int?)max));
+                    context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, variable, variableName, null, (int?)min, (int?)max));
             }
-            else if (value is GraphQLStringValue strLiteral)
+            else if (parsedValue is string str)
             {
-                CheckStringLength(strLiteral.Value.Length);
-            }
-            else if (value is GraphQLVariable vRef && context.Variables != null && context.Variables.TryGetValue(vRef.Name.StringValue, out object? val)) //ISSUE:allocation
-            {
-                if (val is string strVariable)
-                    CheckStringLength(strVariable.Length);
-                else if (val is null && min != null)
-                    context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, node, null, (int?)min, (int?)max));
+                if (min != null && str.Length < (int)min || max != null && str.Length > (int)max)
+                    context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, variable, variableName, str.Length, (int?)min, (int?)max));
             }
 
-            void CheckStringLength(int length)
-            {
-                if (min != null && length < (int)min || max != null && length > (int)max)
-                    context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, node, length, (int?)min, (int?)max));
-            }
+            return default;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override ValueTask<IVariableVisitor?> GetVariableVisitorAsync(ValidationContext context) => new(FieldVisitor.Instance);
+
+    /// <summary>
+    /// Returns a static instance of this validation rule.
+    /// </summary>
+    public static readonly InputFieldsAndArgumentsOfCorrectLength Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="InputFieldsAndArgumentsOfCorrectLengthError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLArgument>((arg, context) => CheckLength(arg, arg.Value, context.TypeInfo.GetArgument(), context)),
+        new MatchingNodeVisitor<GraphQLObjectField>((field, context) =>
+        {
+            if (context.TypeInfo.GetInputType(1)?.GetNamedType() is IInputObjectGraphType input)
+                CheckLength(field, field.Value, input.GetField(field.Name), context);
+        })
+    );
+
+    private static void CheckLength(ASTNode node, GraphQLValue value, IMetadataReader? provider, ValidationContext context)
+    {
+        var lengthDirective = provider?.FindAppliedDirective("length");
+        if (lengthDirective == null)
+            return;
+
+        var min = lengthDirective.FindArgument("min")?.Value;
+        var max = lengthDirective.FindArgument("max")?.Value;
+
+        if (value is GraphQLNullValue)
+        {
+            if (min != null)
+                context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, node, null, (int?)min, (int?)max));
+        }
+        else if (value is GraphQLStringValue strLiteral)
+        {
+            CheckStringLength(strLiteral.Value.Length);
+        }
+        else if (value is GraphQLVariable vRef && context.Variables != null && context.Variables.TryGetValue(vRef.Name.StringValue, out object? val)) //ISSUE:allocation
+        {
+            if (val is string strVariable)
+                CheckStringLength(strVariable.Length);
+            else if (val is null && min != null)
+                context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, node, null, (int?)min, (int?)max));
+        }
+
+        void CheckStringLength(int length)
+        {
+            if (min != null && length < (int)min || max != null && length > (int)max)
+                context.ReportError(new InputFieldsAndArgumentsOfCorrectLengthError(context, node, length, (int?)min, (int?)max));
         }
     }
 }

--- a/src/GraphQL/Validation/Rules/5.7 - Directives/1+2. KnownDirectivesInAllowedLocations.cs
+++ b/src/GraphQL/Validation/Rules/5.7 - Directives/1+2. KnownDirectivesInAllowedLocations.cs
@@ -1,89 +1,88 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Known directives:
+///
+/// GraphQL servers define what directives they support and where they support them.
+/// For each usage of a directive, the directive must be available on that server and
+/// must be used in a location that the server has declared support for.
+/// </summary>
+public class KnownDirectivesInAllowedLocations : ValidationRuleBase
 {
     /// <summary>
-    /// Known directives:
-    ///
-    /// GraphQL servers define what directives they support and where they support them.
-    /// For each usage of a directive, the directive must be available on that server and
-    /// must be used in a location that the server has declared support for.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class KnownDirectivesInAllowedLocations : ValidationRuleBase
+    public static readonly KnownDirectivesInAllowedLocations Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="KnownDirectivesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLDirective>((node, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly KnownDirectivesInAllowedLocations Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="KnownDirectivesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLDirective>((node, context) =>
+        var directiveDef = context.Schema.Directives.Find(node.Name);
+        if (directiveDef == null)
         {
-            var directiveDef = context.Schema.Directives.Find(node.Name);
-            if (directiveDef == null)
-            {
-                context.ReportError(new KnownDirectivesError(context, node));
-            }
-            else
-            {
-                var candidateLocation = DirectiveLocationForAstPath(context);
-                if (!directiveDef.Locations.Contains(candidateLocation))
-                {
-                    context.ReportError(new DirectivesInAllowedLocationsError(context, node, candidateLocation));
-                }
-            }
-        });
-
-        // From https://spec.graphql.org/October2021/#sec-Document:
-        // Documents are only executable by a GraphQL service if they are ExecutableDocument and contain at least
-        // one OperationDefinition. A Document which contains TypeSystemDefinitionOrExtension must not be executed;
-        // GraphQL execution services which receive a Document containing these should return a descriptive error.
-        //
-        // Nevertheless, this method calculates all possible locations.
-        private static DirectiveLocation DirectiveLocationForAstPath(ValidationContext context)
-        {
-            var appliedTo = context.TypeInfo.GetAncestor(1);
-
-            if (appliedTo is GraphQLDirectives || appliedTo is GraphQLArguments)
-            {
-                appliedTo = context.TypeInfo.GetAncestor(2);
-            }
-
-            return appliedTo switch
-            {
-                // https://spec.graphql.org/October2021/#ExecutableDirectiveLocation
-                GraphQLOperationDefinition op => op.Operation switch
-                {
-                    OperationType.Query => DirectiveLocation.Query,
-                    OperationType.Mutation => DirectiveLocation.Mutation,
-                    OperationType.Subscription => DirectiveLocation.Subscription,
-                    _ => throw new InvalidOperationException($"Unknown operation type '{op.Operation}.")
-                },
-                GraphQLField _ => DirectiveLocation.Field,
-                GraphQLFragmentDefinition _ => DirectiveLocation.FragmentDefinition,
-                GraphQLFragmentSpread _ => DirectiveLocation.FragmentSpread,
-                GraphQLInlineFragment _ => DirectiveLocation.InlineFragment,
-                GraphQLVariableDefinition _ => DirectiveLocation.VariableDefinition,
-
-                // https://spec.graphql.org/October2021/#TypeSystemDirectiveLocation
-                GraphQLSchemaDefinition _ => DirectiveLocation.Schema,
-                GraphQLScalarTypeDefinition _ => DirectiveLocation.Scalar,
-                GraphQLObjectTypeDefinition _ => DirectiveLocation.Object,
-                GraphQLFieldDefinition _ => DirectiveLocation.FieldDefinition,
-                //GraphQLArgument?s?Definition => DirectiveLocation.ArgumentDefinition, //TODO: ???
-                GraphQLInterfaceTypeDefinition _ => DirectiveLocation.Interface,
-                GraphQLUnionTypeDefinition _ => DirectiveLocation.Union,
-                GraphQLEnumTypeDefinition _ => DirectiveLocation.Enum,
-                GraphQLEnumValueDefinition _ => DirectiveLocation.EnumValue, //TODO: https://github.com/graphql/graphql-spec/issues/924
-                GraphQLEnumValue _ => DirectiveLocation.EnumValue,
-                GraphQLInputObjectTypeDefinition _ => DirectiveLocation.InputObject,
-                GraphQLInputFieldsDefinition _ => DirectiveLocation.InputFieldDefinition,
-                _ => throw new InvalidOperationException($"Unable to determine directive location for '{appliedTo?.Print()}'.")
-            };
+            context.ReportError(new KnownDirectivesError(context, node));
         }
+        else
+        {
+            var candidateLocation = DirectiveLocationForAstPath(context);
+            if (!directiveDef.Locations.Contains(candidateLocation))
+            {
+                context.ReportError(new DirectivesInAllowedLocationsError(context, node, candidateLocation));
+            }
+        }
+    });
+
+    // From https://spec.graphql.org/October2021/#sec-Document:
+    // Documents are only executable by a GraphQL service if they are ExecutableDocument and contain at least
+    // one OperationDefinition. A Document which contains TypeSystemDefinitionOrExtension must not be executed;
+    // GraphQL execution services which receive a Document containing these should return a descriptive error.
+    //
+    // Nevertheless, this method calculates all possible locations.
+    private static DirectiveLocation DirectiveLocationForAstPath(ValidationContext context)
+    {
+        var appliedTo = context.TypeInfo.GetAncestor(1);
+
+        if (appliedTo is GraphQLDirectives || appliedTo is GraphQLArguments)
+        {
+            appliedTo = context.TypeInfo.GetAncestor(2);
+        }
+
+        return appliedTo switch
+        {
+            // https://spec.graphql.org/October2021/#ExecutableDirectiveLocation
+            GraphQLOperationDefinition op => op.Operation switch
+            {
+                OperationType.Query => DirectiveLocation.Query,
+                OperationType.Mutation => DirectiveLocation.Mutation,
+                OperationType.Subscription => DirectiveLocation.Subscription,
+                _ => throw new InvalidOperationException($"Unknown operation type '{op.Operation}.")
+            },
+            GraphQLField _ => DirectiveLocation.Field,
+            GraphQLFragmentDefinition _ => DirectiveLocation.FragmentDefinition,
+            GraphQLFragmentSpread _ => DirectiveLocation.FragmentSpread,
+            GraphQLInlineFragment _ => DirectiveLocation.InlineFragment,
+            GraphQLVariableDefinition _ => DirectiveLocation.VariableDefinition,
+
+            // https://spec.graphql.org/October2021/#TypeSystemDirectiveLocation
+            GraphQLSchemaDefinition _ => DirectiveLocation.Schema,
+            GraphQLScalarTypeDefinition _ => DirectiveLocation.Scalar,
+            GraphQLObjectTypeDefinition _ => DirectiveLocation.Object,
+            GraphQLFieldDefinition _ => DirectiveLocation.FieldDefinition,
+            //GraphQLArgument?s?Definition => DirectiveLocation.ArgumentDefinition, //TODO: ???
+            GraphQLInterfaceTypeDefinition _ => DirectiveLocation.Interface,
+            GraphQLUnionTypeDefinition _ => DirectiveLocation.Union,
+            GraphQLEnumTypeDefinition _ => DirectiveLocation.Enum,
+            GraphQLEnumValueDefinition _ => DirectiveLocation.EnumValue, //TODO: https://github.com/graphql/graphql-spec/issues/924
+            GraphQLEnumValue _ => DirectiveLocation.EnumValue,
+            GraphQLInputObjectTypeDefinition _ => DirectiveLocation.InputObject,
+            GraphQLInputFieldsDefinition _ => DirectiveLocation.InputFieldDefinition,
+            _ => throw new InvalidOperationException($"Unable to determine directive location for '{appliedTo?.Print()}'.")
+        };
     }
 }

--- a/src/GraphQL/Validation/Rules/5.7 - Directives/3. UniqueDirectivesPerLocation.cs
+++ b/src/GraphQL/Validation/Rules/5.7 - Directives/3. UniqueDirectivesPerLocation.cs
@@ -2,65 +2,64 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Unique directive names per location:
+///
+/// A GraphQL document is only valid if all not repeatable directives
+/// at a given location are uniquely named.
+/// </summary>
+public class UniqueDirectivesPerLocation : ValidationRuleBase
 {
     /// <summary>
-    /// Unique directive names per location:
-    ///
-    /// A GraphQL document is only valid if all not repeatable directives
-    /// at a given location are uniquely named.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class UniqueDirectivesPerLocation : ValidationRuleBase
+    public static readonly UniqueDirectivesPerLocation Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="UniqueDirectivesPerLocationError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLOperationDefinition>((f, context) => CheckDuplicates(context, f.Directives)),
+
+        new MatchingNodeVisitor<GraphQLField>((f, context) => CheckDuplicates(context, f.Directives)),
+
+        new MatchingNodeVisitor<GraphQLFragmentDefinition>((f, context) => CheckDuplicates(context, f.Directives)),
+
+        new MatchingNodeVisitor<GraphQLFragmentSpread>((f, context) => CheckDuplicates(context, f.Directives)),
+
+        new MatchingNodeVisitor<GraphQLInlineFragment>((f, context) => CheckDuplicates(context, f.Directives)),
+
+        new MatchingNodeVisitor<GraphQLVariableDefinition>((f, context) => CheckDuplicates(context, f.Directives))
+    );
+
+    private static void CheckDuplicates(ValidationContext context, GraphQLDirectives? directives)
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly UniqueDirectivesPerLocation Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="UniqueDirectivesPerLocationError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLOperationDefinition>((f, context) => CheckDuplicates(context, f.Directives)),
-
-            new MatchingNodeVisitor<GraphQLField>((f, context) => CheckDuplicates(context, f.Directives)),
-
-            new MatchingNodeVisitor<GraphQLFragmentDefinition>((f, context) => CheckDuplicates(context, f.Directives)),
-
-            new MatchingNodeVisitor<GraphQLFragmentSpread>((f, context) => CheckDuplicates(context, f.Directives)),
-
-            new MatchingNodeVisitor<GraphQLInlineFragment>((f, context) => CheckDuplicates(context, f.Directives)),
-
-            new MatchingNodeVisitor<GraphQLVariableDefinition>((f, context) => CheckDuplicates(context, f.Directives))
-        );
-
-        private static void CheckDuplicates(ValidationContext context, GraphQLDirectives? directives)
+        if (directives?.Count > 0)
         {
-            if (directives?.Count > 0)
+            foreach (var directive in directives)
             {
-                foreach (var directive in directives)
+                var directiveDef = context.Schema.Directives.Find(directive.Name);
+                if (directiveDef != null && !directiveDef.Repeatable && GetCount(directives, directive.Name) > 1)
                 {
-                    var directiveDef = context.Schema.Directives.Find(directive.Name);
-                    if (directiveDef != null && !directiveDef.Repeatable && GetCount(directives, directive.Name) > 1)
-                    {
-                        context.ReportError(new UniqueDirectivesPerLocationError(context, directive));
-                    }
+                    context.ReportError(new UniqueDirectivesPerLocationError(context, directive));
                 }
             }
         }
+    }
 
-        private static int GetCount(GraphQLDirectives directives, ROM name)
+    private static int GetCount(GraphQLDirectives directives, ROM name)
+    {
+        int count = 0;
+
+        foreach (var directive in directives)
         {
-            int count = 0;
-
-            foreach (var directive in directives)
-            {
-                if (directive.Name == name)
-                    ++count;
-            }
-
-            return count;
+            if (directive.Name == name)
+                ++count;
         }
+
+        return count;
     }
 }

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/1. UniqueVariableNames.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/1. UniqueVariableNames.cs
@@ -1,41 +1,40 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Unique variable names:
+///
+/// A GraphQL operation is only valid if all its variables are uniquely named.
+/// </summary>
+public class UniqueVariableNames : ValidationRuleBase
 {
     /// <summary>
-    /// Unique variable names:
-    ///
-    /// A GraphQL operation is only valid if all its variables are uniquely named.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class UniqueVariableNames : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly UniqueVariableNames Instance = new();
+    public static readonly UniqueVariableNames Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="UniqueVariableNamesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="UniqueVariableNamesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLOperationDefinition>((__, context) => context.TypeInfo.UniqueVariableNames_KnownVariables?.Clear()),
-            new MatchingNodeVisitor<GraphQLVariableDefinition>((variableDefinition, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLOperationDefinition>((__, context) => context.TypeInfo.UniqueVariableNames_KnownVariables?.Clear()),
+        new MatchingNodeVisitor<GraphQLVariableDefinition>((variableDefinition, context) =>
+        {
+            var knownVariables = context.TypeInfo.UniqueVariableNames_KnownVariables ??= new();
+
+            var variableName = variableDefinition.Variable.Name;
+
+            if (knownVariables.TryGetValue(variableName, out var variable))
             {
-                var knownVariables = context.TypeInfo.UniqueVariableNames_KnownVariables ??= new();
-
-                var variableName = variableDefinition.Variable.Name;
-
-                if (knownVariables.TryGetValue(variableName, out var variable))
-                {
-                    context.ReportError(new UniqueVariableNamesError(context, variable, variableDefinition));
-                }
-                else
-                {
-                    knownVariables[variableName] = variableDefinition;
-                }
-            })
-        );
-    }
+                context.ReportError(new UniqueVariableNamesError(context, variable, variableDefinition));
+            }
+            else
+            {
+                knownVariables[variableName] = variableDefinition;
+            }
+        })
+    );
 }

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/2. VariablesAreInputTypes.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/2. VariablesAreInputTypes.cs
@@ -2,33 +2,32 @@ using GraphQL.Types;
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Variables are input types:
+///
+/// A GraphQL operation is only valid if all the variables it defines are of
+/// input types (scalar, enum, or input object).
+/// </summary>
+public class VariablesAreInputTypes : ValidationRuleBase
 {
     /// <summary>
-    /// Variables are input types:
-    ///
-    /// A GraphQL operation is only valid if all the variables it defines are of
-    /// input types (scalar, enum, or input object).
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class VariablesAreInputTypes : ValidationRuleBase
+    public static readonly VariablesAreInputTypes Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="VariablesAreInputTypesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLVariableDefinition>((varDef, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly VariablesAreInputTypes Instance = new();
+        var type = varDef.Type.NamedGraphTypeFromType(context.Schema);
 
-        /// <inheritdoc/>
-        /// <exception cref="VariablesAreInputTypesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLVariableDefinition>((varDef, context) =>
+        if (type == null || !type.IsInputType())
         {
-            var type = varDef.Type.NamedGraphTypeFromType(context.Schema);
-
-            if (type == null || !type.IsInputType())
-            {
-                context.ReportError(new VariablesAreInputTypesError(context, varDef, varDef.Type.GraphTypeFromType(context.Schema)!));
-            }
-        });
-    }
+            context.ReportError(new VariablesAreInputTypesError(context, varDef, varDef.Type.GraphTypeFromType(context.Schema)!));
+        }
+    });
 }

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/3. NoUndefinedVariables.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/3. NoUndefinedVariables.cs
@@ -1,50 +1,49 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// No undefined variables:
+///
+/// A GraphQL operation is only valid if all variables encountered, both directly
+/// and via fragment spreads, are defined by that operation.
+/// </summary>
+public class NoUndefinedVariables : ValidationRuleBase
 {
     /// <summary>
-    /// No undefined variables:
-    ///
-    /// A GraphQL operation is only valid if all variables encountered, both directly
-    /// and via fragment spreads, are defined by that operation.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class NoUndefinedVariables : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly NoUndefinedVariables Instance = new();
+    public static readonly NoUndefinedVariables Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="NoUndefinedVariablesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="NoUndefinedVariablesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLVariableDefinition>((varDef, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLVariableDefinition>((varDef, context) =>
+        {
+            var varNameDef = context.TypeInfo.NoUndefinedVariables_VariableNameDefined ??= new();
+            varNameDef.Add(varDef.Variable.Name);
+        }),
+
+        new MatchingNodeVisitor<GraphQLOperationDefinition>(
+            enter: (op, context) => context.TypeInfo.NoUndefinedVariables_VariableNameDefined?.Clear(),
+            leave: (op, context) =>
             {
-                var varNameDef = context.TypeInfo.NoUndefinedVariables_VariableNameDefined ??= new();
-                varNameDef.Add(varDef.Variable.Name);
-            }),
-
-            new MatchingNodeVisitor<GraphQLOperationDefinition>(
-                enter: (op, context) => context.TypeInfo.NoUndefinedVariables_VariableNameDefined?.Clear(),
-                leave: (op, context) =>
+                var varNameDef = context.TypeInfo.NoUndefinedVariables_VariableNameDefined;
+                var usages = context.GetRecursiveVariables(op);
+                if (usages != null)
                 {
-                    var varNameDef = context.TypeInfo.NoUndefinedVariables_VariableNameDefined;
-                    var usages = context.GetRecursiveVariables(op);
-                    if (usages != null)
+                    foreach (var usage in usages)
                     {
-                        foreach (var usage in usages)
+                        var varName = usage.Node.Name;
+                        if (varNameDef == null || !varNameDef.Contains(varName))
                         {
-                            var varName = usage.Node.Name;
-                            if (varNameDef == null || !varNameDef.Contains(varName))
-                            {
-                                context.ReportError(new NoUndefinedVariablesError(context, op, usage.Node));
-                            }
+                            context.ReportError(new NoUndefinedVariablesError(context, op, usage.Node));
                         }
                     }
-                })
-        );
-    }
+                }
+            })
+    );
 }

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/4. NoUnusedVariables.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/4. NoUnusedVariables.cs
@@ -1,62 +1,61 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// No unused variables:
+///
+/// A GraphQL operation is only valid if all variables defined by that operation
+/// are used in that operation or a fragment transitively included by that
+/// operation.
+/// </summary>
+public class NoUnusedVariables : ValidationRuleBase
 {
     /// <summary>
-    /// No unused variables:
-    ///
-    /// A GraphQL operation is only valid if all variables defined by that operation
-    /// are used in that operation or a fragment transitively included by that
-    /// operation.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class NoUnusedVariables : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly NoUnusedVariables Instance = new();
+    public static readonly NoUnusedVariables Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="NoUnusedVariablesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="NoUnusedVariablesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLVariableDefinition>((def, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLVariableDefinition>((def, context) =>
+        {
+            var varDefs = context.TypeInfo.NoUnusedVariables_VariableDefs ??= new();
+            varDefs.Add(def);
+        }),
+
+        new MatchingNodeVisitor<GraphQLOperationDefinition>(
+            enter: (op, context) => context.TypeInfo.NoUnusedVariables_VariableDefs?.Clear(),
+            leave: (op, context) =>
             {
-                var varDefs = context.TypeInfo.NoUnusedVariables_VariableDefs ??= new();
-                varDefs.Add(def);
-            }),
+                var variableDefs = context.TypeInfo.NoUnusedVariables_VariableDefs;
+                if (variableDefs == null || variableDefs.Count == 0)
+                    return;
 
-            new MatchingNodeVisitor<GraphQLOperationDefinition>(
-                enter: (op, context) => context.TypeInfo.NoUnusedVariables_VariableDefs?.Clear(),
-                leave: (op, context) =>
+                var usages = context.GetRecursiveVariables(op);
+
+                foreach (var variableDef in variableDefs)
                 {
-                    var variableDefs = context.TypeInfo.NoUnusedVariables_VariableDefs;
-                    if (variableDefs == null || variableDefs.Count == 0)
-                        return;
-
-                    var usages = context.GetRecursiveVariables(op);
-
-                    foreach (var variableDef in variableDefs)
+                    if (usages == null || !Contains(usages, variableDef))
                     {
-                        if (usages == null || !Contains(usages, variableDef))
-                        {
-                            context.ReportError(new NoUnusedVariablesError(context, variableDef, op));
-                        }
+                        context.ReportError(new NoUnusedVariablesError(context, variableDef, op));
+                    }
+                }
+
+                static bool Contains(List<VariableUsage> usages, GraphQLVariableDefinition def)
+                {
+                    foreach (var usage in usages)
+                    {
+                        if (usage.Node.Name == def.Variable.Name)
+                            return true;
                     }
 
-                    static bool Contains(List<VariableUsage> usages, GraphQLVariableDefinition def)
-                    {
-                        foreach (var usage in usages)
-                        {
-                            if (usage.Node.Name == def.Variable.Name)
-                                return true;
-                        }
-
-                        return false;
-                    }
-                })
-        );
-    }
+                    return false;
+                }
+            })
+    );
 }

--- a/src/GraphQL/Validation/Rules/5.8 - Variables/5. VariablesInAllowedPosition.cs
+++ b/src/GraphQL/Validation/Rules/5.8 - Variables/5. VariablesInAllowedPosition.cs
@@ -2,83 +2,82 @@ using GraphQL.Types;
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Variables passed to field arguments conform to type.
+/// </summary>
+public class VariablesInAllowedPosition : ValidationRuleBase
 {
     /// <summary>
-    /// Variables passed to field arguments conform to type.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class VariablesInAllowedPosition : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly VariablesInAllowedPosition Instance = new();
+    public static readonly VariablesInAllowedPosition Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="VariablesInAllowedPositionError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="VariablesInAllowedPositionError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLVariableDefinition>(
-                (varDefAst, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLVariableDefinition>(
+            (varDefAst, context) =>
+            {
+                var varDefMap = context.TypeInfo.VariablesInAllowedPosition_VarDefMap ??= new();
+                varDefMap[varDefAst.Variable.Name] = varDefAst;
+            }
+        ),
+
+        new MatchingNodeVisitor<GraphQLOperationDefinition>(
+            enter: (op, context) => context.TypeInfo.VariablesInAllowedPosition_VarDefMap?.Clear(),
+            leave: (op, context) =>
+            {
+                var varDefMap = context.TypeInfo.VariablesInAllowedPosition_VarDefMap;
+                if (varDefMap == null)
+                    return;
+
+                var usages = context.GetRecursiveVariables(op);
+                if (usages != null)
                 {
-                    var varDefMap = context.TypeInfo.VariablesInAllowedPosition_VarDefMap ??= new();
-                    varDefMap[varDefAst.Variable.Name] = varDefAst;
-                }
-            ),
-
-            new MatchingNodeVisitor<GraphQLOperationDefinition>(
-                enter: (op, context) => context.TypeInfo.VariablesInAllowedPosition_VarDefMap?.Clear(),
-                leave: (op, context) =>
-                {
-                    var varDefMap = context.TypeInfo.VariablesInAllowedPosition_VarDefMap;
-                    if (varDefMap == null)
-                        return;
-
-                    var usages = context.GetRecursiveVariables(op);
-                    if (usages != null)
+                    foreach (var usage in usages)
                     {
-                        foreach (var usage in usages)
+                        var varName = usage.Node.Name;
+                        if (!varDefMap.TryGetValue(varName, out var varDef) || varDef == null)
                         {
-                            var varName = usage.Node.Name;
-                            if (!varDefMap.TryGetValue(varName, out var varDef) || varDef == null)
-                            {
-                                return;
-                            }
+                            return;
+                        }
 
-                            var varType = varDef.Type.GraphTypeFromType(context.Schema);
+                        var varType = varDef.Type.GraphTypeFromType(context.Schema);
 
-                            if (varType != null && usage.Type != null && !IsVariableUsageAllowed(varDef, varType, usage, context.Schema.Features.AllowScalarVariablesForListTypes))
-                            {
-                                context.ReportError(new VariablesInAllowedPositionError(context, varDef, varType, usage));
-                            }
+                        if (varType != null && usage.Type != null && !IsVariableUsageAllowed(varDef, varType, usage, context.Schema.Features.AllowScalarVariablesForListTypes))
+                        {
+                            context.ReportError(new VariablesInAllowedPositionError(context, varDef, varType, usage));
                         }
                     }
                 }
-            )
-        );
-
-        private static bool IsVariableUsageAllowed(GraphQLVariableDefinition variableDefinition, IGraphType variableType, VariableUsage variableUsage, bool allowScalarsForLists)
-        {
-            // >> If locationType is a non-null type AND variableType is NOT a non-null type:
-            if (variableUsage.Type is NonNullGraphType nonNullUsageType && variableType is not NonNullGraphType)
-            {
-                // >> Let hasNonNullVariableDefaultValue be true if a default value exists for variableDefinition and is not the value null
-                var hasNonNullVariableDefaultValue = variableDefinition.DefaultValue != null;
-                // >> Let hasLocationDefaultValue be true if a default value exists for the Argument or ObjectField where variableUsage is located.
-                var hasLocationDefaultValue = variableUsage.HasDefault;
-                // >> If hasNonNullVariableDefaultValue is NOT true AND hasLocationDefaultValue is NOT true, return false.
-                if (!hasNonNullVariableDefaultValue && !hasLocationDefaultValue)
-                {
-                    return false;
-                }
-                // >> Let nullableLocationType be the unwrapped nullable type of locationType.
-                var nullableLocationType = nonNullUsageType.ResolvedType!;
-                // >> Return AreTypesCompatible(variableType, nullableLocationType).
-                return variableType.IsSubtypeOf(nullableLocationType, allowScalarsForLists);
             }
-            // >> Return AreTypesCompatible(variableType, locationType).
-            return variableType.IsSubtypeOf(variableUsage.Type, allowScalarsForLists);
+        )
+    );
+
+    private static bool IsVariableUsageAllowed(GraphQLVariableDefinition variableDefinition, IGraphType variableType, VariableUsage variableUsage, bool allowScalarsForLists)
+    {
+        // >> If locationType is a non-null type AND variableType is NOT a non-null type:
+        if (variableUsage.Type is NonNullGraphType nonNullUsageType && variableType is not NonNullGraphType)
+        {
+            // >> Let hasNonNullVariableDefaultValue be true if a default value exists for variableDefinition and is not the value null
+            var hasNonNullVariableDefaultValue = variableDefinition.DefaultValue != null;
+            // >> Let hasLocationDefaultValue be true if a default value exists for the Argument or ObjectField where variableUsage is located.
+            var hasLocationDefaultValue = variableUsage.HasDefault;
+            // >> If hasNonNullVariableDefaultValue is NOT true AND hasLocationDefaultValue is NOT true, return false.
+            if (!hasNonNullVariableDefaultValue && !hasLocationDefaultValue)
+            {
+                return false;
+            }
+            // >> Let nullableLocationType be the unwrapped nullable type of locationType.
+            var nullableLocationType = nonNullUsageType.ResolvedType!;
+            // >> Return AreTypesCompatible(variableType, nullableLocationType).
+            return variableType.IsSubtypeOf(nullableLocationType, allowScalarsForLists);
         }
+        // >> Return AreTypesCompatible(variableType, locationType).
+        return variableType.IsSubtypeOf(variableUsage.Type, allowScalarsForLists);
     }
 }

--- a/src/GraphQL/Validation/Rules/ArgumentsOfCorrectType.cs
+++ b/src/GraphQL/Validation/Rules/ArgumentsOfCorrectType.cs
@@ -1,37 +1,36 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Argument values of correct type:
+///
+/// A GraphQL document is only valid if all field argument literal values are
+/// of the type expected by their position.
+/// </summary>
+public class ArgumentsOfCorrectType : ValidationRuleBase
 {
     /// <summary>
-    /// Argument values of correct type:
-    ///
-    /// A GraphQL document is only valid if all field argument literal values are
-    /// of the type expected by their position.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class ArgumentsOfCorrectType : ValidationRuleBase
+    public static readonly ArgumentsOfCorrectType Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentsOfCorrectTypeError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLArgument>((argAst, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly ArgumentsOfCorrectType Instance = new();
+        var argDef = context.TypeInfo.GetArgument();
+        if (argDef == null)
+            return;
 
-        /// <inheritdoc/>
-        /// <exception cref="ArgumentsOfCorrectTypeError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLArgument>((argAst, context) =>
+        var type = argDef.ResolvedType!;
+        var errors = context.IsValidLiteralValue(type, argAst.Value);
+        if (errors != null)
         {
-            var argDef = context.TypeInfo.GetArgument();
-            if (argDef == null)
-                return;
-
-            var type = argDef.ResolvedType!;
-            var errors = context.IsValidLiteralValue(type, argAst.Value);
-            if (errors != null)
-            {
-                context.ReportError(new ArgumentsOfCorrectTypeError(context, argAst, errors));
-            }
-        });
-    }
+            context.ReportError(new ArgumentsOfCorrectTypeError(context, argAst, errors));
+        }
+    });
 }

--- a/src/GraphQL/Validation/Rules/FieldsOnCorrectType.cs
+++ b/src/GraphQL/Validation/Rules/FieldsOnCorrectType.cs
@@ -3,101 +3,100 @@ using GraphQL.Utilities;
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Fields on correct type:
+///
+/// A GraphQL document is only valid if all fields selected are defined by the
+/// parent type, or are an allowed meta field such as __typename.
+/// </summary>
+public class FieldsOnCorrectType : ValidationRuleBase
 {
     /// <summary>
-    /// Fields on correct type:
-    ///
-    /// A GraphQL document is only valid if all fields selected are defined by the
-    /// parent type, or are an allowed meta field such as __typename.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class FieldsOnCorrectType : ValidationRuleBase
+    public static readonly FieldsOnCorrectType Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="FieldsOnCorrectTypeError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLField>((node, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly FieldsOnCorrectType Instance = new();
+        var type = context.TypeInfo.GetParentType()?.GetNamedType();
 
-        /// <inheritdoc/>
-        /// <exception cref="FieldsOnCorrectTypeError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLField>((node, context) =>
+        if (type != null)
         {
-            var type = context.TypeInfo.GetParentType()?.GetNamedType();
-
-            if (type != null)
+            var fieldDef = context.TypeInfo.GetFieldDef();
+            if (fieldDef == null)
             {
-                var fieldDef = context.TypeInfo.GetFieldDef();
-                if (fieldDef == null)
-                {
-                    // This field doesn't exist, lets look for suggestions.
-                    var fieldName = node.Name;
+                // This field doesn't exist, lets look for suggestions.
+                var fieldName = node.Name;
 
-                    // First determine if there are any suggested types to condition on.
-                    var suggestedTypeNames = GetSuggestedTypeNames(type, fieldName.StringValue).ToList(); //ISSUE:allocation
+                // First determine if there are any suggested types to condition on.
+                var suggestedTypeNames = GetSuggestedTypeNames(type, fieldName.StringValue).ToList(); //ISSUE:allocation
 
-                    // If there are no suggested types, then perhaps this was a typo?
-                    var suggestedFieldNames = suggestedTypeNames.Count > 0
-                        ? Array.Empty<string>()
-                        : GetSuggestedFieldNames(type, fieldName.StringValue); //ISSUE:allocation
+                // If there are no suggested types, then perhaps this was a typo?
+                var suggestedFieldNames = suggestedTypeNames.Count > 0
+                    ? Array.Empty<string>()
+                    : GetSuggestedFieldNames(type, fieldName.StringValue); //ISSUE:allocation
 
-                    // Report an error, including helpful suggestions.
-                    context.ReportError(new FieldsOnCorrectTypeError(context, node, type, suggestedTypeNames, suggestedFieldNames));
-                }
+                // Report an error, including helpful suggestions.
+                context.ReportError(new FieldsOnCorrectTypeError(context, node, type, suggestedTypeNames, suggestedFieldNames));
             }
-        });
+        }
+    });
 
-        /// <summary>
-        /// Go through all of the implementations of type, as well as the interfaces
-        /// that they implement. If any of those types include the provided field,
-        /// suggest them, sorted by how often the type is referenced,  starting
-        /// with Interfaces.
-        /// </summary>
-        private static IEnumerable<string> GetSuggestedTypeNames(IGraphType type, string fieldName)
+    /// <summary>
+    /// Go through all of the implementations of type, as well as the interfaces
+    /// that they implement. If any of those types include the provided field,
+    /// suggest them, sorted by how often the type is referenced,  starting
+    /// with Interfaces.
+    /// </summary>
+    private static IEnumerable<string> GetSuggestedTypeNames(IGraphType type, string fieldName)
+    {
+        if (type is IAbstractGraphType absType)
         {
-            if (type is IAbstractGraphType absType)
+            var suggestedObjectTypes = new List<string>();
+            var interfaceUsageCount = new Dictionary<string, int>();
+
+            foreach (var possibleType in absType.PossibleTypes.List)
             {
-                var suggestedObjectTypes = new List<string>();
-                var interfaceUsageCount = new Dictionary<string, int>();
-
-                foreach (var possibleType in absType.PossibleTypes.List)
+                if (possibleType.HasField(fieldName))
                 {
-                    if (possibleType.HasField(fieldName))
-                    {
-                        // This object defines this field.
-                        suggestedObjectTypes.Add(possibleType.Name);
+                    // This object defines this field.
+                    suggestedObjectTypes.Add(possibleType.Name);
 
-                        foreach (var possibleInterface in possibleType.ResolvedInterfaces.List)
+                    foreach (var possibleInterface in possibleType.ResolvedInterfaces.List)
+                    {
+                        if (possibleInterface.HasField(fieldName))
                         {
-                            if (possibleInterface.HasField(fieldName))
-                            {
-                                // This interface type defines this field.
-                                interfaceUsageCount[possibleInterface.Name] = interfaceUsageCount.TryGetValue(possibleInterface.Name, out int value) ? value + 1 : 1;
-                            }
+                            // This interface type defines this field.
+                            interfaceUsageCount[possibleInterface.Name] = interfaceUsageCount.TryGetValue(possibleInterface.Name, out int value) ? value + 1 : 1;
                         }
                     }
                 }
-
-                var suggestedInterfaceTypes = interfaceUsageCount.Keys.OrderBy(x => interfaceUsageCount[x]);
-                return suggestedInterfaceTypes.Concat(suggestedObjectTypes);
             }
 
-            return Enumerable.Empty<string>();
+            var suggestedInterfaceTypes = interfaceUsageCount.Keys.OrderBy(x => interfaceUsageCount[x]);
+            return suggestedInterfaceTypes.Concat(suggestedObjectTypes);
         }
 
-        /// <summary>
-        /// For the field name provided, determine if there are any similar field names
-        /// that may be the result of a typo.
-        /// </summary>
-        private static IEnumerable<string> GetSuggestedFieldNames(IGraphType type, string fieldName)
+        return Enumerable.Empty<string>();
+    }
+
+    /// <summary>
+    /// For the field name provided, determine if there are any similar field names
+    /// that may be the result of a typo.
+    /// </summary>
+    private static IEnumerable<string> GetSuggestedFieldNames(IGraphType type, string fieldName)
+    {
+        if (type is IComplexGraphType complexType)
         {
-            if (type is IComplexGraphType complexType)
-            {
-                return StringUtils.SuggestionList(fieldName, complexType.Fields.Select(x => x.Name));
-            }
-
-            return Enumerable.Empty<string>();
+            return StringUtils.SuggestionList(fieldName, complexType.Fields.Select(x => x.Name));
         }
+
+        return Enumerable.Empty<string>();
     }
 }

--- a/src/GraphQL/Validation/Rules/FragmentsOnCompositeTypes.cs
+++ b/src/GraphQL/Validation/Rules/FragmentsOnCompositeTypes.cs
@@ -1,44 +1,43 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Fragments on composite type:
+///
+/// Fragments use a type condition to determine if they apply, since fragments
+/// can only be spread into a composite type (object, interface, or union), the
+/// type condition must also be a composite type.
+/// </summary>
+public class FragmentsOnCompositeTypes : ValidationRuleBase
 {
     /// <summary>
-    /// Fragments on composite type:
-    ///
-    /// Fragments use a type condition to determine if they apply, since fragments
-    /// can only be spread into a composite type (object, interface, or union), the
-    /// type condition must also be a composite type.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class FragmentsOnCompositeTypes : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly FragmentsOnCompositeTypes Instance = new();
+    public static readonly FragmentsOnCompositeTypes Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="FragmentsOnCompositeTypesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="FragmentsOnCompositeTypesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLInlineFragment>((node, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLInlineFragment>((node, context) =>
+        {
+            var type = context.TypeInfo.GetLastType();
+            if (node.TypeCondition?.Type != null && type != null && !type.IsCompositeType())
             {
-                var type = context.TypeInfo.GetLastType();
-                if (node.TypeCondition?.Type != null && type != null && !type.IsCompositeType())
-                {
-                    context.ReportError(new FragmentsOnCompositeTypesError(context, node));
-                }
-            }),
+                context.ReportError(new FragmentsOnCompositeTypesError(context, node));
+            }
+        }),
 
-            new MatchingNodeVisitor<GraphQLFragmentDefinition>((node, context) =>
+        new MatchingNodeVisitor<GraphQLFragmentDefinition>((node, context) =>
+        {
+            var type = context.TypeInfo.GetLastType();
+            if (type != null && !type.IsCompositeType())
             {
-                var type = context.TypeInfo.GetLastType();
-                if (type != null && !type.IsCompositeType())
-                {
-                    context.ReportError(new FragmentsOnCompositeTypesError(context, node));
-                }
-            })
-        );
-    }
+                context.ReportError(new FragmentsOnCompositeTypesError(context, node));
+            }
+        })
+    );
 }

--- a/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownArgumentNames.cs
@@ -1,53 +1,52 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Known argument names:
+///
+/// A GraphQL field is only valid if all supplied arguments are defined by
+/// that field.
+/// </summary>
+public class KnownArgumentNames : ValidationRuleBase
 {
     /// <summary>
-    /// Known argument names:
-    ///
-    /// A GraphQL field is only valid if all supplied arguments are defined by
-    /// that field.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class KnownArgumentNames : ValidationRuleBase
+    public static readonly KnownArgumentNames Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="KnownArgumentNamesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLArgument>((node, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly KnownArgumentNames Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="KnownArgumentNamesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLArgument>((node, context) =>
+        var argumentOf = context.TypeInfo.GetAncestor(2);
+        if (argumentOf is GraphQLField)
         {
-            var argumentOf = context.TypeInfo.GetAncestor(2);
-            if (argumentOf is GraphQLField)
+            var fieldDef = context.TypeInfo.GetFieldDef();
+            if (fieldDef != null)
             {
-                var fieldDef = context.TypeInfo.GetFieldDef();
-                if (fieldDef != null)
+                var fieldArgDef = fieldDef.Arguments?.Find(node.Name);
+                if (fieldArgDef == null)
                 {
-                    var fieldArgDef = fieldDef.Arguments?.Find(node.Name);
-                    if (fieldArgDef == null)
-                    {
-                        var parentType = context.TypeInfo.GetParentType() ?? throw new InvalidOperationException("Parent type must not be null.");
-                        context.ReportError(new KnownArgumentNamesError(context, node, fieldDef, parentType));
-                    }
+                    var parentType = context.TypeInfo.GetParentType() ?? throw new InvalidOperationException("Parent type must not be null.");
+                    context.ReportError(new KnownArgumentNamesError(context, node, fieldDef, parentType));
                 }
             }
-            else if (argumentOf is GraphQLDirective)
+        }
+        else if (argumentOf is GraphQLDirective)
+        {
+            var directive = context.TypeInfo.GetDirective();
+            if (directive != null)
             {
-                var directive = context.TypeInfo.GetDirective();
-                if (directive != null)
+                var directiveArgDef = directive.Arguments?.Find(node.Name);
+                if (directiveArgDef == null)
                 {
-                    var directiveArgDef = directive.Arguments?.Find(node.Name);
-                    if (directiveArgDef == null)
-                    {
-                        context.ReportError(new KnownArgumentNamesError(context, node, directive));
-                    }
+                    context.ReportError(new KnownArgumentNamesError(context, node, directive));
                 }
             }
-        });
-    }
+        }
+    });
 }

--- a/src/GraphQL/Validation/Rules/KnownFragmentNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownFragmentNames.cs
@@ -2,33 +2,32 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Known fragment names:
+///
+/// A GraphQL document is only valid if all <c>...Fragment</c> fragment spreads refer
+/// to fragments defined in the same document.
+/// </summary>
+public class KnownFragmentNames : ValidationRuleBase
 {
     /// <summary>
-    /// Known fragment names:
-    ///
-    /// A GraphQL document is only valid if all <c>...Fragment</c> fragment spreads refer
-    /// to fragments defined in the same document.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class KnownFragmentNames : ValidationRuleBase
+    public static readonly KnownFragmentNames Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="KnownFragmentNamesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLFragmentSpread>((node, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly KnownFragmentNames Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="KnownFragmentNamesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLFragmentSpread>((node, context) =>
+        var fragmentName = node.FragmentName.Name;
+        var fragment = context.Document.FindFragmentDefinition(fragmentName);
+        if (fragment == null)
         {
-            var fragmentName = node.FragmentName.Name;
-            var fragment = context.Document.FindFragmentDefinition(fragmentName);
-            if (fragment == null)
-            {
-                context.ReportError(new KnownFragmentNamesError(context, node, fragmentName.StringValue));
-            }
-        });
-    }
+            context.ReportError(new KnownFragmentNamesError(context, node, fragmentName.StringValue));
+        }
+    });
 }

--- a/src/GraphQL/Validation/Rules/KnownTypeNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownTypeNames.cs
@@ -2,34 +2,33 @@ using GraphQL.Utilities;
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Known type names:
+///
+/// A GraphQL document is only valid if referenced types (specifically
+/// variable definitions and fragment conditions) are defined by the type schema.
+/// </summary>
+public class KnownTypeNames : ValidationRuleBase
 {
     /// <summary>
-    /// Known type names:
-    ///
-    /// A GraphQL document is only valid if referenced types (specifically
-    /// variable definitions and fragment conditions) are defined by the type schema.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class KnownTypeNames : ValidationRuleBase
+    public static readonly KnownTypeNames Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="KnownTypeNamesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLNamedType>(leave: (node, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly KnownTypeNames Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="KnownTypeNamesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLNamedType>(leave: (node, context) =>
+        var type = context.Schema.AllTypes[node.Name];
+        if (type == null)
         {
-            var type = context.Schema.AllTypes[node.Name];
-            if (type == null)
-            {
-                var typeNames = context.Schema.AllTypes.Dictionary.Values.Select(x => x.Name).ToArray();
-                var suggestionList = StringUtils.SuggestionList(node.Name.StringValue, typeNames); //ISSUE:allocation
-                context.ReportError(new KnownTypeNamesError(context, node, suggestionList));
-            }
-        });
-    }
+            var typeNames = context.Schema.AllTypes.Dictionary.Values.Select(x => x.Name).ToArray();
+            var suggestionList = StringUtils.SuggestionList(node.Name.StringValue, typeNames); //ISSUE:allocation
+            context.ReportError(new KnownTypeNamesError(context, node, suggestionList));
+        }
+    });
 }

--- a/src/GraphQL/Validation/Rules/LoneAnonymousOperation.cs
+++ b/src/GraphQL/Validation/Rules/LoneAnonymousOperation.cs
@@ -2,31 +2,30 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Lone anonymous operation:
+///
+/// A GraphQL document is only valid if when it contains an anonymous operation
+/// (the query short-hand) that it contains only that one operation definition.
+/// </summary>
+public class LoneAnonymousOperation : ValidationRuleBase
 {
     /// <summary>
-    /// Lone anonymous operation:
-    ///
-    /// A GraphQL document is only valid if when it contains an anonymous operation
-    /// (the query short-hand) that it contains only that one operation definition.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class LoneAnonymousOperation : ValidationRuleBase
+    public static readonly LoneAnonymousOperation Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="LoneAnonymousOperationError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLOperationDefinition>((op, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly LoneAnonymousOperation Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="LoneAnonymousOperationError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLOperationDefinition>((op, context) =>
+        if (op.Name is null && context.Document.OperationsCount() > 1)
         {
-            if (op.Name is null && context.Document.OperationsCount() > 1)
-            {
-                context.ReportError(new LoneAnonymousOperationError(context, op));
-            }
-        });
-    }
+            context.ReportError(new LoneAnonymousOperationError(context, op));
+        }
+    });
 }

--- a/src/GraphQL/Validation/Rules/NoFragmentCycles.cs
+++ b/src/GraphQL/Validation/Rules/NoFragmentCycles.cs
@@ -2,87 +2,86 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// No fragment cycles:
+///
+/// A GraphQL document is only valid if it does not contain fragment cycles.
+/// </summary>
+public class NoFragmentCycles : ValidationRuleBase
 {
     /// <summary>
-    /// No fragment cycles:
-    ///
-    /// A GraphQL document is only valid if it does not contain fragment cycles.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class NoFragmentCycles : ValidationRuleBase
+    public static readonly NoFragmentCycles Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="NoFragmentCyclesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
+        => new(context.Document.FragmentsCount() > 0 ? _nodeVisitor : null);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLFragmentDefinition>((node, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly NoFragmentCycles Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="NoFragmentCyclesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
-            => new(context.Document.FragmentsCount() > 0 ? _nodeVisitor : null);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLFragmentDefinition>((node, context) =>
+        var visitedFrags = context.TypeInfo.NoFragmentCycles_VisitedFrags ??= new();
+        var spreadPath = context.TypeInfo.NoFragmentCycles_SpreadPath ??= new();
+        var spreadPathIndexByName = context.TypeInfo.NoFragmentCycles_SpreadPathIndexByName ??= new();
+        if (!visitedFrags.Contains(node.FragmentName.Name))
         {
-            var visitedFrags = context.TypeInfo.NoFragmentCycles_VisitedFrags ??= new();
-            var spreadPath = context.TypeInfo.NoFragmentCycles_SpreadPath ??= new();
-            var spreadPathIndexByName = context.TypeInfo.NoFragmentCycles_SpreadPathIndexByName ??= new();
-            if (!visitedFrags.Contains(node.FragmentName.Name))
-            {
-                DetectCycleRecursive(node, spreadPath, visitedFrags, spreadPathIndexByName, context);
-            }
-        });
-
-        private static void DetectCycleRecursive(
-            GraphQLFragmentDefinition fragment,
-            Stack<GraphQLFragmentSpread> spreadPath,
-            HashSet<ROM> visitedFrags,
-            Dictionary<ROM, int> spreadPathIndexByName,
-            ValidationContext context)
-        {
-            var fragmentName = fragment.FragmentName.Name;
-            visitedFrags.Add(fragmentName);
-
-            var spreadNodes = context.GetFragmentSpreads(fragment.SelectionSet);
-            if (spreadNodes.Count == 0)
-            {
-                return;
-            }
-
-            spreadPathIndexByName[fragmentName] = spreadPath.Count;
-
-            foreach (var spreadNode in spreadNodes)
-            {
-                var spreadName = spreadNode.FragmentName.Name;
-                if (!spreadPathIndexByName.TryGetValue(spreadName, out var cycleIndex))
-                {
-                    spreadPath.Push(spreadNode);
-
-                    if (!visitedFrags.Contains(spreadName))
-                    {
-                        var spreadFragment = context.Document.FindFragmentDefinition(spreadName);
-                        if (spreadFragment != null)
-                        {
-                            DetectCycleRecursive(
-                                spreadFragment,
-                                spreadPath,
-                                visitedFrags,
-                                spreadPathIndexByName,
-                                context);
-                        }
-                    }
-
-                    spreadPath.Pop();
-                }
-                else
-                {
-                    var cyclePath = spreadPath.Reverse().Skip(cycleIndex).ToArray();
-                    var nodes = cyclePath.OfType<ASTNode>().Concat(new[] { spreadNode }).ToArray();
-
-                    context.ReportError(new NoFragmentCyclesError(context, spreadName.StringValue, cyclePath.Select(x => x.FragmentName.Name.StringValue).ToArray(), nodes)); //ISSUE:allocation
-                }
-            }
-
-            spreadPathIndexByName.Remove(fragmentName);
+            DetectCycleRecursive(node, spreadPath, visitedFrags, spreadPathIndexByName, context);
         }
+    });
+
+    private static void DetectCycleRecursive(
+        GraphQLFragmentDefinition fragment,
+        Stack<GraphQLFragmentSpread> spreadPath,
+        HashSet<ROM> visitedFrags,
+        Dictionary<ROM, int> spreadPathIndexByName,
+        ValidationContext context)
+    {
+        var fragmentName = fragment.FragmentName.Name;
+        visitedFrags.Add(fragmentName);
+
+        var spreadNodes = context.GetFragmentSpreads(fragment.SelectionSet);
+        if (spreadNodes.Count == 0)
+        {
+            return;
+        }
+
+        spreadPathIndexByName[fragmentName] = spreadPath.Count;
+
+        foreach (var spreadNode in spreadNodes)
+        {
+            var spreadName = spreadNode.FragmentName.Name;
+            if (!spreadPathIndexByName.TryGetValue(spreadName, out var cycleIndex))
+            {
+                spreadPath.Push(spreadNode);
+
+                if (!visitedFrags.Contains(spreadName))
+                {
+                    var spreadFragment = context.Document.FindFragmentDefinition(spreadName);
+                    if (spreadFragment != null)
+                    {
+                        DetectCycleRecursive(
+                            spreadFragment,
+                            spreadPath,
+                            visitedFrags,
+                            spreadPathIndexByName,
+                            context);
+                    }
+                }
+
+                spreadPath.Pop();
+            }
+            else
+            {
+                var cyclePath = spreadPath.Reverse().Skip(cycleIndex).ToArray();
+                var nodes = cyclePath.OfType<ASTNode>().Concat(new[] { spreadNode }).ToArray();
+
+                context.ReportError(new NoFragmentCyclesError(context, spreadName.StringValue, cyclePath.Select(x => x.FragmentName.Name.StringValue).ToArray(), nodes)); //ISSUE:allocation
+            }
+        }
+
+        spreadPathIndexByName.Remove(fragmentName);
     }
 }

--- a/src/GraphQL/Validation/Rules/NoUnusedFragments.cs
+++ b/src/GraphQL/Validation/Rules/NoUnusedFragments.cs
@@ -2,49 +2,48 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// No unused fragments:
+///
+/// A GraphQL document is only valid if all fragment definitions are spread
+/// within operations, or spread within other fragment spreads within operations.
+/// </summary>
+public class NoUnusedFragments : ValidationRuleBase
 {
     /// <summary>
-    /// No unused fragments:
-    ///
-    /// A GraphQL document is only valid if all fragment definitions are spread
-    /// within operations, or spread within other fragment spreads within operations.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class NoUnusedFragments : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly NoUnusedFragments Instance = new();
+    public static readonly NoUnusedFragments Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="NoUnusedFragmentsError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
-            => new(context.Document.FragmentsCount() > 0 ? _nodeVisitor : null);
+    /// <inheritdoc/>
+    /// <exception cref="NoUnusedFragmentsError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
+        => new(context.Document.FragmentsCount() > 0 ? _nodeVisitor : null);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLOperationDefinition>((node, context) => (context.TypeInfo.NoUnusedFragments_OperationDefs ??= new(1)).Add(node)),
-            new MatchingNodeVisitor<GraphQLFragmentDefinition>((node, context) => (context.TypeInfo.NoUnusedFragments_FragmentDefs ??= new()).Add(node)),
-            new MatchingNodeVisitor<GraphQLDocument>(leave: (document, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLOperationDefinition>((node, context) => (context.TypeInfo.NoUnusedFragments_OperationDefs ??= new(1)).Add(node)),
+        new MatchingNodeVisitor<GraphQLFragmentDefinition>((node, context) => (context.TypeInfo.NoUnusedFragments_FragmentDefs ??= new()).Add(node)),
+        new MatchingNodeVisitor<GraphQLDocument>(leave: (document, context) =>
+        {
+            var fragmentDefs = context.TypeInfo.NoUnusedFragments_FragmentDefs;
+            if (fragmentDefs == null)
+                return;
+
+            var operationDefs = context.TypeInfo.NoUnusedFragments_OperationDefs;
+            if (operationDefs == null)
+                return;
+
+            var fragmentsUsed = context.GetRecursivelyReferencedFragments(operationDefs);
+
+            foreach (var fragmentDef in fragmentDefs)
             {
-                var fragmentDefs = context.TypeInfo.NoUnusedFragments_FragmentDefs;
-                if (fragmentDefs == null)
-                    return;
-
-                var operationDefs = context.TypeInfo.NoUnusedFragments_OperationDefs;
-                if (operationDefs == null)
-                    return;
-
-                var fragmentsUsed = context.GetRecursivelyReferencedFragments(operationDefs);
-
-                foreach (var fragmentDef in fragmentDefs)
+                if (fragmentsUsed == null || !fragmentsUsed.Contains(fragmentDef))
                 {
-                    if (fragmentsUsed == null || !fragmentsUsed.Contains(fragmentDef))
-                    {
-                        context.ReportError(new NoUnusedFragmentsError(context, fragmentDef));
-                    }
+                    context.ReportError(new NoUnusedFragmentsError(context, fragmentDef));
                 }
-            })
-        );
-    }
+            }
+        })
+    );
 }

--- a/src/GraphQL/Validation/Rules/OverlappingFieldsCanBeMerged.cs
+++ b/src/GraphQL/Validation/Rules/OverlappingFieldsCanBeMerged.cs
@@ -3,234 +3,198 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Overlapping fields are mergable:
+///
+/// If multiple field selections with the same response names are encountered during execution,
+/// the field and arguments to execute and the resulting value should be unambiguous. Therefore
+/// any two field selections which might both be encountered for the same object are only valid
+/// if they are equivalent.
+/// </summary>
+public class OverlappingFieldsCanBeMerged : ValidationRuleBase
 {
     /// <summary>
-    /// Overlapping fields are mergable:
-    ///
-    /// If multiple field selections with the same response names are encountered during execution,
-    /// the field and arguments to execute and the resulting value should be unambiguous. Therefore
-    /// any two field selections which might both be encountered for the same object are only valid
-    /// if they are equivalent.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class OverlappingFieldsCanBeMerged : ValidationRuleBase
+    public static readonly OverlappingFieldsCanBeMerged Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="OverlappingFieldsCanBeMergedError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly OverlappingFieldsCanBeMerged Instance = new();
+        //TODO: make static instance when enabling this rule
+        var comparedFragmentPairs = new PairSet();
+        var cachedFieldsAndFragmentNames = new Dictionary<GraphQLSelectionSet, CachedField>();
 
-        /// <inheritdoc/>
-        /// <exception cref="OverlappingFieldsCanBeMergedError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
+        return new ValueTask<INodeVisitor?>(new MatchingNodeVisitor<GraphQLSelectionSet>((selectionSet, context) => //TODO:allocation of Action<GraphQLSelectionSet,ValidationContext>
         {
-            //TODO: make static instance when enabling this rule
-            var comparedFragmentPairs = new PairSet();
-            var cachedFieldsAndFragmentNames = new Dictionary<GraphQLSelectionSet, CachedField>();
+            var conflicts = FindConflictsWithinSelectionSet(
+                    context,
+                    cachedFieldsAndFragmentNames,
+                    comparedFragmentPairs,
+                    context.TypeInfo.GetParentType(),
+                    selectionSet);
 
-            return new ValueTask<INodeVisitor?>(new MatchingNodeVisitor<GraphQLSelectionSet>((selectionSet, context) => //TODO:allocation of Action<GraphQLSelectionSet,ValidationContext>
+            if (conflicts != null)
             {
-                var conflicts = FindConflictsWithinSelectionSet(
-                        context,
-                        cachedFieldsAndFragmentNames,
-                        comparedFragmentPairs,
-                        context.TypeInfo.GetParentType(),
-                        selectionSet);
-
-                if (conflicts != null)
+                foreach (var conflict in conflicts)
                 {
-                    foreach (var conflict in conflicts)
-                    {
-                        context.ReportError(new OverlappingFieldsCanBeMergedError(context, conflict));
-                    }
+                    context.ReportError(new OverlappingFieldsCanBeMergedError(context, conflict));
                 }
-            }));
-        }
+            }
+        }));
+    }
 
-        private static List<Conflict>? FindConflictsWithinSelectionSet(
-            ValidationContext context,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            PairSet comparedFragmentPairs,
-            IGraphType? parentType,
-            GraphQLSelectionSet selectionSet)
+    private static List<Conflict>? FindConflictsWithinSelectionSet(
+        ValidationContext context,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        PairSet comparedFragmentPairs,
+        IGraphType? parentType,
+        GraphQLSelectionSet selectionSet)
+    {
+        List<Conflict>? conflicts = null;
+
+        var cachedField = GetFieldsAndFragmentNames(
+            context,
+            cachedFieldsAndFragmentNames,
+            parentType,
+            selectionSet);
+
+        var fieldMap = cachedField.NodeAndDef;
+        var fragmentNames = cachedField.Names;
+
+        CollectConflictsWithin(
+            context,
+            ref conflicts,
+            cachedFieldsAndFragmentNames,
+            comparedFragmentPairs,
+            fieldMap);
+
+        if (fragmentNames.Count != 0)
         {
-            List<Conflict>? conflicts = null;
-
-            var cachedField = GetFieldsAndFragmentNames(
-                context,
-                cachedFieldsAndFragmentNames,
-                parentType,
-                selectionSet);
-
-            var fieldMap = cachedField.NodeAndDef;
-            var fragmentNames = cachedField.Names;
-
-            CollectConflictsWithin(
-                context,
-                ref conflicts,
-                cachedFieldsAndFragmentNames,
-                comparedFragmentPairs,
-                fieldMap);
-
-            if (fragmentNames.Count != 0)
+            // (B) Then collect conflicts between these fields and those represented by
+            // each spread fragment name found.
+            var comparedFragments = new HashSet<ROM>();
+            for (int i = 0; i < fragmentNames.Count; i++)
             {
-                // (B) Then collect conflicts between these fields and those represented by
-                // each spread fragment name found.
-                var comparedFragments = new HashSet<ROM>();
-                for (int i = 0; i < fragmentNames.Count; i++)
+                CollectConflictsBetweenFieldsAndFragment(
+                  context,
+                  ref conflicts,
+                  cachedFieldsAndFragmentNames,
+                  comparedFragments,
+                  comparedFragmentPairs,
+                  false,
+                  fieldMap,
+                  fragmentNames[i]);
+
+                // (C) Then compare this fragment with all other fragments found in this
+                // selection set to collect conflicts between fragments spread together.
+                // This compares each item in the list of fragment names to every other
+                // item in that same list (except for itself).
+                for (int j = i + 1; j < fragmentNames.Count; j++)
                 {
-                    CollectConflictsBetweenFieldsAndFragment(
+                    CollectConflictsBetweenFragments(
                       context,
                       ref conflicts,
                       cachedFieldsAndFragmentNames,
-                      comparedFragments,
                       comparedFragmentPairs,
                       false,
-                      fieldMap,
-                      fragmentNames[i]);
-
-                    // (C) Then compare this fragment with all other fragments found in this
-                    // selection set to collect conflicts between fragments spread together.
-                    // This compares each item in the list of fragment names to every other
-                    // item in that same list (except for itself).
-                    for (int j = i + 1; j < fragmentNames.Count; j++)
-                    {
-                        CollectConflictsBetweenFragments(
-                          context,
-                          ref conflicts,
-                          cachedFieldsAndFragmentNames,
-                          comparedFragmentPairs,
-                          false,
-                          fragmentNames[i],
-                          fragmentNames[j]);
-                    }
+                      fragmentNames[i],
+                      fragmentNames[j]);
                 }
             }
-            return conflicts;
         }
+        return conflicts;
+    }
 
-        private static void CollectConflictsWithin(
-            ValidationContext context,
-            ref List<Conflict>? conflicts,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            PairSet comparedFragmentPairs,
-            Dictionary<ROM, List<FieldDefPair>> fieldMap)
+    private static void CollectConflictsWithin(
+        ValidationContext context,
+        ref List<Conflict>? conflicts,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        PairSet comparedFragmentPairs,
+        Dictionary<ROM, List<FieldDefPair>> fieldMap)
+    {
+        // A field map is a keyed collection, where each key represents a response
+        // name and the value at that key is a list of all fields which provide that
+        // response name. For every response name, if there are multiple fields, they
+        // must be compared to find a potential conflict.
+        foreach (var entry in fieldMap)
         {
-            // A field map is a keyed collection, where each key represents a response
-            // name and the value at that key is a list of all fields which provide that
-            // response name. For every response name, if there are multiple fields, they
-            // must be compared to find a potential conflict.
-            foreach (var entry in fieldMap)
+            var responseName = entry.Key;
+            var fields = entry.Value;
+
+            // This compares every field in the list to every other field in this list
+            // (except to itself). If the list only has one item, nothing needs to
+            // be compared.
+            if (fields.Count > 1)
             {
-                var responseName = entry.Key;
-                var fields = entry.Value;
-
-                // This compares every field in the list to every other field in this list
-                // (except to itself). If the list only has one item, nothing needs to
-                // be compared.
-                if (fields.Count > 1)
+                for (int i = 0; i < fields.Count; i++)
                 {
-                    for (int i = 0; i < fields.Count; i++)
+                    for (int j = i + 1; j < fields.Count; j++)
                     {
-                        for (int j = i + 1; j < fields.Count; j++)
-                        {
-                            var conflict = FindConflict(
-                                        context,
-                                        cachedFieldsAndFragmentNames,
-                                        comparedFragmentPairs,
-                                        false, // within one collection is never mutually exclusive
-                                        responseName,
-                                        fields[i],
-                                        fields[j]);
+                        var conflict = FindConflict(
+                                    context,
+                                    cachedFieldsAndFragmentNames,
+                                    comparedFragmentPairs,
+                                    false, // within one collection is never mutually exclusive
+                                    responseName,
+                                    fields[i],
+                                    fields[j]);
 
-                            if (conflict != null)
-                            {
-                                (conflicts ??= new()).Add(conflict);
-                            }
+                        if (conflict != null)
+                        {
+                            (conflicts ??= new()).Add(conflict);
                         }
                     }
                 }
-
             }
+
         }
+    }
 
-        private static Conflict? FindConflict(
-            ValidationContext context,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            PairSet comparedFragmentPairs,
-            bool parentFieldsAreMutuallyExclusive,
-            ROM responseName,
-            FieldDefPair fieldDefPair1,
-            FieldDefPair fieldDefPair2)
+    private static Conflict? FindConflict(
+        ValidationContext context,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        PairSet comparedFragmentPairs,
+        bool parentFieldsAreMutuallyExclusive,
+        ROM responseName,
+        FieldDefPair fieldDefPair1,
+        FieldDefPair fieldDefPair2)
+    {
+        var parentType1 = fieldDefPair1.ParentType;
+        var node1 = fieldDefPair1.Field;
+        var def1 = fieldDefPair1.FieldDef;
+
+        var parentType2 = fieldDefPair2.ParentType;
+        var node2 = fieldDefPair2.Field;
+        var def2 = fieldDefPair2.FieldDef;
+
+        // If it is known that two fields could not possibly apply at the same
+        // time, due to the parent types, then it is safe to permit them to diverge
+        // in aliased field or arguments used as they will not present any ambiguity
+        // by differing.
+        // It is known that two parent types could never overlap if they are
+        // different Object types. Interface or Union types might overlap - if not
+        // in the current state of the schema, then perhaps in some future version,
+        // thus may not safely diverge.
+
+        bool areMutuallyExclusive =
+            parentFieldsAreMutuallyExclusive ||
+            parentType1 != parentType2 && isObjectType(parentType1) && isObjectType(parentType2);
+
+        // return type for each field.
+        var type1 = def1?.ResolvedType;
+        var type2 = def2?.ResolvedType;
+
+        if (!areMutuallyExclusive)
         {
-            var parentType1 = fieldDefPair1.ParentType;
-            var node1 = fieldDefPair1.Field;
-            var def1 = fieldDefPair1.FieldDef;
+            // Two aliases must refer to the same field.
+            var name1 = node1.GetName();
+            var name2 = node2.GetName();
 
-            var parentType2 = fieldDefPair2.ParentType;
-            var node2 = fieldDefPair2.Field;
-            var def2 = fieldDefPair2.FieldDef;
-
-            // If it is known that two fields could not possibly apply at the same
-            // time, due to the parent types, then it is safe to permit them to diverge
-            // in aliased field or arguments used as they will not present any ambiguity
-            // by differing.
-            // It is known that two parent types could never overlap if they are
-            // different Object types. Interface or Union types might overlap - if not
-            // in the current state of the schema, then perhaps in some future version,
-            // thus may not safely diverge.
-
-            bool areMutuallyExclusive =
-                parentFieldsAreMutuallyExclusive ||
-                parentType1 != parentType2 && isObjectType(parentType1) && isObjectType(parentType2);
-
-            // return type for each field.
-            var type1 = def1?.ResolvedType;
-            var type2 = def2?.ResolvedType;
-
-            if (!areMutuallyExclusive)
-            {
-                // Two aliases must refer to the same field.
-                var name1 = node1.GetName();
-                var name2 = node2.GetName();
-
-                if (name1 != name2)
-                {
-                    return new Conflict
-                    {
-                        Reason = new ConflictReason
-                        {
-                            Name = (string)responseName, //ISSUE:allocation
-                            Message = new Message
-                            {
-                                Msg = $"{name1} and {name2} are different fields"
-                            }
-                        },
-                        FieldsLeft = new List<ISelectionNode> { node1 },
-                        FieldsRight = new List<ISelectionNode> { node2 }
-                    };
-                }
-
-                // Two field calls must have the same arguments.
-                if (!SameArguments(node1.GetArguments(), node2.GetArguments()))
-                {
-                    return new Conflict
-                    {
-                        Reason = new ConflictReason
-                        {
-                            Name = (string)responseName, //ISSUE:allocation
-                            Message = new Message
-                            {
-                                Msg = "they have differing arguments"
-                            }
-                        },
-                        FieldsLeft = new List<ISelectionNode> { node1 },
-                        FieldsRight = new List<ISelectionNode> { node2 }
-                    };
-                }
-            }
-
-            if (type1 != null && type2 != null && DoTypesConflict(type1, type2))
+            if (name1 != name2)
             {
                 return new Conflict
                 {
@@ -239,7 +203,7 @@ namespace GraphQL.Validation.Rules
                         Name = (string)responseName, //ISSUE:allocation
                         Message = new Message
                         {
-                            Msg = $"they return conflicting types {type1} and {type2}"
+                            Msg = $"{name1} and {name2} are different fields"
                         }
                     },
                     FieldsLeft = new List<ISelectionNode> { node1 },
@@ -247,272 +211,113 @@ namespace GraphQL.Validation.Rules
                 };
             }
 
-            // Collect and compare sub-fields. Use the same "visited fragment names" list
-            // for both collections so fields in a fragment reference are never
-            // compared to themselves.
-            var selectionSet1 = node1.GetSelectionSet();
-            var selectionSet2 = node2.GetSelectionSet();
-
-            if (selectionSet1 != null && selectionSet2 != null)
+            // Two field calls must have the same arguments.
+            if (!SameArguments(node1.GetArguments(), node2.GetArguments()))
             {
-                var conflicts = FindConflictsBetweenSubSelectionSets(
-                    context,
-                    cachedFieldsAndFragmentNames,
-                    comparedFragmentPairs,
-                    areMutuallyExclusive,
-                    type1?.GetNamedType(),
-                    selectionSet1,
-                    type2?.GetNamedType(),
-                    selectionSet2);
-
-                return SubfieldConflicts(conflicts, responseName, node1, node2);
+                return new Conflict
+                {
+                    Reason = new ConflictReason
+                    {
+                        Name = (string)responseName, //ISSUE:allocation
+                        Message = new Message
+                        {
+                            Msg = "they have differing arguments"
+                        }
+                    },
+                    FieldsLeft = new List<ISelectionNode> { node1 },
+                    FieldsRight = new List<ISelectionNode> { node2 }
+                };
             }
-
-            return null;
         }
 
-        private static List<Conflict>? FindConflictsBetweenSubSelectionSets(
-            ValidationContext context,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            PairSet comparedFragmentPairs,
-            bool areMutuallyExclusive,
-            IGraphType? parentType1,
-            GraphQLSelectionSet selectionSet1,
-            IGraphType? parentType2,
-            GraphQLSelectionSet selectionSet2)
+        if (type1 != null && type2 != null && DoTypesConflict(type1, type2))
         {
-            List<Conflict>? conflicts = null;
+            return new Conflict
+            {
+                Reason = new ConflictReason
+                {
+                    Name = (string)responseName, //ISSUE:allocation
+                    Message = new Message
+                    {
+                        Msg = $"they return conflicting types {type1} and {type2}"
+                    }
+                },
+                FieldsLeft = new List<ISelectionNode> { node1 },
+                FieldsRight = new List<ISelectionNode> { node2 }
+            };
+        }
 
-            var cachedField1 = GetFieldsAndFragmentNames(
+        // Collect and compare sub-fields. Use the same "visited fragment names" list
+        // for both collections so fields in a fragment reference are never
+        // compared to themselves.
+        var selectionSet1 = node1.GetSelectionSet();
+        var selectionSet2 = node2.GetSelectionSet();
+
+        if (selectionSet1 != null && selectionSet2 != null)
+        {
+            var conflicts = FindConflictsBetweenSubSelectionSets(
                 context,
                 cachedFieldsAndFragmentNames,
-                parentType1,
-                selectionSet1);
-
-            var fieldMap1 = cachedField1.NodeAndDef;
-            var fragmentNames1 = cachedField1.Names;
-
-            var cachedField2 = GetFieldsAndFragmentNames(
-                context,
-                cachedFieldsAndFragmentNames,
-                parentType2,
+                comparedFragmentPairs,
+                areMutuallyExclusive,
+                type1?.GetNamedType(),
+                selectionSet1,
+                type2?.GetNamedType(),
                 selectionSet2);
 
-            var fieldMap2 = cachedField2.NodeAndDef;
-            var fragmentNames2 = cachedField2.Names;
-
-            // (H) First, collect all conflicts between these two collections of field.
-            CollectConflictsBetween(
-                context,
-                ref conflicts,
-                cachedFieldsAndFragmentNames,
-                comparedFragmentPairs,
-                areMutuallyExclusive,
-                fieldMap1,
-                fieldMap2);
-
-            // (I) Then collect conflicts between the first collection of fields and
-            // those referenced by each fragment name associated with the second.
-            if (fragmentNames2.Count != 0)
-            {
-                var comparedFragments = new HashSet<ROM>();
-
-                for (int j = 0; j < fragmentNames2.Count; j++)
-                {
-                    CollectConflictsBetweenFieldsAndFragment(
-                      context,
-                      ref conflicts,
-                      cachedFieldsAndFragmentNames,
-                      comparedFragments,
-                      comparedFragmentPairs,
-                      areMutuallyExclusive,
-                      fieldMap1,
-                      fragmentNames2[j]);
-                }
-            }
-
-            // (I) Then collect conflicts between the second collection of fields and
-            // those referenced by each fragment name associated with the first.
-            if (fragmentNames1.Count != 0)
-            {
-                var comparedFragments = new HashSet<ROM>();
-
-                for (int i = 0; i < fragmentNames1.Count; i++)
-                {
-                    CollectConflictsBetweenFieldsAndFragment(
-                      context,
-                      ref conflicts,
-                      cachedFieldsAndFragmentNames,
-                      comparedFragments,
-                      comparedFragmentPairs,
-                      areMutuallyExclusive,
-                      fieldMap2,
-                      fragmentNames1[i]);
-                }
-            }
-
-            // (J) Also collect conflicts between any fragment names by the first and
-            // fragment names by the second. This compares each item in the first set of
-            // names to each item in the second set of names.
-            for (int i = 0; i < fragmentNames1.Count; i++)
-            {
-                for (int j = 0; j < fragmentNames2.Count; j++)
-                {
-                    CollectConflictsBetweenFragments(
-                      context,
-                      ref conflicts,
-                      cachedFieldsAndFragmentNames,
-                      comparedFragmentPairs,
-                      areMutuallyExclusive,
-                      fragmentNames1[i],
-                      fragmentNames2[j]);
-                }
-            }
-
-            return conflicts;
+            return SubfieldConflicts(conflicts, responseName, node1, node2);
         }
 
-        private static void CollectConflictsBetweenFragments(
-            ValidationContext context,
-            ref List<Conflict>? conflicts,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            PairSet comparedFragmentPairs,
-            bool areMutuallyExclusive,
-            ROM fragmentName1,
-            ROM fragmentName2)
+        return null;
+    }
+
+    private static List<Conflict>? FindConflictsBetweenSubSelectionSets(
+        ValidationContext context,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        PairSet comparedFragmentPairs,
+        bool areMutuallyExclusive,
+        IGraphType? parentType1,
+        GraphQLSelectionSet selectionSet1,
+        IGraphType? parentType2,
+        GraphQLSelectionSet selectionSet2)
+    {
+        List<Conflict>? conflicts = null;
+
+        var cachedField1 = GetFieldsAndFragmentNames(
+            context,
+            cachedFieldsAndFragmentNames,
+            parentType1,
+            selectionSet1);
+
+        var fieldMap1 = cachedField1.NodeAndDef;
+        var fragmentNames1 = cachedField1.Names;
+
+        var cachedField2 = GetFieldsAndFragmentNames(
+            context,
+            cachedFieldsAndFragmentNames,
+            parentType2,
+            selectionSet2);
+
+        var fieldMap2 = cachedField2.NodeAndDef;
+        var fragmentNames2 = cachedField2.Names;
+
+        // (H) First, collect all conflicts between these two collections of field.
+        CollectConflictsBetween(
+            context,
+            ref conflicts,
+            cachedFieldsAndFragmentNames,
+            comparedFragmentPairs,
+            areMutuallyExclusive,
+            fieldMap1,
+            fieldMap2);
+
+        // (I) Then collect conflicts between the first collection of fields and
+        // those referenced by each fragment name associated with the second.
+        if (fragmentNames2.Count != 0)
         {
-            // No need to compare a fragment to itself.
-            if (fragmentName1 == fragmentName2)
-            {
-                return;
-            }
+            var comparedFragments = new HashSet<ROM>();
 
-            // Memoize so two fragments are not compared for conflicts more than once.
-            if (comparedFragmentPairs.Has(fragmentName1, fragmentName2, areMutuallyExclusive))
-            {
-                return;
-            }
-
-            comparedFragmentPairs.Add(fragmentName1, fragmentName2, areMutuallyExclusive);
-
-            var fragment1 = context.Document.FindFragmentDefinition(fragmentName1);
-            var fragment2 = context.Document.FindFragmentDefinition(fragmentName2);
-
-            if (fragment1 == null || fragment2 == null)
-            {
-                return;
-            }
-
-            var cachedField1 =
-                GetReferencedFieldsAndFragmentNames(
-                    context,
-                    cachedFieldsAndFragmentNames,
-                    fragment1);
-
-            var fieldMap1 = cachedField1.NodeAndDef;
-            var fragmentNames1 = cachedField1.Names;
-
-            var cachedField2 =
-                GetReferencedFieldsAndFragmentNames(
-                      context,
-                      cachedFieldsAndFragmentNames,
-                      fragment2);
-
-            var fieldMap2 = cachedField2.NodeAndDef;
-            var fragmentNames2 = cachedField2.Names;
-
-            // (F) First, collect all conflicts between these two collections of fields
-            // (not including any nested fragments).
-            CollectConflictsBetween(
-              context,
-              ref conflicts,
-              cachedFieldsAndFragmentNames,
-              comparedFragmentPairs,
-              areMutuallyExclusive,
-              fieldMap1,
-              fieldMap2);
-
-            // (G) Then collect conflicts between the first fragment and any nested
-            // fragments spread in the second fragment.
             for (int j = 0; j < fragmentNames2.Count; j++)
-            {
-                CollectConflictsBetweenFragments(
-                  context,
-                  ref conflicts,
-                  cachedFieldsAndFragmentNames,
-                  comparedFragmentPairs,
-                  areMutuallyExclusive,
-                  fragmentName1,
-                  fragmentNames2[j]);
-            }
-
-            // (G) Then collect conflicts between the second fragment and any nested
-            // fragments spread in the first fragment.
-            for (int i = 0; i < fragmentNames1.Count; i++)
-            {
-                CollectConflictsBetweenFragments(
-                  context,
-                  ref conflicts,
-                  cachedFieldsAndFragmentNames,
-                  comparedFragmentPairs,
-                  areMutuallyExclusive,
-                  fragmentNames1[i],
-                  fragmentName2);
-            }
-        }
-
-        private static void CollectConflictsBetweenFieldsAndFragment(
-            ValidationContext context,
-            ref List<Conflict>? conflicts,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            HashSet<ROM> comparedFragments,
-            PairSet comparedFragmentPairs,
-            bool areMutuallyExclusive,
-            Dictionary<ROM, List<FieldDefPair>> fieldMap,
-            ROM fragmentName)
-        {
-            // Memoize so a fragment is not compared for conflicts more than once.
-            if (!comparedFragments.Add(fragmentName))
-            {
-                return;
-            }
-
-            var fragment = context.Document.FindFragmentDefinition(fragmentName);
-
-            if (fragment == null)
-            {
-                return;
-            }
-
-            var cachedField =
-                GetReferencedFieldsAndFragmentNames(
-                    context,
-                    cachedFieldsAndFragmentNames,
-                    fragment);
-
-            var fieldMap2 = cachedField.NodeAndDef;
-            var fragmentNames2 = cachedField.Names;
-
-            // Do not compare a fragment's fieldMap to itself.
-            if (fieldMap == fieldMap2)
-            {
-                return;
-            }
-
-            // (D) First collect any conflicts between the provided collection of fields
-            // and the collection of fields represented by the given fragment.
-            CollectConflictsBetween(
-                context,
-                ref conflicts,
-                cachedFieldsAndFragmentNames,
-                comparedFragmentPairs,
-                areMutuallyExclusive,
-                fieldMap,
-                fieldMap2);
-
-            // (E) Then collect any conflicts between the provided collection of fields
-            // and any fragment names found in the given fragment.
-            for (int i = 0; i < fragmentNames2.Count; i++)
             {
                 CollectConflictsBetweenFieldsAndFragment(
                   context,
@@ -521,401 +326,595 @@ namespace GraphQL.Validation.Rules
                   comparedFragments,
                   comparedFragmentPairs,
                   areMutuallyExclusive,
-                  fieldMap,
-                  fragmentNames2[i]);
+                  fieldMap1,
+                  fragmentNames2[j]);
             }
         }
 
-        private static void CollectConflictsBetween(
-            ValidationContext context,
-            ref List<Conflict>? conflicts,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            PairSet comparedFragmentPairs,
-            bool parentFieldsAreMutuallyExclusive,
-            Dictionary<ROM, List<FieldDefPair>> fieldMap1,
-            Dictionary<ROM, List<FieldDefPair>> fieldMap2)
+        // (I) Then collect conflicts between the second collection of fields and
+        // those referenced by each fragment name associated with the first.
+        if (fragmentNames1.Count != 0)
         {
-            // A field map is a keyed collection, where each key represents a response
-            // name and the value at that key is a list of all fields which provide that
-            // response name. For any response name which appears in both provided field
-            // maps, each field from the first field map must be compared to every field
-            // in the second field map to find potential conflicts.
+            var comparedFragments = new HashSet<ROM>();
 
-            foreach (var responseName in fieldMap1.Keys)
+            for (int i = 0; i < fragmentNames1.Count; i++)
             {
-                if (fieldMap2.TryGetValue(responseName, out var fields2) && fields2.Count != 0)
-                {
-                    var fields1 = fieldMap1[responseName];
-                    for (int i = 0; i < fields1.Count; i++)
-                    {
-                        for (int j = 0; j < fields2.Count; j++)
-                        {
-                            var conflict = FindConflict(
-                              context,
-                              cachedFieldsAndFragmentNames,
-                              comparedFragmentPairs,
-                              parentFieldsAreMutuallyExclusive,
-                              responseName,
-                              fields1[i],
-                              fields2[j]);
+                CollectConflictsBetweenFieldsAndFragment(
+                  context,
+                  ref conflicts,
+                  cachedFieldsAndFragmentNames,
+                  comparedFragments,
+                  comparedFragmentPairs,
+                  areMutuallyExclusive,
+                  fieldMap2,
+                  fragmentNames1[i]);
+            }
+        }
 
-                            if (conflict != null)
-                            {
-                                (conflicts ??= new()).Add(conflict);
-                            }
+        // (J) Also collect conflicts between any fragment names by the first and
+        // fragment names by the second. This compares each item in the first set of
+        // names to each item in the second set of names.
+        for (int i = 0; i < fragmentNames1.Count; i++)
+        {
+            for (int j = 0; j < fragmentNames2.Count; j++)
+            {
+                CollectConflictsBetweenFragments(
+                  context,
+                  ref conflicts,
+                  cachedFieldsAndFragmentNames,
+                  comparedFragmentPairs,
+                  areMutuallyExclusive,
+                  fragmentNames1[i],
+                  fragmentNames2[j]);
+            }
+        }
+
+        return conflicts;
+    }
+
+    private static void CollectConflictsBetweenFragments(
+        ValidationContext context,
+        ref List<Conflict>? conflicts,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        PairSet comparedFragmentPairs,
+        bool areMutuallyExclusive,
+        ROM fragmentName1,
+        ROM fragmentName2)
+    {
+        // No need to compare a fragment to itself.
+        if (fragmentName1 == fragmentName2)
+        {
+            return;
+        }
+
+        // Memoize so two fragments are not compared for conflicts more than once.
+        if (comparedFragmentPairs.Has(fragmentName1, fragmentName2, areMutuallyExclusive))
+        {
+            return;
+        }
+
+        comparedFragmentPairs.Add(fragmentName1, fragmentName2, areMutuallyExclusive);
+
+        var fragment1 = context.Document.FindFragmentDefinition(fragmentName1);
+        var fragment2 = context.Document.FindFragmentDefinition(fragmentName2);
+
+        if (fragment1 == null || fragment2 == null)
+        {
+            return;
+        }
+
+        var cachedField1 =
+            GetReferencedFieldsAndFragmentNames(
+                context,
+                cachedFieldsAndFragmentNames,
+                fragment1);
+
+        var fieldMap1 = cachedField1.NodeAndDef;
+        var fragmentNames1 = cachedField1.Names;
+
+        var cachedField2 =
+            GetReferencedFieldsAndFragmentNames(
+                  context,
+                  cachedFieldsAndFragmentNames,
+                  fragment2);
+
+        var fieldMap2 = cachedField2.NodeAndDef;
+        var fragmentNames2 = cachedField2.Names;
+
+        // (F) First, collect all conflicts between these two collections of fields
+        // (not including any nested fragments).
+        CollectConflictsBetween(
+          context,
+          ref conflicts,
+          cachedFieldsAndFragmentNames,
+          comparedFragmentPairs,
+          areMutuallyExclusive,
+          fieldMap1,
+          fieldMap2);
+
+        // (G) Then collect conflicts between the first fragment and any nested
+        // fragments spread in the second fragment.
+        for (int j = 0; j < fragmentNames2.Count; j++)
+        {
+            CollectConflictsBetweenFragments(
+              context,
+              ref conflicts,
+              cachedFieldsAndFragmentNames,
+              comparedFragmentPairs,
+              areMutuallyExclusive,
+              fragmentName1,
+              fragmentNames2[j]);
+        }
+
+        // (G) Then collect conflicts between the second fragment and any nested
+        // fragments spread in the first fragment.
+        for (int i = 0; i < fragmentNames1.Count; i++)
+        {
+            CollectConflictsBetweenFragments(
+              context,
+              ref conflicts,
+              cachedFieldsAndFragmentNames,
+              comparedFragmentPairs,
+              areMutuallyExclusive,
+              fragmentNames1[i],
+              fragmentName2);
+        }
+    }
+
+    private static void CollectConflictsBetweenFieldsAndFragment(
+        ValidationContext context,
+        ref List<Conflict>? conflicts,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        HashSet<ROM> comparedFragments,
+        PairSet comparedFragmentPairs,
+        bool areMutuallyExclusive,
+        Dictionary<ROM, List<FieldDefPair>> fieldMap,
+        ROM fragmentName)
+    {
+        // Memoize so a fragment is not compared for conflicts more than once.
+        if (!comparedFragments.Add(fragmentName))
+        {
+            return;
+        }
+
+        var fragment = context.Document.FindFragmentDefinition(fragmentName);
+
+        if (fragment == null)
+        {
+            return;
+        }
+
+        var cachedField =
+            GetReferencedFieldsAndFragmentNames(
+                context,
+                cachedFieldsAndFragmentNames,
+                fragment);
+
+        var fieldMap2 = cachedField.NodeAndDef;
+        var fragmentNames2 = cachedField.Names;
+
+        // Do not compare a fragment's fieldMap to itself.
+        if (fieldMap == fieldMap2)
+        {
+            return;
+        }
+
+        // (D) First collect any conflicts between the provided collection of fields
+        // and the collection of fields represented by the given fragment.
+        CollectConflictsBetween(
+            context,
+            ref conflicts,
+            cachedFieldsAndFragmentNames,
+            comparedFragmentPairs,
+            areMutuallyExclusive,
+            fieldMap,
+            fieldMap2);
+
+        // (E) Then collect any conflicts between the provided collection of fields
+        // and any fragment names found in the given fragment.
+        for (int i = 0; i < fragmentNames2.Count; i++)
+        {
+            CollectConflictsBetweenFieldsAndFragment(
+              context,
+              ref conflicts,
+              cachedFieldsAndFragmentNames,
+              comparedFragments,
+              comparedFragmentPairs,
+              areMutuallyExclusive,
+              fieldMap,
+              fragmentNames2[i]);
+        }
+    }
+
+    private static void CollectConflictsBetween(
+        ValidationContext context,
+        ref List<Conflict>? conflicts,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        PairSet comparedFragmentPairs,
+        bool parentFieldsAreMutuallyExclusive,
+        Dictionary<ROM, List<FieldDefPair>> fieldMap1,
+        Dictionary<ROM, List<FieldDefPair>> fieldMap2)
+    {
+        // A field map is a keyed collection, where each key represents a response
+        // name and the value at that key is a list of all fields which provide that
+        // response name. For any response name which appears in both provided field
+        // maps, each field from the first field map must be compared to every field
+        // in the second field map to find potential conflicts.
+
+        foreach (var responseName in fieldMap1.Keys)
+        {
+            if (fieldMap2.TryGetValue(responseName, out var fields2) && fields2.Count != 0)
+            {
+                var fields1 = fieldMap1[responseName];
+                for (int i = 0; i < fields1.Count; i++)
+                {
+                    for (int j = 0; j < fields2.Count; j++)
+                    {
+                        var conflict = FindConflict(
+                          context,
+                          cachedFieldsAndFragmentNames,
+                          comparedFragmentPairs,
+                          parentFieldsAreMutuallyExclusive,
+                          responseName,
+                          fields1[i],
+                          fields2[j]);
+
+                        if (conflict != null)
+                        {
+                            (conflicts ??= new()).Add(conflict);
                         }
                     }
                 }
             }
         }
+    }
 
-        private static bool DoTypesConflict(IGraphType type1, IGraphType type2)
+    private static bool DoTypesConflict(IGraphType type1, IGraphType type2)
+    {
+        if (type1 is ListGraphType type1List)
         {
-            if (type1 is ListGraphType type1List)
-            {
-                return type2 is ListGraphType type2List
-                    ? DoTypesConflict(type1List.ResolvedType!, type2List.ResolvedType!)
-                    : true;
-            }
+            return type2 is ListGraphType type2List
+                ? DoTypesConflict(type1List.ResolvedType!, type2List.ResolvedType!)
+                : true;
+        }
 
-            if (type2 is ListGraphType)
-            {
-                return true;
-            }
+        if (type2 is ListGraphType)
+        {
+            return true;
+        }
 
-            if (type1 is NonNullGraphType type1NonNull)
-            {
-                return type2 is NonNullGraphType type2NonNull
-                    ? DoTypesConflict(type1NonNull.ResolvedType!, type2NonNull.ResolvedType!)
-                    : true;
-            }
+        if (type1 is NonNullGraphType type1NonNull)
+        {
+            return type2 is NonNullGraphType type2NonNull
+                ? DoTypesConflict(type1NonNull.ResolvedType!, type2NonNull.ResolvedType!)
+                : true;
+        }
 
-            if (type2 is NonNullGraphType)
-            {
-                return true;
-            }
+        if (type2 is NonNullGraphType)
+        {
+            return true;
+        }
 
-            if (type1.IsLeafType() || type2.IsLeafType())
-            {
-                return !type1.Equals(type2);
-            }
+        if (type1.IsLeafType() || type2.IsLeafType())
+        {
+            return !type1.Equals(type2);
+        }
 
+        return false;
+    }
+
+    private static bool SameArguments(GraphQLArguments? arguments1, GraphQLArguments? arguments2)
+    {
+        if (arguments1 == null && arguments2 == null)
+            return true;
+
+        if (arguments1 != null && arguments2 == null)
+            return false;
+
+        if (arguments1 == null && arguments2 != null)
+            return false;
+
+        if (arguments1!.Count != arguments2!.Count)
+        {
             return false;
         }
 
-        private static bool SameArguments(GraphQLArguments? arguments1, GraphQLArguments? arguments2)
+        return arguments1.All(arg1 =>
         {
-            if (arguments1 == null && arguments2 == null)
-                return true;
+            var arg2 = arguments2.FirstOrDefault(x => x.Name == arg1.Name);
 
-            if (arguments1 != null && arguments2 == null)
-                return false;
-
-            if (arguments1 == null && arguments2 != null)
-                return false;
-
-            if (arguments1!.Count != arguments2!.Count)
+            if (arg2 == null)
             {
                 return false;
             }
+            return SameValue(arg1, arg2);
+        });
+    }
 
-            return arguments1.All(arg1 =>
-            {
-                var arg2 = arguments2.FirstOrDefault(x => x.Name == arg1.Name);
+    private static bool SameValue(GraphQLArgument arg1, GraphQLArgument arg2)
+    {
+        // normalize values prior to comparison by using ASTNode.Print
+        return arg1.Value is null && arg2.Value is null ||
+            arg1.Value is not null && arg2.Value is not null && arg1.Value.Print() == arg2.Value.Print(); //TODO: change
+    }
 
-                if (arg2 == null)
-                {
-                    return false;
-                }
-                return SameValue(arg1, arg2);
-            });
-        }
-
-        private static bool SameValue(GraphQLArgument arg1, GraphQLArgument arg2)
+    private static CachedField GetFieldsAndFragmentNames(
+        ValidationContext context,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        IGraphType? parentType,
+        GraphQLSelectionSet selectionSet)
+    {
+        if (!cachedFieldsAndFragmentNames.TryGetValue(selectionSet, out var cached))
         {
-            // normalize values prior to comparison by using ASTNode.Print
-            return arg1.Value is null && arg2.Value is null ||
-                arg1.Value is not null && arg2.Value is not null && arg1.Value.Print() == arg2.Value.Print(); //TODO: change
+            var nodeAndDef = new Dictionary<ROM, List<FieldDefPair>>();
+            var fragmentNames = new HashSet<ROM>();
+
+            CollectFieldsAndFragmentNames(
+                context,
+                parentType,
+                selectionSet,
+                nodeAndDef,
+                fragmentNames);
+
+            cached = new CachedField { NodeAndDef = nodeAndDef, Names = fragmentNames.ToList() };
+            cachedFieldsAndFragmentNames.Add(selectionSet, cached);
         }
+        return cached;
+    }
 
-        private static CachedField GetFieldsAndFragmentNames(
-            ValidationContext context,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            IGraphType? parentType,
-            GraphQLSelectionSet selectionSet)
+    // Given a reference to a fragment, return the represented collection of fields
+    // as well as a list of nested fragment names referenced via fragment spreads.
+    private static CachedField GetReferencedFieldsAndFragmentNames(
+        ValidationContext context,
+        Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
+        GraphQLFragmentDefinition fragment)
+    {
+        // Short-circuit building a type from the node if possible.
+        if (cachedFieldsAndFragmentNames.TryGetValue(fragment.SelectionSet, out var cached))
         {
-            if (!cachedFieldsAndFragmentNames.TryGetValue(selectionSet, out var cached))
-            {
-                var nodeAndDef = new Dictionary<ROM, List<FieldDefPair>>();
-                var fragmentNames = new HashSet<ROM>();
-
-                CollectFieldsAndFragmentNames(
-                    context,
-                    parentType,
-                    selectionSet,
-                    nodeAndDef,
-                    fragmentNames);
-
-                cached = new CachedField { NodeAndDef = nodeAndDef, Names = fragmentNames.ToList() };
-                cachedFieldsAndFragmentNames.Add(selectionSet, cached);
-            }
             return cached;
         }
 
-        // Given a reference to a fragment, return the represented collection of fields
-        // as well as a list of nested fragment names referenced via fragment spreads.
-        private static CachedField GetReferencedFieldsAndFragmentNames(
-            ValidationContext context,
-            Dictionary<GraphQLSelectionSet, CachedField> cachedFieldsAndFragmentNames,
-            GraphQLFragmentDefinition fragment)
-        {
-            // Short-circuit building a type from the node if possible.
-            if (cachedFieldsAndFragmentNames.TryGetValue(fragment.SelectionSet, out var cached))
-            {
-                return cached;
-            }
-
-            var fragmentType = fragment.TypeCondition.Type.GraphTypeFromType(context.Schema);
-            return GetFieldsAndFragmentNames(
-                context,
-                cachedFieldsAndFragmentNames,
-                fragmentType,
-                fragment.SelectionSet);
-        }
-
-        private static void CollectFieldsAndFragmentNames(
-            ValidationContext context,
-            IGraphType? parentType,
-            GraphQLSelectionSet selectionSet,
-            Dictionary<ROM, List<FieldDefPair>> nodeAndDefs,
-            HashSet<ROM> fragments)
-        {
-            for (int i = 0; i < selectionSet.Selections.Count; i++)
-            {
-                var selection = selectionSet.Selections[i];
-
-                if (selection is GraphQLField field)
-                {
-                    var fieldName = field.Name;
-                    FieldType? fieldDef = null;
-                    if (isObjectType(parentType) || isInterfaceType(parentType))
-                    {
-                        fieldDef = (parentType as IComplexGraphType)!.GetField(fieldName);
-                    }
-
-                    var responseName = field.Alias is null ? fieldName : field.Alias.Name;
-
-                    if (!nodeAndDefs.ContainsKey(responseName))
-                    {
-                        nodeAndDefs[responseName] = new List<FieldDefPair>();
-                    }
-
-                    nodeAndDefs[responseName].Add(new FieldDefPair
-                    {
-                        ParentType = parentType,
-                        Field = field,
-                        FieldDef = fieldDef
-                    });
-
-                }
-                else if (selection is GraphQLFragmentSpread fragmentSpread)
-                {
-                    fragments.Add(fragmentSpread.FragmentName.Name);
-
-                }
-                else if (selection is GraphQLInlineFragment inlineFragment)
-                {
-                    var typeCondition = inlineFragment.TypeCondition?.Type;
-                    var inlineFragmentType =
-                        typeCondition != null
-                            ? typeCondition.GraphTypeFromType(context.Schema)
-                            : parentType;
-
-                    CollectFieldsAndFragmentNames(
-                        context,
-                        inlineFragmentType,
-                        inlineFragment.SelectionSet,
-                        nodeAndDefs,
-                        fragments);
-                }
-            }
-        }
-
-        private sealed class FieldDefPair
-        {
-            public IGraphType? ParentType { get; set; } = null!;
-            public ISelectionNode Field { get; set; } = null!;
-            public FieldType? FieldDef { get; set; }
-        }
-
-        private static bool isInterfaceType(IGraphType? parentType) => parentType is IInterfaceGraphType;
-
-        private static bool isObjectType(IGraphType? parentType) => parentType is IObjectGraphType;
-
-        // Given a series of Conflicts which occurred between two sub-fields,
-        // generate a single Conflict.
-        private static Conflict? SubfieldConflicts(
-            List<Conflict>? conflicts,
-            ROM responseName,
-            ISelectionNode node1,
-            ISelectionNode node2)
-        {
-            if (conflicts?.Count > 0)
-            {
-                return new Conflict
-                {
-                    Reason = new ConflictReason
-                    {
-                        Name = (string)responseName, //ISSUE:allocation
-                        Message = new Message
-                        {
-                            Msgs = conflicts.Select(c => c.Reason).ToList()
-                        }
-                    },
-                    FieldsLeft = conflicts.Aggregate(new List<ISelectionNode> { node1 }, (allfields, conflict) =>
-                    {
-                        allfields.AddRange(conflict.FieldsLeft);
-                        return allfields;
-                    }),
-                    FieldsRight = conflicts.Aggregate(new List<ISelectionNode> { node2 }, (allfields, conflict) =>
-                    {
-                        allfields.AddRange(conflict.FieldsRight);
-                        return allfields;
-                    })
-                };
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Describes a conflict between two fields in a document.
-        /// </summary>
-        public class Conflict
-        {
-            /// <summary>
-            /// Returns the reason for the conflict.
-            /// </summary>
-            public ConflictReason Reason { get; set; } = null!;
-
-            /// <summary>
-            /// Returns a list of fields that are in conflict.
-            /// </summary>
-            public List<ISelectionNode> FieldsLeft { get; set; } = null!;
-
-            /// <summary>
-            /// Returns a list of fields that are in conflict.
-            /// </summary>
-            public List<ISelectionNode> FieldsRight { get; set; } = null!;
-        }
-
-        /// <summary>
-        /// Describes the reason for a conflict.
-        /// </summary>
-        public class ConflictReason
-        {
-            /// <summary>
-            /// The name of the field in conflict.
-            /// </summary>
-            public string Name { get; set; } = null!;
-
-            /// <summary>
-            /// Returns a message descriptor describing the conflict.
-            /// </summary>
-            public Message Message { get; set; } = null!;
-        }
-
-        /// <summary>
-        /// A message descriptor describing a conflict.
-        /// </summary>
-        public class Message
-        {
-            /// <summary>
-            /// Returns the conflict message.
-            /// </summary>
-            public string? Msg { get; set; }
-
-            /// <summary>
-            /// Returns a list of conflict reasons that triggered this conflict.
-            /// </summary>
-            public List<ConflictReason>? Msgs { get; set; }
-        }
-
-        private sealed class CachedField
-        {
-            public Dictionary<ROM, List<FieldDefPair>> NodeAndDef { get; set; } = null!;
-            public List<ROM> Names { get; set; } = null!;
-        }
-
-        private sealed class PairSet
-        {
-            private readonly Dictionary<ROM, Dictionary<ROM, bool>> _data;
-
-            public PairSet()
-            {
-                _data = new Dictionary<ROM, Dictionary<ROM, bool>>();
-            }
-
-            public bool Has(ROM a, ROM b, bool areMutuallyExclusive)
-            {
-                _data.TryGetValue(a, out var first);
-
-                if (first == null || !first.TryGetValue(b, out bool result))
-                {
-                    return false;
-                }
-
-                if (areMutuallyExclusive == false)
-                {
-                    return result == false;
-                }
-
-                return true;
-            }
-
-            public void Add(ROM a, ROM b, bool areMutuallyExclusive)
-            {
-                PairSetAdd(a, b, areMutuallyExclusive);
-                PairSetAdd(b, a, areMutuallyExclusive);
-            }
-
-            private void PairSetAdd(ROM a, ROM b, bool areMutuallyExclusive)
-            {
-                _data.TryGetValue(a, out var map);
-
-                if (map == null)
-                {
-                    map = new Dictionary<ROM, bool>();
-                    _data[a] = map;
-                }
-                map[b] = areMutuallyExclusive;
-            }
-        }
+        var fragmentType = fragment.TypeCondition.Type.GraphTypeFromType(context.Schema);
+        return GetFieldsAndFragmentNames(
+            context,
+            cachedFieldsAndFragmentNames,
+            fragmentType,
+            fragment.SelectionSet);
     }
 
-    internal static class ISelectionNodeExtensions
+    private static void CollectFieldsAndFragmentNames(
+        ValidationContext context,
+        IGraphType? parentType,
+        GraphQLSelectionSet selectionSet,
+        Dictionary<ROM, List<FieldDefPair>> nodeAndDefs,
+        HashSet<ROM> fragments)
     {
-        public static ROM GetName(this ISelectionNode selection)
-             => selection switch
-             {
-                 GraphQLField field => field.Name,
-                 GraphQLFragmentSpread fragmentSpread => fragmentSpread.FragmentName.Name,
-                 _ => default
-             };
-
-        public static GraphQLArguments? GetArguments(this ISelectionNode selection)
+        for (int i = 0; i < selectionSet.Selections.Count; i++)
         {
-            return selection is GraphQLField field
-                ? field.Arguments
-                : null;
+            var selection = selectionSet.Selections[i];
+
+            if (selection is GraphQLField field)
+            {
+                var fieldName = field.Name;
+                FieldType? fieldDef = null;
+                if (isObjectType(parentType) || isInterfaceType(parentType))
+                {
+                    fieldDef = (parentType as IComplexGraphType)!.GetField(fieldName);
+                }
+
+                var responseName = field.Alias is null ? fieldName : field.Alias.Name;
+
+                if (!nodeAndDefs.ContainsKey(responseName))
+                {
+                    nodeAndDefs[responseName] = new List<FieldDefPair>();
+                }
+
+                nodeAndDefs[responseName].Add(new FieldDefPair
+                {
+                    ParentType = parentType,
+                    Field = field,
+                    FieldDef = fieldDef
+                });
+
+            }
+            else if (selection is GraphQLFragmentSpread fragmentSpread)
+            {
+                fragments.Add(fragmentSpread.FragmentName.Name);
+
+            }
+            else if (selection is GraphQLInlineFragment inlineFragment)
+            {
+                var typeCondition = inlineFragment.TypeCondition?.Type;
+                var inlineFragmentType =
+                    typeCondition != null
+                        ? typeCondition.GraphTypeFromType(context.Schema)
+                        : parentType;
+
+                CollectFieldsAndFragmentNames(
+                    context,
+                    inlineFragmentType,
+                    inlineFragment.SelectionSet,
+                    nodeAndDefs,
+                    fragments);
+            }
+        }
+    }
+
+    private sealed class FieldDefPair
+    {
+        public IGraphType? ParentType { get; set; } = null!;
+        public ISelectionNode Field { get; set; } = null!;
+        public FieldType? FieldDef { get; set; }
+    }
+
+    private static bool isInterfaceType(IGraphType? parentType) => parentType is IInterfaceGraphType;
+
+    private static bool isObjectType(IGraphType? parentType) => parentType is IObjectGraphType;
+
+    // Given a series of Conflicts which occurred between two sub-fields,
+    // generate a single Conflict.
+    private static Conflict? SubfieldConflicts(
+        List<Conflict>? conflicts,
+        ROM responseName,
+        ISelectionNode node1,
+        ISelectionNode node2)
+    {
+        if (conflicts?.Count > 0)
+        {
+            return new Conflict
+            {
+                Reason = new ConflictReason
+                {
+                    Name = (string)responseName, //ISSUE:allocation
+                    Message = new Message
+                    {
+                        Msgs = conflicts.Select(c => c.Reason).ToList()
+                    }
+                },
+                FieldsLeft = conflicts.Aggregate(new List<ISelectionNode> { node1 }, (allfields, conflict) =>
+                {
+                    allfields.AddRange(conflict.FieldsLeft);
+                    return allfields;
+                }),
+                FieldsRight = conflicts.Aggregate(new List<ISelectionNode> { node2 }, (allfields, conflict) =>
+                {
+                    allfields.AddRange(conflict.FieldsRight);
+                    return allfields;
+                })
+            };
         }
 
-        public static GraphQLSelectionSet? GetSelectionSet(this ISelectionNode selection)
-            => selection switch
-            {
-                GraphQLField field => field.SelectionSet,
-                GraphQLInlineFragment inlineFragment => inlineFragment.SelectionSet,
-                _ => null
-            };
+        return null;
     }
+
+    /// <summary>
+    /// Describes a conflict between two fields in a document.
+    /// </summary>
+    public class Conflict
+    {
+        /// <summary>
+        /// Returns the reason for the conflict.
+        /// </summary>
+        public ConflictReason Reason { get; set; } = null!;
+
+        /// <summary>
+        /// Returns a list of fields that are in conflict.
+        /// </summary>
+        public List<ISelectionNode> FieldsLeft { get; set; } = null!;
+
+        /// <summary>
+        /// Returns a list of fields that are in conflict.
+        /// </summary>
+        public List<ISelectionNode> FieldsRight { get; set; } = null!;
+    }
+
+    /// <summary>
+    /// Describes the reason for a conflict.
+    /// </summary>
+    public class ConflictReason
+    {
+        /// <summary>
+        /// The name of the field in conflict.
+        /// </summary>
+        public string Name { get; set; } = null!;
+
+        /// <summary>
+        /// Returns a message descriptor describing the conflict.
+        /// </summary>
+        public Message Message { get; set; } = null!;
+    }
+
+    /// <summary>
+    /// A message descriptor describing a conflict.
+    /// </summary>
+    public class Message
+    {
+        /// <summary>
+        /// Returns the conflict message.
+        /// </summary>
+        public string? Msg { get; set; }
+
+        /// <summary>
+        /// Returns a list of conflict reasons that triggered this conflict.
+        /// </summary>
+        public List<ConflictReason>? Msgs { get; set; }
+    }
+
+    private sealed class CachedField
+    {
+        public Dictionary<ROM, List<FieldDefPair>> NodeAndDef { get; set; } = null!;
+        public List<ROM> Names { get; set; } = null!;
+    }
+
+    private sealed class PairSet
+    {
+        private readonly Dictionary<ROM, Dictionary<ROM, bool>> _data;
+
+        public PairSet()
+        {
+            _data = new Dictionary<ROM, Dictionary<ROM, bool>>();
+        }
+
+        public bool Has(ROM a, ROM b, bool areMutuallyExclusive)
+        {
+            _data.TryGetValue(a, out var first);
+
+            if (first == null || !first.TryGetValue(b, out bool result))
+            {
+                return false;
+            }
+
+            if (areMutuallyExclusive == false)
+            {
+                return result == false;
+            }
+
+            return true;
+        }
+
+        public void Add(ROM a, ROM b, bool areMutuallyExclusive)
+        {
+            PairSetAdd(a, b, areMutuallyExclusive);
+            PairSetAdd(b, a, areMutuallyExclusive);
+        }
+
+        private void PairSetAdd(ROM a, ROM b, bool areMutuallyExclusive)
+        {
+            _data.TryGetValue(a, out var map);
+
+            if (map == null)
+            {
+                map = new Dictionary<ROM, bool>();
+                _data[a] = map;
+            }
+            map[b] = areMutuallyExclusive;
+        }
+    }
+}
+
+internal static class ISelectionNodeExtensions
+{
+    public static ROM GetName(this ISelectionNode selection)
+         => selection switch
+         {
+             GraphQLField field => field.Name,
+             GraphQLFragmentSpread fragmentSpread => fragmentSpread.FragmentName.Name,
+             _ => default
+         };
+
+    public static GraphQLArguments? GetArguments(this ISelectionNode selection)
+    {
+        return selection is GraphQLField field
+            ? field.Arguments
+            : null;
+    }
+
+    public static GraphQLSelectionSet? GetSelectionSet(this ISelectionNode selection)
+        => selection switch
+        {
+            GraphQLField field => field.SelectionSet,
+            GraphQLInlineFragment inlineFragment => inlineFragment.SelectionSet,
+            _ => null
+        };
 }

--- a/src/GraphQL/Validation/Rules/PossibleFragmentSpreads.cs
+++ b/src/GraphQL/Validation/Rules/PossibleFragmentSpreads.cs
@@ -3,55 +3,54 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Possible fragment spread:
+///
+/// A fragment spread is only valid if the type condition could ever possibly
+/// be <see langword="true"/>: if there is a non-empty intersection of the
+/// possible parent types, and possible types which pass the type condition.
+/// </summary>
+public class PossibleFragmentSpreads : ValidationRuleBase
 {
     /// <summary>
-    /// Possible fragment spread:
-    ///
-    /// A fragment spread is only valid if the type condition could ever possibly
-    /// be <see langword="true"/>: if there is a non-empty intersection of the
-    /// possible parent types, and possible types which pass the type condition.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class PossibleFragmentSpreads : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly PossibleFragmentSpreads Instance = new();
+    public static readonly PossibleFragmentSpreads Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="PossibleFragmentSpreadsError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="PossibleFragmentSpreadsError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLInlineFragment>((node, context) =>
-            {
-                var fragType = context.TypeInfo.GetLastType();
-                var parentType = context.TypeInfo.GetParentType()?.GetNamedType();
-
-                if (fragType != null && parentType != null && !GraphQLExtensions.DoTypesOverlap(fragType, parentType))
-                {
-                    context.ReportError(new PossibleFragmentSpreadsError(context, node, parentType, fragType));
-                }
-            }),
-
-            new MatchingNodeVisitor<GraphQLFragmentSpread>((node, context) =>
-            {
-                var fragName = node.FragmentName.Name;
-                var fragType = getFragmentType(context, fragName);
-                var parentType = context.TypeInfo.GetParentType()?.GetNamedType();
-
-                if (fragType != null && parentType != null && !GraphQLExtensions.DoTypesOverlap(fragType, parentType))
-                {
-                    context.ReportError(new PossibleFragmentSpreadsError(context, node, parentType, fragType));
-                }
-            })
-        );
-
-        private static IGraphType? getFragmentType(ValidationContext context, ROM name)
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLInlineFragment>((node, context) =>
         {
-            var frag = context.Document.FindFragmentDefinition(name);
-            return frag?.TypeCondition.Type.GraphTypeFromType(context.Schema);
-        }
+            var fragType = context.TypeInfo.GetLastType();
+            var parentType = context.TypeInfo.GetParentType()?.GetNamedType();
+
+            if (fragType != null && parentType != null && !GraphQLExtensions.DoTypesOverlap(fragType, parentType))
+            {
+                context.ReportError(new PossibleFragmentSpreadsError(context, node, parentType, fragType));
+            }
+        }),
+
+        new MatchingNodeVisitor<GraphQLFragmentSpread>((node, context) =>
+        {
+            var fragName = node.FragmentName.Name;
+            var fragType = getFragmentType(context, fragName);
+            var parentType = context.TypeInfo.GetParentType()?.GetNamedType();
+
+            if (fragType != null && parentType != null && !GraphQLExtensions.DoTypesOverlap(fragType, parentType))
+            {
+                context.ReportError(new PossibleFragmentSpreadsError(context, node, parentType, fragType));
+            }
+        })
+    );
+
+    private static IGraphType? getFragmentType(ValidationContext context, ROM name)
+    {
+        var frag = context.Document.FindFragmentDefinition(name);
+        return frag?.TypeCondition.Type.GraphTypeFromType(context.Schema);
     }
 }

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -2,62 +2,61 @@ using GraphQL.Types;
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Provided required arguments:
+///
+/// A field or directive is only valid if all required (non-null) field arguments
+/// have been provided.
+/// </summary>
+public class ProvidedNonNullArguments : ValidationRuleBase
 {
     /// <summary>
-    /// Provided required arguments:
-    ///
-    /// A field or directive is only valid if all required (non-null) field arguments
-    /// have been provided.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class ProvidedNonNullArguments : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly ProvidedNonNullArguments Instance = new();
+    public static readonly ProvidedNonNullArguments Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="ProvidedNonNullArgumentsError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="ProvidedNonNullArgumentsError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLField>(leave: (node, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLField>(leave: (node, context) =>
+        {
+            var fieldDef = context.TypeInfo.GetFieldDef();
+
+            if (fieldDef?.Arguments?.Count > 0)
             {
-                var fieldDef = context.TypeInfo.GetFieldDef();
-
-                if (fieldDef?.Arguments?.Count > 0)
+                foreach (var arg in fieldDef.Arguments.List!)
                 {
-                    foreach (var arg in fieldDef.Arguments.List!)
+                    if (arg.DefaultValue == null &&
+                        arg.ResolvedType is NonNullGraphType &&
+                        node.Arguments?.ValueFor(arg.Name) == null)
                     {
-                        if (arg.DefaultValue == null &&
-                            arg.ResolvedType is NonNullGraphType &&
-                            node.Arguments?.ValueFor(arg.Name) == null)
-                        {
-                            context.ReportError(new ProvidedNonNullArgumentsError(context, node, arg));
-                        }
+                        context.ReportError(new ProvidedNonNullArgumentsError(context, node, arg));
                     }
                 }
-            }),
+            }
+        }),
 
-            new MatchingNodeVisitor<GraphQLDirective>(leave: (node, context) =>
+        new MatchingNodeVisitor<GraphQLDirective>(leave: (node, context) =>
+        {
+            var directive = context.TypeInfo.GetDirective();
+
+            if (directive?.Arguments?.Count > 0)
             {
-                var directive = context.TypeInfo.GetDirective();
-
-                if (directive?.Arguments?.Count > 0)
+                foreach (var arg in directive.Arguments.List!)
                 {
-                    foreach (var arg in directive.Arguments.List!)
-                    {
-                        var argAst = node.Arguments?.ValueFor(arg.Name);
-                        var type = arg.ResolvedType;
+                    var argAst = node.Arguments?.ValueFor(arg.Name);
+                    var type = arg.ResolvedType;
 
-                        if (argAst == null && type is NonNullGraphType)
-                        {
-                            context.ReportError(new ProvidedNonNullArgumentsError(context, node, arg));
-                        }
+                    if (argAst == null && type is NonNullGraphType)
+                    {
+                        context.ReportError(new ProvidedNonNullArgumentsError(context, node, arg));
                     }
                 }
-            })
-        );
-    }
+            }
+        })
+    );
 }

--- a/src/GraphQL/Validation/Rules/ScalarLeafs.cs
+++ b/src/GraphQL/Validation/Rules/ScalarLeafs.cs
@@ -2,46 +2,45 @@ using GraphQL.Types;
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Scalar leafs:
+///
+/// A GraphQL document is valid only if all leaf fields (fields without
+/// sub selections) are of scalar or enum types.
+/// </summary>
+public class ScalarLeafs : ValidationRuleBase
 {
     /// <summary>
-    /// Scalar leafs:
-    ///
-    /// A GraphQL document is valid only if all leaf fields (fields without
-    /// sub selections) are of scalar or enum types.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class ScalarLeafs : ValidationRuleBase
+    public static readonly ScalarLeafs Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="ScalarLeafsError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor =
+        new MatchingNodeVisitor<GraphQLField>((f, context) => Field(context.TypeInfo.GetLastType(), f, context));
+
+    private static void Field(IGraphType? type, GraphQLField field, ValidationContext context)
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly ScalarLeafs Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="ScalarLeafsError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor =
-            new MatchingNodeVisitor<GraphQLField>((f, context) => Field(context.TypeInfo.GetLastType(), f, context));
-
-        private static void Field(IGraphType? type, GraphQLField field, ValidationContext context)
+        if (type == null)
         {
-            if (type == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            if (type.IsLeafType())
+        if (type.IsLeafType())
+        {
+            if (field.SelectionSet != null && field.SelectionSet.Selections.Count > 0)
             {
-                if (field.SelectionSet != null && field.SelectionSet.Selections.Count > 0)
-                {
-                    context.ReportError(new ScalarLeafsError(context, field.SelectionSet, field, type));
-                }
+                context.ReportError(new ScalarLeafsError(context, field.SelectionSet, field, type));
             }
-            else if (field.SelectionSet == null || field.SelectionSet.Selections.Count == 0)
-            {
-                context.ReportError(new ScalarLeafsError(context, field, type));
-            }
+        }
+        else if (field.SelectionSet == null || field.SelectionSet.Selections.Count == 0)
+        {
+            context.ReportError(new ScalarLeafsError(context, field, type));
         }
     }
 }

--- a/src/GraphQL/Validation/Rules/SingleRootFieldSubscriptions.cs
+++ b/src/GraphQL/Validation/Rules/SingleRootFieldSubscriptions.cs
@@ -2,57 +2,56 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Subscription operations must have exactly one root field.
+/// </summary>
+public class SingleRootFieldSubscriptions : ValidationRuleBase
 {
     /// <summary>
-    /// Subscription operations must have exactly one root field.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class SingleRootFieldSubscriptions : ValidationRuleBase
+    public static readonly SingleRootFieldSubscriptions Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="SingleRootFieldSubscriptionsError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLOperationDefinition>((operation, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly SingleRootFieldSubscriptions Instance = new();
+        if (operation.Operation != OperationType.Subscription)
+            return;
 
-        /// <inheritdoc/>
-        /// <exception cref="SingleRootFieldSubscriptionsError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+        var rootFields = operation.SelectionSet.Selections;
 
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLOperationDefinition>((operation, context) =>
+        if (rootFields.Count != 1)
+            context.ReportError(new SingleRootFieldSubscriptionsError(context, operation, rootFields.Skip(1).ToArray()));
+
+        if (rootFields[0] is GraphQLField field && IsIntrospectionField(field))
+            context.ReportError(new SingleRootFieldSubscriptionsError(context, operation, field));
+
+        var fragment = operation.SelectionSet.Selections.Find(node => node is GraphQLFragmentSpread || node is GraphQLInlineFragment);
+
+        if (fragment == null)
+            return;
+
+        if (fragment is GraphQLFragmentSpread fragmentSpread)
         {
-            if (operation.Operation != OperationType.Subscription)
+            var fragmentDefinition = context.Document.FindFragmentDefinition(fragmentSpread.FragmentName.Name);
+            if (fragmentDefinition == null)
                 return;
 
-            var rootFields = operation.SelectionSet.Selections;
+            rootFields = fragmentDefinition.SelectionSet.Selections;
+        }
+        else if (fragment is GraphQLInlineFragment inlineFragment)
+        {
+            rootFields = inlineFragment.SelectionSet.Selections;
+        }
 
-            if (rootFields.Count != 1)
-                context.ReportError(new SingleRootFieldSubscriptionsError(context, operation, rootFields.Skip(1).ToArray()));
+        if (rootFields.Count != 1 || (rootFields[0] is GraphQLField field2 && IsIntrospectionField(field2)))
+            context.ReportError(new SingleRootFieldSubscriptionsError(context, operation, fragment));
+    });
 
-            if (rootFields[0] is GraphQLField field && IsIntrospectionField(field))
-                context.ReportError(new SingleRootFieldSubscriptionsError(context, operation, field));
-
-            var fragment = operation.SelectionSet.Selections.Find(node => node is GraphQLFragmentSpread || node is GraphQLInlineFragment);
-
-            if (fragment == null)
-                return;
-
-            if (fragment is GraphQLFragmentSpread fragmentSpread)
-            {
-                var fragmentDefinition = context.Document.FindFragmentDefinition(fragmentSpread.FragmentName.Name);
-                if (fragmentDefinition == null)
-                    return;
-
-                rootFields = fragmentDefinition.SelectionSet.Selections;
-            }
-            else if (fragment is GraphQLInlineFragment inlineFragment)
-            {
-                rootFields = inlineFragment.SelectionSet.Selections;
-            }
-
-            if (rootFields.Count != 1 || (rootFields[0] is GraphQLField field2 && IsIntrospectionField(field2)))
-                context.ReportError(new SingleRootFieldSubscriptionsError(context, operation, fragment));
-        });
-
-        private static bool IsIntrospectionField(GraphQLField field) => field.Name.Value.Length >= 2 && field.Name.Value.Span[0] == '_' && field.Name.Value.Span[1] == '_';
-    }
+    private static bool IsIntrospectionField(GraphQLField field) => field.Name.Value.Length >= 2 && field.Name.Value.Span[0] == '_' && field.Name.Value.Span[1] == '_';
 }

--- a/src/GraphQL/Validation/Rules/UniqueArgumentNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueArgumentNames.cs
@@ -1,41 +1,40 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Unique argument names:
+///
+/// A GraphQL field or directive is only valid if all supplied arguments at a given field
+/// are uniquely named.
+/// </summary>
+public class UniqueArgumentNames : ValidationRuleBase
 {
     /// <summary>
-    /// Unique argument names:
-    ///
-    /// A GraphQL field or directive is only valid if all supplied arguments at a given field
-    /// are uniquely named.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class UniqueArgumentNames : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly UniqueArgumentNames Instance = new();
+    public static readonly UniqueArgumentNames Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="UniqueArgumentNamesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="UniqueArgumentNamesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-            new MatchingNodeVisitor<GraphQLField>((__, context) => context.TypeInfo.UniqueArgumentNames_KnownArgs?.Clear()),
-            new MatchingNodeVisitor<GraphQLDirective>((__, context) => context.TypeInfo.UniqueArgumentNames_KnownArgs?.Clear()),
-            new MatchingNodeVisitor<GraphQLArgument>((argument, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+        new MatchingNodeVisitor<GraphQLField>((__, context) => context.TypeInfo.UniqueArgumentNames_KnownArgs?.Clear()),
+        new MatchingNodeVisitor<GraphQLDirective>((__, context) => context.TypeInfo.UniqueArgumentNames_KnownArgs?.Clear()),
+        new MatchingNodeVisitor<GraphQLArgument>((argument, context) =>
+        {
+            var knownArgs = context.TypeInfo.UniqueArgumentNames_KnownArgs ??= new();
+            var argName = argument.Name;
+            if (knownArgs.TryGetValue(argName, out var arg))
             {
-                var knownArgs = context.TypeInfo.UniqueArgumentNames_KnownArgs ??= new();
-                var argName = argument.Name;
-                if (knownArgs.TryGetValue(argName, out var arg))
-                {
-                    context.ReportError(new UniqueArgumentNamesError(context, arg, argument));
-                }
-                else
-                {
-                    knownArgs[argName] = argument;
-                }
-            })
-        );
-    }
+                context.ReportError(new UniqueArgumentNamesError(context, arg, argument));
+            }
+            else
+            {
+                knownArgs[argName] = argument;
+            }
+        })
+    );
 }

--- a/src/GraphQL/Validation/Rules/UniqueFragmentNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueFragmentNames.cs
@@ -2,38 +2,37 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Unique fragment names:
+///
+/// A GraphQL document is only valid if all defined fragments have unique names.
+/// </summary>
+public class UniqueFragmentNames : ValidationRuleBase
 {
     /// <summary>
-    /// Unique fragment names:
-    ///
-    /// A GraphQL document is only valid if all defined fragments have unique names.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class UniqueFragmentNames : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly UniqueFragmentNames Instance = new();
+    public static readonly UniqueFragmentNames Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="UniqueFragmentNamesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
-            => new(context.Document.FragmentsCount() > 1 ? _nodeVisitor : null);
+    /// <inheritdoc/>
+    /// <exception cref="UniqueFragmentNamesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
+        => new(context.Document.FragmentsCount() > 1 ? _nodeVisitor : null);
 
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLFragmentDefinition>((fragmentDefinition, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLFragmentDefinition>((fragmentDefinition, context) =>
+        {
+            var knownFragments = context.TypeInfo.UniqueFragmentNames_KnownFragments ??= new();
+
+            var fragmentName = fragmentDefinition.FragmentName.Name;
+            if (knownFragments.TryGetValue(fragmentName, out var frag)) // .NET 2.2+ has TryAdd
             {
-                var knownFragments = context.TypeInfo.UniqueFragmentNames_KnownFragments ??= new();
-
-                var fragmentName = fragmentDefinition.FragmentName.Name;
-                if (knownFragments.TryGetValue(fragmentName, out var frag)) // .NET 2.2+ has TryAdd
-                {
-                    context.ReportError(new UniqueFragmentNamesError(context, frag, fragmentDefinition));
-                }
-                else
-                {
-                    knownFragments[fragmentName] = fragmentDefinition;
-                }
-            });
-    }
+                context.ReportError(new UniqueFragmentNamesError(context, frag, fragmentDefinition));
+            }
+            else
+            {
+                knownFragments[fragmentName] = fragmentDefinition;
+            }
+        });
 }

--- a/src/GraphQL/Validation/Rules/UniqueInputFieldNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueInputFieldNames.cs
@@ -1,50 +1,49 @@
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Unique input field names:
+///
+/// A GraphQL input object value is only valid if all supplied fields are
+/// uniquely named.
+/// </summary>
+public class UniqueInputFieldNames : ValidationRuleBase
 {
     /// <summary>
-    /// Unique input field names:
-    ///
-    /// A GraphQL input object value is only valid if all supplied fields are
-    /// uniquely named.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class UniqueInputFieldNames : ValidationRuleBase
-    {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly UniqueInputFieldNames Instance = new();
+    public static readonly UniqueInputFieldNames Instance = new();
 
-        /// <inheritdoc/>
-        /// <exception cref="UniqueInputFieldNamesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+    /// <inheritdoc/>
+    /// <exception cref="UniqueInputFieldNamesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
 
-        private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
-                new MatchingNodeVisitor<GraphQLObjectValue>(
-                    enter: (objVal, context) =>
+    private static readonly INodeVisitor _nodeVisitor = new NodeVisitors(
+            new MatchingNodeVisitor<GraphQLObjectValue>(
+                enter: (objVal, context) =>
+                {
+                    var knownNameStack = context.TypeInfo.UniqueInputFieldNames_KnownNameStack ??= new();
+
+                    knownNameStack.Push(context.TypeInfo.UniqueInputFieldNames_KnownNames!);
+                    context.TypeInfo.UniqueInputFieldNames_KnownNames = null;
+                },
+                leave: (objVal, context) => context.TypeInfo.UniqueInputFieldNames_KnownNames = context.TypeInfo.UniqueInputFieldNames_KnownNameStack!.Pop()),
+
+            new MatchingNodeVisitor<GraphQLObjectField>(
+                leave: (objField, context) =>
+                {
+                    var knownNames = context.TypeInfo.UniqueInputFieldNames_KnownNames ??= new();
+
+                    if (knownNames.TryGetValue(objField.Name, out var value))
                     {
-                        var knownNameStack = context.TypeInfo.UniqueInputFieldNames_KnownNameStack ??= new();
-
-                        knownNameStack.Push(context.TypeInfo.UniqueInputFieldNames_KnownNames!);
-                        context.TypeInfo.UniqueInputFieldNames_KnownNames = null;
-                    },
-                    leave: (objVal, context) => context.TypeInfo.UniqueInputFieldNames_KnownNames = context.TypeInfo.UniqueInputFieldNames_KnownNameStack!.Pop()),
-
-                new MatchingNodeVisitor<GraphQLObjectField>(
-                    leave: (objField, context) =>
+                        context.ReportError(new UniqueInputFieldNamesError(context, value, objField));
+                    }
+                    else
                     {
-                        var knownNames = context.TypeInfo.UniqueInputFieldNames_KnownNames ??= new();
-
-                        if (knownNames.TryGetValue(objField.Name, out var value))
-                        {
-                            context.ReportError(new UniqueInputFieldNamesError(context, value, objField));
-                        }
-                        else
-                        {
-                            knownNames[objField.Name] = objField.Value;
-                        }
-                    })
-            );
-    }
+                        knownNames[objField.Name] = objField.Value;
+                    }
+                })
+        );
 }

--- a/src/GraphQL/Validation/Rules/UniqueOperationNames.cs
+++ b/src/GraphQL/Validation/Rules/UniqueOperationNames.cs
@@ -2,38 +2,37 @@ using GraphQL.Validation.Errors;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation.Rules
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Unique operation names:
+///
+/// A GraphQL document is only valid if all defined operations have unique names.
+/// </summary>
+public class UniqueOperationNames : ValidationRuleBase
 {
     /// <summary>
-    /// Unique operation names:
-    ///
-    /// A GraphQL document is only valid if all defined operations have unique names.
+    /// Returns a static instance of this validation rule.
     /// </summary>
-    public class UniqueOperationNames : ValidationRuleBase
+    public static readonly UniqueOperationNames Instance = new();
+
+    /// <inheritdoc/>
+    /// <exception cref="UniqueOperationNamesError"/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
+        => new(context.Document.OperationsCount() < 2 ? null : _nodeVisitor);
+
+    private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLOperationDefinition>((op, context) =>
     {
-        /// <summary>
-        /// Returns a static instance of this validation rule.
-        /// </summary>
-        public static readonly UniqueOperationNames Instance = new();
-
-        /// <inheritdoc/>
-        /// <exception cref="UniqueOperationNamesError"/>
-        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
-            => new(context.Document.OperationsCount() < 2 ? null : _nodeVisitor);
-
-        private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLOperationDefinition>((op, context) =>
+        if (op.Name is null)
         {
-            if (op.Name is null)
-            {
-                return;
-            }
+            return;
+        }
 
-            var frequency = context.TypeInfo.UniqueOperationNames_Frequency ??= new();
+        var frequency = context.TypeInfo.UniqueOperationNames_Frequency ??= new();
 
-            if (!frequency.Add(op.Name))
-            {
-                context.ReportError(new UniqueOperationNamesError(context, op));
-            }
-        });
-    }
+        if (!frequency.Add(op.Name))
+        {
+            context.ReportError(new UniqueOperationNamesError(context, op));
+        }
+    });
 }

--- a/src/GraphQL/Validation/TypeInfo.cs
+++ b/src/GraphQL/Validation/TypeInfo.cs
@@ -2,338 +2,337 @@ using GraphQL.Types;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Provides information pertaining to the current state of the AST tree while being walked.
+/// Thus, validation rules checking is designed for sequential execution.
+/// </summary>
+public class TypeInfo : INodeVisitor
 {
+    private readonly ISchema _schema;
+    private readonly Stack<IGraphType?> _typeStack = new();
+    private readonly Stack<IGraphType?> _inputTypeStack = new();
+    private readonly Stack<IGraphType> _parentTypeStack = new();
+    private readonly Stack<FieldType?> _fieldDefStack = new();
+    private readonly Stack<ASTNode> _ancestorStack = new();
+    private Directive? _directive;
+    private QueryArgument? _argument;
+
     /// <summary>
-    /// Provides information pertaining to the current state of the AST tree while being walked.
-    /// Thus, validation rules checking is designed for sequential execution.
+    /// Initializes a new instance for the specified schema.
     /// </summary>
-    public class TypeInfo : INodeVisitor
+    public TypeInfo(ISchema schema)
     {
-        private readonly ISchema _schema;
-        private readonly Stack<IGraphType?> _typeStack = new();
-        private readonly Stack<IGraphType?> _inputTypeStack = new();
-        private readonly Stack<IGraphType> _parentTypeStack = new();
-        private readonly Stack<FieldType?> _fieldDefStack = new();
-        private readonly Stack<ASTNode> _ancestorStack = new();
-        private Directive? _directive;
-        private QueryArgument? _argument;
-
-        /// <summary>
-        /// Initializes a new instance for the specified schema.
-        /// </summary>
-        public TypeInfo(ISchema schema)
-        {
-            _schema = schema;
-        }
-
-        /// <summary>
-        /// Clears information about the current state of the AST tree.
-        /// </summary>
-        public void Clear()
-        {
-            _typeStack.Clear();
-            _inputTypeStack.Clear();
-            _parentTypeStack.Clear();
-            _fieldDefStack.Clear();
-            _ancestorStack.Clear();
-            _directive = null;
-            _argument = null;
-            // these will not be needed for post-variable-coercion validation rules
-            NoFragmentCycles_VisitedFrags = null;
-            NoFragmentCycles_SpreadPath = null;
-            NoFragmentCycles_SpreadPathIndexByName = null;
-            NoUndefinedVariables_VariableNameDefined = null;
-            NoUnusedFragments_OperationDefs = null;
-            NoUnusedFragments_FragmentDefs = null;
-            NoUnusedVariables_VariableDefs = null;
-            UniqueArgumentNames_KnownArgs = null;
-            UniqueFragmentNames_KnownFragments = null;
-            UniqueInputFieldNames_KnownNameStack = null;
-            UniqueInputFieldNames_KnownNames = null;
-            UniqueOperationNames_Frequency = null;
-            UniqueVariableNames_KnownVariables = null;
-            VariablesInAllowedPosition_VarDefMap = null;
-        }
-
-        private static T? PeekElement<T>(Stack<T> from, int index)
-        {
-            if (index == 0)
-            {
-                return from.Count > 0 ? from.Peek() : default;
-            }
-            else
-            {
-                if (index >= from.Count)
-                    throw new InvalidOperationException($"Stack contains only {from.Count} items");
-
-                using var e = from.GetEnumerator();
-
-                int i = index;
-                do
-                {
-                    _ = e.MoveNext();
-                }
-                while (i-- > 0);
-
-                return e.Current;
-            }
-        }
-
-        /// <summary>
-        /// Returns an ancestor of the current node.
-        /// </summary>
-        /// <param name="index">Index of the ancestor; 0 for the node itself, 1 for the direct ancestor and so on.</param>
-        public ASTNode? GetAncestor(int index) => PeekElement(_ancestorStack, index);
-
-        /// <summary>
-        /// Returns the last graph type matched, or <see langword="null"/> if none.
-        /// </summary>
-        /// <param name="index">Index of the type; 0 for the top-most type, 1 for the direct ancestor and so on.</param>
-        public IGraphType? GetLastType(int index = 0) => PeekElement(_typeStack, index);
-
-        /// <summary>
-        /// Returns the last input graph type matched, or <see langword="null"/> if none.
-        /// </summary>
-        /// <param name="index">Index of the type; 0 for the top-most type, 1 for the direct ancestor and so on.</param>
-        public IGraphType? GetInputType(int index = 0) => PeekElement(_inputTypeStack, index);
-
-        /// <summary>
-        /// Returns the parent graph type of the current node, or <see langword="null"/> if none.
-        /// </summary>
-        /// <param name="index">Index of the type; 0 for the top-most type, 1 for the direct ancestor and so on.</param>
-        public IGraphType? GetParentType(int index = 0) => PeekElement(_parentTypeStack, index);
-
-        /// <summary>
-        /// Returns the last field type matched, or <see langword="null"/> if none.
-        /// </summary>
-        /// <param name="index">Index of the field; 0 for the top-most field, 1 for the direct ancestor and so on.</param>
-        public FieldType? GetFieldDef(int index = 0) => PeekElement(_fieldDefStack, index);
-
-        /// <summary>
-        /// Returns the last directive specified, or <see langword="null"/> if none.
-        /// </summary>
-        public Directive? GetDirective() => _directive;
-
-        /// <summary>
-        /// Returns the last query argument matched, or <see langword="null"/> if none.
-        /// </summary>
-        public QueryArgument? GetArgument() => _argument;
-
-        /// <inheritdoc/>
-        public ValueTask EnterAsync(ASTNode node, ValidationContext context)
-        {
-            _ancestorStack.Push(node);
-
-            if (node is GraphQLSelectionSet)
-            {
-                _parentTypeStack.Push(GetLastType()!);
-                return default;
-            }
-
-            if (node is GraphQLField field)
-            {
-                var parentType = _parentTypeStack.Peek().GetNamedType();
-                var fieldType = GetFieldDef(_schema, parentType, field);
-                _fieldDefStack.Push(fieldType);
-                var targetType = fieldType?.ResolvedType;
-                _typeStack.Push(targetType);
-                return default;
-            }
-
-            if (node is GraphQLDirective directive)
-            {
-                _directive = _schema.Directives.Find(directive.Name);
-            }
-
-            if (node is GraphQLOperationDefinition op)
-            {
-                IGraphType? type = null;
-                if (op.Operation == OperationType.Query)
-                {
-                    type = _schema.Query;
-                }
-                else if (op.Operation == OperationType.Mutation)
-                {
-                    type = _schema.Mutation;
-                }
-                else if (op.Operation == OperationType.Subscription)
-                {
-                    type = _schema.Subscription;
-                }
-                _typeStack.Push(type);
-                return default;
-            }
-
-            if (node is GraphQLFragmentDefinition def1)
-            {
-                var type = _schema.AllTypes[def1.TypeCondition.Type.Name];
-                _typeStack.Push(type);
-                return default;
-            }
-
-            if (node is GraphQLInlineFragment def)
-            {
-                var type = def.TypeCondition != null ? _schema.AllTypes[def.TypeCondition.Type.Name] : GetLastType();
-                _typeStack.Push(type);
-                return default;
-            }
-
-            if (node is GraphQLVariableDefinition varDef)
-            {
-                var inputType = varDef.Type.GraphTypeFromType(_schema);
-                _inputTypeStack.Push(inputType);
-                return default;
-            }
-
-            if (node is GraphQLArgument argAst)
-            {
-                QueryArgument? argDef = null;
-                IGraphType? argType = null;
-
-                var args = GetDirective() != null ? GetDirective()?.Arguments : GetFieldDef()?.Arguments;
-
-                if (args != null)
-                {
-                    argDef = args.Find(argAst.Name);
-                    argType = argDef?.ResolvedType;
-                }
-
-                _argument = argDef;
-                _inputTypeStack.Push(argType);
-            }
-
-            if (node is GraphQLListValue)
-            {
-                var type = GetInputType()?.GetNamedType();
-                _inputTypeStack.Push(type);
-            }
-
-            if (node is GraphQLObjectField objectField)
-            {
-                var objectType = GetInputType()?.GetNamedType();
-                IGraphType? fieldType = null;
-                FieldType? inputField = null;
-
-                if (objectType is IInputObjectGraphType complexType)
-                {
-                    inputField = complexType.GetField(objectField.Name);
-
-                    fieldType = inputField?.ResolvedType;
-                }
-
-                _inputTypeStack.Push(fieldType);
-                _fieldDefStack.Push(inputField);
-            }
-
-            return default;
-        }
-
-        /// <inheritdoc/>
-        public ValueTask LeaveAsync(ASTNode node, ValidationContext context)
-        {
-            _ancestorStack.Pop();
-
-            if (node is GraphQLSelectionSet)
-            {
-                _parentTypeStack.Pop();
-            }
-            else if (node is GraphQLField)
-            {
-                _fieldDefStack.Pop();
-                _typeStack.Pop();
-            }
-            else if (node is GraphQLDirective)
-            {
-                _directive = null;
-            }
-            else if (node is GraphQLOperationDefinition || node is GraphQLFragmentDefinition || node is GraphQLInlineFragment)
-            {
-                _typeStack.Pop();
-            }
-            else if (node is GraphQLVariableDefinition)
-            {
-                _inputTypeStack.Pop();
-            }
-            else if (node is GraphQLArgument)
-            {
-                _argument = null;
-                _inputTypeStack.Pop();
-            }
-            else if (node is GraphQLListValue)
-            {
-                _inputTypeStack.Pop();
-            }
-            else if (node is GraphQLObjectField)
-            {
-                _inputTypeStack.Pop();
-                _fieldDefStack.Pop();
-            }
-
-            return default;
-        }
-
-        private static FieldType? GetFieldDef(ISchema schema, IGraphType parentType, GraphQLField field)
-        {
-            var name = field.Name;
-
-            if (name == schema.SchemaMetaFieldType.Name && Equals(schema.Query, parentType))
-            {
-                return schema.SchemaMetaFieldType;
-            }
-
-            if (name == schema.TypeMetaFieldType.Name && Equals(schema.Query, parentType))
-            {
-                return schema.TypeMetaFieldType;
-            }
-
-            if (name == schema.TypeNameMetaFieldType.Name && parentType.IsCompositeType())
-            {
-                return schema.TypeNameMetaFieldType;
-            }
-
-            if (parentType is IObjectGraphType || parentType is IInterfaceGraphType)
-            {
-                var complexType = (IComplexGraphType)parentType;
-
-                return complexType.GetField(field.Name);
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Tracks already visited fragments to maintain O(N) and to ensure that cycles
-        /// are not redundantly reported.
-        /// </summary>
-        internal HashSet<ROM>? NoFragmentCycles_VisitedFrags;
-        /// <summary>
-        /// Array of AST nodes used to produce meaningful errors
-        /// </summary>
-        internal Stack<GraphQLFragmentSpread>? NoFragmentCycles_SpreadPath;
-        /// <summary>
-        /// Position in the spread path
-        /// </summary>
-        internal Dictionary<ROM, int>? NoFragmentCycles_SpreadPathIndexByName;
-
-        internal HashSet<ROM>? NoUndefinedVariables_VariableNameDefined;
-
-        internal List<GraphQLOperationDefinition>? NoUnusedFragments_OperationDefs;
-        internal List<GraphQLFragmentDefinition>? NoUnusedFragments_FragmentDefs;
-
-        internal List<GraphQLVariableDefinition>? NoUnusedVariables_VariableDefs;
-
-        internal Dictionary<ROM, GraphQLArgument>? UniqueArgumentNames_KnownArgs;
-
-        internal Dictionary<ROM, GraphQLFragmentDefinition>? UniqueFragmentNames_KnownFragments;
-
-        internal Stack<Dictionary<ROM, GraphQLValue>>? UniqueInputFieldNames_KnownNameStack;
-        internal Dictionary<ROM, GraphQLValue>? UniqueInputFieldNames_KnownNames;
-
-        internal HashSet<ROM>? UniqueOperationNames_Frequency;
-
-        internal Dictionary<ROM, GraphQLVariableDefinition>? UniqueVariableNames_KnownVariables;
-
-        internal Dictionary<ROM, GraphQLVariableDefinition>? VariablesInAllowedPosition_VarDefMap;
+        _schema = schema;
     }
+
+    /// <summary>
+    /// Clears information about the current state of the AST tree.
+    /// </summary>
+    public void Clear()
+    {
+        _typeStack.Clear();
+        _inputTypeStack.Clear();
+        _parentTypeStack.Clear();
+        _fieldDefStack.Clear();
+        _ancestorStack.Clear();
+        _directive = null;
+        _argument = null;
+        // these will not be needed for post-variable-coercion validation rules
+        NoFragmentCycles_VisitedFrags = null;
+        NoFragmentCycles_SpreadPath = null;
+        NoFragmentCycles_SpreadPathIndexByName = null;
+        NoUndefinedVariables_VariableNameDefined = null;
+        NoUnusedFragments_OperationDefs = null;
+        NoUnusedFragments_FragmentDefs = null;
+        NoUnusedVariables_VariableDefs = null;
+        UniqueArgumentNames_KnownArgs = null;
+        UniqueFragmentNames_KnownFragments = null;
+        UniqueInputFieldNames_KnownNameStack = null;
+        UniqueInputFieldNames_KnownNames = null;
+        UniqueOperationNames_Frequency = null;
+        UniqueVariableNames_KnownVariables = null;
+        VariablesInAllowedPosition_VarDefMap = null;
+    }
+
+    private static T? PeekElement<T>(Stack<T> from, int index)
+    {
+        if (index == 0)
+        {
+            return from.Count > 0 ? from.Peek() : default;
+        }
+        else
+        {
+            if (index >= from.Count)
+                throw new InvalidOperationException($"Stack contains only {from.Count} items");
+
+            using var e = from.GetEnumerator();
+
+            int i = index;
+            do
+            {
+                _ = e.MoveNext();
+            }
+            while (i-- > 0);
+
+            return e.Current;
+        }
+    }
+
+    /// <summary>
+    /// Returns an ancestor of the current node.
+    /// </summary>
+    /// <param name="index">Index of the ancestor; 0 for the node itself, 1 for the direct ancestor and so on.</param>
+    public ASTNode? GetAncestor(int index) => PeekElement(_ancestorStack, index);
+
+    /// <summary>
+    /// Returns the last graph type matched, or <see langword="null"/> if none.
+    /// </summary>
+    /// <param name="index">Index of the type; 0 for the top-most type, 1 for the direct ancestor and so on.</param>
+    public IGraphType? GetLastType(int index = 0) => PeekElement(_typeStack, index);
+
+    /// <summary>
+    /// Returns the last input graph type matched, or <see langword="null"/> if none.
+    /// </summary>
+    /// <param name="index">Index of the type; 0 for the top-most type, 1 for the direct ancestor and so on.</param>
+    public IGraphType? GetInputType(int index = 0) => PeekElement(_inputTypeStack, index);
+
+    /// <summary>
+    /// Returns the parent graph type of the current node, or <see langword="null"/> if none.
+    /// </summary>
+    /// <param name="index">Index of the type; 0 for the top-most type, 1 for the direct ancestor and so on.</param>
+    public IGraphType? GetParentType(int index = 0) => PeekElement(_parentTypeStack, index);
+
+    /// <summary>
+    /// Returns the last field type matched, or <see langword="null"/> if none.
+    /// </summary>
+    /// <param name="index">Index of the field; 0 for the top-most field, 1 for the direct ancestor and so on.</param>
+    public FieldType? GetFieldDef(int index = 0) => PeekElement(_fieldDefStack, index);
+
+    /// <summary>
+    /// Returns the last directive specified, or <see langword="null"/> if none.
+    /// </summary>
+    public Directive? GetDirective() => _directive;
+
+    /// <summary>
+    /// Returns the last query argument matched, or <see langword="null"/> if none.
+    /// </summary>
+    public QueryArgument? GetArgument() => _argument;
+
+    /// <inheritdoc/>
+    public ValueTask EnterAsync(ASTNode node, ValidationContext context)
+    {
+        _ancestorStack.Push(node);
+
+        if (node is GraphQLSelectionSet)
+        {
+            _parentTypeStack.Push(GetLastType()!);
+            return default;
+        }
+
+        if (node is GraphQLField field)
+        {
+            var parentType = _parentTypeStack.Peek().GetNamedType();
+            var fieldType = GetFieldDef(_schema, parentType, field);
+            _fieldDefStack.Push(fieldType);
+            var targetType = fieldType?.ResolvedType;
+            _typeStack.Push(targetType);
+            return default;
+        }
+
+        if (node is GraphQLDirective directive)
+        {
+            _directive = _schema.Directives.Find(directive.Name);
+        }
+
+        if (node is GraphQLOperationDefinition op)
+        {
+            IGraphType? type = null;
+            if (op.Operation == OperationType.Query)
+            {
+                type = _schema.Query;
+            }
+            else if (op.Operation == OperationType.Mutation)
+            {
+                type = _schema.Mutation;
+            }
+            else if (op.Operation == OperationType.Subscription)
+            {
+                type = _schema.Subscription;
+            }
+            _typeStack.Push(type);
+            return default;
+        }
+
+        if (node is GraphQLFragmentDefinition def1)
+        {
+            var type = _schema.AllTypes[def1.TypeCondition.Type.Name];
+            _typeStack.Push(type);
+            return default;
+        }
+
+        if (node is GraphQLInlineFragment def)
+        {
+            var type = def.TypeCondition != null ? _schema.AllTypes[def.TypeCondition.Type.Name] : GetLastType();
+            _typeStack.Push(type);
+            return default;
+        }
+
+        if (node is GraphQLVariableDefinition varDef)
+        {
+            var inputType = varDef.Type.GraphTypeFromType(_schema);
+            _inputTypeStack.Push(inputType);
+            return default;
+        }
+
+        if (node is GraphQLArgument argAst)
+        {
+            QueryArgument? argDef = null;
+            IGraphType? argType = null;
+
+            var args = GetDirective() != null ? GetDirective()?.Arguments : GetFieldDef()?.Arguments;
+
+            if (args != null)
+            {
+                argDef = args.Find(argAst.Name);
+                argType = argDef?.ResolvedType;
+            }
+
+            _argument = argDef;
+            _inputTypeStack.Push(argType);
+        }
+
+        if (node is GraphQLListValue)
+        {
+            var type = GetInputType()?.GetNamedType();
+            _inputTypeStack.Push(type);
+        }
+
+        if (node is GraphQLObjectField objectField)
+        {
+            var objectType = GetInputType()?.GetNamedType();
+            IGraphType? fieldType = null;
+            FieldType? inputField = null;
+
+            if (objectType is IInputObjectGraphType complexType)
+            {
+                inputField = complexType.GetField(objectField.Name);
+
+                fieldType = inputField?.ResolvedType;
+            }
+
+            _inputTypeStack.Push(fieldType);
+            _fieldDefStack.Push(inputField);
+        }
+
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public ValueTask LeaveAsync(ASTNode node, ValidationContext context)
+    {
+        _ancestorStack.Pop();
+
+        if (node is GraphQLSelectionSet)
+        {
+            _parentTypeStack.Pop();
+        }
+        else if (node is GraphQLField)
+        {
+            _fieldDefStack.Pop();
+            _typeStack.Pop();
+        }
+        else if (node is GraphQLDirective)
+        {
+            _directive = null;
+        }
+        else if (node is GraphQLOperationDefinition || node is GraphQLFragmentDefinition || node is GraphQLInlineFragment)
+        {
+            _typeStack.Pop();
+        }
+        else if (node is GraphQLVariableDefinition)
+        {
+            _inputTypeStack.Pop();
+        }
+        else if (node is GraphQLArgument)
+        {
+            _argument = null;
+            _inputTypeStack.Pop();
+        }
+        else if (node is GraphQLListValue)
+        {
+            _inputTypeStack.Pop();
+        }
+        else if (node is GraphQLObjectField)
+        {
+            _inputTypeStack.Pop();
+            _fieldDefStack.Pop();
+        }
+
+        return default;
+    }
+
+    private static FieldType? GetFieldDef(ISchema schema, IGraphType parentType, GraphQLField field)
+    {
+        var name = field.Name;
+
+        if (name == schema.SchemaMetaFieldType.Name && Equals(schema.Query, parentType))
+        {
+            return schema.SchemaMetaFieldType;
+        }
+
+        if (name == schema.TypeMetaFieldType.Name && Equals(schema.Query, parentType))
+        {
+            return schema.TypeMetaFieldType;
+        }
+
+        if (name == schema.TypeNameMetaFieldType.Name && parentType.IsCompositeType())
+        {
+            return schema.TypeNameMetaFieldType;
+        }
+
+        if (parentType is IObjectGraphType || parentType is IInterfaceGraphType)
+        {
+            var complexType = (IComplexGraphType)parentType;
+
+            return complexType.GetField(field.Name);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Tracks already visited fragments to maintain O(N) and to ensure that cycles
+    /// are not redundantly reported.
+    /// </summary>
+    internal HashSet<ROM>? NoFragmentCycles_VisitedFrags;
+    /// <summary>
+    /// Array of AST nodes used to produce meaningful errors
+    /// </summary>
+    internal Stack<GraphQLFragmentSpread>? NoFragmentCycles_SpreadPath;
+    /// <summary>
+    /// Position in the spread path
+    /// </summary>
+    internal Dictionary<ROM, int>? NoFragmentCycles_SpreadPathIndexByName;
+
+    internal HashSet<ROM>? NoUndefinedVariables_VariableNameDefined;
+
+    internal List<GraphQLOperationDefinition>? NoUnusedFragments_OperationDefs;
+    internal List<GraphQLFragmentDefinition>? NoUnusedFragments_FragmentDefs;
+
+    internal List<GraphQLVariableDefinition>? NoUnusedVariables_VariableDefs;
+
+    internal Dictionary<ROM, GraphQLArgument>? UniqueArgumentNames_KnownArgs;
+
+    internal Dictionary<ROM, GraphQLFragmentDefinition>? UniqueFragmentNames_KnownFragments;
+
+    internal Stack<Dictionary<ROM, GraphQLValue>>? UniqueInputFieldNames_KnownNameStack;
+    internal Dictionary<ROM, GraphQLValue>? UniqueInputFieldNames_KnownNames;
+
+    internal HashSet<ROM>? UniqueOperationNames_Frequency;
+
+    internal Dictionary<ROM, GraphQLVariableDefinition>? UniqueVariableNames_KnownVariables;
+
+    internal Dictionary<ROM, GraphQLVariableDefinition>? VariablesInAllowedPosition_VarDefMap;
 }

--- a/src/GraphQL/Validation/ValidationContext.GetRecursivelyReferencedFragments.cs
+++ b/src/GraphQL/Validation/ValidationContext.GetRecursivelyReferencedFragments.cs
@@ -2,112 +2,111 @@ using GraphQLParser;
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+public partial class ValidationContext
 {
-    public partial class ValidationContext
+    private static readonly GetRecursivelyReferencedFragmentsVisitor _visitor = new();
+    private readonly Dictionary<GraphQLOperationDefinition, List<GraphQLFragmentDefinition>?> _fragments = new();
+
+    /// <summary>
+    /// For a specified operation within a document, returns a list of all fragment definitions in use.
+    /// </summary>
+    public List<GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLOperationDefinition operation)
     {
-        private static readonly GetRecursivelyReferencedFragmentsVisitor _visitor = new();
-        private readonly Dictionary<GraphQLOperationDefinition, List<GraphQLFragmentDefinition>?> _fragments = new();
-
-        /// <summary>
-        /// For a specified operation within a document, returns a list of all fragment definitions in use.
-        /// </summary>
-        public List<GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLOperationDefinition operation)
+        if (_fragments.TryGetValue(operation, out var results)) //TODO: possible remove from cache
         {
-            if (_fragments.TryGetValue(operation, out var results)) //TODO: possible remove from cache
-            {
-                return results;
-            }
+            return results;
+        }
 
-            var context = new GetRecursivelyReferencedFragmentsVisitorContext(this);
-            _visitor.VisitAsync(operation.SelectionSet, context).GetAwaiter().GetResult();
-            var fragments = context.GetFragments(reset: true);
-            _fragments[operation] = fragments;
+        var context = new GetRecursivelyReferencedFragmentsVisitorContext(this);
+        _visitor.VisitAsync(operation.SelectionSet, context).GetAwaiter().GetResult();
+        var fragments = context.GetFragments(reset: true);
+        _fragments[operation] = fragments;
+        return fragments;
+    }
+
+    /// <summary>
+    /// For a specified operations within a document, returns a list of all fragment definitions in use.
+    /// </summary>
+    public List<GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(List<GraphQLOperationDefinition> operations)
+    {
+        if (operations.Count == 1)
+        {
+            return GetRecursivelyReferencedFragments(operations[0]);
+        }
+        else
+        {
+            List<GraphQLFragmentDefinition>? fragments = null;
+            foreach (var operation in operations)
+            {
+                var items = GetRecursivelyReferencedFragments(operation);
+                if (items != null)
+                    (fragments ??= new()).AddRange(items);
+            }
             return fragments;
         }
+    }
 
-        /// <summary>
-        /// For a specified operations within a document, returns a list of all fragment definitions in use.
-        /// </summary>
-        public List<GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(List<GraphQLOperationDefinition> operations)
+    // struct intentionally - works only on stack
+    private readonly struct GetRecursivelyReferencedFragmentsVisitorContext : IASTVisitorContext
+    {
+        public GetRecursivelyReferencedFragmentsVisitorContext(ValidationContext validationContext)
         {
-            if (operations.Count == 1)
+            ValidationContext = validationContext;
+        }
+
+        public ValidationContext ValidationContext { get; }
+
+        public CancellationToken CancellationToken => default;
+
+        public void AddFragment(GraphQLFragmentDefinition fragment)
+            => ValidationContext.AddListItem(nameof(GetRecursivelyReferencedFragmentsVisitorContext), fragment);
+
+        public List<GraphQLFragmentDefinition>? GetFragments(bool reset)
+            => ValidationContext.GetList<GraphQLFragmentDefinition>(nameof(GetRecursivelyReferencedFragmentsVisitorContext), reset);
+    }
+
+    private sealed class GetRecursivelyReferencedFragmentsVisitor : ASTVisitor<GetRecursivelyReferencedFragmentsVisitorContext>
+    {
+        protected override ValueTask VisitOperationDefinitionAsync(GraphQLOperationDefinition operationDefinition, GetRecursivelyReferencedFragmentsVisitorContext context)
+            => VisitAsync(operationDefinition.SelectionSet, context);
+
+        protected override ValueTask VisitSelectionSetAsync(GraphQLSelectionSet selectionSet, GetRecursivelyReferencedFragmentsVisitorContext context)
+            => VisitAsync(selectionSet.Selections, context);
+
+        protected override ValueTask VisitFieldAsync(GraphQLField field, GetRecursivelyReferencedFragmentsVisitorContext context)
+            => VisitAsync(field.SelectionSet, context);
+
+        protected override ValueTask VisitInlineFragmentAsync(GraphQLInlineFragment inlineFragment, GetRecursivelyReferencedFragmentsVisitorContext context)
+            => VisitAsync(inlineFragment.SelectionSet, context);
+
+        protected override async ValueTask VisitFragmentSpreadAsync(GraphQLFragmentSpread fragmentSpread, GetRecursivelyReferencedFragmentsVisitorContext context)
+        {
+            if (!Contains(fragmentSpread, context))
             {
-                return GetRecursivelyReferencedFragments(operations[0]);
-            }
-            else
-            {
-                List<GraphQLFragmentDefinition>? fragments = null;
-                foreach (var operation in operations)
+                var fragmentDefinition = context.ValidationContext.Document.FindFragmentDefinition(fragmentSpread.FragmentName.Name);
+                if (fragmentDefinition != null)
                 {
-                    var items = GetRecursivelyReferencedFragments(operation);
-                    if (items != null)
-                        (fragments ??= new()).AddRange(items);
+                    context.AddFragment(fragmentDefinition);
+                    await VisitSelectionSetAsync(fragmentDefinition.SelectionSet, context).ConfigureAwait(false);
                 }
-                return fragments;
             }
         }
 
-        // struct intentionally - works only on stack
-        private readonly struct GetRecursivelyReferencedFragmentsVisitorContext : IASTVisitorContext
+        private bool Contains(GraphQLFragmentSpread fragmentSpread, GetRecursivelyReferencedFragmentsVisitorContext context)
         {
-            public GetRecursivelyReferencedFragmentsVisitorContext(ValidationContext validationContext)
-            {
-                ValidationContext = validationContext;
-            }
-
-            public ValidationContext ValidationContext { get; }
-
-            public CancellationToken CancellationToken => default;
-
-            public void AddFragment(GraphQLFragmentDefinition fragment)
-                => ValidationContext.AddListItem(nameof(GetRecursivelyReferencedFragmentsVisitorContext), fragment);
-
-            public List<GraphQLFragmentDefinition>? GetFragments(bool reset)
-                => ValidationContext.GetList<GraphQLFragmentDefinition>(nameof(GetRecursivelyReferencedFragmentsVisitorContext), reset);
-        }
-
-        private sealed class GetRecursivelyReferencedFragmentsVisitor : ASTVisitor<GetRecursivelyReferencedFragmentsVisitorContext>
-        {
-            protected override ValueTask VisitOperationDefinitionAsync(GraphQLOperationDefinition operationDefinition, GetRecursivelyReferencedFragmentsVisitorContext context)
-                => VisitAsync(operationDefinition.SelectionSet, context);
-
-            protected override ValueTask VisitSelectionSetAsync(GraphQLSelectionSet selectionSet, GetRecursivelyReferencedFragmentsVisitorContext context)
-                => VisitAsync(selectionSet.Selections, context);
-
-            protected override ValueTask VisitFieldAsync(GraphQLField field, GetRecursivelyReferencedFragmentsVisitorContext context)
-                => VisitAsync(field.SelectionSet, context);
-
-            protected override ValueTask VisitInlineFragmentAsync(GraphQLInlineFragment inlineFragment, GetRecursivelyReferencedFragmentsVisitorContext context)
-                => VisitAsync(inlineFragment.SelectionSet, context);
-
-            protected override async ValueTask VisitFragmentSpreadAsync(GraphQLFragmentSpread fragmentSpread, GetRecursivelyReferencedFragmentsVisitorContext context)
-            {
-                if (!Contains(fragmentSpread, context))
-                {
-                    var fragmentDefinition = context.ValidationContext.Document.FindFragmentDefinition(fragmentSpread.FragmentName.Name);
-                    if (fragmentDefinition != null)
-                    {
-                        context.AddFragment(fragmentDefinition);
-                        await VisitSelectionSetAsync(fragmentDefinition.SelectionSet, context).ConfigureAwait(false);
-                    }
-                }
-            }
-
-            private bool Contains(GraphQLFragmentSpread fragmentSpread, GetRecursivelyReferencedFragmentsVisitorContext context)
-            {
-                var fragments = context.GetFragments(reset: false);
-                if (fragments == null)
-                    return false;
-
-                foreach (var frag in fragments)
-                {
-                    if (frag.FragmentName.Name == fragmentSpread.FragmentName.Name)
-                        return true;
-                }
-
+            var fragments = context.GetFragments(reset: false);
+            if (fragments == null)
                 return false;
+
+            foreach (var frag in fragments)
+            {
+                if (frag.FragmentName.Name == fragmentSpread.FragmentName.Name)
+                    return true;
             }
+
+            return false;
         }
     }
 }

--- a/src/GraphQL/Validation/ValidationContext.GetVariables.cs
+++ b/src/GraphQL/Validation/ValidationContext.GetVariables.cs
@@ -1,118 +1,117 @@
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+public partial class ValidationContext
 {
-    public partial class ValidationContext
+    private static readonly GetVariablesVisitor _getVariablesVisitor = new();
+    private readonly Dictionary<GraphQLOperationDefinition, List<VariableUsage>?> _variables = new();
+
+    /// <summary>
+    /// For a node with a selection set, returns a list of variable references along with what input type each were referenced for.
+    /// </summary>
+    public List<VariableUsage>? GetVariables<TNode>(TNode node)
+        where TNode : ASTNode, IHasSelectionSetNode
     {
-        private static readonly GetVariablesVisitor _getVariablesVisitor = new();
-        private readonly Dictionary<GraphQLOperationDefinition, List<VariableUsage>?> _variables = new();
+        var context = new GetVariablesVisitorContext(this, new TypeInfo(Schema));
+        _getVariablesVisitor.VisitAsync(node, context).GetAwaiter().GetResult();
+        return context.GetVariableUsages();
+    }
 
-        /// <summary>
-        /// For a node with a selection set, returns a list of variable references along with what input type each were referenced for.
-        /// </summary>
-        public List<VariableUsage>? GetVariables<TNode>(TNode node)
-            where TNode : ASTNode, IHasSelectionSetNode
+    /// <summary>
+    /// For a specified operation with a document, returns a list of variable references
+    /// along with what input type each was referenced for.
+    /// </summary>
+    public List<VariableUsage>? GetRecursiveVariables(GraphQLOperationDefinition operation)
+    {
+        if (_variables.TryGetValue(operation, out var results))
         {
-            var context = new GetVariablesVisitorContext(this, new TypeInfo(Schema));
-            _getVariablesVisitor.VisitAsync(node, context).GetAwaiter().GetResult();
-            return context.GetVariableUsages();
+            return results;
         }
 
-        /// <summary>
-        /// For a specified operation with a document, returns a list of variable references
-        /// along with what input type each was referenced for.
-        /// </summary>
-        public List<VariableUsage>? GetRecursiveVariables(GraphQLOperationDefinition operation)
+        var usages = GetVariables(operation);
+
+        var frags = GetRecursivelyReferencedFragments(operation);
+
+        if (frags != null)
         {
-            if (_variables.TryGetValue(operation, out var results))
+            foreach (var fragment in frags)
             {
-                return results;
-            }
-
-            var usages = GetVariables(operation);
-
-            var frags = GetRecursivelyReferencedFragments(operation);
-
-            if (frags != null)
-            {
-                foreach (var fragment in frags)
+                var usagesFromFragment = GetVariables(fragment);
+                if (usagesFromFragment != null)
                 {
-                    var usagesFromFragment = GetVariables(fragment);
-                    if (usagesFromFragment != null)
-                    {
-                        if (usages == null)
-                            usages = usagesFromFragment;
-                        else
-                            usages.AddRange(usagesFromFragment);
-                    }
+                    if (usages == null)
+                        usages = usagesFromFragment;
+                    else
+                        usages.AddRange(usagesFromFragment);
                 }
             }
-
-            _variables[operation] = usages;
-
-            return usages;
         }
 
-        // struct intentionally - works only on stack
-        private readonly struct GetVariablesVisitorContext : IASTVisitorContext
+        _variables[operation] = usages;
+
+        return usages;
+    }
+
+    // struct intentionally - works only on stack
+    private readonly struct GetVariablesVisitorContext : IASTVisitorContext
+    {
+        public GetVariablesVisitorContext(ValidationContext validationContext, TypeInfo typeInfo)
         {
-            public GetVariablesVisitorContext(ValidationContext validationContext, TypeInfo typeInfo)
-            {
-                ValidationContext = validationContext;
-                Info = typeInfo;
-            }
-
-            public ValidationContext ValidationContext { get; }
-
-            public TypeInfo Info { get; }
-
-            public CancellationToken CancellationToken => default;
-
-            public void AddVariableUsage(VariableUsage usage)
-                => ValidationContext.AddListItem(nameof(GetVariablesVisitorContext), usage);
-
-            public List<VariableUsage>? GetVariableUsages()
-                => ValidationContext.GetList<VariableUsage>(nameof(GetVariablesVisitorContext), reset: true);
+            ValidationContext = validationContext;
+            Info = typeInfo;
         }
 
-        private sealed class GetVariablesVisitor : ASTVisitor<GetVariablesVisitorContext>
+        public ValidationContext ValidationContext { get; }
+
+        public TypeInfo Info { get; }
+
+        public CancellationToken CancellationToken => default;
+
+        public void AddVariableUsage(VariableUsage usage)
+            => ValidationContext.AddListItem(nameof(GetVariablesVisitorContext), usage);
+
+        public List<VariableUsage>? GetVariableUsages()
+            => ValidationContext.GetList<VariableUsage>(nameof(GetVariablesVisitorContext), reset: true);
+    }
+
+    private sealed class GetVariablesVisitor : ASTVisitor<GetVariablesVisitorContext>
+    {
+        public override async ValueTask VisitAsync(ASTNode? node, GetVariablesVisitorContext context)
         {
-            public override async ValueTask VisitAsync(ASTNode? node, GetVariablesVisitorContext context)
+            if (node == null)
+                return;
+
+            await context.Info.EnterAsync(node, context.ValidationContext).ConfigureAwait(false);
+
+            await base.VisitAsync(node, context).ConfigureAwait(false);
+
+            await context.Info.LeaveAsync(node, context.ValidationContext).ConfigureAwait(false);
+        }
+
+        protected override ValueTask VisitVariableAsync(GraphQLVariable variable, GetVariablesVisitorContext context)
+        {
+            // GraphQLVariable AST node represents both variable definition and variable usage so check parent node
+            var ancestor = context.Info.GetAncestor(1);
+            if (ancestor is not GraphQLVariableDefinition)
             {
-                if (node == null)
-                    return;
-
-                await context.Info.EnterAsync(node, context.ValidationContext).ConfigureAwait(false);
-
-                await base.VisitAsync(node, context).ConfigureAwait(false);
-
-                await context.Info.LeaveAsync(node, context.ValidationContext).ConfigureAwait(false);
-            }
-
-            protected override ValueTask VisitVariableAsync(GraphQLVariable variable, GetVariablesVisitorContext context)
-            {
-                // GraphQLVariable AST node represents both variable definition and variable usage so check parent node
-                var ancestor = context.Info.GetAncestor(1);
-                if (ancestor is not GraphQLVariableDefinition)
+                bool lastHasDefault = false;
+                if (ancestor is GraphQLArgument)
                 {
-                    bool lastHasDefault = false;
-                    if (ancestor is GraphQLArgument)
-                    {
-                        var arg = context.Info.GetArgument();
-                        if (arg != null && arg.DefaultValue != null)
-                            lastHasDefault = true;
-                    }
-                    if (ancestor is GraphQLObjectField)
-                    {
-                        var field = context.Info.GetFieldDef();
-                        if (field != null && field.DefaultValue != null)
-                            lastHasDefault = true;
-                    }
-                    context.AddVariableUsage(new VariableUsage(variable, context.Info.GetInputType()!, lastHasDefault));
+                    var arg = context.Info.GetArgument();
+                    if (arg != null && arg.DefaultValue != null)
+                        lastHasDefault = true;
                 }
-                return default;
+                if (ancestor is GraphQLObjectField)
+                {
+                    var field = context.Info.GetFieldDef();
+                    if (field != null && field.DefaultValue != null)
+                        lastHasDefault = true;
+                }
+                context.AddVariableUsage(new VariableUsage(variable, context.Info.GetInputType()!, lastHasDefault));
             }
+            return default;
         }
     }
 }

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -5,569 +5,519 @@ using GraphQL.Instrumentation;
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Provides contextual information about the validation of the document.
+/// </summary>
+public partial class ValidationContext : IProvideUserContext
 {
-    /// <summary>
-    /// Provides contextual information about the validation of the document.
-    /// </summary>
-    public partial class ValidationContext : IProvideUserContext
+    private List<ValidationError>? _errors;
+
+    internal void Reset()
     {
-        private List<ValidationError>? _errors;
+        _errors = null;
+        _fragments.Clear();
+        _variables.Clear();
+        Operation = null!;
+        Schema = null!;
+        Document = null!;
+        TypeInfo = null!;
+        UserContext = null!;
+        NonUserContext = null;
+        Variables = null!;
+        Extensions = null!;
+        RequestServices = null!;
+        Metrics = null!;
+        User = null;
+    }
 
-        internal void Reset()
+    /// <summary>
+    /// Returns the operation requested to be executed.
+    /// </summary>
+    public GraphQLOperationDefinition Operation { get; set; } = null!;
+
+    /// <inheritdoc cref="IExecutionContext.Schema"/>
+    public ISchema Schema { get; set; } = null!;
+
+    /// <inheritdoc cref="IExecutionContext.Document"/>
+    public GraphQLDocument Document { get; set; } = null!;
+
+    /// <inheritdoc cref="Validation.TypeInfo"/>
+    public TypeInfo TypeInfo { get; set; } = null!;
+
+    /// <inheritdoc/>
+    public IDictionary<string, object?> UserContext { get; set; } = null!;
+
+    /// <inheritdoc cref="IExecutionContext.Metrics"/>
+    public Metrics Metrics { get; set; } = null!;
+
+    /// <summary>
+    /// Dictionary of temporary data used by validation rules.
+    /// TODO: think about internal reusable fields in TypeInfo
+    /// </summary>
+    internal Dictionary<string, object?>? NonUserContext { get; set; }
+
+    /// <summary>
+    /// Returns a list of validation errors for this document.
+    /// </summary>
+    public IEnumerable<ValidationError> Errors => (IEnumerable<ValidationError>?)_errors ?? Array.Empty<ValidationError>();
+
+    /// <summary>
+    /// Returns <see langword="true"/> if there are any validation errors for this document.
+    /// </summary>
+    public bool HasErrors => _errors?.Count > 0;
+
+    /// <inheritdoc cref="ExecutionOptions.Variables"/>
+    public Inputs Variables { get; set; } = null!;
+
+    /// <inheritdoc cref="ExecutionOptions.Extensions"/>
+    public Inputs Extensions { get; set; } = null!;
+
+    /// <inheritdoc cref="ExecutionOptions.RequestServices"/>
+    public IServiceProvider? RequestServices { get; set; }
+
+    /// <inheritdoc cref="ExecutionOptions.User"/>
+    public ClaimsPrincipal? User { get; set; }
+
+    /// <summary>
+    /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;
+    /// defaults to <see cref="CancellationToken.None"/>
+    /// </summary>
+    public CancellationToken CancellationToken { get; set; }
+
+    /// <summary>
+    /// A dictionary of fields, and for each field, a dictionary of arguments defined for the field with their values.
+    /// During validation rule execution via <see cref="IValidationRule.GetPreNodeVisitorAsync(ValidationContext)"/>,
+    /// this value will be <see langword="null"/>. While executing variable validation via
+    /// <see cref="IValidationRule.GetPostNodeVisitorAsync(ValidationContext)"/>, this value will be initialized
+    /// unless no field arguments were found, in which case the value will be <see langword="null"/>.
+    /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
+    /// </summary>
+    public Dictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; }
+
+    /// <summary>
+    /// A dictionary of fields, and for each field, a dictionary of directives defined for the field with their values.
+    /// During validation rule execution via <see cref="IValidationRule.GetPreNodeVisitorAsync(ValidationContext)"/>,
+    /// this value will be <see langword="null"/>. While executing variable validation via
+    /// <see cref="IValidationRule.GetPostNodeVisitorAsync(ValidationContext)"/>, this value will be initialized
+    /// unless no field arguments were found, in which case the value will be <see langword="null"/>.
+    /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
+    /// </summary>
+    public Dictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; }
+
+    /// <summary>
+    /// Adds a validation error to the list of validation errors.
+    /// </summary>
+    public void ReportError(ValidationError error)
+    {
+        if (error == null)
+            throw new ArgumentNullException(nameof(error), "Must provide a validation error.");
+        (_errors ??= new()).Add(error);
+    }
+
+    /// <summary>
+    /// Returns a list of fragment spreads within the specified node.
+    /// </summary>
+    public List<GraphQLFragmentSpread> GetFragmentSpreads(GraphQLSelectionSet node)
+    {
+        var spreads = new List<GraphQLFragmentSpread>();
+
+        var setsToVisit = new Stack<GraphQLSelectionSet>();
+        setsToVisit.Push(node);
+
+        while (setsToVisit.Count > 0)
         {
-            _errors = null;
-            _fragments.Clear();
-            _variables.Clear();
-            Operation = null!;
-            Schema = null!;
-            Document = null!;
-            TypeInfo = null!;
-            UserContext = null!;
-            NonUserContext = null;
-            Variables = null!;
-            Extensions = null!;
-            RequestServices = null!;
-            Metrics = null!;
-            User = null;
-        }
+            var set = setsToVisit.Pop();
 
-        /// <summary>
-        /// Returns the operation requested to be executed.
-        /// </summary>
-        public GraphQLOperationDefinition Operation { get; set; } = null!;
-
-        /// <inheritdoc cref="IExecutionContext.Schema"/>
-        public ISchema Schema { get; set; } = null!;
-
-        /// <inheritdoc cref="IExecutionContext.Document"/>
-        public GraphQLDocument Document { get; set; } = null!;
-
-        /// <inheritdoc cref="Validation.TypeInfo"/>
-        public TypeInfo TypeInfo { get; set; } = null!;
-
-        /// <inheritdoc/>
-        public IDictionary<string, object?> UserContext { get; set; } = null!;
-
-        /// <inheritdoc cref="IExecutionContext.Metrics"/>
-        public Metrics Metrics { get; set; } = null!;
-
-        /// <summary>
-        /// Dictionary of temporary data used by validation rules.
-        /// TODO: think about internal reusable fields in TypeInfo
-        /// </summary>
-        internal Dictionary<string, object?>? NonUserContext { get; set; }
-
-        /// <summary>
-        /// Returns a list of validation errors for this document.
-        /// </summary>
-        public IEnumerable<ValidationError> Errors => (IEnumerable<ValidationError>?)_errors ?? Array.Empty<ValidationError>();
-
-        /// <summary>
-        /// Returns <see langword="true"/> if there are any validation errors for this document.
-        /// </summary>
-        public bool HasErrors => _errors?.Count > 0;
-
-        /// <inheritdoc cref="ExecutionOptions.Variables"/>
-        public Inputs Variables { get; set; } = null!;
-
-        /// <inheritdoc cref="ExecutionOptions.Extensions"/>
-        public Inputs Extensions { get; set; } = null!;
-
-        /// <inheritdoc cref="ExecutionOptions.RequestServices"/>
-        public IServiceProvider? RequestServices { get; set; }
-
-        /// <inheritdoc cref="ExecutionOptions.User"/>
-        public ClaimsPrincipal? User { get; set; }
-
-        /// <summary>
-        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;
-        /// defaults to <see cref="CancellationToken.None"/>
-        /// </summary>
-        public CancellationToken CancellationToken { get; set; }
-
-        /// <summary>
-        /// A dictionary of fields, and for each field, a dictionary of arguments defined for the field with their values.
-        /// During validation rule execution via <see cref="IValidationRule.GetPreNodeVisitorAsync(ValidationContext)"/>,
-        /// this value will be <see langword="null"/>. While executing variable validation via
-        /// <see cref="IValidationRule.GetPostNodeVisitorAsync(ValidationContext)"/>, this value will be initialized
-        /// unless no field arguments were found, in which case the value will be <see langword="null"/>.
-        /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
-        /// </summary>
-        public Dictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; }
-
-        /// <summary>
-        /// A dictionary of fields, and for each field, a dictionary of directives defined for the field with their values.
-        /// During validation rule execution via <see cref="IValidationRule.GetPreNodeVisitorAsync(ValidationContext)"/>,
-        /// this value will be <see langword="null"/>. While executing variable validation via
-        /// <see cref="IValidationRule.GetPostNodeVisitorAsync(ValidationContext)"/>, this value will be initialized
-        /// unless no field arguments were found, in which case the value will be <see langword="null"/>.
-        /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
-        /// </summary>
-        public Dictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; }
-
-        /// <summary>
-        /// Adds a validation error to the list of validation errors.
-        /// </summary>
-        public void ReportError(ValidationError error)
-        {
-            if (error == null)
-                throw new ArgumentNullException(nameof(error), "Must provide a validation error.");
-            (_errors ??= new()).Add(error);
-        }
-
-        /// <summary>
-        /// Returns a list of fragment spreads within the specified node.
-        /// </summary>
-        public List<GraphQLFragmentSpread> GetFragmentSpreads(GraphQLSelectionSet node)
-        {
-            var spreads = new List<GraphQLFragmentSpread>();
-
-            var setsToVisit = new Stack<GraphQLSelectionSet>();
-            setsToVisit.Push(node);
-
-            while (setsToVisit.Count > 0)
+            foreach (var selection in set.Selections)
             {
-                var set = setsToVisit.Pop();
-
-                foreach (var selection in set.Selections)
+                if (selection is GraphQLFragmentSpread spread)
                 {
-                    if (selection is GraphQLFragmentSpread spread)
-                    {
-                        spreads.Add(spread);
-                    }
-                    else if (selection is IHasSelectionSetNode hasSet && hasSet.SelectionSet != null)
-                    {
-                        setsToVisit.Push(hasSet.SelectionSet);
-                    }
+                    spreads.Add(spread);
+                }
+                else if (selection is IHasSelectionSetNode hasSet && hasSet.SelectionSet != null)
+                {
+                    setsToVisit.Push(hasSet.SelectionSet);
                 }
             }
-
-            return spreads;
         }
 
-        /// <summary>
-        /// Returns all of the variable values defined for the operation from the attached <see cref="Variables"/> object.
-        /// Only correctly validated variables are returned. If the variable is specified incorrectly, then an instance of
-        /// <see cref="ValidationError"/> is returned within the list of errors.
-        /// </summary>
-        public async ValueTask<(Variables Variables, List<ValidationError>? Errors)> GetVariablesValuesAsync(IVariableVisitor? visitor = null)
+        return spreads;
+    }
+
+    /// <summary>
+    /// Returns all of the variable values defined for the operation from the attached <see cref="Variables"/> object.
+    /// Only correctly validated variables are returned. If the variable is specified incorrectly, then an instance of
+    /// <see cref="ValidationError"/> is returned within the list of errors.
+    /// </summary>
+    public async ValueTask<(Variables Variables, List<ValidationError>? Errors)> GetVariablesValuesAsync(IVariableVisitor? visitor = null)
+    {
+        var variableDefinitions = Operation?.Variables;
+
+        if ((variableDefinitions?.Count ?? 0) == 0)
         {
-            var variableDefinitions = Operation?.Variables;
+            return (Validation.Variables.None, null);
+        }
 
-            if ((variableDefinitions?.Count ?? 0) == 0)
+        var usages = GetRecursiveVariables(Operation!);
+
+        List<ValidationError>? errors = null;
+        var variablesObj = new Variables(variableDefinitions!.Count);
+
+        if (variableDefinitions != null)
+        {
+            foreach (var variableDef in variableDefinitions.Items)
             {
-                return (Validation.Variables.None, null);
-            }
+                string variableDefName = variableDef.Variable.Name.StringValue; //ISSUE:allocation
+                // find the IGraphType instance for the variable type
+                var graphType = variableDef.Type.GraphTypeFromType(Schema);
 
-            var usages = GetRecursiveVariables(Operation!);
-
-            List<ValidationError>? errors = null;
-            var variablesObj = new Variables(variableDefinitions!.Count);
-
-            if (variableDefinitions != null)
-            {
-                foreach (var variableDef in variableDefinitions.Items)
+                if (graphType == null)
                 {
-                    string variableDefName = variableDef.Variable.Name.StringValue; //ISSUE:allocation
-                    // find the IGraphType instance for the variable type
-                    var graphType = variableDef.Type.GraphTypeFromType(Schema);
+                    (errors ??= new()).Add(new InvalidVariableError(this, variableDef, variableDefName, $"Variable has unknown type '{variableDef.Type.Name()}'"));
+                    continue;
+                }
 
-                    if (graphType == null)
+                // create a new variable object
+                var variable = new Variable(variableDefName, variableDef);
+
+                // attempt to retrieve the variable value from the inputs
+                if (Variables.TryGetValue(variableDefName, out object? variableValue))
+                {
+                    // for nullable variable types that are supplied (not default value),
+                    if (graphType is not NonNullGraphType)
                     {
-                        (errors ??= new()).Add(new InvalidVariableError(this, variableDef, variableDefName, $"Variable has unknown type '{variableDef.Type.Name()}'"));
-                        continue;
-                    }
-
-                    // create a new variable object
-                    var variable = new Variable(variableDefName, variableDef);
-
-                    // attempt to retrieve the variable value from the inputs
-                    if (Variables.TryGetValue(variableDefName, out object? variableValue))
-                    {
-                        // for nullable variable types that are supplied (not default value),
-                        if (graphType is not NonNullGraphType)
+                        // determine if a non-null value is required
+                        //   (it may have passed validation for a nullable type if the variable definition,
+                        //    argument definition, or input object field definition includes a default value)
+                        bool requiresNonNull = false;
+                        if (usages != null)
                         {
-                            // determine if a non-null value is required
-                            //   (it may have passed validation for a nullable type if the variable definition,
-                            //    argument definition, or input object field definition includes a default value)
-                            bool requiresNonNull = false;
-                            if (usages != null)
+                            foreach (var usage in usages)
                             {
-                                foreach (var usage in usages)
+                                if (usage.Node.Name == variableDef.Variable.Name && usage.Type is NonNullGraphType)
                                 {
-                                    if (usage.Node.Name == variableDef.Variable.Name && usage.Type is NonNullGraphType)
-                                    {
-                                        requiresNonNull = true;
-                                        break;
-                                    }
+                                    requiresNonNull = true;
+                                    break;
                                 }
                             }
-                            if (requiresNonNull)
-                                graphType = new NonNullGraphType(graphType);
                         }
-
-                        // parse the variable via ParseValue (for scalars) and ParseDictionary (for objects) as applicable
-                        try
-                        {
-                            variable.Value = await GetVariableValueAsync(graphType, variableDef, variableValue, visitor).ConfigureAwait(false);
-                        }
-                        catch (ValidationError error)
-                        {
-                            (errors ??= new()).Add(error);
-                            continue;
-                        }
+                        if (requiresNonNull)
+                            graphType = new NonNullGraphType(graphType);
                     }
-                    else if (variableDef.DefaultValue != null)
-                    {
-                        // if the variable was not specified in the inputs, and a default literal value was specified, use the specified default variable value
 
-                        // parse the variable literal via ParseLiteral (for scalars) and ParseDictionary (for objects) as applicable
-                        try
-                        {
-                            variable.Value = ExecutionHelper.CoerceValue(graphType, variableDef.DefaultValue, new ExecutionHelper.CoerceValueContext()
-                            {
-                                Document = Document,
-                                ParentNode = variableDef,
-                            }).Value;
-                        }
-                        catch (ValidationError ex)
-                        {
-                            (errors ??= new()).Add(ex);
-                            continue;
-                        }
-                        variable.IsDefault = true;
-                    }
-                    else if (graphType is NonNullGraphType)
+                    // parse the variable via ParseValue (for scalars) and ParseDictionary (for objects) as applicable
+                    try
                     {
-                        (errors ??= new()).Add(new InvalidVariableError(this, variableDef, variable.Name, "No value provided for a non-null variable."));
+                        variable.Value = await GetVariableValueAsync(graphType, variableDef, variableValue, visitor).ConfigureAwait(false);
+                    }
+                    catch (ValidationError error)
+                    {
+                        (errors ??= new()).Add(error);
                         continue;
                     }
-
-                    // if the variable was not specified and no default was specified, do not set variable.Value
-
-                    // add the variable to the list of parsed variables defined for the operation
-                    variablesObj.Add(variable);
                 }
-            }
+                else if (variableDef.DefaultValue != null)
+                {
+                    // if the variable was not specified in the inputs, and a default literal value was specified, use the specified default variable value
 
-            // return the list of parsed variables defined for the operation
-            return (variablesObj, errors);
+                    // parse the variable literal via ParseLiteral (for scalars) and ParseDictionary (for objects) as applicable
+                    try
+                    {
+                        variable.Value = ExecutionHelper.CoerceValue(graphType, variableDef.DefaultValue, new ExecutionHelper.CoerceValueContext()
+                        {
+                            Document = Document,
+                            ParentNode = variableDef,
+                        }).Value;
+                    }
+                    catch (ValidationError ex)
+                    {
+                        (errors ??= new()).Add(ex);
+                        continue;
+                    }
+                    variable.IsDefault = true;
+                }
+                else if (graphType is NonNullGraphType)
+                {
+                    (errors ??= new()).Add(new InvalidVariableError(this, variableDef, variable.Name, "No value provided for a non-null variable."));
+                    continue;
+                }
+
+                // if the variable was not specified and no default was specified, do not set variable.Value
+
+                // add the variable to the list of parsed variables defined for the operation
+                variablesObj.Add(variable);
+            }
         }
 
-        /// <summary>
-        /// Return the specified variable's value for the document from the attached <see cref="Variables"/> object.
-        /// <br/><br/>
-        /// Validates and parses the supplied input object according to the variable's type, and converts the object
-        /// with <see cref="ScalarGraphType.ParseValue(object)"/> and
-        /// <see cref="IInputObjectGraphType.ParseDictionary(IDictionary{string, object})"/> as applicable.
-        /// <br/><br/>
-        /// Since v3.3, returns null for variables set to null rather than the variable's default value.
-        /// </summary>
-        private ValueTask<object?> GetVariableValueAsync(IGraphType graphType, GraphQLVariableDefinition variableDef, object? input, IVariableVisitor? visitor)
+        // return the list of parsed variables defined for the operation
+        return (variablesObj, errors);
+    }
+
+    /// <summary>
+    /// Return the specified variable's value for the document from the attached <see cref="Variables"/> object.
+    /// <br/><br/>
+    /// Validates and parses the supplied input object according to the variable's type, and converts the object
+    /// with <see cref="ScalarGraphType.ParseValue(object)"/> and
+    /// <see cref="IInputObjectGraphType.ParseDictionary(IDictionary{string, object})"/> as applicable.
+    /// <br/><br/>
+    /// Since v3.3, returns null for variables set to null rather than the variable's default value.
+    /// </summary>
+    private ValueTask<object?> GetVariableValueAsync(IGraphType graphType, GraphQLVariableDefinition variableDef, object? input, IVariableVisitor? visitor)
+    {
+        return ParseValueAsync(graphType, variableDef, variableDef.Variable.Name.StringValue, input, visitor); //ISSUE:allocation
+
+        // Coerces a value depending on the graph type.
+        async ValueTask<object?> ParseValueAsync(IGraphType type, GraphQLVariableDefinition variableDef, VariableName variableName, object? value, IVariableVisitor? visitor)
         {
-            return ParseValueAsync(graphType, variableDef, variableDef.Variable.Name.StringValue, input, visitor); //ISSUE:allocation
-
-            // Coerces a value depending on the graph type.
-            async ValueTask<object?> ParseValueAsync(IGraphType type, GraphQLVariableDefinition variableDef, VariableName variableName, object? value, IVariableVisitor? visitor)
+            if (type is IInputObjectGraphType inputObjectGraphType)
             {
-                if (type is IInputObjectGraphType inputObjectGraphType)
+                object? parsedValue = await ParseValueObjectAsync(inputObjectGraphType, variableDef, variableName, value, visitor).ConfigureAwait(false);
+                if (visitor != null)
+                    await visitor.VisitObjectAsync(this, variableDef, variableName, inputObjectGraphType, value, parsedValue).ConfigureAwait(false);
+                return parsedValue;
+            }
+            else if (type is NonNullGraphType nonNullGraphType)
+            {
+                return value == null
+                    ? throw new InvalidVariableError(this, variableDef, variableName, "Received a null input for a non-null variable.")
+                    : await ParseValueAsync(nonNullGraphType.ResolvedType!, variableDef, variableName, value, visitor).ConfigureAwait(false);
+            }
+            else if (type is ListGraphType listGraphType)
+            {
+                var parsedValue = await ParseValueListAsync(listGraphType, variableDef, variableName, value, visitor).ConfigureAwait(false);
+                if (visitor != null)
+                    await visitor.VisitListAsync(this, variableDef, variableName, listGraphType, value, parsedValue).ConfigureAwait(false);
+                return parsedValue;
+            }
+            else if (type is ScalarGraphType scalarGraphType)
+            {
+                object? parsedValue = ParseValueScalar(scalarGraphType, variableDef, variableName, value);
+                if (visitor != null)
+                    await visitor.VisitScalarAsync(this, variableDef, variableName, scalarGraphType, value, parsedValue).ConfigureAwait(false);
+                return parsedValue;
+            }
+            else
+            {
+                throw new InvalidVariableError(this, variableDef, variableName, $"The graph type '{type.Name}' is not an input graph type.");
+            }
+        }
+
+        // Coerces a scalar value
+        object? ParseValueScalar(ScalarGraphType scalarGraphType, GraphQLVariableDefinition variableDef, VariableName variableName, object? value)
+        {
+            try
+            {
+                return scalarGraphType.ParseValue(value);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidVariableError(this, variableDef, variableName, $"Unable to convert '{value}' to '{scalarGraphType.Name}'", ex);
+            }
+        }
+
+        async ValueTask<IList<object?>?> ParseValueListAsync(ListGraphType listGraphType, GraphQLVariableDefinition variableDef, VariableName variableName, object? value, IVariableVisitor? visitor)
+        {
+            if (value == null)
+                return null;
+
+            // note: a list can have a single child element which will automatically be interpreted as a list of 1 elements. (see below rule)
+            // so, to prevent a string as being interpreted as a list of chars (which get converted to strings), we ignore considering a string as an IEnumerable
+            if (value is IEnumerable values && value is not string)
+            {
+                // create a list containing the parsed elements in the input list
+                if (values is IList list)
                 {
-                    object? parsedValue = await ParseValueObjectAsync(inputObjectGraphType, variableDef, variableName, value, visitor).ConfigureAwait(false);
-                    if (visitor != null)
-                        await visitor.VisitObjectAsync(this, variableDef, variableName, inputObjectGraphType, value, parsedValue).ConfigureAwait(false);
-                    return parsedValue;
-                }
-                else if (type is NonNullGraphType nonNullGraphType)
-                {
-                    return value == null
-                        ? throw new InvalidVariableError(this, variableDef, variableName, "Received a null input for a non-null variable.")
-                        : await ParseValueAsync(nonNullGraphType.ResolvedType!, variableDef, variableName, value, visitor).ConfigureAwait(false);
-                }
-                else if (type is ListGraphType listGraphType)
-                {
-                    var parsedValue = await ParseValueListAsync(listGraphType, variableDef, variableName, value, visitor).ConfigureAwait(false);
-                    if (visitor != null)
-                        await visitor.VisitListAsync(this, variableDef, variableName, listGraphType, value, parsedValue).ConfigureAwait(false);
-                    return parsedValue;
-                }
-                else if (type is ScalarGraphType scalarGraphType)
-                {
-                    object? parsedValue = ParseValueScalar(scalarGraphType, variableDef, variableName, value);
-                    if (visitor != null)
-                        await visitor.VisitScalarAsync(this, variableDef, variableName, scalarGraphType, value, parsedValue).ConfigureAwait(false);
-                    return parsedValue;
+                    var valueOutputs = new object?[list.Count];
+                    for (int index = 0; index < list.Count; index++)
+                    {
+                        // parse/validate values as required by graph type
+                        valueOutputs[index] = await ParseValueAsync(listGraphType.ResolvedType!, variableDef, new VariableName(variableName, index), list[index], visitor).ConfigureAwait(false);
+                    }
+                    return valueOutputs;
                 }
                 else
                 {
-                    throw new InvalidVariableError(this, variableDef, variableName, $"The graph type '{type.Name}' is not an input graph type.");
+                    var valueOutputs = new List<object?>(values is ICollection collection ? collection.Count : 0);
+                    int index = 0;
+                    foreach (object val in values)
+                    {
+                        // parse/validate values as required by graph type
+                        valueOutputs.Add(await ParseValueAsync(listGraphType.ResolvedType!, variableDef, new VariableName(variableName, index++), val, visitor).ConfigureAwait(false));
+                    }
+                    return valueOutputs;
                 }
             }
-
-            // Coerces a scalar value
-            object? ParseValueScalar(ScalarGraphType scalarGraphType, GraphQLVariableDefinition variableDef, VariableName variableName, object? value)
+            else
             {
-                try
-                {
-                    return scalarGraphType.ParseValue(value);
-                }
-                catch (Exception ex)
-                {
-                    throw new InvalidVariableError(this, variableDef, variableName, $"Unable to convert '{value}' to '{scalarGraphType.Name}'", ex);
-                }
+                // RULE: If the value passed as an input to a list type is not a list and not the null value,
+                // then the result of input coercion is a list of size one, where the single item value is the
+                // result of input coercion for the list’s item type on the provided value (note this may apply
+                // recursively for nested lists).
+                object? result = await ParseValueAsync(listGraphType.ResolvedType!, variableDef, variableName, value, visitor).ConfigureAwait(false);
+                return new object?[] { result };
             }
+        }
 
-            async ValueTask<IList<object?>?> ParseValueListAsync(ListGraphType listGraphType, GraphQLVariableDefinition variableDef, VariableName variableName, object? value, IVariableVisitor? visitor)
+        async ValueTask<object?> ParseValueObjectAsync(IInputObjectGraphType graphType, GraphQLVariableDefinition variableDef, VariableName variableName, object? value, IVariableVisitor? visitor)
+        {
+            if (value == null)
+                return null;
+
+            if (value is not IDictionary<string, object?> dic)
             {
-                if (value == null)
-                    return null;
-
-                // note: a list can have a single child element which will automatically be interpreted as a list of 1 elements. (see below rule)
-                // so, to prevent a string as being interpreted as a list of chars (which get converted to strings), we ignore considering a string as an IEnumerable
-                if (value is IEnumerable values && value is not string)
-                {
-                    // create a list containing the parsed elements in the input list
-                    if (values is IList list)
-                    {
-                        var valueOutputs = new object?[list.Count];
-                        for (int index = 0; index < list.Count; index++)
-                        {
-                            // parse/validate values as required by graph type
-                            valueOutputs[index] = await ParseValueAsync(listGraphType.ResolvedType!, variableDef, new VariableName(variableName, index), list[index], visitor).ConfigureAwait(false);
-                        }
-                        return valueOutputs;
-                    }
-                    else
-                    {
-                        var valueOutputs = new List<object?>(values is ICollection collection ? collection.Count : 0);
-                        int index = 0;
-                        foreach (object val in values)
-                        {
-                            // parse/validate values as required by graph type
-                            valueOutputs.Add(await ParseValueAsync(listGraphType.ResolvedType!, variableDef, new VariableName(variableName, index++), val, visitor).ConfigureAwait(false));
-                        }
-                        return valueOutputs;
-                    }
-                }
-                else
-                {
-                    // RULE: If the value passed as an input to a list type is not a list and not the null value,
-                    // then the result of input coercion is a list of size one, where the single item value is the
-                    // result of input coercion for the list’s item type on the provided value (note this may apply
-                    // recursively for nested lists).
-                    object? result = await ParseValueAsync(listGraphType.ResolvedType!, variableDef, variableName, value, visitor).ConfigureAwait(false);
-                    return new object?[] { result };
-                }
-            }
-
-            async ValueTask<object?> ParseValueObjectAsync(IInputObjectGraphType graphType, GraphQLVariableDefinition variableDef, VariableName variableName, object? value, IVariableVisitor? visitor)
-            {
-                if (value == null)
-                    return null;
-
-                if (value is not IDictionary<string, object?> dic)
-                {
-                    // RULE: The value for an input object should be an input object literal
-                    // or an unordered map supplied by a variable, otherwise a query error
-                    // must be thrown.
-
-                    throw new InvalidVariableError(this, variableDef, variableName, $"Unable to parse input as a '{graphType.Name}' type. Did you provide a List or Scalar value accidentally?");
-                }
-
-                var newDictionary = new Dictionary<string, object?>(dic.Count);
-                foreach (var field in graphType.Fields.List)
-                {
-                    var childFieldVariableName = new VariableName(variableName, field.Name);
-
-                    if (dic.TryGetValue(field.Name, out object? fieldValue))
-                    {
-                        // RULE: If the value null was provided for an input object field, and
-                        // the field’s type is not a non‐null type, an entry in the coerced
-                        // unordered map is given the value null. In other words, there is a
-                        // semantic difference between the explicitly provided value null
-                        // versus having not provided a value.
-
-                        // Note: we always call ParseValue even for null values, and if it
-                        // is a non-null graph type, the NonNullGraphType.ParseValue method will throw an error
-                        object? parsedFieldValue = await ParseValueAsync(field.ResolvedType!, variableDef, childFieldVariableName, fieldValue, visitor).ConfigureAwait(false);
-                        try
-                        {
-                            if (parsedFieldValue != null && field.Parser != null)
-                                parsedFieldValue = field.Parser(parsedFieldValue);
-                            if (parsedFieldValue != null && field.Validator != null)
-                                field.Validator(parsedFieldValue);
-                        }
-                        catch (ValidationError ex)
-                        {
-                            ex.AddNode(Document.Source, variableDef);
-                            throw;
-                        }
-                        catch (ExecutionError ex)
-                        {
-                            ex.AddLocation(GraphQLParser.Location.FromLinearPosition(Document.Source, variableDef.Location.Start));
-                            throw;
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new InvalidVariableError(this, variableDef, childFieldVariableName, ex.Message, ex);
-                        }
-                        if (visitor != null)
-                            await visitor.VisitFieldAsync(this, variableDef, childFieldVariableName, graphType, field, fieldValue, parsedFieldValue).ConfigureAwait(false);
-                        newDictionary[field.Name] = parsedFieldValue;
-                    }
-                    else if (field.DefaultValue != null)
-                    {
-                        // RULE: If no value is provided for a defined input object field and that
-                        // field definition provides a default value, the default value should be used.
-                        newDictionary[field.Name] = field.DefaultValue;
-                    }
-                    else if (field.ResolvedType is NonNullGraphType)
-                    {
-                        // RULE: If no default value is provided and the input object field’s type is non‐null,
-                        // an error should be thrown.
-                        throw new InvalidVariableError(this, variableDef, childFieldVariableName, "No value provided for a non-null variable.");
-                    }
-
-                    // RULE: Otherwise, if the field is not required, then no
-                    // entry is added to the coerced unordered map.
-
-                    // so do not do this:    else { newDictionary[field.Name] = null; }
-                }
-
                 // RULE: The value for an input object should be an input object literal
                 // or an unordered map supplied by a variable, otherwise a query error
-                // must be thrown. In either case, the input object literal or unordered
-                // map must not contain any entries with names not defined by a field
-                // of this input object type, ***otherwise an error must be thrown.***
-                List<string>? unknownFields = null;
-                foreach (string key in dic.Keys)
-                {
-                    bool match = false;
+                // must be thrown.
 
-                    foreach (var field in graphType.Fields.List)
-                    {
-                        if (key == field.Name)
-                        {
-                            match = true;
-                            break;
-                        }
-                    }
-
-                    if (!match)
-                        (unknownFields ??= new(1)).Add(key);
-                }
-
-                if (unknownFields?.Count > 0)
-                {
-                    throw new InvalidVariableError(this, variableDef, variableName, $"Unrecognized input fields {string.Join(", ", unknownFields.Select(k => $"'{k}'"))} for type '{graphType.Name}'.");
-                }
-
-                return graphType.ParseDictionary(newDictionary);
+                throw new InvalidVariableError(this, variableDef, variableName, $"Unable to parse input as a '{graphType.Name}' type. Did you provide a List or Scalar value accidentally?");
             }
+
+            var newDictionary = new Dictionary<string, object?>(dic.Count);
+            foreach (var field in graphType.Fields.List)
+            {
+                var childFieldVariableName = new VariableName(variableName, field.Name);
+
+                if (dic.TryGetValue(field.Name, out object? fieldValue))
+                {
+                    // RULE: If the value null was provided for an input object field, and
+                    // the field’s type is not a non‐null type, an entry in the coerced
+                    // unordered map is given the value null. In other words, there is a
+                    // semantic difference between the explicitly provided value null
+                    // versus having not provided a value.
+
+                    // Note: we always call ParseValue even for null values, and if it
+                    // is a non-null graph type, the NonNullGraphType.ParseValue method will throw an error
+                    object? parsedFieldValue = await ParseValueAsync(field.ResolvedType!, variableDef, childFieldVariableName, fieldValue, visitor).ConfigureAwait(false);
+                    try
+                    {
+                        if (parsedFieldValue != null && field.Parser != null)
+                            parsedFieldValue = field.Parser(parsedFieldValue);
+                        if (parsedFieldValue != null && field.Validator != null)
+                            field.Validator(parsedFieldValue);
+                    }
+                    catch (ValidationError ex)
+                    {
+                        ex.AddNode(Document.Source, variableDef);
+                        throw;
+                    }
+                    catch (ExecutionError ex)
+                    {
+                        ex.AddLocation(GraphQLParser.Location.FromLinearPosition(Document.Source, variableDef.Location.Start));
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidVariableError(this, variableDef, childFieldVariableName, ex.Message, ex);
+                    }
+                    if (visitor != null)
+                        await visitor.VisitFieldAsync(this, variableDef, childFieldVariableName, graphType, field, fieldValue, parsedFieldValue).ConfigureAwait(false);
+                    newDictionary[field.Name] = parsedFieldValue;
+                }
+                else if (field.DefaultValue != null)
+                {
+                    // RULE: If no value is provided for a defined input object field and that
+                    // field definition provides a default value, the default value should be used.
+                    newDictionary[field.Name] = field.DefaultValue;
+                }
+                else if (field.ResolvedType is NonNullGraphType)
+                {
+                    // RULE: If no default value is provided and the input object field’s type is non‐null,
+                    // an error should be thrown.
+                    throw new InvalidVariableError(this, variableDef, childFieldVariableName, "No value provided for a non-null variable.");
+                }
+
+                // RULE: Otherwise, if the field is not required, then no
+                // entry is added to the coerced unordered map.
+
+                // so do not do this:    else { newDictionary[field.Name] = null; }
+            }
+
+            // RULE: The value for an input object should be an input object literal
+            // or an unordered map supplied by a variable, otherwise a query error
+            // must be thrown. In either case, the input object literal or unordered
+            // map must not contain any entries with names not defined by a field
+            // of this input object type, ***otherwise an error must be thrown.***
+            List<string>? unknownFields = null;
+            foreach (string key in dic.Keys)
+            {
+                bool match = false;
+
+                foreach (var field in graphType.Fields.List)
+                {
+                    if (key == field.Name)
+                    {
+                        match = true;
+                        break;
+                    }
+                }
+
+                if (!match)
+                    (unknownFields ??= new(1)).Add(key);
+            }
+
+            if (unknownFields?.Count > 0)
+            {
+                throw new InvalidVariableError(this, variableDef, variableName, $"Unrecognized input fields {string.Join(", ", unknownFields.Select(k => $"'{k}'"))} for type '{graphType.Name}'.");
+            }
+
+            return graphType.ParseDictionary(newDictionary);
+        }
+    }
+
+    /// <summary>
+    /// Validates that the specified AST value is valid for the specified scalar or input graph type.
+    /// Graph types that are lists or non-null types are handled appropriately by this method.
+    /// Returns a string representing the errors encountered while validating the value.
+    /// </summary>
+    public string? IsValidLiteralValue(IGraphType type, GraphQLValue valueAst)
+    {
+        if (type is NonNullGraphType nonNull)
+        {
+            var ofType = nonNull.ResolvedType!;
+
+            if (valueAst == null || valueAst is GraphQLNullValue)
+            {
+                return ofType == null
+                    ? "Expected non-null value, found null"
+                    : $"Expected '{ofType.Name}!', found null.";
+            }
+
+            return IsValidLiteralValue(ofType, valueAst);
+        }
+        else if (valueAst is GraphQLNullValue)
+        {
+            return null;
         }
 
-        /// <summary>
-        /// Validates that the specified AST value is valid for the specified scalar or input graph type.
-        /// Graph types that are lists or non-null types are handled appropriately by this method.
-        /// Returns a string representing the errors encountered while validating the value.
-        /// </summary>
-        public string? IsValidLiteralValue(IGraphType type, GraphQLValue valueAst)
+        if (valueAst == null)
         {
-            if (type is NonNullGraphType nonNull)
+            return null;
+        }
+
+        // This function only tests literals, and assumes variables will provide
+        // values of the correct type.
+        if (valueAst is GraphQLVariable)
+        {
+            return null;
+        }
+
+        if (type is ListGraphType list)
+        {
+            var ofType = list.ResolvedType!;
+
+            if (valueAst is GraphQLListValue listValue)
             {
-                var ofType = nonNull.ResolvedType!;
-
-                if (valueAst == null || valueAst is GraphQLNullValue)
-                {
-                    return ofType == null
-                        ? "Expected non-null value, found null"
-                        : $"Expected '{ofType.Name}!', found null.";
-                }
-
-                return IsValidLiteralValue(ofType, valueAst);
-            }
-            else if (valueAst is GraphQLNullValue)
-            {
-                return null;
-            }
-
-            if (valueAst == null)
-            {
-                return null;
-            }
-
-            // This function only tests literals, and assumes variables will provide
-            // values of the correct type.
-            if (valueAst is GraphQLVariable)
-            {
-                return null;
-            }
-
-            if (type is ListGraphType list)
-            {
-                var ofType = list.ResolvedType!;
-
-                if (valueAst is GraphQLListValue listValue)
-                {
-                    List<string>? errors = null;
-
-                    if (listValue.Values != null)
-                    {
-                        for (int index = 0; index < listValue.Values.Count; ++index)
-                        {
-                            string? error = IsValidLiteralValue(ofType, listValue.Values[index]);
-                            if (error != null)
-                                (errors ??= new()).Add($"In element #{index + 1}: [{error}]");
-                        }
-                    }
-
-                    return errors == null
-                        ? null
-                        : string.Join(" ", errors);
-                }
-
-                return IsValidLiteralValue(ofType, valueAst);
-            }
-
-            if (type is IInputObjectGraphType inputType)
-            {
-                if (valueAst is not GraphQLObjectValue objValue)
-                {
-                    return $"Expected '{inputType.Name}', found not an object.";
-                }
-
-                var fields = inputType.Fields.List;
-                var fieldAsts = objValue.Fields;
-
                 List<string>? errors = null;
 
-                // ensure every provided field is defined
-                if (fieldAsts != null)
+                if (listValue.Values != null)
                 {
-                    foreach (var providedFieldAst in fieldAsts)
+                    for (int index = 0; index < listValue.Values.Count; ++index)
                     {
-                        var found = fields.Find(x => x.Name == providedFieldAst.Name);
-                        if (found == null)
-                        {
-                            (errors ??= new()).Add($"In field '{providedFieldAst.Name}': Unknown field.");
-                        }
-                    }
-                }
-
-                // ensure every defined field is valid
-                foreach (var field in fields)
-                {
-                    var fieldAst = fieldAsts?.Find(x => x.Name == field.Name);
-
-                    if (fieldAst != null)
-                    {
-                        string? error = IsValidLiteralValue(field.ResolvedType!, fieldAst.Value);
+                        string? error = IsValidLiteralValue(ofType, listValue.Values[index]);
                         if (error != null)
-                            (errors ??= new()).Add($"In field '{field.Name}': [{error}]");
-                    }
-                    else if (field.ResolvedType is NonNullGraphType nonNull2 && field.DefaultValue == null)
-                    {
-                        (errors ??= new()).Add($"Missing required field '{field.Name}' of type '{nonNull2.ResolvedType}'.");
+                            (errors ??= new()).Add($"In element #{index + 1}: [{error}]");
                     }
                 }
 
@@ -576,53 +526,102 @@ namespace GraphQL.Validation
                     : string.Join(" ", errors);
             }
 
-            if (type is ScalarGraphType scalar)
+            return IsValidLiteralValue(ofType, valueAst);
+        }
+
+        if (type is IInputObjectGraphType inputType)
+        {
+            if (valueAst is not GraphQLObjectValue objValue)
             {
-                return scalar.CanParseLiteral(valueAst)
-                    ? null
-                    : $"Expected type '{type.Name}', found {valueAst.Print()}.";
+                return $"Expected '{inputType.Name}', found not an object.";
             }
 
-            throw new ArgumentOutOfRangeException(nameof(type), $"Type {type?.Name ?? "<NULL>"} is not a valid input graph type.");
+            var fields = inputType.Fields.List;
+            var fieldAsts = objValue.Fields;
+
+            List<string>? errors = null;
+
+            // ensure every provided field is defined
+            if (fieldAsts != null)
+            {
+                foreach (var providedFieldAst in fieldAsts)
+                {
+                    var found = fields.Find(x => x.Name == providedFieldAst.Name);
+                    if (found == null)
+                    {
+                        (errors ??= new()).Add($"In field '{providedFieldAst.Name}': Unknown field.");
+                    }
+                }
+            }
+
+            // ensure every defined field is valid
+            foreach (var field in fields)
+            {
+                var fieldAst = fieldAsts?.Find(x => x.Name == field.Name);
+
+                if (fieldAst != null)
+                {
+                    string? error = IsValidLiteralValue(field.ResolvedType!, fieldAst.Value);
+                    if (error != null)
+                        (errors ??= new()).Add($"In field '{field.Name}': [{error}]");
+                }
+                else if (field.ResolvedType is NonNullGraphType nonNull2 && field.DefaultValue == null)
+                {
+                    (errors ??= new()).Add($"Missing required field '{field.Name}' of type '{nonNull2.ResolvedType}'.");
+                }
+            }
+
+            return errors == null
+                ? null
+                : string.Join(" ", errors);
+        }
+
+        if (type is ScalarGraphType scalar)
+        {
+            return scalar.CanParseLiteral(valueAst)
+                ? null
+                : $"Expected type '{type.Name}', found {valueAst.Print()}.";
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(type), $"Type {type?.Name ?? "<NULL>"} is not a valid input graph type.");
+    }
+}
+
+internal static class ValidationContextExtensions
+{
+    public static void AddListItem<T>(this ValidationContext context, string listKey, T item)
+    {
+        List<T> items;
+        if (context.NonUserContext?.TryGetValue(listKey, out object? obj) == true)
+        {
+            items = (List<T>)obj!;
+            items.Add(item);
+        }
+        else
+        {
+            items = new List<T> { item };
+            (context.NonUserContext ??= new()).Add(listKey, items);
         }
     }
 
-    internal static class ValidationContextExtensions
+    public static List<T>? GetList<T>(this ValidationContext context, string listKey, bool reset)
     {
-        public static void AddListItem<T>(this ValidationContext context, string listKey, T item)
-        {
-            List<T> items;
-            if (context.NonUserContext?.TryGetValue(listKey, out object? obj) == true)
-            {
-                items = (List<T>)obj!;
-                items.Add(item);
-            }
-            else
-            {
-                items = new List<T> { item };
-                (context.NonUserContext ??= new()).Add(listKey, items);
-            }
-        }
-
-        public static List<T>? GetList<T>(this ValidationContext context, string listKey, bool reset)
-        {
 #if NETSTANDARD2_1_OR_GREATER
-            object? items = null;
-            return (reset ? context.NonUserContext?.Remove(listKey, out items) : context.NonUserContext?.TryGetValue(listKey, out items)) == true
-                ? (List<T>?)items
-                : null;
+        object? items = null;
+        return (reset ? context.NonUserContext?.Remove(listKey, out items) : context.NonUserContext?.TryGetValue(listKey, out items)) == true
+            ? (List<T>?)items
+            : null;
 #else
-            if (context.NonUserContext?.TryGetValue(listKey, out object? items) == true)
-            {
-                if (reset)
-                    context.NonUserContext.Remove(listKey);
-                return (List<T>?)items;
-            }
-            else
-            {
-                return null;
-            }
-#endif
+        if (context.NonUserContext?.TryGetValue(listKey, out object? items) == true)
+        {
+            if (reset)
+                context.NonUserContext.Remove(listKey);
+            return (List<T>?)items;
         }
+        else
+        {
+            return null;
+        }
+#endif
     }
 }

--- a/src/GraphQL/Validation/ValidationError.cs
+++ b/src/GraphQL/Validation/ValidationError.cs
@@ -2,128 +2,127 @@ using GraphQL.Execution;
 using GraphQLParser;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Represents an error generated while validating the document.
+/// </summary>
+[Serializable]
+public class ValidationError : DocumentError
 {
+    private readonly List<ASTNode> _nodes = new();
+
     /// <summary>
-    /// Represents an error generated while validating the document.
+    /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified error message.
+    /// Sets the <see cref="ExecutionError.Code">Code</see> property based on the exception type.
     /// </summary>
-    [Serializable]
-    public class ValidationError : DocumentError
+    public ValidationError(string message) : base(message)
     {
-        private readonly List<ASTNode> _nodes = new();
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified error message.
-        /// Sets the <see cref="ExecutionError.Code">Code</see> property based on the exception type.
-        /// </summary>
-        public ValidationError(string message) : base(message)
-        {
-            Code = GetValidationErrorCode(GetType());
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified
-        /// error message and inner exception. Sets the <see cref="ExecutionError.Code">Code</see>
-        /// property based on the exception type. Loads any exception data from the inner exception
-        /// into this instance.
-        /// </summary>
-        public ValidationError(string message, Exception? innerException) : base(message, innerException)
-        {
-            Code = GetValidationErrorCode(GetType());
-        }
-
-        /// <inheritdoc cref="ValidationError(ROM, string, string, ASTNode[])"/>
-        public ValidationError(ROM originalQuery, string? number, string message, ASTNode node)
-            : this(originalQuery, number, message, (Exception?)null, node)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified
-        /// error message, code and number. Sets locations based on the original query and specified
-        /// AST nodes that this error applies to.
-        /// </summary>
-        public ValidationError(ROM originalQuery, string? number, string message, params ASTNode[] nodes)
-            : this(originalQuery, number, message, null, nodes)
-        {
-        }
-
-        /// <inheritdoc cref="ValidationError(ROM, string, string, Exception, ASTNode[])"/>
-        public ValidationError(
-            ROM originalQuery,
-            string? number,
-            string message,
-            Exception? innerException,
-            ASTNode node)
-            : base(message, innerException)
-        {
-            Code = GetValidationErrorCode(GetType());
-            Number = number;
-
-            if (node != null)
-            {
-                _nodes.Add(node);
-                AddLocation(Location.FromLinearPosition(originalQuery, node.Location.Start));
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified
-        /// error message and inner exception. Sets the <see cref="ExecutionError.Code">Code</see>
-        /// property based on the exception type. Sets locations based on the original query and
-        /// specified AST nodes that this error applies to. Loads any exception data from the inner
-        /// exception into this instance.
-        /// </summary>
-        public ValidationError(
-            ROM originalQuery,
-            string? number,
-            string message,
-            Exception? innerException,
-            params ASTNode[]? nodes)
-            : base(message, innerException)
-        {
-            Code = GetValidationErrorCode(GetType());
-            Number = number;
-
-            if (nodes != null)
-            {
-                foreach (var n in nodes)
-                {
-                    _nodes.Add(n);
-                    AddLocation(Location.FromLinearPosition(originalQuery, n.Location.Start));
-                }
-            }
-        }
-
-        internal static string GetValidationErrorCode(Type type)
-        {
-            var code = ErrorInfoProvider.GetErrorCode(type);
-            if (code != "VALIDATION_ERROR" && code.EndsWith("_ERROR"))
-                code = code.Substring(0, code.Length - 6);
-            return code;
-        }
-
-        /// <summary>
-        /// Ensures that the specified node's location is specified in the error's locations.
-        /// </summary>
-        internal void AddNode(ROM source, ASTNode node)
-        {
-            if (!_nodes.Contains(node))
-            {
-                _nodes.Add(node);
-                AddLocation(Location.FromLinearPosition(source, node.Location.Start));
-            }
-        }
-
-        /// <summary>
-        /// Returns a list of AST nodes that this error applies to.
-        /// </summary>
-        public IEnumerable<ASTNode> Nodes => _nodes;
-
-        /// <summary>
-        /// Gets or sets the rule number of this validation error corresponding
-        /// to the paragraph number from the official specification if any.
-        /// </summary>
-        public string? Number { get; set; }
+        Code = GetValidationErrorCode(GetType());
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified
+    /// error message and inner exception. Sets the <see cref="ExecutionError.Code">Code</see>
+    /// property based on the exception type. Loads any exception data from the inner exception
+    /// into this instance.
+    /// </summary>
+    public ValidationError(string message, Exception? innerException) : base(message, innerException)
+    {
+        Code = GetValidationErrorCode(GetType());
+    }
+
+    /// <inheritdoc cref="ValidationError(ROM, string, string, ASTNode[])"/>
+    public ValidationError(ROM originalQuery, string? number, string message, ASTNode node)
+        : this(originalQuery, number, message, (Exception?)null, node)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified
+    /// error message, code and number. Sets locations based on the original query and specified
+    /// AST nodes that this error applies to.
+    /// </summary>
+    public ValidationError(ROM originalQuery, string? number, string message, params ASTNode[] nodes)
+        : this(originalQuery, number, message, null, nodes)
+    {
+    }
+
+    /// <inheritdoc cref="ValidationError(ROM, string, string, Exception, ASTNode[])"/>
+    public ValidationError(
+        ROM originalQuery,
+        string? number,
+        string message,
+        Exception? innerException,
+        ASTNode node)
+        : base(message, innerException)
+    {
+        Code = GetValidationErrorCode(GetType());
+        Number = number;
+
+        if (node != null)
+        {
+            _nodes.Add(node);
+            AddLocation(Location.FromLinearPosition(originalQuery, node.Location.Start));
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationError"/> class with a specified
+    /// error message and inner exception. Sets the <see cref="ExecutionError.Code">Code</see>
+    /// property based on the exception type. Sets locations based on the original query and
+    /// specified AST nodes that this error applies to. Loads any exception data from the inner
+    /// exception into this instance.
+    /// </summary>
+    public ValidationError(
+        ROM originalQuery,
+        string? number,
+        string message,
+        Exception? innerException,
+        params ASTNode[]? nodes)
+        : base(message, innerException)
+    {
+        Code = GetValidationErrorCode(GetType());
+        Number = number;
+
+        if (nodes != null)
+        {
+            foreach (var n in nodes)
+            {
+                _nodes.Add(n);
+                AddLocation(Location.FromLinearPosition(originalQuery, n.Location.Start));
+            }
+        }
+    }
+
+    internal static string GetValidationErrorCode(Type type)
+    {
+        var code = ErrorInfoProvider.GetErrorCode(type);
+        if (code != "VALIDATION_ERROR" && code.EndsWith("_ERROR"))
+            code = code.Substring(0, code.Length - 6);
+        return code;
+    }
+
+    /// <summary>
+    /// Ensures that the specified node's location is specified in the error's locations.
+    /// </summary>
+    internal void AddNode(ROM source, ASTNode node)
+    {
+        if (!_nodes.Contains(node))
+        {
+            _nodes.Add(node);
+            AddLocation(Location.FromLinearPosition(source, node.Location.Start));
+        }
+    }
+
+    /// <summary>
+    /// Returns a list of AST nodes that this error applies to.
+    /// </summary>
+    public IEnumerable<ASTNode> Nodes => _nodes;
+
+    /// <summary>
+    /// Gets or sets the rule number of this validation error corresponding
+    /// to the paragraph number from the official specification if any.
+    /// </summary>
+    public string? Number { get; set; }
 }

--- a/src/GraphQL/Validation/ValidationOptions.cs
+++ b/src/GraphQL/Validation/ValidationOptions.cs
@@ -3,103 +3,102 @@ using GraphQL.Instrumentation;
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Options used by <see cref="IDocumentValidator.ValidateAsync(in ValidationOptions)"/>.
+/// </summary>
+public readonly struct ValidationOptions
 {
     /// <summary>
-    /// Options used by <see cref="IDocumentValidator.ValidateAsync(in ValidationOptions)"/>.
+    /// Creates a default instance of <see cref="ValidationOptions"/>.
     /// </summary>
-    public readonly struct ValidationOptions
+    public ValidationOptions()
     {
-        /// <summary>
-        /// Creates a default instance of <see cref="ValidationOptions"/>.
-        /// </summary>
-        public ValidationOptions()
-        {
-        }
-
-        /// <summary>
-        /// Creates a default instance of <see cref="ValidationOptions"/> with the specified options.
-        /// </summary>
-        public ValidationOptions(
-            ISchema schema,
-            GraphQLDocument document,
-            IEnumerable<IValidationRule>? rules,
-            IDictionary<string, object?> userContext,
-            Metrics metrics,
-            Inputs variables,
-            Inputs extensions,
-            GraphQLOperationDefinition operation,
-            IServiceProvider? requestServices,
-            ClaimsPrincipal? user,
-            CancellationToken cancellationToken)
-        {
-            // this constructor is required for C# 8.0 and prior consumers, as they cannot write to init-only properties
-            Schema = schema;
-            Document = document;
-            Rules = rules;
-            UserContext = userContext;
-            Metrics = metrics;
-            Variables = variables;
-            Extensions = extensions;
-            Operation = operation;
-            RequestServices = requestServices;
-            User = user;
-            CancellationToken = cancellationToken;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="ISchema"/> to validate the <see cref="GraphQLDocument"/> against.
-        /// </summary>
-        public ISchema Schema { get; init; } = null!;
-
-        /// <summary>
-        /// Gets or sets the <see cref="GraphQLDocument"/> to validate.
-        /// </summary>
-        public GraphQLDocument Document { get; init; } = null!;
-
-        /// <summary>
-        /// Gets or sets a list of rules to use to validate the <see cref="GraphQLDocument"/>.
-        /// If no rules are specified, <see cref="DocumentValidator.CoreRules"/> are used.
-        /// </summary>
-        public IEnumerable<IValidationRule>? Rules { get; init; } = null;
-
-        /// <summary>
-        /// Gets or sets the user context, which can be used by validation rules
-        /// during document validation.
-        /// </summary>
-        public IDictionary<string, object?> UserContext { get; init; } = null!;
-
-        /// <summary>
-        /// Gets or sets object for performance metrics, which can be used by
-        /// validation rules during document validation.
-        /// </summary>
-        public Metrics Metrics { get; init; } = null!;
-
-        /// <summary>
-        /// Gets or sets the input variables.
-        /// </summary>
-        public Inputs Variables { get; init; } = null!;
-
-        /// <summary>
-        /// Gets or sets the input extensions.
-        /// </summary>
-        public Inputs Extensions { get; init; } = null!;
-
-        /// <summary>
-        /// Executed operation.
-        /// </summary>
-        public GraphQLOperationDefinition Operation { get; init; } = null!;
-
-        /// <inheritdoc cref="ExecutionOptions.RequestServices"/>
-        public IServiceProvider? RequestServices { get; init; } = null;
-
-        /// <inheritdoc cref="ExecutionOptions.User"/>
-        public ClaimsPrincipal? User { get; init; } = null;
-
-        /// <summary>
-        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;
-        /// defaults to <see cref="CancellationToken.None"/>
-        /// </summary>
-        public CancellationToken CancellationToken { get; init; } = default;
     }
+
+    /// <summary>
+    /// Creates a default instance of <see cref="ValidationOptions"/> with the specified options.
+    /// </summary>
+    public ValidationOptions(
+        ISchema schema,
+        GraphQLDocument document,
+        IEnumerable<IValidationRule>? rules,
+        IDictionary<string, object?> userContext,
+        Metrics metrics,
+        Inputs variables,
+        Inputs extensions,
+        GraphQLOperationDefinition operation,
+        IServiceProvider? requestServices,
+        ClaimsPrincipal? user,
+        CancellationToken cancellationToken)
+    {
+        // this constructor is required for C# 8.0 and prior consumers, as they cannot write to init-only properties
+        Schema = schema;
+        Document = document;
+        Rules = rules;
+        UserContext = userContext;
+        Metrics = metrics;
+        Variables = variables;
+        Extensions = extensions;
+        Operation = operation;
+        RequestServices = requestServices;
+        User = user;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ISchema"/> to validate the <see cref="GraphQLDocument"/> against.
+    /// </summary>
+    public ISchema Schema { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets the <see cref="GraphQLDocument"/> to validate.
+    /// </summary>
+    public GraphQLDocument Document { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets a list of rules to use to validate the <see cref="GraphQLDocument"/>.
+    /// If no rules are specified, <see cref="DocumentValidator.CoreRules"/> are used.
+    /// </summary>
+    public IEnumerable<IValidationRule>? Rules { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets the user context, which can be used by validation rules
+    /// during document validation.
+    /// </summary>
+    public IDictionary<string, object?> UserContext { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets object for performance metrics, which can be used by
+    /// validation rules during document validation.
+    /// </summary>
+    public Metrics Metrics { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets the input variables.
+    /// </summary>
+    public Inputs Variables { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets the input extensions.
+    /// </summary>
+    public Inputs Extensions { get; init; } = null!;
+
+    /// <summary>
+    /// Executed operation.
+    /// </summary>
+    public GraphQLOperationDefinition Operation { get; init; } = null!;
+
+    /// <inheritdoc cref="ExecutionOptions.RequestServices"/>
+    public IServiceProvider? RequestServices { get; init; } = null;
+
+    /// <inheritdoc cref="ExecutionOptions.User"/>
+    public ClaimsPrincipal? User { get; init; } = null;
+
+    /// <summary>
+    /// <see cref="System.Threading.CancellationToken">CancellationToken</see> to cancel validation of request;
+    /// defaults to <see cref="CancellationToken.None"/>
+    /// </summary>
+    public CancellationToken CancellationToken { get; init; } = default;
 }

--- a/src/GraphQL/Validation/ValidationResult.cs
+++ b/src/GraphQL/Validation/ValidationResult.cs
@@ -1,80 +1,79 @@
 using GraphQL.Execution;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <inheritdoc cref="IValidationResult"/>
+public class ValidationResult : IValidationResult
 {
-    /// <inheritdoc cref="IValidationResult"/>
-    public class ValidationResult : IValidationResult
-    {
-        /// <summary>
-        /// Initializes a new instance with the specified set of validation errors.
-        /// </summary>
-        /// <param name="errors">Set of validation errors.</param>
-        public ValidationResult(IEnumerable<ValidationError> errors)
-        {
-            if (errors.Any())
-            {
-                Errors.AddRange(errors);
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified set of validation errors.
-        /// </summary>
-        /// <param name="errors">Set of validation errors.</param>
-        public ValidationResult(params ValidationError[] errors)
-            : this((IEnumerable<ValidationError>)errors)
-        {
-        }
-
-        /// <inheritdoc/>
-        public bool IsValid => (_errors?.Count ?? 0) == 0;
-
-        private ExecutionErrors? _errors;
-
-        /// <inheritdoc/>
-        public ExecutionErrors Errors => _errors ??= new ExecutionErrors();
-
-        /// <inheritdoc/>
-        public Variables? Variables { get; set; }
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; }
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; }
-    }
-
-    // Optimization for validation "green path" - does not allocate memory in managed heap.
     /// <summary>
-    /// A validation result that indicates no errors were found during validation of the document.
+    /// Initializes a new instance with the specified set of validation errors.
     /// </summary>
-    internal sealed class SuccessfullyValidatedResult : IValidationResult
+    /// <param name="errors">Set of validation errors.</param>
+    public ValidationResult(IEnumerable<ValidationError> errors)
     {
-        private SuccessfullyValidatedResult() { }
-
-        /// <summary>
-        /// Returns a static instance of this class.
-        /// </summary>
-        public static readonly IValidationResult Instance = new SuccessfullyValidatedResult();
-
-        /// <summary>
-        /// Returns <see langword="true"/> indicating that the document was successfully validated.
-        /// </summary>
-        public bool IsValid => true;
-
-        /// <summary>
-        /// Returns an empty list of execution errors.
-        /// </summary>
-        public ExecutionErrors Errors => EmptyExecutionErrors.Instance;
-
-        /// <inheritdoc/>
-        public Variables? Variables => Variables.None;
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues => null;
-
-        /// <inheritdoc/>
-        public IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues => null;
+        if (errors.Any())
+        {
+            Errors.AddRange(errors);
+        }
     }
+
+    /// <summary>
+    /// Initializes a new instance with the specified set of validation errors.
+    /// </summary>
+    /// <param name="errors">Set of validation errors.</param>
+    public ValidationResult(params ValidationError[] errors)
+        : this((IEnumerable<ValidationError>)errors)
+    {
+    }
+
+    /// <inheritdoc/>
+    public bool IsValid => (_errors?.Count ?? 0) == 0;
+
+    private ExecutionErrors? _errors;
+
+    /// <inheritdoc/>
+    public ExecutionErrors Errors => _errors ??= new ExecutionErrors();
+
+    /// <inheritdoc/>
+    public Variables? Variables { get; set; }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; }
+}
+
+// Optimization for validation "green path" - does not allocate memory in managed heap.
+/// <summary>
+/// A validation result that indicates no errors were found during validation of the document.
+/// </summary>
+internal sealed class SuccessfullyValidatedResult : IValidationResult
+{
+    private SuccessfullyValidatedResult() { }
+
+    /// <summary>
+    /// Returns a static instance of this class.
+    /// </summary>
+    public static readonly IValidationResult Instance = new SuccessfullyValidatedResult();
+
+    /// <summary>
+    /// Returns <see langword="true"/> indicating that the document was successfully validated.
+    /// </summary>
+    public bool IsValid => true;
+
+    /// <summary>
+    /// Returns an empty list of execution errors.
+    /// </summary>
+    public ExecutionErrors Errors => EmptyExecutionErrors.Instance;
+
+    /// <inheritdoc/>
+    public Variables? Variables => Variables.None;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues => null;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues => null;
 }

--- a/src/GraphQL/Validation/Variable.cs
+++ b/src/GraphQL/Validation/Variable.cs
@@ -1,51 +1,50 @@
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Represents a variable name and value tuple that has been gathered from the document and attached <see cref="Inputs"/>.
+/// </summary>
+public class Variable
 {
     /// <summary>
-    /// Represents a variable name and value tuple that has been gathered from the document and attached <see cref="Inputs"/>.
+    /// Initializes a new instance with the specified name and definition.
     /// </summary>
-    public class Variable
+    public Variable(string name, GraphQLParser.AST.GraphQLVariableDefinition definition)
     {
-        /// <summary>
-        /// Initializes a new instance with the specified name and definition.
-        /// </summary>
-        public Variable(string name, GraphQLParser.AST.GraphQLVariableDefinition definition)
-        {
-            Name = name;
-            Definition = definition;
-        }
-
-        /// <summary>
-        /// Gets or sets the name of the variable.
-        /// </summary>
-        public string Name { get; }
-
-        private object? _value;
-        /// <summary>
-        /// Gets or sets the value of the variable.
-        /// </summary>
-        public object? Value
-        {
-            get => _value;
-            set
-            {
-                _value = value;
-                ValueSpecified = true;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the definition of the variable.
-        /// </summary>
-        public GraphQLParser.AST.GraphQLVariableDefinition Definition { get; set; }
-
-        /// <summary>
-        /// Indicates if the variable value has been set.
-        /// </summary>
-        public bool ValueSpecified { get; private set; }
-
-        /// <summary>
-        /// Indicates if the variable's value is the variable's configured default value.
-        /// </summary>
-        public bool IsDefault { get; set; }
+        Name = name;
+        Definition = definition;
     }
+
+    /// <summary>
+    /// Gets or sets the name of the variable.
+    /// </summary>
+    public string Name { get; }
+
+    private object? _value;
+    /// <summary>
+    /// Gets or sets the value of the variable.
+    /// </summary>
+    public object? Value
+    {
+        get => _value;
+        set
+        {
+            _value = value;
+            ValueSpecified = true;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the definition of the variable.
+    /// </summary>
+    public GraphQLParser.AST.GraphQLVariableDefinition Definition { get; set; }
+
+    /// <summary>
+    /// Indicates if the variable value has been set.
+    /// </summary>
+    public bool ValueSpecified { get; private set; }
+
+    /// <summary>
+    /// Indicates if the variable's value is the variable's configured default value.
+    /// </summary>
+    public bool IsDefault { get; set; }
 }

--- a/src/GraphQL/Validation/VariableUsage.cs
+++ b/src/GraphQL/Validation/VariableUsage.cs
@@ -1,39 +1,38 @@
 using GraphQL.Types;
 using GraphQLParser.AST;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Represents a variable reference node and the graph type it is referenced to be used for.
+/// </summary>
+public class VariableUsage
 {
     /// <summary>
-    /// Represents a variable reference node and the graph type it is referenced to be used for.
+    /// Returns a variable reference node.
     /// </summary>
-    public class VariableUsage
+    public GraphQLVariable Node { get; }
+
+    /// <summary>
+    /// Returns a graph type.
+    /// </summary>
+    public IGraphType Type { get; }
+
+    /// <summary>
+    /// Indicates if the variable usage has a default field value.
+    /// </summary>
+    public bool HasDefault { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the specified parameters.
+    /// </summary>
+    /// <param name="node">A variable reference node.</param>
+    /// <param name="type">A graph type.</param>
+    /// <param name="hasDefault">Indicates if the field has a default value.</param>
+    public VariableUsage(GraphQLVariable node, IGraphType type, bool hasDefault)
     {
-        /// <summary>
-        /// Returns a variable reference node.
-        /// </summary>
-        public GraphQLVariable Node { get; }
-
-        /// <summary>
-        /// Returns a graph type.
-        /// </summary>
-        public IGraphType Type { get; }
-
-        /// <summary>
-        /// Indicates if the variable usage has a default field value.
-        /// </summary>
-        public bool HasDefault { get; }
-
-        /// <summary>
-        /// Initializes a new instance with the specified parameters.
-        /// </summary>
-        /// <param name="node">A variable reference node.</param>
-        /// <param name="type">A graph type.</param>
-        /// <param name="hasDefault">Indicates if the field has a default value.</param>
-        public VariableUsage(GraphQLVariable node, IGraphType type, bool hasDefault)
-        {
-            Node = node;
-            Type = type;
-            HasDefault = hasDefault;
-        }
+        Node = node;
+        Type = type;
+        HasDefault = hasDefault;
     }
 }

--- a/src/GraphQL/Validation/Variables.cs
+++ b/src/GraphQL/Validation/Variables.cs
@@ -2,88 +2,86 @@ using System.Collections;
 using GraphQL.Execution;
 using GraphQLParser;
 
-namespace GraphQL.Validation
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Contains a list of variables (name &amp; value tuples) that have been gathered from the document and attached <see cref="Inputs"/>.
+/// </summary>
+public class Variables : IEnumerable<Variable>
 {
+    private List<Variable>? _variables;
+
     /// <summary>
-    /// Contains a list of variables (name &amp; value tuples) that have been gathered from the document and attached <see cref="Inputs"/>.
+    /// Initializes a new instance.
     /// </summary>
-    public class Variables : IEnumerable<Variable>
+    public Variables()
     {
-        private List<Variable>? _variables;
-
-        /// <summary>
-        /// Initializes a new instance.
-        /// </summary>
-        public Variables()
-        {
-        }
-
-        internal Variables(int initialCount)
-        {
-            _variables = new List<Variable>(initialCount);
-        }
-
-        /// <summary>
-        /// Adds a variable to the list.
-        /// </summary>
-        public virtual void Add(Variable variable) => (_variables ??= new()).Add(variable ?? throw new ArgumentNullException(nameof(variable)));
-
-        /// <summary>
-        /// Returns the first variable with a matching name, or <paramref name="defaultValue"/> if none are found.
-        /// </summary>
-        public object? ValueFor(string name, object? defaultValue = null)
-        {
-            return ValueFor(name, out var value) ? value.Value : defaultValue;
-        }
-
-        /// <summary>
-        /// Gets the first variable with a matching name.
-        /// </summary>
-        public Variable? Find(ROM name)
-        {
-            if (_variables != null)
-            {
-                foreach (var v in _variables)
-                {
-                    if (v.Name == name)
-                    {
-                        return v;
-                    }
-                }
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Gets the first variable with a matching name. Returns <see langword="true"/> if a match is found.
-        /// </summary>
-        public bool ValueFor(ROM name, out ArgumentValue value)
-        {
-            var v = Find(name);
-            if (v != null)
-            {
-                value = new ArgumentValue(v.Value, v.IsDefault || !v.ValueSpecified ? ArgumentSource.VariableDefault : ArgumentSource.Variable);
-                return v.ValueSpecified;
-            }
-
-            value = default;
-            return false;
-        }
-
-        /// <inheritdoc/>
-        public IEnumerator<Variable> GetEnumerator() => (_variables ?? Enumerable.Empty<Variable>()).GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        /// <summary>
-        /// Returns a static instance that holds no variables.
-        /// </summary>
-        public static Variables None { get; } = new NoVariables();
-
-        private sealed class NoVariables : Variables
-        {
-            public override void Add(Variable variable) => throw new InvalidOperationException("Cannot add variables to this instance.");
-        }
     }
 
+    internal Variables(int initialCount)
+    {
+        _variables = new List<Variable>(initialCount);
+    }
+
+    /// <summary>
+    /// Adds a variable to the list.
+    /// </summary>
+    public virtual void Add(Variable variable) => (_variables ??= new()).Add(variable ?? throw new ArgumentNullException(nameof(variable)));
+
+    /// <summary>
+    /// Returns the first variable with a matching name, or <paramref name="defaultValue"/> if none are found.
+    /// </summary>
+    public object? ValueFor(string name, object? defaultValue = null)
+    {
+        return ValueFor(name, out var value) ? value.Value : defaultValue;
+    }
+
+    /// <summary>
+    /// Gets the first variable with a matching name.
+    /// </summary>
+    public Variable? Find(ROM name)
+    {
+        if (_variables != null)
+        {
+            foreach (var v in _variables)
+            {
+                if (v.Name == name)
+                {
+                    return v;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the first variable with a matching name. Returns <see langword="true"/> if a match is found.
+    /// </summary>
+    public bool ValueFor(ROM name, out ArgumentValue value)
+    {
+        var v = Find(name);
+        if (v != null)
+        {
+            value = new ArgumentValue(v.Value, v.IsDefault || !v.ValueSpecified ? ArgumentSource.VariableDefault : ArgumentSource.Variable);
+            return v.ValueSpecified;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<Variable> GetEnumerator() => (_variables ?? Enumerable.Empty<Variable>()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Returns a static instance that holds no variables.
+    /// </summary>
+    public static Variables None { get; } = new NoVariables();
+
+    private sealed class NoVariables : Variables
+    {
+        public override void Add(Variable variable) => throw new InvalidOperationException("Cannot add variables to this instance.");
+    }
 }


### PR DESCRIPTION
We should probably only merge this if/when we are sure we are not making additional changes to v7, so as to minimize merge conflicts.  Now?

All changes in this PR were done automatically by VS.  No other changes were done, besides a single change to `.editorconfig` to require file-scoped namespaces on all files.