### PR TITLE
Add PatternMatchingDirective and PatternMatchingVisitor sample

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -258,7 +258,11 @@ services.AddGraphQL(b => b
     .AddSchema<MyQuery>()
     .ConfigureSchema(s =>
     {
+        // add the directive to the schema
         s.Directives.Register(new PatternMatchingDirective());
+
+        // add the visitor to the schema, which will apply validation rules to all field
+        // arguments and input fields that have the @pattern directive applied
         s.RegisterVisitor(new PatternMatchingVisitor());
     }));
 ```

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -246,6 +246,44 @@ At this time GraphQL.NET does not directly support the `MaxLength` and similar a
 implement your own attributes as shown above, or call the `Validate` method to set a validation
 function.
 
+### 6. `@pattern` custom directive added for validating input values against a regular expression pattern
+
+This directive allows for specifying a regular expression pattern to validate the input value.
+It can also be used as sample code for designing new custom directives, and is now the preferred
+design over the older `InputFieldsAndArgumentsOfCorrectLength` validation rule.
+This directive is not enabled by default, and must be added to the schema as follows:
+
+```csharp
+services.AddGraphQL(b => b
+    .AddSchema<MyQuery>()
+    .ConfigureSchema(s =>
+    {
+        s.Directives.Register(new PatternMatchingDirective());
+        s.RegisterVisitor(new PatternMatchingVisitor());
+    }));
+```
+
+You can then apply the directive to any input field or argument as follows:
+
+```csharp
+Field(x => x.FirstName)
+    .ApplyDirective("pattern", "regex", "[A-Z]+"); // uppercase only
+```
+
+### 7. DirectiveAttribute added to support applying directives to type-first graph types and fields
+
+For example:
+
+```csharp
+private class Query
+{
+    public static string Hello(
+        [Directive("pattern", "regex", "[A-Z]+")] // uppercase only
+        string arg)
+        => arg;
+}
+```
+
 ## Breaking Changes
 
 ### 1. Query type is required

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2484,7 +2484,6 @@ namespace GraphQL.Types
     {
         public PatternMatchingDirective() { }
         public override bool? Introspectable { get; }
-        public override void Validate(GraphQL.Types.AppliedDirective applied) { }
     }
     public class PossibleTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IObjectGraphType>, System.Collections.IEnumerable
     {

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -818,6 +818,26 @@ namespace GraphQL
         public static GraphQL.VariableName op_Implicit(string name) { }
     }
 }
+namespace GraphQL.Attributes
+{
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class DirectiveAttribute : GraphQL.GraphQLAttribute
+    {
+        public System.Collections.Generic.Dictionary<string, object?> Arguments;
+        public DirectiveAttribute(string name) { }
+        public DirectiveAttribute(string name, params object[] argsAndValues) { }
+        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
+        public string Name { get; }
+        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+}
 namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
@@ -2460,6 +2480,12 @@ namespace GraphQL.Types
         public PascalCaseAttribute() { }
         public override string ChangeEnumCase(string val) { }
     }
+    public class PatternMatchingDirective : GraphQL.Types.Directive
+    {
+        public PatternMatchingDirective() { }
+        public override bool? Introspectable { get; }
+        public override void Validate(GraphQL.Types.AppliedDirective applied) { }
+    }
     public class PossibleTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IObjectGraphType>, System.Collections.IEnumerable
     {
         public PossibleTypes() { }
@@ -3097,6 +3123,12 @@ namespace GraphQL.Utilities.Federation
 }
 namespace GraphQL.Utilities.Visitors
 {
+    public class PatternMatchingVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public PatternMatchingVisitor() { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
     public sealed class RemoveDeprecationReasonsVisitor : GraphQLParser.Visitors.ASTVisitor<GraphQLParser.Visitors.NullVisitorContext>
     {
         protected override System.Threading.Tasks.ValueTask VisitDirectiveAsync(GraphQLParser.AST.GraphQLDirective directive, GraphQLParser.Visitors.NullVisitorContext context) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2491,7 +2491,6 @@ namespace GraphQL.Types
     {
         public PatternMatchingDirective() { }
         public override bool? Introspectable { get; }
-        public override void Validate(GraphQL.Types.AppliedDirective applied) { }
     }
     public class PossibleTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IObjectGraphType>, System.Collections.IEnumerable
     {

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -818,6 +818,26 @@ namespace GraphQL
         public static GraphQL.VariableName op_Implicit(string name) { }
     }
 }
+namespace GraphQL.Attributes
+{
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class DirectiveAttribute : GraphQL.GraphQLAttribute
+    {
+        public System.Collections.Generic.Dictionary<string, object?> Arguments;
+        public DirectiveAttribute(string name) { }
+        public DirectiveAttribute(string name, params object[] argsAndValues) { }
+        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
+        public string Name { get; }
+        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+}
 namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
@@ -2467,6 +2487,12 @@ namespace GraphQL.Types
         public PascalCaseAttribute() { }
         public override string ChangeEnumCase(string val) { }
     }
+    public class PatternMatchingDirective : GraphQL.Types.Directive
+    {
+        public PatternMatchingDirective() { }
+        public override bool? Introspectable { get; }
+        public override void Validate(GraphQL.Types.AppliedDirective applied) { }
+    }
     public class PossibleTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IObjectGraphType>, System.Collections.IEnumerable
     {
         public PossibleTypes() { }
@@ -3111,6 +3137,12 @@ namespace GraphQL.Utilities.Federation
 }
 namespace GraphQL.Utilities.Visitors
 {
+    public class PatternMatchingVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public PatternMatchingVisitor() { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
     public sealed class RemoveDeprecationReasonsVisitor : GraphQLParser.Visitors.ASTVisitor<GraphQLParser.Visitors.NullVisitorContext>
     {
         protected override System.Threading.Tasks.ValueTask VisitDirectiveAsync(GraphQLParser.AST.GraphQLDirective directive, GraphQLParser.Visitors.NullVisitorContext context) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2411,7 +2411,6 @@ namespace GraphQL.Types
     {
         public PatternMatchingDirective() { }
         public override bool? Introspectable { get; }
-        public override void Validate(GraphQL.Types.AppliedDirective applied) { }
     }
     public class PossibleTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IObjectGraphType>, System.Collections.IEnumerable
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -786,6 +786,26 @@ namespace GraphQL
         public static GraphQL.VariableName op_Implicit(string name) { }
     }
 }
+namespace GraphQL.Attributes
+{
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class DirectiveAttribute : GraphQL.GraphQLAttribute
+    {
+        public System.Collections.Generic.Dictionary<string, object?> Arguments;
+        public DirectiveAttribute(string name) { }
+        public DirectiveAttribute(string name, params object[] argsAndValues) { }
+        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
+        public string Name { get; }
+        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+}
 namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
@@ -2387,6 +2407,12 @@ namespace GraphQL.Types
         public PascalCaseAttribute() { }
         public override string ChangeEnumCase(string val) { }
     }
+    public class PatternMatchingDirective : GraphQL.Types.Directive
+    {
+        public PatternMatchingDirective() { }
+        public override bool? Introspectable { get; }
+        public override void Validate(GraphQL.Types.AppliedDirective applied) { }
+    }
     public class PossibleTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IObjectGraphType>, System.Collections.IEnumerable
     {
         public PossibleTypes() { }
@@ -3024,6 +3050,12 @@ namespace GraphQL.Utilities.Federation
 }
 namespace GraphQL.Utilities.Visitors
 {
+    public class PatternMatchingVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public PatternMatchingVisitor() { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
     public sealed class RemoveDeprecationReasonsVisitor : GraphQLParser.Visitors.ASTVisitor<GraphQLParser.Visitors.NullVisitorContext>
     {
         protected override System.Threading.Tasks.ValueTask VisitDirectiveAsync(GraphQLParser.AST.GraphQLDirective directive, GraphQLParser.Visitors.NullVisitorContext context) { }

--- a/src/GraphQL.Tests/Utilities/Visitors/PatternMatchingVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/PatternMatchingVisitorTests.cs
@@ -26,8 +26,7 @@ public class PatternMatchingVisitorTests
         result.ShouldBeSimilarTo("""{"data":{"hello":"HELLO"}}""");
 
         result = await schema.ExecuteAsync(o => o.Query = """{ hello(arg: "hello") }""");
-        result.ShouldBeSimilarTo(
-            """
+        result.ShouldBeSimilarTo("""
             {
                 "errors": [
                     {

--- a/src/GraphQL.Tests/Utilities/Visitors/PatternMatchingVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/PatternMatchingVisitorTests.cs
@@ -1,0 +1,62 @@
+using GraphQL.Attributes;
+using GraphQL.Types;
+using GraphQL.Utilities.Visitors;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Tests.Utilities.Visitors;
+
+public class PatternMatchingVisitorTests
+{
+    [Fact]
+    public async Task UppercaseRegex()
+    {
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddAutoSchema<Query>()
+            .ConfigureSchema(s =>
+            {
+                s.Directives.Register(new PatternMatchingDirective());
+                s.RegisterVisitor(new PatternMatchingVisitor());
+            }));
+
+        using var provider = services.BuildServiceProvider();
+        var schema = provider.GetRequiredService<ISchema>();
+
+        var result = await schema.ExecuteAsync(o => o.Query = """{ hello(arg: "HELLO") }""");
+        result.ShouldBeSimilarTo("""{"data":{"hello":"HELLO"}}""");
+
+        result = await schema.ExecuteAsync(o => o.Query = """{ hello(arg: "hello") }""");
+        result.ShouldBeSimilarTo(
+            """
+            {
+                "errors": [
+                    {
+                        "message": "Invalid value for argument \u0027arg\u0027 of field \u0027hello\u0027. Value 'hello' does not match the regex pattern '[A-Z]+'.",
+                        "locations": [
+                            {
+                                "line": 1,
+                                "column": 14
+                            }
+                        ],
+                        "extensions": {
+                            "code": "INVALID_VALUE",
+                            "codes": [
+                                "INVALID_VALUE",
+                                "ARGUMENT"
+                            ],
+                            "number": "5.6"
+                        }
+                    }
+                ]
+            }
+            """);
+    }
+
+    private class Query
+    {
+        public static string Hello(
+            [Directive("pattern", "regex", "[A-Z]+")] // uppercase only
+            string arg)
+            => arg;
+    }
+}

--- a/src/GraphQL/Attributes/DirectiveAttribute.cs
+++ b/src/GraphQL/Attributes/DirectiveAttribute.cs
@@ -1,0 +1,91 @@
+using GraphQL.Types;
+using GraphQL.Utilities;
+
+namespace GraphQL.Attributes;
+
+/// <summary>
+/// Applies a directive to part of a schema.
+/// </summary>
+[AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true)]
+public class DirectiveAttribute : GraphQLAttribute
+{
+    /// <inheritdoc cref="DirectiveAttribute"/>
+    public DirectiveAttribute(string name)
+    {
+        Name = name;
+    }
+
+    /// <inheritdoc cref="DirectiveAttribute"/>
+    public DirectiveAttribute(string name, string argumentName, object argumentValue)
+    {
+        Name = name;
+        Arguments.Add(argumentName, argumentValue);
+    }
+
+    /// <inheritdoc cref="DirectiveAttribute"/>
+    public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2)
+    {
+        Name = name;
+        Arguments.Add(argumentName1, argumentValue1);
+        Arguments.Add(argumentName2, argumentValue2);
+    }
+
+    /// <inheritdoc cref="DirectiveAttribute"/>
+    public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3)
+    {
+        Name = name;
+        Arguments.Add(argumentName1, argumentValue1);
+        Arguments.Add(argumentName2, argumentValue2);
+        Arguments.Add(argumentName3, argumentValue3);
+    }
+
+    /// <inheritdoc cref="DirectiveAttribute"/>
+    /// <remarks>
+    /// The <paramref name="argsAndValues"/> parameter must contain an even number of elements, where
+    /// the first element of each pair is the argument name and the second element is the argument value.
+    /// </remarks>
+    public DirectiveAttribute(string name, params object[] argsAndValues)
+    {
+        Name = name;
+        for (int i = 0; i < argsAndValues.Length; i += 2)
+        {
+            Arguments.Add((string)argsAndValues[i], argsAndValues[i + 1]);
+        }
+    }
+
+    /// <summary>
+    /// The name of the directive.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The arguments to the directive.
+    /// </summary>
+    public Dictionary<string, object?> Arguments = new();
+
+    /// <inheritdoc/>
+    public override void Modify(TypeConfig type) => type.ApplyDirective(Name, ApplyDirectives);
+
+    /// <inheritdoc/>
+    public override void Modify(FieldConfig field) => field.ApplyDirective(Name, ApplyDirectives);
+
+    /// <inheritdoc/>
+    public override void Modify(EnumValueDefinition enumValueDefinition) => enumValueDefinition.ApplyDirective(Name, ApplyDirectives);
+
+    /// <inheritdoc/>
+    public override void Modify(IGraphType graphType) => graphType.ApplyDirective(Name, ApplyDirectives);
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType) => fieldType.ApplyDirective(Name, ApplyDirectives);
+
+    /// <inheritdoc/>
+    public override void Modify(QueryArgument queryArgument) => queryArgument.ApplyDirective(Name, ApplyDirectives);
+
+    private void ApplyDirectives(AppliedDirective directive)
+    {
+        foreach (var arg in Arguments)
+        {
+            directive.AddArgument(new DirectiveArgument(arg.Key) { Value = arg.Value });
+        }
+    }
+}

--- a/src/GraphQL/GraphQL.csproj
+++ b/src/GraphQL/GraphQL.csproj
@@ -21,9 +21,7 @@
   <ItemGroup>
     <!-- We don't consume the analyzers in this library itself,
          but we reference the project to add a package dependency so users of this library will automatically get the analyzers. -->
-    <ProjectReference Include="..\GraphQL.Analyzers.Package\GraphQL.Analyzers.Package.csproj"
-                      PrivateAssets="none"
-                      Condition="'$(ExcludeRestorePackageImports)' != ''"  />
+    <ProjectReference Include="..\GraphQL.Analyzers.Package\GraphQL.Analyzers.Package.csproj" PrivateAssets="none" Condition="'$(ExcludeRestorePackageImports)' != ''" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQL/Types/Directives/Custom/PatternMatchingDirective.cs
+++ b/src/GraphQL/Types/Directives/Custom/PatternMatchingDirective.cs
@@ -37,18 +37,11 @@ public class PatternMatchingDirective : Directive
     {
         Description = "Used to specify a regex pattern for an input field or argument.";
         Arguments = new QueryArguments(
-            new QueryArgument<IntGraphType>
+            new QueryArgument<NonNullGraphType<StringGraphType>>
             {
                 Name = "regex",
                 Description = "The regex pattern that the input field or argument must match."
             }
         );
-    }
-
-    /// <inheritdoc/>
-    public override void Validate(AppliedDirective applied)
-    {
-        _ = (applied.FindArgument("regex")?.Value)
-            ?? throw new ArgumentException("Argument 'regex' must be specified for @pattern directive.");
     }
 }

--- a/src/GraphQL/Types/Directives/Custom/PatternMatchingDirective.cs
+++ b/src/GraphQL/Types/Directives/Custom/PatternMatchingDirective.cs
@@ -1,0 +1,58 @@
+using GraphQL.Utilities.Visitors;
+using GraphQLParser.AST;
+
+namespace GraphQL.Types;
+
+/// <summary>
+/// Directive named <c>@pattern</c> used to specify a regex pattern that must match the input field or argument.
+/// <br/><br/>
+/// When applied to argument or input field, this directive itself does not check anything. It only
+/// declares the necessary requirements and these requirements will be visible in introspection if
+/// <see cref="ExperimentalFeatures.AppliedDirectives"/> is enabled on schema. Use
+/// <see cref="PatternMatchingVisitor"/> schema visitor if you want to enable validation of arguments
+/// and input fields.
+/// <code>
+/// services.AddGraphQL(b => b
+///     .AddSchema&lt;MySchema&gt;()
+///     .ConfigureSchema(s =>
+///     {
+///         s.Directives.Register(new <see cref="PatternMatchingDirective"/>());
+///         s.RegisterVisitor(new <see cref="PatternMatchingVisitor"/>());
+///     }));
+///
+/// field.Field(x => x.Email)
+///     .ApplyDirective("pattern", "regex", @".+\@.+\..+");
+/// </code>
+/// </summary>
+public class PatternMatchingDirective : Directive
+{
+    /// <inheritdoc/>
+    public override bool? Introspectable => true;
+
+    /// <summary>
+    /// Initializes a new instance of the 'pattern' directive.
+    /// </summary>
+    public PatternMatchingDirective()
+        : base("pattern", DirectiveLocation.InputFieldDefinition, DirectiveLocation.ArgumentDefinition)
+    {
+        ObjectGraphType g = new();
+g.Field<StringGraphType, string>("Email")
+    .ApplyDirective("pattern", "regex", @".+\@.+\..+");
+
+        Description = "Used to specify a regex pattern for an input field or argument.";
+        Arguments = new QueryArguments(
+            new QueryArgument<IntGraphType>
+            {
+                Name = "regex",
+                Description = "The regex pattern that the input field or argument must match."
+            }
+        );
+    }
+
+    /// <inheritdoc/>
+    public override void Validate(AppliedDirective applied)
+    {
+        _ = (applied.FindArgument("regex")?.Value)
+            ?? throw new ArgumentException("Argument 'regex' must be specified for @pattern directive.");
+    }
+}

--- a/src/GraphQL/Types/Directives/Custom/PatternMatchingDirective.cs
+++ b/src/GraphQL/Types/Directives/Custom/PatternMatchingDirective.cs
@@ -35,10 +35,6 @@ public class PatternMatchingDirective : Directive
     public PatternMatchingDirective()
         : base("pattern", DirectiveLocation.InputFieldDefinition, DirectiveLocation.ArgumentDefinition)
     {
-        ObjectGraphType g = new();
-g.Field<StringGraphType, string>("Email")
-    .ApplyDirective("pattern", "regex", @".+\@.+\..+");
-
         Description = "Used to specify a regex pattern for an input field or argument.";
         Arguments = new QueryArguments(
             new QueryArgument<IntGraphType>

--- a/src/GraphQL/Utilities/Visitors/Custom/PatternMatchingVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/Custom/PatternMatchingVisitor.cs
@@ -29,7 +29,9 @@ public class PatternMatchingVisitor : BaseSchemaNodeVisitor
         if (applied?.FindArgument("regex")?.Value is not string regex)
             return;
 
-        // compile the regex
+        // if GlobalSwitches.DynamicallyCompileToObject is true, then compile
+        // the regex (or pull from the static cache if already compiled)
+        // (note that GlobalSwitches.DynamicallyCompileToObject is false for AOT schemas and scoped schemas)
         var regexObject = new Regex($"^{regex}$",
             GlobalSwitches.DynamicallyCompileToObject ? RegexOptions.Compiled : RegexOptions.None);
 

--- a/src/GraphQL/Utilities/Visitors/Custom/PatternMatchingVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/Custom/PatternMatchingVisitor.cs
@@ -1,0 +1,67 @@
+using System.Text.RegularExpressions;
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Visitors;
+
+/// <summary>
+/// A schema visitor that adds validation for the <see cref="PatternMatchingDirective"/> directive.
+/// Use as follows to enable validation of arguments and input fields:
+/// <code>
+/// services.AddGraphQL(b => b
+///     .AddSchema&lt;MySchema&gt;()
+///     .ConfigureSchema(s =>
+///     {
+///         s.Directives.Register(new <see cref="PatternMatchingDirective"/>());
+///         s.RegisterVisitor(new <see cref="PatternMatchingVisitor"/>());
+///     }));
+///
+/// field.Field(x => x.Email)
+///     .ApplyDirective("pattern", "regex", @".+\@.+\..+");
+/// </code>
+/// </summary>
+public class PatternMatchingVisitor : BaseSchemaNodeVisitor
+{
+    /// <inheritdoc/>
+    public override void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema)
+    {
+        // look for @pattern directive applied to the field, and if found, use Validate to set the validation method
+        var applied = field.FindAppliedDirective("pattern");
+        if (applied?.FindArgument("regex")?.Value is not string regex)
+            return;
+
+        // compile the regex
+        var regexObject = new Regex($"^{regex}$",
+            GlobalSwitches.DynamicallyCompileToObject ? RegexOptions.Compiled : RegexOptions.None);
+
+        // set the validation method
+        field.Validator += (value) =>
+        {
+            if (value is string stringValue && !regexObject.IsMatch(stringValue))
+            {
+                throw new ArgumentException($"Value '{stringValue}' does not match the regex pattern '{regex}'.");
+            }
+        };
+    }
+
+    /// <inheritdoc/>
+    public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema)
+    {
+        // look for @pattern directive applied to the field, and if found, use Validate to set the validation method
+        var applied = argument.FindAppliedDirective("pattern");
+        if (applied?.FindArgument("regex")?.Value is not string regex)
+            return;
+
+        // compile the regex
+        var regexObject = new Regex(regex,
+            GlobalSwitches.DynamicallyCompileToObject ? RegexOptions.Compiled : RegexOptions.None);
+
+        // set the validation method
+        argument.Validator += (value) =>
+        {
+            if (value is string stringValue && !regexObject.IsMatch(stringValue))
+            {
+                throw new ArgumentException($"Value '{stringValue}' does not match the regex pattern '{regex}'.");
+            }
+        };
+    }
+}

--- a/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
+++ b/src/GraphQL/Validation/Rules.Custom/InputFieldsAndArgumentsOfCorrectLength.cs
@@ -1,4 +1,5 @@
 using GraphQL.Types;
+using GraphQL.Utilities.Visitors;
 using GraphQL.Validation.Errors;
 using GraphQLParser.AST;
 
@@ -13,6 +14,10 @@ namespace GraphQL.Validation.Rules
     /// <see cref="ExecutionOptions.CachedDocumentValidationRules">ExecutionOptions.CachedDocumentValidationRules</see>
     /// needs to be set as well (if using caching).
     /// </summary>
+    /// <remarks>
+    /// Please copy the newer <see cref="PatternMatchingDirective"/> and <see cref="PatternMatchingVisitor"/>
+    /// when designing new custom directives that can be used to validate input fields and arguments.
+    /// </remarks>
     public class InputFieldsAndArgumentsOfCorrectLength : IValidationRule, IVariableVisitorProvider
     {
         private sealed class FieldVisitor : BaseVariableVisitor


### PR DESCRIPTION
This PR includes a new/better sample for directive-based validation, which may be useful.  Then I noticed that we were missing `DirectiveAttribute` for applying directives to type-first schemas.  So I added that in #3886 .