### PR TITLE
Optimize scalar lists

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -947,6 +947,15 @@ rethrow the `OperationCanceledException` to the caller, regardless of the `Timeo
 Please review the documentation for the new complexity analyzer to understand how to use it and how to configure it.
 See the 'Complexity Analzyer' document with the 'Guides' section of the documentation for more information.
 
+### 26. Optimization when returning lists of scalars
+
+When returning a list of scalars, specifically of intrinsic types such as `int`, `string`, and `bool`, the matching
+scalar type (e.g. `IntGraphType`, `StringGraphType`, `BooleanGraphType`) will be used to serialize the list as a whole
+rather than each individual item. This can result in a significant performance improvement when returning large lists
+of scalars. Be sure the returned list type (e.g. `IEnumerable<int>`) matches the scalar type (e.g. `IntGraphType`)
+to take advantage of this optimization. Scalar types that require conversion, such as `DateTimeGraphType` are not
+currently optimized in this way.
+
 ## Breaking Changes
 
 ### 1. Query type is required
@@ -1270,3 +1279,7 @@ services.AddGraphQL(b => b
     })
 );
 ```
+
+### 24. ID graph type serialization is culture-invariant
+
+The `IdGraphType` now serializes values using the invariant culture.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1222,6 +1222,7 @@ namespace GraphQL.Execution
     {
         public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQLParser.AST.GraphQLField field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode>? Items { get; set; }
+        public System.Collections.IEnumerable? SerializedResult { get; set; }
         public void ApplyToChildren<TState>(System.Action<GraphQL.Execution.ExecutionNode, TState> action, TState state, bool reverse = false) { }
         public override bool PropagateNull() { }
         public override object? ToValue() { }
@@ -2281,6 +2282,7 @@ namespace GraphQL.Types
     {
         public BigIntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2289,6 +2291,7 @@ namespace GraphQL.Types
         public BooleanGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override GraphQLParser.AST.GraphQLValue ToAST(object? value) { }
@@ -2297,6 +2300,7 @@ namespace GraphQL.Types
     {
         public ByteGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2416,6 +2420,7 @@ namespace GraphQL.Types
         public ComplexScalarGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
@@ -2451,6 +2456,7 @@ namespace GraphQL.Types
     {
         public DecimalGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2570,6 +2576,7 @@ namespace GraphQL.Types
     {
         public FloatGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2605,14 +2612,17 @@ namespace GraphQL.Types
         public GuidGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
+        public override System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
     }
     public class HalfGraphType : GraphQL.Types.ScalarGraphType
     {
         public HalfGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2738,9 +2748,11 @@ namespace GraphQL.Types
     {
         public IdGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
+        public override System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
     }
     public class IncludeDirective : GraphQL.Types.Directive
     {
@@ -2763,6 +2775,7 @@ namespace GraphQL.Types
     {
         public IntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2810,6 +2823,7 @@ namespace GraphQL.Types
     {
         public LongGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2910,6 +2924,7 @@ namespace GraphQL.Types
     {
         public SByteGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2918,6 +2933,7 @@ namespace GraphQL.Types
         protected ScalarGraphType() { }
         public virtual bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public virtual bool CanParseValue(object? value) { }
+        public virtual bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override void Initialize(GraphQL.Types.ISchema schema) { }
         public virtual bool IsValidDefault(object value) { }
         protected double ParseDoubleAccordingSpec<TValueNode>(TValueNode node)
@@ -2925,6 +2941,7 @@ namespace GraphQL.Types
         public virtual object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public abstract object? ParseValue(object? value);
         public virtual object? Serialize(object? value) { }
+        public virtual System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         protected GraphQLParser.AST.GraphQLValue ThrowASTConversionError(object? value) { }
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -3018,6 +3035,7 @@ namespace GraphQL.Types
     {
         public ShortGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3030,6 +3048,7 @@ namespace GraphQL.Types
         public StringGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3087,6 +3106,7 @@ namespace GraphQL.Types
     {
         public UIntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3094,6 +3114,7 @@ namespace GraphQL.Types
     {
         public ULongGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3101,6 +3122,7 @@ namespace GraphQL.Types
     {
         public UShortGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1222,6 +1222,7 @@ namespace GraphQL.Execution
     {
         public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQLParser.AST.GraphQLField field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode>? Items { get; set; }
+        public System.Collections.IEnumerable? SerializedResult { get; set; }
         public void ApplyToChildren<TState>(System.Action<GraphQL.Execution.ExecutionNode, TState> action, TState state, bool reverse = false) { }
         public override bool PropagateNull() { }
         public override object? ToValue() { }
@@ -2281,6 +2282,7 @@ namespace GraphQL.Types
     {
         public BigIntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2289,6 +2291,7 @@ namespace GraphQL.Types
         public BooleanGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override GraphQLParser.AST.GraphQLValue ToAST(object? value) { }
@@ -2297,6 +2300,7 @@ namespace GraphQL.Types
     {
         public ByteGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2416,6 +2420,7 @@ namespace GraphQL.Types
         public ComplexScalarGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
@@ -2458,6 +2463,7 @@ namespace GraphQL.Types
     {
         public DecimalGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2577,6 +2583,7 @@ namespace GraphQL.Types
     {
         public FloatGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2612,14 +2619,17 @@ namespace GraphQL.Types
         public GuidGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
+        public override System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
     }
     public class HalfGraphType : GraphQL.Types.ScalarGraphType
     {
         public HalfGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2745,9 +2755,11 @@ namespace GraphQL.Types
     {
         public IdGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
+        public override System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
     }
     public class IncludeDirective : GraphQL.Types.Directive
     {
@@ -2770,6 +2782,7 @@ namespace GraphQL.Types
     {
         public IntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2817,6 +2830,7 @@ namespace GraphQL.Types
     {
         public LongGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2917,6 +2931,7 @@ namespace GraphQL.Types
     {
         public SByteGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2925,6 +2940,7 @@ namespace GraphQL.Types
         protected ScalarGraphType() { }
         public virtual bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public virtual bool CanParseValue(object? value) { }
+        public virtual bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override void Initialize(GraphQL.Types.ISchema schema) { }
         public virtual bool IsValidDefault(object value) { }
         protected double ParseDoubleAccordingSpec<TValueNode>(TValueNode node)
@@ -2932,6 +2948,7 @@ namespace GraphQL.Types
         public virtual object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public abstract object? ParseValue(object? value);
         public virtual object? Serialize(object? value) { }
+        public virtual System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         protected GraphQLParser.AST.GraphQLValue ThrowASTConversionError(object? value) { }
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -3025,6 +3042,7 @@ namespace GraphQL.Types
     {
         public ShortGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3037,6 +3055,7 @@ namespace GraphQL.Types
         public StringGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3101,6 +3120,7 @@ namespace GraphQL.Types
     {
         public UIntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3108,6 +3128,7 @@ namespace GraphQL.Types
     {
         public ULongGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3115,6 +3136,7 @@ namespace GraphQL.Types
     {
         public UShortGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1187,6 +1187,7 @@ namespace GraphQL.Execution
     {
         public ArrayExecutionNode(GraphQL.Execution.ExecutionNode parent, GraphQL.Types.IGraphType graphType, GraphQLParser.AST.GraphQLField field, GraphQL.Types.FieldType fieldDefinition, int? indexInParentNode) { }
         public System.Collections.Generic.List<GraphQL.Execution.ExecutionNode>? Items { get; set; }
+        public System.Collections.IEnumerable? SerializedResult { get; set; }
         public void ApplyToChildren<TState>(System.Action<GraphQL.Execution.ExecutionNode, TState> action, TState state, bool reverse = false) { }
         public override bool PropagateNull() { }
         public override object? ToValue() { }
@@ -2215,6 +2216,7 @@ namespace GraphQL.Types
     {
         public BigIntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2223,6 +2225,7 @@ namespace GraphQL.Types
         public BooleanGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override GraphQLParser.AST.GraphQLValue ToAST(object? value) { }
@@ -2231,6 +2234,7 @@ namespace GraphQL.Types
     {
         public ByteGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2350,6 +2354,7 @@ namespace GraphQL.Types
         public ComplexScalarGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
@@ -2385,6 +2390,7 @@ namespace GraphQL.Types
     {
         public DecimalGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2504,6 +2510,7 @@ namespace GraphQL.Types
     {
         public FloatGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2539,9 +2546,11 @@ namespace GraphQL.Types
         public GuidGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
+        public override System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
     }
     public interface IAbstractGraphType : GraphQL.Types.IGraphType, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
@@ -2665,9 +2674,11 @@ namespace GraphQL.Types
     {
         public IdGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
         public override object? Serialize(object? value) { }
+        public override System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
     }
     public class IncludeDirective : GraphQL.Types.Directive
     {
@@ -2690,6 +2701,7 @@ namespace GraphQL.Types
     {
         public IntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2737,6 +2749,7 @@ namespace GraphQL.Types
     {
         public LongGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2837,6 +2850,7 @@ namespace GraphQL.Types
     {
         public SByteGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2845,6 +2859,7 @@ namespace GraphQL.Types
         protected ScalarGraphType() { }
         public virtual bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public virtual bool CanParseValue(object? value) { }
+        public virtual bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override void Initialize(GraphQL.Types.ISchema schema) { }
         public virtual bool IsValidDefault(object value) { }
         protected double ParseDoubleAccordingSpec<TValueNode>(TValueNode node)
@@ -2852,6 +2867,7 @@ namespace GraphQL.Types
         public virtual object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public abstract object? ParseValue(object? value);
         public virtual object? Serialize(object? value) { }
+        public virtual System.Collections.IEnumerable SerializeList(System.Collections.IEnumerable list) { }
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         protected GraphQLParser.AST.GraphQLValue ThrowASTConversionError(object? value) { }
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -2945,6 +2961,7 @@ namespace GraphQL.Types
     {
         public ShortGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -2957,6 +2974,7 @@ namespace GraphQL.Types
         public StringGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override bool CanParseValue(object? value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3014,6 +3032,7 @@ namespace GraphQL.Types
     {
         public UIntGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3021,6 +3040,7 @@ namespace GraphQL.Types
     {
         public ULongGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }
@@ -3028,6 +3048,7 @@ namespace GraphQL.Types
     {
         public UShortGraphType() { }
         public override bool CanParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
+        public override bool CanSerializeList(System.Collections.IEnumerable list, bool allowNulls) { }
         public override object? ParseLiteral(GraphQLParser.AST.GraphQLValue value) { }
         public override object? ParseValue(object? value) { }
     }

--- a/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.NewtonsoftJson/ExecutionResultJsonConverter.cs
@@ -87,7 +87,26 @@ public class ExecutionResultJsonConverter : JsonConverter
             var items = arrayExecutionNode.Items;
             if (items == null)
             {
-                writer.WriteNull();
+                var result = arrayExecutionNode.SerializedResult;
+                if (result == null)
+                {
+                    writer.WriteNull();
+                }
+                // there is a special case where a list of byte scalars has been fast-serialized as a list;
+                // we need to ensure that byte arrays are returned as byte arrays, and not as base64
+                else if (result.GetType() == typeof(byte[]))
+                {
+                    writer.WriteStartArray();
+                    foreach (var b in (byte[])result)
+                    {
+                        writer.WriteValue(b);
+                    }
+                    writer.WriteEndArray();
+                }
+                else
+                {
+                    serializer.Serialize(writer, arrayExecutionNode.SerializedResult);
+                }
             }
             else
             {

--- a/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
+++ b/src/GraphQL.SystemTextJson/ExecutionResultJsonConverter.cs
@@ -70,7 +70,7 @@ public class ExecutionResultJsonConverter : JsonConverter<ExecutionResult>
             var items = arrayExecutionNode.Items;
             if (items == null)
             {
-                writer.WriteNullValue();
+                JsonSerializer.Serialize(writer, arrayExecutionNode.SerializedResult, options);
             }
             else
             {

--- a/src/GraphQL.Tests/Serialization/ExecutionResultTests.cs
+++ b/src/GraphQL.Tests/Serialization/ExecutionResultTests.cs
@@ -187,7 +187,14 @@ public class ExecutionResultTests
         var result = await new DocumentExecuter().ExecuteAsync(new ExecutionOptions
         {
             Schema = schema,
-            Query = "{ bools bools2 sBytes sBytes2 bytes bytes2 bytes3 shorts shorts2 uShorts uShorts2 ints ints2 ints3 uInts uInts2 longs longs2 uLongs uLongs2 singles singles2 doubles doubles2 decimals decimals2 bigIntegers bigIntegers2 strings strings2 }"
+            Query = """
+                {
+                    bools bools2 sBytes sBytes2 bytes bytes2 bytes3 shorts shorts2 uShorts uShorts2
+                    ints ints2 ints3 uInts uInts2 longs longs2 uLongs uLongs2 singles singles2
+                    doubles doubles2 decimals decimals2 bigIntegers bigIntegers2 strings strings2
+                    guids guids2 ids1 ids2 ids3 ids4 ids5 ids6
+                }
+                """
         });
         string actual = serializer.Serialize(result);
         actual.ShouldBeCrossPlatJson("""
@@ -222,7 +229,15 @@ public class ExecutionResultTests
                 "bigIntegers": [-1, 0, 1],
                 "bigIntegers2": [-1, null, 1],
                 "strings": ["abc", "def", "ghi"],
-                "strings2": ["abc", null, "ghi"]
+                "strings2": ["abc", null, "ghi"],
+                "guids": ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000"],
+                "guids2": ["00000000-0000-0000-0000-000000000000", null, "00000000-0000-0000-0000-000000000000"],
+                "ids1": ["1", "2", "3"],
+                "ids2": ["1", null, "3"],
+                "ids3": ["1", "2", "3"],
+                "ids4": ["1", null, "3"],
+                "ids5": ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000"],
+                "ids6": ["00000000-0000-0000-0000-000000000000", null, "00000000-0000-0000-0000-000000000000"]
               }
             }
             """);
@@ -262,5 +277,19 @@ public class ExecutionResultTests
         public static BigInteger?[] BigIntegers2 => [-1, null, 1];
         public static string[] Strings => ["abc", "def", "ghi"];
         public static string?[] Strings2 => ["abc", null, "ghi"];
+        public static Guid[] Guids => [Guid.Empty, Guid.Empty, Guid.Empty];
+        public static Guid?[] Guids2 => [Guid.Empty, null, Guid.Empty];
+        [Id]
+        public static int[] Ids1 => [1, 2, 3];
+        [Id]
+        public static int?[] Ids2 => [1, null, 3];
+        [Id]
+        public static long[] Ids3 => [1, 2, 3];
+        [Id]
+        public static long?[] Ids4 => [1, null, 3];
+        [Id]
+        public static Guid[] Ids5 => [Guid.Empty, Guid.Empty, Guid.Empty];
+        [Id]
+        public static Guid?[] Ids6 => [Guid.Empty, null, Guid.Empty];
     }
 }

--- a/src/GraphQL.Tests/Serialization/ExecutionResultTests.cs
+++ b/src/GraphQL.Tests/Serialization/ExecutionResultTests.cs
@@ -1,4 +1,6 @@
+using System.Numerics;
 using GraphQL.Tests.StarWars;
+using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.Tests.Serialization;
@@ -171,5 +173,94 @@ public class ExecutionResultTests
         await serializer.WriteAsync(stream, result);
         string asyncResult = System.Text.Encoding.UTF8.GetString(stream.ToArray());
         syncResult.ShouldBe(asyncResult);
+    }
+
+    [Theory]
+    [ClassData(typeof(GraphQLSerializersTestData))]
+    public async Task IntegralListTypesSerializeCorrectly(IGraphQLTextSerializer serializer)
+    {
+        var schema = new Schema
+        {
+            Query = new AutoRegisteringObjectGraphType<ArraySampleQuery>(),
+        };
+        schema.Initialize();
+        var result = await new DocumentExecuter().ExecuteAsync(new ExecutionOptions
+        {
+            Schema = schema,
+            Query = "{ bools bools2 sBytes sBytes2 bytes bytes2 bytes3 shorts shorts2 uShorts uShorts2 ints ints2 ints3 uInts uInts2 longs longs2 uLongs uLongs2 singles singles2 doubles doubles2 decimals decimals2 bigIntegers bigIntegers2 strings strings2 }"
+        });
+        string actual = serializer.Serialize(result);
+        actual.ShouldBeCrossPlatJson("""
+            {
+              "data": {
+                "bools": [true, false],
+                "bools2": [true, null],
+                "sBytes": [-1, 0, 1],
+                "sBytes2": [-1, null, 1],
+                "bytes": [0, 1, 2],
+                "bytes2": [null, 1, 2],
+                "bytes3": [0, 1, 2],
+                "shorts": [-1, 0, 1],
+                "shorts2": [-1, null, 1],
+                "uShorts": [0, 1, 2],
+                "uShorts2": [null, 1, 2],
+                "ints": [-1, 0, 1],
+                "ints2": [-1, null, 1],
+                "ints3": [-1, 0, 1],
+                "uInts": [0, 1, 2],
+                "uInts2": [null, 1, 2],
+                "longs": [-1, 0, 1],
+                "longs2": [-1, null, 1],
+                "uLongs": [0, 1, 2],
+                "uLongs2": [null, 1, 2],
+                "singles": [-1.5, 0, 1.5],
+                "singles2": [-1.5, null, 1.5],
+                "doubles": [-1.5, 0, 1.5],
+                "doubles2": [-1.5, null, 1.5],
+                "decimals": [-1.5, 0, 1.5],
+                "decimals2": [-1.5, null, 1.5],
+                "bigIntegers": [-1, 0, 1],
+                "bigIntegers2": [-1, null, 1],
+                "strings": ["abc", "def", "ghi"],
+                "strings2": ["abc", null, "ghi"]
+              }
+            }
+            """);
+    }
+
+    private class ArraySampleQuery()
+    {
+        public static bool[] Bools => [true, false];
+        public static bool?[] Bools2 => [true, null];
+
+        public static sbyte[] SBytes => [-1, 0, 1];
+        public static sbyte?[] SBytes2 => [-1, null, 1];
+        public static byte[] Bytes => [0, 1, 2];
+        public static byte?[] Bytes2 => [null, 1, 2];
+        public static List<byte> Bytes3 => [0, 1, 2];
+        public static short[] Shorts => [-1, 0, 1];
+        public static short?[] Shorts2 => [-1, null, 1];
+        public static ushort[] UShorts => [0, 1, 2];
+        public static ushort?[] UShorts2 => [null, 1, 2];
+        public static int[] Ints => [-1, 0, 1];
+        public static int?[] Ints2 => [-1, null, 1];
+        [OutputType(typeof(NonNullGraphType<ListGraphType<NonNullGraphType<IntGraphType>>>))]
+        public static long[] Ints3 => [-1, 0, 1];
+        public static uint[] UInts => [0, 1, 2];
+        public static uint?[] UInts2 => [null, 1, 2];
+        public static long[] Longs => [-1, 0, 1];
+        public static long?[] Longs2 => [-1, null, 1];
+        public static ulong[] ULongs => [0, 1, 2];
+        public static ulong?[] ULongs2 => [null, 1, 2];
+        public static float[] Singles => [-1.5f, 0, 1.5f];
+        public static float?[] Singles2 => [-1.5f, null, 1.5f];
+        public static double[] Doubles => [-1.5, 0, 1.5];
+        public static double?[] Doubles2 => [-1.5, null, 1.5];
+        public static decimal[] Decimals => [-1.5m, 0, 1.5m];
+        public static decimal?[] Decimals2 => [-1.5m, null, 1.5m];
+        public static BigInteger[] BigIntegers => [-1, 0, 1];
+        public static BigInteger?[] BigIntegers2 => [-1, null, 1];
+        public static string[] Strings => ["abc", "def", "ghi"];
+        public static string?[] Strings2 => ["abc", null, "ghi"];
     }
 }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -413,12 +413,22 @@ public abstract class ExecutionStrategy : IExecutionStrategy
         var listType = (ListGraphType)parent.GraphType!;
         var itemType = listType.ResolvedType!;
 
+        bool allowNulls = true;
         if (itemType is NonNullGraphType nonNullGraphType)
+        {
+            allowNulls = false;
             itemType = nonNullGraphType.ResolvedType!;
+        }
 
         if (parent.Result is not IEnumerable data)
         {
-            throw new InvalidOperationException($"Expected an IEnumerable list though did not find one. Found: {parent.Result?.GetType().Name}");
+            throw new InvalidOperationException($"Expected an IEnumerable list though did not find one. Found: {parent.Result?.GetType().GetFriendlyName()}");
+        }
+
+        if (itemType is ScalarGraphType scalarType && scalarType.CanSerializeList(data, allowNulls))
+        {
+            parent.SerializedResult = scalarType.SerializeList(data);
+            return;
         }
 
         int index = 0;

--- a/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
+++ b/src/GraphQL/Execution/Nodes/ArrayExecutionNode.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using GraphQL.Types;
 using GraphQLParser.AST;
 
@@ -14,6 +15,11 @@ public class ArrayExecutionNode : ExecutionNode, IParentExecutionNode
     public List<ExecutionNode>? Items { get; set; }
 
     /// <summary>
+    /// Returns a serialized result of the child execution nodes.
+    /// </summary>
+    public IEnumerable? SerializedResult { get; set; }
+
+    /// <summary>
     /// Initializes an <see cref="ArrayExecutionNode"/> instance with the specified values.
     /// </summary>
     public ArrayExecutionNode(ExecutionNode parent, IGraphType graphType, GraphQLField field, FieldType fieldDefinition, int? indexInParentNode)
@@ -28,7 +34,7 @@ public class ArrayExecutionNode : ExecutionNode, IParentExecutionNode
     public override object? ToValue()
     {
         if (Items == null)
-            return null;
+            return SerializedResult;
 
         var items = new object?[Items.Count];
         for (int i = 0; i < Items.Count; ++i)
@@ -43,7 +49,7 @@ public class ArrayExecutionNode : ExecutionNode, IParentExecutionNode
     public override bool PropagateNull()
     {
         if (Items == null)
-            return true;
+            return SerializedResult == null;
 
         if (Items.Count == 0)
             return false;

--- a/src/GraphQL/Extensions/EnumerableExtensions.cs
+++ b/src/GraphQL/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,24 @@
+namespace GraphQL;
+
+internal static class EnumerableExtensions
+{
+    /// <inheritdoc cref="Enumerable.All{TSource}(IEnumerable{TSource}, Func{TSource, bool})"/>
+    public static bool FastAll<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+    {
+        // .NET 9 already includes this optimization
+#if !NET9_0_OR_GREATER
+        // no-allocation check
+        if (source is IList<T> list)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (!predicate(list[i]))
+                    return false;
+            }
+            return true;
+        }
+#endif
+        // fallback to LINQ
+        return source.All(predicate);
+    }
+}

--- a/src/GraphQL/Types/Scalars/BigIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BigIntGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class BigIntGraphType : ScalarGraphType
         ulong ul => new BigInteger(ul),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<BigInteger>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/BooleanGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BooleanGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using GraphQLParser.AST;
 
 namespace GraphQL.Types;
@@ -38,4 +39,8 @@ public class BooleanGraphType : ScalarGraphType
         null => GraphQLValuesCache.Null,
         _ => ThrowASTConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<bool>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/ByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ByteGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class ByteGraphType : ScalarGraphType
         BigInteger bi => checked((byte)bi),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<byte>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/ComplexScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ComplexScalarGraphType.cs
@@ -44,6 +44,10 @@ public class ComplexScalarGraphType : ScalarGraphType
     public override object? Serialize(object? value) => value;
 
     /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => allowNulls || list is IEnumerable<object?> objectList && objectList.FastAll(value => value != null);
+
+    /// <inheritdoc/>
     public override GraphQLValue ToAST(object? value)
     {
         return value switch

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -45,4 +46,8 @@ public class DecimalGraphType : ScalarGraphType
         BigInteger bi => (decimal)bi,
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<decimal>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -49,4 +50,8 @@ public class FloatGraphType : ScalarGraphType
         BigInteger bi => (double)bi,
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<double>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/GuidGraphType.cs
+++ b/src/GraphQL/Types/Scalars/GuidGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Globalization;
 using GraphQLParser.AST;
 
@@ -56,5 +57,18 @@ public class GuidGraphType : ScalarGraphType
         Guid g => g.ToString("D", CultureInfo.InvariantCulture),
         null => null,
         _ => ThrowSerializationError(value)
+    };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<Guid>(list, allowNulls);
+
+    /// <inheritdoc/>
+    public override IEnumerable SerializeList(IEnumerable list) => list switch
+    {
+        // while not ideal, this does provide a notable performance benefit over constructing an execution node for each value
+        IEnumerable<Guid> list2 => list2.Select(g => g.ToString("D", CultureInfo.InvariantCulture)),
+        IEnumerable<Guid?> list2 => list2.Select(g => g?.ToString("D", CultureInfo.InvariantCulture)),
+        _ => throw new NotSupportedException()
     };
 }

--- a/src/GraphQL/Types/Scalars/HalfGraphType.cs
+++ b/src/GraphQL/Types/Scalars/HalfGraphType.cs
@@ -1,5 +1,6 @@
 #if NET5_0_OR_GREATER
 
+using System.Collections;
 using System.Numerics;
 using GraphQLParser;
 using GraphQLParser.AST;
@@ -64,6 +65,10 @@ public class HalfGraphType : ScalarGraphType
         BigInteger bi => NotInfinity(checked((Half)(double)bi)),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<Half>(list, allowNulls);
 }
 
 #endif

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -91,6 +91,7 @@ public class IdGraphType : ScalarGraphType
     /// <inheritdoc/>
     public override IEnumerable SerializeList(IEnumerable list) => list switch
     {
+        // CanSerializeList has already verified that these are not uint[] or ulong[]
         IEnumerable<int> values => values.Select(value => value.ToString(CultureInfo.InvariantCulture)),
         IEnumerable<int?> values => values.Select(value => value?.ToString(CultureInfo.InvariantCulture)),
         IEnumerable<long> values => values.Select(value => value.ToString(CultureInfo.InvariantCulture)),

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Globalization;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -62,5 +64,39 @@ public class IdGraphType : ScalarGraphType
     };
 
     /// <inheritdoc/>
-    public override object? Serialize(object? value) => ParseValue(value)?.ToString();
+    public override object? Serialize(object? value) => value switch
+    {
+        string _ => value,
+        int i => i.ToString(CultureInfo.InvariantCulture),
+        long l => l.ToString(CultureInfo.InvariantCulture),
+        Guid g => g.ToString("D"),
+        null => null,
+        byte b => b.ToString(CultureInfo.InvariantCulture),
+        sbyte sb => sb.ToString(CultureInfo.InvariantCulture),
+        short s => s.ToString(CultureInfo.InvariantCulture),
+        ushort us => us.ToString(CultureInfo.InvariantCulture),
+        uint ui => ui.ToString(CultureInfo.InvariantCulture),
+        ulong ul => ul.ToString(CultureInfo.InvariantCulture),
+        BigInteger bi => bi.ToString(CultureInfo.InvariantCulture),
+        _ => ThrowSerializationError(value)
+    };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls) =>
+        CanSerializeList<int>(list, allowNulls) ||
+        CanSerializeList<long>(list, allowNulls) ||
+        CanSerializeList<Guid>(list, allowNulls) ||
+        list is IEnumerable<string?> values && values.FastAll(static s => s != null);
+
+    /// <inheritdoc/>
+    public override IEnumerable SerializeList(IEnumerable list) => list switch
+    {
+        IEnumerable<int> values => values.Select(value => value.ToString(CultureInfo.InvariantCulture)),
+        IEnumerable<int?> values => values.Select(value => value?.ToString(CultureInfo.InvariantCulture)),
+        IEnumerable<long> values => values.Select(value => value.ToString(CultureInfo.InvariantCulture)),
+        IEnumerable<long?> values => values.Select(value => value?.ToString(CultureInfo.InvariantCulture)),
+        IEnumerable<Guid> values => values.Select(value => value.ToString("D")),
+        IEnumerable<Guid?> values => values.Select(value => value?.ToString("D")),
+        _ => throw new NotSupportedException(),
+    };
 }

--- a/src/GraphQL/Types/Scalars/IntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IntGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class IntGraphType : ScalarGraphType
         BigInteger bi => checked((int)bi),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<int>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class LongGraphType : ScalarGraphType
         BigInteger bi => checked((long)bi),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<long>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/SByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/SByteGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class SByteGraphType : ScalarGraphType
         BigInteger bi => checked((sbyte)bi),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<sbyte>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/ScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ScalarGraphType.cs
@@ -64,7 +64,7 @@ public abstract class ScalarGraphType : GraphType
 
     /// <summary>
     /// Given a list where <see cref="CanSerializeList(IEnumerable, bool)"/> has already returned <see langword="true"/>,
-    /// this method must serialize each member of the list.and return the new list without an exception. Behavior when
+    /// this method must serialize each member of the list and return the new list without an exception. Behavior when
     /// <see cref="CanSerializeList(IEnumerable, bool)"/> does not return <see langword="true"/> is undefined.
     /// </summary>
     public virtual IEnumerable SerializeList(IEnumerable list) => list;

--- a/src/GraphQL/Types/Scalars/ScalarGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ScalarGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -32,6 +33,41 @@ public abstract class ScalarGraphType : GraphType
     /// value by the serialization layer. Returning <see langword="null"/> is valid.
     /// </returns>
     public virtual object? Serialize(object? value) => ParseValue(value);
+
+    /// <summary>
+    /// Indicates if the scalar can serialize a list of values without possibility of an exception.
+    /// The <paramref name="allowNulls"/> parameter indicates if the list may contain <see langword="null"/>
+    /// values. Typical implementations may check to see if the list is an <see cref="IEnumerable{T}"/> of
+    /// the correct type. An implementation may also check each member to see if it can be serialized
+    /// to the destination type.
+    /// </summary>
+    public virtual bool CanSerializeList(IEnumerable list, bool allowNulls) => false;
+
+    internal static bool CanSerializeList<T>(IEnumerable list, bool allowNulls)
+        where T : struct
+    {
+        // int[] matches on IEnumerable<int> and also IEnumerable<uint>, so we need to directly check array
+        // types before matching against IEnumerable (List<int> does not match on both interfaces)
+        var listType = list.GetType();
+        if (listType == typeof(T[]))
+            return true;
+        if (listType == typeof(T?[]))
+            return allowNulls || ((T?[])list).FastAll(t => t.HasValue);
+        if (listType.IsArray)
+            return false;
+        if (listType is IEnumerable<T>)
+            return true;
+        if (listType is IEnumerable<T?> nullableList)
+            return allowNulls || nullableList.FastAll(t => t.HasValue);
+        return false;
+    }
+
+    /// <summary>
+    /// Given a list where <see cref="CanSerializeList(IEnumerable, bool)"/> has already returned <see langword="true"/>,
+    /// this method must serialize each member of the list.and return the new list without an exception. Behavior when
+    /// <see cref="CanSerializeList(IEnumerable, bool)"/> does not return <see langword="true"/> is undefined.
+    /// </summary>
+    public virtual IEnumerable SerializeList(IEnumerable list) => list;
 
     /// <summary>
     /// Literal input coercion. It takes an abstract syntax tree (AST) element from a schema

--- a/src/GraphQL/Types/Scalars/ShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ShortGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class ShortGraphType : ScalarGraphType
         BigInteger bi => checked((short)bi),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<short>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using GraphQLParser.AST;
 
 namespace GraphQL.Types;
@@ -29,4 +30,8 @@ public class StringGraphType : ScalarGraphType
 
     /// <inheritdoc/>
     public override bool CanParseValue(object? value) => value is string || value == null;
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => list is IEnumerable<string?> strings && (allowNulls || strings.FastAll(s => s != null));
 }

--- a/src/GraphQL/Types/Scalars/UIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UIntGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class UIntGraphType : ScalarGraphType
         BigInteger bi => checked((uint)bi),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<uint>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/ULongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ULongGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class ULongGraphType : ScalarGraphType
         uint ui => checked((ulong)ui),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<ulong>(list, allowNulls);
 }

--- a/src/GraphQL/Types/Scalars/UShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UShortGraphType.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Numerics;
 using GraphQLParser.AST;
 
@@ -40,4 +41,8 @@ public class UShortGraphType : ScalarGraphType
         BigInteger bi => checked((ushort)bi),
         _ => ThrowValueConversionError(value)
     };
+
+    /// <inheritdoc/>
+    public override bool CanSerializeList(IEnumerable list, bool allowNulls)
+        => CanSerializeList<ushort>(list, allowNulls);
 }


### PR DESCRIPTION
This change makes it so that when serializing a list of intrinsic types, such as `int[]` for `ListGraphType<IntGraphType>`, the scalar can serialize the entire list at once.  This eliminates at least two allocations per element and it should be much faster to boot. Of course the use case is narrow, but is certainly advantageous if you want to return a large list of metrics or similar values out of GraphQL.  Note that no changes are made for input types.

## Performance

Given this type-first schema, where each field returns 100 elements:

```cs
public class MyQuery
{
    public static int[] Ints { get; } = Enumerable.Range(1, 100).ToArray();
    public static string[] Strings { get; } = Enumerable.Range(1, 100).Select(x => x.ToString()).ToArray();
    public static Guid[] Guids { get; } = Enumerable.Range(1, 100).Select(x => Guid.NewGuid()).ToArray();
}
```

And one of three queries (cached, so query parsing & validation is not timed):

```gql
query Ints { ints }
query Strings { strings }
query Guids { guids }
```

Below metrics include either:
1. Only execution, or
2. Execution and serialization

### Before

| Method  | Serialize | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|-------- |---------- |----------:|----------:|----------:|-------:|-------:|----------:|
| Ints    | False     |  9.740 us | 0.0540 us | 0.0505 us | 0.6104 | 0.0153 |  11.43 KB |
| Strings | False     |  7.168 us | 0.1009 us | 0.0944 us | 0.4883 | 0.0076 |   9.09 KB |
| Guids   | False     | 10.275 us | 0.1981 us | 0.2281 us | 1.1597 | 0.0610 |  21.59 KB |
| Ints    | True      | 12.197 us | 0.1425 us | 0.1333 us | 0.6561 | 0.0153 |  12.06 KB |
| Strings | True      | 10.457 us | 0.1583 us | 0.1481 us | 0.5493 | 0.0153 |  10.12 KB |
| Guids   | True      | 14.122 us | 0.1393 us | 0.1235 us | 1.5869 | 0.0916 |  29.27 KB |

### After

| Method  | Serialize | Mean     | Error     | StdDev    | Gen0   | Allocated |
|-------- |---------- |---------:|----------:|----------:|-------:|----------:|
| Ints    | False     | 1.075 us | 0.0088 us | 0.0083 us | 0.1087 |   2.01 KB |
| Strings | False     | 1.056 us | 0.0123 us | 0.0103 us | 0.1087 |   2.01 KB |
| Guids   | False     | 1.088 us | 0.0158 us | 0.0148 us | 0.1106 |   2.05 KB |
| Ints    | True      | 4.226 us | 0.0602 us | 0.0563 us | 0.2670 |   5.02 KB |
| Strings | True      | 3.300 us | 0.0404 us | 0.0378 us | 0.1640 |   3.07 KB |
| Guids   | True      | 4.807 us | 0.0538 us | 0.0503 us | 1.0376 |  19.11 KB |
