### PR TITLE
Rename ComplexityAnalyzer to LegacyComplexityAnalyzer and mark as obsolete

### DIFF
--- a/docs2/site/docs/getting-started/dependency-injection.md
+++ b/docs2/site/docs/getting-started/dependency-injection.md
@@ -74,7 +74,6 @@ A list of the available extension methods is below:
 | `AddAutoClrMappings`    | Configures unmapped CLR types to use auto-registering graph types | |
 | `AddAutoSchema`         | Registers a schema based on CLR types | |
 | `AddClrTypeMappings`    | Scans the specified assembly for graph types intended to represent CLR types and registers them within the schema | |
-| `AddComplexityAnalyzer` | Enables the complexity analyzer and configures its options | |
 | `AddDataLoader`         | Registers classes necessary for data loader support | GraphQL.DataLoader |
 | `AddDocumentCache<>`    | Registers the specified document caching service | |
 | `AddDocumentExecuter<>` | Registers the specified document executer; useful when needed to change the execution strategy utilized | |

--- a/docs2/site/docs/getting-started/dependency-injection.md
+++ b/docs2/site/docs/getting-started/dependency-injection.md
@@ -85,6 +85,7 @@ A list of the available extension methods is below:
 | `AddFederation`         | Registers the federation types and configures the schema to support Apollo Federation | |
 | `AddGraphTypes`         | Scans the specified assembly for graph types and registers them within the DI framework | |
 | `AddGraphTypeMappingProvider` | Registers a graph type mapping provider for unmapped CLR types | |
+| `AddLegacyComplexityAnalyzer` | Enables the v7 complexity analyzer and configures its options | |
 | `AddNewtonsoftJson`     | Registers the serializer that uses Newtonsoft.Json as its underlying JSON serialization engine | GraphQL.NewtonsoftJson |
 | `AddSchema<>`           | Registers the specified schema | |
 | `AddSchemaVisitor<>`    | Registers the specified schema visitor and configures it to be used at schema initialization | |

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1030,6 +1030,22 @@ When defining the field with expression, the graph type nullability will be infe
 Null Reference Types (NRT) by default. See the new features section for more details.  
 To revert to old behavior set the global switch before initializing the schema
 
