### PR TITLE
Ignore NU1903 for System.Text.Json 4.7.2

### DIFF
--- a/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
+++ b/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" NoWarn="NU1903" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
System.Text.Json < 8.0.4 have all been marked as vulnerable due to https://github.com/advisories/GHSA-hh2w-p6rv-4g7w which relates to calling `DeserializeAsyncEnumerable`.  However, the notice at https://github.com/dotnet/announcements/issues/315 states that this vulnerability only applies to .NET 7.0 and newer, so it is likely that System.Text.Json 4.7.2 has been incorrectly marked as vulnerable.  In fact, `DeserializeAsyncEnumerable` is not even present within System.Text.Json 4.7.2.

This PR ignores the warning (which is treated as an error) so that the project will build.

We should remove the `NoWarn` tag once MS fixes the vulnerability flag on the nuget package

See discussion here:
- https://github.com/dotnet/runtime/issues/104619