### PR TITLE
Add another Modify overload to GraphQLAttribute

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -243,6 +243,7 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Utilities.FieldConfig field) { }
         public virtual void Modify(GraphQL.Utilities.TypeConfig type) { }
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -243,6 +243,7 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Utilities.FieldConfig field) { }
         public virtual void Modify(GraphQL.Utilities.TypeConfig type) { }
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -243,6 +243,7 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Utilities.FieldConfig field) { }
         public virtual void Modify(GraphQL.Utilities.TypeConfig type) { }
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }
     }

--- a/src/GraphQL/Attributes/GraphQLAttribute.cs
+++ b/src/GraphQL/Attributes/GraphQLAttribute.cs
@@ -49,6 +49,20 @@ namespace GraphQL
         }
 
         /// <summary>
+        /// Updates the properties of the specified <see cref="FieldType"/> as necessary
+        /// when adding a field to a graph type. Typically you should use <see cref="Modify(FieldType, bool)"/>
+        /// instead of this method unless you need the additional properties exposed in this method.
+        /// </summary>
+        /// <param name="graphType">The <see cref="IGraphType"/> the field will be added to.</param>
+        /// <param name="fieldType">The <see cref="FieldType"/> to update.</param>
+        /// <param name="memberInfo">The <see cref="MemberInfo"/> that the field was generated from.</param>
+        /// <param name="isInputType">Indicates if the graph type containing this field is an input type.</param>
+        /// <param name="ignore">Indicates that the field should not be added to the graph type.</param>
+        public virtual void Modify(IGraphType graphType, MemberInfo memberInfo, FieldType fieldType, bool isInputType, ref bool ignore)
+        {
+        }
+
+        /// <summary>
         /// Updates the properties of the specified <see cref="TypeInformation"/> as necessary.
         /// </summary>
         public virtual void Modify(TypeInformation typeInformation)

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -141,16 +141,16 @@ namespace GraphQL.Types
         /// <summary>
         /// Creates a <see cref="FieldType"/> for the specified <see cref="MemberInfo"/>.
         /// </summary>
-        internal static FieldType CreateField(MemberInfo memberInfo, Func<MemberInfo, TypeInformation> getTypeInformation, Action<FieldType, MemberInfo>? buildFieldType, bool isInputType)
+        internal static FieldType? CreateField(IGraphType graphType, MemberInfo memberInfo, Func<MemberInfo, TypeInformation> getTypeInformation, Action<FieldType, MemberInfo>? buildFieldType, bool isInputType)
         {
             var typeInformation = getTypeInformation(memberInfo);
-            var graphType = typeInformation.ConstructGraphType();
-            var fieldType = CreateField(memberInfo, graphType, isInputType);
+            var fieldGraphType = typeInformation.ConstructGraphType();
+            var fieldType = CreateField(memberInfo, fieldGraphType, isInputType);
             // set resolver, if applicable
             buildFieldType?.Invoke(fieldType, memberInfo);
             // apply field attributes after resolver has been set
-            ApplyFieldAttributes(memberInfo, fieldType, isInputType);
-            return fieldType;
+            ApplyFieldAttributes(graphType, memberInfo, fieldType, isInputType, out var ignore);
+            return ignore ? null : fieldType;
         }
 
         /// <summary>
@@ -186,13 +186,15 @@ namespace GraphQL.Types
         /// Applies <see cref="GraphQLAttribute"/>s defined on <paramref name="memberInfo"/> to <paramref name="fieldType"/>.
         /// Also scans the member's owning module and assembly for globally-applied attributes.
         /// </summary>
-        internal static void ApplyFieldAttributes(MemberInfo memberInfo, FieldType fieldType, bool isInputType)
+        internal static void ApplyFieldAttributes(IGraphType graphType, MemberInfo memberInfo, FieldType fieldType, bool isInputType, out bool ignore)
         {
             // Apply derivatives of GraphQLAttribute
             var attributes = memberInfo.GetGraphQLAttributes();
+            ignore = false;
             foreach (var attr in attributes)
             {
                 attr.Modify(fieldType, isInputType);
+                attr.Modify(graphType, memberInfo, fieldType, isInputType, ref ignore);
             }
         }
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInputObjectGraphType.cs
@@ -92,7 +92,7 @@ namespace GraphQL.Types
         /// May return <see langword="null"/> to skip a property.
         /// </summary>
         protected virtual FieldType? CreateField(MemberInfo memberInfo)
-            => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, null, true);
+            => AutoRegisteringHelper.CreateField(this, memberInfo, GetTypeInformation, null, true);
 
         /// <summary>
         /// Returns a list of properties or fields that should have fields created for them.

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -98,7 +98,7 @@ public class AutoRegisteringInterfaceGraphType<[DynamicallyAccessedMembers(Dynam
 
     /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.CreateField(MemberInfo)"/>
     protected virtual FieldType? CreateField(MemberInfo memberInfo)
-        => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, BuildFieldType, false);
+        => AutoRegisteringHelper.CreateField(this, memberInfo, GetTypeInformation, BuildFieldType, false);
 
     /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.BuildFieldType(FieldType, MemberInfo)"/>
     protected void BuildFieldType(FieldType fieldType, MemberInfo memberInfo)

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -103,7 +103,7 @@ namespace GraphQL.Types
         /// May return <see langword="null"/> to skip a member.
         /// </summary>
         protected virtual FieldType? CreateField(MemberInfo memberInfo)
-            => AutoRegisteringHelper.CreateField(memberInfo, GetTypeInformation, BuildFieldType, false);
+            => AutoRegisteringHelper.CreateField(this, memberInfo, GetTypeInformation, BuildFieldType, false);
 
         /// <inheritdoc cref="AutoRegisteringOutputHelper.BuildFieldType(MemberInfo, FieldType, Func{MemberInfo, LambdaExpression}, Func{Type, Func{FieldType, ParameterInfo, ArgumentInformation}}, Action{ParameterInfo, QueryArgument})"/>
         protected void BuildFieldType(FieldType fieldType, MemberInfo memberInfo)


### PR DESCRIPTION
Prerequisite for GraphQL Federation in #3921 .  Added to v7.9 as this is not a breaking change.  Will add to v8 release notes in a separate PR that targets `develop`.