### PR TITLE
Allow applied directives to be imported from another schema

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -688,7 +688,7 @@ options to the same url, or with a separate URL to link multiple schemas.
 
 ### 19. `FromSchemaUrl` added to `AppliedDirective`
 
-This supports using a directive that was separately imported via `@link`. After importing the schema as described
+This property supports using a directive that was separately imported via `@link`. After importing the schema as described
 above, apply imported directives to your schema similar to the example below:
 
 ```csharp

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -686,6 +686,21 @@ schema
 Note that you may call `LinkSchema` multiple times with the same URL to apply additional configuration
 options to the same url, or with a separate URL to link multiple schemas.
 
+### 19. `FromSchemaUrl` added to `AppliedDirective`
+
+This supports using a directive that was separately imported via `@link`. After importing the schema as described
+above, apply imported directives to your schema similar to the example below:
+
+```csharp
+graphType.ApplyDirective("shareable", s => s.FromSchemaUrl = "https://specs.apollo.dev/federation/"); // applies to any version
+// or
+graphType.ApplyDirective("shareable", s => s.FromSchemaUrl = "https://specs.apollo.dev/federation/v2.3"); // only version 2.3
+```
+
+During schema initialization, the name of the applied directive will be resolved to the fully-qualified name.
+In the above example, if `@shareable` was imported, the directive will be applied as `@shareable`, but if not, it will
+be applied as `@federation__shareable`. Aliases are also supported.
+
 ## Breaking Changes
 
 ### 1. Query type is required

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2064,6 +2064,7 @@ namespace GraphQL.Types
     {
         public AppliedDirective(string name) { }
         public int ArgumentsCount { get; }
+        public string? FromSchemaUrl { get; set; }
         public string Name { get; set; }
         public GraphQL.Types.AppliedDirective AddArgument(GraphQL.Types.DirectiveArgument argument) { }
         public GraphQL.Types.DirectiveArgument? FindArgument(string argumentName) { }
@@ -3471,6 +3472,24 @@ namespace GraphQL.Utilities.Visitors
             public System.Collections.Generic.List<string>? ImportedNamespaces { get; set; }
             public System.Collections.Generic.HashSet<string>? ImportedTypes { get; set; }
         }
+    }
+    public sealed class RenameImportedDirectivesVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public RenameImportedDirectivesVisitor(System.Collections.Generic.List<GraphQL.Utilities.LinkConfiguration> linkConfigurations) { }
+        public override void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitScalar(GraphQL.Types.ScalarGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
 }
 namespace GraphQL.Validation

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -964,6 +964,7 @@ namespace GraphQL.Builders
     {
         protected FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument(GraphQL.Types.IGraphType type, string name, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2064,6 +2064,7 @@ namespace GraphQL.Types
     {
         public AppliedDirective(string name) { }
         public int ArgumentsCount { get; }
+        public string? FromSchemaUrl { get; set; }
         public string Name { get; set; }
         public GraphQL.Types.AppliedDirective AddArgument(GraphQL.Types.DirectiveArgument argument) { }
         public GraphQL.Types.DirectiveArgument? FindArgument(string argumentName) { }
@@ -3485,6 +3486,24 @@ namespace GraphQL.Utilities.Visitors
             public System.Collections.Generic.List<string>? ImportedNamespaces { get; set; }
             public System.Collections.Generic.HashSet<string>? ImportedTypes { get; set; }
         }
+    }
+    public sealed class RenameImportedDirectivesVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public RenameImportedDirectivesVisitor(System.Collections.Generic.List<GraphQL.Utilities.LinkConfiguration> linkConfigurations) { }
+        public override void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitScalar(GraphQL.Types.ScalarGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
 }
 namespace GraphQL.Validation

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -964,6 +964,7 @@ namespace GraphQL.Builders
     {
         protected FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument(GraphQL.Types.IGraphType type, string name, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -931,6 +931,7 @@ namespace GraphQL.Builders
     {
         protected FieldBuilder(GraphQL.Types.FieldType fieldType) { }
         public GraphQL.Types.FieldType FieldType { get; }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument(GraphQL.Types.IGraphType type, string name, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument(System.Type type, string name, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2002,6 +2002,7 @@ namespace GraphQL.Types
     {
         public AppliedDirective(string name) { }
         public int ArgumentsCount { get; }
+        public string? FromSchemaUrl { get; set; }
         public string Name { get; set; }
         public GraphQL.Types.AppliedDirective AddArgument(GraphQL.Types.DirectiveArgument argument) { }
         public GraphQL.Types.DirectiveArgument? FindArgument(string argumentName) { }
@@ -3399,6 +3400,24 @@ namespace GraphQL.Utilities.Visitors
             public System.Collections.Generic.List<string>? ImportedNamespaces { get; set; }
             public System.Collections.Generic.HashSet<string>? ImportedTypes { get; set; }
         }
+    }
+    public sealed class RenameImportedDirectivesVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public RenameImportedDirectivesVisitor(System.Collections.Generic.List<GraphQL.Utilities.LinkConfiguration> linkConfigurations) { }
+        public override void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitEnumValue(GraphQL.Types.EnumValueDefinition value, GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObject(GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitScalar(GraphQL.Types.ScalarGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
 }
 namespace GraphQL.Validation

--- a/src/GraphQL.Tests/Utilities/LinkedSchemaTests.AppliedDirectivesAreProperlyRenamed.approved.txt
+++ b/src/GraphQL.Tests/Utilities/LinkedSchemaTests.AppliedDirectivesAreProperlyRenamed.approved.txt
@@ -1,0 +1,64 @@
+schema @link(import: ["@link"], url: "https://specs.apollo.dev/link/v1.0") @link(import: ["@importedA"], url: "https://spec.example.com/exampleA") @link(import: ["@importedB"], url: "https://spec.example.com/exampleB/v1.0") @link(as: "customC", import: [{as: "@aliasC", name: "@importedC"}], url: "https://spec.example.com/exampleC") {
+  query: Query
+}
+
+directive @aliasC on FIELD_DEFINITION
+
+directive @customC__testC on FIELD_DEFINITION
+
+directive @exampleA__testA on FIELD_DEFINITION
+
+directive @exampleB__testB on FIELD_DEFINITION
+
+directive @failB on FIELD_DEFINITION
+
+directive @importedA on FIELD_DEFINITION
+
+directive @importedB on FIELD_DEFINITION
+
+directive @link(as: String, import: [link__Import], purpose: link__Purpose, url: String!) repeatable on SCHEMA
+
+scalar link__Import
+
+enum link__Purpose {
+  "`EXECUTION` features provide metadata necessary for operation execution."
+  EXECUTION
+  "`SECURITY` features provide metadata necessary to securely resolve fields."
+  SECURITY
+}
+
+type Query {
+  field1: String @importedA
+  field10: String @aliasC
+  field11: String @customC__testC
+  field2: String @exampleA__testA
+  field3: String @failB
+  field4: String @importedB
+  field5: String @exampleB__testB
+  field6: String @failB
+  field7: String @importedB
+  field8: String @exampleB__testB
+  field9: String @failB
+}
+
+==== Without Imported Types ====
+
+schema @link(import: ["@link"], url: "https://specs.apollo.dev/link/v1.0") @link(import: ["@importedA"], url: "https://spec.example.com/exampleA") @link(import: ["@importedB"], url: "https://spec.example.com/exampleB/v1.0") @link(as: "customC", import: [{as: "@aliasC", name: "@importedC"}], url: "https://spec.example.com/exampleC") {
+  query: Query
+}
+
+directive @failB on FIELD_DEFINITION
+
+type Query {
+  field1: String @importedA
+  field10: String @aliasC
+  field11: String @customC__testC
+  field2: String @exampleA__testA
+  field3: String @failB
+  field4: String @importedB
+  field5: String @exampleB__testB
+  field6: String @failB
+  field7: String @importedB
+  field8: String @exampleB__testB
+  field9: String @failB
+}

--- a/src/GraphQL.Tests/Utilities/LinkedSchemaTests.AppliedDirectivesAreProperlyRenamedForAllLocations.approved.txt
+++ b/src/GraphQL.Tests/Utilities/LinkedSchemaTests.AppliedDirectivesAreProperlyRenamedForAllLocations.approved.txt
@@ -1,0 +1,98 @@
+schema @link(import: ["@link"], url: "https://specs.apollo.dev/link/v1.0") @link(import: [{as: "@testAlias", name: "@test"}], url: "https://spec.example.com/example") @testAlias {
+  query: Query
+  mutation: Mutation
+}
+
+directive @link(as: String, import: [link__Import], purpose: link__Purpose, url: String!) repeatable on SCHEMA
+
+directive @testAlias on ARGUMENT_DEFINITION | ENUM | ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | SCHEMA | UNION
+
+"The `Date` scalar type represents a year, month and day in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard."
+scalar Date @testAlias
+
+scalar link__Import
+
+enum link__Purpose {
+  "`EXECUTION` features provide metadata necessary for operation execution."
+  EXECUTION
+  "`SECURITY` features provide metadata necessary to securely resolve fields."
+  SECURITY
+}
+
+type Mutation {
+  createUser(input: UserInput @testAlias): User
+}
+
+interface Node @testAlias {
+  id: ID!
+}
+
+type Post {
+  title: String
+}
+
+type Query {
+  getUser(id: ID @testAlias): User
+}
+
+enum Role @testAlias {
+  ADMIN @testAlias
+  USER
+}
+
+union SearchResult @testAlias = Post | User
+
+type User @testAlias {
+  age: Int
+  id: ID! @testAlias
+  name: String @testAlias
+}
+
+input UserInput @testAlias {
+  age: Int
+  name: String! @testAlias
+}
+
+==== Without Imported Types ====
+
+schema @link(import: ["@link"], url: "https://specs.apollo.dev/link/v1.0") @link(import: [{as: "@testAlias", name: "@test"}], url: "https://spec.example.com/example") @testAlias {
+  query: Query
+  mutation: Mutation
+}
+
+"The `Date` scalar type represents a year, month and day in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard."
+scalar Date @testAlias
+
+type Mutation {
+  createUser(input: UserInput @testAlias): User
+}
+
+interface Node @testAlias {
+  id: ID!
+}
+
+type Post {
+  title: String
+}
+
+type Query {
+  getUser(id: ID @testAlias): User
+}
+
+enum Role @testAlias {
+  ADMIN @testAlias
+  USER
+}
+
+union SearchResult @testAlias = Post | User
+
+type User @testAlias {
+  age: Int
+  id: ID! @testAlias
+  name: String @testAlias
+}
+
+input UserInput @testAlias {
+  age: Int
+  name: String! @testAlias
+}

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -322,6 +322,25 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     }
 
     /// <summary>
+    /// Adds an argument to the field.
+    /// </summary>
+    /// <param name="type">The graph type of the argument.</param>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="configure">A delegate to further configure the argument.</param>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument(IGraphType type, string name, Action<QueryArgument>? configure = null)
+    {
+        var arg = new QueryArgument(type)
+        {
+            Name = name,
+        };
+        configure?.Invoke(arg);
+        FieldType.Arguments ??= new();
+        FieldType.Arguments.Add(arg);
+        return this;
+    }
+
+    /// <summary>
     /// Adds the specified collection of arguments to the field.
     /// </summary>
     /// <param name="arguments">Arguments to add.</param>

--- a/src/GraphQL/Extensions/SchemaExtensions.cs
+++ b/src/GraphQL/Extensions/SchemaExtensions.cs
@@ -484,7 +484,7 @@ public static class SchemaExtensions
                         link.ConfigureAppliedDirective(appliedDirective);
                         return;
                     }
-                    if (url == LinkConfiguration.LINK_URL)
+                    if (urlMatch == LinkConfiguration.LINK_URL)
                         linkInstalled = true;
                 }
             }

--- a/src/GraphQL/Federation/Extensions/FederationFieldMetadataExtensions.cs
+++ b/src/GraphQL/Federation/Extensions/FederationFieldMetadataExtensions.cs
@@ -21,7 +21,7 @@ public static class FederationFieldMetadataExtensions
     /// </remarks>
     public static TMetadataWriter Shareable<TMetadataWriter>(this TMetadataWriter graphType)
         where TMetadataWriter : IFieldMetadataWriter
-        => graphType.ApplyDirective(SHAREABLE_DIRECTIVE);
+        => graphType.ApplyDirective(SHAREABLE_DIRECTIVE, s => s.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL);
 
     /// <summary>
     /// Adds the "@override" directive to a GraphQL field.
@@ -39,7 +39,11 @@ public static class FederationFieldMetadataExtensions
     /// </remarks>
     public static TMetadataWriter Override<TMetadataWriter>(this TMetadataWriter fieldType, string from)
         where TMetadataWriter : IFieldMetadataWriter
-        => fieldType.ApplyDirective(OVERRIDE_DIRECTIVE, d => d.AddArgument(new(FROM_ARGUMENT) { Value = from }));
+        => fieldType.ApplyDirective(OVERRIDE_DIRECTIVE, d =>
+        {
+            d.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL;
+            d.AddArgument(new(FROM_ARGUMENT) { Value = from });
+        });
 
     /// <summary>
     /// Adds the "@external" directive to a GraphQL field.
@@ -56,7 +60,7 @@ public static class FederationFieldMetadataExtensions
     /// </remarks>
     public static TMetadataWriter External<TMetadataWriter>(this TMetadataWriter fieldType)
         where TMetadataWriter : IFieldMetadataWriter
-        => fieldType.ApplyDirective(EXTERNAL_DIRECTIVE);
+        => fieldType.ApplyDirective(EXTERNAL_DIRECTIVE, c => c.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL);
 
     /// <summary>
     /// Adds the "@provides" directive to a GraphQL field.
@@ -92,7 +96,11 @@ public static class FederationFieldMetadataExtensions
     /// </remarks>
     public static TMetadataWriter Provides<TMetadataWriter>(this TMetadataWriter fieldType, string fields)
         where TMetadataWriter : IFieldMetadataWriter
-        => fieldType.ApplyDirective(PROVIDES_DIRECTIVE, d => d.AddArgument(new(FIELDS_ARGUMENT) { Value = fields }));
+        => fieldType.ApplyDirective(PROVIDES_DIRECTIVE, d =>
+        {
+            d.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL;
+            d.AddArgument(new(FIELDS_ARGUMENT) { Value = fields });
+        });
 
     /// <summary>
     /// Adds the "@requires" directive to a GraphQL field.
@@ -130,5 +138,9 @@ public static class FederationFieldMetadataExtensions
     /// </remarks>
     public static TMetadataWriter Requires<TMetadataWriter>(this TMetadataWriter fieldType, string fields)
         where TMetadataWriter : IFieldMetadataWriter
-        => fieldType.ApplyDirective(REQUIRES_DIRECTIVE, d => d.AddArgument(new(FIELDS_ARGUMENT) { Value = fields }));
+        => fieldType.ApplyDirective(REQUIRES_DIRECTIVE, d =>
+        {
+            d.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL;
+            d.AddArgument(new(FIELDS_ARGUMENT) { Value = fields });
+        });
 }

--- a/src/GraphQL/Federation/Extensions/FederationInterfaceMetadataExtensions.cs
+++ b/src/GraphQL/Federation/Extensions/FederationInterfaceMetadataExtensions.cs
@@ -44,6 +44,7 @@ public static class FederationInterfaceMetadataExtensions
         where TMetadataWriter : IMetadataWriter, IInterfaceGraphType
         => graphType.ApplyDirective(KEY_DIRECTIVE, d =>
         {
+            d.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL;
             d.AddArgument(new(FIELDS_ARGUMENT) { Value = fields });
             if (!resolvable)
                 d.AddArgument(new(RESOLVABLE_ARGUMENT) { Value = false });

--- a/src/GraphQL/Federation/Extensions/FederationMetadataExtensions.cs
+++ b/src/GraphQL/Federation/Extensions/FederationMetadataExtensions.cs
@@ -24,5 +24,5 @@ public static class FederationMetadataExtensions
     /// </remarks>
     public static TMetadataWriter Inaccessible<TMetadataWriter>(this TMetadataWriter graphType)
         where TMetadataWriter : IMetadataWriter
-        => graphType.ApplyDirective(INACCESSIBLE_DIRECTIVE);
+        => graphType.ApplyDirective(INACCESSIBLE_DIRECTIVE, c => c.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL);
 }

--- a/src/GraphQL/Federation/Extensions/FederationObjectMetadataExtensions.cs
+++ b/src/GraphQL/Federation/Extensions/FederationObjectMetadataExtensions.cs
@@ -16,6 +16,7 @@ public static class FederationObjectMetadataExtensions
         where TMetadataWriter : IMetadataWriter, IObjectGraphType
         => graphType.ApplyDirective(KEY_DIRECTIVE, d =>
         {
+            d.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL;
             d.AddArgument(new(FIELDS_ARGUMENT) { Value = fields });
             if (!resolvable)
                 d.AddArgument(new(RESOLVABLE_ARGUMENT) { Value = false });
@@ -36,7 +37,7 @@ public static class FederationObjectMetadataExtensions
     /// </remarks>
     public static TMetadataWriter Shareable<TMetadataWriter>(this TMetadataWriter graphType)
         where TMetadataWriter : IMetadataWriter, IObjectGraphType
-        => graphType.ApplyDirective(SHAREABLE_DIRECTIVE);
+        => graphType.ApplyDirective(SHAREABLE_DIRECTIVE, c => c.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL);
 
     /// <summary>
     /// Adds the "@external" directive to a GraphQL type.
@@ -53,5 +54,5 @@ public static class FederationObjectMetadataExtensions
     /// </remarks>
     public static TMetadataWriter External<TMetadataWriter>(this TMetadataWriter fieldType)
         where TMetadataWriter : IMetadataWriter, IObjectGraphType
-        => fieldType.ApplyDirective(EXTERNAL_DIRECTIVE);
+        => fieldType.ApplyDirective(EXTERNAL_DIRECTIVE, c => c.FromSchemaUrl = FEDERATION_LINK_SCHEMA_URL);
 }

--- a/src/GraphQL/Federation/FederationHelper.cs
+++ b/src/GraphQL/Federation/FederationHelper.cs
@@ -9,6 +9,7 @@ internal static class FederationHelper
     public const string RESOLVER_METADATA = "__FedResolver__";
     public const string FEDERATION_RESOLVER_FIELD = "_FederationResolverField_";
     public const string LINK_SCHEMA_EXTENSION_METADATA = "__FedLinkSchemaExtension__";
+    public const string FEDERATION_LINK_SCHEMA_URL = "https://specs.apollo.dev/federation/";
 
     public const string LINK_DIRECTIVE = "link";
     public const string KEY_DIRECTIVE = "key";

--- a/src/GraphQL/Types/Directives/AppliedDirective.cs
+++ b/src/GraphQL/Types/Directives/AppliedDirective.cs
@@ -35,6 +35,17 @@ public class AppliedDirective : MetadataProvider, IEnumerable<DirectiveArgument>
     }
 
     /// <summary>
+    /// Indicates the schema url that this directive was imported from via the @link directive.
+    /// Use a trailing slash to match any version of the specified schema. Upon schema initialization,
+    /// the directive name will be updated to match the alias defined in the @link directive.
+    /// <code>
+    /// FromSchemaUrl = "https://example.com/schema/"; // matches any version of the schema such as https://example.com/schema/v2.3
+    /// FromSchemaUrl = "https://example.com/schema/v1.0"; // matches only the specified version of the schema
+    /// </code>
+    /// </summary>
+    public string? FromSchemaUrl { get; set; }
+
+    /// <summary>
     /// Returns the number of directive arguments.
     /// </summary>
     public int ArgumentsCount => List?.Count ?? 0;

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -486,11 +486,20 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
         //TODO: add different validations, also see SchemaBuilder.Validate
         //TODO: checks for parsed SDL may be expanded in the future, see https://github.com/graphql/graphql-spec/issues/653
         // Do not change the order of these validations.
+
+        // coerce input field or argument default values properly
         CoerceInputTypeDefaultValues();
+        // parse @link directives defined via schema-first
         ParseLinkVisitor.Instance.Run(this);
+        // rename any applied directives that were imported from another schema to use the alias defined in the @link directive or the proper namespace
+        RenameImportedDirectivesVisitor.Run(this);
+        // run general schema validation code
         SchemaValidationVisitor.Instance.Run(this);
+        // validate that all applied directives are valid
         AppliedDirectivesValidationVisitor.Instance.Run(this);
+        // initialize default field arguments for optimized execution
         FieldTypeDefaultArgumentsVisitor.Instance.Run(this);
+        // removes types and fields that have IsPrivate set
         RemovePrivateTypesAndFieldsVisitor.Instance.Run(this); // This should be the last validation, so default field values are properly set.
     }
 

--- a/src/GraphQL/Utilities/Visitors/RenameImportedDirectivesVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/RenameImportedDirectivesVisitor.cs
@@ -72,7 +72,7 @@ public sealed class RenameImportedDirectivesVisitor : BaseSchemaNodeVisitor
     private void VisitNode(IMetadataReader metadataReader)
     {
         var appliedDirectives = metadataReader.GetAppliedDirectives();
-        if (appliedDirectives == null || appliedDirectives.List == null)
+        if (appliedDirectives?.List == null)
             return;
 
         foreach (var appliedDirective in appliedDirectives.List)

--- a/src/GraphQL/Utilities/Visitors/RenameImportedDirectivesVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/RenameImportedDirectivesVisitor.cs
@@ -1,0 +1,93 @@
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Visitors;
+
+/// <summary>
+/// Visitor that renames imported directives based on the @link directive.
+/// </summary>
+public sealed class RenameImportedDirectivesVisitor : BaseSchemaNodeVisitor
+{
+    private readonly List<LinkConfiguration> _linkConfigurations;
+
+    /// <inheritdoc cref="RenameImportedDirectivesVisitor"/>
+    public RenameImportedDirectivesVisitor(List<LinkConfiguration> linkConfigurations)
+    {
+        _linkConfigurations = linkConfigurations;
+    }
+
+    /// <inheritdoc cref="SchemaExtensions.Run(ISchemaNodeVisitor, ISchema)"/>
+    public static void Run(ISchema schema)
+    {
+        var appliedDirectives = schema.GetAppliedDirectives();
+        if (appliedDirectives == null)
+            return;
+
+        List<LinkConfiguration>? links = null;
+        foreach (var appliedDirective in appliedDirectives)
+        {
+            var link = LinkConfiguration.GetConfiguration(appliedDirective);
+            if (link == null)
+                continue;
+            links ??= new();
+            links.Add(link);
+        }
+
+        if (links == null)
+            return;
+        var visitor = new RenameImportedDirectivesVisitor(links);
+        visitor.Run(schema);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitEnum(EnumerationGraphType type, ISchema schema) => VisitNode(type);
+    /// <inheritdoc/>
+    public override void VisitEnumValue(EnumValueDefinition value, EnumerationGraphType type, ISchema schema) => VisitNode(value);
+    /// <inheritdoc/>
+    public override void VisitInputObject(IInputObjectGraphType type, ISchema schema) => VisitNode(type);
+    /// <inheritdoc/>
+    public override void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema) => VisitNode(field);
+    /// <inheritdoc/>
+    public override void VisitInterface(IInterfaceGraphType type, ISchema schema) => VisitNode(type);
+    /// <inheritdoc/>
+    public override void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema) => VisitNode(argument);
+    /// <inheritdoc/>
+    public override void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema) => VisitNode(field);
+    /// <inheritdoc/>
+    public override void VisitObject(IObjectGraphType type, ISchema schema) => VisitNode(type);
+    /// <inheritdoc/>
+    public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema) => VisitNode(argument);
+    /// <inheritdoc/>
+    public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema) => VisitNode(field);
+    /// <inheritdoc/>
+    public override void VisitScalar(ScalarGraphType type, ISchema schema) => VisitNode(type);
+    /// <inheritdoc/>
+    public override void VisitSchema(ISchema schema) => VisitNode(schema);
+    /// <inheritdoc/>
+    public override void VisitUnion(UnionGraphType type, ISchema schema) => VisitNode(type);
+
+    /// <summary>
+    /// Scan all applied directives to see if any were imported from another schema, and if so,
+    /// rename them with the appropriate alias as defined by the @link directive.
+    /// </summary>
+    private void VisitNode(IMetadataReader metadataReader)
+    {
+        var appliedDirectives = metadataReader.GetAppliedDirectives();
+        if (appliedDirectives == null || appliedDirectives.List == null)
+            return;
+
+        foreach (var appliedDirective in appliedDirectives.List)
+        {
+            if (appliedDirective.FromSchemaUrl == null)
+                continue;
+
+            foreach (var link in _linkConfigurations)
+            {
+                if (appliedDirective.FromSchemaUrl.EndsWith("/") ? link.Url.StartsWith(appliedDirective.FromSchemaUrl) : link.Url == appliedDirective.FromSchemaUrl)
+                {
+                    appliedDirective.Name = link.NameForDirective(appliedDirective.Name);
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Now that schemas can be linked, the next step is to make it so that directives that are imported get automatically renamed properly.  This PR adds `FromSchemaUrl` to `AppliedDirective` to allow specifying the schema url that the directive is imported from.  During schema initiailization, any directive that has a `FromSchemaUrl` that matches an `@link` directive will get the proper alias applied to it.  By design, if no match, it is unaffected.  All Federation directives have been updated.