### PR TITLE
Remove some deprecated methods

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -427,7 +427,7 @@ The following methods have been removed:
 
 | Method | Comment |
 |--------|---------|
-| `TypeExtensions.IsConcrete` | Was equivalent to `!type.IsAbstract && !type.IsInterface` but did not account for generic types |
+| `TypeExtensions.IsConcrete` | Use `!type.IsAbstract` |
 | `GraphQLTelemetryProvider.StartActivityAsync` | Use `StartActivity` |
 | `AutoRegisteringInterfaceGraphType.BuildMemberInstanceExpression` | Interfaces cannot contain resolvers so this method was unused |
 | `ValidationContext.GetVariableValuesAsync` | Use `GetVariablesValuesAsync` |

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -411,3 +411,30 @@ Please see the v7 migration document regarding the new `schema.ToAST()` and
 For federated schemas, the `ServiceGraphType`'s `sdl` field will now use the
 new implementation to print the schema. Please raise an issue if this causes
 a problem for your federated schema.
+
+### 11. Removed deprecated methods.
+
+The following GraphQL DI builder methods have been removed:
+
+| Method | Replacement |
+|--------|-------------|
+| `AddApolloTracing` | `UseApolloTracing` |
+| `AddMiddleware` | `UseMiddleware` |
+| `AddAutomaticPersistedQueries` | `UseAutomaticPersistedQueries` |
+| `AddMemoryCache` | `UseMemoryCache` |
+
+The following methods have been removed:
+
+| Method | Comment |
+|--------|---------|
+| `TypeExtensions.IsConcrete` | Was equivalent to `!type.IsAbstract && !type.IsInterface` but did not account for generic types |
+| `GraphQLTelemetryProvider.StartActivityAsync` | Use `StartActivity` |
+| `AutoRegisteringInterfaceGraphType.BuildMemberInstanceExpression` | Interfaces cannot contain resolvers so this method was unused |
+| `ValidationContext.GetVariableValuesAsync` | Use `GetVariablesValuesAsync` |
+
+The following constructors have been removed:
+
+| Class | Comment |
+|-------|---------|
+| `Variable` | Use new constructor with `definition` argument |
+| `VariableUsage` | Use new constructor with `hasDefault` argument |