-```c#
+```csharp
 GlobalSwitches.InferFieldNullabilityFromNRTAnnotations = false;
 ```
+
+### 21. The complexity analyzer has been rewritten and functions differently
+
+The complexity analyzer has been rewritten to be more efficient and to support more complex
+scenarios. Please read the documentation on the new complexity analyzer to understand how it
+works and how to configure it. To revert to the old behavior, use the `LegacyComplexityValidationRule`
+or GraphQL builder method as follows:
+
+```csharp
+services.AddGraphQL(b => b
+    .AddSchema<MyQuery>()
+    .AddLegacyComplexityAnalyzer(c => c.MaxComplexity = 100)  // use the v7 complexity analyzer
+);
+```
+
+The legacy complexity analyzer will be removed in v9.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -57,7 +57,8 @@ namespace GraphQL
     }
     public static class ComplexityAnalayzerMetadataExtensions
     {
-        [System.Obsolete("Please use GetComplexityImpactDelegate instead.")]
+        [System.Obsolete("Please use GetComplexityImpactDelegate instead. This method will be removed in v9" +
+            ".")]
         public static double? GetComplexityImpact(this GraphQL.Types.IMetadataReader provider) { }
         public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
             where TMetadataProvider : GraphQL.Types.IFieldMetadataWriter { }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -57,9 +57,10 @@ namespace GraphQL
     }
     public static class ComplexityAnalayzerMetadataExtensions
     {
+        [System.Obsolete("Please use GetComplexityImpactDelegate instead.")]
         public static double? GetComplexityImpact(this GraphQL.Types.IMetadataReader provider) { }
         public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
-            where TMetadataProvider : GraphQL.Types.IMetadataWriter { }
+            where TMetadataProvider : GraphQL.Types.IFieldMetadataWriter { }
     }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
@@ -262,8 +263,6 @@ namespace GraphQL
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Please ensure that the graph types used by your schema and their constructors are" +
             " not trimmed by the compiler.")]
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
-        public static GraphQL.DI.IGraphQLBuilder AddComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.ComplexityConfiguration>? action = null) { }
-        public static GraphQL.DI.IGraphQLBuilder AddComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.ComplexityConfiguration, System.IServiceProvider?>? action) { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder)
             where TDocumentExecuter :  class, GraphQL.IDocumentExecuter { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, TDocumentExecuter> documentExecuterFactory)
@@ -304,6 +303,12 @@ namespace GraphQL
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
+        [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+            "d in v9.")]
+        public static GraphQL.DI.IGraphQLBuilder AddLegacyComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.LegacyComplexityConfiguration>? action = null) { }
+        [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+            "d in v9.")]
+        public static GraphQL.DI.IGraphQLBuilder AddLegacyComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.LegacyComplexityConfiguration, System.IServiceProvider>? action) { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, TSchema schema)
@@ -3644,7 +3649,7 @@ namespace GraphQL.Validation
         public System.Threading.Tasks.ValueTask<System.ValueTuple<GraphQL.Validation.Variables, System.Collections.Generic.List<GraphQL.Validation.ValidationError>?>> GetVariablesValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQLParser.AST.GraphQLValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
-        protected virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
+        public virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
     }
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError
@@ -3721,17 +3726,19 @@ namespace GraphQL.Validation
 }
 namespace GraphQL.Validation.Complexity
 {
-    public class ComplexityConfiguration
+    [System.Obsolete("Please use the new complexity analyzer.")]
+    public class LegacyComplexityConfiguration
     {
-        public ComplexityConfiguration() { }
+        public LegacyComplexityConfiguration() { }
         public double? FieldImpact { get; set; }
         public int? MaxComplexity { get; set; }
         public int? MaxDepth { get; set; }
         public int MaxRecursionCount { get; set; }
     }
-    public class ComplexityResult
+    [System.Obsolete("Please use the new complexity analyzer.")]
+    public class LegacyComplexityResult
     {
-        public ComplexityResult() { }
+        public LegacyComplexityResult() { }
         public double Complexity { get; set; }
         public System.Collections.Generic.Dictionary<GraphQLParser.AST.ASTNode, double> ComplexityMap { get; }
         public int TotalQueryDepth { get; set; }
@@ -4090,10 +4097,12 @@ namespace GraphQL.Validation.Rules
 }
 namespace GraphQL.Validation.Rules.Custom
 {
-    public class ComplexityValidationRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
+    [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+        "d in v9.")]
+    public class LegacyComplexityValidationRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
     {
-        public ComplexityValidationRule(GraphQL.Validation.Complexity.ComplexityConfiguration complexityConfiguration) { }
-        protected virtual void Analyzed(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityResult complexityResult) { }
+        public LegacyComplexityValidationRule(GraphQL.Validation.Complexity.LegacyComplexityConfiguration complexityConfiguration) { }
+        protected virtual void Analyzed(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.LegacyComplexityResult complexityResult) { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         public void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Types.ISchema schema) { }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -57,7 +57,8 @@ namespace GraphQL
     }
     public static class ComplexityAnalayzerMetadataExtensions
     {
-        [System.Obsolete("Please use GetComplexityImpactDelegate instead.")]
+        [System.Obsolete("Please use GetComplexityImpactDelegate instead. This method will be removed in v9" +
+            ".")]
         public static double? GetComplexityImpact(this GraphQL.Types.IMetadataReader provider) { }
         public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
             where TMetadataProvider : GraphQL.Types.IFieldMetadataWriter { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -57,9 +57,10 @@ namespace GraphQL
     }
     public static class ComplexityAnalayzerMetadataExtensions
     {
+        [System.Obsolete("Please use GetComplexityImpactDelegate instead.")]
         public static double? GetComplexityImpact(this GraphQL.Types.IMetadataReader provider) { }
         public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
-            where TMetadataProvider : GraphQL.Types.IMetadataWriter { }
+            where TMetadataProvider : GraphQL.Types.IFieldMetadataWriter { }
     }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
@@ -262,8 +263,6 @@ namespace GraphQL
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Please ensure that the graph types used by your schema and their constructors are" +
             " not trimmed by the compiler.")]
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
-        public static GraphQL.DI.IGraphQLBuilder AddComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.ComplexityConfiguration>? action = null) { }
-        public static GraphQL.DI.IGraphQLBuilder AddComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.ComplexityConfiguration, System.IServiceProvider?>? action) { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder)
             where TDocumentExecuter :  class, GraphQL.IDocumentExecuter { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, TDocumentExecuter> documentExecuterFactory)
@@ -304,6 +303,12 @@ namespace GraphQL
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
+        [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+            "d in v9.")]
+        public static GraphQL.DI.IGraphQLBuilder AddLegacyComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.LegacyComplexityConfiguration>? action = null) { }
+        [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+            "d in v9.")]
+        public static GraphQL.DI.IGraphQLBuilder AddLegacyComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.LegacyComplexityConfiguration, System.IServiceProvider>? action) { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, TSchema schema)
@@ -3658,7 +3663,7 @@ namespace GraphQL.Validation
         public System.Threading.Tasks.ValueTask<System.ValueTuple<GraphQL.Validation.Variables, System.Collections.Generic.List<GraphQL.Validation.ValidationError>?>> GetVariablesValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQLParser.AST.GraphQLValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
-        protected virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
+        public virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
     }
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError
@@ -3735,17 +3740,19 @@ namespace GraphQL.Validation
 }
 namespace GraphQL.Validation.Complexity
 {
-    public class ComplexityConfiguration
+    [System.Obsolete("Please use the new complexity analyzer.")]
+    public class LegacyComplexityConfiguration
     {
-        public ComplexityConfiguration() { }
+        public LegacyComplexityConfiguration() { }
         public double? FieldImpact { get; set; }
         public int? MaxComplexity { get; set; }
         public int? MaxDepth { get; set; }
         public int MaxRecursionCount { get; set; }
     }
-    public class ComplexityResult
+    [System.Obsolete("Please use the new complexity analyzer.")]
+    public class LegacyComplexityResult
     {
-        public ComplexityResult() { }
+        public LegacyComplexityResult() { }
         public double Complexity { get; set; }
         public System.Collections.Generic.Dictionary<GraphQLParser.AST.ASTNode, double> ComplexityMap { get; }
         public int TotalQueryDepth { get; set; }
@@ -4104,10 +4111,12 @@ namespace GraphQL.Validation.Rules
 }
 namespace GraphQL.Validation.Rules.Custom
 {
-    public class ComplexityValidationRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
+    [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+        "d in v9.")]
+    public class LegacyComplexityValidationRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
     {
-        public ComplexityValidationRule(GraphQL.Validation.Complexity.ComplexityConfiguration complexityConfiguration) { }
-        protected virtual void Analyzed(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityResult complexityResult) { }
+        public LegacyComplexityValidationRule(GraphQL.Validation.Complexity.LegacyComplexityConfiguration complexityConfiguration) { }
+        protected virtual void Analyzed(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.LegacyComplexityResult complexityResult) { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         public void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Types.ISchema schema) { }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -57,7 +57,8 @@ namespace GraphQL
     }
     public static class ComplexityAnalayzerMetadataExtensions
     {
-        [System.Obsolete("Please use GetComplexityImpactDelegate instead.")]
+        [System.Obsolete("Please use GetComplexityImpactDelegate instead. This method will be removed in v9" +
+            ".")]
         public static double? GetComplexityImpact(this GraphQL.Types.IMetadataReader provider) { }
         public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
             where TMetadataProvider : GraphQL.Types.IFieldMetadataWriter { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -57,9 +57,10 @@ namespace GraphQL
     }
     public static class ComplexityAnalayzerMetadataExtensions
     {
+        [System.Obsolete("Please use GetComplexityImpactDelegate instead.")]
         public static double? GetComplexityImpact(this GraphQL.Types.IMetadataReader provider) { }
         public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
-            where TMetadataProvider : GraphQL.Types.IMetadataWriter { }
+            where TMetadataProvider : GraphQL.Types.IFieldMetadataWriter { }
     }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
@@ -254,8 +255,6 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddAutoSchema<TQueryClrType>(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.IConfigureAutoSchema>? configure = null) { }
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddClrTypeMappings(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
-        public static GraphQL.DI.IGraphQLBuilder AddComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.ComplexityConfiguration>? action = null) { }
-        public static GraphQL.DI.IGraphQLBuilder AddComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.ComplexityConfiguration, System.IServiceProvider?>? action) { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder)
             where TDocumentExecuter :  class, GraphQL.IDocumentExecuter { }
         public static GraphQL.DI.IGraphQLBuilder AddDocumentExecuter<TDocumentExecuter>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, TDocumentExecuter> documentExecuterFactory)
@@ -296,6 +295,12 @@ namespace GraphQL
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
+        [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+            "d in v9.")]
+        public static GraphQL.DI.IGraphQLBuilder AddLegacyComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.LegacyComplexityConfiguration>? action = null) { }
+        [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+            "d in v9.")]
+        public static GraphQL.DI.IGraphQLBuilder AddLegacyComplexityAnalyzer(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Validation.Complexity.LegacyComplexityConfiguration, System.IServiceProvider>? action) { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
         public static GraphQL.DI.IGraphQLBuilder AddSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, TSchema schema)
@@ -3572,7 +3577,7 @@ namespace GraphQL.Validation
         public System.Threading.Tasks.ValueTask<System.ValueTuple<GraphQL.Validation.Variables, System.Collections.Generic.List<GraphQL.Validation.ValidationError>?>> GetVariablesValuesAsync(GraphQL.Validation.IVariableVisitor? visitor = null) { }
         public string? IsValidLiteralValue(GraphQL.Types.IGraphType type, GraphQLParser.AST.GraphQLValue valueAst) { }
         public void ReportError(GraphQL.Validation.ValidationError error) { }
-        protected virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
+        public virtual bool ShouldIncludeNode(GraphQLParser.AST.ASTNode node) { }
     }
     [System.Serializable]
     public class ValidationError : GraphQL.Execution.DocumentError
@@ -3649,17 +3654,19 @@ namespace GraphQL.Validation
 }
 namespace GraphQL.Validation.Complexity
 {
-    public class ComplexityConfiguration
+    [System.Obsolete("Please use the new complexity analyzer.")]
+    public class LegacyComplexityConfiguration
     {
-        public ComplexityConfiguration() { }
+        public LegacyComplexityConfiguration() { }
         public double? FieldImpact { get; set; }
         public int? MaxComplexity { get; set; }
         public int? MaxDepth { get; set; }
         public int MaxRecursionCount { get; set; }
     }
-    public class ComplexityResult
+    [System.Obsolete("Please use the new complexity analyzer.")]
+    public class LegacyComplexityResult
     {
-        public ComplexityResult() { }
+        public LegacyComplexityResult() { }
         public double Complexity { get; set; }
         public System.Collections.Generic.Dictionary<GraphQLParser.AST.ASTNode, double> ComplexityMap { get; }
         public int TotalQueryDepth { get; set; }
@@ -4018,10 +4025,12 @@ namespace GraphQL.Validation.Rules
 }
 namespace GraphQL.Validation.Rules.Custom
 {
-    public class ComplexityValidationRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
+    [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
+        "d in v9.")]
+    public class LegacyComplexityValidationRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
     {
-        public ComplexityValidationRule(GraphQL.Validation.Complexity.ComplexityConfiguration complexityConfiguration) { }
-        protected virtual void Analyzed(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.ComplexityResult complexityResult) { }
+        public LegacyComplexityValidationRule(GraphQL.Validation.Complexity.LegacyComplexityConfiguration complexityConfiguration) { }
+        protected virtual void Analyzed(GraphQLParser.AST.GraphQLDocument document, GraphQL.Validation.Complexity.LegacyComplexityResult complexityResult) { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         public void Validate(GraphQLParser.AST.GraphQLDocument document, GraphQL.Types.ISchema schema) { }
     }

--- a/src/GraphQL.Tests/Complexity/LegacyComplexityBasicTests.cs
+++ b/src/GraphQL.Tests/Complexity/LegacyComplexityBasicTests.cs
@@ -1,6 +1,6 @@
 namespace GraphQL.Tests.Complexity;
 
-public class ComplexityBasicTests : ComplexityTestBase
+public class LegacyComplexityBasicTests : LegacyComplexityTestBase
 {
     [Fact]
     public void empty_query_complexity()

--- a/src/GraphQL.Tests/Complexity/LegacyComplexityMetaDataTests.cs
+++ b/src/GraphQL.Tests/Complexity/LegacyComplexityMetaDataTests.cs
@@ -6,11 +6,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.Tests.Complexity;
 
-public class ComplexityMetaDataTests : IClassFixture<ComplexityMetaDataFixture>
+public class LegacyComplexityMetaDataTests : IClassFixture<ComplexityMetaDataFixture>
 {
     private readonly ComplexityMetaDataFixture _fixture;
 
-    public ComplexityMetaDataTests(ComplexityMetaDataFixture fixture)
+    public LegacyComplexityMetaDataTests(ComplexityMetaDataFixture fixture)
     {
         _fixture = fixture;
     }
@@ -113,7 +113,7 @@ public class ComplexityMetaDataFixture : IDisposable
 
     private readonly ServiceProvider _provider;
     private readonly IDocumentBuilder _documentBuilder;
-    private readonly ComplexityConfiguration _config;
+    private readonly LegacyComplexityConfiguration _config;
     private readonly ISchema _schema;
     private readonly IDocumentExecuter _executer;
 
@@ -122,16 +122,16 @@ public class ComplexityMetaDataFixture : IDisposable
         _provider = new ServiceCollection()
             .AddGraphQL(builder => builder
                 .AddSchema<ComplexitySchema>()
-                .AddComplexityAnalyzer()
+                .AddLegacyComplexityAnalyzer()
             ).BuildServiceProvider();
 
         _documentBuilder = _provider.GetRequiredService<IDocumentBuilder>();
-        _config = _provider.GetRequiredService<ComplexityConfiguration>();
+        _config = _provider.GetRequiredService<LegacyComplexityConfiguration>();
         _schema = _provider.GetRequiredService<ISchema>();
         _executer = _provider.GetRequiredService<IDocumentExecuter<ComplexitySchema>>();
     }
 
-    public async Task<ComplexityResult> AnalyzeAsync(string query)
+    public async Task<LegacyComplexityResult> AnalyzeAsync(string query)
     {
         var result = await _executer.ExecuteAsync(o =>
         {
@@ -140,7 +140,7 @@ public class ComplexityMetaDataFixture : IDisposable
         }).ConfigureAwait(false);
         result.Errors.ShouldBeNull();
 
-        return ComplexityValidationRule.Analyze(_documentBuilder.Build(query), _config.FieldImpact ?? 2f, _config.MaxRecursionCount, _schema);
+        return LegacyComplexityValidationRule.Analyze(_documentBuilder.Build(query), _config.FieldImpact ?? 2f, _config.MaxRecursionCount, _schema);
     }
 
     public void Dispose() => _provider.Dispose();

--- a/src/GraphQL.Tests/Complexity/LegacyComplexityTestBase.cs
+++ b/src/GraphQL.Tests/Complexity/LegacyComplexityTestBase.cs
@@ -7,23 +7,23 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.Tests.Complexity;
 
-public class ComplexityTestBase
+public class LegacyComplexityTestBase
 {
     // For our heuristics in these tests it is assumed that each Field returns on average of two results.
     public IDocumentBuilder DocumentBuilder { get; } = new GraphQLDocumentBuilder { MaxDepth = 1000 };
 
     public StarWarsTestBase StarWarsTestBase { get; } = new StarWarsBasicQueryTests();
 
-    protected ComplexityResult AnalyzeComplexity(string query) => ComplexityValidationRule.Analyze(DocumentBuilder.Build(query), 2.0d, 250);
+    protected LegacyComplexityResult AnalyzeComplexity(string query) => LegacyComplexityValidationRule.Analyze(DocumentBuilder.Build(query), 2.0d, 250);
 
-    public async Task<ExecutionResult> Execute(ComplexityConfiguration complexityConfig, string query, bool onlyComplexityRule = false) =>
+    public async Task<ExecutionResult> Execute(LegacyComplexityConfiguration complexityConfig, string query, bool onlyComplexityRule = false) =>
         await StarWarsTestBase.Executer.ExecuteAsync(options =>
         {
             options.Schema = CreateSchema();
             options.Query = query;
             options.ValidationRules = onlyComplexityRule
-                ? new[] { new ComplexityValidationRule(complexityConfig) }
-                : GraphQL.Validation.DocumentValidator.CoreRules.Append(new ComplexityValidationRule(complexityConfig));
+                ? new[] { new LegacyComplexityValidationRule(complexityConfig) }
+                : GraphQL.Validation.DocumentValidator.CoreRules.Append(new LegacyComplexityValidationRule(complexityConfig));
         }).ConfigureAwait(false);
 
     //ISSUE: manually created test instance with ServiceProvider

--- a/src/GraphQL.Tests/Complexity/LegacyComplexityTests.cs
+++ b/src/GraphQL.Tests/Complexity/LegacyComplexityTests.cs
@@ -4,7 +4,7 @@ using GraphQL.Validation.Rules.Custom;
 
 namespace GraphQL.Tests.Complexity;
 
-public class ComplexityTests : ComplexityTestBase
+public class LegacyComplexityTests : LegacyComplexityTestBase
 {
     [Fact]
     public void inline_fragments_test()
@@ -380,7 +380,7 @@ public class ComplexityTests : ComplexityTestBase
     {
         _ = idx;
         var schema = SchemaFor(sdl);
-        var result = ComplexityValidationRule.Analyze(GraphQLParser.Parser.Parse(query), avgImpact, 250, schema); //notice: nowhere are variables requested (or used)
+        var result = LegacyComplexityValidationRule.Analyze(GraphQLParser.Parser.Parse(query), avgImpact, 250, schema); //notice: nowhere are variables requested (or used)
         var actual = (result.Complexity, result.TotalQueryDepth);
         actual.ShouldBe((complexity, totalQueryDepth));
     }

--- a/src/GraphQL.Tests/Complexity/LegacyComplexityTestsWithLimits.cs
+++ b/src/GraphQL.Tests/Complexity/LegacyComplexityTestsWithLimits.cs
@@ -1,6 +1,6 @@
 namespace GraphQL.Tests.Complexity;
 
-public class ComplexityTestsWithLimits : ComplexityTestBase
+public class LegacyComplexityTestsWithLimits : LegacyComplexityTestBase
 {
     [Fact]
     public void simple_query_avec_limit()

--- a/src/GraphQL.Tests/Complexity/LegacyComplexityValidationTests.cs
+++ b/src/GraphQL.Tests/Complexity/LegacyComplexityValidationTests.cs
@@ -4,7 +4,7 @@ using GraphQL.Validation.Errors.Custom;
 
 namespace GraphQL.Tests.Complexity;
 
-public class ComplexityValidationTest : ComplexityTestBase
+public class LegacyComplexityValidationTest : LegacyComplexityTestBase
 {
     [Fact]
     public async Task should_work_when_complexity_within_params()
@@ -17,7 +17,7 @@ public class ComplexityValidationTest : ComplexityTestBase
             }
             """;
 
-        var complexityConfiguration = new ComplexityConfiguration { FieldImpact = 2, MaxComplexity = 6, MaxDepth = 1 };
+        var complexityConfiguration = new LegacyComplexityConfiguration { FieldImpact = 2, MaxComplexity = 6, MaxDepth = 1 };
         var res = await Execute(complexityConfiguration, query);
 
         res.Errors.ShouldBe(null);
@@ -39,7 +39,7 @@ public class ComplexityValidationTest : ComplexityTestBase
             }
             """;
 
-        var complexityConfiguration = new ComplexityConfiguration { MaxDepth = 2 };
+        var complexityConfiguration = new LegacyComplexityConfiguration { MaxDepth = 2 };
         var res = await Execute(complexityConfiguration, query);
 
         res.Errors.ShouldNotBeNull();
@@ -62,7 +62,7 @@ public class ComplexityValidationTest : ComplexityTestBase
             }
             """;
 
-        var complexityConfiguration = new ComplexityConfiguration { FieldImpact = 5, MaxComplexity = 10 };
+        var complexityConfiguration = new LegacyComplexityConfiguration { FieldImpact = 5, MaxComplexity = 10 };
         var res = await Execute(complexityConfiguration, query);
 
         res.Errors.ShouldNotBeNull();
@@ -91,7 +91,7 @@ public class ComplexityValidationTest : ComplexityTestBase
             }
             """;
 
-        var complexityConfiguration = new ComplexityConfiguration
+        var complexityConfiguration = new LegacyComplexityConfiguration
         {
             FieldImpact = 5,
             MaxComplexity = 25,
@@ -131,7 +131,7 @@ public class ComplexityValidationTest : ComplexityTestBase
             }
             """;
 
-        var complexityConfiguration = new ComplexityConfiguration();
+        var complexityConfiguration = new LegacyComplexityConfiguration();
         var res = await Execute(complexityConfiguration, query);
 
         res.Errors.ShouldNotBeNull();
@@ -164,7 +164,7 @@ public class ComplexityValidationTest : ComplexityTestBase
             }
             """;
 
-        var complexityConfiguration = new ComplexityConfiguration();
+        var complexityConfiguration = new LegacyComplexityConfiguration();
         var res = await Execute(complexityConfiguration, query, onlyComplexityRule: true);
 
         res.Errors.ShouldNotBeNull();

--- a/src/GraphQL.Tests/DI/GraphQLBuilderExtensionTests.cs
+++ b/src/GraphQL.Tests/DI/GraphQLBuilderExtensionTests.cs
@@ -346,23 +346,23 @@ public class GraphQLBuilderExtensionTests
     [InlineData(false, true)]
     public void AddComplexityAnalyzer(bool withAction, bool withAction2)
     {
-        var ruleInstance = new ComplexityValidationRule(new ComplexityConfiguration());
-        MockSetupRegister<ComplexityValidationRule, ComplexityValidationRule>();
-        MockSetupRegister<IValidationRule, ComplexityValidationRule>();
+        var ruleInstance = new LegacyComplexityValidationRule(new LegacyComplexityConfiguration());
+        MockSetupRegister<LegacyComplexityValidationRule, LegacyComplexityValidationRule>();
+        MockSetupRegister<IValidationRule, LegacyComplexityValidationRule>();
         var mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
-        mockServiceProvider.Setup(s => s.GetService(typeof(ComplexityValidationRule))).Returns(ruleInstance).Verifiable();
+        mockServiceProvider.Setup(s => s.GetService(typeof(LegacyComplexityValidationRule))).Returns(ruleInstance).Verifiable();
         var getOpts = MockSetupConfigureExecution(mockServiceProvider.Object);
         if (withAction)
         {
-            var action = MockSetupConfigure1<ComplexityConfiguration>();
-            _builder.AddComplexityAnalyzer(action);
+            var action = MockSetupConfigure1<LegacyComplexityConfiguration>();
+            _builder.AddLegacyComplexityAnalyzer(action);
         }
         else
         {
-            var action = withAction2 ? MockSetupConfigure2<ComplexityConfiguration>() : null;
+            var action = withAction2 ? MockSetupConfigure2<LegacyComplexityConfiguration>() : null;
             if (!withAction2)
-                MockSetupConfigureNull<ComplexityConfiguration>();
-            _builder.AddComplexityAnalyzer(action!);
+                MockSetupConfigureNull<LegacyComplexityConfiguration>();
+            _builder.AddLegacyComplexityAnalyzer(action!);
         }
         var opts = getOpts();
         opts.ValidationRules.ShouldNotBeNull();

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -442,7 +442,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
         => this.ApplyDirective(name, configure);
 
     /// <summary>
-    /// Specify field's complexity impact which will be taken into account by <see cref="ComplexityValidationRule"/>.
+    /// Specify field's complexity impact which will be taken into account by <see cref="LegacyComplexityValidationRule"/>.
     /// </summary>
     /// <param name="impact">Field's complexity impact.</param>
     [Obsolete("Please use the WithComplexityImpact method")]

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -382,19 +382,21 @@ public static class GraphQLBuilderExtensions // TODO: split
 
     #region - AddComplexityAnalyzer -
     /// <summary>
-    /// Enables the default complexity analyzer and configures it with the specified configuration delegate.
+    /// Enables the legacy complexity analyzer and configures it with the specified configuration delegate.
     /// </summary>
-    public static IGraphQLBuilder AddComplexityAnalyzer(this IGraphQLBuilder builder, Action<ComplexityConfiguration>? action = null)
+    [Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be removed in v9.")]
+    public static IGraphQLBuilder AddLegacyComplexityAnalyzer(this IGraphQLBuilder builder, Action<LegacyComplexityConfiguration>? action = null)
     {
-        builder.AddValidationRule<ComplexityValidationRule>();
+        builder.AddValidationRule<LegacyComplexityValidationRule>();
         builder.Services.Configure(action);
         return builder;
     }
 
-    /// <inheritdoc cref="AddComplexityAnalyzer(IGraphQLBuilder, Action{ComplexityConfiguration})"/>
-    public static IGraphQLBuilder AddComplexityAnalyzer(this IGraphQLBuilder builder, Action<ComplexityConfiguration, IServiceProvider?>? action)
+    /// <inheritdoc cref="AddLegacyComplexityAnalyzer(IGraphQLBuilder, Action{LegacyComplexityConfiguration})"/>
+    [Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be removed in v9.")]
+    public static IGraphQLBuilder AddLegacyComplexityAnalyzer(this IGraphQLBuilder builder, Action<LegacyComplexityConfiguration, IServiceProvider>? action)
     {
-        builder.AddValidationRule<ComplexityValidationRule>();
+        builder.AddValidationRule<LegacyComplexityValidationRule>();
         builder.Services.Configure(action);
         return builder;
     }

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
@@ -26,7 +26,7 @@ public static class ComplexityAnalayzerMetadataExtensions
     /// </summary>
     /// <param name="provider">Metadata provider which must implement <see cref="IProvideMetadata"/> interface.</param>
     /// <returns>Field's complexity impact.</returns>
-    [Obsolete("Please use GetComplexityImpactDelegate instead.")]
+    [Obsolete("Please use GetComplexityImpactDelegate instead. This method will be removed in v9.")]
     public static double? GetComplexityImpact(this IMetadataReader provider)
         => provider.GetMetadata<double?>(COMPLEXITY_IMPACT);
 }

--- a/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
+++ b/src/GraphQL/Validation/Complexity/ComplexityAnalayzerMetadataExtensions.cs
@@ -11,21 +11,22 @@ public static class ComplexityAnalayzerMetadataExtensions
     private const string COMPLEXITY_IMPACT = "__COMPLEXITY_IMPACT__";
 
     /// <summary>
-    /// Specify field's complexity impact which will be taken into account by <see cref="ComplexityValidationRule"/>.
+    /// Specify field's complexity impact which will be taken into account by <see cref="LegacyComplexityValidationRule"/>.
     /// </summary>
     /// <typeparam name="TMetadataProvider">The type of metadata provider. Generics are used here to let compiler infer the returning type to allow methods chaining.</typeparam>
     /// <param name="provider">Metadata provider which must implement <see cref="IMetadataWriter"/> interface.</param>
     /// <param name="impact">Field's complexity impact.</param>
     /// <returns>The reference to the specified <paramref name="provider"/>.</returns>
     public static TMetadataProvider WithComplexityImpact<TMetadataProvider>(this TMetadataProvider provider, double impact)
-        where TMetadataProvider : IMetadataWriter
+        where TMetadataProvider : IFieldMetadataWriter
         => provider.WithMetadata(COMPLEXITY_IMPACT, impact);
 
     /// <summary>
-    /// Get field's complexity impact which will be taken into account by <see cref="ComplexityValidationRule"/>.
+    /// Get field's complexity impact which will be taken into account by <see cref="LegacyComplexityValidationRule"/>.
     /// </summary>
     /// <param name="provider">Metadata provider which must implement <see cref="IProvideMetadata"/> interface.</param>
     /// <returns>Field's complexity impact.</returns>
+    [Obsolete("Please use GetComplexityImpactDelegate instead.")]
     public static double? GetComplexityImpact(this IMetadataReader provider)
         => provider.GetMetadata<double?>(COMPLEXITY_IMPACT);
 }

--- a/src/GraphQL/Validation/Complexity/LegacyAnalysisContext.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyAnalysisContext.cs
@@ -3,7 +3,8 @@ using GraphQLParser.Visitors;
 
 namespace GraphQL.Validation.Complexity;
 
-internal sealed class AnalysisContext : IASTVisitorContext
+[Obsolete("Please use the new complexity analyzer.")]
+internal sealed class LegacyAnalysisContext : IASTVisitorContext
 {
     public double AvgImpact { get; set; }
 
@@ -11,9 +12,9 @@ internal sealed class AnalysisContext : IASTVisitorContext
 
     public double CurrentEndNodeImpact { get; set; }
 
-    public FragmentComplexity CurrentFragmentComplexity { get; set; } = null!;
+    public LegacyFragmentComplexity CurrentFragmentComplexity { get; set; } = null!;
 
-    public ComplexityResult Result { get; } = new ComplexityResult();
+    public LegacyComplexityResult Result { get; } = new LegacyComplexityResult();
 
     public int LoopCounter { get; set; }
 
@@ -21,7 +22,7 @@ internal sealed class AnalysisContext : IASTVisitorContext
 
     public bool FragmentMapAlreadyBuilt { get; set; }
 
-    public Dictionary<string, FragmentComplexity> FragmentMap { get; } = new Dictionary<string, FragmentComplexity>();
+    public Dictionary<string, LegacyFragmentComplexity> FragmentMap { get; } = new Dictionary<string, LegacyFragmentComplexity>();
 
     public CancellationToken CancellationToken => default;
 

--- a/src/GraphQL/Validation/Complexity/LegacyComplexityConfiguration.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyComplexityConfiguration.cs
@@ -3,7 +3,8 @@ namespace GraphQL.Validation.Complexity;
 /// <summary>
 /// Configuration parameters for a complexity analyzer.
 /// </summary>
-public class ComplexityConfiguration
+[Obsolete("Please use the new complexity analyzer.")]
+public class LegacyComplexityConfiguration
 {
     /// <summary>
     /// Gets or sets the allowed maximum depth of the query.

--- a/src/GraphQL/Validation/Complexity/LegacyComplexityResult.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyComplexityResult.cs
@@ -5,7 +5,8 @@ namespace GraphQL.Validation.Complexity;
 /// <summary>
 /// Contains the result of a complexity analysis.
 /// </summary>
-public class ComplexityResult
+[Obsolete("Please use the new complexity analyzer.")]
+public class LegacyComplexityResult
 {
     /// <summary>
     /// Returns a dictionary of nodes and their complexity factors.

--- a/src/GraphQL/Validation/Complexity/LegacyFragmentComplexity.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyFragmentComplexity.cs
@@ -3,7 +3,8 @@ namespace GraphQL.Validation.Complexity;
 /// <summary>
 /// Class to track complexity of fragment defined in GraphQL document.
 /// </summary>
-internal sealed class FragmentComplexity
+[Obsolete("Please use the new complexity analyzer.")]
+internal sealed class LegacyFragmentComplexity
 {
     /// <summary>
     /// Depth of fragment.

--- a/src/GraphQL/Validation/Rules.Custom/LegacyComplexityValidationRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/LegacyComplexityValidationRule.cs
@@ -10,14 +10,15 @@ namespace GraphQL.Validation.Rules.Custom;
 /// <summary>
 /// Analyzes a document to determine if its complexity exceeds a threshold.
 /// </summary>
-public class ComplexityValidationRule : ValidationRuleBase, INodeVisitor
+[Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be removed in v9.")]
+public class LegacyComplexityValidationRule : ValidationRuleBase, INodeVisitor
 {
-    private ComplexityConfiguration ComplexityConfiguration { get; }
+    private LegacyComplexityConfiguration ComplexityConfiguration { get; }
 
     /// <summary>
     /// Initializes an instance with the specified complexity configuration.
     /// </summary>
-    public ComplexityValidationRule(ComplexityConfiguration complexityConfiguration)
+    public LegacyComplexityValidationRule(LegacyComplexityConfiguration complexityConfiguration)
     {
         ComplexityConfiguration = complexityConfiguration;
     }
@@ -80,9 +81,9 @@ public class ComplexityValidationRule : ValidationRuleBase, INodeVisitor
 
     /// <summary>
     /// Executes after the complexity analysis has completed, before comparing results to the complexity configuration parameters.
-    /// This method is made to be able to access the calculated <see cref="ComplexityResult"/> and handle it, for example, for logging.
+    /// This method is made to be able to access the calculated <see cref="LegacyComplexityResult"/> and handle it, for example, for logging.
     /// </summary>
-    protected virtual void Analyzed(GraphQLDocument document, ComplexityResult complexityResult)
+    protected virtual void Analyzed(GraphQLDocument document, LegacyComplexityResult complexityResult)
     {
 #if DEBUG
         Debug.WriteLine($"Complexity: {complexityResult.Complexity}");
@@ -95,18 +96,18 @@ public class ComplexityValidationRule : ValidationRuleBase, INodeVisitor
     /// <summary>
     /// Analyzes the complexity of a document.
     /// </summary>
-    internal static ComplexityResult Analyze(GraphQLDocument doc, double avgImpact, int maxRecursionCount, ISchema? schema = null)
+    internal static LegacyComplexityResult Analyze(GraphQLDocument doc, double avgImpact, int maxRecursionCount, ISchema? schema = null)
     {
         if (avgImpact <= 1)
             throw new ArgumentOutOfRangeException(nameof(avgImpact));
 
-        var context = new AnalysisContext
+        var context = new LegacyAnalysisContext
         {
             MaxRecursionCount = maxRecursionCount,
             AvgImpact = avgImpact,
             CurrentEndNodeImpact = 1d
         };
-        var visitor = schema == null ? new ComplexityVisitor() : new ComplexityVisitor(schema);
+        var visitor = schema == null ? new LegacyComplexityVisitor() : new LegacyComplexityVisitor(schema);
 
         // https://github.com/graphql-dotnet/graphql-dotnet/issues/3030
         // Sort fragment definitions so that independent fragments go in front.

--- a/src/GraphQL/Validation/ValidationContext.GetRecursivelyReferencedFragments.cs
+++ b/src/GraphQL/Validation/ValidationContext.GetRecursivelyReferencedFragments.cs
@@ -63,7 +63,7 @@ public partial class ValidationContext
     /// will not reflect the change. Also ignores any overridden behavior within
     /// <see cref="Execution.ExecutionStrategy.ShouldIncludeNode{TASTNode}(Execution.ExecutionContext, TASTNode)">ExecutionStrategy.ShouldIncludeNode</see>.
     /// </remarks>
-    protected virtual bool ShouldIncludeNode(ASTNode node)
+    public virtual bool ShouldIncludeNode(ASTNode node)
     {
         // according to GraphQL spec, directives with the same name may be defined so long as they cannot be
         // placed on the same node types as other directives with the same name; so here we verify that the


### PR DESCRIPTION
Prep towards #3989 

- Rename `ComplexityValidationRule` to `LegacyComplexityValidationRule` and mark as obsolete
- Rename `ComplexityConfiguration` to `LegacyComplexityConfiguration` and mark as obsolete
- Rename `AddComplexityAnalyzer` to `AddLegacyComplexityAnalyzer` and mark as obsolete
- Prefix supporting classes and tests with `Legacy`
- Change type condition on `WithComplexityImpact` to `IFieldMetadataWriter`
- Mark `ShouldIncludeNode` as public
- Add migration note

Shouldn't be any changes other than the few changes listed above.

The goal here is to continue to support the existing "v7" complexity analyzer logic throughout the lifetime of v8, removing it in favor of the new analyzer in v9.  Since the calculations of the v7 analyzer are drastically different than the v8 analyzer, even though the API is quite similar, users may not wish to utilize the new calculations until they update all of their impact settings across their schema.