### PR TITLE
Revert "Ignore NU1903 for System.Text.Json 4.7.2 (#3984)"

### DIFF
--- a/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
+++ b/src/GraphQL.SystemTextJson/GraphQL.SystemTextJson.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GraphQL\GraphQL.csproj" PackageVersion="[$(Version),$(NextVersion))" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" NoWarn="NU1903" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Patch has been fixed; STJ 4.7.2 is no longer marked as vulnerable