--- a/src/GraphQL.ApiTests/GraphQL.MemoryCache.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.MemoryCache.approved.txt
@@ -63,14 +63,6 @@ namespace GraphQL
 {
     public static class MemoryCacheGraphQLBuilderExtensions
     {
-        [System.Obsolete("Please use UseAutomaticPersistedQueries. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddAutomaticPersistedQueries(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Caching.AutomaticPersistedQueriesCacheOptions>? action = null) { }
-        [System.Obsolete("Please use UseAutomaticPersistedQueries. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddAutomaticPersistedQueries(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Caching.AutomaticPersistedQueriesCacheOptions, System.IServiceProvider>? action) { }
-        [System.Obsolete("Please use UseMemoryCache. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMemoryCache(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Caching.MemoryDocumentCacheOptions>? action = null) { }
-        [System.Obsolete("Please use UseMemoryCache. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMemoryCache(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Caching.MemoryDocumentCacheOptions, System.IServiceProvider>? action) { }
         public static GraphQL.DI.IGraphQLBuilder UseAutomaticPersistedQueries(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Caching.AutomaticPersistedQueriesCacheOptions>? action = null) { }
         public static GraphQL.DI.IGraphQLBuilder UseAutomaticPersistedQueries(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Caching.AutomaticPersistedQueriesCacheOptions, System.IServiceProvider>? action) { }
         public static GraphQL.DI.IGraphQLBuilder UseMemoryCache(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Caching.MemoryDocumentCacheOptions>? action = null) { }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -244,10 +244,6 @@ namespace GraphQL
     }
     public static class GraphQLBuilderExtensions
     {
-        [System.Obsolete("Please use UseApolloTracing. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddApolloTracing(this GraphQL.DI.IGraphQLBuilder builder, bool enableMetrics = true) { }
-        [System.Obsolete("Please use UseApolloTracing. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddApolloTracing(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, bool> enableMetricsPredicate) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Please ensure that the CLR types used by your schema are not trimmed by the compi" +
             "ler.")]
         public static GraphQL.DI.IGraphQLBuilder AddAutoClrMappings(this GraphQL.DI.IGraphQLBuilder builder, bool mapInputTypes = true, bool mapOutputTypes = true) { }
@@ -302,18 +298,6 @@ namespace GraphQL
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, bool install = true, GraphQL.DI.ServiceLifetime serviceLifetime = 2)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, GraphQL.Types.ISchema, bool> installPredicate, GraphQL.DI.ServiceLifetime serviceLifetime = 2)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, TMiddleware middleware, bool install = true)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, TMiddleware middleware, System.Func<System.IServiceProvider, GraphQL.Types.ISchema, bool> installPredicate)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, TSchema schema)
@@ -791,8 +775,6 @@ namespace GraphQL
         public static System.Type GetGraphTypeFromType(this System.Type type, bool isNullable = false, GraphQL.TypeMappingMode mode = 0) { }
         public static string GraphQLName(this System.Type type) { }
         public static bool ImplementsGenericType(this System.Type type, System.Type genericType) { }
-        [System.Obsolete("This method will be removed in a future version of GraphQL.NET.")]
-        public static bool IsConcrete(this System.Type type) { }
         public static bool IsGraphType(this System.Type type) { }
         public static string? ObsoleteMessage(this System.Reflection.MemberInfo memberInfo) { }
     }
@@ -1806,8 +1788,6 @@ namespace GraphQL.Telemetry
         protected virtual System.Threading.Tasks.Task SetOperationTagsAsync(System.Diagnostics.Activity activity, GraphQL.ExecutionOptions options, GraphQL.Types.ISchema schema, GraphQLParser.AST.GraphQLDocument document, GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         protected virtual System.Threading.Tasks.Task SetResultTagsAsync(System.Diagnostics.Activity activity, GraphQL.ExecutionOptions executionOptions, GraphQL.ExecutionResult result) { }
         protected virtual System.Diagnostics.Activity? StartActivity(GraphQL.ExecutionOptions options) { }
-        [System.Obsolete("Use the sync method \'StartActivity\'. This method will be removed in v8.")]
-        protected virtual System.Threading.Tasks.ValueTask<System.Diagnostics.Activity?> StartActivityAsync(GraphQL.ExecutionOptions options) { }
     }
 }
 namespace GraphQL.Transport
@@ -1905,9 +1885,6 @@ namespace GraphQL.Types
         public AutoRegisteringInterfaceGraphType(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[]? excludedProperties) { }
         protected virtual void ApplyArgumentAttributes(System.Reflection.ParameterInfo parameterInfo, GraphQL.Types.QueryArgument queryArgument) { }
         protected void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
-        [System.Obsolete("Interface graph types do not support field resolvers; use of this method is unnec" +
-            "essary.")]
-        protected virtual System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
         protected virtual void ConfigureGraph() { }
         protected virtual GraphQL.Types.FieldType? CreateField(System.Reflection.MemberInfo memberInfo) { }
         protected virtual GraphQL.Types.ArgumentInformation GetArgumentInformation<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
@@ -2458,16 +2435,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v8.")]
+    [System.Obsolete("This class will be removed in v9.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
@@ -3276,9 +3253,6 @@ namespace GraphQL.Validation
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetRecursiveVariables(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationDefinition> operations) { }
-        [System.Obsolete("This method can repeatedly add the same error into ValidationContext.Errors colle" +
-            "ction when called multiple times. Use GetVariablesValuesAsync method instead.")]
-        public System.Threading.Tasks.ValueTask<GraphQL.Validation.Variables> GetVariableValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetVariables<TNode>(TNode node)
             where TNode : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasSelectionSetNode { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
@@ -3328,8 +3302,6 @@ namespace GraphQL.Validation
     }
     public class Variable
     {
-        [System.Obsolete("Please specify the variable definition when constructing a variable.")]
-        public Variable(string name) { }
         public Variable(string name, GraphQLParser.AST.GraphQLVariableDefinition definition) { }
         public GraphQLParser.AST.GraphQLVariableDefinition Definition { get; set; }
         public bool IsDefault { get; set; }
@@ -3339,9 +3311,6 @@ namespace GraphQL.Validation
     }
     public class VariableUsage
     {
-        [System.Obsolete("Please specify whether the field has a default value when constructing this varia" +
-            "ble usage.")]
-        public VariableUsage(GraphQLParser.AST.GraphQLVariable node, GraphQL.Types.IGraphType type) { }
         public VariableUsage(GraphQLParser.AST.GraphQLVariable node, GraphQL.Types.IGraphType type, bool hasDefault) { }
         public bool HasDefault { get; }
         public GraphQLParser.AST.GraphQLVariable Node { get; }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2435,16 +2435,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v9.")]
+    [System.Obsolete("This class will be removed in v8.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v9.")]
+            "n v8.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v9.")]
+            "n v8.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2442,16 +2442,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v9.")]
+    [System.Obsolete("This class will be removed in v8.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v9.")]
+            "n v8.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v9.")]
+            "n v8.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -244,10 +244,6 @@ namespace GraphQL
     }
     public static class GraphQLBuilderExtensions
     {
-        [System.Obsolete("Please use UseApolloTracing. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddApolloTracing(this GraphQL.DI.IGraphQLBuilder builder, bool enableMetrics = true) { }
-        [System.Obsolete("Please use UseApolloTracing. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddApolloTracing(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, bool> enableMetricsPredicate) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Please ensure that the CLR types used by your schema are not trimmed by the compi" +
             "ler.")]
         public static GraphQL.DI.IGraphQLBuilder AddAutoClrMappings(this GraphQL.DI.IGraphQLBuilder builder, bool mapInputTypes = true, bool mapOutputTypes = true) { }
@@ -302,18 +298,6 @@ namespace GraphQL
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, bool install = true, GraphQL.DI.ServiceLifetime serviceLifetime = 2)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, GraphQL.Types.ISchema, bool> installPredicate, GraphQL.DI.ServiceLifetime serviceLifetime = 2)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, TMiddleware middleware, bool install = true)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, TMiddleware middleware, System.Func<System.IServiceProvider, GraphQL.Types.ISchema, bool> installPredicate)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, TSchema schema)
@@ -791,8 +775,6 @@ namespace GraphQL
         public static System.Type GetGraphTypeFromType(this System.Type type, bool isNullable = false, GraphQL.TypeMappingMode mode = 0) { }
         public static string GraphQLName(this System.Type type) { }
         public static bool ImplementsGenericType(this System.Type type, System.Type genericType) { }
