### PR TITLE
Support throwing ValidationError from validation delegates, bug fixes

### DIFF
--- a/docs2/site/docs/getting-started/query-validation.md
+++ b/docs2/site/docs/getting-started/query-validation.md
@@ -87,6 +87,10 @@ delegate will produce a response similar to the following:
 }
 ```
 
+For additional control over the error message, you can throw a `ValidationError` or derived
+exception class with a custom error message. The `locations` property will be automatically
+set to the location of the input field or argument, but the message will remain the same.
+
 For type-first schemas, you may define your own attributes to perform validation, either on input
 fields or on output field arguments. For example:
 

--- a/src/GraphQL.Tests/Execution/ExecutionHelperTests.cs
+++ b/src/GraphQL.Tests/Execution/ExecutionHelperTests.cs
@@ -1,0 +1,252 @@
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQLParser.AST;
+
+namespace GraphQL.Tests.Execution;
+
+public class ExecutionHelperTests
+{
+    [Fact]
+    public async Task Argument_Validation_Supports_ValidationError()
+    {
+        var query = new ObjectGraphType();
+        query.Field<StringGraphType>("test")
+            .Argument<StringGraphType>("arg", configure: arg => arg.Validate(_ => throw new MyValidationError()));
+        var schema = new Schema { Query = query };
+        var result = await schema.ExecuteAsync(_ => _.Query = "{ test(arg: \"123\") }");
+        result.ShouldBeCrossPlatJson("""
+            {
+              "errors": [
+                {
+                  "message": "My validation error",
+                  "locations": [
+                    {
+                      "line": 1,
+                      "column": 8
+                    }
+                  ],
+                  "extensions": {
+                    "code": "MY_VALIDATION",
+                    "codes": [
+                      "MY_VALIDATION"
+                    ]
+                  }
+                }
+              ]
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Argument_Validation_Supports_ExecutionError()
+    {
+        var query = new ObjectGraphType();
+        query.Field<StringGraphType>("test")
+            .Argument<StringGraphType>("arg", configure: arg => arg.Validate(_ => throw new MyValidationError2()));
+        var schema = new Schema { Query = query };
+        var result = await schema.ExecuteAsync(_ => _.Query = "{ test(arg: \"123\") }");
+        result.ShouldBeCrossPlatJson("""
+            {
+              "errors": [
+                {
+                  "message": "My validation error2",
+                  "locations": [
+                    {
+                      "line": 1,
+                      "column": 8
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Argument_Validation_Supports_WrapsUnknownErrors()
+    {
+        var query = new ObjectGraphType();
+        query.Field<StringGraphType>("test")
+            .Argument<StringGraphType>("arg", configure: arg => arg.Validate(_ => throw new InvalidOperationException("Sample error.")));
+        var schema = new Schema { Query = query };
+        var result = await schema.ExecuteAsync(_ => _.Query = "{ test(arg: \"123\") }");
+        result.ShouldBeCrossPlatJson("""
+            {
+              "errors": [
+                {
+                  "message": "Invalid value for argument 'arg' of field 'test'. Sample error.",
+                  "locations": [
+                    {
+                      "line": 1,
+                      "column": 13
+                    }
+                  ],
+                  "extensions": {
+                    "code": "INVALID_VALUE",
+                    "codes": [
+                      "INVALID_VALUE",
+                      "INVALID_OPERATION"
+                    ],
+                    "number": "5.6"
+                  }
+                }
+              ]
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task InputField_Validation_Supports_ValidationError()
+    {
+        var input = new InputObjectGraphType();
+        input.Field<StringGraphType>("test")
+            .Validate(_ => throw new MyValidationError());
+        var query = new ObjectGraphType();
+        query.Field<StringGraphType>("test")
+            .Arguments(new QueryArguments(new QueryArgument(input) { Name = "arg" }));
+        var schema = new Schema { Query = query };
+        var result = await schema.ExecuteAsync(_ => _.Query = "{ test(arg: { test: \"123\" }) }");
+        result.ShouldBeCrossPlatJson("""
+            {
+              "errors": [
+                {
+                  "message": "My validation error",
+                  "locations": [
+                    {
+                      "line": 1,
+                      "column": 15
+                    }
+                  ],
+                  "extensions": {
+                    "code": "MY_VALIDATION",
+                    "codes": [
+                      "MY_VALIDATION"
+                    ]
+                  }
+                }
+              ]
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task InputField_Validation_Supports_ExecutionError()
+    {
+        var input = new InputObjectGraphType();
+        input.Field<StringGraphType>("test")
+            .Validate(_ => throw new MyValidationError2());
+        var query = new ObjectGraphType();
+        query.Field<StringGraphType>("test")
+            .Arguments(new QueryArguments(new QueryArgument(input) { Name = "arg" }));
+        var schema = new Schema { Query = query };
+        var result = await schema.ExecuteAsync(_ => _.Query = "{ test(arg: { test: \"123\" }) }");
+        result.ShouldBeCrossPlatJson("""
+            {
+              "errors": [
+                {
+                  "message": "My validation error2",
+                  "locations": [
+                    {
+                      "line": 1,
+                      "column": 15
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task InputField_Validation_Supports_WrapsUnknownErrors()
+    {
+        var input = new InputObjectGraphType();
+        input.Field<StringGraphType>("test1")
+            .Validate(_ => throw new InvalidOperationException("Sample error."));
+        var query = new ObjectGraphType();
+        query.Field<StringGraphType>("test")
+            .Arguments(new QueryArguments(new QueryArgument(input) { Name = "arg" }));
+        var schema = new Schema { Query = query };
+        var result = await schema.ExecuteAsync(_ => _.Query = "{ test(arg: { test1: \"123\" }) }");
+        result.ShouldBeCrossPlatJson("""
+            {
+              "errors": [
+                {
+                  "message": "Invalid value for argument 'arg' of field 'test'. Sample error.",
+                  "locations": [
+                    {
+                      "line": 1,
+                      "column": 15
+                    }
+                  ],
+                  "extensions": {
+                    "code": "INVALID_VALUE",
+                    "codes": [
+                      "INVALID_VALUE",
+                      "INVALID_OPERATION"
+                    ],
+                    "number": "5.6"
+                  }
+                }
+              ]
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Directive_Validation_Wrapping()
+    {
+        var input = new InputObjectGraphType();
+        input.Field<StringGraphType>("test1")
+            .Validate(_ => throw new InvalidOperationException("Sample error."));
+        var directive = new Directive("test2")
+        {
+            Arguments = new QueryArguments(new QueryArgument(input) { Name = "arg" })
+        };
+        directive.Locations.Add(DirectiveLocation.Field);
+        var query = new ObjectGraphType();
+        query.Field<StringGraphType>("test");
+        var schema = new Schema { Query = query };
+        schema.Directives.Register(directive);
+        var result = await schema.ExecuteAsync(_ => _.Query = "{ test @test2(arg: { test1: \"123\" }) }");
+        result.ShouldBeCrossPlatJson("""
+            {
+              "errors": [
+                {
+                  "message": "Invalid value for argument 'arg' of directive 'test2' for field 'test'. Sample error.",
+                  "locations": [
+                    {
+                      "line": 1,
+                      "column": 22
+                    }
+                  ],
+                  "extensions": {
+                    "code": "INVALID_VALUE",
+                    "codes": [
+                      "INVALID_VALUE",
+                      "INVALID_OPERATION"
+                    ],
+                    "number": "5.6"
+                  }
+                }
+              ]
+            }
+            """);
+    }
+
+    private class MyValidationError : ValidationError
+    {
+        public MyValidationError()
+            : base("My validation error")
+        {
+        }
+    }
+
+    private class MyValidationError2 : ExecutionError
+    {
+        public MyValidationError2()
+            : base("My validation error2")
+        {
+        }
+    }
+}

--- a/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
@@ -157,7 +157,7 @@ public class InputObjectGraphTypeTests
                 {"errors":[
                     {
                         "message":"Invalid value for argument \u0027input\u0027 of field \u0027test\u0027. Invalid URI: The format of the URI could not be determined.",
-                        "locations":[{"line":1,"column":15}],
+                        "locations":[{"line":1,"column":17}],
                         "extensions":{
                             "code":"INVALID_VALUE",
                             "codes":["INVALID_VALUE","URI_FORMAT"],
@@ -214,7 +214,7 @@ public class InputObjectGraphTypeTests
                 {"errors":[
                     {
                         "message":"Invalid value for argument \u0027input\u0027 of field \u0027test\u0027. String must be a length of 5 characters.",
-                        "locations":[{"line":1,"column":15}],
+                        "locations":[{"line":1,"column":17}],
                         "extensions":{
                             "code":"INVALID_VALUE",
                             "codes":["INVALID_VALUE","ARGUMENT"],

--- a/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/InputObjectGraphTypeTests.cs
@@ -157,7 +157,7 @@ public class InputObjectGraphTypeTests
                 {"errors":[
                     {
                         "message":"Invalid value for argument \u0027input\u0027 of field \u0027test\u0027. Invalid URI: The format of the URI could not be determined.",
-                        "locations":[{"line":1,"column":17}],
+                        "locations":[{"line":1,"column":22}],
                         "extensions":{
                             "code":"INVALID_VALUE",
                             "codes":["INVALID_VALUE","URI_FORMAT"],
@@ -214,7 +214,7 @@ public class InputObjectGraphTypeTests
                 {"errors":[
                     {
                         "message":"Invalid value for argument \u0027input\u0027 of field \u0027test\u0027. String must be a length of 5 characters.",
-                        "locations":[{"line":1,"column":17}],
+                        "locations":[{"line":1,"column":25}],
                         "extensions":{
                             "code":"INVALID_VALUE",
                             "codes":["INVALID_VALUE","ARGUMENT"],

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -304,12 +304,12 @@ namespace GraphQL.Execution
                                 }
                                 catch (ExecutionError ex) when (context.Document != null)
                                 {
-                                    ex.AddLocation(Location.FromLinearPosition(context.Document.Source, objectField.Location.Start));
+                                    ex.AddLocation(Location.FromLinearPosition(context.Document.Source, objectField.Value.Location.Start));
                                     throw;
                                 }
                                 catch (Exception ex) when (context.Document != null && context.ParentNode != null)
                                 {
-                                    throw new InvalidValueError(context.Document, context.ParentNode, context.Directive, context.Argument, objectField, ex);
+                                    throw new InvalidValueError(context.Document, context.ParentNode, context.Directive, context.Argument, objectField.Value, ex);
                                 }
                             }
                             obj[field.Name] = parsedValue;

--- a/src/GraphQL/Execution/ExecutionHelper.cs
+++ b/src/GraphQL/Execution/ExecutionHelper.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using GraphQL.Types;
 using GraphQL.Validation;
+using GraphQLParser;
 using GraphQLParser.AST;
 
 namespace GraphQL.Execution
@@ -88,6 +89,18 @@ namespace GraphQL.Execution
                                 parsedValue = arg.Parser(parsedValue);
                             if (parsedValue != null && arg.Validator != null)
                                 arg.Validator(parsedValue);
+                        }
+                        catch (ValidationError ex)
+                        {
+                            if (argNode != null)
+                                ex.AddNode(document.Source, argNode);
+                            throw;
+                        }
+                        catch (ExecutionError ex)
+                        {
+                            if (argNode != null)
+                                ex.AddLocation(Location.FromLinearPosition(document.Source, argNode.Location.Start));
+                            throw;
                         }
                         catch (Exception ex)
                         {
@@ -284,9 +297,19 @@ namespace GraphQL.Execution
                                     if (parsedValue != null && field.Validator != null)
                                         field.Validator(parsedValue);
                                 }
+                                catch (ValidationError ex) when (context.Document != null)
+                                {
+                                    ex.AddNode(context.Document.Source, objectField);
+                                    throw;
+                                }
+                                catch (ExecutionError ex) when (context.Document != null)
+                                {
+                                    ex.AddLocation(Location.FromLinearPosition(context.Document.Source, objectField.Location.Start));
+                                    throw;
+                                }
                                 catch (Exception ex) when (context.Document != null && context.ParentNode != null)
                                 {
-                                    throw new InvalidValueError(context.Document, context.ParentNode, context.Directive, context.Argument, input, ex);
+                                    throw new InvalidValueError(context.Document, context.ParentNode, context.Directive, context.Argument, objectField, ex);
                                 }
                             }
                             obj[field.Name] = parsedValue;

--- a/src/GraphQL/Validation/ValidationError.cs
+++ b/src/GraphQL/Validation/ValidationError.cs
@@ -104,6 +104,18 @@ namespace GraphQL.Validation
         }
 
         /// <summary>
+        /// Ensures that the specified node's location is specified in the error's locations.
+        /// </summary>
+        internal void AddNode(ROM source, ASTNode node)
+        {
+            if (!_nodes.Contains(node))
+            {
+                _nodes.Add(node);
+                AddLocation(Location.FromLinearPosition(source, node.Location.Start));
+            }
+        }
+
+        /// <summary>
         /// Returns a list of AST nodes that this error applies to.
         /// </summary>
         public IEnumerable<ASTNode> Nodes => _nodes;


### PR DESCRIPTION
This PR lets `.Validate( ... )` code throw an `ExecutionError` or `ValidationError` without wrapping it within `InvalidValueError`.

Users are encouraged to throw any exception they desire for default wrapping, but (similar to the rest of the library), throwing an `ExecutionError` will pass the error through to the result unchanged.

Also related bug fixes:
- fix location for errors due to validation delegates
- support validation delegates for input object fields within variables

Added more tests