### PR TITLE
Add IResolveFieldContext.ExecutionContext

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -27,7 +27,7 @@ GraphQL.NET v8 is a major release that includes many new features, including:
 - Optimize scalar lists (e.g. `ListGraphType<IntGraphType>`)
 - Allow GraphQL interfaces to implement other GraphQL interfaces (based on spec)
 
-Some of these features require changes to the infrastrucutre, which can cause breaking changes during upgrades.
+Some of these features require changes to the infrastructure, which can cause breaking changes during upgrades.
 Most notably, if your server uses any of the following features, you are likely to encounter migration issues:
 
 - Custom validation rules, schema node visitors, or IResolveFieldContext implementations

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -39,7 +39,7 @@ Most notably, if your server uses any of the following features, you are likely 
 - Generic graph types
 - Methods previously marked as obsolete
 - GraphQL types which improperly implement interfaces
-- Calls `ExecutionHelper.GetArguments`
+- Calls to `ExecutionHelper.GetArguments`
 
 Below we have documented each new feature and breaking change, outlining the steps you need to take to upgrade your
 application to v8.0. When possible, we have provided code examples to help you understand the changes required, and

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -30,8 +30,7 @@ GraphQL.NET v8 is a major release that includes many new features, including:
 Some of these features require changes to the infrastrucutre, which can cause breaking changes during upgrades.
 Most notably, if your server uses any of the following features, you are likely to encounter migration issues:
 
-- Custom validation rules
-- Custom schema node visitors
+- Custom validation rules, schema node visitors, or IResolveFieldContext implementations
 - The complexity analyzer
 - Apollo Federation subgraph support
 - Custom implementations of GraphQL.NET infrastructure (e.g. custom `IGraphType` implementations not based on an included class)
@@ -40,6 +39,7 @@ Most notably, if your server uses any of the following features, you are likely 
 - Generic graph types
 - Methods previously marked as obsolete
 - GraphQL types which improperly implement interfaces
+- Calls `ExecutionHelper.GetArguments`
 
 Below we have documented each new feature and breaking change, outlining the steps you need to take to upgrade your
 application to v8.0. When possible, we have provided code examples to help you understand the changes required, and
@@ -1011,7 +1011,7 @@ of scalars. Be sure the returned list type (e.g. `IEnumerable<int>`) matches the
 to take advantage of this optimization. Scalar types that require conversion, such as `DateTimeGraphType` are not
 currently optimized in this way.
 
-### 27. Interfaces may implement other interfaces
+### 27. GraphQL interfaces may implement other interfaces
 
 Pursuant to the current GraphQL specification, interfaces may implement other interfaces. Add implemented interfaces
 to your interface type definition as done for object graph types, as shown below:
@@ -1064,6 +1064,12 @@ public interface Character : Node
     string Name { get; }
 }
 ```
+
+### 28. `IResolveFieldContext.ExecutionContext` property added
+
+The `ExecutionContext` property has been added to the `IResolveFieldContext` interface to allow access to the
+underlying execution context. This is useful for accessing the parsed arguments and directives from the operation
+via `IExecutionContext.GetArguments` and `GetDirectives`.
 
 ## Breaking Changes
 
@@ -1414,6 +1420,32 @@ pursuant to GraphQL specifications.
 - `ErrorInfoProviderOptions.ExposeExceptionStackTrace` has been replaced with `ExposeExceptionDetails` and `ExposeExceptionDetailsMode`.
 
 See prior migration documents for more details concerning these changes.
+
+### 29. `IResolveFieldContext.ExecutionContext` added and `ExecutionContext.GetArguments` signature has changed
+
+If you are using the `ExecutionContext.GetArguments` method to parse arguments directly, for example to retrieve
+the arguments of child fields in a resolver, we suggest using the new `IExecutionContext.GetArguments` and
+`IExecutionContext.GetDirectives` methods instead. These take advantage of the fact that all arguments
+are parsed during the validation phase and need not be parsed again. See example below:
+
+```csharp
+// v7
+IResolveFieldContext context;       // parent context
+FieldType fieldDefinition;          // field definition from which to get arguments
+GraphQLField fieldAst;              // field AST from which to get arguments
+var arguments = ExecutionHelper.GetArguments(fieldDefinition.Arguments, fieldAst.Arguments, context.Variables);
+
+// v8
+IResolveFieldContext context;       // parent context
+FieldType fieldDefinition;          // field definition from which to get arguments
+GraphQLField fieldAst;              // field AST from which to get arguments
+var arguments = context.ExecutionContext.GetArguments(fieldDefinition, fieldAst);
+```
+
+To continue to use the `ExecutionHelper.GetArguments` method, you may need to refer to the GraphQL.NET source
+for reference.
+
+If you directly implement `IResolveFieldContext`, you must now also implement the `ExecutionContext` property.
 
 ## Appendix
 

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -153,6 +153,11 @@ namespace GraphQL
     {
         public static System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(this GraphQL.IDocumentExecuter executer, System.Action<GraphQL.ExecutionOptions> configure) { }
     }
+    public static class ExecutionContextExtensions
+    {
+        public static System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue>? GetArguments(this GraphQL.Execution.IExecutionContext executionContext, GraphQL.Types.FieldType fieldDefinition, GraphQLParser.AST.GraphQLField astField) { }
+        public static System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? GetDirectives(this GraphQL.Execution.IExecutionContext executionContext, GraphQLParser.AST.ASTNode astNode) { }
+    }
     [System.Serializable]
     public class ExecutionError : System.Exception
     {

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -545,6 +545,7 @@ namespace GraphQL
         System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         GraphQLParser.AST.GraphQLDocument Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
+        GraphQL.Execution.IExecutionContext ExecutionContext { get; }
         GraphQLParser.AST.GraphQLField FieldAst { get; }
         GraphQL.Types.FieldType FieldDefinition { get; }
         System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
@@ -730,6 +731,7 @@ namespace GraphQL
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         public GraphQLParser.AST.GraphQLDocument Document { get; }
         public GraphQL.ExecutionErrors Errors { get; }
+        public GraphQL.Execution.IExecutionContext ExecutionContext { get; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; }
         public GraphQL.Types.FieldType FieldDefinition { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
@@ -762,6 +764,7 @@ namespace GraphQL
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; set; }
         public GraphQLParser.AST.GraphQLDocument Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
+        public GraphQL.Execution.IExecutionContext ExecutionContext { get; set; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -153,6 +153,11 @@ namespace GraphQL
     {
         public static System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(this GraphQL.IDocumentExecuter executer, System.Action<GraphQL.ExecutionOptions> configure) { }
     }
+    public static class ExecutionContextExtensions
+    {
+        public static System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue>? GetArguments(this GraphQL.Execution.IExecutionContext executionContext, GraphQL.Types.FieldType fieldDefinition, GraphQLParser.AST.GraphQLField astField) { }
+        public static System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? GetDirectives(this GraphQL.Execution.IExecutionContext executionContext, GraphQLParser.AST.ASTNode astNode) { }
+    }
     [System.Serializable]
     public class ExecutionError : System.Exception
     {

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -545,6 +545,7 @@ namespace GraphQL
         System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         GraphQLParser.AST.GraphQLDocument Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
+        GraphQL.Execution.IExecutionContext ExecutionContext { get; }
         GraphQLParser.AST.GraphQLField FieldAst { get; }
         GraphQL.Types.FieldType FieldDefinition { get; }
         System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
@@ -730,6 +731,7 @@ namespace GraphQL
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         public GraphQLParser.AST.GraphQLDocument Document { get; }
         public GraphQL.ExecutionErrors Errors { get; }
+        public GraphQL.Execution.IExecutionContext ExecutionContext { get; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; }
         public GraphQL.Types.FieldType FieldDefinition { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
@@ -762,6 +764,7 @@ namespace GraphQL
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; set; }
         public GraphQLParser.AST.GraphQLDocument Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
+        public GraphQL.Execution.IExecutionContext ExecutionContext { get; set; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -520,6 +520,7 @@ namespace GraphQL
         System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         GraphQLParser.AST.GraphQLDocument Document { get; }
         GraphQL.ExecutionErrors Errors { get; }
+        GraphQL.Execution.IExecutionContext ExecutionContext { get; }
         GraphQLParser.AST.GraphQLField FieldAst { get; }
         GraphQL.Types.FieldType FieldDefinition { get; }
         System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
@@ -704,6 +705,7 @@ namespace GraphQL
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         public GraphQLParser.AST.GraphQLDocument Document { get; }
         public GraphQL.ExecutionErrors Errors { get; }
+        public GraphQL.Execution.IExecutionContext ExecutionContext { get; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; }
         public GraphQL.Types.FieldType FieldDefinition { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; }
@@ -736,6 +738,7 @@ namespace GraphQL
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; set; }
         public GraphQLParser.AST.GraphQLDocument Document { get; set; }
         public GraphQL.ExecutionErrors Errors { get; set; }
+        public GraphQL.Execution.IExecutionContext ExecutionContext { get; set; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> InputExtensions { get; set; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -152,6 +152,11 @@ namespace GraphQL
     {
         public static System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteAsync(this GraphQL.IDocumentExecuter executer, System.Action<GraphQL.ExecutionOptions> configure) { }
     }
+    public static class ExecutionContextExtensions
+    {
+        public static System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue>? GetArguments(this GraphQL.Execution.IExecutionContext executionContext, GraphQL.Types.FieldType fieldDefinition, GraphQLParser.AST.GraphQLField astField) { }
+        public static System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? GetDirectives(this GraphQL.Execution.IExecutionContext executionContext, GraphQLParser.AST.ASTNode astNode) { }
+    }
     [System.Serializable]
     public class ExecutionError : System.Exception
     {

--- a/src/GraphQL.MicrosoftDI/ScopedResolveConnectionContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveConnectionContextAdapter.cs
@@ -79,4 +79,6 @@ internal sealed class ScopedResolveConnectionContextAdapter<TSource> : IResolveC
     public int? PageSize => _baseContext.PageSize;
 
     public ClaimsPrincipal? User => _baseContext.User;
+
+    public IExecutionContext ExecutionContext => _baseContext.ExecutionContext;
 }

--- a/src/GraphQL.MicrosoftDI/ScopedResolveFieldContextAdapter.cs
+++ b/src/GraphQL.MicrosoftDI/ScopedResolveFieldContextAdapter.cs
@@ -83,4 +83,6 @@ internal sealed class ScopedResolveFieldContextAdapter<TSource> : IResolveFieldC
     public IExecutionArrayPool ArrayPool => _baseContext.ArrayPool;
 
     public ClaimsPrincipal? User => _baseContext.User;
+
+    public IExecutionContext ExecutionContext => _baseContext.ExecutionContext;
 }

--- a/src/GraphQL/Extensions/ExecutionContextExtensions.cs
+++ b/src/GraphQL/Extensions/ExecutionContextExtensions.cs
@@ -1,0 +1,25 @@
+using GraphQL.Execution;
+using GraphQL.Types;
+using GraphQLParser.AST;
+
+namespace GraphQL;
+
+/// <summary>
+/// Extension methods for <see cref="Execution.IExecutionContext"/>
+/// </summary>
+public static class ExecutionContextExtensions
+{
+    /// <summary>
+    /// Gets the arguments for the specified field.
+    /// Returns <see langword="null"/> if no arguments were defined for the field.
+    /// </summary>
+    public static IDictionary<string, ArgumentValue>? GetArguments(this IExecutionContext executionContext, FieldType fieldDefinition, GraphQLField astField)
+        => executionContext.ArgumentValues?.TryGetValue(astField, out var args) == true ? args : fieldDefinition.DefaultArgumentValues;
+
+    /// <summary>
+    /// Gets the directives for the specified AST node.
+    /// Returns <see langword="null"/> if no directives were supplied for the node.
+    /// </summary>
+    public static IDictionary<string, DirectiveInfo>? GetDirectives(this IExecutionContext executionContext, ASTNode astNode)
+        => executionContext.DirectiveValues?.TryGetValue(astNode, out var directives) == true ? directives : null;
+}

--- a/src/GraphQL/Federation/Attributes/FederationResolverAttribute.FederationNonStaticResolver.cs
+++ b/src/GraphQL/Federation/Attributes/FederationResolverAttribute.FederationNonStaticResolver.cs
@@ -81,6 +81,7 @@ public partial class FederationResolverAttribute
             public IExecutionArrayPool ArrayPool => _context.ArrayPool;
             public ClaimsPrincipal? User => _context.User;
             public IDictionary<string, object?> UserContext => _context.UserContext;
+            public IExecutionContext ExecutionContext => _context.ExecutionContext;
         }
     }
 }

--- a/src/GraphQL/Federation/Attributes/FederationResolverAttribute.FederationStaticResolver.cs
+++ b/src/GraphQL/Federation/Attributes/FederationResolverAttribute.FederationStaticResolver.cs
@@ -138,6 +138,7 @@ public partial class FederationResolverAttribute
             public IExecutionArrayPool ArrayPool => _context.ArrayPool;
             public ClaimsPrincipal? User => _context.User;
             public IDictionary<string, object?> UserContext => _context.UserContext;
+            public IExecutionContext ExecutionContext => _context.ExecutionContext;
         }
     }
 }

--- a/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/IResolveFieldContext.cs
@@ -118,6 +118,11 @@ public interface IResolveFieldContext : IProvideUserContext
 
     /// <inheritdoc cref="IExecutionContext.User"/>
     ClaimsPrincipal? User { get; }
+
+    /// <summary>
+    /// Returns the execution context for the current request.
+    /// </summary>
+    IExecutionContext ExecutionContext { get; }
 }
 
 /// <inheritdoc cref="IResolveFieldContext"/>

--- a/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ReadonlyResolveFieldContext.cs
@@ -70,12 +70,10 @@ public class ReadonlyResolveFieldContext : IResolveFieldContext<object?>
     }
 
     /// <inheritdoc/>
-    public IDictionary<string, ArgumentValue>? Arguments
-        => _executionContext.ArgumentValues?.TryGetValue(FieldAst, out var ret) ?? false ? ret : FieldDefinition.DefaultArgumentValues;
+    public IDictionary<string, ArgumentValue>? Arguments => _executionContext.GetArguments(FieldDefinition, FieldAst);
 
     /// <inheritdoc/>
-    public IDictionary<string, DirectiveInfo>? Directives
-        => _executionContext.DirectiveValues?.TryGetValue(FieldAst, out var ret) ?? false ? ret : null;
+    public IDictionary<string, DirectiveInfo>? Directives => _executionContext.GetDirectives(FieldAst);
 
     /// <inheritdoc/>
     public object? RootValue => _executionContext.RootValue;
@@ -130,4 +128,7 @@ public class ReadonlyResolveFieldContext : IResolveFieldContext<object?>
 
     /// <inheritdoc/>
     public ClaimsPrincipal? User => _executionContext.User;
+
+    /// <inheritdoc/>
+    public IExecutionContext ExecutionContext => _executionContext;
 }

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContext.cs
@@ -84,6 +84,9 @@ public class ResolveFieldContext : IResolveFieldContext<object?>
     /// <inheritdoc/>
     public ClaimsPrincipal? User { get; set; }
 
+    /// <inheritdoc/>
+    public IExecutionContext ExecutionContext { get; set; }
+
     /// <summary>
     /// Initializes a new instance with all fields set to their default values.
     /// </summary>
@@ -120,6 +123,7 @@ public class ResolveFieldContext : IResolveFieldContext<object?>
         InputExtensions = context.InputExtensions;
         OutputExtensions = context.OutputExtensions;
         ArrayPool = context.ArrayPool;
+        ExecutionContext = context.ExecutionContext;
     }
 }
 

--- a/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
+++ b/src/GraphQL/ResolveFieldContext/ResolveFieldContextAdapter.cs
@@ -103,4 +103,7 @@ internal sealed class ResolveFieldContextAdapter<T> : IResolveFieldContext<T>
 
     /// <inheritdoc/>
     public ClaimsPrincipal? User => _baseContext.User;
+
+    /// <inheritdoc/>
+    public IExecutionContext ExecutionContext => _baseContext.ExecutionContext;
 }

--- a/src/GraphQL/Resolvers/ObservableFromAsyncEnumerable.cs
+++ b/src/GraphQL/Resolvers/ObservableFromAsyncEnumerable.cs
@@ -142,5 +142,6 @@ internal sealed class ObservableFromAsyncEnumerable<T> : IObservable<object?>, I
         public IExecutionArrayPool ArrayPool => _context.ArrayPool;
         public ClaimsPrincipal? User => _context.User;
         public IDictionary<string, object?> UserContext => _context.UserContext;
+        public IExecutionContext ExecutionContext => _context.ExecutionContext;
     }
 }


### PR DESCRIPTION
With the new variable parsing in #3424 , the `ExecutionHelper.GetArguments` signature has changed, and it is not preferred to use that method anymore since all the arguments have already been parsed -- it's essentially an internal detail now.  Because of this, code that synthesizes an `IResolveFieldContext` for child fields within a resolver, or any similar code which needs to examine arguments of child fields, needs modification.  This PR adds `IResolveFieldContext.ExecutionContext` so that code can easily pull already-parsed argument values for any part of the document.