### PR TITLE
Aggregate schema initialization errors

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3223,7 +3223,6 @@ namespace GraphQL.Utilities
 {
     public sealed class AppliedDirectivesValidationVisitor : GraphQL.Utilities.ISchemaNodeVisitor
     {
-        public static readonly GraphQL.Utilities.AppliedDirectivesValidationVisitor Instance;
         public void PostVisitSchema(GraphQL.Types.ISchema schema) { }
         public void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
@@ -3240,6 +3239,7 @@ namespace GraphQL.Utilities
         public void VisitScalar(GraphQL.Types.ScalarGraphType type, GraphQL.Types.ISchema schema) { }
         public void VisitSchema(GraphQL.Types.ISchema schema) { }
         public void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
     public class ArgumentConfig : GraphQL.Utilities.MetadataProvider
     {
@@ -3461,7 +3461,6 @@ namespace GraphQL.Utilities
     }
     public sealed class SchemaValidationVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
-        public static readonly GraphQL.Utilities.SchemaValidationVisitor Instance;
         public override void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public override void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
@@ -3475,6 +3474,7 @@ namespace GraphQL.Utilities
         public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
         public override void VisitSchema(GraphQL.Types.ISchema schema) { }
         public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
     public static class StringUtils
     {

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3237,7 +3237,6 @@ namespace GraphQL.Utilities
 {
     public sealed class AppliedDirectivesValidationVisitor : GraphQL.Utilities.ISchemaNodeVisitor
     {
-        public static readonly GraphQL.Utilities.AppliedDirectivesValidationVisitor Instance;
         public void PostVisitSchema(GraphQL.Types.ISchema schema) { }
         public void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
@@ -3254,6 +3253,7 @@ namespace GraphQL.Utilities
         public void VisitScalar(GraphQL.Types.ScalarGraphType type, GraphQL.Types.ISchema schema) { }
         public void VisitSchema(GraphQL.Types.ISchema schema) { }
         public void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
     public class ArgumentConfig : GraphQL.Utilities.MetadataProvider
     {
@@ -3475,7 +3475,6 @@ namespace GraphQL.Utilities
     }
     public sealed class SchemaValidationVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
-        public static readonly GraphQL.Utilities.SchemaValidationVisitor Instance;
         public override void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public override void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
@@ -3489,6 +3488,7 @@ namespace GraphQL.Utilities
         public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
         public override void VisitSchema(GraphQL.Types.ISchema schema) { }
         public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
     public static class StringUtils
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3149,7 +3149,6 @@ namespace GraphQL.Utilities
 {
     public sealed class AppliedDirectivesValidationVisitor : GraphQL.Utilities.ISchemaNodeVisitor
     {
-        public static readonly GraphQL.Utilities.AppliedDirectivesValidationVisitor Instance;
         public void PostVisitSchema(GraphQL.Types.ISchema schema) { }
         public void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
@@ -3166,6 +3165,7 @@ namespace GraphQL.Utilities
         public void VisitScalar(GraphQL.Types.ScalarGraphType type, GraphQL.Types.ISchema schema) { }
         public void VisitSchema(GraphQL.Types.ISchema schema) { }
         public void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
     public class ArgumentConfig : GraphQL.Utilities.MetadataProvider
     {
@@ -3387,7 +3387,6 @@ namespace GraphQL.Utilities
     }
     public sealed class SchemaValidationVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
-        public static readonly GraphQL.Utilities.SchemaValidationVisitor Instance;
         public override void VisitDirective(GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public override void VisitDirectiveArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.Directive directive, GraphQL.Types.ISchema schema) { }
         public override void VisitEnum(GraphQL.Types.EnumerationGraphType type, GraphQL.Types.ISchema schema) { }
@@ -3401,6 +3400,7 @@ namespace GraphQL.Utilities
         public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
         public override void VisitSchema(GraphQL.Types.ISchema schema) { }
         public override void VisitUnion(GraphQL.Types.UnionGraphType type, GraphQL.Types.ISchema schema) { }
+        public static void Run(GraphQL.Types.ISchema schema) { }
     }
     public static class StringUtils
     {

--- a/src/GraphQL.Tests/Initialization/SchemaInitializationTestBase.cs
+++ b/src/GraphQL.Tests/Initialization/SchemaInitializationTestBase.cs
@@ -21,4 +21,10 @@ public abstract class SchemaInitializationTestBase
     {
         new TSchema().Initialize();
     }
+
+    public AggregateException ShouldThrowMultiple<TSchema>()
+        where TSchema : Schema, new()
+    {
+        return Should.Throw<AggregateException>(() => new TSchema().Initialize());
+    }
 }

--- a/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
+++ b/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
@@ -64,7 +64,10 @@ public class SchemaInitializationTests : SchemaInitializationTestBase
     [Fact]
     public void SchemaWithNotFullSpecifiedResolvedType_Should_Throw()
     {
-        ShouldThrow<SchemaWithNotFullSpecifiedResolvedType, InvalidOperationException>("The field 'in' of an Input Object type 'InputString' must have non-null 'ResolvedType' property for all types in the chain.");
+        var ex = ShouldThrowMultiple<SchemaWithNotFullSpecifiedResolvedType>();
+        ex.InnerExceptions.Count.ShouldBe(2);
+        ex.InnerExceptions[0].ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("The field 'in' of an Input Object type 'InputString' must have non-null 'ResolvedType' property for all types in the chain.");
+        ex.InnerExceptions[1].ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("The field 'not' of an Input Object type 'InputString' must have non-null 'ResolvedType' property for all types in the chain.");
     }
 
     // https://github.com/graphql-dotnet/graphql-dotnet/pull/2707/files#r757949833
@@ -114,8 +117,14 @@ public class SchemaInitializationTests : SchemaInitializationTestBase
     public void StreamResolver_On_Wrong_Fields_Should_Produce_Friendly_Error()
     {
         ShouldThrow<SchemaWithFieldStreamResolverOnNonRootSubscriptionField, InvalidOperationException>("The field 'str' of an Object type 'MyQuery' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
-        ShouldThrow<SchemaWithFieldStreamResolverOnFieldOfInterface, InvalidOperationException>("The field 'id' of an Interface type 'My' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
-        ShouldThrow<SchemaWithFieldStreamResolverOnFieldOfInputObject, InvalidOperationException>("The field 'name' of an Input Object type 'PersonInput' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+        var ex1 = ShouldThrowMultiple<SchemaWithFieldStreamResolverOnFieldOfInterface>();
+        ex1.InnerExceptions.Count.ShouldBe(2);
+        ex1.InnerExceptions[0].ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("The field 'id' of an Interface type 'My' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+        ex1.InnerExceptions[1].ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("The field 'id' of an Interface type 'My' must not have Resolver set. Each interface is translated to a concrete type during request execution. You should set Resolver only for fields of object output types.");
+        var ex2 = ShouldThrowMultiple<SchemaWithFieldStreamResolverOnFieldOfInputObject>();
+        ex2.InnerExceptions.Count.ShouldBe(2);
+        ex2.InnerExceptions[0].ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("The field 'name' of an Input Object type 'PersonInput' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions.");
+        ex2.InnerExceptions[1].ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("The field 'name' of an Input Object type 'PersonInput' must not have Resolver set. You should set Resolver only for fields of object output types.");
     }
 
     // https://github.com/graphql-dotnet/graphql-dotnet/issues/1176

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -494,9 +494,9 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
         // rename any applied directives that were imported from another schema to use the alias defined in the @link directive or the proper namespace
         RenameImportedDirectivesVisitor.Run(this);
         // run general schema validation code
-        SchemaValidationVisitor.Instance.Run(this);
+        SchemaValidationVisitor.Run(this);
         // validate that all applied directives are valid
-        AppliedDirectivesValidationVisitor.Instance.Run(this);
+        AppliedDirectivesValidationVisitor.Run(this);
         // initialize default field arguments for optimized execution
         FieldTypeDefaultArgumentsVisitor.Instance.Run(this);
         // removes types and fields that have IsPrivate set


### PR DESCRIPTION
Closes #3875 

Note that until the schema passes basic validation, the applied directives' validation is not run.  And there are a few exceptions that are thrown outside of either validation class.  But for the most part, the validation occurs within those two schema visitors.