### PR TITLE
Unhandled exception processing enhancements

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -331,8 +331,12 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddSerializer<TSerializer>(this GraphQL.DI.IGraphQLBuilder builder, TSerializer serializer)
             where TSerializer :  class, GraphQL.IGraphQLSerializer { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext> unhandledExceptionDelegate) { }
+        [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
+            "g this overload.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
+        [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
+            "g this overload.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddValidationRule<TValidationRule>(this GraphQL.DI.IGraphQLBuilder builder, bool useForCachedDocuments = false, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TValidationRule :  class, GraphQL.Validation.IValidationRule { }
@@ -1252,6 +1256,7 @@ namespace GraphQL.Execution
         public System.Collections.Generic.IReadOnlyDictionary<GraphQLParser.AST.ASTNode, System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>>? DirectiveValues { get; set; }
         public GraphQLParser.AST.GraphQLDocument Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
+        public GraphQL.ExecutionOptions ExecutionOptions { get; set; }
         public GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; set; }
@@ -1370,6 +1375,7 @@ namespace GraphQL.Execution
         System.Collections.Generic.IReadOnlyDictionary<GraphQLParser.AST.ASTNode, System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>>? DirectiveValues { get; }
         GraphQLParser.AST.GraphQLDocument Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
+        GraphQL.ExecutionOptions ExecutionOptions { get; }
         GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; }
         System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