-        [System.Obsolete("This method will be removed in a future version of GraphQL.NET.")]
-        public static bool IsConcrete(this System.Type type) { }
         public static bool IsGraphType(this System.Type type) { }
         public static string? ObsoleteMessage(this System.Reflection.MemberInfo memberInfo) { }
     }
@@ -1806,8 +1788,6 @@ namespace GraphQL.Telemetry
         protected virtual System.Threading.Tasks.Task SetOperationTagsAsync(System.Diagnostics.Activity activity, GraphQL.ExecutionOptions options, GraphQL.Types.ISchema schema, GraphQLParser.AST.GraphQLDocument document, GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         protected virtual System.Threading.Tasks.Task SetResultTagsAsync(System.Diagnostics.Activity activity, GraphQL.ExecutionOptions executionOptions, GraphQL.ExecutionResult result) { }
         protected virtual System.Diagnostics.Activity? StartActivity(GraphQL.ExecutionOptions options) { }
-        [System.Obsolete("Use the sync method \'StartActivity\'. This method will be removed in v8.")]
-        protected virtual System.Threading.Tasks.ValueTask<System.Diagnostics.Activity?> StartActivityAsync(GraphQL.ExecutionOptions options) { }
     }
 }
 namespace GraphQL.Transport
@@ -1905,9 +1885,6 @@ namespace GraphQL.Types
         public AutoRegisteringInterfaceGraphType(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[]? excludedProperties) { }
         protected virtual void ApplyArgumentAttributes(System.Reflection.ParameterInfo parameterInfo, GraphQL.Types.QueryArgument queryArgument) { }
         protected void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
-        [System.Obsolete("Interface graph types do not support field resolvers; use of this method is unnec" +
-            "essary.")]
-        protected virtual System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
         protected virtual void ConfigureGraph() { }
         protected virtual GraphQL.Types.FieldType? CreateField(System.Reflection.MemberInfo memberInfo) { }
         protected virtual GraphQL.Types.ArgumentInformation GetArgumentInformation<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
