### PR TITLE
Add IsPrivate and SkipTypeCheck properties to IGraphType / IFieldType

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -363,6 +363,28 @@ Finally, if you simply need to map an interface list type to a concrete list typ
 ValueConverter.RegisterListConverterFactory(typeof(IList<>), typeof(List<>)); // default mapping is T[]
 ```
 
+### 10. `IGraphType.IsPrivate` and `IFieldType.IsPrivate` properties added
+
+Allows to set a graph type or field as private within a schema visitor, effectively removing it from the schema.
+Introspection queries will not be able to query the type/field, and queries will not be able to reference the type/field.
+Exporting the schema as a SDL (or printing it) will not include the private types or fields.
+
+Private types are fully 'resolved' and validated; you can obtain references to these types or fields in a schema validation
+visitor before they are removed from the schema. After initialization is complete, these types and fields will not be present
+within SchemaTypes or TypeFields. The only exception for validation is that private types are not required have any fields
+or, for interfaces and unions, possible types.
+
+This makes it possible to create a private type used within the schema but not exposed to the client. For instance,
+it is possible to dynamically create input object types to deserialize GraphQL Federation entity representations, which
+are normally sent via the `_Any` type.
+
+### 11. `IObjectGraphType.SkipTypeCheck` property added
+
+Allows to skip the type check for a specific object graph type during resolver execution. This is useful
+for schema-first schemas where the CLR type is not defined while the resolver is built, while allowing
+`IsTypeOf` to be set automatically for other use cases. Schema-first schemas will automatically set this
+property to `true` for all object graph types to retain the existing behavior.
+
 ## Breaking Changes
 
 ### 1. Query type is required
@@ -532,3 +554,8 @@ public interface IValidationRule
 
 It is recommended to inherit from `ValidationRuleBase` for custom validation rules
 and override only the methods you need to implement.
+
+### 13. New properties added to `IGraphType`, `IFieldType` and `IObjectGraphType`
+
+See the new features section for details on the new properties added to these interfaces.
+Unless you directly implement these interfaces, you should not be impacted by these changes.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2212,6 +2212,7 @@ namespace GraphQL.Types
         public object? DefaultValue { get; set; }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         public System.Func<object, object>? Parser { get; set; }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
@@ -2235,6 +2236,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public string TypeName { get; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public override bool Equals(object? obj) { }
@@ -2245,6 +2247,7 @@ namespace GraphQL.Types
         protected GraphType() { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         protected bool Equals(GraphQL.Types.IGraphType other) { }
         public override bool Equals(object? obj) { }
@@ -2284,10 +2287,12 @@ namespace GraphQL.Types
     public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
+        bool IsPrivate { get; set; }
         string Name { get; set; }
     }
     public interface IGraphType : GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
+        bool IsPrivate { get; set; }
         void Initialize(GraphQL.Types.ISchema schema);
     }
     public interface IGraphTypeFactory<out TGraphType>
@@ -2327,6 +2332,7 @@ namespace GraphQL.Types
     public interface IObjectGraphType : GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         System.Func<object, bool>? IsTypeOf { get; set; }
+        bool SkipTypeCheck { get; set; }
         void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType);
     }
     public interface IProvideDeprecationReason
@@ -2494,6 +2500,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public void Interface(System.Type type) { }
         public void Interface<TInterface>()
@@ -2934,6 +2941,18 @@ namespace GraphQL.Utilities
         public bool IncludeDescriptions { get; set; }
         public bool IncludeFederationTypes { get; set; }
         public System.StringComparison? StringComparison { get; set; }
+    }
+    public sealed class RemovePrivateTypesAndFieldsVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public static readonly GraphQL.Utilities.RemovePrivateTypesAndFieldsVisitor Instance;
+        public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
     }
     public class SchemaBuilder
     {

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2219,6 +2219,7 @@ namespace GraphQL.Types
         public object? DefaultValue { get; set; }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         public System.Func<object, object>? Parser { get; set; }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
@@ -2242,6 +2243,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public string TypeName { get; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public override bool Equals(object? obj) { }
@@ -2252,6 +2254,7 @@ namespace GraphQL.Types
         protected GraphType() { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         protected bool Equals(GraphQL.Types.IGraphType other) { }
         public override bool Equals(object? obj) { }
@@ -2291,10 +2294,12 @@ namespace GraphQL.Types
     public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
+        bool IsPrivate { get; set; }
         string Name { get; set; }
     }
     public interface IGraphType : GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
+        bool IsPrivate { get; set; }
         void Initialize(GraphQL.Types.ISchema schema);
     }
     public interface IGraphTypeFactory<out TGraphType>
@@ -2334,6 +2339,7 @@ namespace GraphQL.Types
     public interface IObjectGraphType : GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         System.Func<object, bool>? IsTypeOf { get; set; }
+        bool SkipTypeCheck { get; set; }
         void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType);
     }
     public interface IProvideDeprecationReason
@@ -2501,6 +2507,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public void Interface(System.Type type) { }
         public void Interface<TInterface>()
@@ -2948,6 +2955,18 @@ namespace GraphQL.Utilities
         public bool IncludeDescriptions { get; set; }
         public bool IncludeFederationTypes { get; set; }
         public System.StringComparison? StringComparison { get; set; }
+    }
+    public sealed class RemovePrivateTypesAndFieldsVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public static readonly GraphQL.Utilities.RemovePrivateTypesAndFieldsVisitor Instance;
+        public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
     }
     public class SchemaBuilder
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2147,6 +2147,7 @@ namespace GraphQL.Types
         public object? DefaultValue { get; set; }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         public System.Func<object, object>? Parser { get; set; }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
@@ -2170,6 +2171,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public string TypeName { get; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public override bool Equals(object? obj) { }
@@ -2180,6 +2182,7 @@ namespace GraphQL.Types
         protected GraphType() { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
+        public bool IsPrivate { get; set; }
         public string Name { get; set; }
         protected bool Equals(GraphQL.Types.IGraphType other) { }
         public override bool Equals(object? obj) { }
@@ -2212,10 +2215,12 @@ namespace GraphQL.Types
     public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
+        bool IsPrivate { get; set; }
         string Name { get; set; }
     }
     public interface IGraphType : GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
+        bool IsPrivate { get; set; }
         void Initialize(GraphQL.Types.ISchema schema);
     }
     public interface IGraphTypeFactory<out TGraphType>
@@ -2255,6 +2260,7 @@ namespace GraphQL.Types
     public interface IObjectGraphType : GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         System.Func<object, bool>? IsTypeOf { get; set; }
+        bool SkipTypeCheck { get; set; }
         void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType);
     }
     public interface IProvideDeprecationReason
@@ -2422,6 +2428,7 @@ namespace GraphQL.Types
         public GraphQL.Types.Interfaces Interfaces { get; }
         public System.Func<object, bool>? IsTypeOf { get; set; }
         public GraphQL.Types.ResolvedInterfaces ResolvedInterfaces { get; }
+        public bool SkipTypeCheck { get; set; }
         public void AddResolvedInterface(GraphQL.Types.IInterfaceGraphType graphType) { }
         public void Interface(System.Type type) { }
         public void Interface<TInterface>()
@@ -2862,6 +2869,18 @@ namespace GraphQL.Utilities
         public bool IncludeDescriptions { get; set; }
         public bool IncludeFederationTypes { get; set; }
         public System.StringComparison? StringComparison { get; set; }
+    }
+    public sealed class RemovePrivateTypesAndFieldsVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public static readonly GraphQL.Utilities.RemovePrivateTypesAndFieldsVisitor Instance;
+        public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
     }
     public class SchemaBuilder
     {

--- a/src/GraphQL.Tests/Utilities/Visitors/IsPrivateTests.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/IsPrivateTests.cs
@@ -1,0 +1,112 @@
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Tests.Utilities.Visitors;
+
+public class IsPrivateTests
+{
+    private readonly ISchema _schema;
+    private readonly IServiceProvider _provider;
+    private readonly IDocumentExecuter _executer;
+
+    public IsPrivateTests()
+    {
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddAutoSchema<MyQuery>());
+        _provider = services.BuildServiceProvider();
+        _schema = _provider.GetRequiredService<ISchema>();
+        _executer = _provider.GetRequiredService<IDocumentExecuter<ISchema>>();
+    }
+
+    [Fact]
+    public void VerifySchema()
+    {
+        var sdl = _schema.Print();
+        sdl.ShouldBe("""
+            schema {
+              query: MyQuery
+            }
+
+            type MyQuery {
+              favoriteProduct: Product!
+            }
+
+            type Product implements IProduct {
+              name: String!
+            }
+
+            interface IProduct {
+              name: String!
+            }
+            """, StringCompareShould.IgnoreLineEndings);
+    }
+
+    [Fact]
+    public async Task CannotRequestPrivateField()
+    {
+        var result = await _executer.ExecuteAsync(new()
+        {
+            Query = "{ hello }",
+            RequestServices = _provider,
+        });
+        var error = result.Errors.ShouldNotBeNull().ShouldHaveSingleItem();
+        error.Message.ShouldBe("Cannot query field 'hello' on type 'MyQuery'.");
+    }
+
+    [Fact]
+    public async Task CannotIntrospectPrivateType()
+    {
+        var result = await _executer.ExecuteAsync(new()
+        {
+            Query = """{ __type(name: "IProduct2") { name } }""",
+            RequestServices = _provider,
+        });
+        var resultString = new SystemTextJson.GraphQLSerializer().Serialize(result);
+        resultString.ShouldBe("""{"data":{"__type":null}}""");
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Interface, Inherited = true)]
+    private class PrivateAttribute : GraphQLAttribute
+    {
+        public override void Modify(FieldType fieldType, bool isInputType) => fieldType.IsPrivate = true;
+
+        public override void Modify(IGraphType graphType) => graphType.IsPrivate = true;
+    }
+
+    private class MyQuery
+    {
+        public static Product FavoriteProduct => new Product("Test");
+
+        [Private]
+        public static string Hello => "World";
+    }
+
+    [Implements(typeof(IProduct))]
+    private class Product : IProduct, IProduct2
+    {
+        public Product(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        [Private]
+        public string Test => "test2";
+    }
+
+    private interface IProduct
+    {
+        string Name { get; }
+
+        [Private]
+        string Test { get; }
+    }
+
+    [Private]
+    private interface IProduct2
+    {
+        string Name { get; }
+    }
+}

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -655,7 +655,7 @@ public abstract class ExecutionStrategy : IExecutionStrategy
             }
         }
 
-        if (objectType?.IsTypeOf != null && !objectType.IsTypeOf(result))
+        if (objectType?.IsTypeOf != null && !objectType.SkipTypeCheck && !objectType.IsTypeOf(result))
         {
             throw new InvalidOperationException($"'{result}' value of type '{result.GetType()}' is not allowed for '{objectType.Name}'. Either change IsTypeOf method of '{objectType.Name}' to accept this value or return another value from your resolver.");
         }

--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -11,6 +11,11 @@ public interface IObjectGraphType : IComplexGraphType, IImplementInterfaces
     Func<object, bool>? IsTypeOf { get; set; }
 
     /// <summary>
+    /// Instructs GraphQL.NET to skip type checking when a resolver of a field that returns this graph type returns an object.
+    /// </summary>
+    bool SkipTypeCheck { get; set; }
+
+    /// <summary>
     /// Adds an instance of <see cref="IInterfaceGraphType"/> to the list of interface instances supported by this object graph type.
     /// </summary>
     void AddResolvedInterface(IInterfaceGraphType graphType);
@@ -24,6 +29,9 @@ public class ObjectGraphType<[NotAGraphType] TSourceType> : ComplexGraphType<TSo
 {
     /// <inheritdoc/>
     public Func<object, bool>? IsTypeOf { get; set; }
+
+    /// <inheritdoc/>
+    public bool SkipTypeCheck { get; set; }
 
     /// <inheritdoc/>
     public ObjectGraphType()

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -107,4 +107,7 @@ public class FieldType : MetadataProvider, IFieldType
     /// Only applicable to fields of input graph types.
     /// </summary>
     public Action<object>? Validator { get; set; }
+
+    /// <inheritdoc/>
+    public bool IsPrivate { get; set; }
 }

--- a/src/GraphQL/Types/Fields/IFieldType.cs
+++ b/src/GraphQL/Types/Fields/IFieldType.cs
@@ -14,4 +14,9 @@ public interface IFieldType : IHaveDefaultValue, IMetadataReader, IMetadataWrite
     /// Gets or sets a list of arguments for the field.
     /// </summary>
     QueryArguments? Arguments { get; set; }
+
+    /// <summary>
+    /// Indicates that the field is not exposed through introspection and cannot be queried.
+    /// </summary>
+    bool IsPrivate { get; set; }
 }

--- a/src/GraphQL/Types/GraphQLTypeReference.cs
+++ b/src/GraphQL/Types/GraphQLTypeReference.cs
@@ -21,10 +21,17 @@ public sealed class GraphQLTypeReference : InterfaceGraphType, IObjectGraphType
     /// <summary>
     /// Returns the GraphQL type name that this reference is a placeholder for.
     /// </summary>
-    public string TypeName { get; private set; }
+    public string TypeName { get; }
 
     /// <inheritdoc/>
     public Func<object, bool>? IsTypeOf
+    {
+        get => throw Invalid();
+        set => throw Invalid();
+    }
+
+    /// <inheritdoc/>
+    public bool SkipTypeCheck
     {
         get => throw Invalid();
         set => throw Invalid();
@@ -64,6 +71,8 @@ public sealed class GraphQLClrOutputTypeReference<[NotAGraphType] T> : Interface
     }
 
     Func<object, bool>? IObjectGraphType.IsTypeOf { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    bool IObjectGraphType.SkipTypeCheck { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
     Interfaces IImplementInterfaces.Interfaces => throw new NotImplementedException();
 

--- a/src/GraphQL/Types/GraphType.cs
+++ b/src/GraphQL/Types/GraphType.cs
@@ -134,4 +134,7 @@ public abstract class GraphType : MetadataProvider, IGraphType
 
     /// <inheritdoc />
     public override int GetHashCode() => Name?.GetHashCode() ?? 0;
+
+    /// <inheritdoc/>
+    public bool IsPrivate { get; set; }
 }

--- a/src/GraphQL/Types/IGraphType.cs
+++ b/src/GraphQL/Types/IGraphType.cs
@@ -46,4 +46,9 @@ public interface IGraphType : IMetadataReader, IMetadataWriter, IProvideDescript
     /// Initializes the graph type.
     /// </summary>
     void Initialize(ISchema schema);
+
+    /// <summary>
+    /// Indicates that the graph type is not exposed through introspection and cannot be used as type conditions within queries.
+    /// </summary>
+    bool IsPrivate { get; set; }
 }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -489,6 +489,7 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
         SchemaValidationVisitor.Instance.Run(this);
         AppliedDirectivesValidationVisitor.Instance.Run(this);
         FieldTypeDefaultArgumentsVisitor.Instance.Run(this);
+        RemovePrivateTypesAndFieldsVisitor.Instance.Run(this); // This should be the last validation, so default field values are properly set.
     }
 
     /// <summary>

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -269,7 +269,7 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
         var typeFactory = ServiceProvider.GetService(typeof(IGraphTypeFactory<ObjectGraphType>)) as IGraphTypeFactory<ObjectGraphType>;
         var type = _types.TryGetValue(name, out var t)
             ? t as ObjectGraphType ?? throw new InvalidOperationException($"Type '{name} should be ObjectGraphType")
-            : typeFactory?.Create() ?? new ObjectGraphType();
+            : typeFactory?.Create() ?? new ObjectGraphType() { SkipTypeCheck = true };
 
         type.Name = name;
 

--- a/src/GraphQL/Utilities/TypeConfig.cs
+++ b/src/GraphQL/Utilities/TypeConfig.cs
@@ -30,6 +30,8 @@ public class TypeConfig : MetadataProvider
         set
         {
             _type = value;
+            if (value != null)
+                IsTypeOfFunc ??= value.IsInstanceOfType;
             ApplyMetadata(value);
         }
     }

--- a/src/GraphQL/Utilities/Visitors/RemovePrivateTypesAndFieldsVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/RemovePrivateTypesAndFieldsVisitor.cs
@@ -1,0 +1,111 @@
+using GraphQL.Types;
+using GraphQLParser;
+
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// Removes private types and fields from a schema.
+/// </summary>
+public sealed class RemovePrivateTypesAndFieldsVisitor : BaseSchemaNodeVisitor
+{
+    /// <summary>
+    /// A singleton instance of the <see cref="RemovePrivateTypesAndFieldsVisitor"/> class,
+    /// which can be used to visit a schema and remove private types and fields.
+    /// </summary>
+    public static readonly RemovePrivateTypesAndFieldsVisitor Instance = new();
+
+    private RemovePrivateTypesAndFieldsVisitor()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override void VisitSchema(ISchema schema)
+    {
+        if (schema.Query?.IsPrivate == true)
+            throw new InvalidOperationException("Schema's Query type must not be a private type.");
+        if (schema.Mutation?.IsPrivate == true)
+            schema.Mutation = null;
+        if (schema.Subscription?.IsPrivate == true)
+            schema.Subscription = null;
+
+        List<ROM>? typesToRemove = null;
+        foreach (var pair in schema.AllTypes.Dictionary)
+        {
+            if (pair.Value.IsPrivate)
+                (typesToRemove ??= new()).Add(pair.Key);
+        }
+        if (typesToRemove != null)
+        {
+            foreach (var key in typesToRemove)
+                schema.AllTypes.Dictionary.Remove(key);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInputObject(IInputObjectGraphType type, ISchema schema) => ExamineFields(type, type.Fields);
+
+    /// <inheritdoc/>
+    public override void VisitObject(IObjectGraphType type, ISchema schema)
+    {
+        ExamineFields(type, type.Fields);
+        var interfaceList = type.ResolvedInterfaces.List;
+        for (int i = interfaceList.Count - 1; i >= 0; i--)
+        {
+            if (interfaceList[i].IsPrivate)
+                interfaceList.RemoveAt(i);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInterface(IInterfaceGraphType type, ISchema schema)
+    {
+        ExamineFields(type, type.Fields);
+        // todo: remove inherited interfaces that are private (interface inheritance not currently supported by GraphQL.NET)
+        RemovePrivateTypes(type.PossibleTypes);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitUnion(UnionGraphType type, ISchema schema) => RemovePrivateTypes(type.PossibleTypes);
+
+    /// <inheritdoc/>
+    public override void VisitDirectiveArgumentDefinition(QueryArgument argument, Directive directive, ISchema schema)
+    {
+        if (argument.ResolvedType?.IsPrivate == true)
+            throw new InvalidOperationException($"Cannot reference the private type '{argument.ResolvedType.Name}' in a public directive argument '@{directive.Name}.{argument.Name}'.");
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema) => ValidateFieldArgument(type, field, argument);
+
+    /// <inheritdoc/>
+    public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema) => ValidateFieldArgument(type, field, argument);
+
+    private static void ValidateFieldArgument(IGraphType parentType, FieldType field, QueryArgument argument)
+    {
+        if (argument.ResolvedType?.IsPrivate == true)
+            throw new InvalidOperationException($"Cannot reference the private type '{argument.ResolvedType.Name}' in a public field argument '{parentType.Name}.{field.Name}.{argument.Name}'.");
+    }
+
+    private static void RemovePrivateTypes(PossibleTypes possibleTypes)
+    {
+        var list = possibleTypes.List;
+        for (int i = list.Count - 1; i >= 0; i--)
+        {
+            if (list[i].IsPrivate)
+                list.RemoveAt(i);
+        }
+    }
+
+    private static void ExamineFields(IGraphType parentType, TypeFields typeFields)
+    {
+        var fields = typeFields.List;
+        for (int i = fields.Count - 1; i >= 0; i--)
+        {
+            var field = fields[i];
+            if (field.IsPrivate)
+                fields.RemoveAt(i);
+            else if (field.ResolvedType?.IsPrivate == true)
+                throw new InvalidOperationException($"Cannot reference the private type '{field.ResolvedType.Name}' in a public field '{parentType.Name}.{field.Name}'.");
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -28,7 +28,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitObject(IObjectGraphType type, ISchema schema)
     {
         // 1
-        if (type.Fields.Count == 0)
+        if (!type.IsPrivate && type.Fields.Count == 0)
             throw new InvalidOperationException($"An Object type '{type.Name}' must define one or more fields.");
 
         // 2.1
@@ -109,7 +109,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitInterface(IInterfaceGraphType type, ISchema schema)
     {
         // 1
-        if (type.Fields.Count == 0)
+        if (!type.IsPrivate && type.Fields.Count == 0)
             throw new InvalidOperationException($"An Interface type '{type.Name}' must define one or more fields.");
 
         // 2.1
@@ -187,7 +187,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitInputObject(IInputObjectGraphType type, ISchema schema)
     {
         // 1
-        if (type.Fields.Count == 0)
+        if (!type.IsPrivate && type.Fields.Count == 0)
             throw new InvalidOperationException($"An Input Object type '{type.Name}' must define one or more input fields.");
 
         // 2.1
@@ -266,7 +266,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitUnion(UnionGraphType type, ISchema schema)
     {
         // 1
-        if (type.PossibleTypes.Count == 0)
+        if (!type.IsPrivate && type.PossibleTypes.Count == 0)
             throw new InvalidOperationException($"A Union type '{type.Name}' must include one or more unique member types.");
 
         // 2 [requirement met by design]
@@ -281,7 +281,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
     public override void VisitEnum(EnumerationGraphType type, ISchema schema)
     {
         // 1
-        if (type.Values.Count == 0)
+        if (!type.IsPrivate && type.Values.Count == 0)
             throw new InvalidOperationException($"An Enum type '{type.Name}' must define one or more unique enum values.");
     }
 


### PR DESCRIPTION
These are prerequisites for GraphQL Federation support in #3921 .  This PR targets v8.

## IsPrivate

Allows schema visitors to set `IGraphType.IsPrivate` or `IFieldType.IsPrivate` to remove a graph type or field from the schema after initialization.  Introspection queries cannot see these graph types or fields, and requests cannot reference them.  This is the only viable solution currently because `SchemaTypes` builds a read-only list during initialization, and similarly the fields cannot be removed from graph types.

## SkipTypeCheck

For schema-first schemas, skips `IsTypeOf` checks, while allowing to set `IsTypeOf` for other scenarios.