@@ -1509,10 +1515,12 @@ namespace GraphQL.Execution
     }
     public class UnhandledExceptionContext
     {
-        public UnhandledExceptionContext(GraphQL.Execution.IExecutionContext? context, GraphQL.IResolveFieldContext? fieldContext, System.Exception originalException) { }
+        public UnhandledExceptionContext(GraphQL.ExecutionOptions options, System.Exception originalException) { }
+        public UnhandledExceptionContext(GraphQL.Execution.IExecutionContext context, GraphQL.IResolveFieldContext? fieldContext, System.Exception originalException) { }
         public GraphQL.Execution.IExecutionContext? Context { get; }
         public string? ErrorMessage { get; set; }
         public System.Exception Exception { get; set; }
+        public GraphQL.ExecutionOptions ExecutionOptions { get; }
         public GraphQL.IResolveFieldContext? FieldContext { get; }
         public System.Exception OriginalException { get; }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -331,8 +331,12 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddSerializer<TSerializer>(this GraphQL.DI.IGraphQLBuilder builder, TSerializer serializer)
             where TSerializer :  class, GraphQL.IGraphQLSerializer { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext> unhandledExceptionDelegate) { }
+        [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
+            "g this overload.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
+        [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
+            "g this overload.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddValidationRule<TValidationRule>(this GraphQL.DI.IGraphQLBuilder builder, bool useForCachedDocuments = false, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TValidationRule :  class, GraphQL.Validation.IValidationRule { }
@@ -1252,6 +1256,7 @@ namespace GraphQL.Execution
         public System.Collections.Generic.IReadOnlyDictionary<GraphQLParser.AST.ASTNode, System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>>? DirectiveValues { get; set; }
         public GraphQLParser.AST.GraphQLDocument Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
+        public GraphQL.ExecutionOptions ExecutionOptions { get; set; }
         public GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; set; }
@@ -1370,6 +1375,7 @@ namespace GraphQL.Execution
         System.Collections.Generic.IReadOnlyDictionary<GraphQLParser.AST.ASTNode, System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>>? DirectiveValues { get; }
         GraphQLParser.AST.GraphQLDocument Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
+        GraphQL.ExecutionOptions ExecutionOptions { get; }
         GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; }
         System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
@@ -1509,10 +1515,12 @@ namespace GraphQL.Execution
     }
     public class UnhandledExceptionContext
     {
-        public UnhandledExceptionContext(GraphQL.Execution.IExecutionContext? context, GraphQL.IResolveFieldContext? fieldContext, System.Exception originalException) { }
+        public UnhandledExceptionContext(GraphQL.ExecutionOptions options, System.Exception originalException) { }
+        public UnhandledExceptionContext(GraphQL.Execution.IExecutionContext context, GraphQL.IResolveFieldContext? fieldContext, System.Exception originalException) { }
         public GraphQL.Execution.IExecutionContext? Context { get; }
         public string? ErrorMessage { get; set; }
         public System.Exception Exception { get; set; }
+        public GraphQL.ExecutionOptions ExecutionOptions { get; }
         public GraphQL.IResolveFieldContext? FieldContext { get; }
         public System.Exception OriginalException { get; }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -323,8 +323,12 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddSerializer<TSerializer>(this GraphQL.DI.IGraphQLBuilder builder, TSerializer serializer)
             where TSerializer :  class, GraphQL.IGraphQLSerializer { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext> unhandledExceptionDelegate) { }
+        [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
+            "g this overload.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
+        [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
+            "g this overload.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddValidationRule<TValidationRule>(this GraphQL.DI.IGraphQLBuilder builder, bool useForCachedDocuments = false, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TValidationRule :  class, GraphQL.Validation.IValidationRule { }
@@ -1218,6 +1222,7 @@ namespace GraphQL.Execution
         public System.Collections.Generic.IReadOnlyDictionary<GraphQLParser.AST.ASTNode, System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>>? DirectiveValues { get; set; }
         public GraphQLParser.AST.GraphQLDocument Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
+        public GraphQL.ExecutionOptions ExecutionOptions { get; set; }
         public GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }
         public System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; set; }
@@ -1336,6 +1341,7 @@ namespace GraphQL.Execution
         System.Collections.Generic.IReadOnlyDictionary<GraphQLParser.AST.ASTNode, System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>>? DirectiveValues { get; }
         GraphQLParser.AST.GraphQLDocument Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
+        GraphQL.ExecutionOptions ExecutionOptions { get; }
         GraphQL.Execution.IExecutionStrategy ExecutionStrategy { get; }
         System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
         System.Collections.Generic.List<GraphQL.Execution.IDocumentExecutionListener> Listeners { get; }
@@ -1475,10 +1481,12 @@ namespace GraphQL.Execution
     }
     public class UnhandledExceptionContext
     {
-        public UnhandledExceptionContext(GraphQL.Execution.IExecutionContext? context, GraphQL.IResolveFieldContext? fieldContext, System.Exception originalException) { }
+        public UnhandledExceptionContext(GraphQL.ExecutionOptions options, System.Exception originalException) { }
+        public UnhandledExceptionContext(GraphQL.Execution.IExecutionContext context, GraphQL.IResolveFieldContext? fieldContext, System.Exception originalException) { }
         public GraphQL.Execution.IExecutionContext? Context { get; }
         public string? ErrorMessage { get; set; }
         public System.Exception Exception { get; set; }
+        public GraphQL.ExecutionOptions ExecutionOptions { get; }
         public GraphQL.IResolveFieldContext? FieldContext { get; }
         public System.Exception OriginalException { get; }
     }

--- a/src/GraphQL.Tests/DI/GraphQLBuilderExtensionTests.cs
+++ b/src/GraphQL.Tests/DI/GraphQLBuilderExtensionTests.cs
@@ -895,7 +895,7 @@ public class GraphQLBuilderExtensionTests
             return Task.CompletedTask;
         });
         var opts = execute();
-        var e = new UnhandledExceptionContext(null, null, new Exception());
+        var e = new UnhandledExceptionContext(opts, new Exception());
         await opts.UnhandledExceptionDelegate(e);
         e2.ShouldBe(e);
         o2.ShouldBe(opts);
@@ -912,7 +912,7 @@ public class GraphQLBuilderExtensionTests
             return Task.CompletedTask;
         });
         var opts = execute();
-        var e = new UnhandledExceptionContext(null, null, new Exception());
+        var e = new UnhandledExceptionContext(opts, new Exception());
         await opts.UnhandledExceptionDelegate(e);
         e2.ShouldBe(e);
     }
