### PR TITLE
Federation prep: Remove union check

### DIFF
--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -585,10 +585,6 @@ public class SchemaTypes : IEnumerable<IGraphType>
         if (type is UnionGraphType union)
         {
             using var _ = context.Trace("Loop for possible types of union type '{0}'", union.Name);
-            if (!union.Types.Any() && !union.PossibleTypes.Any())
-            {
-                throw new InvalidOperationException($"Must provide types for Union '{union}'.");
-            }
 
             foreach (var unionedType in union.PossibleTypes)
             {


### PR DESCRIPTION
For:
- #3921 

This check already exists within the schema validator code and is not necessary here.  It must be removed to allow the federation PR to dynamically build the union graph type after the schema has been initialized.  It must be built after the schema is initialized as the initialization process recursively discovers all of output graph types referenced by the schema.