### PR TITLE
[WIP] Infer field nullability from NRT annotations

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -218,6 +218,7 @@ namespace GraphQL
         public static bool EnableReadDescriptionFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromXmlDocumentation { get; set; }
         public static bool EnableReflectionCaching { get; set; }
+        public static bool InferFieldNullabilityFromNRTAnnotations { get; set; }
         [System.Obsolete("The query root operation type must be provided and must be an Object type. See ht" +
             "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types")]
         public static bool RequireRootQueryType { get; set; }
@@ -2240,11 +2241,15 @@ namespace GraphQL.Types
         [System.Obsolete("Please call Field<TGraphType>(string name) instead.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>(string name)
             where TGraphType : GraphQL.Types.IGraphType { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<TReturnType>(string name, bool nullable = false) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable = false, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable = false, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
             "ned on it or just use AddField() method directly. This method may be removed in " +
             "a future release. For now you can continue to use this API but we do not encoura" +

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -218,6 +218,7 @@ namespace GraphQL
         public static bool EnableReadDescriptionFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromXmlDocumentation { get; set; }
         public static bool EnableReflectionCaching { get; set; }
+        public static bool InferFieldNullabilityFromNRTAnnotations { get; set; }
         [System.Obsolete("The query root operation type must be provided and must be an Object type. See ht" +
             "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types")]
         public static bool RequireRootQueryType { get; set; }
@@ -2240,11 +2241,15 @@ namespace GraphQL.Types
         [System.Obsolete("Please call Field<TGraphType>(string name) instead.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>(string name)
             where TGraphType : GraphQL.Types.IGraphType { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<TReturnType>(string name, bool nullable = false) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable = false, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable = false, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
             "ned on it or just use AddField() method directly. This method may be removed in " +
             "a future release. For now you can continue to use this API but we do not encoura" +

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -218,6 +218,7 @@ namespace GraphQL
         public static bool EnableReadDescriptionFromAttributes { get; set; }
         public static bool EnableReadDescriptionFromXmlDocumentation { get; set; }
         public static bool EnableReflectionCaching { get; set; }
+        public static bool InferFieldNullabilityFromNRTAnnotations { get; set; }
         [System.Obsolete("The query root operation type must be provided and must be an Object type. See ht" +
             "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types")]
         public static bool RequireRootQueryType { get; set; }
@@ -2175,11 +2176,15 @@ namespace GraphQL.Types
         [System.Obsolete("Please call Field<TGraphType>(string name) instead.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>(string name)
             where TGraphType : GraphQL.Types.IGraphType { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<TReturnType>(string name, bool nullable = false) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable = false, System.Type? type = null) { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable = false, System.Type? type = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
             "ned on it or just use AddField() method directly. This method may be removed in " +
             "a future release. For now you can continue to use this API but we do not encoura" +

--- a/src/GraphQL.Tests/Bugs/Bug1831.cs
+++ b/src/GraphQL.Tests/Bugs/Bug1831.cs
@@ -80,15 +80,15 @@ public class Bug1831InputGraphType : InputObjectGraphType<Bug1831Class>
 {
     public Bug1831InputGraphType()
     {
-        Field("id", x => x.Id, true, typeof(StringGraphType));
-        Field("rows", x => x.Rows, true, typeof(ListGraphType<Bug1831RowInputGraphType>));
+        Field("id", x => x.Id, typeof(StringGraphType));
+        Field("rows", x => x.Rows, typeof(ListGraphType<Bug1831RowInputGraphType>));
     }
 }
 public class Bug1831RowInputGraphType : InputObjectGraphType<Bug1831Row>
 {
     public Bug1831RowInputGraphType()
     {
-        Field("id", x => x.Id, true, typeof(StringGraphType));
-        Field("name", x => x.Name, true, typeof(StringGraphType));
+        Field("id", x => x.Id, typeof(StringGraphType));
+        Field("name", x => x.Name, typeof(StringGraphType));
     }
 }

--- a/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
+++ b/src/GraphQL.Tests/Subscription/SubscriptionSchema.cs
@@ -104,7 +104,7 @@ public class MessageType : ObjectGraphType<Message>
     {
         Field(o => o.Content);
         Field(o => o.SentAt);
-        Field(o => o.From, false, typeof(MessageFromType)).Resolve(ResolveFrom);
+        Field(o => o.From, typeof(MessageFromType)).Resolve(ResolveFrom);
     }
 
     private MessageFrom ResolveFrom(IResolveFieldContext<Message> context)

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -184,7 +184,7 @@ public class ComplexGraphTypeTests
     }
 
     [Fact]
-    public void accepts_property_expressions2()
+    public void infer_nullability_from_nrt()
     {
         var schema = new Schema();
         var type = new ComplexType<NrtTest>();

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -163,14 +163,62 @@ public class ComplexGraphTypeTests
     [Fact]
     public void accepts_property_expressions()
     {
+        bool old = GlobalSwitches.InferFieldNullabilityFromNRTAnnotations;
+        GlobalSwitches.InferFieldNullabilityFromNRTAnnotations = false;
+
+        try
+        {
+            var schema = new Schema();
+            var type = new ComplexType<Droid>();
+            _ = type.Field(d => d.Name);
+            schema.Query = type;
+            schema.Initialize();
+
+            type.Fields.Last().Name.ShouldBe("name");
+            type.Fields.Last().Type.ShouldBe(typeof(NonNullGraphType<StringGraphType>));
+        }
+        finally
+        {
+            GlobalSwitches.InferFieldNullabilityFromNRTAnnotations = old;
+        }
+    }
+
+    [Fact]
+    public void accepts_property_expressions2()
+    {
         var schema = new Schema();
-        var type = new ComplexType<Droid>();
-        _ = type.Field(d => d.Name);
+        var type = new ComplexType<NrtTest>();
+        _ = type.Field(d => d.Str1);
+        _ = type.Field(d => d.Str2);
+        _ = type.Field(d => d.List1);
+        _ = type.Field(d => d.List2);
+        _ = type.Field(d => d.List3);
         schema.Query = type;
         schema.Initialize();
 
-        type.Fields.Last().Name.ShouldBe("name");
-        type.Fields.Last().Type.ShouldBe(typeof(NonNullGraphType<StringGraphType>));
+        var field = type.Fields.FirstOrDefault(f => f.Name == "str1").ShouldNotBeNull();
+        field.Type.ShouldBe(typeof(NonNullGraphType<StringGraphType>));
+
+        field = type.Fields.FirstOrDefault(f => f.Name == "str2").ShouldNotBeNull();
+        field.Type.ShouldBe(typeof(StringGraphType));
+
+        field = type.Fields.FirstOrDefault(f => f.Name == "list1").ShouldNotBeNull();
+        field.Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>));
+
+        field = type.Fields.FirstOrDefault(f => f.Name == "list2").ShouldNotBeNull();
+        field.Type.ShouldBe(typeof(NonNullGraphType<ListGraphType<StringGraphType>>));
+
+        field = type.Fields.FirstOrDefault(f => f.Name == "list3").ShouldNotBeNull();
+        field.Type.ShouldBe(typeof(ListGraphType<StringGraphType>));
+    }
+
+    private class NrtTest
+    {
+        public string Str1 { get; set; }
+        public string? Str2 { get; set; }
+        public IList<string> List1 { get; set; }
+        public IList<string?> List2 { get; set; }
+        public IList<string?>? List3 { get; set; }
     }
 
     [Fact]
@@ -273,7 +321,7 @@ public class ComplexGraphTypeTests
     {
         var type = new ComplexType<TestObject>();
 
-        var exp = Should.Throw<ArgumentException>(() => type.Field(d => d.someInt));
+        var exp = Should.Throw<ArgumentException>(() => type.Field(d => d.someInt, nullable: false));
 
         exp.InnerException.ShouldNotBeNull().Message.ShouldStartWith("Explicitly nullable type: Nullable<Int32> cannot be coerced to a non nullable GraphQL type.");
     }

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -125,4 +125,9 @@ public static class GlobalSwitches
 #else
         System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled;
 #endif
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public static bool InferFieldNullabilityFromNRTAnnotations { get; set; } = true;
 }

--- a/src/GraphQL/Resolvers/IFieldResolver.cs
+++ b/src/GraphQL/Resolvers/IFieldResolver.cs
@@ -8,13 +8,13 @@ namespace GraphQL.Resolvers;
 /// </para><para>
 /// The <see cref="FieldType.Resolver"/> property defines the field resolver to be used for the field.
 /// </para><para>
-/// Typically an instance of <see cref="FuncFieldResolver{TSourceType, TReturnType}">FuncFieldResolver</see>
+/// Typically, an instance of <see cref="FuncFieldResolver{TSourceType, TReturnType}">FuncFieldResolver</see>
 /// is created when code needs to execute within the field resolver - typically by calling
 /// <see cref="Builders.FieldBuilder{TSourceType, TReturnType}">FieldBuilder</see>.<see cref="Builders.FieldBuilder{TSourceType, TReturnType}.Resolve(Func{IResolveFieldContext{TSourceType}, TReturnType})">Resolve</see>
 /// or <see cref="Builders.FieldBuilder{TSourceType, TReturnType}">FieldBuilder</see>.<see cref="Builders.FieldBuilder{TSourceType, TReturnType}.ResolveAsync(Func{IResolveFieldContext{TSourceType}, Task{TReturnType}})">ResolveAsync</see>.
 /// </para><para>
 /// When mapping fields to source object properties via
-/// <see cref="ComplexGraphType{TSourceType}.Field{TProperty}(System.Linq.Expressions.Expression{Func{TSourceType, TProperty}}, bool, Type)">Field(x => x.Name)</see>,
+/// <see cref="ComplexGraphType{TSourceType}.Field{TProperty}(System.Linq.Expressions.Expression{Func{TSourceType, TProperty}})">Field(x => x.Name)</see>,
 /// <see cref="ExpressionFieldResolver{TSourceType, TProperty}">ExpressionFieldResolver</see> is used.
 /// </para><para>
 /// When a field resolver is not defined, such as with <see cref="ComplexGraphType{TSourceType}.Field{TGraphType, TReturnType}(string)">Field("Name")</see>,


### PR DESCRIPTION
POC.

Fixes
- #3969

The `Field` methods accepting `Expression` were changed to prevent incompatible configurations. It's not possible anymore to configure `nullable` when `type` is defined because it will be ignored anyway.

All the overloads preserve their old behavior except the one accepting only expression.
```c#
Field(x => x.Name);
```
In this case, the type and its nullability will be inferred from NRT annotations. The old behavior can be configured with the global switch:
```c#
GlobalSwitches.InferFieldNullabilityFromNRTAnnotations = false;
```
Or by passing explicit `false` to `nullable` parameter
```c#
Field(x => x.Name, nullable: false);
```

Note that most of the changes are source-compatible. The only scenario in which the user will need to adjust the code is when the `nullable` and `type` are defined together. The user will need to remove the `nullable` argument.