### PR TITLE
Reorder attribute method arguments

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -246,7 +246,7 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
         public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Type sourceType) { }
         public virtual void Modify(GraphQL.Types.QueryArgument queryArgument, System.Reflection.ParameterInfo parameterInfo) { }
-        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
+        public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType, GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -246,7 +246,7 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
         public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Type sourceType) { }
         public virtual void Modify(GraphQL.Types.QueryArgument queryArgument, System.Reflection.ParameterInfo parameterInfo) { }
-        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
+        public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType, GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -246,7 +246,7 @@ namespace GraphQL
         public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
         public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Type sourceType) { }
         public virtual void Modify(GraphQL.Types.QueryArgument queryArgument, System.Reflection.ParameterInfo parameterInfo) { }
-        public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, GraphQL.Types.FieldType fieldType, bool isInputType, ref bool ignore) { }
+        public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType, GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, ref bool ignore) { }
         public virtual void Modify<TParameterType>(GraphQL.Types.ArgumentInformation argumentInformation) { }
         public virtual bool ShouldInclude(System.Reflection.MemberInfo memberInfo, bool? isInputType) { }
     }

--- a/src/GraphQL/Attributes/GraphQLAttribute.cs
+++ b/src/GraphQL/Attributes/GraphQLAttribute.cs
@@ -65,7 +65,7 @@ namespace GraphQL
         /// <param name="memberInfo">The <see cref="MemberInfo"/> that the field was generated from.</param>
         /// <param name="isInputType">Indicates if the graph type containing this field is an input type.</param>
         /// <param name="ignore">Indicates that the field should not be added to the graph type.</param>
-        public virtual void Modify(IGraphType graphType, MemberInfo memberInfo, FieldType fieldType, bool isInputType, ref bool ignore)
+        public virtual void Modify(FieldType fieldType, bool isInputType, IGraphType graphType, MemberInfo memberInfo, ref bool ignore)
         {
         }
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -198,7 +198,7 @@ namespace GraphQL.Types
             foreach (var attr in attributes)
             {
                 attr.Modify(fieldType, isInputType);
-                attr.Modify(graphType, memberInfo, fieldType, isInputType, ref ignore);
+                attr.Modify(fieldType, isInputType, graphType, memberInfo, ref ignore);
             }
         }
 


### PR DESCRIPTION
This additional `Modify` overload for GraphQLAttribute was added in #3952 targeting 7.9 as a prerequisite for federation changes in 8.0.  I think the order of arguments should be modified so that the overloads for field modification appear together - e.g. when typing `override` and looking at the intellisense popup.  This is not a breaking change as neither 7.9 nor 8.0 have been released yet.

With this change:

```
// modifies the graph type
public virtual void Modify(GraphQL.Types.IGraphType graphType) { }
public virtual void Modify(GraphQL.Types.IGraphType graphType, System.Type sourceType) { }

// modifies the field type
public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
public virtual void Modify(GraphQL.Types.FieldType fieldType, bool isInputType, GraphQL.Types.IGraphType graphType, System.Reflection.MemberInfo memberInfo, ref bool ignore) { }

// modifies the field argument
public virtual void Modify(GraphQL.Types.QueryArgument queryArgument) { }
public virtual void Modify(GraphQL.Types.QueryArgument queryArgument, System.Reflection.ParameterInfo parameterInfo) { }
```

Note that in #4011 I tried to add additional arguments to the last definition, but there's multiple reasons why it doesn't work [easily].  So in the end I was stuck with only the `queryArgument` and `parameterInfo`.  At least from the `ParameterInfo` you can get the defining method, and from that the defining type.