### PR TITLE
GetArgument improvements

### DIFF
--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -254,6 +254,28 @@ public class AutoRegisteringObjectGraphTypeTests
         }
     }
 
+    [Fact]
+    public async Task DefaultValueIsCoerced()
+    {
+        var schema = new Schema
+        {
+            Query = new AutoRegisteringObjectGraphType<ArgumentTests>()
+        };
+        schema.Initialize();
+        var result = await schema.ExecuteAsync(o =>
+        {
+            o.Root = new ArgumentTests();
+            o.Query = """
+                query {
+                    withDefaultString
+                }
+                """;
+        });
+        result.ShouldBeSimilarTo("""
+            {"data":{"withDefaultString":"test"}}
+            """);
+    }
+
     [Theory]
     [InlineData(nameof(ArgumentTests.WithNonNullString), "arg1", "hello", null, "hello")]
     [InlineData(nameof(ArgumentTests.WithNullableString), "arg1", "hello", null, "hello")]
@@ -261,7 +283,7 @@ public class AutoRegisteringObjectGraphTypeTests
     [InlineData(nameof(ArgumentTests.WithNullableString), null, null, null, null)]
     [InlineData(nameof(ArgumentTests.WithDefaultString), "arg1", "hello", null, "hello")]
     [InlineData(nameof(ArgumentTests.WithDefaultString), "arg1", null, null, null)]
-    [InlineData(nameof(ArgumentTests.WithDefaultString), null, null, null, "test")]
+    //[InlineData(nameof(ArgumentTests.WithDefaultString), null, null, null, "test")] //cannot occur -- TryGetArgumentExact returns true for args with default values
     [InlineData(nameof(ArgumentTests.WithCancellationToken), null, null, null, true)]
     [InlineData(nameof(ArgumentTests.WithFromServices), null, null, null, "testService")]
     [InlineData(nameof(ArgumentTests.NamedArg), "arg1rename", "hello", null, "hello")]

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -228,10 +228,11 @@ namespace GraphQL.Types
         private static readonly MethodInfo _getArgumentMethod = typeof(AutoRegisteringHelper).GetMethod(nameof(GetArgumentInternal), BindingFlags.NonPublic | BindingFlags.Static)!;
         /// <summary>
         /// Returns the value for the specified query argument, or <c>default(T)</c> if the argument
-        /// was not specified and no default argument value was specified.
+        /// was not specified and the argument is not configured with a default value.
         /// </summary>
         private static T? GetArgumentInternal<T>(IResolveFieldContext context, QueryArgument queryArgument)
         {
+            // note: if the query argument has a default value, TryGetArgumentExact will always return true
             return context.TryGetArgumentExact(typeof(T), queryArgument.Name, out var value)
                 ? (T?)value
                 : default;

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -227,20 +227,14 @@ namespace GraphQL.Types
 
         private static readonly MethodInfo _getArgumentMethod = typeof(AutoRegisteringHelper).GetMethod(nameof(GetArgumentInternal), BindingFlags.NonPublic | BindingFlags.Static)!;
         /// <summary>
-        /// Returns the value for the specified query argument, or the default value of the query argument
-        /// if a value was not specified in the request.
-        /// <br/><br/>
-        /// Unlike <see cref="ResolveFieldContextExtensions.GetArgument{TType}(IResolveFieldContext, string, TType)"/>,
-        /// the default value is not returned if <see langword="null"/> was explicitly supplied within the query.
-        /// The default value is only returned if no value was supplied to the query.
+        /// Returns the value for the specified query argument, or <c>default(T)</c> if the argument
+        /// was not specified and no default argument value was specified.
         /// </summary>
         private static T? GetArgumentInternal<T>(IResolveFieldContext context, QueryArgument queryArgument)
         {
-            // GetArgument changes null values to DefaultValue even if null is explicitly specified,
-            // so do not use GetArgument here
-            return context.TryGetArgument(typeof(T), queryArgument.Name, out var value)
+            return context.TryGetArgumentExact(typeof(T), queryArgument.Name, out var value)
                 ? (T?)value
-                : (T?)queryArgument.DefaultValue;
+                : default;
         }
 
         /// <summary>


### PR DESCRIPTION
- Most of TryGetArgument logic moved to TryGetArgumentExact
- GetArgumentInternal now calls TryGetArgumentExact as argument names do not need to pass through name conversion since `QueryArgument.Name` at runtime will contain the converted name.
- TryGetArgumentExact has shortcut logic when the value is null or can be directly coerced to the target type