### PR TITLE
Add MapAutoClrTypeAttribute

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -609,6 +609,11 @@ namespace GraphQL
         public bool TryRetrieve(TKey key, out TValue? value) { }
         public void WithValue(TKey key, System.Action<TValue> action) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    public sealed class MapAutoClrTypeAttribute : System.Attribute
+    {
+        public MapAutoClrTypeAttribute() { }
+    }
     public static class MemoryExtensions
     {
         public static System.Collections.Generic.IList<T> Constrained<T>(this T[] array, int count) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -609,6 +609,11 @@ namespace GraphQL
         public bool TryRetrieve(TKey key, out TValue? value) { }
         public void WithValue(TKey key, System.Action<TValue> action) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    public sealed class MapAutoClrTypeAttribute : System.Attribute
+    {
+        public MapAutoClrTypeAttribute() { }
+    }
     public static class MemoryExtensions
     {
         public static System.Collections.Generic.IList<T> Constrained<T>(this T[] array, int count) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -585,6 +585,11 @@ namespace GraphQL
         public bool TryRetrieve(TKey key, out TValue? value) { }
         public void WithValue(TKey key, System.Action<TValue> action) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    public sealed class MapAutoClrTypeAttribute : System.Attribute
+    {
+        public MapAutoClrTypeAttribute() { }
+    }
     public static class MemoryExtensions
     {
         public static System.Collections.Generic.IList<T> Constrained<T>(this T[] array, int count) { }

--- a/src/GraphQL/Attributes/MapAutoClrTypeAttribute.cs
+++ b/src/GraphQL/Attributes/MapAutoClrTypeAttribute.cs
@@ -1,0 +1,12 @@
+namespace GraphQL;
+
+/// <summary>
+/// Indicates that <see cref="GraphQLBuilderExtensions.AddAutoClrMappings(DI.IGraphQLBuilder, bool, bool)"/>
+/// should include this class when creating auto CLR type mappings, even when <c>mapInputTypes</c>
+/// or <c>mapOutputTypes</c> is <see langword="false"/>.
+/// This attribute should be placed on the CLR type that comprises the mapping.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class MapAutoClrTypeAttribute : Attribute
+{
+}

--- a/src/GraphQL/Types/Collections/AutoRegisteringGraphTypeMappingProvider.cs
+++ b/src/GraphQL/Types/Collections/AutoRegisteringGraphTypeMappingProvider.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace GraphQL.Types;
 
 /// <summary>
@@ -40,8 +42,8 @@ public class AutoRegisteringGraphTypeMappingProvider : IGraphTypeMappingProvider
         if (preferredType != null)
             return preferredType;
 
-        if (isInputType && !_mapInputTypes ||
-            !isInputType && !_mapOutputTypes ||
+        if (isInputType && !_mapInputTypes && !IsForcedType(clrType) ||
+            !isInputType && !_mapOutputTypes && !IsForcedType(clrType) ||
             clrType.IsEnum ||
             SchemaTypes.BuiltInScalarMappings.ContainsKey(clrType))
             return null;
@@ -58,5 +60,7 @@ public class AutoRegisteringGraphTypeMappingProvider : IGraphTypeMappingProvider
         {
             return typeof(AutoRegisteringObjectGraphType<>).MakeGenericType(clrType);
         }
+
+        static bool IsForcedType(Type type) => type.GetCustomAttribute<MapAutoClrTypeAttribute>() != null;
     }
 }


### PR DESCRIPTION
Allows users to selectively map CLR types to auto-registering graph types.