### PR TITLE
Use ThreadStatic for cached fields

### DIFF
--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -169,20 +169,4 @@ public class ExecutionContext : IExecutionContext, IExecutionArrayPool, IDisposa
             _trackedArrays.Clear();
         }
     }
-
-    /// <summary>
-    /// Allows for an execution strategy to reuse an instance of <see cref="ReadonlyResolveFieldContext"/>.
-    /// This field may be accessed by multiple threads at the same time, so
-    /// access is restricted to <see cref="Interlocked.Exchange{T}(ref T, T)"/>
-    /// and <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>.
-    /// </summary>
-    internal ReadonlyResolveFieldContext? ReusableReadonlyResolveFieldContext;
-
-    /// <summary>
-    /// Allows for an execution strategy to reuse an instance of <see cref="Dictionary{TKey, TValue}"/>.
-    /// This field may be accessed by multiple threads at the same time, so
-    /// access is restricted to <see cref="Interlocked.Exchange{T}(ref T, T)"/>
-    /// and <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>.
-    /// </summary>
-    internal Dictionary<string, (GraphQLField field, FieldType fieldType)>? ReusableFields;
 }


### PR DESCRIPTION
The `IResolveFieldContext` instance and dictionary are heavily used and so currently use `Interlocked.Exchange` to reuse a cached instance.  The instance is cached per `ExecutionContext` so that concurrent executions each have their own shared field.  This enhances the concept so that it is per thread rather than per execution.  Performance shows nearly the same results with existing test suite (which execute only synchronous fields), but the code is better organized.

Before:

| Method        | UseCaching | Mean       | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|-------------- |----------- |-----------:|----------:|----------:|-------:|-------:|----------:|
| Introspection | False      | 425.171 us | 8.1294 us | 9.6774 us | 9.7656 | 2.9297 | 187.21 KB |
| Hero          | False      |   9.897 us | 0.0465 us | 0.0435 us | 0.3357 |      - |   6.37 KB |
| Introspection | True       | 249.638 us | 1.6388 us | 1.4528 us | 7.8125 | 1.9531 | 144.19 KB |
| Hero          | True       |   1.853 us | 0.0214 us | 0.0190 us | 0.1354 |      - |   2.52 KB |

After:

| Method        | UseCaching | Mean       | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|-------------- |----------- |-----------:|----------:|----------:|-------:|-------:|----------:|
| Introspection | False      | 411.722 us | 1.7013 us | 1.5914 us | 9.7656 | 2.4414 | 185.97 KB |
| Hero          | False      |   9.893 us | 0.0517 us | 0.0459 us | 0.3204 |      - |   6.07 KB |
| Introspection | True       | 243.321 us | 1.4652 us | 1.3705 us | 7.3242 | 1.9531 | 142.95 KB |
| Hero          | True       |   1.818 us | 0.0325 us | 0.0304 us | 0.1183 |      - |   2.23 KB |

