### PR TITLE
Move new attributes to correct namespace

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1283,3 +1283,7 @@ services.AddGraphQL(b => b
 ### 24. ID graph type serialization is culture-invariant
 
 The `IdGraphType` now serializes values using the invariant culture.
+
+### 25. DirectiveAttribute moved to GraphQL namespace
+
+The `DirectiveAttribute` has been moved to the `GraphQL` namespace.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -70,10 +70,48 @@ namespace GraphQL
         public static TSchema WithIntrospectionComplexityImpact<TSchema>(this TSchema schema, double impact)
             where TSchema : GraphQL.Types.ISchema { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
+    public class ComplexityAttribute : GraphQL.GraphQLAttribute
+    {
+        public ComplexityAttribute(double fieldImpact) { }
+        public ComplexityAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] System.Type fieldComplexityAnalyzer) { }
+        public ComplexityAttribute(double fieldImpact, double childImpactMultiplier) { }
+        public double? ChildImpactMultiplier { get; }
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public System.Type? FieldComplexityAnalyzer { get; }
+        public double? FieldImpact { get; }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
+    public class ComplexityAttribute<T> : GraphQL.GraphQLAttribute
+        where T :  class, GraphQL.Validation.Complexity.IFieldComplexityAnalyzer, new ()
+    {
+        public ComplexityAttribute() { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
         public DefaultServiceProvider() { }
         public object? GetService(System.Type serviceType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class DirectiveAttribute : GraphQL.GraphQLAttribute
+    {
+        public System.Collections.Generic.Dictionary<string, object?> Arguments;
+        public DirectiveAttribute(string name) { }
+        public DirectiveAttribute(string name, params object[] argsAndValues) { }
+        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
+        public string Name { get; }
+        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
     public static class DirectivesExtensions
     {
@@ -863,47 +901,6 @@ namespace GraphQL
         public override string ToString() { }
         public static string op_Implicit(GraphQL.VariableName variableName) { }
         public static GraphQL.VariableName op_Implicit(string name) { }
-    }
-}
-namespace GraphQL.Attributes
-{
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
-    public class ComplexityAttribute : GraphQL.GraphQLAttribute
-    {
-        public ComplexityAttribute(double fieldImpact) { }
-        public ComplexityAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] System.Type fieldComplexityAnalyzer) { }
-        public ComplexityAttribute(double fieldImpact, double childImpactMultiplier) { }
-        public double? ChildImpactMultiplier { get; }
-        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-        public System.Type? FieldComplexityAnalyzer { get; }
-        public double? FieldImpact { get; }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
-    }
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
-    public class ComplexityAttribute<T> : GraphQL.GraphQLAttribute
-        where T :  class, GraphQL.Validation.Complexity.IFieldComplexityAnalyzer, new ()
-    {
-        public ComplexityAttribute() { }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
-    }
-    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
-    public class DirectiveAttribute : GraphQL.GraphQLAttribute
-    {
-        public System.Collections.Generic.Dictionary<string, object?> Arguments;
-        public DirectiveAttribute(string name) { }
-        public DirectiveAttribute(string name, params object[] argsAndValues) { }
-        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
-        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
-        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
-        public string Name { get; }
-        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
-        public override void Modify(GraphQL.Types.IGraphType graphType) { }
-        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
 }
 namespace GraphQL.Builders

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -70,10 +70,48 @@ namespace GraphQL
         public static TSchema WithIntrospectionComplexityImpact<TSchema>(this TSchema schema, double impact)
             where TSchema : GraphQL.Types.ISchema { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
+    public class ComplexityAttribute : GraphQL.GraphQLAttribute
+    {
+        public ComplexityAttribute(double fieldImpact) { }
+        public ComplexityAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] System.Type fieldComplexityAnalyzer) { }
+        public ComplexityAttribute(double fieldImpact, double childImpactMultiplier) { }
+        public double? ChildImpactMultiplier { get; }
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public System.Type? FieldComplexityAnalyzer { get; }
+        public double? FieldImpact { get; }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
+    public class ComplexityAttribute<T> : GraphQL.GraphQLAttribute
+        where T :  class, GraphQL.Validation.Complexity.IFieldComplexityAnalyzer, new ()
+    {
+        public ComplexityAttribute() { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
         public DefaultServiceProvider() { }
         public object? GetService(System.Type serviceType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class DirectiveAttribute : GraphQL.GraphQLAttribute
+    {
+        public System.Collections.Generic.Dictionary<string, object?> Arguments;
+        public DirectiveAttribute(string name) { }
+        public DirectiveAttribute(string name, params object[] argsAndValues) { }
+        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
+        public string Name { get; }
+        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
     public static class DirectivesExtensions
     {
@@ -863,47 +901,6 @@ namespace GraphQL
         public override string ToString() { }
         public static string op_Implicit(GraphQL.VariableName variableName) { }
         public static GraphQL.VariableName op_Implicit(string name) { }
-    }
-}
-namespace GraphQL.Attributes
-{
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
-    public class ComplexityAttribute : GraphQL.GraphQLAttribute
-    {
-        public ComplexityAttribute(double fieldImpact) { }
-        public ComplexityAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] System.Type fieldComplexityAnalyzer) { }
-        public ComplexityAttribute(double fieldImpact, double childImpactMultiplier) { }
-        public double? ChildImpactMultiplier { get; }
-        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-        public System.Type? FieldComplexityAnalyzer { get; }
-        public double? FieldImpact { get; }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
-    }
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
-    public class ComplexityAttribute<T> : GraphQL.GraphQLAttribute
-        where T :  class, GraphQL.Validation.Complexity.IFieldComplexityAnalyzer, new ()
-    {
-        public ComplexityAttribute() { }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
-    }
-    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
-    public class DirectiveAttribute : GraphQL.GraphQLAttribute
-    {
-        public System.Collections.Generic.Dictionary<string, object?> Arguments;
-        public DirectiveAttribute(string name) { }
-        public DirectiveAttribute(string name, params object[] argsAndValues) { }
-        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
-        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
-        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
-        public string Name { get; }
-        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
-        public override void Modify(GraphQL.Types.IGraphType graphType) { }
-        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
 }
 namespace GraphQL.Builders

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -70,10 +70,47 @@ namespace GraphQL
         public static TSchema WithIntrospectionComplexityImpact<TSchema>(this TSchema schema, double impact)
             where TSchema : GraphQL.Types.ISchema { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
+    public class ComplexityAttribute : GraphQL.GraphQLAttribute
+    {
+        public ComplexityAttribute(double fieldImpact) { }
+        public ComplexityAttribute(System.Type fieldComplexityAnalyzer) { }
+        public ComplexityAttribute(double fieldImpact, double childImpactMultiplier) { }
+        public double? ChildImpactMultiplier { get; }
+        public System.Type? FieldComplexityAnalyzer { get; }
+        public double? FieldImpact { get; }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
+    public class ComplexityAttribute<T> : GraphQL.GraphQLAttribute
+        where T :  class, GraphQL.Validation.Complexity.IFieldComplexityAnalyzer, new ()
+    {
+        public ComplexityAttribute() { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
         public DefaultServiceProvider() { }
         public object? GetService(System.Type serviceType) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class DirectiveAttribute : GraphQL.GraphQLAttribute
+    {
+        public System.Collections.Generic.Dictionary<string, object?> Arguments;
+        public DirectiveAttribute(string name) { }
+        public DirectiveAttribute(string name, params object[] argsAndValues) { }
+        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
+        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
+        public string Name { get; }
+        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
+        public override void Modify(GraphQL.Types.IGraphType graphType) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
     public static class DirectivesExtensions
     {
@@ -830,46 +867,6 @@ namespace GraphQL
         public override string ToString() { }
         public static string op_Implicit(GraphQL.VariableName variableName) { }
         public static GraphQL.VariableName op_Implicit(string name) { }
-    }
-}
-namespace GraphQL.Attributes
-{
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
-    public class ComplexityAttribute : GraphQL.GraphQLAttribute
-    {
-        public ComplexityAttribute(double fieldImpact) { }
-        public ComplexityAttribute(System.Type fieldComplexityAnalyzer) { }
-        public ComplexityAttribute(double fieldImpact, double childImpactMultiplier) { }
-        public double? ChildImpactMultiplier { get; }
-        public System.Type? FieldComplexityAnalyzer { get; }
-        public double? FieldImpact { get; }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
-    }
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false)]
-    public class ComplexityAttribute<T> : GraphQL.GraphQLAttribute
-        where T :  class, GraphQL.Validation.Complexity.IFieldComplexityAnalyzer, new ()
-    {
-        public ComplexityAttribute() { }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
-    }
-    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Parameter, AllowMultiple=true)]
-    public class DirectiveAttribute : GraphQL.GraphQLAttribute
-    {
-        public System.Collections.Generic.Dictionary<string, object?> Arguments;
-        public DirectiveAttribute(string name) { }
-        public DirectiveAttribute(string name, params object[] argsAndValues) { }
-        public DirectiveAttribute(string name, string argumentName, object argumentValue) { }
-        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2) { }
-        public DirectiveAttribute(string name, string argumentName1, object argumentValue1, string argumentName2, object argumentValue2, string argumentName3, object argumentValue3) { }
-        public string Name { get; }
-        public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
-        public override void Modify(GraphQL.Types.IGraphType graphType) { }
-        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
-        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
 }
 namespace GraphQL.Builders

--- a/src/GraphQL.Tests/Complexity/ComplexityTests.cs
+++ b/src/GraphQL.Tests/Complexity/ComplexityTests.cs
@@ -1,4 +1,3 @@
-using GraphQL.Attributes;
 using GraphQL.Execution;
 using GraphQL.Types;
 using GraphQL.Validation;

--- a/src/GraphQL.Tests/Utilities/Visitors/PatternMatchingVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/PatternMatchingVisitorTests.cs
@@ -1,4 +1,3 @@
-using GraphQL.Attributes;
 using GraphQL.Types;
 using GraphQL.Utilities.Visitors;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/GraphQL/Attributes/ComplexityAttribute.cs
+++ b/src/GraphQL/Attributes/ComplexityAttribute.cs
@@ -2,7 +2,7 @@ using GraphQL.Types;
 using GraphQL.Utilities;
 using GraphQL.Validation.Complexity;
 
-namespace GraphQL.Attributes;
+namespace GraphQL;
 
 /// <summary>
 /// Specifies the complexity impact and/or child impact multiplier of a field.

--- a/src/GraphQL/Attributes/DirectiveAttribute.cs
+++ b/src/GraphQL/Attributes/DirectiveAttribute.cs
@@ -1,7 +1,7 @@
 using GraphQL.Types;
 using GraphQL.Utilities;
 
-namespace GraphQL.Attributes;
+namespace GraphQL;
 
 /// <summary>
 /// Applies a directive to part of a schema.

--- a/src/GraphQL/Validation/Complexity/IFieldComplexityAnalyzer.cs
+++ b/src/GraphQL/Validation/Complexity/IFieldComplexityAnalyzer.cs
@@ -1,5 +1,3 @@
-using GraphQL.Attributes;
-
 namespace GraphQL.Validation.Complexity;
 
 /// <summary>


### PR DESCRIPTION
All type-first attributes are in the `GraphQL` namespace for ease of use.  Two attributes are in the wrong (`GraphQL.Attributes`) namespace:

- `ComplexityAttribute`, not yet released
- `DirectiveAttribute`, released in 7.8
