### PR TITLE
Remove/review obsolete methods

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1351,3 +1351,11 @@ If you have custom implementations of these interfaces, you may need to update t
 
 Verfies that the arguments defined on fields of interfaces are also defined on fields of implementing types,
 pursuant to GraphQL specifications.
+
+### 28. APIs marked obsolete since v5 have been removed
+
+- `GraphQLMetadataAttribute.InputType` has been replaced with `InputTypeAttribute`.
+- `GraphQLMetadataAttribute.OutputType` has been replaced with `OutputTypeAttribute`.
+- `ErrorInfoProviderOptions.ExposeExceptionStackTrace` has been replaced with `ExposeExceptionDetails` and `ExposeExceptionDetailsMode`.
+
+See prior migration documents for more details concerning these changes.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -906,22 +906,22 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -960,22 +960,22 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -1003,7 +1003,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
-            "\'Connection\' method. This will be removed in v9.")]
+            "\'Connection\' method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -1055,7 +1055,7 @@ namespace GraphQL.Builders
         [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
         [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
-            "d\' method. This will be removed in v9.")]
+            "d\' method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ParseValue(System.Func<object, object> parseValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
@@ -1067,13 +1067,13 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
-            " removed in v9.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
-            " removed in v9.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1282,8 +1282,6 @@ namespace GraphQL.Execution
         public bool ExposeData { get; set; }
         public bool ExposeExceptionDetails { get; set; }
         public GraphQL.Execution.ExposeExceptionDetailsMode ExposeExceptionDetailsMode { get; set; }
-        [System.Obsolete("Use ExposeExceptionDetails property instead. This method will be removed in v9.")]
-        public bool ExposeExceptionStackTrace { get; set; }
         public bool ExposeExtensions { get; set; }
     }
     public class ExecutionContext : GraphQL.Execution.IExecutionArrayPool, GraphQL.Execution.IExecutionContext, GraphQL.Execution.IProvideUserContext, System.IDisposable

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -275,7 +275,8 @@ namespace GraphQL
         public static bool EnableReflectionCaching { get; set; }
         public static bool InferFieldNullabilityFromNRTAnnotations { get; set; }
         [System.Obsolete("The query root operation type must be provided and must be an Object type. See ht" +
-            "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types")]
+            "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types. This property will" +
+            " be removed in v9.")]
         public static bool RequireRootQueryType { get; set; }
         public static bool TrackGraphTypeInitialization { get; set; }
         public static bool UseDeclaringTypeNames { get; set; }
@@ -383,7 +384,7 @@ namespace GraphQL
             where TSerializer :  class, GraphQL.IGraphQLSerializer { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext> unhandledExceptionDelegate) { }
         [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
-            "g this overload.")]
+            "g this overload. This method will be removed in v9.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
@@ -504,12 +505,8 @@ namespace GraphQL
         public GraphQLMetadataAttribute(string name) { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
-        [System.Obsolete("Please use the [InputType] attribute instead of this property.")]
-        public System.Type? InputType { get; set; }
         public System.Type? IsTypeOf { get; set; }
         public string? Name { get; set; }
-        [System.Obsolete("Please use the [OutputType] attribute instead of this property.")]
-        public System.Type? OutputType { get; set; }
         public GraphQL.ResolverType ResolverType { get; set; }
         public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
         public override void Modify(GraphQL.Types.IGraphType graphType) { }
@@ -909,19 +906,22 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -960,19 +960,22 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -1000,7 +1003,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
-            "\'Connection\' method.")]
+            "\'Connection\' method. This will be removed in v9.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -1032,27 +1035,27 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         [System.Obsolete("Please use Action<QueryArgument> parameter from other Argument() method overloads" +
             " to set default value for parameter or use Arguments() method. This method will " +
-            "be removed in v8.")]
+            "be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string? description, TArgumentType? defaultValue = default, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(params GraphQL.Types.QueryArgument[] arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
-        [System.Obsolete("Please use the WithComplexityImpact method")]
+        [System.Obsolete("Please use the WithComplexityImpact method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ComplexityImpact(double impact) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Configure(System.Action<GraphQL.Types.FieldType> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType? defaultValue = default) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Description(string? description) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
         [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
-            "d\' method.")]
+            "d\' method. This will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ParseValue(System.Func<object, object> parseValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
@@ -1064,11 +1067,13 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
+            " removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
+            " removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -1277,7 +1282,7 @@ namespace GraphQL.Execution
         public bool ExposeData { get; set; }
         public bool ExposeExceptionDetails { get; set; }
         public GraphQL.Execution.ExposeExceptionDetailsMode ExposeExceptionDetailsMode { get; set; }
-        [System.Obsolete("Use ExposeExceptionDetails property instead")]
+        [System.Obsolete("Use ExposeExceptionDetails property instead. This method will be removed in v9.")]
         public bool ExposeExceptionStackTrace { get; set; }
         public bool ExposeExtensions { get; set; }
     }