@@ -929,7 +929,7 @@ public class GraphQLBuilderExtensionTests
             e2 = e1;
         });
         var opts = execute();
-        var e = new UnhandledExceptionContext(null, null, new Exception());
+        var e = new UnhandledExceptionContext(opts, new Exception());
         await opts.UnhandledExceptionDelegate(e);
         e2.ShouldBe(e);
         o2.ShouldBe(opts);
@@ -942,7 +942,7 @@ public class GraphQLBuilderExtensionTests
         var execute = MockSetupConfigureExecution();
         _builder.AddUnhandledExceptionHandler(e1 => e2 = e1);
         var opts = execute();
-        var e = new UnhandledExceptionContext(null, null, new Exception());
+        var e = new UnhandledExceptionContext(opts, new Exception());
         await opts.UnhandledExceptionDelegate(e);
         e2.ShouldBe(e);
     }

--- a/src/GraphQL.Tests/Execution/DocumentExecuterTests.cs
+++ b/src/GraphQL.Tests/Execution/DocumentExecuterTests.cs
@@ -3,6 +3,7 @@ using GraphQL.Execution;
 using GraphQL.Types;
 using GraphQL.Validation;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 
 namespace GraphQL.Tests.Execution;
 
@@ -95,6 +96,240 @@ public class DocumentExecuterTests
         var executer = provider.GetRequiredService<IDocumentExecuter>();
         var ret = await executer.ExecuteAsync(new());
         ret.ShouldBeNull(); // validates that all configured executions have run, as normally this would never be null
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ConfigureExecution_Does_Not_Wrap_OCE(bool throwOnUnhandledException)
+    {
+        bool hit = false;
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddUnhandledExceptionHandler(_ => throw new NotSupportedException())
+            .ConfigureExecution((options, next) =>
+            {
+                hit = true;
+                options.CancellationToken.ThrowIfCancellationRequested();
+                return next(options);
+            })
+        );
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        using var provider = services.BuildServiceProvider();
+        var executer = provider.GetRequiredService<IDocumentExecuter>();
+        var executionOptions = new ExecutionOptions
+        {
+            Query = "{hero}",
+            RequestServices = provider,
+            CancellationToken = cts.Token,
+            ThrowOnUnhandledException = throwOnUnhandledException,
+        };
+        await executer.ExecuteAsync(executionOptions).ShouldThrowAsync<OperationCanceledException>();
+        hit.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Execution_Does_Not_Wrap_OCE(bool throwOnUnhandledException)
+    {
+        using var cts = new CancellationTokenSource();
+        bool hit = false;
+        var schema = new Mock<ISchema>(MockBehavior.Loose);
+        schema.Setup(s => s.Initialize()).Callback(() =>
+        {
+            hit = true;
+            cts.Cancel();
+            cts.Token.ThrowIfCancellationRequested();
+        });
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddSchema(schema.Object)
+            .AddUnhandledExceptionHandler(_ => throw new NotSupportedException())
+        );
+        using var provider = services.BuildServiceProvider();
+        var executer = provider.GetRequiredService<IDocumentExecuter<ISchema>>();
+        var executionOptions = new ExecutionOptions
+        {
+            Query = "{hero}",
+            RequestServices = provider,
+            CancellationToken = cts.Token,
+            ThrowOnUnhandledException = throwOnUnhandledException,
+        };
+        await executer.ExecuteAsync(executionOptions).ShouldThrowAsync<OperationCanceledException>();
+        hit.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ConfigureExecution_Returns_ExecutionError(bool throwOnUnhandledException)
+    {
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddUnhandledExceptionHandler(_ => throw new NotSupportedException())
+            .ConfigureExecution((options, next) => throw new MyExecutionError("Testing"))
+        );
+        using var provider = services.BuildServiceProvider();
+        var executer = provider.GetRequiredService<IDocumentExecuter>();
+        var executionOptions = new ExecutionOptions
+        {
+            Query = "{hero}",
+            RequestServices = provider,
+            ThrowOnUnhandledException = throwOnUnhandledException,
+        };
+        var ret = await executer.ExecuteAsync(executionOptions);
+        ret.Errors.ShouldHaveSingleItem().ShouldBeOfType<MyExecutionError>()
+            .Message.ShouldBe("Testing");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Execution_Returns_ExecutionError(bool throwOnUnhandledException)
+    {
+        var schema = new Mock<ISchema>(MockBehavior.Loose);
+        schema.Setup(s => s.Initialize()).Callback(() => throw new MyExecutionError("Testing"));
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddUnhandledExceptionHandler(_ => throw new NotSupportedException())
+            .AddSchema(schema.Object)
+        );
+        using var provider = services.BuildServiceProvider();
+        var executer = provider.GetRequiredService<IDocumentExecuter<ISchema>>();
+        var executionOptions = new ExecutionOptions
+        {
+            Query = "{hero}",
+            RequestServices = provider,
+            ThrowOnUnhandledException = throwOnUnhandledException,
+        };
+        var ret = await executer.ExecuteAsync(executionOptions);
+        ret.Errors.ShouldHaveSingleItem().ShouldBeOfType<MyExecutionError>()
+            .Message.ShouldBe("Testing");
+    }
+
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, false, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    public async Task ConfigureExecution_Wraps_OtherExeceptions(bool throwOnUnhandledException, bool overrideMessage, bool setCustomError)
+    {
+        var ran = false;
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .ConfigureExecution((options, next) => throw new ApplicationException("Testing"))
+            .AddUnhandledExceptionHandler(context =>
+            {
+                ran = true;
+                context.Exception.ShouldBeOfType<ApplicationException>().Message.ShouldBe("Testing");
+                context.Exception = setCustomError
+                    ? new MyExecutionError("Testing 2")
+                    : new ApplicationException("Testing 3");
+                if (overrideMessage)
+                    context.ErrorMessage = "Testing 4";
+                return Task.CompletedTask;
+            })
+        );
+        using var provider = services.BuildServiceProvider();
+        var executer = provider.GetRequiredService<IDocumentExecuter>();
+        var executionOptions = new ExecutionOptions
+        {
+            Query = "{hero}",
+            RequestServices = provider,
+            ThrowOnUnhandledException = throwOnUnhandledException,
+        };
+        if (throwOnUnhandledException)
+        {
+            var ex = await executer.ExecuteAsync(executionOptions).ShouldThrowAsync<ApplicationException>();
+            ex.Message.ShouldBe("Testing");
+            ran.ShouldBeFalse();
+        }
+        else
+        {
+            var ret = await executer.ExecuteAsync(executionOptions);
+            if (!setCustomError)
+            {
+                var ex = ret.Errors.ShouldHaveSingleItem().ShouldBeOfType<UnhandledError>();
+                ex.Message.ShouldBe(overrideMessage ? "Testing 4" : "Error executing document.");
+                ex.InnerException.ShouldBeOfType<ApplicationException>()
+                    .Message.ShouldBe("Testing 3");
+            }
+            else
+            {
+                ret.Errors.ShouldHaveSingleItem().ShouldBeOfType<MyExecutionError>()
+                    .Message.ShouldBe("Testing 2");
+            }
+            ran.ShouldBeTrue();
+        }
+    }
+
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, false, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    public async Task Execution_Wraps_OtherExeceptions(bool throwOnUnhandledException, bool overrideMessage, bool setCustomError)
+    {
+        ExecutionOptions executionOptions = null!;
+        var schema = new Mock<ISchema>(MockBehavior.Loose);
+        schema.Setup(s => s.Initialize()).Callback(() => throw new ApplicationException("Testing"));
+        var ran = false;
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddSchema(schema.Object)
+            .AddUnhandledExceptionHandler(context =>
+            {
+                ran = true;
+                context.ExecutionOptions.ShouldBe(executionOptions);
+                context.FieldContext.ShouldBeNull();
+                context.Context.ShouldBeNull();
+                context.Exception.ShouldBeOfType<ApplicationException>().Message.ShouldBe("Testing");
+                context.Exception = setCustomError
+                    ? new MyExecutionError("Testing 2")
+                    : new ApplicationException("Testing 3");
+                if (overrideMessage)
+                    context.ErrorMessage = "Testing 4";
+                return Task.CompletedTask;
+            })
+        );
+        using var provider = services.BuildServiceProvider();
+        var executer = provider.GetRequiredService<IDocumentExecuter>();
+        executionOptions = new ExecutionOptions
+        {
+            Query = "{hero}",
+            RequestServices = provider,
+            ThrowOnUnhandledException = throwOnUnhandledException,
+        };
+        if (throwOnUnhandledException)
+        {
+            var ex = await executer.ExecuteAsync(executionOptions).ShouldThrowAsync<ApplicationException>();
+            ex.Message.ShouldBe("Testing");
+            ran.ShouldBeFalse();
+        }
+        else
+        {
+            var ret = await executer.ExecuteAsync(executionOptions);
+            if (!setCustomError)
+            {
+                var ex = ret.Errors.ShouldHaveSingleItem().ShouldBeOfType<UnhandledError>();
+                ex.Message.ShouldBe(overrideMessage ? "Testing 4" : "Error executing document.");
+                ex.InnerException.ShouldBeOfType<ApplicationException>()
+                    .Message.ShouldBe("Testing 3");
+            }
+            else
+            {
+                ret.Errors.ShouldHaveSingleItem().ShouldBeOfType<MyExecutionError>()
+                    .Message.ShouldBe("Testing 2");
+            }
+            ran.ShouldBeTrue();
+        }
+    }
+
+    private class MyExecutionError : ExecutionError
+    {
+        public MyExecutionError(string message) : base(message) { }
     }
 
     private class MyConfigureExecution : IConfigureExecution

