### PR TITLE
Add IsGraphQLSymbol tests

### DIFF
--- a/src/GraphQL.Analyzers.Tests/GraphQLExtensionsTests.cs
+++ b/src/GraphQL.Analyzers.Tests/GraphQLExtensionsTests.cs
@@ -1,0 +1,45 @@
+using GraphQL.Analyzers.Helpers;
+using GraphQL.Types;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace GraphQL.Analyzers.Tests;
+
+public class GraphQLExtensionsTests
+{
+    [Theory]
+    [InlineData("GraphQL.Types", true)]
+    [InlineData("Sample.Server", false)]
+    public async Task IsGraphQLSymbol_TrueWhenDefinedInGraphQLLib(string @namespace, bool expected)
+    {
+        var tree = CSharpSyntaxTree.ParseText(
+            $$"""
+            namespace Sample.Server;
+
+            public class MyClass
+            {
+            	{{@namespace}}.ISchema MyMethod() => null;
+            }
+
+            public interface ISchema { }
+            """);
+
+        var compilation = CreateCompilation(tree);
+        var syntaxRoot = await tree.GetRootAsync();
+        var myMethod = syntaxRoot.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+
+        var model = compilation.GetSemanticModel(tree);
+        myMethod.ReturnType.IsGraphQLSymbol(model).ShouldBe(expected);
+    }
+
+    private static CSharpCompilation CreateCompilation(SyntaxTree syntaxTree) =>
+        CSharpCompilation.Create(
+            assemblyName: "GraphQL.Analyzers.Tests",
+            syntaxTrees: [syntaxTree],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(ISchema).Assembly.Location)
+            ]);
+}

--- a/src/GraphQL.Analyzers/Helpers/GraphQLExtensions.cs
+++ b/src/GraphQL.Analyzers/Helpers/GraphQLExtensions.cs
@@ -5,6 +5,8 @@ namespace GraphQL.Analyzers.Helpers;
 
 public static class GraphQLExtensions
 {
+    private static readonly byte[] _publicKey = typeof(GraphQLExtensions).Assembly.GetName().GetPublicKey();
+
     /// <summary>
     /// Checks if the given <see cref="ExpressionSyntax"/> represents a symbol defined by the GraphQL library.
     /// </summary>
@@ -22,8 +24,6 @@ public static class GraphQLExtensions
                ?? symbolInfo.CandidateSymbols
                    .All(symbol => symbol.IsGraphQLSymbol());
     }
-
-    private static readonly byte[] _publicKey = typeof(GraphQLExtensions).Assembly.GetName().GetPublicKey();
 
     /// <summary>
     /// Checks if the given <see cref="ISymbol"/> represents a symbol defined by the GraphQL library.


### PR DESCRIPTION
Unlike `FieldAndNameMethodsCalled_NotGraphQLBuilder_NoDiagnostics`, this test is not coupled to any analyzer, so it's not affected by changes or possible removal of the analyzers.