### PR TITLE
Update GetRecursivelyReferencedFragments to allow retrieving only used fragments

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -777,6 +777,13 @@ type Person {
 }
 ```
 
+### 22. `ValidationContext.GetRecursivelyReferencedFragments` updated with `@skip` and `@include` directive support
+
+When developing a custom validation rule, such as an authorization rule, you may need to determine which fragments are
+recursively referenced by an operation by calling `GetRecursivelyReferencedFragments` with the `onlyUsed` argument
+set to `true`. The method will then ignore fragments that are conditionally skipped by the `@skip` or `@include`
+directives.
+
 ## Breaking Changes
 
 ### 1. Query type is required

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3634,8 +3634,8 @@ namespace GraphQL.Validation
         public GraphQL.Inputs Variables { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentSpread> GetFragmentSpreads(GraphQLParser.AST.GraphQLSelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetRecursiveVariables(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationDefinition> operations) { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation, bool onlyUsed = false) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetVariables<TNode>(TNode node)
             where TNode : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasSelectionSetNode { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
@@ -3644,6 +3644,7 @@ namespace GraphQL.Validation
         public System.Threading.Tasks.ValueTask<System.ValueTuple<GraphQL.Validation.Variables, System.Collections.Generic.List<GraphQL.Validation.ValidationError>?>> GetVariablesValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQLParser.AST.GraphQLValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
+        protected virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
     }
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3648,8 +3648,8 @@ namespace GraphQL.Validation
         public GraphQL.Inputs Variables { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentSpread> GetFragmentSpreads(GraphQLParser.AST.GraphQLSelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetRecursiveVariables(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationDefinition> operations) { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation, bool onlyUsed = false) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetVariables<TNode>(TNode node)
             where TNode : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasSelectionSetNode { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
@@ -3658,6 +3658,7 @@ namespace GraphQL.Validation
         public System.Threading.Tasks.ValueTask<System.ValueTuple<GraphQL.Validation.Variables, System.Collections.Generic.List<GraphQL.Validation.ValidationError>?>> GetVariablesValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQLParser.AST.GraphQLValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
+        protected virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
     }
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3562,8 +3562,8 @@ namespace GraphQL.Validation
         public GraphQL.Inputs Variables { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentSpread> GetFragmentSpreads(GraphQLParser.AST.GraphQLSelectionSet node) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetRecursiveVariables(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation) { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationDefinition> operations) { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLParser.AST.GraphQLOperationDefinition operation, bool onlyUsed = false) { }
         public System.Collections.Generic.List<GraphQL.Validation.VariableUsage>? GetVariables<TNode>(TNode node)
             where TNode : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasSelectionSetNode { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
@@ -3572,6 +3572,7 @@ namespace GraphQL.Validation
         public System.Threading.Tasks.ValueTask<System.ValueTuple<GraphQL.Validation.Variables, System.Collections.Generic.List<GraphQL.Validation.ValidationError>?>> GetVariablesValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQLParser.AST.GraphQLValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
+        protected virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
     }
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError

--- a/src/GraphQL/Validation/ValidationContext.GetRecursivelyReferencedFragments.cs
+++ b/src/GraphQL/Validation/ValidationContext.GetRecursivelyReferencedFragments.cs
@@ -1,3 +1,4 @@
+using GraphQL.Types;
 using GraphQLParser;
 using GraphQLParser.AST;
 using GraphQLParser.Visitors;
@@ -6,28 +7,125 @@ namespace GraphQL.Validation;
 
 public partial class ValidationContext
 {
-    private static readonly GetRecursivelyReferencedFragmentsVisitor _visitor = new();
-    private readonly Dictionary<GraphQLOperationDefinition, List<GraphQLFragmentDefinition>?> _fragments = new();
+    private Dictionary<GraphQLOperationDefinition, List<GraphQLFragmentDefinition>?>? _fragments = new();
+    private Dictionary<GraphQLOperationDefinition, List<GraphQLFragmentDefinition>?>? _usedFragments = new();
+    private bool? _noFragments;
 
     /// <summary>
-    /// For a specified operation within a document, returns a list of all fragment definitions in use.
+    /// For a specified operation within a document, returns a list of all fragment definitions referenced by
+    /// the specified operation, or <see langword="null"/> if there are none. When specified by the <paramref name="onlyUsed"/>
+    /// parameter, returns only the fragments that are not skipped by the @skip or @include directive.
     /// </summary>
-    public List<GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLOperationDefinition operation)
+    public List<GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(GraphQLOperationDefinition operation, bool onlyUsed = false)
     {
-        if (_fragments.TryGetValue(operation, out var results)) //TODO: possible remove from cache
+        // if we have already determined that there are no fragments in the document, return null
+        if (_noFragments == true)
+            return null;
+
+        // if we have already determined that there are fragments in the document, check if the fragments have already been calculated
+        if (_noFragments == false)
         {
-            return results;
+            if ((onlyUsed ? _usedFragments : _fragments)?.TryGetValue(operation, out var results) == true)
+            {
+                return results;
+            }
+        }
+        else
+        {
+            // check if there are no fragments in the document (common scenario)
+            _noFragments = true;
+            foreach (var def in Document.Definitions)
+            {
+                if (def is GraphQLFragmentDefinition)
+                {
+                    _noFragments = false;
+                    break;
+                }
+            }
+
+            // no fragments were found
+            if (_noFragments == true)
+                return null;
         }
 
-        var context = new GetRecursivelyReferencedFragmentsVisitorContext(this);
-        _visitor.VisitAsync(operation.SelectionSet, context).GetAwaiter().GetResult();
+        // if we found a fragment, visit the document to find all referenced fragments
+        var context = new GetRecursivelyReferencedFragmentsVisitorContext(this, onlyUsed);
+        GetRecursivelyReferencedFragmentsVisitor.Instance.VisitAsync(operation.SelectionSet, context).GetAwaiter().GetResult();
         var fragments = context.GetFragments(reset: true);
-        _fragments[operation] = fragments;
+        (onlyUsed ? _usedFragments ??= new() : _fragments ??= new())[operation] = fragments;
         return fragments;
     }
 
+    // TODO: deduplicate with ExecutionStrategy.ShouldIncludeNode
+    /// <inheritdoc cref="Execution.ExecutionStrategy.ShouldIncludeNode{TASTNode}(Execution.ExecutionContext, TASTNode)"/>
+    /// <remarks>
+    /// Ignores typical parsing, so if BooleanGraphType is overridden (e.g. to coerce strings to booleans), this method
+    /// will not reflect the change. Also ignores any overridden behavior within
+    /// <see cref="Execution.ExecutionStrategy.ShouldIncludeNode{TASTNode}(Execution.ExecutionContext, TASTNode)">ExecutionStrategy.ShouldIncludeNode</see>.
+    /// </remarks>
+    protected virtual bool ShouldIncludeNode(ASTNode node)
+    {
+        // according to GraphQL spec, directives with the same name may be defined so long as they cannot be
+        // placed on the same node types as other directives with the same name; so here we verify that the
+        // node is a field, fragment spread, or inline fragment, the only nodes allowed by the built-in @skip
+        // and @include directives
+        if (node is not GraphQLField && node is not GraphQLFragmentSpread && node is not GraphQLInlineFragment)
+            return true;
+
+        var directives = ((IHasDirectivesNode)node).Directives;
+        if (directives == null)
+            return true;
+
+        var skipDirective = directives.Find("skip");
+        if (skipDirective != null)
+        {
+            var value = GetDirectiveValue(skipDirective, false);
+            if (value)
+                return false;
+        }
+
+        var includeDirective = directives.Find("include");
+        if (includeDirective != null)
+        {
+            var value = GetDirectiveValue(includeDirective, true);
+            if (!value)
+                return false;
+        }
+
+        return true;
+
+        bool GetDirectiveValue(GraphQLDirective directive, bool defaultValue)
+        {
+            var ifArg = directive.Arguments?.Find("if");
+            if (ifArg != null)
+            {
+                if (ifArg.Value is GraphQLBooleanValue boolValue)
+                {
+                    return boolValue.BoolValue;
+                }
+                else if (ifArg.Value is GraphQLVariable variable && Operation.Variables != null)
+                {
+                    foreach (var varDef in Operation.Variables.Items)
+                    {
+                        if (varDef.Variable.Name == variable.Name)
+                        {
+                            return varDef.Type.Name() == "Boolean"
+                                ? (Variables.TryGetValue(variable.Name.StringValue, out var value) && value is bool boolValue2
+                                    ? boolValue2
+                                    : varDef.DefaultValue is GraphQLBooleanValue boolValue3
+                                    ? boolValue3.BoolValue
+                                    : defaultValue) // invalid default value or error: variable not specified
+                                : defaultValue; // error: variable type is not Boolean
+                        }
+                    }
+                }
+            }
+            return defaultValue; // error: no "if" argument or invalid argument value
+        }
+    }
+
     /// <summary>
-    /// For a specified operations within a document, returns a list of all fragment definitions in use.
+    /// For a specified operations within a document, returns a list of all fragment definitions in use, or <see langword="null"/> if there are none.
     /// </summary>
     public List<GraphQLFragmentDefinition>? GetRecursivelyReferencedFragments(List<GraphQLOperationDefinition> operations)
     {
@@ -51,10 +149,13 @@ public partial class ValidationContext
     // struct intentionally - works only on stack
     private readonly struct GetRecursivelyReferencedFragmentsVisitorContext : IASTVisitorContext
     {
-        public GetRecursivelyReferencedFragmentsVisitorContext(ValidationContext validationContext)
+        public GetRecursivelyReferencedFragmentsVisitorContext(ValidationContext validationContext, bool onlyUsedFragments)
         {
             ValidationContext = validationContext;
+            OnlyUsedFragments = onlyUsedFragments;
         }
+
+        public bool OnlyUsedFragments { get; }
 
         public ValidationContext ValidationContext { get; }
 
@@ -69,6 +170,21 @@ public partial class ValidationContext
 
     private sealed class GetRecursivelyReferencedFragmentsVisitor : ASTVisitor<GetRecursivelyReferencedFragmentsVisitorContext>
     {
+        private GetRecursivelyReferencedFragmentsVisitor()
+        {
+        }
+
+        public static GetRecursivelyReferencedFragmentsVisitor Instance { get; } = new();
+
+        public override ValueTask VisitAsync(ASTNode? node, GetRecursivelyReferencedFragmentsVisitorContext context)
+        {
+            // check if this node should be skipped or not (check @skip and @include directives)
+            if (node == null || !context.OnlyUsedFragments || context.ValidationContext.ShouldIncludeNode(node))
+                return base.VisitAsync(node, context);
+
+            return default;
+        }
+
         protected override ValueTask VisitOperationDefinitionAsync(GraphQLOperationDefinition operationDefinition, GetRecursivelyReferencedFragmentsVisitorContext context)
             => VisitAsync(operationDefinition.SelectionSet, context);
 
@@ -83,18 +199,22 @@ public partial class ValidationContext
 
         protected override async ValueTask VisitFragmentSpreadAsync(GraphQLFragmentSpread fragmentSpread, GetRecursivelyReferencedFragmentsVisitorContext context)
         {
+            // if we have not encountered this fragment before
             if (!Contains(fragmentSpread, context))
             {
+                // find the fragment definition
                 var fragmentDefinition = context.ValidationContext.Document.FindFragmentDefinition(fragmentSpread.FragmentName.Name);
                 if (fragmentDefinition != null)
                 {
+                    // add the fragment definition to our known list
                     context.AddFragment(fragmentDefinition);
+                    // walk the fragment definition
                     await VisitSelectionSetAsync(fragmentDefinition.SelectionSet, context).ConfigureAwait(false);
                 }
             }
         }
 
-        private bool Contains(GraphQLFragmentSpread fragmentSpread, GetRecursivelyReferencedFragmentsVisitorContext context)
+        private static bool Contains(GraphQLFragmentSpread fragmentSpread, GetRecursivelyReferencedFragmentsVisitorContext context)
         {
             var fragments = context.GetFragments(reset: false);
             if (fragments == null)

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -20,7 +20,7 @@ public partial class ValidationContext : IProvideUserContext
         _errors = null;
         _fragments?.Clear();
         _usedFragments?.Clear();
-        _noFragments = false;
+        _noFragments = null;
         _variables.Clear();
         Operation = null!;
         Schema = null!;

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -18,7 +18,9 @@ public partial class ValidationContext : IProvideUserContext
     internal void Reset()
     {
         _errors = null;
-        _fragments.Clear();
+        _fragments?.Clear();
+        _usedFragments?.Clear();
+        _noFragments = false;
         _variables.Clear();
         Operation = null!;
         Schema = null!;


### PR DESCRIPTION
See:
- #3980 

Notes:
- duplicates `ShouldIncludeNode` logic; ideally this code should be consolidated in a separate PR