--- a/src/GraphQL.Tests/Instrumentation/OpenTelemetryTests.cs
+++ b/src/GraphQL.Tests/Instrumentation/OpenTelemetryTests.cs
@@ -346,6 +346,7 @@ public sealed class OpenTelemetryTests : IDisposable
         {
             Query = "query withActivityQuery { withActivity }",
             RequestServices = _host.Services,
+            ThrowOnUnhandledException = true,
         };
         bool ranFilter = false;
         _options.Filter = options =>
@@ -396,6 +397,7 @@ public sealed class OpenTelemetryTests : IDisposable
         {
             Query = "query helloQuery { hello }",
             RequestServices = _host.Services,
+            ThrowOnUnhandledException = true,
         };
 
         _options.Filter = _ => filter ?? throw new FilterException();

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -65,7 +65,39 @@ public class DocumentExecuter : IDocumentExecuter
             var nextExecution = execution;
             execution = async options => await action.ExecuteAsync(options, nextExecution).ConfigureAwait(false);
         }
-        return execution;
+        return async options =>
+        {
+            try
+            {
+                return await execution(options).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (options.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (ExecutionError ex)
+            {
+                return new ExecutionResult(ex);
+            }
+            catch (Exception ex)
+            {
+                if (options.ThrowOnUnhandledException)
+                    throw;
+
+                UnhandledExceptionContext? exceptionContext = null;
+                if (options.UnhandledExceptionDelegate != null)
+                {
+                    exceptionContext = new UnhandledExceptionContext(options, ex);
+                    await options.UnhandledExceptionDelegate(exceptionContext).ConfigureAwait(false);
+                    ex = exceptionContext.Exception;
+                }
+
+                var executionError = ex as ExecutionError ??
+                    new UnhandledError(exceptionContext?.ErrorMessage ?? "Error executing document.", ex);
+
+                return new ExecutionResult(executionError);
+            }
+        };
     }
 
     /// <inheritdoc/>
@@ -197,7 +229,9 @@ public class DocumentExecuter : IDocumentExecuter
             UnhandledExceptionContext? exceptionContext = null;
             if (options.UnhandledExceptionDelegate != null)
             {
-                exceptionContext = new UnhandledExceptionContext(context, null, ex);
+                exceptionContext = context == null
+                    ? new UnhandledExceptionContext(options, ex)
+                    : new UnhandledExceptionContext(context, null, ex);
                 await options.UnhandledExceptionDelegate(exceptionContext).ConfigureAwait(false);
                 ex = exceptionContext.Exception;
             }
@@ -227,6 +261,7 @@ public class DocumentExecuter : IDocumentExecuter
             Schema = options.Schema!,
             RootValue = options.Root,
             UserContext = options.UserContext,
+            ExecutionOptions = options,
 
             Operation = operation,
             Variables = validationResult.Variables ?? Variables.None,

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -44,6 +44,7 @@ public class ExecutionContext : IExecutionContext, IExecutionArrayPool, IDisposa
         InputExtensions = context.InputExtensions;
         RequestServices = context.RequestServices;
         User = context.User;
+        ExecutionOptions = context.ExecutionOptions;
     }
 
     /// <inheritdoc/>