@@ -2313,19 +2318,22 @@ namespace GraphQL.Types
         protected ComplexGraphType() { }
         public GraphQL.Types.TypeFields Fields { get; }
         public virtual GraphQL.Types.FieldType AddField(GraphQL.Types.FieldType fieldType) { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -2334,20 +2342,22 @@ namespace GraphQL.Types
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, GraphQL.Types.IGraphType type) { }
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType Field([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, string? deprecationReason = null) { }
-        [System.Obsolete("Please call Field<TGraphType>(string name) instead.")]
+        [System.Obsolete("Please call Field<TGraphType>(string name) instead. This method will be removed i" +
+            "n v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
@@ -2366,49 +2376,43 @@ namespace GraphQL.Types
             "guments. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType Field<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
+        [System.Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead. This method will" +
+            " be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>()
             where TGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType, TReturnType>(string name)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object?>>? resolve = null, string? deprecationReason = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object?>>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType, TReturnType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldDelegate<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Delegate? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldSubscribe<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, System.Func<GraphQL.IResolveFieldContext, System.IObservable<object?>>? subscribe = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldSubscribeAsync<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<object?>>>? subscribeAsync = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         public GraphQL.Types.FieldType? GetField(GraphQLParser.ROM name) { }
@@ -2846,16 +2850,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v8.")]
+    [System.Obsolete("This class will be removed in v9.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
@@ -3891,7 +3895,7 @@ namespace GraphQL.Validation.Complexity
     {
         GraphQL.Validation.Complexity.FieldComplexityResult Analyze(GraphQL.Validation.Complexity.FieldImpactContext context);
     }
-    [System.Obsolete("Please use the new complexity analyzer.")]
+    [System.Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
     public class LegacyComplexityConfiguration
     {
         public LegacyComplexityConfiguration() { }
@@ -3900,7 +3904,7 @@ namespace GraphQL.Validation.Complexity
         public int? MaxDepth { get; set; }
         public int MaxRecursionCount { get; set; }
     }
-    [System.Obsolete("Please use the new complexity analyzer.")]
+    [System.Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
     public class LegacyComplexityResult
     {
         public LegacyComplexityResult() { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -275,7 +275,8 @@ namespace GraphQL
         public static bool EnableReflectionCaching { get; set; }
         public static bool InferFieldNullabilityFromNRTAnnotations { get; set; }
         [System.Obsolete("The query root operation type must be provided and must be an Object type. See ht" +
-            "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types")]
+            "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types. This property will" +
+            " be removed in v9.")]
         public static bool RequireRootQueryType { get; set; }
         public static bool TrackGraphTypeInitialization { get; set; }
         public static bool UseDeclaringTypeNames { get; set; }
@@ -383,7 +384,7 @@ namespace GraphQL
             where TSerializer :  class, GraphQL.IGraphQLSerializer { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext> unhandledExceptionDelegate) { }
         [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
-            "g this overload.")]
+            "g this overload. This method will be removed in v9.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
@@ -504,12 +505,8 @@ namespace GraphQL
         public GraphQLMetadataAttribute(string name) { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
-        [System.Obsolete("Please use the [InputType] attribute instead of this property.")]
-        public System.Type? InputType { get; set; }
         public System.Type? IsTypeOf { get; set; }
         public string? Name { get; set; }
-        [System.Obsolete("Please use the [OutputType] attribute instead of this property.")]
-        public System.Type? OutputType { get; set; }
         public GraphQL.ResolverType ResolverType { get; set; }
         public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
         public override void Modify(GraphQL.Types.IGraphType graphType) { }
@@ -909,19 +906,22 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -960,19 +960,22 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -1000,7 +1003,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
-            "\'Connection\' method.")]
+            "\'Connection\' method. This will be removed in v9.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -1032,27 +1035,27 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         [System.Obsolete("Please use Action<QueryArgument> parameter from other Argument() method overloads" +
             " to set default value for parameter or use Arguments() method. This method will " +
-            "be removed in v8.")]
+            "be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string? description, TArgumentType? defaultValue = default, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(params GraphQL.Types.QueryArgument[] arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
-        [System.Obsolete("Please use the WithComplexityImpact method")]
+        [System.Obsolete("Please use the WithComplexityImpact method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ComplexityImpact(double impact) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Configure(System.Action<GraphQL.Types.FieldType> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType? defaultValue = default) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Description(string? description) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
         [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
-            "d\' method.")]
+            "d\' method. This will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ParseValue(System.Func<object, object> parseValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
@@ -1064,11 +1067,13 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
+            " removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
+            " removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -1277,7 +1282,7 @@ namespace GraphQL.Execution
         public bool ExposeData { get; set; }
         public bool ExposeExceptionDetails { get; set; }
         public GraphQL.Execution.ExposeExceptionDetailsMode ExposeExceptionDetailsMode { get; set; }
-        [System.Obsolete("Use ExposeExceptionDetails property instead")]
+        [System.Obsolete("Use ExposeExceptionDetails property instead. This method will be removed in v9.")]
         public bool ExposeExceptionStackTrace { get; set; }
         public bool ExposeExtensions { get; set; }
     }
@@ -2313,19 +2318,22 @@ namespace GraphQL.Types
         protected ComplexGraphType() { }
         public GraphQL.Types.TypeFields Fields { get; }
         public virtual GraphQL.Types.FieldType AddField(GraphQL.Types.FieldType fieldType) { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -2334,20 +2342,22 @@ namespace GraphQL.Types
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, GraphQL.Types.IGraphType type) { }
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType Field([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, string? deprecationReason = null) { }
-        [System.Obsolete("Please call Field<TGraphType>(string name) instead.")]
+        [System.Obsolete("Please call Field<TGraphType>(string name) instead. This method will be removed i" +
+            "n v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
@@ -2366,49 +2376,43 @@ namespace GraphQL.Types
             "guments. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType Field<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
+        [System.Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead. This method will" +
+            " be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>()
             where TGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType, TReturnType>(string name)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type, string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object?>>? resolve = null, string? deprecationReason = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object?>>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType, TReturnType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldDelegate<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Delegate? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldSubscribe<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, System.Func<GraphQL.IResolveFieldContext, System.IObservable<object?>>? subscribe = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldSubscribeAsync<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<object?>>>? subscribeAsync = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         public GraphQL.Types.FieldType? GetField(GraphQLParser.ROM name) { }
@@ -2853,16 +2857,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v8.")]
+    [System.Obsolete("This class will be removed in v9.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
@@ -3905,7 +3909,7 @@ namespace GraphQL.Validation.Complexity
     {
         GraphQL.Validation.Complexity.FieldComplexityResult Analyze(GraphQL.Validation.Complexity.FieldImpactContext context);
     }
-    [System.Obsolete("Please use the new complexity analyzer.")]
+    [System.Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
     public class LegacyComplexityConfiguration
     {
         public LegacyComplexityConfiguration() { }
@@ -3914,7 +3918,7 @@ namespace GraphQL.Validation.Complexity
         public int? MaxDepth { get; set; }
         public int MaxRecursionCount { get; set; }
     }
-    [System.Obsolete("Please use the new complexity analyzer.")]
+    [System.Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
     public class LegacyComplexityResult
     {
         public LegacyComplexityResult() { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -906,22 +906,22 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -960,22 +960,22 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -1003,7 +1003,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
-            "\'Connection\' method. This will be removed in v9.")]
+            "\'Connection\' method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -1055,7 +1055,7 @@ namespace GraphQL.Builders
         [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
         [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
-            "d\' method. This will be removed in v9.")]
+            "d\' method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ParseValue(System.Func<object, object> parseValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
@@ -1067,13 +1067,13 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
-            " removed in v9.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
-            " removed in v9.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1282,8 +1282,6 @@ namespace GraphQL.Execution
         public bool ExposeData { get; set; }
         public bool ExposeExceptionDetails { get; set; }
         public GraphQL.Execution.ExposeExceptionDetailsMode ExposeExceptionDetailsMode { get; set; }
-        [System.Obsolete("Use ExposeExceptionDetails property instead. This method will be removed in v9.")]
-        public bool ExposeExceptionStackTrace { get; set; }
         public bool ExposeExtensions { get; set; }
     }
     public class ExecutionContext : GraphQL.Execution.IExecutionArrayPool, GraphQL.Execution.IExecutionContext, GraphQL.Execution.IProvideUserContext, System.IDisposable

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1247,8 +1247,6 @@ namespace GraphQL.Execution
         public bool ExposeData { get; set; }
         public bool ExposeExceptionDetails { get; set; }
         public GraphQL.Execution.ExposeExceptionDetailsMode ExposeExceptionDetailsMode { get; set; }
-        [System.Obsolete("Use ExposeExceptionDetails property instead. This method will be removed in v9.")]
-        public bool ExposeExceptionStackTrace { get; set; }
         public bool ExposeExtensions { get; set; }
     }
     public class ExecutionContext : GraphQL.Execution.IExecutionArrayPool, GraphQL.Execution.IExecutionContext, GraphQL.Execution.IProvideUserContext, System.IDisposable

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -872,22 +872,22 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -926,22 +926,22 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
-            "moved in v9.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -969,7 +969,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
-            "\'Connection\' method. This will be removed in v9.")]
+            "\'Connection\' method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -1021,7 +1021,7 @@ namespace GraphQL.Builders
         [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
         [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
-            "d\' method. This will be removed in v9.")]
+            "d\' method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ParseValue(System.Func<object, object> parseValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
@@ -1033,13 +1033,13 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
-            " removed in v9.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, System.Type? type = null) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
-            " removed in v9.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -274,7 +274,8 @@ namespace GraphQL
         public static bool EnableReflectionCaching { get; set; }
         public static bool InferFieldNullabilityFromNRTAnnotations { get; set; }
         [System.Obsolete("The query root operation type must be provided and must be an Object type. See ht" +
-            "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types")]
+            "tps://spec.graphql.org/October2021/#sec-Root-Operation-Types. This property will" +
+            " be removed in v9.")]
         public static bool RequireRootQueryType { get; set; }
         public static bool TrackGraphTypeInitialization { get; set; }
         public static bool UseDeclaringTypeNames { get; set; }
@@ -374,7 +375,7 @@ namespace GraphQL
             where TSerializer :  class, GraphQL.IGraphQLSerializer { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext> unhandledExceptionDelegate) { }
         [System.Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of usin" +
-            "g this overload.")]
+            "g this overload. This method will be removed in v9.")]
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Action<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
         public static GraphQL.DI.IGraphQLBuilder AddUnhandledExceptionHandler(this GraphQL.DI.IGraphQLBuilder builder, System.Func<GraphQL.Execution.UnhandledExceptionContext, GraphQL.ExecutionOptions, System.Threading.Tasks.Task> unhandledExceptionDelegate) { }
@@ -479,12 +480,8 @@ namespace GraphQL
         public GraphQLMetadataAttribute(string name) { }
         public string? DeprecationReason { get; set; }
         public string? Description { get; set; }
-        [System.Obsolete("Please use the [InputType] attribute instead of this property.")]
-        public System.Type? InputType { get; set; }
         public System.Type? IsTypeOf { get; set; }
         public string? Name { get; set; }
-        [System.Obsolete("Please use the [OutputType] attribute instead of this property.")]
-        public System.Type? OutputType { get; set; }
         public GraphQL.ResolverType ResolverType { get; set; }
         public override void Modify(GraphQL.Types.EnumValueDefinition enumValueDefinition) { }
         public override void Modify(GraphQL.Types.IGraphType graphType) { }
@@ -875,19 +872,22 @@ namespace GraphQL.Builders
 {
     public static class ConnectionBuilder
     {
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TSourceType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, TSourceType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -926,19 +926,22 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ResolveAsync(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, System.Threading.Tasks.Task<object?>> resolver) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType> ReturnAll() { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This will be re" +
+            "moved in v9.")]
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -966,7 +969,7 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
         [System.Obsolete("Please configure the connection name by providing the name as an argument to the " +
-            "\'Connection\' method.")]
+            "\'Connection\' method. This will be removed in v9.")]
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> PageSize(int? pageSize) { }
         public virtual GraphQL.Builders.ConnectionBuilder<TSourceType, TReturnType> Resolve(System.Func<GraphQL.Builders.IResolveConnectionContext<TSourceType>, TReturnType?> resolver) { }
@@ -998,27 +1001,27 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         [System.Obsolete("Please use Action<QueryArgument> parameter from other Argument() method overloads" +
             " to set default value for parameter or use Arguments() method. This method will " +
-            "be removed in v8.")]
+            "be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, TArgumentType>(string name, string? description, TArgumentType? defaultValue = default, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(params GraphQL.Types.QueryArgument[] arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
-        [System.Obsolete("Please use the WithComplexityImpact method")]
+        [System.Obsolete("Please use the WithComplexityImpact method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ComplexityImpact(double impact) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Configure(System.Action<GraphQL.Types.FieldType> configure) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DefaultValue(TReturnType? defaultValue = default) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> DeprecationReason(string? deprecationReason) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Description(string? description) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, System.Action<GraphQL.Types.AppliedDirective> configure) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue) { }
-        [System.Obsolete("Please use the ApplyDirective method")]
+        [System.Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value) { }
         [System.Obsolete("Please configure the field name by providing the name as an argument to the \'Fiel" +
-            "d\' method.")]
+            "d\' method. This will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Name(string name) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ParseValue(System.Func<object, object> parseValue) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Resolve(GraphQL.Resolvers.IFieldResolver? resolver) { }
@@ -1030,11 +1033,13 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
+            " removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, GraphQL.Types.IGraphType type) { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(string name, System.Type? type = null) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This will be" +
+            " removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(System.Type? type = null, string name = "default") { }
     }
     public interface IResolveConnectionContext : GraphQL.Execution.IProvideUserContext, GraphQL.IResolveFieldContext
@@ -1242,7 +1247,7 @@ namespace GraphQL.Execution
         public bool ExposeData { get; set; }
         public bool ExposeExceptionDetails { get; set; }
         public GraphQL.Execution.ExposeExceptionDetailsMode ExposeExceptionDetailsMode { get; set; }
-        [System.Obsolete("Use ExposeExceptionDetails property instead")]
+        [System.Obsolete("Use ExposeExceptionDetails property instead. This method will be removed in v9.")]
         public bool ExposeExceptionStackTrace { get; set; }
         public bool ExposeExtensions { get; set; }
     }
@@ -2247,19 +2252,22 @@ namespace GraphQL.Types
         protected ComplexGraphType() { }
         public GraphQL.Types.TypeFields Fields { get; }
         public virtual GraphQL.Types.FieldType AddField(GraphQL.Types.FieldType fieldType) { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>()
             where TNodeType : GraphQL.Types.IGraphType { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>(string name)
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType> { }
-        [System.Obsolete("Please use the overload that accepts the mandatory name argument.")]
+        [System.Obsolete("Please use the overload that accepts the mandatory name argument. This method wil" +
+            "l be removed in v9.")]
         public GraphQL.Builders.ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
@@ -2268,20 +2276,22 @@ namespace GraphQL.Types
             where TNodeType : GraphQL.Types.IGraphType
             where TEdgeType : GraphQL.Types.Relay.EdgeType<TNodeType>
             where TConnectionType : GraphQL.Types.Relay.ConnectionType<TNodeType, TEdgeType> { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(GraphQL.Types.IGraphType type) { }
-        [System.Obsolete("Please use the overload that accepts the name as the first argument.")]
+        [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
+            "will be removed in v9.")]
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(System.Type type) { }
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, GraphQL.Types.IGraphType type) { }
         protected virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> CreateBuilder<TReturnType>(string name, System.Type type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field(string name, System.Type type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType Field(System.Type type, string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, string? deprecationReason = null) { }
-        [System.Obsolete("Please call Field<TGraphType>(string name) instead.")]
+        [System.Obsolete("Please call Field<TGraphType>(string name) instead. This method will be removed i" +
+            "n v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, object> Field<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression) { }
@@ -2300,49 +2310,43 @@ namespace GraphQL.Types
             "guments. This method will be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TProperty> Field<TProperty>(string name, System.Linq.Expressions.Expression<System.Func<TSourceType, TProperty>> expression, bool nullable, System.Type? type) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType Field<TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
-        [System.Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
+        [System.Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead. This method will" +
+            " be removed in v9.")]
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>()
             where TGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Field<TGraphType, TReturnType>(string name)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync(System.Type type, string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object?>>? resolve = null, string? deprecationReason = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync<TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<object?>>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldAsync<TGraphType, TReturnType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, System.Threading.Tasks.Task<TReturnType?>>? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldDelegate<TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Delegate? resolve = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldSubscribe<TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, System.Func<GraphQL.IResolveFieldContext, System.IObservable<object?>>? subscribe = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defi" +
-            "ned on it or just use AddField() method directly. This method may be removed in " +
-            "a future release. For now you can continue to use this API but we do not encoura" +
-            "ge this.")]
+            "ned on it or just use AddField() method directly. This method will be removed in" +
+            " v9.")]
         public GraphQL.Types.FieldType FieldSubscribeAsync<TGraphType>(string name, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext<TSourceType>, object?>? resolve = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<object?>>>? subscribeAsync = null, string? deprecationReason = null)
             where TGraphType : GraphQL.Types.IGraphType { }
         public GraphQL.Types.FieldType? GetField(GraphQLParser.ROM name) { }
@@ -2772,16 +2776,16 @@ namespace GraphQL.Types
     {
         public ObjectGraphType() { }
     }
-    [System.Obsolete("This class will be removed in v8.")]
+    [System.Obsolete("This class will be removed in v9.")]
     public static class ObjectGraphTypeExtensions
     {
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void Field(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, object?>? resolve = null) { }
         [System.Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods def" +
             "ined on it or just use AddField() method directly. This method will be removed i" +
-            "n v8.")]
+            "n v9.")]
         public static void FieldAsync(this GraphQL.Types.IObjectGraphType obj, string name, GraphQL.Types.IGraphType type, string? description = null, GraphQL.Types.QueryArguments? arguments = null, System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<object?>>? resolve = null) { }
     }
     public class ObjectGraphType<TSourceType> : GraphQL.Types.ComplexGraphType<TSourceType>, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IObjectGraphType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
@@ -3817,7 +3821,7 @@ namespace GraphQL.Validation.Complexity
     {
         GraphQL.Validation.Complexity.FieldComplexityResult Analyze(GraphQL.Validation.Complexity.FieldImpactContext context);
     }
-    [System.Obsolete("Please use the new complexity analyzer.")]
+    [System.Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
     public class LegacyComplexityConfiguration
     {
         public LegacyComplexityConfiguration() { }
@@ -3826,7 +3830,7 @@ namespace GraphQL.Validation.Complexity
         public int? MaxDepth { get; set; }
         public int MaxRecursionCount { get; set; }
     }
-    [System.Obsolete("Please use the new complexity analyzer.")]
+    [System.Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
     public class LegacyComplexityResult
     {
         public LegacyComplexityResult() { }

--- a/src/GraphQL.Tests/Bugs/Issue2275.cs
+++ b/src/GraphQL.Tests/Bugs/Issue2275.cs
@@ -71,7 +71,7 @@ public class Issue2275
         }
     }
 
-    [GraphQLMetadata(InputType = typeof(FilterInputGraphType))]
+    [InputType(typeof(FilterInputGraphType))]
     public class Filter
     {
         public string Key { get; set; }

--- a/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/ComplexGraphTypeTests.cs
@@ -57,7 +57,7 @@ public class ComplexGraphTypeTests
         public Money? someMoney { get; set; }
     }
 
-    [GraphQLMetadata(InputType = typeof(AutoRegisteringInputObjectGraphType<Money>), OutputType = typeof(AutoRegisteringObjectGraphType<Money>))]
+    [InputType(typeof(AutoRegisteringInputObjectGraphType<Money>)), OutputType(typeof(AutoRegisteringObjectGraphType<Money>))]
     internal class Money
     {
         public decimal Amount { get; set; }

--- a/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
+++ b/src/GraphQL.Tests/Utilities/GetGraphTypeFromTypeTests.cs
@@ -450,13 +450,13 @@ public class GetGraphTypeFromTypeTests
     {
     }
 
-    [GraphQLMetadata(InputType = typeof(CustomInputGraphType), OutputType = typeof(CustomOutputGraphType))]
+    [InputType(typeof(CustomInputGraphType)), OutputType(typeof(CustomOutputGraphType))]
     private class AttributeTest1 { }
 
-    [GraphQLMetadata(InputType = typeof(CustomInputGraphType))]
+    [InputType(typeof(CustomInputGraphType))]
     private class AttributeTest2 { }
 
-    [GraphQLMetadata(OutputType = typeof(CustomOutputGraphType))]
+    [OutputType(typeof(CustomOutputGraphType))]
     private class AttributeTest3 { }
 
 #if NET48

--- a/src/GraphQL/Attributes/GraphQLMetadataAttribute.cs
+++ b/src/GraphQL/Attributes/GraphQLMetadataAttribute.cs
@@ -9,9 +9,6 @@ namespace GraphQL;
 [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
 public sealed class GraphQLMetadataAttribute : GraphQLAttribute
 {
-    private Type? _mappedToInput;
-    private Type? _mappedToOutput;
-
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
@@ -52,38 +49,6 @@ public sealed class GraphQLMetadataAttribute : GraphQLAttribute
     /// Indicates the CLR type that this graph type represents.
     /// </summary>
     public Type? IsTypeOf { get; set; }
-
-    /// <summary>
-    /// Indicates which GraphType input type this CLR type is mapped to (if used in input context).
-    /// </summary>
-    [Obsolete("Please use the [InputType] attribute instead of this property.")]
-    public Type? InputType
-    {
-        get => _mappedToInput;
-        set
-        {
-            if (value != null && !value.IsInputType())
-                throw new ArgumentException(nameof(InputType), $"'{value}' should be of input type");
-
-            _mappedToInput = value;
-        }
-    }
-
-    /// <summary>
-    /// Indicates which GraphType output type this CLR type is mapped to (if used in output context).
-    /// </summary>
-    [Obsolete("Please use the [OutputType] attribute instead of this property.")]
-    public Type? OutputType
-    {
-        get => _mappedToOutput;
-        set
-        {
-            if (value != null && !value.IsOutputType())
-                throw new ArgumentException(nameof(OutputType), $"'{value}' should be of output type");
-
-            _mappedToOutput = value;
-        }
-    }
 
     /// <inheritdoc/>
     public override void Modify(TypeConfig type)
@@ -142,12 +107,6 @@ public sealed class GraphQLMetadataAttribute : GraphQLAttribute
 
         if (DeprecationReason != null)
             fieldType.DeprecationReason = DeprecationReason == "" ? null : DeprecationReason;
-
-        if (isInputType && _mappedToInput != null)
-            fieldType.Type = _mappedToInput;
-
-        if (!isInputType && _mappedToOutput != null)
-            fieldType.Type = _mappedToOutput;
     }
 }
 

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -16,7 +16,7 @@ public static class ConnectionBuilder
     /// </summary>
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
     /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, [NotAGraphType] TSourceType>()
         where TNodeType : IGraphType
         => ConnectionBuilder<TSourceType>.Create<TNodeType>();
@@ -40,7 +40,7 @@ public static class ConnectionBuilder
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
     /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
     /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, [NotAGraphType] TSourceType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>
@@ -66,7 +66,7 @@ public static class ConnectionBuilder
     /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
     /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
     /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, [NotAGraphType] TSourceType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>
@@ -123,7 +123,7 @@ public class ConnectionBuilder<[NotAGraphType] TSourceType> : IFieldMetadataWrit
     /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
     /// </summary>
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType>()
         where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>();
 
@@ -143,7 +143,7 @@ public class ConnectionBuilder<[NotAGraphType] TSourceType> : IFieldMetadataWrit
     /// </summary>
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
     /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>
@@ -167,7 +167,7 @@ public class ConnectionBuilder<[NotAGraphType] TSourceType> : IFieldMetadataWrit
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
     /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
     /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>

--- a/src/GraphQL/Builders/ConnectionBuilder.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder.cs
@@ -16,7 +16,7 @@ public static class ConnectionBuilder
     /// </summary>
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
     /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, [NotAGraphType] TSourceType>()
         where TNodeType : IGraphType
         => ConnectionBuilder<TSourceType>.Create<TNodeType>();
@@ -40,7 +40,7 @@ public static class ConnectionBuilder
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
     /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
     /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, [NotAGraphType] TSourceType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>
@@ -66,7 +66,7 @@ public static class ConnectionBuilder
     /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
     /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
     /// <typeparam name="TSourceType">The type of <see cref="IResolveFieldContext.Source"/>.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType, [NotAGraphType] TSourceType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>
@@ -123,7 +123,7 @@ public class ConnectionBuilder<[NotAGraphType] TSourceType> : IFieldMetadataWrit
     /// The connection type is <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;&gt;.
     /// </summary>
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType>()
         where TNodeType : IGraphType => Create<TNodeType, EdgeType<TNodeType>>();
 
@@ -143,7 +143,7 @@ public class ConnectionBuilder<[NotAGraphType] TSourceType> : IFieldMetadataWrit
     /// </summary>
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
     /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>
@@ -167,7 +167,7 @@ public class ConnectionBuilder<[NotAGraphType] TSourceType> : IFieldMetadataWrit
     /// <typeparam name="TNodeType">The graph type of the connection's node.</typeparam>
     /// <typeparam name="TEdgeType">The graph type of the connection's edge. Must derive from <see cref="EdgeType{TNodeType}">EdgeType</see>&lt;<typeparamref name="TNodeType"/>&gt;.</typeparam>
     /// <typeparam name="TConnectionType">The graph type of the connection. Must derive from <see cref="ConnectionType{TNodeType, TEdgeType}">ConnectionType</see>&lt;<typeparamref name="TNodeType"/>, <typeparamref name="TEdgeType"/>&gt;.</typeparam>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This will be removed in v9.")]
     public static ConnectionBuilder<TSourceType> Create<TNodeType, TEdgeType, TConnectionType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -98,7 +98,7 @@ public class ConnectionBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TRet
     }
 
     /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Name(string)"/>
-    [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method. This will be removed in v9.")]
+    [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method. This method will be removed in v9.")]
     public virtual ConnectionBuilder<TSourceType, TReturnType> Name(string name)
     {
         FieldType.Name = name;

--- a/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
+++ b/src/GraphQL/Builders/ConnectionBuilder_Typed.cs
@@ -98,7 +98,7 @@ public class ConnectionBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TRet
     }
 
     /// <inheritdoc cref="FieldBuilder{TSourceType, TReturnType}.Name(string)"/>
-    [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method.")]
+    [Obsolete("Please configure the connection name by providing the name as an argument to the 'Connection' method. This will be removed in v9.")]
     public virtual ConnectionBuilder<TSourceType, TReturnType> Name(string name)
     {
         FieldType.Name = name;

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -30,7 +30,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// </summary>
     /// <param name="type">The graph type of the field.</param>
     /// <param name="name">The name of the field.</param>
-    [Obsolete("Please use the overload that accepts the name as the first argument.")]
+    [Obsolete("Please use the overload that accepts the name as the first argument. This will be removed in v9.")]
     public static FieldBuilder<TSourceType, TReturnType> Create(IGraphType type, string name = "default")
     {
         var fieldType = new FieldType
@@ -57,7 +57,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     }
 
     /// <inheritdoc cref="Create(IGraphType, string)"/>
-    [Obsolete("Please use the overload that accepts the name as the first argument.")]
+    [Obsolete("Please use the overload that accepts the name as the first argument. This will be removed in v9.")]
     public static FieldBuilder<TSourceType, TReturnType> Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null, string name = "default")
     {
         var fieldType = new FieldType
@@ -92,7 +92,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// <summary>
     /// Sets the name of the field.
     /// </summary>
-    [Obsolete("Please configure the field name by providing the name as an argument to the 'Field' method.")]
+    [Obsolete("Please configure the field name by providing the name as an argument to the 'Field' method. This will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> Name(string name)
     {
         FieldType.Name = name;
@@ -230,7 +230,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// <param name="description">The description of the argument.</param>
     /// <param name="defaultValue">The default value of the argument.</param>
     /// <param name="configure">A delegate to further configure the argument.</param>
-    [Obsolete("Please use Action<QueryArgument> parameter from other Argument() method overloads to set default value for parameter or use Arguments() method. This method will be removed in v8.")]
+    [Obsolete("Please use Action<QueryArgument> parameter from other Argument() method overloads to set default value for parameter or use Arguments() method. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType, [NotAGraphType] TArgumentType>(string name, string? description,
         TArgumentType? defaultValue = default, Action<QueryArgument>? configure = null)
         where TArgumentGraphType : IGraphType
@@ -404,7 +404,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// then their default values (if any) will be used.
     /// </summary>
     /// <param name="name">Directive name.</param>
-    [Obsolete("Please use the ApplyDirective method")]
+    [Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name)
         => this.ApplyDirective(name);
 
@@ -415,7 +415,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// <param name="name">Directive name.</param>
     /// <param name="argumentName">Argument name.</param>
     /// <param name="argumentValue">Argument value.</param>
-    [Obsolete("Please use the ApplyDirective method")]
+    [Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, string argumentName, object? argumentValue)
         => this.ApplyDirective(name, argumentName, argumentValue);
 
@@ -428,7 +428,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// <param name="argument1Value">First argument value.</param>
     /// <param name="argument2Name">Second argument name.</param>
     /// <param name="argument2Value">Second argument value.</param>
-    [Obsolete("Please use the ApplyDirective method")]
+    [Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, string argument1Name, object? argument1Value, string argument2Name, object? argument2Value)
         => this.ApplyDirective(name, argument1Name, argument1Value, argument2Name, argument2Value);
 
@@ -437,7 +437,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// </summary>
     /// <param name="name">Directive name.</param>
     /// <param name="configure">Configuration delegate.</param>
-    [Obsolete("Please use the ApplyDirective method")]
+    [Obsolete("Please use the ApplyDirective method. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> Directive(string name, Action<AppliedDirective> configure)
         => this.ApplyDirective(name, configure);
 
@@ -445,7 +445,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// Specify field's complexity impact which will be taken into account by <see cref="LegacyComplexityValidationRule"/>.
     /// </summary>
     /// <param name="impact">Field's complexity impact.</param>
-    [Obsolete("Please use the WithComplexityImpact method")]
+    [Obsolete("Please use the WithComplexityImpact method. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> ComplexityImpact(double impact)
         => this.WithComplexityImpact(impact);
 

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -30,7 +30,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// </summary>
     /// <param name="type">The graph type of the field.</param>
     /// <param name="name">The name of the field.</param>
-    [Obsolete("Please use the overload that accepts the name as the first argument. This will be removed in v9.")]
+    [Obsolete("Please use the overload that accepts the name as the first argument. This method will be removed in v9.")]
     public static FieldBuilder<TSourceType, TReturnType> Create(IGraphType type, string name = "default")
     {
         var fieldType = new FieldType
@@ -57,7 +57,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     }
 
     /// <inheritdoc cref="Create(IGraphType, string)"/>
-    [Obsolete("Please use the overload that accepts the name as the first argument. This will be removed in v9.")]
+    [Obsolete("Please use the overload that accepts the name as the first argument. This method will be removed in v9.")]
     public static FieldBuilder<TSourceType, TReturnType> Create([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? type = null, string name = "default")
     {
         var fieldType = new FieldType
@@ -92,7 +92,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// <summary>
     /// Sets the name of the field.
     /// </summary>
-    [Obsolete("Please configure the field name by providing the name as an argument to the 'Field' method. This will be removed in v9.")]
+    [Obsolete("Please configure the field name by providing the name as an argument to the 'Field' method. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> Name(string name)
     {
         FieldType.Name = name;

--- a/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
+++ b/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
@@ -10,7 +10,7 @@ public class ErrorInfoProviderOptions
     /// <summary>
     /// Specifies whether stack traces should be serialized.
     /// </summary>
-    [Obsolete("Use ExposeExceptionDetails property instead")]
+    [Obsolete("Use ExposeExceptionDetails property instead. This method will be removed in v9.")]
     public bool ExposeExceptionStackTrace
     {
         get => ExposeExceptionDetails;

--- a/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
+++ b/src/GraphQL/Execution/ErrorInfoProviderOptions.cs
@@ -8,21 +8,6 @@ namespace GraphQL.Execution;
 public class ErrorInfoProviderOptions
 {
     /// <summary>
-    /// Specifies whether stack traces should be serialized.
-    /// </summary>
-    [Obsolete("Use ExposeExceptionDetails property instead. This method will be removed in v9.")]
-    public bool ExposeExceptionStackTrace
-    {
-        get => ExposeExceptionDetails;
-        set
-        {
-            ExposeExceptionDetails = value;
-            if (value)
-                ExposeExceptionDetailsMode = ExposeExceptionDetailsMode.Message;
-        }
-    }
-
-    /// <summary>
     /// Specifies whether detailed exception information (exception types, stack traces, inner exceptions)
     /// should be serialized.
     /// </summary>

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -1241,7 +1241,7 @@ public static class GraphQLBuilderExtensions // TODO: split
     }
 
     /// <inheritdoc cref="AddUnhandledExceptionHandler(IGraphQLBuilder, Func{UnhandledExceptionContext, Task})"/>
-    [Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of using this overload.")]
+    [Obsolete("Reference the UnhandledExceptionContext.ExecutionOptions property instead of using this overload. This method will be removed in v9.")]
     public static IGraphQLBuilder AddUnhandledExceptionHandler(this IGraphQLBuilder builder, Action<UnhandledExceptionContext, ExecutionOptions> unhandledExceptionDelegate)
     {
         if (unhandledExceptionDelegate == null)

--- a/src/GraphQL/Extensions/TypeExtensions.cs
+++ b/src/GraphQL/Extensions/TypeExtensions.cs
@@ -252,19 +252,6 @@ public static class TypeExtensions
         }
         else
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            var attr = type.GetCustomAttribute<GraphQLMetadataAttribute>();
-            if (attr != null)
-            {
-                if (mode == TypeMappingMode.InputType)
-                    graphType = attr.InputType;
-                else if (mode == TypeMappingMode.OutputType)
-                    graphType = attr.OutputType;
-                else if (attr.InputType == attr.OutputType) // scalar
-                    graphType = attr.InputType;
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-
             if (mode == TypeMappingMode.InputType)
             {
                 var inputAttr = type.GetCustomAttribute<InputTypeAttribute>();

--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -89,7 +89,7 @@ public static class GlobalSwitches
     /// This is required by the GraphQL specification.
     /// See <see href="https://spec.graphql.org/October2021/#sec-Root-Operation-Types">Root Operation Types</see>.
     /// </summary>
-    [Obsolete("The query root operation type must be provided and must be an Object type. See https://spec.graphql.org/October2021/#sec-Root-Operation-Types")]
+    [Obsolete("The query root operation type must be provided and must be an Object type. See https://spec.graphql.org/October2021/#sec-Root-Operation-Types. This property will be removed in v9.")]
     public static bool RequireRootQueryType { get; set; } = true;
 
     /// <summary>

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -158,7 +158,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <summary>
     /// Creates a field builder used by Field() methods.
     /// </summary>
-    [Obsolete("Please use the overload that accepts the name as the first argument.")]
+    [Obsolete("Please use the overload that accepts the name as the first argument. This method will be removed in v9.")]
     protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         return FieldBuilder<TSourceType, TReturnType>.Create(type);
@@ -175,7 +175,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <summary>
     /// Creates a field builder used by Field() methods.
     /// </summary>
-    [Obsolete("Please use the overload that accepts the name as the first argument.")]
+    [Obsolete("Please use the overload that accepts the name as the first argument. This method will be removed in v9.")]
     protected virtual FieldBuilder<TSourceType, TReturnType> CreateBuilder<[NotAGraphType] TReturnType>(IGraphType type)
     {
         return FieldBuilder<TSourceType, TReturnType>.Create(type);
@@ -199,7 +199,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
     /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
     /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public FieldType Field(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
         string name,
@@ -231,7 +231,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
     /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
     /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public FieldType Field<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
         string name,
         string? description = null,
@@ -263,7 +263,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
     /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
     /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public FieldType FieldDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
         string name,
         string? description = null,
@@ -306,7 +306,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
     /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
     /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public FieldType FieldAsync(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
         string name,
@@ -338,7 +338,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
     /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
     /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public FieldType FieldAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
         string name,
         string? description = null,
@@ -371,7 +371,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <param name="resolve">A field resolver delegate. Only applicable to fields of output graph types. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
     /// <param name="deprecationReason">The deprecation reason for the field. Applicable only for output graph types.</param>
     /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public FieldType FieldAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType, [NotAGraphType] TReturnType>(
         string name,
         string? description = null,
@@ -404,7 +404,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <param name="subscribe">A source stream resolver delegate.</param>
     /// <param name="deprecationReason">The deprecation reason for the field.</param>
     /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public FieldType FieldSubscribe<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
         string name,
         string? description = null,
@@ -441,7 +441,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     /// <param name="subscribeAsync">A source stream resolver delegate.</param>
     /// <param name="deprecationReason">The deprecation reason for the field.</param>
     /// <returns>The newly added <see cref="FieldType"/> instance.</returns>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method may be removed in a future release. For now you can continue to use this API but we do not encourage this.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and the methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public FieldType FieldSubscribeAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGraphType>(
         string name,
         string? description = null,
@@ -482,13 +482,13 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     }
 
     /// <inheritdoc cref="Field{TGraphType, TReturnType}(string)"/>
-    [Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead.")]
+    [Obsolete("Please call Field<TGraphType, TReturnType>(string name) instead. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, TReturnType> Field<TGraphType, [NotAGraphType] TReturnType>()
         where TGraphType : IGraphType
         => Field<TGraphType, TReturnType>("default");
 
     /// <inheritdoc cref="Field{TGraphType}(string)"/>
-    [Obsolete("Please call Field<TGraphType>(string name) instead.")]
+    [Obsolete("Please call Field<TGraphType>(string name) instead. This method will be removed in v9.")]
     public virtual FieldBuilder<TSourceType, object> Field<TGraphType>()
         where TGraphType : IGraphType
         => Field<TGraphType, object>("default");
@@ -803,7 +803,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
         Field(expression, nullable: null, type);
 
     /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType}(string)"/>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public ConnectionBuilder<TSourceType> Connection<TNodeType>()
         where TNodeType : IGraphType
     {
@@ -822,7 +822,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     }
 
     /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType}(string)"/>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>
@@ -843,7 +843,7 @@ public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType,
     }
 
     /// <inheritdoc cref="ConnectionBuilder{TSourceType}.Create{TNodeType, TEdgeType, TConnectionType}(string)"/>
-    [Obsolete("Please use the overload that accepts the mandatory name argument.")]
+    [Obsolete("Please use the overload that accepts the mandatory name argument. This method will be removed in v9.")]
     public ConnectionBuilder<TSourceType> Connection<TNodeType, TEdgeType, TConnectionType>()
         where TNodeType : IGraphType
         where TEdgeType : EdgeType<TNodeType>

--- a/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphTypeExtensions.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types;
 /// <summary>
 /// Provides methods to add fields to output graph types.
 /// </summary>
-[Obsolete("This class will be removed in v8.")]
+[Obsolete("This class will be removed in v9.")]
 public static class ObjectGraphTypeExtensions
 {
     /// <summary>
@@ -17,7 +17,7 @@ public static class ObjectGraphTypeExtensions
     /// <param name="description">The description of the field.</param>
     /// <param name="arguments">A list of arguments for the field.</param>
     /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public static void Field(
         this IObjectGraphType obj,
         string name,
@@ -46,7 +46,7 @@ public static class ObjectGraphTypeExtensions
     /// <param name="description">The description of the field.</param>
     /// <param name="arguments">A list of arguments for the field.</param>
     /// <param name="resolve">A field resolver delegate. If not specified, <see cref="NameFieldResolver"/> will be used.</param>
-    [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v8.")]
+    [Obsolete("Please use one of the Field() methods returning FieldBuilder and then methods defined on it or just use AddField() method directly. This method will be removed in v9.")]
     public static void FieldAsync(
         this IObjectGraphType obj,
         string name,

--- a/src/GraphQL/Validation/Complexity/LegacyAnalysisContext.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyAnalysisContext.cs
@@ -3,7 +3,7 @@ using GraphQLParser.Visitors;
 
 namespace GraphQL.Validation.Complexity;
 
-[Obsolete("Please use the new complexity analyzer.")]
+[Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
 internal sealed class LegacyAnalysisContext : IASTVisitorContext
 {
     public double AvgImpact { get; set; }

--- a/src/GraphQL/Validation/Complexity/LegacyComplexityConfiguration.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyComplexityConfiguration.cs
@@ -3,7 +3,7 @@ namespace GraphQL.Validation.Complexity;
 /// <summary>
 /// Configuration parameters for a complexity analyzer.
 /// </summary>
-[Obsolete("Please use the new complexity analyzer.")]
+[Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
 public class LegacyComplexityConfiguration
 {
     /// <summary>

--- a/src/GraphQL/Validation/Complexity/LegacyComplexityResult.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyComplexityResult.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Validation.Complexity;
 /// <summary>
 /// Contains the result of a complexity analysis.
 /// </summary>
-[Obsolete("Please use the new complexity analyzer.")]
+[Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
 public class LegacyComplexityResult
 {
     /// <summary>

--- a/src/GraphQL/Validation/Complexity/LegacyComplexityVisitor.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyComplexityVisitor.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Validation.Complexity;
 /// Phase 1. Calculate complexity of all fragments defined in GraphQL document; <see cref="LegacyAnalysisContext.FragmentMapAlreadyBuilt"/> is false.
 /// Phase 2. Calculate complexity of executed operation; <see cref="LegacyAnalysisContext.FragmentMapAlreadyBuilt"/> is true.
 /// </summary>
-[Obsolete("Please use the new complexity analyzer.")]
+[Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
 internal class LegacyComplexityVisitor : ASTVisitor<LegacyAnalysisContext>
 {
     private readonly TypeInfo? _visitor;

--- a/src/GraphQL/Validation/Complexity/LegacyFragmentComplexity.cs
+++ b/src/GraphQL/Validation/Complexity/LegacyFragmentComplexity.cs
@@ -3,7 +3,7 @@ namespace GraphQL.Validation.Complexity;
 /// <summary>
 /// Class to track complexity of fragment defined in GraphQL document.
 /// </summary>
-[Obsolete("Please use the new complexity analyzer.")]
+[Obsolete("Please use the new complexity analyzer. This class will be removed in v9.")]
 internal sealed class LegacyFragmentComplexity
 {
     /// <summary>


### PR DESCRIPTION
Goals, to the extent reasonable:

- Field builder APIs should be marked as obsolete for 2 major versions
- Commonly-used infrastructure APIs should be marked as obsolete for 1 major version (e.g. legacy complexity analyzer, `IGraphQLBuilder` extension methods)
- Public APIs supporting internal infrastructure can be changed/removed during a major version bump (e.g. `IInterfaceGraphType`)

I've briefly reviewed all obsolete methods/classes in the codebase.  Most fell into a few different groups:

1. Field builder methods that did not require name parameter, marked as obsolete in v7.6.  These were noted to be removed in v9.  Note that this is a bit less than "2 major versions", but users can now apply fixes from analyzers.
2. Old field builder methods which returned `FieldType` instead of `FieldBuilder`.  These were marked as obsolete in 7, so allowing for 2 major versions (version 7 and version 8), means they should be removed in version 9.
3. Other APIs that were marked as obsolete in v8, such as the legacy complexity analyzer.  These should be removed in v9.

Notes:
- There were a very few APIs that were marked as obsolete in v5.  Those have been removed in this PR.
- I did not see any field builder methods marked as obsolete in v5 still remaining in the codebase.
- All obsolete messages have been updated to include the version we expect to remove them from the codebase.
- It would be good to check all obsolete field builder methods to see if they all have analyzers to expedite upgrading.  I did not do so.