### PR TITLE
Add IsPrivate and SkipTypeCheck properties to IGraphType / IFieldType

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -363,6 +363,18 @@ Finally, if you simply need to map an interface list type to a concrete list typ
 ValueConverter.RegisterListConverterFactory(typeof(IList<>), typeof(List<>)); // default mapping is T[]
 ```
 
+### 10. `IGraphType.IsPrivate` and `IFieldType.IsPrivate` properties added
+
+Allows to set a graph type or field as private within a schema visitor, effectively removing it from the schema.
+Introspection queries will not be able to query the type/field, and queries will not be able to reference the type/field.
+
+### 11. `IObjectGraphType.SkipTypeCheck` property added
+
+Allows to skip the type check for a specific object graph type during resolver execution. This is useful
+for schema-first schemas where the CLR type is not defined while the resolver is built, while allowing
+`IsTypeOf` to be set automatically for other use cases. Schema-first schemas will automatically set this
+property to `true` for all object graph types to retain the existing behavior.
+
 ## Breaking Changes
 
 ### 1. Query type is required
@@ -532,3 +544,8 @@ public interface IValidationRule
 
 It is recommended to inherit from `ValidationRuleBase` for custom validation rules
 and override only the methods you need to implement.
+
+### 13. New properties added to `IGraphType`, `IFieldType` and `IObjectGraphType`
+
+See the new features section for details on the new properties added to these interfaces.
+Unless you directly implement these interfaces, you should not be impacted by these changes.

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -367,6 +367,12 @@ ValueConverter.RegisterListConverterFactory(typeof(IList<>), typeof(List<>)); //
 
 Allows to set a graph type or field as private within a schema visitor, effectively removing it from the schema.
 Introspection queries will not be able to query the type/field, and queries will not be able to reference the type/field.
+Exporting the schema as a SDL (or printing it) will not include the private types or fields.
+
+Private types are fully 'resolved', and it is possible to reference the private types through the `SchemaTypes` dictionary.
+This makes it possible to create a private type used within the schema but not exposed to the client. For instance,
+it is possible to dynamically create input object types to deserialize GraphQL Federation entity representations, which are
+normally sent via the `_Any` type.
 
 ### 11. `IObjectGraphType.SkipTypeCheck` property added
 

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2212,6 +2212,7 @@ namespace GraphQL.Types
         public object? DefaultValue { get; set; }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         public System.Func<object, object>? Parser { get; set; }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
@@ -2235,6 +2236,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public string TypeName { get; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public override bool Equals(object? obj) { }
@@ -2245,6 +2247,7 @@ namespace GraphQL.Types
         protected GraphType() { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         protected bool Equals(GraphQL.Types.IGraphType other) { }
         public override bool Equals(object? obj) { }
@@ -2284,10 +2287,12 @@ namespace GraphQL.Types
     public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
+        bool IsPrivate { get; set; }
         string Name { get; set; }
     }
     public interface IGraphType : GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
+        bool IsPrivate { get; set; }
         void Initialize(GraphQL.Types.ISchema schema);
     }
     public interface IGraphTypeFactory<out TGraphType>
@@ -2327,6 +2332,7 @@ namespace GraphQL.Types
     public interface IObjectGraphType : GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         System.Func<object, bool>? IsTypeOf { get; set; }
+        bool SkipTypeCheck { get; set; }
         void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType);
     }
     public interface IProvideDeprecationReason
@@ -2494,6 +2500,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public void Interface(System.Type type) { }
         public void Interface<TInterface>()
@@ -2978,8 +2985,8 @@ namespace GraphQL.Utilities
         protected virtual GraphQLParser.AST.GraphQLDirectiveDefinition ExportDirectiveDefinition(GraphQL.Types.Directive directive) { }
         protected virtual GraphQLParser.AST.GraphQLEnumTypeDefinition ExportEnumTypeDefinition(GraphQL.Types.EnumerationGraphType enumType) { }
         protected virtual GraphQLParser.AST.GraphQLFieldDefinition ExportFieldDefinition(GraphQL.Types.FieldType fieldType) { }
+        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputFieldDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInputObjectTypeDefinition ExportInputObjectTypeDefinition(GraphQL.Types.IInputObjectGraphType graphType) { }
-        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputValueDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInterfaceTypeDefinition ExportInterfaceTypeDefinition(GraphQL.Types.IInterfaceGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLObjectTypeDefinition ExportObjectTypeDefinition(GraphQL.Types.IObjectGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLScalarTypeDefinition ExportScalarTypeDefinition(GraphQL.Types.ScalarGraphType scalarType) { }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2985,8 +2985,8 @@ namespace GraphQL.Utilities
         protected virtual GraphQLParser.AST.GraphQLDirectiveDefinition ExportDirectiveDefinition(GraphQL.Types.Directive directive) { }
         protected virtual GraphQLParser.AST.GraphQLEnumTypeDefinition ExportEnumTypeDefinition(GraphQL.Types.EnumerationGraphType enumType) { }
         protected virtual GraphQLParser.AST.GraphQLFieldDefinition ExportFieldDefinition(GraphQL.Types.FieldType fieldType) { }
-        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputFieldDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInputObjectTypeDefinition ExportInputObjectTypeDefinition(GraphQL.Types.IInputObjectGraphType graphType) { }
+        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputValueDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInterfaceTypeDefinition ExportInterfaceTypeDefinition(GraphQL.Types.IInterfaceGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLObjectTypeDefinition ExportObjectTypeDefinition(GraphQL.Types.IObjectGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLScalarTypeDefinition ExportScalarTypeDefinition(GraphQL.Types.ScalarGraphType scalarType) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2999,8 +2999,8 @@ namespace GraphQL.Utilities
         protected virtual GraphQLParser.AST.GraphQLDirectiveDefinition ExportDirectiveDefinition(GraphQL.Types.Directive directive) { }
         protected virtual GraphQLParser.AST.GraphQLEnumTypeDefinition ExportEnumTypeDefinition(GraphQL.Types.EnumerationGraphType enumType) { }
         protected virtual GraphQLParser.AST.GraphQLFieldDefinition ExportFieldDefinition(GraphQL.Types.FieldType fieldType) { }
-        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputFieldDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInputObjectTypeDefinition ExportInputObjectTypeDefinition(GraphQL.Types.IInputObjectGraphType graphType) { }
+        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputValueDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInterfaceTypeDefinition ExportInterfaceTypeDefinition(GraphQL.Types.IInterfaceGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLObjectTypeDefinition ExportObjectTypeDefinition(GraphQL.Types.IObjectGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLScalarTypeDefinition ExportScalarTypeDefinition(GraphQL.Types.ScalarGraphType scalarType) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2219,6 +2219,7 @@ namespace GraphQL.Types
         public object? DefaultValue { get; set; }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         public System.Func<object, object>? Parser { get; set; }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
@@ -2242,6 +2243,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public string TypeName { get; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public override bool Equals(object? obj) { }
@@ -2252,6 +2254,7 @@ namespace GraphQL.Types
         protected GraphType() { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         protected bool Equals(GraphQL.Types.IGraphType other) { }
         public override bool Equals(object? obj) { }
@@ -2291,10 +2294,12 @@ namespace GraphQL.Types
     public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
+        bool IsPrivate { get; set; }
         string Name { get; set; }
     }
     public interface IGraphType : GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
+        bool IsPrivate { get; set; }
         void Initialize(GraphQL.Types.ISchema schema);
     }
     public interface IGraphTypeFactory<out TGraphType>
@@ -2334,6 +2339,7 @@ namespace GraphQL.Types
     public interface IObjectGraphType : GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         System.Func<object, bool>? IsTypeOf { get; set; }
+        bool SkipTypeCheck { get; set; }
         void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType);
     }
     public interface IProvideDeprecationReason
@@ -2501,6 +2507,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public void Interface(System.Type type) { }
         public void Interface<TInterface>()
@@ -2992,8 +2999,8 @@ namespace GraphQL.Utilities
         protected virtual GraphQLParser.AST.GraphQLDirectiveDefinition ExportDirectiveDefinition(GraphQL.Types.Directive directive) { }
         protected virtual GraphQLParser.AST.GraphQLEnumTypeDefinition ExportEnumTypeDefinition(GraphQL.Types.EnumerationGraphType enumType) { }
         protected virtual GraphQLParser.AST.GraphQLFieldDefinition ExportFieldDefinition(GraphQL.Types.FieldType fieldType) { }
+        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputFieldDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInputObjectTypeDefinition ExportInputObjectTypeDefinition(GraphQL.Types.IInputObjectGraphType graphType) { }
-        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputValueDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInterfaceTypeDefinition ExportInterfaceTypeDefinition(GraphQL.Types.IInterfaceGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLObjectTypeDefinition ExportObjectTypeDefinition(GraphQL.Types.IObjectGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLScalarTypeDefinition ExportScalarTypeDefinition(GraphQL.Types.ScalarGraphType scalarType) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2913,8 +2913,8 @@ namespace GraphQL.Utilities
         protected virtual GraphQLParser.AST.GraphQLDirectiveDefinition ExportDirectiveDefinition(GraphQL.Types.Directive directive) { }
         protected virtual GraphQLParser.AST.GraphQLEnumTypeDefinition ExportEnumTypeDefinition(GraphQL.Types.EnumerationGraphType enumType) { }
         protected virtual GraphQLParser.AST.GraphQLFieldDefinition ExportFieldDefinition(GraphQL.Types.FieldType fieldType) { }
-        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputFieldDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInputObjectTypeDefinition ExportInputObjectTypeDefinition(GraphQL.Types.IInputObjectGraphType graphType) { }
+        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputValueDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInterfaceTypeDefinition ExportInterfaceTypeDefinition(GraphQL.Types.IInterfaceGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLObjectTypeDefinition ExportObjectTypeDefinition(GraphQL.Types.IObjectGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLScalarTypeDefinition ExportScalarTypeDefinition(GraphQL.Types.ScalarGraphType scalarType) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2147,6 +2147,7 @@ namespace GraphQL.Types
         public object? DefaultValue { get; set; }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         public System.Func<object, object>? Parser { get; set; }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
@@ -2170,6 +2171,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public string TypeName { get; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public override bool Equals(object? obj) { }
@@ -2180,6 +2182,7 @@ namespace GraphQL.Types
         protected GraphType() { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         protected bool Equals(GraphQL.Types.IGraphType other) { }
         public override bool Equals(object? obj) { }
@@ -2212,10 +2215,12 @@ namespace GraphQL.Types
     public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
+        bool IsPrivate { get; set; }
         string Name { get; set; }
     }
     public interface IGraphType : GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
+        bool IsPrivate { get; set; }
         void Initialize(GraphQL.Types.ISchema schema);
     }
     public interface IGraphTypeFactory<out TGraphType>
@@ -2255,6 +2260,7 @@ namespace GraphQL.Types
     public interface IObjectGraphType : GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         System.Func<object, bool>? IsTypeOf { get; set; }
+        bool SkipTypeCheck { get; set; }
         void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType);
     }
     public interface IProvideDeprecationReason
@@ -2422,6 +2428,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public void Interface(System.Type type) { }
         public void Interface<TInterface>()
@@ -2906,8 +2913,8 @@ namespace GraphQL.Utilities
         protected virtual GraphQLParser.AST.GraphQLDirectiveDefinition ExportDirectiveDefinition(GraphQL.Types.Directive directive) { }
         protected virtual GraphQLParser.AST.GraphQLEnumTypeDefinition ExportEnumTypeDefinition(GraphQL.Types.EnumerationGraphType enumType) { }
         protected virtual GraphQLParser.AST.GraphQLFieldDefinition ExportFieldDefinition(GraphQL.Types.FieldType fieldType) { }
+        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputFieldDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInputObjectTypeDefinition ExportInputObjectTypeDefinition(GraphQL.Types.IInputObjectGraphType graphType) { }
-        protected virtual GraphQLParser.AST.GraphQLInputValueDefinition ExportInputValueDefinition(GraphQL.Types.FieldType fieldType) { }
         protected virtual GraphQLParser.AST.GraphQLInterfaceTypeDefinition ExportInterfaceTypeDefinition(GraphQL.Types.IInterfaceGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLObjectTypeDefinition ExportObjectTypeDefinition(GraphQL.Types.IObjectGraphType graphType) { }
         protected virtual GraphQLParser.AST.GraphQLScalarTypeDefinition ExportScalarTypeDefinition(GraphQL.Types.ScalarGraphType scalarType) { }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -60,13 +60,13 @@ public abstract class ExecutionStrategy : IExecutionStrategy
 
             case OperationType.Mutation:
                 type = context.Schema.Mutation;
-                if (type == null)
+                if (type == null || type.IsPrivate)
                     throw new InvalidOperationError("Schema is not configured for mutations").AddLocation(context.Operation, context.Document);
                 break;
 
             case OperationType.Subscription:
                 type = context.Schema.Subscription;
-                if (type == null)
+                if (type == null || type.IsPrivate)
                     throw new InvalidOperationError("Schema is not configured for subscriptions").AddLocation(context.Operation, context.Document);
                 break;
 
@@ -655,7 +655,7 @@ public abstract class ExecutionStrategy : IExecutionStrategy
             }
         }
 
-        if (objectType?.IsTypeOf != null && !objectType.IsTypeOf(result))
+        if (objectType?.IsTypeOf != null && !objectType.SkipTypeCheck && !objectType.IsTypeOf(result))
         {
             throw new InvalidOperationException($"'{result}' value of type '{result.GetType()}' is not allowed for '{objectType.Name}'. Either change IsTypeOf method of '{objectType.Name}' to accept this value or return another value from your resolver.");
         }

--- a/src/GraphQL/Introspection/TypeMetaFieldType.cs
+++ b/src/GraphQL/Introspection/TypeMetaFieldType.cs
@@ -18,6 +18,10 @@ public class TypeMetaFieldType : FieldType
         Type = typeof(__Type);
         Description = "Request the type information of a single type.";
         Arguments = new QueryArguments(new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "name" });
-        Resolver = new FuncFieldResolver<object>(context => context.Schema.AllTypes[context.GetArgument<string>("name")!]);
+        Resolver = new FuncFieldResolver<object?>(context =>
+        {
+            var graphType = context.Schema.AllTypes[context.GetArgument<string>("name")];
+            return graphType == null || graphType.IsPrivate ? null : graphType;
+        });
     }
 }

--- a/src/GraphQL/Introspection/__Schema.cs
+++ b/src/GraphQL/Introspection/__Schema.cs
@@ -32,7 +32,7 @@ public class __Schema : ObjectGraphType<ISchema>
                 int index = 0;
                 foreach (var item in context.Schema.AllTypes.Dictionary)
                 {
-                    if (await context.Schema.Filter.AllowType(item.Value).ConfigureAwait(false))
+                    if (!item.Value.IsPrivate && await context.Schema.Filter.AllowType(item.Value).ConfigureAwait(false))
                         types[index++] = item.Value;
                 }
 
@@ -51,7 +51,7 @@ public class __Schema : ObjectGraphType<ISchema>
             .Description("If this server supports mutation, the type that mutation operations will be rooted at.")
             .ResolveAsync(async context =>
             {
-                return context.Schema.Mutation != null && await context.Schema.Filter.AllowType(context.Schema.Mutation).ConfigureAwait(false)
+                return context.Schema.Mutation != null && !context.Schema.Mutation.IsPrivate && await context.Schema.Filter.AllowType(context.Schema.Mutation).ConfigureAwait(false)
                     ? context.Schema.Mutation
                     : null;
             });
@@ -60,7 +60,7 @@ public class __Schema : ObjectGraphType<ISchema>
             .Description("If this server supports subscription, the type that subscription operations will be rooted at.")
             .ResolveAsync(async context =>
             {
-                return context.Schema.Subscription != null && await context.Schema.Filter.AllowType(context.Schema.Subscription).ConfigureAwait(false)
+                return context.Schema.Subscription != null && !context.Schema.Subscription.IsPrivate && await context.Schema.Filter.AllowType(context.Schema.Subscription).ConfigureAwait(false)
                     ? context.Schema.Subscription
                     : null;
             });

--- a/src/GraphQL/Introspection/__Type.cs
+++ b/src/GraphQL/Introspection/__Type.cs
@@ -67,7 +67,7 @@ public class __Type : ObjectGraphType<IGraphType>
                     int index = 0;
                     foreach (var field in type.Fields.List)
                     {
-                        if ((includeDeprecated || string.IsNullOrWhiteSpace(field.DeprecationReason)) && await context.Schema.Filter.AllowField(type, field).ConfigureAwait(false))
+                        if (!field.IsPrivate && (includeDeprecated || string.IsNullOrWhiteSpace(field.DeprecationReason)) && await context.Schema.Filter.AllowField(type, field).ConfigureAwait(false))
                             fields[index++] = field;
                     }
 
@@ -164,7 +164,7 @@ public class __Type : ObjectGraphType<IGraphType>
                 int index = 0;
                 foreach (var field in type.Fields.List)
                 {
-                    if ((includeDeprecated || string.IsNullOrWhiteSpace(field.DeprecationReason)) && await context.Schema.Filter.AllowField(type, field).ConfigureAwait(false))
+                    if (!field.IsPrivate && (includeDeprecated || string.IsNullOrWhiteSpace(field.DeprecationReason)) && await context.Schema.Filter.AllowField(type, field).ConfigureAwait(false))
                         inputFields[index++] = field;
                 }
 

--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -11,6 +11,11 @@ public interface IObjectGraphType : IComplexGraphType, IImplementInterfaces
     Func<object, bool>? IsTypeOf { get; set; }
 
     /// <summary>
+    /// Instructs GraphQL.NET to skip type checking when a resolver of a field that returns this graph type returns an object.
+    /// </summary>
+    bool SkipTypeCheck { get; set; }
+
+    /// <summary>
     /// Adds an instance of <see cref="IInterfaceGraphType"/> to the list of interface instances supported by this object graph type.
     /// </summary>
     void AddResolvedInterface(IInterfaceGraphType graphType);
@@ -24,6 +29,9 @@ public class ObjectGraphType<[NotAGraphType] TSourceType> : ComplexGraphType<TSo
 {
     /// <inheritdoc/>
     public Func<object, bool>? IsTypeOf { get; set; }
+
+    /// <inheritdoc/>
+    public bool SkipTypeCheck { get; set; }
 
     /// <inheritdoc/>
     public ObjectGraphType()

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -107,4 +107,7 @@ public class FieldType : MetadataProvider, IFieldType
     /// Only applicable to fields of input graph types.
     /// </summary>
     public Action<object>? Validator { get; set; }
+
+    /// <inheritdoc/>
+    public bool IsPrivate { get; set; }
 }

--- a/src/GraphQL/Types/Fields/IFieldType.cs
+++ b/src/GraphQL/Types/Fields/IFieldType.cs
@@ -14,4 +14,9 @@ public interface IFieldType : IHaveDefaultValue, IMetadataReader, IMetadataWrite
     /// Gets or sets a list of arguments for the field.
     /// </summary>
     QueryArguments? Arguments { get; set; }
+
+    /// <summary>
+    /// Indicates that the field is not exposed through introspection and cannot be queried.
+    /// </summary>
+    bool IsPrivate { get; set; }
 }

--- a/src/GraphQL/Types/GraphQLTypeReference.cs
+++ b/src/GraphQL/Types/GraphQLTypeReference.cs
@@ -21,10 +21,17 @@ public sealed class GraphQLTypeReference : InterfaceGraphType, IObjectGraphType
     /// <summary>
     /// Returns the GraphQL type name that this reference is a placeholder for.
     /// </summary>
-    public string TypeName { get; private set; }
+    public string TypeName { get; }
 
     /// <inheritdoc/>
     public Func<object, bool>? IsTypeOf
+    {
+        get => throw Invalid();
+        set => throw Invalid();
+    }
+
+    /// <inheritdoc/>
+    public bool SkipTypeCheck
     {
         get => throw Invalid();
         set => throw Invalid();
@@ -64,6 +71,8 @@ public sealed class GraphQLClrOutputTypeReference<[NotAGraphType] T> : Interface
     }
 
     Func<object, bool>? IObjectGraphType.IsTypeOf { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    bool IObjectGraphType.SkipTypeCheck { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
     Interfaces IImplementInterfaces.Interfaces => throw new NotImplementedException();
 

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -134,4 +134,7 @@ public abstract class GraphType : MetadataProvider, IGraphType
 
     /// <inheritdoc />
     public override int GetHashCode() => Name?.GetHashCode() ?? 0;
+
+    /// <inheritdoc/>
+    public bool IsPrivate { get; set; }
 }

--- a/src/GraphQL/Types/IGraphType.cs
+++ b/src/GraphQL/Types/IGraphType.cs
@@ -46,4 +46,9 @@ public interface IGraphType : IMetadataReader, IMetadataWriter, IProvideDescript
     /// Initializes the graph type.
     /// </summary>
     void Initialize(ISchema schema);
+
+    /// <summary>
+    /// Indicates that the graph type is not exposed through introspection and cannot be used as type conditions within queries.
+    /// </summary>
+    bool IsPrivate { get; set; }
 }

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -269,7 +269,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
         var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<ObjectGraphType>)) as IGraphTypeFactory<ObjectGraphType>;
         var type = _types.TryGetValue(name, out var t)
             ? t as ObjectGraphType ?? throw new InvalidOperationException($"Type '{name} should be ObjectGraphType")
-            : typeFactory?.Create() ?? new ObjectGraphType();
+            : typeFactory?.Create() ?? new ObjectGraphType() { SkipTypeCheck = true };
 
         type.Name = name;
 

--- a/src/GraphQL/Utilities/SchemaExporter.cs
+++ b/src/GraphQL/Utilities/SchemaExporter.cs
@@ -155,7 +155,7 @@ public class SchemaExporter
             foreach (var field in graphType.Fields)
             {
                 if (!field.IsPrivate)
-                    list.Add(ExportInputFieldDefinition(field));
+                    list.Add(ExportInputValueDefinition(field));
             }
             fields = new(list);
         }
@@ -169,7 +169,7 @@ public class SchemaExporter
     /// <summary>
     /// Exports the specified <see cref="FieldType"/> as a <see cref="GraphQLInputValueDefinition"/>.
     /// </summary>
-    protected virtual GraphQLInputValueDefinition ExportInputFieldDefinition(FieldType fieldType)
+    protected virtual GraphQLInputValueDefinition ExportInputValueDefinition(FieldType fieldType)
     {
         var ret = new GraphQLInputValueDefinition(new(fieldType.Name), ExportTypeReference(fieldType.ResolvedType!))
         {

--- a/src/GraphQL/Utilities/SchemaExporter.cs
+++ b/src/GraphQL/Utilities/SchemaExporter.cs
@@ -65,7 +65,7 @@ public class SchemaExporter
         // export types
         foreach (var type in Schema.AllTypes)
         {
-            if (!IsIntrospectionType(type.Name) && !IsBuiltInScalar(type.Name))
+            if (!IsIntrospectionType(type.Name) && !IsBuiltInScalar(type.Name) && !type.IsPrivate)
                 definitions.Add(ApplyExtend(ExportTypeDefinition(type), type));
         }
 
@@ -154,7 +154,8 @@ public class SchemaExporter
             var list = new List<GraphQLInputValueDefinition>(graphType.Fields.Count);
             foreach (var field in graphType.Fields)
             {
-                list.Add(ExportInputValueDefinition(field));
+                if (!field.IsPrivate)
+                    list.Add(ExportInputFieldDefinition(field));
             }
             fields = new(list);
         }
@@ -168,7 +169,7 @@ public class SchemaExporter
     /// <summary>
     /// Exports the specified <see cref="FieldType"/> as a <see cref="GraphQLInputValueDefinition"/>.
     /// </summary>
-    protected virtual GraphQLInputValueDefinition ExportInputValueDefinition(FieldType fieldType)
+    protected virtual GraphQLInputValueDefinition ExportInputFieldDefinition(FieldType fieldType)
     {
         var ret = new GraphQLInputValueDefinition(new(fieldType.Name), ExportTypeReference(fieldType.ResolvedType!))
         {
@@ -191,7 +192,8 @@ public class SchemaExporter
             var list = new List<GraphQLFieldDefinition>(graphType.Fields.Count);
             foreach (var field in graphType.Fields)
             {
-                list.Add(ExportFieldDefinition(field));
+                if (!field.IsPrivate)
+                    list.Add(ExportFieldDefinition(field));
             }
             fields = new(list);
         }
@@ -223,7 +225,8 @@ public class SchemaExporter
             var list = new List<GraphQLFieldDefinition>(graphType.Fields.Count);
             foreach (var field in graphType.Fields)
             {
-                list.Add(ExportFieldDefinition(field));
+                if (!field.IsPrivate)
+                    list.Add(ExportFieldDefinition(field));
             }
             fields = new(list);
         }
@@ -378,7 +381,7 @@ public class SchemaExporter
                 Type = new GraphQLNamedType(new(Schema.Query.Name))
             }
         };
-        if (Schema.Mutation != null)
+        if (Schema.Mutation != null && !Schema.Mutation.IsPrivate)
         {
             definitions.Add(new GraphQLRootOperationTypeDefinition()
             {
@@ -386,7 +389,7 @@ public class SchemaExporter
                 Type = new GraphQLNamedType(new(Schema.Mutation.Name))
             });
         }
-        if (Schema.Subscription != null)
+        if (Schema.Subscription != null && !Schema.Subscription.IsPrivate)
         {
             definitions.Add(new GraphQLRootOperationTypeDefinition()
             {

--- a/src/GraphQL/Utilities/TypeConfig.cs
+++ b/src/GraphQL/Utilities/TypeConfig.cs
@@ -30,6 +30,8 @@ public class TypeConfig : MetadataProvider
         set
         {
             _type = value;
+            if (value != null)
+                IsTypeOfFunc ??= value.IsInstanceOfType;
             ApplyMetadata(value);
         }
     }

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -28,7 +28,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitObject(IObjectGraphType type, ISchema schema)
     {
         // 1
-        if (type.Fields.Count == 0)
+        if (!type.IsPrivate && type.Fields.Count == 0)
             throw new InvalidOperationException($"An Object type '{type.Name}' must define one or more fields.");
 
         // 2.1
@@ -109,7 +109,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitInterface(IInterfaceGraphType type, ISchema schema)
     {
         // 1
-        if (type.Fields.Count == 0)
+        if (!type.IsPrivate && type.Fields.Count == 0)
             throw new InvalidOperationException($"An Interface type '{type.Name}' must define one or more fields.");
 
         // 2.1
@@ -187,7 +187,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitInputObject(IInputObjectGraphType type, ISchema schema)
     {
         // 1
-        if (type.Fields.Count == 0)
+        if (!type.IsPrivate && type.Fields.Count == 0)
             throw new InvalidOperationException($"An Input Object type '{type.Name}' must define one or more input fields.");
 
         // 2.1
@@ -266,7 +266,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitUnion(UnionGraphType type, ISchema schema)
     {
         // 1
-        if (type.PossibleTypes.Count == 0)
+        if (!type.IsPrivate && type.PossibleTypes.Count == 0)
             throw new InvalidOperationException($"A Union type '{type.Name}' must include one or more unique member types.");
 
         // 2 [requirement met by design]
@@ -281,7 +281,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitEnum(EnumerationGraphType type, ISchema schema)
     {
         // 1
-        if (type.Values.Count == 0)
+        if (!type.IsPrivate && type.Values.Count == 0)
             throw new InvalidOperationException($"An Enum type '{type.Name}' must define one or more unique enum values.");
     }
 

--- a/src/GraphQL/Validation/Rules/KnownTypeNames.cs
+++ b/src/GraphQL/Validation/Rules/KnownTypeNames.cs
@@ -24,9 +24,9 @@ public class KnownTypeNames : ValidationRuleBase
     private static readonly INodeVisitor _nodeVisitor = new MatchingNodeVisitor<GraphQLNamedType>(leave: (node, context) =>
     {
         var type = context.Schema.AllTypes[node.Name];
-        if (type == null)
+        if (type == null || type.IsPrivate)
         {
-            var typeNames = context.Schema.AllTypes.Dictionary.Values.Select(x => x.Name).ToArray();
+            var typeNames = context.Schema.AllTypes.Dictionary.Values.Where(x => !x.IsPrivate).Select(x => x.Name).ToArray();
             var suggestionList = StringUtils.SuggestionList(node.Name.StringValue, typeNames); //ISSUE:allocation
             context.ReportError(new KnownTypeNamesError(context, node, suggestionList));
         }


### PR DESCRIPTION
These are prerequisites for GraphQL Federation support in #3921 .  This PR targets v8.

## IsPrivate

Allows schema visitors to set `IGraphType.IsPrivate` or `IFieldType.IsPrivate` to effectively remove a graph type or field from the schema.  Introspection queries cannot see these graph types or fields, and requests cannot reference them.  This is the only viable solution currently because `SchemaTypes` builds a read-only list during initialization, and similarly the fields cannot be removed from graph types.

## SkipTypeCheck

For schema-first schemas, skips `IsTypeOf` checks, while allowing to set `IsTypeOf` for other scenarios.