@@ -106,6 +107,9 @@ public class ExecutionContext : IExecutionContext, IExecutionArrayPool, IDisposa
 
     /// <inheritdoc/>
     public ClaimsPrincipal? User { get; set; }
+
+    /// <inheritdoc/>
+    public ExecutionOptions ExecutionOptions { get; set; }
 
     /// <inheritdoc/>
     public TElement[] Rent<TElement>(int minimumLength)

--- a/src/GraphQL/Execution/IExecutionContext.cs
+++ b/src/GraphQL/Execution/IExecutionContext.cs
@@ -108,4 +108,9 @@ public interface IExecutionContext : IProvideUserContext
     /// Gets security information for the executing request.
     /// </summary>
     ClaimsPrincipal? User { get; }
+
+    /// <summary>
+    /// Returns the <see cref="ExecutionOptions"/> used to configure the current execution.
+    /// </summary>
+    ExecutionOptions ExecutionOptions { get; }
 }

--- a/src/GraphQL/Execution/UnhandledExceptionContext.cs
+++ b/src/GraphQL/Execution/UnhandledExceptionContext.cs
@@ -8,10 +8,21 @@ public class UnhandledExceptionContext
     /// <summary>
     /// Initializes a new instance with the specified properties.
     /// </summary>
-    public UnhandledExceptionContext(IExecutionContext? context, IResolveFieldContext? fieldContext, Exception originalException)
+    public UnhandledExceptionContext(IExecutionContext context, IResolveFieldContext? fieldContext, Exception originalException)
     {
         Context = context;
+        ExecutionOptions = context.ExecutionOptions;
         FieldContext = fieldContext;
+        OriginalException = originalException;
+        Exception = originalException;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified properties.
+    /// </summary>
+    public UnhandledExceptionContext(ExecutionOptions options, Exception originalException)
+    {
+        ExecutionOptions = options;
         OriginalException = originalException;
         Exception = originalException;
     }
@@ -27,6 +38,9 @@ public class UnhandledExceptionContext
     /// Also will be <see langword="null"/> between resolvers execution if <c>cancellationToken</c> is canceled.
     /// </summary>
     public IResolveFieldContext? FieldContext { get; }
+
+    /// <inheritdoc cref="IExecutionContext.ExecutionOptions"/>
+    public ExecutionOptions ExecutionOptions { get; }
 
     /// <summary>
     /// Original exception from field resolver or <see cref="DocumentExecuter"/>.

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -1173,7 +1173,7 @@ public static class GraphQLBuilderExtensions // TODO: split
 #endif
     #endregion
 
-    #region - ConfigureUnhandledExceptionHandler -
+    #region - AddUnhandledExceptionHandler -
     /// <summary>
     /// Configures the delegate to be called when an unhandled exception occurs during document execution.
     /// This is typically used to log exceptions to a database for further review.
@@ -1205,7 +1205,8 @@ public static class GraphQLBuilderExtensions // TODO: split
         if (unhandledExceptionDelegate == null)
             throw new ArgumentNullException(nameof(unhandledExceptionDelegate));
 
-        return builder.ConfigureExecutionOptions(settings => settings.UnhandledExceptionDelegate = context => unhandledExceptionDelegate(context, settings));
+        var handler = (UnhandledExceptionContext context) => unhandledExceptionDelegate(context, context.ExecutionOptions);
+        return builder.ConfigureExecutionOptions(settings => settings.UnhandledExceptionDelegate = handler);
     }
 
     /// <inheritdoc cref="AddUnhandledExceptionHandler(IGraphQLBuilder, Func{UnhandledExceptionContext, Task})"/>
