### PR TITLE
Schema builder fixes; add schema validation of subscription fields

### DIFF
--- a/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
@@ -211,7 +211,7 @@ public class SubscriptionExecutionStrategyTests : IDisposable
             Subscription = subscriptionType
         };
         Should.Throw<InvalidOperationException>(() => schema.Initialize())
-            .Message.ShouldBe("The field 'notSubscriptionField' of the subscription root type 'Subscription' must have StreamResolver set. You should set StreamResolver only all root fields of subscriptions.");
+            .Message.ShouldBe("The field 'notSubscriptionField' of the subscription root type 'Subscription' must have StreamResolver set.");
     }
 
     public int Counter = 0;

--- a/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionExecutionStrategyTests.cs
@@ -201,9 +201,17 @@ public class SubscriptionExecutionStrategyTests : IDisposable
     [Fact]
     public async Task NotSubscriptionField()
     {
-        var result = await ExecuteAsync("subscription { notSubscriptionField }");
-        result.ShouldNotBeSuccessful();
-        result.ShouldBeSimilarTo("""{"errors":[{"message":"Handled custom exception: Stream resolver not set for field \u0027notSubscriptionField\u0027.","locations":[{"line":1,"column":16}],"path":["notSubscriptionField"],"extensions":{"code":"INVALID_OPERATION","codes":["INVALID_OPERATION"]}}],"data":null}""");
+        var queryType = new ObjectGraphType() { Name = "Query" };
+        queryType.Field<StringGraphType>("dummy");
+        var subscriptionType = new ObjectGraphType() { Name = "Subscription" };
+        subscriptionType.Field<StringGraphType>("notSubscriptionField");
+        var schema = new Schema()
+        {
+            Query = queryType,
+            Subscription = subscriptionType
+        };
+        Should.Throw<InvalidOperationException>(() => schema.Initialize())
+            .Message.ShouldBe("The field 'notSubscriptionField' of the subscription root type 'Subscription' must have StreamResolver set. You should set StreamResolver only all root fields of subscriptions.");
     }
 
     public int Counter = 0;
@@ -567,7 +575,7 @@ public class SubscriptionExecutionStrategyTests : IDisposable
 
         public static IObservable<string> TestObservableNull() => null!;
 
-        public static string NotSubscriptionField() => "testing";
+        //public static string NotSubscriptionField() => "testing";
     }
 
     private class MyWidget

--- a/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
+++ b/src/GraphQL.Tests/Utilities/SchemaBuilderTests.cs
@@ -98,7 +98,7 @@ public class SchemaBuilderTests
             }
             """;
 
-        var schema = Schema.For(definitions);
+        var schema = Schema.For(definitions, b => b.Types.Include<DummySubscription>("Subscription"));
         schema.Initialize();
 
         var subscription = schema.Subscription;
@@ -107,6 +107,15 @@ public class SchemaBuilderTests
         subscription.Fields.Count.ShouldBe(1);
 
         subscription.Fields.Single().Name.ShouldBe("subscribe");
+    }
+
+    private class DummySubscription
+    {
+        [GraphQLMetadata("subscribe")]
+        public string SubscribeResolver(IResolveFieldContext context) => (string)context.Source!;
+
+        [GraphQLMetadata(ResolverType = ResolverType.StreamResolver)]
+        public IObservable<string> Subscribe() => throw new NotImplementedException();
     }
 
     [Fact]
@@ -132,7 +141,7 @@ public class SchemaBuilderTests
             }
             """;
 
-        var schema = Schema.For(definitions);
+        var schema = Schema.For(definitions, b => b.Types.Include<DummySubscription>("MySubscription"));
         schema.Initialize();
 
         var query = schema.Query;
@@ -177,7 +186,7 @@ public class SchemaBuilderTests
             }
             """;
 
-        var schema = Schema.For(definitions);
+        var schema = Schema.For(definitions, b => b.Types.Include<DummySubscription>("MySubscription"));
         schema.Directives.Register(new Directive("public", DirectiveLocation.Schema));
         schema.Directives.Register(new Directive("requireAuth", DirectiveLocation.Object) { Arguments = new QueryArguments(new QueryArgument<StringGraphType> { Name = "role" }) });
         schema.Directives.Register(new Directive("traits", DirectiveLocation.FieldDefinition) { Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<BooleanGraphType>> { Name = "volatile" }, new QueryArgument<BooleanGraphType> { Name = "documented" }, new QueryArgument<EnumerationGraphType<TestEnum>> { Name = "enumerated" }) });

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -111,6 +111,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
 
             var directives = new List<Directive>();
 
+            // process the schema definition first
             foreach (var def in document.Definitions)
             {
                 if (def is GraphQLSchemaDefinition schemaDef)
@@ -118,7 +119,11 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
                     _schemaDef = schemaDef;
                     schema.SetAstType(schemaDef);
                 }
-                else if (def is GraphQLObjectTypeDefinition objDef)
+            }
+
+            foreach (var def in document.Definitions)
+            {
+                if (def is GraphQLObjectTypeDefinition objDef)
                 {
                     var type = ToObjectGraphType(objDef);
                     _types[type.Name] = type;

--- a/src/GraphQL/Utilities/TypeSettings.cs
+++ b/src/GraphQL/Utilities/TypeSettings.cs
@@ -74,7 +74,7 @@ namespace GraphQL.Utilities
         /// </summary>
         public void Include(string name, Type type)
         {
-            _typeConfigurations[name].Type = type;
+            For(name).Type = type;
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace GraphQL.Utilities
         /// </summary>
         public void Include(string name, Type type, Type typeOfType)
         {
-            var config = _typeConfigurations[name];
+            var config = For(name);
             config.Type = type;
             config.IsTypeOfFunc = obj => obj?.GetType().IsAssignableFrom(typeOfType) ?? false;
         }

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -243,7 +243,7 @@ namespace GraphQL.Utilities
                 foreach (var field in schema.Subscription.Fields.List)
                 {
                     if (field.StreamResolver == null)
-                        throw new InvalidOperationException($"The field '{field.Name}' of the subscription root type '{schema.Subscription.Name}' must have StreamResolver set. You should set StreamResolver only all root fields of subscriptions.");
+                        throw new InvalidOperationException($"The field '{field.Name}' of the subscription root type '{schema.Subscription.Name}' must have StreamResolver set.");
                 }
             }
         }

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -238,6 +238,14 @@ namespace GraphQL.Utilities
             var n3 = schema.Subscription?.Name;
             if (n1 == n2 && n1 != null || n1 == n3 && n1 != null || n2 == n3 && n2 != null)
                 throw new InvalidOperationException("The query, mutation, and subscription root types must all be different types if provided.");
+            if (schema.Subscription != null)
+            {
+                foreach (var field in schema.Subscription.Fields.List)
+                {
+                    if (field.StreamResolver == null)
+                        throw new InvalidOperationException($"The field '{field.Name}' of the subscription root type '{schema.Subscription.Name}' must have StreamResolver set. You should set StreamResolver only all root fields of subscriptions.");
+                }
+            }
         }
 
         // See 'Type Validation' section in https://spec.graphql.org/October2021/#sec-Unions


### PR DESCRIPTION
Fixes #3580 

Adds schema validation to ensure that `StreamResolver` is set for fields of root subscription types.  This is a non-breaking change because without the validation, attempting to resolve these fields would fail at runtime.

Trying to write a fix for #3580 I found two bugs in the schema-first SchemaBuilder (as far as I can tell).
- `Include` does not include configurations via `ForAll`
- Subscriptions don't work properly when the `schema` definition is listed after the subscription definition