### PR TITLE
Add IFieldMetadataWriter

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -26,7 +26,8 @@ Both interfaces extend `IProvideMetadata` with read/write access to the metadata
 Be sure not to write metadata during the execution of a query, as the same graph/field type instance may be used for
 multiple queries and you would run into concurrency issues.
 
-In addition, the `IFieldMetadataWriter` interface has been added to scoping extension methods to fields only.  For example:
+In addition, the `IFieldMetadataWriter` interface has been added to allow scoping extension methods to fields only.
+For example:
 
 ```csharp
 // adds the GraphQL Federation '@requires' directive to the field

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -31,9 +31,9 @@ For example:
 
 ```csharp
 // adds the GraphQL Federation '@requires' directive to the field
-public static TMetadataWriter Requires<TMetadataWriter>(this TMetadataWriter fieldType, string[] fields)
+public static TMetadataWriter Requires<TMetadataWriter>(this TMetadataWriter fieldType, string fields)
     where TMetadataWriter : IFieldMetadataWriter
-    => fieldType.Requires(string.Join(" ", fields));
+    => fieldType.ApplyDirective(PROVIDES_DIRECTIVE, d => d.AddArgument(new(FIELDS_ARGUMENT) { Value = fields }));
 ```
 
 ### 2. Built-in scalars may be overridden via DI registrations

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -5,7 +5,7 @@ See [issues](https://github.com/graphql-dotnet/graphql-dotnet/issues?q=milestone
 
 ## New Features
 
-### 1. `IMetadataReader` and `IMetadataWriter` interfaces added
+### 1. `IMetadataReader`, `IMetadataWriter` and `IFieldMetadataWriter` interfaces added
 
 This makes it convenient to add extension methods to graph types or fields that can be used to read or write metadata
 such as authentication information. Methods for `IMetadataWriter` types will appear on both field builders and graph/field
@@ -25,6 +25,15 @@ public static TMetadataBuilder RequireAdmin<TMetadataBuilder>(this TMetadataBuil
 Both interfaces extend `IProvideMetadata` with read/write access to the metadata contained within the graph or field type.
 Be sure not to write metadata during the execution of a query, as the same graph/field type instance may be used for
 multiple queries and you would run into concurrency issues.
+
+In addition, the `IFieldMetadataWriter` interface has been added to scoping extension methods to fields only.  For example:
+
+```csharp
+// adds the GraphQL Federation '@requires' directive to the field
+public static TMetadataWriter Requires<TMetadataWriter>(this TMetadataWriter fieldType, string[] fields)
+    where TMetadataWriter : IFieldMetadataWriter
+    => fieldType.Requires(string.Join(" ", fields));
+```
 
 ### 2. Built-in scalars may be overridden via DI registrations
 

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -866,7 +866,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class ConnectionBuilder<TSourceType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class ConnectionBuilder<TSourceType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
@@ -917,7 +917,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class ConnectionBuilder<TSourceType, TReturnType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class ConnectionBuilder<TSourceType, TReturnType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
@@ -951,7 +951,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class FieldBuilder<TSourceType, TReturnType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class FieldBuilder<TSourceType, TReturnType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2211,7 +2211,7 @@ namespace GraphQL.Types
         protected override GraphQL.Types.EnumValuesBase CreateValues() { }
         public override object? ParseValue(object? value) { }
     }
-    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
+    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         public FieldType() { }
         public GraphQL.Types.QueryArguments? Arguments { get; set; }
@@ -2290,7 +2290,8 @@ namespace GraphQL.Types
         GraphQL.Types.FieldType? GetField(GraphQLParser.ROM name);
         bool HasField(string name);
     }
-    public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
+    public interface IFieldMetadataWriter : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata { }
+    public interface IFieldType : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
         bool IsPrivate { get; set; }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2218,7 +2218,7 @@ namespace GraphQL.Types
         protected override GraphQL.Types.EnumValuesBase CreateValues() { }
         public override object? ParseValue(object? value) { }
     }
-    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
+    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         public FieldType() { }
         public GraphQL.Types.QueryArguments? Arguments { get; set; }
@@ -2297,7 +2297,8 @@ namespace GraphQL.Types
         GraphQL.Types.FieldType? GetField(GraphQLParser.ROM name);
         bool HasField(string name);
     }
-    public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
+    public interface IFieldMetadataWriter : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata { }
+    public interface IFieldType : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
         bool IsPrivate { get; set; }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -866,7 +866,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class ConnectionBuilder<TSourceType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class ConnectionBuilder<TSourceType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
@@ -917,7 +917,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class ConnectionBuilder<TSourceType, TReturnType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class ConnectionBuilder<TSourceType, TReturnType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
@@ -951,7 +951,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class FieldBuilder<TSourceType, TReturnType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class FieldBuilder<TSourceType, TReturnType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -833,7 +833,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class ConnectionBuilder<TSourceType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class ConnectionBuilder<TSourceType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
@@ -884,7 +884,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class ConnectionBuilder<TSourceType, TReturnType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class ConnectionBuilder<TSourceType, TReturnType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected ConnectionBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; set; }
@@ -918,7 +918,7 @@ namespace GraphQL.Builders
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
     }
-    public class FieldBuilder<TSourceType, TReturnType> : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
+    public class FieldBuilder<TSourceType, TReturnType> : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata
     {
         protected FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2146,7 +2146,7 @@ namespace GraphQL.Types
         protected override GraphQL.Types.EnumValuesBase CreateValues() { }
         public override object? ParseValue(object? value) { }
     }
-    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
+    public class FieldType : GraphQL.Utilities.MetadataProvider, GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IFieldType, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         public FieldType() { }
         public GraphQL.Types.QueryArguments? Arguments { get; set; }
@@ -2218,7 +2218,8 @@ namespace GraphQL.Types
         GraphQL.Types.FieldType? GetField(GraphQLParser.ROM name);
         bool HasField(string name);
     }
-    public interface IFieldType : GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
+    public interface IFieldMetadataWriter : GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideMetadata { }
+    public interface IFieldType : GraphQL.Types.IFieldMetadataWriter, GraphQL.Types.IHaveDefaultValue, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata, GraphQL.Types.IProvideResolvedType
     {
         GraphQL.Types.QueryArguments? Arguments { get; set; }
         bool IsPrivate { get; set; }

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -92,7 +92,7 @@ public static class ConnectionBuilder
 /// Builds a connection field for graphs that have the specified source type.
 /// </summary>
 // TODO: Remove in v5
-public class ConnectionBuilder<[NotAGraphType] TSourceType> : IMetadataWriter
+public class ConnectionBuilder<[NotAGraphType] TSourceType> : IFieldMetadataWriter
 {
     internal const string PAGE_SIZE_METADATA_KEY = "__ConnectionBuilder_PageSize";
 

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Builders;
 /// <summary>
 /// Builds a connection field for graphs that have the specified source and return type.
 /// </summary>
-public class ConnectionBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnType> : IMetadataWriter
+public class ConnectionBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnType> : IFieldMetadataWriter
 {
     private bool IsBidirectional => FieldType.Arguments?.Find("before")?.Type == typeof(StringGraphType) && FieldType.Arguments.Find("last")?.Type == typeof(IntGraphType);
 

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Builders;
 /// </summary>
 /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
 /// <typeparam name="TReturnType">The type of the return value of the resolver.</typeparam>
-public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnType> : IMetadataWriter
+public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnType> : IFieldMetadataWriter
 {
     /// <summary>
     /// Returns the generated field.

--- a/src/GraphQL/Types/Fields/IFieldMetadataWriter.cs
+++ b/src/GraphQL/Types/Fields/IFieldMetadataWriter.cs
@@ -1,0 +1,9 @@
+namespace GraphQL.Types;
+
+/// <summary>
+/// Provides basic capabilities for getting and setting arbitrary meta information on fields.
+/// This interface is implemented by field builders and field types for configuring metadata.
+/// </summary>
+public interface IFieldMetadataWriter : IMetadataWriter
+{
+}

--- a/src/GraphQL/Types/Fields/IFieldType.cs
+++ b/src/GraphQL/Types/Fields/IFieldType.cs
@@ -3,7 +3,7 @@ namespace GraphQL.Types;
 /// <summary>
 /// Represents a field of a graph type.
 /// </summary>
-public interface IFieldType : IHaveDefaultValue, IMetadataReader, IMetadataWriter, IProvideDescription, IProvideDeprecationReason
+public interface IFieldType : IHaveDefaultValue, IMetadataReader, IFieldMetadataWriter, IProvideDescription, IProvideDeprecationReason
 {
     /// <summary>
     /// Gets or sets the name of the field.

--- a/src/GraphQL/Types/IMetadataWriter.cs
+++ b/src/GraphQL/Types/IMetadataWriter.cs
@@ -2,7 +2,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// Provides basic capabilities for getting and setting arbitrary meta information.
-/// This interface is implemented by field builders, field types, graph types and schemas for configuring metadata,
+/// This interface is implemented by field builders, field types, graph types and schemas for configuring metadata.
 /// </summary>
 public interface IMetadataWriter : IProvideMetadata
 {

--- a/src/GraphQL/Types/IMetadataWriter.cs
+++ b/src/GraphQL/Types/IMetadataWriter.cs
@@ -2,7 +2,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// Provides basic capabilities for getting and setting arbitrary meta information.
-/// This interface is implemented by field builders and field types for configuring metadata.
+/// This interface is implemented by field builders, field types, graph types and schemas for configuring metadata,
 /// </summary>
 public interface IMetadataWriter : IProvideMetadata
 {


### PR DESCRIPTION
Note: `IFieldMetadataReader` is not added because this would only apply to `IFieldType`.  Extension methods designed for reading field metadata can scope to `IFieldType`, which inherits `IMetadataReader` for using other metadata-reading extension methods.

I did not see any existing extension methods to update with the `IFieldMetadataWriter` constraint.  Most of the methods that use `IMetadataWriter` are authorization methods which will apply to both schemas / objects / fields.