@@ -1230,11 +1231,12 @@ public static class GraphQLBuilderExtensions // TODO: split
         if (unhandledExceptionDelegate == null)
             throw new ArgumentNullException(nameof(unhandledExceptionDelegate));
 
-        builder.ConfigureExecutionOptions(settings => settings.UnhandledExceptionDelegate = context =>
+        var handler = (UnhandledExceptionContext context) =>
         {
-            unhandledExceptionDelegate(context, settings);
+            unhandledExceptionDelegate(context, context.ExecutionOptions);
             return Task.CompletedTask;
-        });
+        };
+        builder.ConfigureExecutionOptions(settings => settings.UnhandledExceptionDelegate = handler);
         return builder;
     }
     #endregion

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -1199,6 +1199,7 @@ public static class GraphQLBuilderExtensions // TODO: split
     }
 
     /// <inheritdoc cref="AddUnhandledExceptionHandler(IGraphQLBuilder, Func{UnhandledExceptionContext, Task})"/>
+    [Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of using this overload.")]
     public static IGraphQLBuilder AddUnhandledExceptionHandler(this IGraphQLBuilder builder, Func<UnhandledExceptionContext, ExecutionOptions, Task> unhandledExceptionDelegate)
     {
         if (unhandledExceptionDelegate == null)
@@ -1223,6 +1224,7 @@ public static class GraphQLBuilderExtensions // TODO: split
     }
 
     /// <inheritdoc cref="AddUnhandledExceptionHandler(IGraphQLBuilder, Func{UnhandledExceptionContext, Task})"/>
+    [Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of using this overload.")]
     public static IGraphQLBuilder AddUnhandledExceptionHandler(this IGraphQLBuilder builder, Action<UnhandledExceptionContext, ExecutionOptions> unhandledExceptionDelegate)
     {
         if (unhandledExceptionDelegate == null)


### PR DESCRIPTION
### `UnhandledExceptionContext.ExecutionOptions` added

In certain cases, such as when an exception was thrown during schema initialization, there was no `ExecutionContext` available, and so both the `Context` and `FieldContext` properties were null, preventing access to any relevant information about the request that caused the failure, and also preventing access to the `RequestServices` property to pull logging services from the DI service provider.

In the past a workaround was implemented by setting the delegate during the execution configuration chain, getting a reference to the options class in the process.  With the newly added property, this is no longer necessary, so the workaround overload has been marked as deprecated.

While the situations where this is applicable were rare, now due to the feature listed below, adding this property is increasingly important (or users need to continue to use the workaround).

### Handle errors thrown during GraphQL execution configuration delegates

For example, for the newly added persisted document handler, if a database error were to occur within the `IPersistedDocumentLoader` implementation, the exception would bubble all the way to ASP.NET Core, skipping the unhandled exception delegate and returning a 500 error to the client.

Now any errors that occur there will go through the unhandled exception handler used by the rest of the GraphQL.NET execution, allowing for:
1. Logging of these errors
2. Wrapping them with UnhandledError or as defined
3. ErrorInfoProvider can reformat the message within the returned response if desired (e.g. for authenticated requests)