@@ -2465,16 +2442,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v8.")]
+    [System.Obsolete("This class will be removed in v9.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
@@ -3290,9 +3267,6 @@ namespace GraphQL.Validation
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetRecursiveVariables(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationDefinition> operations) { }
-        [System.Obsolete("This method can repeatedly add the same error into ValidationContext.Errors colle" +
-            "ction when called multiple times. Use GetVariablesValuesAsync method instead.")]
-        public System.Threading.Tasks.ValueTask<GraphQL.Validation.Variables> GetVariableValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetVariables<TNode>(TNode node)
             where TNode : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasSelectionSetNode { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
@@ -3342,8 +3316,6 @@ namespace GraphQL.Validation
     }
     public class Variable
     {
-        [System.Obsolete("Please specify the variable definition when constructing a variable.")]
-        public Variable(string name) { }
         public Variable(string name, GraphQLParser.AST.GraphQLVariableDefinition definition) { }
         public GraphQLParser.AST.GraphQLVariableDefinition Definition { get; set; }
         public bool IsDefault { get; set; }
@@ -3353,9 +3325,6 @@ namespace GraphQL.Validation
     }
     public class VariableUsage
     {
-        [System.Obsolete("Please specify whether the field has a default value when constructing this varia" +
-            "ble usage.")]
-        public VariableUsage(GraphQLParser.AST.GraphQLVariable node, GraphQL.Types.IGraphType type) { }
         public VariableUsage(GraphQLParser.AST.GraphQLVariable node, GraphQL.Types.IGraphType type, bool hasDefault) { }
         public bool HasDefault { get; }
         public GraphQLParser.AST.GraphQLVariable Node { get; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2364,16 +2364,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v9.")]
+    [System.Obsolete("This class will be removed in v8.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v9.")]
+            "n v8.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v9.")]
+            "n v8.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -244,10 +244,6 @@ namespace GraphQL
     }
     public static class GraphQLBuilderExtensions
     {
-        [System.Obsolete("Please use UseApolloTracing. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddApolloTracing(this GraphQL.DI.IGraphQLBuilder builder, bool enableMetrics = true) { }
-        [System.Obsolete("Please use UseApolloTracing. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddApolloTracing(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.ExecutionOptions, bool> enableMetricsPredicate) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoClrMappings(this GraphQL.DI.IGraphQLBuilder builder, bool mapInputTypes = true, bool mapOutputTypes = true) { }
         public static GraphQL.DI.IGraphQLBuilder AddAutoSchema<TQueryClrType>(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.IConfigureAutoSchema>? configure = null) { }
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder) { }
@@ -294,18 +290,6 @@ namespace GraphQL
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, bool install = true, GraphQL.DI.ServiceLifetime serviceLifetime = 2)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, GraphQL.Types.ISchema, bool> installPredicate, GraphQL.DI.ServiceLifetime serviceLifetime = 2)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, TMiddleware middleware, bool install = true)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
-        [System.Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-        public static GraphQL.DI.IGraphQLBuilder AddMiddleware<TMiddleware>(this GraphQL.DI.IGraphQLBuilder builder, TMiddleware middleware, System.Func<System.IServiceProvider, GraphQL.Types.ISchema, bool> installPredicate)
-            where TMiddleware :  class, GraphQL.Instrumentation.IFieldMiddleware { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, TSchema schema)
@@ -759,8 +743,6 @@ namespace GraphQL
         public static System.Type GetGraphTypeFromType(this System.Type type, bool isNullable = false, GraphQL.TypeMappingMode mode = 0) { }
         public static string GraphQLName(this System.Type type) { }
         public static bool ImplementsGenericType(this System.Type type, System.Type genericType) { }
-        [System.Obsolete("This method will be removed in a future version of GraphQL.NET.")]
-        public static bool IsConcrete(this System.Type type) { }
         public static bool IsGraphType(this System.Type type) { }
         public static string? ObsoleteMessage(this System.Reflection.MemberInfo memberInfo) { }
     }
@@ -1839,9 +1821,6 @@ namespace GraphQL.Types
         public AutoRegisteringInterfaceGraphType(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[]? excludedProperties) { }
         protected virtual void ApplyArgumentAttributes(System.Reflection.ParameterInfo parameterInfo, GraphQL.Types.QueryArgument queryArgument) { }
         protected void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
-        [System.Obsolete("Interface graph types do not support field resolvers; use of this method is unnec" +
-            "essary.")]
-        protected virtual System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
         protected virtual void ConfigureGraph() { }
         protected virtual GraphQL.Types.FieldType? CreateField(System.Reflection.MemberInfo memberInfo) { }
         protected virtual GraphQL.Types.ArgumentInformation GetArgumentInformation<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
@@ -2385,16 +2364,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v8.")]
+    [System.Obsolete("This class will be removed in v9.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
@@ -3203,9 +3182,6 @@ namespace GraphQL.Validation
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetRecursiveVariables(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationDefinition> operations) { }
-        [System.Obsolete("This method can repeatedly add the same error into ValidationContext.Errors colle" +
-            "ction when called multiple times. Use GetVariablesValuesAsync method instead.")]
-        public System.Threading.Tasks.ValueTask<GraphQL.Validation.Variables> GetVariableValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetVariables<TNode>(TNode node)
             where TNode : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasSelectionSetNode { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
@@ -3255,8 +3231,6 @@ namespace GraphQL.Validation
     }
     public class Variable
     {
-        [System.Obsolete("Please specify the variable definition when constructing a variable.")]
-        public Variable(string name) { }
         public Variable(string name, GraphQLParser.AST.GraphQLVariableDefinition definition) { }
         public GraphQLParser.AST.GraphQLVariableDefinition Definition { get; set; }
         public bool IsDefault { get; set; }
@@ -3266,9 +3240,6 @@ namespace GraphQL.Validation
     }
     public class VariableUsage
     {
-        [System.Obsolete("Please specify whether the field has a default value when constructing this varia" +
-            "ble usage.")]
-        public VariableUsage(GraphQLParser.AST.GraphQLVariable node, GraphQL.Types.IGraphType type) { }
         public VariableUsage(GraphQLParser.AST.GraphQLVariable node, GraphQL.Types.IGraphType type, bool hasDefault) { }
         public bool HasDefault { get; }
         public GraphQLParser.AST.GraphQLVariable Node { get; }

--- a/src/GraphQL.MemoryCache/MemoryCacheGraphQLBuilderExtensions.cs
+++ b/src/GraphQL.MemoryCache/MemoryCacheGraphQLBuilderExtensions.cs
@@ -10,43 +10,15 @@ public static class MemoryCacheGraphQLBuilderExtensions
     /// Registers <see cref="MemoryDocumentCache"/> as a singleton of type <see cref="IConfigureExecution"/> within
     /// the dependency injection framework, and configures it with the specified configuration delegate.
     /// </summary>
-    [Obsolete("Please use UseMemoryCache. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddMemoryCache(this IGraphQLBuilder builder, Action<MemoryDocumentCacheOptions>? action = null)
-        => builder.AddMemoryCache(action == null ? null : (options, _) => action(options));
-
-    /// <inheritdoc cref="AddMemoryCache(IGraphQLBuilder, Action{MemoryDocumentCacheOptions})"/>
-    [Obsolete("Please use UseMemoryCache. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddMemoryCache(this IGraphQLBuilder builder, Action<MemoryDocumentCacheOptions, IServiceProvider>? action)
-    {
-        builder.Services
-            .Configure(action)
-            .TryRegister<IConfigureExecution, MemoryDocumentCache>(ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
-        return builder;
-    }
-
-    /// <summary>
-    /// Registers <see cref="MemoryDocumentCache"/> as a singleton of type <see cref="IConfigureExecution"/> within
-    /// the dependency injection framework, and configures it with the specified configuration delegate.
-    /// </summary>
     public static IGraphQLBuilder UseMemoryCache(this IGraphQLBuilder builder, Action<MemoryDocumentCacheOptions>? action = null)
      => builder.UseMemoryCache(action == null ? null : (options, _) => action(options));
 
-    /// <inheritdoc cref="AddMemoryCache(IGraphQLBuilder, Action{MemoryDocumentCacheOptions})"/>
+    /// <inheritdoc cref="UseMemoryCache(IGraphQLBuilder, Action{MemoryDocumentCacheOptions})"/>
     public static IGraphQLBuilder UseMemoryCache(this IGraphQLBuilder builder, Action<MemoryDocumentCacheOptions, IServiceProvider>? action)
     {
         builder.Services.Configure(action);
         return builder.ConfigureExecution<MemoryDocumentCache>();
     }
-
-    /// <inheritdoc cref="UseAutomaticPersistedQueries(IGraphQLBuilder, Action{AutomaticPersistedQueriesCacheOptions}?)"/>
-    [Obsolete("Please use UseAutomaticPersistedQueries. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddAutomaticPersistedQueries(this IGraphQLBuilder builder, Action<AutomaticPersistedQueriesCacheOptions>? action = null)
-        => UseAutomaticPersistedQueries(builder, action);
-
-    /// <inheritdoc cref="UseAutomaticPersistedQueries(IGraphQLBuilder, Action{AutomaticPersistedQueriesCacheOptions, IServiceProvider}?)"/>
-    [Obsolete("Please use UseAutomaticPersistedQueries. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddAutomaticPersistedQueries(this IGraphQLBuilder builder, Action<AutomaticPersistedQueriesCacheOptions, IServiceProvider>? action)
-        => UseAutomaticPersistedQueries(builder, action);
 
     /// <summary>
     /// Adds support of Automatic Persisted Queries in the form of implementation of <see cref="IConfigureExecution"/>.

--- a/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.ComponentModel;
-using System.Linq.Expressions;
 using System.Reflection;
 using GraphQL.DataLoader;
 using GraphQL.Execution;
@@ -521,19 +520,6 @@ public class AutoRegisteringInterfaceGraphTypeTests
             ThrowOnUnhandledException = true,
         }));
         ex.Message.ShouldBe("Abstract type IAnimal must resolve to an Object type at runtime for field TestQuery3.find with value 'GraphQL.Tests.Types.AutoRegisteringInterfaceGraphTypeTests+Cat', received 'null'.");
-    }
-
-    [Fact]
-    public void BuildsWithoutMemberInstanceExpression()
-    {
-        var type = new NoMemberInstanceExpression<IAnimal>();
-        type.Fields.Find("Id").ShouldNotBeNull();
-    }
-
-    public class NoMemberInstanceExpression<T> : AutoRegisteringInterfaceGraphType<T>
-    {
-        [Obsolete]
-        protected override LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo) => null!;
     }
 
     [Fact]

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -631,30 +631,6 @@ public static class GraphQLBuilderExtensions // TODO: split
     #endregion
 
     #region - UseMiddleware -
-    /// <inheritdoc cref="UseMiddleware{TMiddleware}(IGraphQLBuilder, bool, ServiceLifetime)"/>
-    [Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddMiddleware<TMiddleware>(this IGraphQLBuilder builder, bool install = true, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
-        where TMiddleware : class, IFieldMiddleware
-        => UseMiddleware<TMiddleware>(builder, install, serviceLifetime);
-
-    /// <inheritdoc cref="UseMiddleware{TMiddleware}(IGraphQLBuilder, Func{IServiceProvider, ISchema, bool}, ServiceLifetime)"/>
-    [Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddMiddleware<TMiddleware>(this IGraphQLBuilder builder, Func<IServiceProvider, ISchema, bool> installPredicate, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
-        where TMiddleware : class, IFieldMiddleware
-        => UseMiddleware<TMiddleware>(builder, installPredicate, serviceLifetime);
-
-    /// <inheritdoc cref="UseMiddleware{TMiddleware}(IGraphQLBuilder, TMiddleware, bool)"/>
-    [Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddMiddleware<TMiddleware>(this IGraphQLBuilder builder, TMiddleware middleware, bool install = true)
-        where TMiddleware : class, IFieldMiddleware
-        => UseMiddleware(builder, middleware, install);
-
-    /// <inheritdoc cref="UseMiddleware{TMiddleware}(IGraphQLBuilder, TMiddleware, Func{IServiceProvider, ISchema, bool})"/>
-    [Obsolete("Please use UseMiddleware. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddMiddleware<TMiddleware>(this IGraphQLBuilder builder, TMiddleware middleware, Func<IServiceProvider, ISchema, bool> installPredicate)
-        where TMiddleware : class, IFieldMiddleware
-        => UseMiddleware(builder, middleware, installPredicate);
-
     /// <summary>
     /// Registers <typeparamref name="TMiddleware"/> with the dependency injection framework as both <typeparamref name="TMiddleware"/> and
     /// <see cref="IFieldMiddleware"/>. If <paramref name="install"/> is <see langword="true"/>, installs the middleware by configuring schema
@@ -980,16 +956,6 @@ public static class GraphQLBuilderExtensions // TODO: split
     #endregion
 
     #region - UseApolloTracing -
-    /// <inheritdoc cref="UseApolloTracing(IGraphQLBuilder, bool)"/>
-    [Obsolete("Please use UseApolloTracing. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddApolloTracing(this IGraphQLBuilder builder, bool enableMetrics = true)
-        => UseApolloTracing(builder, enableMetrics);
-
-    /// <inheritdoc cref="UseApolloTracing(IGraphQLBuilder, Func{ExecutionOptions, bool})"/>
-    [Obsolete("Please use UseApolloTracing. This method will be removed in v8.")]
-    public static IGraphQLBuilder AddApolloTracing(this IGraphQLBuilder builder, Func<ExecutionOptions, bool> enableMetricsPredicate)
-        => UseApolloTracing(builder, enableMetricsPredicate);
-
     /// <summary>
     /// Registers <see cref="InstrumentFieldsMiddleware"/> within the dependency injection framework and
     /// configures it to be installed within the schema, and configures responses to include Apollo

--- a/src/GraphQL/Extensions/TypeExtensions.cs
+++ b/src/GraphQL/Extensions/TypeExtensions.cs
@@ -14,22 +14,6 @@ namespace GraphQL
     public static class TypeExtensions
     {
         /// <summary>
-        /// Determines whether this instance is a concrete type.
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <returns>
-        ///   <see langword="true"/> if the specified type is neither abstract nor an interface; otherwise, <see langword="false"/>.
-        /// </returns>
-        [Obsolete("This method will be removed in a future version of GraphQL.NET.")]
-        public static bool IsConcrete(this Type type)
-        {
-            if (type == null)
-                return false;
-
-            return !type.IsAbstract && !type.IsInterface; // && !type.IsGenericTypeDefinition; ??
-        }
-
-        /// <summary>
         /// Determines whether the indicated type implements IGraphType.
         /// </summary>
         /// <param name="type">The type.</param>

--- a/src/GraphQL/Telemetry/GraphQLTelemetryProvider.cs
+++ b/src/GraphQL/Telemetry/GraphQLTelemetryProvider.cs
@@ -74,9 +74,7 @@ public class GraphQLTelemetryProvider : IConfigureExecution
     private async Task<ExecutionResult> ExecuteInternalAsync(ExecutionOptions options, ExecutionDelegate next)
     {
         // start the Activity, in fact Activity.Stop() will be called from within Activity.Dispose() at the end of using block
-#pragma warning disable CS0618 // Type or member is obsolete
-        using var activity = await StartActivityAsync(options).ConfigureAwait(false);
-#pragma warning restore CS0618 // Type or member is obsolete
+        using var activity = StartActivity(options);
 
         // do not record any telemetry if there are no listeners or it decided not to sample the current request
         if (activity == null)
@@ -117,11 +115,6 @@ public class GraphQLTelemetryProvider : IConfigureExecution
         // return the result
         return result;
     }
-
-    /// <inheritdoc cref="StartActivity"/>
-    [Obsolete("Use the sync method 'StartActivity'. This method will be removed in v8.")]
-    protected virtual ValueTask<Activity?> StartActivityAsync(ExecutionOptions options)
-        => new(StartActivity(options));
 
     /// <summary>
     /// Creates an <see cref="Activity"/> for the specified <see cref="ExecutionOptions"/> and starts it.

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -118,11 +118,6 @@ public class AutoRegisteringInterfaceGraphType<[DynamicallyAccessedMembers(Dynam
             ApplyArgumentAttributes);
     }
 
-    /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.BuildMemberInstanceExpression(MemberInfo)"/>
-    [Obsolete("Interface graph types do not support field resolvers; use of this method is unnecessary.")]
-    protected virtual LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo)
-        => throw new NotSupportedException("Interface graph types do not support field resolvers");
-
     private static readonly MethodInfo _getArgumentInformationInternalMethodInfo = typeof(AutoRegisteringInterfaceGraphType<TSourceType>).GetMethod(nameof(GetArgumentInformationInternal), BindingFlags.NonPublic | BindingFlags.Instance)!;
     private ArgumentInformation GetArgumentInformationInternal<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)
         => GetArgumentInformation<TParameterType>(fieldType, parameterInfo);

--- a/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types
     /// <summary>
     /// Provides methods to add fields to output graph types.
     /// </summary>
-    [Obsolete("This class will be removed in v9.")]
+    [Obsolete("This class will be removed in v8.")]
     public static class ObjectGraphTypeExtensions
     {
         /// <summary>
@@ -17,7 +17,7 @@ namespace GraphQL.Types
         /// <param name="description">The description of the field.</param>
         /// <param name="arguments">A list of arguments for the field.</param>
         /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
+        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
         public static void Field(
             this IObjectGraphType obj,
             string name,
@@ -46,7 +46,7 @@ namespace GraphQL.Types
         /// <param name="description">The description of the field.</param>
         /// <param name="arguments">A list of arguments for the field.</param>
         /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
+        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
         public static void FieldAsync(
             this IObjectGraphType obj,
             string name,

--- a/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types
     /// <summary>
     /// Provides methods to add fields to output graph types.
     /// </summary>
-    [Obsolete("This class will be removed in v8.")]
+    [Obsolete("This class will be removed in v9.")]
     public static class ObjectGraphTypeExtensions
     {
         /// <summary>
@@ -17,7 +17,7 @@ namespace GraphQL.Types
         /// <param name="description">The description of the field.</param>
         /// <param name="arguments">A list of arguments for the field.</param>
         /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
+        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
         public static void Field(
             this IObjectGraphType obj,
             string name,
@@ -46,7 +46,7 @@ namespace GraphQL.Types
         /// <param name="description">The description of the field.</param>
         /// <param name="arguments">A list of arguments for the field.</param>
         /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
+        [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
         public static void FieldAsync(
             this IObjectGraphType obj,
             string name,

--- a/src/GraphQL/Validation/IVariableVisitor.cs
+++ b/src/GraphQL/Validation/IVariableVisitor.cs
@@ -4,7 +4,7 @@ using GraphQLParser.AST;
 namespace GraphQL.Validation
 {
     /// <summary>
-    /// Visitor which methods are called when parsing the inputs into variables in <see cref="ValidationContext.GetVariableValuesAsync"/>.
+    /// Visitor whose methods are called when parsing the inputs into variables in <see cref="ValidationContext.GetVariablesValuesAsync(IVariableVisitor?)"/>.
     /// </summary>
     public interface IVariableVisitor
     {

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -129,25 +129,6 @@ namespace GraphQL.Validation
         /// <summary>
         /// Returns all of the variable values defined for the operation from the attached <see cref="Variables"/> object.
         /// Only correctly validated variables are returned. If the variable is specified incorrectly, then an instance of
-        /// <see cref="ValidationError"/> is added to the <see cref="Errors"/>.
-        /// </summary>
-        [Obsolete("This method can repeatedly add the same error into ValidationContext.Errors collection when called multiple times. Use GetVariablesValuesAsync method instead.")]
-        public async ValueTask<Variables> GetVariableValuesAsync(IVariableVisitor? visitor = null)
-        {
-            (var variables, var errors) = await GetVariablesValuesAsync(visitor).ConfigureAwait(false);
-
-            if (errors != null)
-            {
-                foreach (var error in errors)
-                    ReportError(error);
-            }
-
-            return variables;
-        }
-
-        /// <summary>
-        /// Returns all of the variable values defined for the operation from the attached <see cref="Variables"/> object.
-        /// Only correctly validated variables are returned. If the variable is specified incorrectly, then an instance of
         /// <see cref="ValidationError"/> is returned within the list of errors.
         /// </summary>
         public async ValueTask<(Variables Variables, List<ValidationError>? Errors)> GetVariablesValuesAsync(IVariableVisitor? visitor = null)

--- a/src/GraphQL/Validation/Variable.cs
+++ b/src/GraphQL/Validation/Variable.cs
@@ -6,16 +6,6 @@ namespace GraphQL.Validation
     public class Variable
     {
         /// <summary>
-        /// Initializes a new instance with the specified name.
-        /// </summary>
-        [Obsolete("Please specify the variable definition when constructing a variable.")]
-        public Variable(string name)
-        {
-            Name = name;
-            Definition = null!;
-        }
-
-        /// <summary>
         /// Initializes a new instance with the specified name and definition.
         /// </summary>
         public Variable(string name, GraphQLParser.AST.GraphQLVariableDefinition definition)

--- a/src/GraphQL/Validation/VariableUsage.cs
+++ b/src/GraphQL/Validation/VariableUsage.cs
@@ -28,18 +28,6 @@ namespace GraphQL.Validation
         /// </summary>
         /// <param name="node">A variable reference node.</param>
         /// <param name="type">A graph type.</param>
-        [Obsolete("Please specify whether the field has a default value when constructing this variable usage.")]
-        public VariableUsage(GraphQLVariable node, IGraphType type)
-        {
-            Node = node;
-            Type = type;
-        }
-
-        /// <summary>
-        /// Initializes a new instance with the specified parameters.
-        /// </summary>
-        /// <param name="node">A variable reference node.</param>
-        /// <param name="type">A graph type.</param>
         /// <param name="hasDefault">Indicates if the field has a default value.</param>
         public VariableUsage(GraphQLVariable node, IGraphType type, bool hasDefault)
         {


### PR DESCRIPTION
The deprecated methods removed in this PR, I believe, should be removed in v9 due to these reasons:

- Some `Add...` IGraphQLBuilder methods were replaced by `Use...` methods.  (1) there is an important distinction between `Add` and `Use`, and (2) changes are very easy to fix and all consolidated in the user's startup file
- `IsConcrete` has no useful purpose; it is functionally identical to `!type.IsAbstract`
- Telemetry provider is very new and now is a good time to change `StartActivityAsync` back to `StartActivity` (which is necessary since otherwise it would not be compatible with `AsyncLocal` internals)
- Validation code is all changing anyway
