### PR TITLE
Extend attribute usage

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -244,6 +244,8 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Utilities.FieldConfig field) { }
         public virtual void Modify(GraphQL.Utilities.TypeConfig type) { }
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Type sourceType) { }
+        public virtual void Modify(GraphQL.Types.QueryArgument queryArgument, System.Reflection.ParameterInfo parameterInfo) { }
         public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -244,6 +244,8 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Utilities.FieldConfig field) { }
         public virtual void Modify(GraphQL.Utilities.TypeConfig type) { }
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Type sourceType) { }
+        public virtual void Modify(GraphQL.Types.QueryArgument queryArgument, System.Reflection.ParameterInfo parameterInfo) { }
         public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -244,6 +244,8 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Utilities.FieldConfig field) { }
         public virtual void Modify(GraphQL.Utilities.TypeConfig type) { }
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Type sourceType) { }
+        public virtual void Modify(GraphQL.Types.QueryArgument queryArgument, System.Reflection.ParameterInfo parameterInfo) { }
         public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }

--- a/src/GraphQL/Attributes/GraphQLAttribute.cs
+++ b/src/GraphQL/Attributes/GraphQLAttribute.cs
@@ -33,6 +33,13 @@ namespace GraphQL
         }
 
         /// <summary>
+        /// Updates the properties of the specified <see cref="IGraphType"/> as necessary.
+        /// </summary>
+        public virtual void Modify(IGraphType graphType, Type sourceType)
+        {
+        }
+
+        /// <summary>
         /// Updates the properties of the specified <see cref="EnumValueDefinition"/> as necessary.
         /// </summary>
         public virtual void Modify(EnumValueDefinition enumValueDefinition)
@@ -99,6 +106,13 @@ namespace GraphQL
         /// Updates the properties of the specified <see cref="QueryArgument"/> as necessary.
         /// </summary>
         public virtual void Modify(QueryArgument queryArgument)
+        {
+        }
+
+        /// <summary>
+        /// Updates the properties of the specified <see cref="QueryArgument"/> as necessary.
+        /// </summary>
+        public virtual void Modify(QueryArgument queryArgument, ParameterInfo parameterInfo)
         {
         }
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -71,7 +71,10 @@ namespace GraphQL.Types
                     // as the generated query argument's name is used within the expression for the call to GetArgument
                     var attributes = parameterInfo.GetGraphQLAttributes();
                     foreach (var attr in attributes)
+                    {
                         attr.Modify(queryArgument);
+                        attr.Modify(queryArgument, parameterInfo);
+                    }
                 }
                 expression ??= GetParameterExpression(
                     parameterInfo.ParameterType,
@@ -127,6 +130,7 @@ namespace GraphQL.Types
             foreach (var attr in attributes)
             {
                 attr.Modify(graphType);
+                attr.Modify(graphType, typeof(TSourceType));
             }
         }
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringOutputHelper.cs
@@ -203,6 +203,7 @@ internal static class AutoRegisteringOutputHelper
         foreach (var attr in attributes)
         {
             attr.Modify(queryArgument);
+            attr.Modify(queryArgument, parameterInfo);
         }
     }
 }

--- a/src/GraphQL/Types/Scalars/Enumeration/EnumerationGraphType.cs
+++ b/src/GraphQL/Types/Scalars/Enumeration/EnumerationGraphType.cs
@@ -172,6 +172,7 @@ public class EnumerationGraphType<TEnum> : EnumerationGraphType
         foreach (var attr in type.GetGraphQLAttributes())
         {
             attr.Modify(this);
+            attr.Modify(this, typeof(TEnum));
         }
     }
 


### PR DESCRIPTION
Allows for inspecting the source type when modifying graph types, or inspecting the source argument when modifying query arguments.

Prerequisite to supporting `[GraphQLInterface]` via attribute extensibility 'plugins'.