### PR TITLE
Add validation for field arguments

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -335,6 +335,12 @@ Field<string>("example")
     });
 ```
 
+Please throw a `ValidationError` exception or call `ctx.ReportError` to return a validation error to
+the client. Throwing `ExecutionError` will prevent further validation rules from being executed,
+and throwing other exceptions will be caught by the unhandled exception handler. This is different
+than the `Parser` and `Validator` delegates, or scalar coercion methods, which will not trigger the
+unhandled exception handler.
+
 ### 7. `@pattern` custom directive added for validating input values against a regular expression pattern
 
 This directive allows for specifying a regular expression pattern to validate the input value.

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -12,6 +12,7 @@ GraphQL.NET v8 is a major release that includes many new features, including:
 
 - Argument parsing now occurs during validation
 - Fields and arguments can have custom parsers applied, which will catch more coercion errors during validation rather than execution
+- Fields can configure validation code for argument values which will run during the validation stage
 - Validation rules can execute after arguments have been parsed
 - Complexity analyzer rewritten; can examine arguments to facilitate analysis
 - Federation support is simplified and Federation 2 is supported
@@ -313,7 +314,28 @@ At this time GraphQL.NET does not directly support the `MaxLength` and similar a
 implement your own attributes as shown above, or call the `Validate` method to set a validation
 function.
 
-### 6. `@pattern` custom directive added for validating input values against a regular expression pattern
+### 6. `ArgumentValidator` delegate added to input object/interface field definitions (since 8.1)
+
+This allows for custom validation of the coerced argument values. It can be used when you must
+enforce certain relationships between arguments, such as ensuring that at least one of multiple
+arguments are provided, or that a specific argument is provided when another argument is set to
+a specific value. It can be set by configuring the `ValidateArguments` delegate on the `FieldType`
+class or calling the `ValidateArguments` method on the field builder. Here is an example:
+
+```csharp
+Field<string>("example")
+    .Argument<string>("str1", true)
+    .Argument<string>("str2", true)
+    .ValidateArguments(ctx =>
+    {
+        var str1 = ctx.GetArgument<string>("str1");
+        var str2 = ctx.GetArgument<string>("str2");
+        if (str1 == null && str2 == null)
+            throw new InvalidOperationException("Must provide str1 or str2");
+    });
+```
+
+### 7. `@pattern` custom directive added for validating input values against a regular expression pattern
 
 This directive allows for specifying a regular expression pattern to validate the input value.
 It can also be used as sample code for designing new custom directives, and is now the preferred
@@ -341,7 +363,7 @@ Field(x => x.FirstName)
     .ApplyDirective("pattern", "regex", "[A-Z]+"); // uppercase only
 ```
 
-### 7. DirectiveAttribute added to support applying directives to type-first graph types and fields
+### 8. DirectiveAttribute added to support applying directives to type-first graph types and fields
 
 For example:
 
@@ -355,7 +377,7 @@ private class Query
 }
 ```
 
-### 8. Validation rules can read or validate field arguments and directive arguments
+### 9. Validation rules can read or validate field arguments and directive arguments
 
 Validation rules can now execute validation code either before or after field arguments
 have been read. This is useful for edge cases, such as when a complexity analyzer needs
@@ -386,7 +408,7 @@ Documentation has been added to the [Query Validation](https://graphql-dotnet.gi
 section of the documentation to explain how to create custom validation rules using the
 revised `IValidationRule` interface and related classes.
 
-### 9. List coercion can be customized
+### 10. List coercion can be customized
 
 Previously only specific list types were natively supported, such as `List<T>` and `IEnumerable<T>`,
 and list types that implemented `IList`. Now, any list-like type such as `HashSet<T>` or `Queue<T>`
@@ -430,7 +452,7 @@ Finally, if you simply need to map an interface list type to a concrete list typ
 ValueConverter.RegisterListConverterFactory(typeof(IList<>), typeof(List<>)); // default mapping is T[]
 ```
 
-### 10. `IGraphType.IsPrivate` and `IFieldType.IsPrivate` properties added
+### 11. `IGraphType.IsPrivate` and `IFieldType.IsPrivate` properties added
 
 Allows to set a graph type or field as private within a schema visitor, effectively removing it from the schema.
 Introspection queries will not be able to query the type/field, and queries will not be able to reference the type/field.
@@ -445,18 +467,18 @@ This makes it possible to create a private type used within the schema but not e
 it is possible to dynamically create input object types to deserialize GraphQL Federation entity representations, which
 are normally sent via the `_Any` type.
 
-### 11. `IObjectGraphType.SkipTypeCheck` property added
+### 12. `IObjectGraphType.SkipTypeCheck` property added
 
 Allows to skip the type check for a specific object graph type during resolver execution. This is useful
 for schema-first schemas where the CLR type is not defined while the resolver is built, while allowing
 `IsTypeOf` to be set automatically for other use cases. Schema-first schemas will automatically set this
 property to `true` for all object graph types to retain the existing behavior.
 
-### 12. `ISchemaNodeVisitor.PostVisitSchema` method added
+### 13. `ISchemaNodeVisitor.PostVisitSchema` method added
 
 Allows to revisit the schema after all other methods (types/fields/etc) have been visited.
 
-### 13. GraphQL Federation v2 graph types added
+### 14. GraphQL Federation v2 graph types added
 
 These graph types have been added to the `GraphQL.Federation.Types` namespace:
 
@@ -468,7 +490,7 @@ These graph types have been added to the `GraphQL.Federation.Types` namespace:
 - `LinkPurposeGraphType`
 - `ServiceGraphType`
 
-### 14. Extension methods and attributes added to simplify applying GraphQL Federation directives in code-first and type-first schemas
+### 15. Extension methods and attributes added to simplify applying GraphQL Federation directives in code-first and type-first schemas
 
 These extension methods and attributes simplify the process of applying GraphQL Federation directives:
 
@@ -482,7 +504,7 @@ These extension methods and attributes simplify the process of applying GraphQL 
 | `@shareable` | `Shareable()` | `[Shareable]` | Indicates that an object type's field is allowed to be resolved by multiple subgraphs (by default in Federation 2, object fields can be resolved by only one subgraph). |
 | `@inaccessible` | `Inaccessible()` | `[Inaccessible]` | Indicates that a definition in the subgraph schema should be omitted from the router's API schema, even if that definition is also present in other subgraphs. This means that the field is not exposed to clients at all. |
 
-### 15. OneOf Input Object support added
+### 16. OneOf Input Object support added
 
 OneOf Input Objects are a special variant of Input Objects where the type system
 asserts that exactly one of the fields must be set and non-null, all others
@@ -500,7 +522,7 @@ Note: the feature is still a draft and has not made it into the official GraphQL
 It is expected to be added once it has been implemented in multiple libraries and proven to be useful.
 It is not expected to change from the current draft.
 
-### 16. Federation entity resolver configuration methods and attributes added for code-first and type-first schemas
+### 17. Federation entity resolver configuration methods and attributes added for code-first and type-first schemas
 
 Extension methods have been added for defining entity resolvers in code-first and type-first schemas
 for GraphQL Federation.
@@ -669,12 +691,12 @@ public class Widget
 }
 ```
 
-### 17. Applied directives may contain metadata
+### 18. Applied directives may contain metadata
 
 `AppliedDirective` now implements `IProvideMetadata`, `IMetadataReader` and `IMetadataWriter`
 to allow for reading and writing metadata to applied directives.
 
-### 18. Support added for the Apollo `@link` directive
+### 19. Support added for the Apollo `@link` directive
 
 This directive indicates that some types and/or directives are to be imported from another schema.
 Types and directives can be explicitly imported, either with their original name or with an alias.
@@ -743,7 +765,7 @@ schema
 Note that you may call `LinkSchema` multiple times with the same URL to apply additional configuration
 options to the same url, or with a separate URL to link multiple schemas.
 
-### 19. `FromSchemaUrl` added to `AppliedDirective`
+### 20. `FromSchemaUrl` added to `AppliedDirective`
 
 This property supports using a directive that was separately imported via `@link`. After importing the schema as described
 above, apply imported directives to your schema similar to the example below:
@@ -758,7 +780,7 @@ During schema initialization, the name of the applied directive will be resolved
 In the above example, if `@shareable` was imported, the directive will be applied as `@shareable`, but if not, it will
 be applied as `@federation__shareable`. Aliases are also supported.
 
-### 20. `AddFederation` GraphQL builder call added to initialize any schema for federation support
+### 21. `AddFederation` GraphQL builder call added to initialize any schema for federation support
 
 This method will automatically add the necessary types and directives to support GraphQL Federation.
 Simply call `AddFederation` with the version number of the Federation specification that you wish to import
@@ -787,7 +809,7 @@ parts of your schema with `@extends`. This is not required for version 2.0 and l
 You may add additional configuration to the `AddFederation` call to import additional directives or types, remove imports,
 change import aliases, or change the namespace used for directives that are not explicitly imported.
 
-### 21. Infer field nullability from NRT annotations is enabled by default
+### 22. Infer field nullability from NRT annotations is enabled by default
 
 When defining the field with expression, the graph type nullability will be inferred from
 Null Reference Types (NRT) by default. To disable the feature, set the
@@ -834,14 +856,14 @@ type Person {
 }
 ```
 
-### 22. `ValidationContext.GetRecursivelyReferencedFragments` updated with `@skip` and `@include` directive support
+### 23. `ValidationContext.GetRecursivelyReferencedFragments` updated with `@skip` and `@include` directive support
 
 When developing a custom validation rule, such as an authorization rule, you may need to determine which fragments are
 recursively referenced by an operation by calling `GetRecursivelyReferencedFragments` with the `onlyUsed` argument
 set to `true`. The method will then ignore fragments that are conditionally skipped by the `@skip` or `@include`
 directives.
 
-### 23. Persisted Document support
+### 24. Persisted Document support
 
 GraphQL.NET now supports persisted documents based on the draft spec [listed here](https://github.com/graphql/graphql-over-http/pull/264).
 Persisted documents are a way to store a query string on the server and reference it by a unique identifier, typically

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -331,7 +331,7 @@ Field<string>("example")
         var str1 = ctx.GetArgument<string>("str1");
         var str2 = ctx.GetArgument<string>("str2");
         if (str1 == null && str2 == null)
-            throw new InvalidOperationException("Must provide str1 or str2");
+            throw new ValidationError("Must provide str1 or str2");
     });
 ```
 

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1075,6 +1075,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ValidateArguments(System.Action<GraphQL.Validation.FieldArgumentsValidationContext> validation) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ValidateArguments(System.Func<GraphQL.Validation.FieldArgumentsValidationContext, System.Threading.Tasks.ValueTask> validation) { }
         [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
             "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
@@ -2579,6 +2581,7 @@ namespace GraphQL.Types
         public GraphQL.Resolvers.IFieldResolver? Resolver { get; set; }
         public GraphQL.Resolvers.ISourceStreamResolver? StreamResolver { get; set; }
         public System.Type? Type { get; set; }
+        public System.Func<GraphQL.Validation.FieldArgumentsValidationContext, System.Threading.Tasks.ValueTask>? ValidateArguments { get; set; }
         public System.Action<object>? Validator { get; set; }
     }
     public class FloatGraphType : GraphQL.Types.ScalarGraphType
@@ -3678,6 +3681,18 @@ namespace GraphQL.Validation
         public DocumentValidator() { }
         public System.Threading.Tasks.Task<GraphQL.Validation.IValidationResult> ValidateAsync(in GraphQL.Validation.ValidationOptions options) { }
     }
+    public struct FieldArgumentsValidationContext
+    {
+        public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue>? Arguments { get; set; }
+        public System.Threading.CancellationToken CancellationToken { get; }
+        public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
+        public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
+        public GraphQL.Types.FieldType FieldDefinition { get; set; }
+        public GraphQL.Types.IGraphType ParentType { get; }
+        public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
+        public T GetArgument<T>(string name, T defaultValue = default) { }
+        public void SetArgument(string name, object? value) { }
+    }
     public interface IDocumentValidator
     {
         System.Threading.Tasks.Task<GraphQL.Validation.IValidationResult> ValidateAsync(in GraphQL.Validation.ValidationOptions options);
@@ -4098,6 +4113,13 @@ namespace GraphQL.Validation.Rules
         public static readonly GraphQL.Validation.Rules.DefaultValuesOfCorrectType Instance;
         public DefaultValuesOfCorrectType() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
+    }
+    public sealed class FieldArgumentsAreValidRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
+    {
+        public const string HAS_FIELD_ARGUMENT_VALIDATION_KEY = "__GraphQL_Has_Field_Argument_Validation__";
+        public FieldArgumentsAreValidRule() { }
+        public static GraphQL.Validation.Rules.FieldArgumentsAreValidRule Instance { get; }
+        public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }
     public class FieldsOnCorrectType : GraphQL.Validation.ValidationRuleBase
     {

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3692,6 +3692,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }
+        public void ReportError(GraphQL.Validation.ValidationError error) { }
         public void SetArgument(string name, object? value) { }
     }
     public interface IDocumentValidator

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3689,6 +3689,7 @@ namespace GraphQL.Validation
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
         public GraphQL.Types.IGraphType ParentType { get; }
+        public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }
         public void SetArgument(string name, object? value) { }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -4118,7 +4118,6 @@ namespace GraphQL.Validation.Rules
     public sealed class FieldArgumentsAreValidRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
     {
         public const string HAS_FIELD_ARGUMENT_VALIDATION_KEY = "__GraphQL_Has_Field_Argument_Validation__";
-        public FieldArgumentsAreValidRule() { }
         public static GraphQL.Validation.Rules.FieldArgumentsAreValidRule Instance { get; }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3688,7 +3688,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
-        public GraphQL.Types.IGraphType ParentType { get; }
+        public GraphQL.Types.IGraphType? ParentType { get; }
         public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3703,6 +3703,7 @@ namespace GraphQL.Validation
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
         public GraphQL.Types.IGraphType ParentType { get; }
+        public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }
         public void SetArgument(string name, object? value) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -4132,7 +4132,6 @@ namespace GraphQL.Validation.Rules
     public sealed class FieldArgumentsAreValidRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
     {
         public const string HAS_FIELD_ARGUMENT_VALIDATION_KEY = "__GraphQL_Has_Field_Argument_Validation__";
-        public FieldArgumentsAreValidRule() { }
         public static GraphQL.Validation.Rules.FieldArgumentsAreValidRule Instance { get; }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1075,6 +1075,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ValidateArguments(System.Action<GraphQL.Validation.FieldArgumentsValidationContext> validation) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ValidateArguments(System.Func<GraphQL.Validation.FieldArgumentsValidationContext, System.Threading.Tasks.ValueTask> validation) { }
         [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
             "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
@@ -2586,6 +2588,7 @@ namespace GraphQL.Types
         public GraphQL.Resolvers.IFieldResolver? Resolver { get; set; }
         public GraphQL.Resolvers.ISourceStreamResolver? StreamResolver { get; set; }
         public System.Type? Type { get; set; }
+        public System.Func<GraphQL.Validation.FieldArgumentsValidationContext, System.Threading.Tasks.ValueTask>? ValidateArguments { get; set; }
         public System.Action<object>? Validator { get; set; }
     }
     public class FloatGraphType : GraphQL.Types.ScalarGraphType
@@ -3692,6 +3695,18 @@ namespace GraphQL.Validation
         public DocumentValidator() { }
         public System.Threading.Tasks.Task<GraphQL.Validation.IValidationResult> ValidateAsync(in GraphQL.Validation.ValidationOptions options) { }
     }
+    public struct FieldArgumentsValidationContext
+    {
+        public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue>? Arguments { get; set; }
+        public System.Threading.CancellationToken CancellationToken { get; }
+        public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
+        public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
+        public GraphQL.Types.FieldType FieldDefinition { get; set; }
+        public GraphQL.Types.IGraphType ParentType { get; }
+        public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
+        public T GetArgument<T>(string name, T defaultValue = default) { }
+        public void SetArgument(string name, object? value) { }
+    }
     public interface IDocumentValidator
     {
         System.Threading.Tasks.Task<GraphQL.Validation.IValidationResult> ValidateAsync(in GraphQL.Validation.ValidationOptions options);
@@ -4112,6 +4127,13 @@ namespace GraphQL.Validation.Rules
         public static readonly GraphQL.Validation.Rules.DefaultValuesOfCorrectType Instance;
         public DefaultValuesOfCorrectType() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
+    }
+    public sealed class FieldArgumentsAreValidRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
+    {
+        public const string HAS_FIELD_ARGUMENT_VALIDATION_KEY = "__GraphQL_Has_Field_Argument_Validation__";
+        public FieldArgumentsAreValidRule() { }
+        public static GraphQL.Validation.Rules.FieldArgumentsAreValidRule Instance { get; }
+        public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }
     public class FieldsOnCorrectType : GraphQL.Validation.ValidationRuleBase
     {

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3702,7 +3702,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
-        public GraphQL.Types.IGraphType ParentType { get; }
+        public GraphQL.Types.IGraphType? ParentType { get; }
         public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3706,6 +3706,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }
+        public void ReportError(GraphQL.Validation.ValidationError error) { }
         public void SetArgument(string name, object? value) { }
     }
     public interface IDocumentValidator

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3618,6 +3618,7 @@ namespace GraphQL.Validation
         public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }
+        public void ReportError(GraphQL.Validation.ValidationError error) { }
         public void SetArgument(string name, object? value) { }
     }
     public interface IDocumentValidator

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3614,7 +3614,7 @@ namespace GraphQL.Validation
         public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
-        public GraphQL.Types.IGraphType ParentType { get; }
+        public GraphQL.Types.IGraphType? ParentType { get; }
         public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3615,6 +3615,7 @@ namespace GraphQL.Validation
         public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
         public GraphQL.Types.FieldType FieldDefinition { get; set; }
         public GraphQL.Types.IGraphType ParentType { get; }
+        public System.IServiceProvider? RequestServices { get; }
         public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
         public T GetArgument<T>(string name, T defaultValue = default) { }
         public void SetArgument(string name, object? value) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -4044,7 +4044,6 @@ namespace GraphQL.Validation.Rules
     public sealed class FieldArgumentsAreValidRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
     {
         public const string HAS_FIELD_ARGUMENT_VALIDATION_KEY = "__GraphQL_Has_Field_Argument_Validation__";
-        public FieldArgumentsAreValidRule() { }
         public static GraphQL.Validation.Rules.FieldArgumentsAreValidRule Instance { get; }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1041,6 +1041,8 @@ namespace GraphQL.Builders
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TNewReturnType> Returns<TNewReturnType>() { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Type(GraphQL.Types.IGraphType type) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Validate(System.Action<object> validation) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ValidateArguments(System.Action<GraphQL.Validation.FieldArgumentsValidationContext> validation) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> ValidateArguments(System.Func<GraphQL.Validation.FieldArgumentsValidationContext, System.Threading.Tasks.ValueTask> validation) { }
         [System.Obsolete("Please use the overload that accepts the name as the first argument. This method " +
             "will be removed in v9.")]
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Create(GraphQL.Types.IGraphType type, string name = "default") { }
@@ -2513,6 +2515,7 @@ namespace GraphQL.Types
         public GraphQL.Resolvers.IFieldResolver? Resolver { get; set; }
         public GraphQL.Resolvers.ISourceStreamResolver? StreamResolver { get; set; }
         public System.Type? Type { get; set; }
+        public System.Func<GraphQL.Validation.FieldArgumentsValidationContext, System.Threading.Tasks.ValueTask>? ValidateArguments { get; set; }
         public System.Action<object>? Validator { get; set; }
     }
     public class FloatGraphType : GraphQL.Types.ScalarGraphType
@@ -3604,6 +3607,18 @@ namespace GraphQL.Validation
         public DocumentValidator() { }
         public System.Threading.Tasks.Task<GraphQL.Validation.IValidationResult> ValidateAsync(in GraphQL.Validation.ValidationOptions options) { }
     }
+    public struct FieldArgumentsValidationContext
+    {
+        public System.Collections.Generic.IDictionary<string, GraphQL.Execution.ArgumentValue>? Arguments { get; set; }
+        public System.Threading.CancellationToken CancellationToken { get; }
+        public System.Collections.Generic.IDictionary<string, GraphQL.Execution.DirectiveInfo>? Directives { get; }
+        public GraphQLParser.AST.GraphQLField FieldAst { get; set; }
+        public GraphQL.Types.FieldType FieldDefinition { get; set; }
+        public GraphQL.Types.IGraphType ParentType { get; }
+        public GraphQL.Validation.ValidationContext ValidationContext { get; set; }
+        public T GetArgument<T>(string name, T defaultValue = default) { }
+        public void SetArgument(string name, object? value) { }
+    }
     public interface IDocumentValidator
     {
         System.Threading.Tasks.Task<GraphQL.Validation.IValidationResult> ValidateAsync(in GraphQL.Validation.ValidationOptions options);
@@ -4024,6 +4039,13 @@ namespace GraphQL.Validation.Rules
         public static readonly GraphQL.Validation.Rules.DefaultValuesOfCorrectType Instance;
         public DefaultValuesOfCorrectType() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
+    }
+    public sealed class FieldArgumentsAreValidRule : GraphQL.Validation.ValidationRuleBase, GraphQL.Validation.INodeVisitor
+    {
+        public const string HAS_FIELD_ARGUMENT_VALIDATION_KEY = "__GraphQL_Has_Field_Argument_Validation__";
+        public FieldArgumentsAreValidRule() { }
+        public static GraphQL.Validation.Rules.FieldArgumentsAreValidRule Instance { get; }
+        public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }
     public class FieldsOnCorrectType : GraphQL.Validation.ValidationRuleBase
     {

--- a/src/GraphQL.Tests/Validation/FieldArgumentsAreValidRuleTests.cs
+++ b/src/GraphQL.Tests/Validation/FieldArgumentsAreValidRuleTests.cs
@@ -51,4 +51,16 @@ public class FieldArgumentsAreValidRuleTests : ValidationTestBase<FieldArguments
             });
         });
     }
+
+    [Fact]
+    public void bubbles_unhandled_errors()
+    {
+        Should.Throw<InvalidOperationException>(() =>
+            ShouldPassRule("""
+                {
+                    argValidation (str1: "error")
+                }
+                """))
+            .Message.ShouldBe("critical failure");
+    }
 }

--- a/src/GraphQL.Tests/Validation/FieldArgumentsAreValidRuleTests.cs
+++ b/src/GraphQL.Tests/Validation/FieldArgumentsAreValidRuleTests.cs
@@ -1,0 +1,54 @@
+using GraphQL.Validation.Rules;
+
+namespace GraphQL.Tests.Validation;
+
+public class FieldArgumentsAreValidRuleTests : ValidationTestBase<FieldArgumentsAreValidRule, ValidationSchema>
+{
+    [Fact]
+    public void works_with_str1()
+    {
+        ShouldPassRule("""
+            {
+              argValidation (str1: "abc")
+            }
+            """);
+    }
+
+    [Fact]
+    public void works_with_str2()
+    {
+        ShouldPassRule("""
+            {
+              argValidation (str2: "abc")
+            }
+            """);
+    }
+
+    [Fact]
+    public void works_with_str1_and_str2()
+    {
+        ShouldPassRule("""
+            {
+              argValidation (str1: "abc", str2: "def")
+            }
+            """);
+    }
+
+    [Fact]
+    public void fails_with_neither()
+    {
+        ShouldFailRule(_ =>
+        {
+            _.Query = """
+                {
+                  argValidation
+                }
+                """;
+            _.Error(err =>
+            {
+                err.Message = "Must provide str1 or str2";
+                err.Loc(2, 3);
+            });
+        });
+    }
+}

--- a/src/GraphQL.Tests/Validation/ValidationSchema.cs
+++ b/src/GraphQL.Tests/Validation/ValidationSchema.cs
@@ -1,4 +1,5 @@
 using GraphQL.Types;
+using GraphQL.Validation;
 using GraphQLParser.AST;
 
 namespace GraphQL.Tests.Validation;
@@ -264,7 +265,9 @@ public class ValidationQueryRoot : ObjectGraphType
                 var str1 = ctx.GetArgument<string>("str1");
                 var str2 = ctx.GetArgument<string>("str2");
                 if (str1 == null && str2 == null)
-                    throw new InvalidOperationException("Must provide str1 or str2");
+                    throw new ValidationError("Must provide str1 or str2");
+                if (str1 == "error")
+                    throw new InvalidOperationException("critical failure");
                 ctx.SetArgument("str2", "str2override");
             });
     }

--- a/src/GraphQL.Tests/Validation/ValidationSchema.cs
+++ b/src/GraphQL.Tests/Validation/ValidationSchema.cs
@@ -245,6 +245,7 @@ public class ValidationQueryRoot : ObjectGraphType
 {
     public ValidationQueryRoot()
     {
+        Name = "Query";
         Field<Human>("human")
             .Argument<IdGraphType>("id", arg => arg.ApplyDirective("length", "min", 2, "max", 5));
         Field<Human>("human2")
@@ -255,6 +256,17 @@ public class ValidationQueryRoot : ObjectGraphType
         Field<DogOrHuman>("dogOrHuman");
         Field<HumanOrAlien>("humanOrAlien");
         Field<ComplicatedArgs>("complicatedArgs");
+        Field<string>("argValidation")
+            .Argument<string>("str1", true)
+            .Argument<string>("str2", true)
+            .ValidateArguments(ctx =>
+            {
+                var str1 = ctx.GetArgument<string>("str1");
+                var str2 = ctx.GetArgument<string>("str2");
+                if (str1 == null && str2 == null)
+                    throw new InvalidOperationException("Must provide str1 or str2");
+                ctx.SetArgument("str2", "str2override");
+            });
     }
 }
 

--- a/src/GraphQL.Tests/Validation/ValidationTestBase.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestBase.cs
@@ -100,6 +100,6 @@ public class ValidationTestBase<TRule, TSchema>
             Rules = rules,
             Operation = document.Definitions.OfType<GraphQLOperationDefinition>().FirstOrDefault()!,
             Variables = variables
-        }).Result;
+        }).GetAwaiter().GetResult();
     }
 }

--- a/src/GraphQL.Tests/Validation/ValidationTestBase.cs
+++ b/src/GraphQL.Tests/Validation/ValidationTestBase.cs
@@ -6,12 +6,13 @@ using GraphQLParser.AST;
 namespace GraphQL.Tests.Validation;
 
 public class ValidationTestBase<TRule, TSchema>
-    where TRule : IValidationRule, new()
+    where TRule : IValidationRule
     where TSchema : ISchema, new()
 {
     public ValidationTestBase()
     {
-        Rule = new TRule();
+        // create an instance of the rule and schema, using the default private/public constructor
+        Rule = (TRule)typeof(TRule).GetConstructors(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Single(x => x.GetParameters().Length == 0).Invoke([]);
         Schema = new TSchema();
     }
 

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using GraphQL.Resolvers;
 using GraphQL.Types;
+using GraphQL.Validation;
 using GraphQL.Validation.Rules.Custom;
 
 namespace GraphQL.Builders;
@@ -158,9 +159,9 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
         return this;
     }
 
-    /// <inheritdoc cref="ValidateArguments(Func{Validation.FieldArgumentsValidationContext, ValueTask})"/>
+    /// <inheritdoc cref="ValidateArguments(Func{FieldArgumentsValidationContext, ValueTask})"/>
     [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-    public virtual FieldBuilder<TSourceType, TReturnType> ValidateArguments(Action<Validation.FieldArgumentsValidationContext> validation)
+    public virtual FieldBuilder<TSourceType, TReturnType> ValidateArguments(Action<FieldArgumentsValidationContext> validation)
     {
         FieldType.ValidateArguments = ctx => { validation(ctx); return default; };
         return this;
@@ -169,12 +170,13 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// <summary>
     /// Sets argument validation to the field, replacing any existing validation function.
     /// Runs after all arguments have been coerced and validated as appropriate.
-    /// Throw an exception within the delegate if necessary to indicate a problem; any thrown
-    /// exceptions will be reported as a validation error.
+    /// Throw a <see cref="ValidationError"/> exception within the delegate if necessary to indicate
+    /// a problem; they will be reported as a validation error. Other exceptions bubble
+    /// up to the <see cref="DocumentExecuter"/> to be handled by the unhandled exception delegate.
     /// Applies only to output fields.
     /// </summary>
     [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-    public virtual FieldBuilder<TSourceType, TReturnType> ValidateArguments(Func<Validation.FieldArgumentsValidationContext, ValueTask> validation)
+    public virtual FieldBuilder<TSourceType, TReturnType> ValidateArguments(Func<FieldArgumentsValidationContext, ValueTask> validation)
     {
         FieldType.ValidateArguments = validation;
         return this;

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -159,6 +159,7 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     }
 
     /// <inheritdoc cref="ValidateArguments(Func{Validation.FieldArgumentsValidationContext, ValueTask})"/>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
     public virtual FieldBuilder<TSourceType, TReturnType> ValidateArguments(Action<Validation.FieldArgumentsValidationContext> validation)
     {
         FieldType.ValidateArguments = ctx => { validation(ctx); return default; };
@@ -168,8 +169,11 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// <summary>
     /// Sets argument validation to the field, replacing any existing validation function.
     /// Runs after all arguments have been coerced and validated as appropriate.
+    /// Throw an exception within the delegate if necessary to indicate a problem; any thrown
+    /// exceptions will be reported as a validation error.
     /// Applies only to output fields.
     /// </summary>
+    [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
     public virtual FieldBuilder<TSourceType, TReturnType> ValidateArguments(Func<Validation.FieldArgumentsValidationContext, ValueTask> validation)
     {
         FieldType.ValidateArguments = validation;

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -158,6 +158,24 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
         return this;
     }
 
+    /// <inheritdoc cref="ValidateArguments(Func{Validation.FieldArgumentsValidationContext, ValueTask})"/>
+    public virtual FieldBuilder<TSourceType, TReturnType> ValidateArguments(Action<Validation.FieldArgumentsValidationContext> validation)
+    {
+        FieldType.ValidateArguments = ctx => { validation(ctx); return default; };
+        return this;
+    }
+
+    /// <summary>
+    /// Sets argument validation to the field, replacing any existing validation function.
+    /// Runs after all arguments have been coerced and validated as appropriate.
+    /// Applies only to output fields.
+    /// </summary>
+    public virtual FieldBuilder<TSourceType, TReturnType> ValidateArguments(Func<Validation.FieldArgumentsValidationContext, ValueTask> validation)
+    {
+        FieldType.ValidateArguments = validation;
+        return this;
+    }
+
     /// <summary>
     /// Sets the resolver for the field.
     /// </summary>

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -3,7 +3,6 @@ using GraphQL.Execution;
 using GraphQL.Resolvers;
 using GraphQL.Utilities;
 using GraphQL.Validation;
-using GraphQLParser.AST;
 
 namespace GraphQL.Types;
 
@@ -105,13 +104,18 @@ public class FieldType : MetadataProvider, IFieldType
     /// <summary>
     /// Validates the value received from the client when the value is not <see langword="null"/>.
     /// Occurs during validation after <see cref="Parser"/> has parsed the value.
-    /// Throw an exception if necessary to indicate a problem.
+    /// Throw an exception if necessary to indicate a problem; any thrown exceptions will be
+    /// reported as a validation error.
     /// Only applicable to fields of input graph types.
     /// </summary>
     public Action<object>? Validator { get; set; }
 
     /// <summary>
     /// Validates the arguments of the field.
+    /// Occurs during validation after field arguments have been parsed.
+    /// Throw an exception if necessary to indicate a problem; any thrown exceptions will be
+    /// reported as a validation error.
+    /// Only applicable to fields of output graph types.
     /// </summary>
     public Func<FieldArgumentsValidationContext, ValueTask>? ValidateArguments { get; set; }
 

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using GraphQL.Execution;
 using GraphQL.Resolvers;
 using GraphQL.Utilities;
+using GraphQL.Validation;
+using GraphQLParser.AST;
 
 namespace GraphQL.Types;
 
@@ -107,6 +109,11 @@ public class FieldType : MetadataProvider, IFieldType
     /// Only applicable to fields of input graph types.
     /// </summary>
     public Action<object>? Validator { get; set; }
+
+    /// <summary>
+    /// Validates the arguments of the field.
+    /// </summary>
+    public Func<FieldArgumentsValidationContext, ValueTask>? ValidateArguments { get; set; }
 
     /// <inheritdoc/>
     public bool IsPrivate { get; set; }

--- a/src/GraphQL/Types/Fields/FieldType.cs
+++ b/src/GraphQL/Types/Fields/FieldType.cs
@@ -113,8 +113,9 @@ public class FieldType : MetadataProvider, IFieldType
     /// <summary>
     /// Validates the arguments of the field.
     /// Occurs during validation after field arguments have been parsed.
-    /// Throw an exception if necessary to indicate a problem; any thrown exceptions will be
-    /// reported as a validation error.
+    /// Throw a <see cref="ValidationError"/> exception if necessary to indicate a
+    /// problem; they will be reported as a validation error. Other exceptions bubble
+    /// up to the <see cref="DocumentExecuter"/> to be handled by the unhandled exception delegate.
     /// Only applicable to fields of output graph types.
     /// </summary>
     public Func<FieldArgumentsValidationContext, ValueTask>? ValidateArguments { get; set; }

--- a/src/GraphQL/Validation/DocumentValidator.cs
+++ b/src/GraphQL/Validation/DocumentValidator.cs
@@ -49,6 +49,7 @@ public partial class DocumentValidator : IDocumentValidator
         VariablesInAllowedPosition.Instance,
         UniqueInputFieldNames.Instance,
         OverlappingFieldsCanBeMerged.Instance,
+        FieldArgumentsAreValidRule.Instance,
     };
 
     /// <inheritdoc/>

--- a/src/GraphQL/Validation/FieldArgumentsValidationContext.cs
+++ b/src/GraphQL/Validation/FieldArgumentsValidationContext.cs
@@ -49,6 +49,9 @@ public struct FieldArgumentsValidationContext
     /// <inheritdoc cref="IResolveFieldContext.Directives"/>
     public IDictionary<string, DirectiveInfo>? Directives => ValidationContext.DirectiveValues?.TryGetValue(FieldAst, out var dirs) == true ? dirs : null;
 
+    /// <inheritdoc cref="IResolveFieldContext.RequestServices"/>
+    public IServiceProvider? RequestServices => ValidationContext.RequestServices;
+
     /// <inheritdoc cref="IResolveFieldContext.CancellationToken"/>
     public CancellationToken CancellationToken => ValidationContext.CancellationToken;
 

--- a/src/GraphQL/Validation/FieldArgumentsValidationContext.cs
+++ b/src/GraphQL/Validation/FieldArgumentsValidationContext.cs
@@ -1,0 +1,73 @@
+using GraphQL.Execution;
+using GraphQL.Types;
+using GraphQLParser.AST;
+
+namespace GraphQL.Validation;
+
+/// <summary>
+/// Represents the context for validating field arguments.
+/// </summary>
+public struct FieldArgumentsValidationContext
+{
+    /// <inheritdoc cref="IResolveFieldContext.FieldAst"/>
+    public GraphQLField FieldAst { get; set; }
+
+    /// <inheritdoc cref="IResolveFieldContext.FieldDefinition"/>
+    public FieldType FieldDefinition { get; set; }
+
+    private IGraphType? _parentType;
+    /// <inheritdoc cref="IResolveFieldContext.ParentType"/>
+    public IGraphType ParentType => _parentType ??= (ValidationContext.TypeInfo.GetLastType() ?? throw new InvalidOperationException("Unable to retrieve the parent type for this field."));
+
+    /// <inheritdoc cref="Validation.ValidationContext"/>
+    public ValidationContext ValidationContext { get; set; }
+
+    private IDictionary<string, ArgumentValue>? _arguments;
+    private bool _argumentsSet;
+    /// <inheritdoc cref="IResolveFieldContext.Arguments"/>
+    public IDictionary<string, ArgumentValue>? Arguments
+    {
+        get
+        {
+            if (_argumentsSet)
+                return _arguments;
+            _argumentsSet = true;
+            return _arguments = ValidationContext.ArgumentValues?.TryGetValue(FieldAst, out var args) == true ? args : null;
+        }
+        set
+        {
+            ValidationContext.ArgumentValues ??= new();
+            if (value != null)
+                ValidationContext.ArgumentValues[FieldAst] = value;
+            else
+                ValidationContext.ArgumentValues.Remove(FieldAst);
+            _arguments = value;
+            _argumentsSet = true;
+        }
+    }
+
+    /// <inheritdoc cref="IResolveFieldContext.Directives"/>
+    public IDictionary<string, DirectiveInfo>? Directives => ValidationContext.DirectiveValues?.TryGetValue(FieldAst, out var dirs) == true ? dirs : null;
+
+    /// <inheritdoc cref="IResolveFieldContext.CancellationToken"/>
+    public CancellationToken CancellationToken => ValidationContext.CancellationToken;
+
+    /// <summary>
+    /// Gets the argument specified by name.
+    /// </summary>
+    public T GetArgument<T>(string name, T defaultValue = default!)
+    {
+        if (Arguments?.TryGetValue(name, out var arg) == true)
+            return (T)arg.Value! ?? defaultValue;
+
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Sets the argument specified by name.
+    /// </summary>
+    public void SetArgument(string name, object? value)
+    {
+        (Arguments ??= new Dictionary<string, ArgumentValue>())[name] = new ArgumentValue(value, ArgumentSource.Literal);
+    }
+}

--- a/src/GraphQL/Validation/FieldArgumentsValidationContext.cs
+++ b/src/GraphQL/Validation/FieldArgumentsValidationContext.cs
@@ -50,10 +50,10 @@ public struct FieldArgumentsValidationContext
     public IDictionary<string, DirectiveInfo>? Directives => ValidationContext.DirectiveValues?.TryGetValue(FieldAst, out var dirs) == true ? dirs : null;
 
     /// <inheritdoc cref="IResolveFieldContext.RequestServices"/>
-    public IServiceProvider? RequestServices => ValidationContext.RequestServices;
+    public readonly IServiceProvider? RequestServices => ValidationContext.RequestServices;
 
     /// <inheritdoc cref="IResolveFieldContext.CancellationToken"/>
-    public CancellationToken CancellationToken => ValidationContext.CancellationToken;
+    public readonly CancellationToken CancellationToken => ValidationContext.CancellationToken;
 
     /// <summary>
     /// Gets the argument specified by name.
@@ -72,5 +72,12 @@ public struct FieldArgumentsValidationContext
     public void SetArgument(string name, object? value)
     {
         (Arguments ??= new Dictionary<string, ArgumentValue>())[name] = new ArgumentValue(value, ArgumentSource.Literal);
+    }
+
+    /// <inheritdoc cref="ValidationContext.ReportError(ValidationError)"/>
+    public readonly void ReportError(ValidationError error)
+    {
+        error.AddNode(ValidationContext.Document.Source, FieldAst);
+        ValidationContext.ReportError(error);
     }
 }

--- a/src/GraphQL/Validation/FieldArgumentsValidationContext.cs
+++ b/src/GraphQL/Validation/FieldArgumentsValidationContext.cs
@@ -17,7 +17,7 @@ public struct FieldArgumentsValidationContext
 
     private IGraphType? _parentType;
     /// <inheritdoc cref="IResolveFieldContext.ParentType"/>
-    public IGraphType ParentType => _parentType ??= (ValidationContext.TypeInfo.GetLastType() ?? throw new InvalidOperationException("Unable to retrieve the parent type for this field."));
+    public IGraphType? ParentType => _parentType ??= ValidationContext.TypeInfo.GetLastType();
 
     /// <inheritdoc cref="Validation.ValidationContext"/>
     public ValidationContext ValidationContext { get; set; }

--- a/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
@@ -1,4 +1,6 @@
+using System.Reflection.Metadata;
 using GraphQL.Types;
+using GraphQLParser;
 using GraphQLParser.AST;
 
 namespace GraphQL.Validation.Rules;
@@ -55,6 +57,12 @@ public sealed class FieldArgumentsAreValidRule : ValidationRuleBase, INodeVisito
             {
                 throw;
             }
+            catch (ValidationError ex)
+            {
+                ex.AddNode(ctx.ValidationContext.Document.Source, ctx.FieldAst);
+                ctx.ValidationContext.ReportError(ex);
+            }
+            // note: ValidationContext can only contain ValidationErrors, not ExecutionErrors
             catch (Exception ex)
             {
                 ctx.ValidationContext.ReportError(new ValidationError(ctx.ValidationContext.Document.Source, null, ex.Message, ex, ctx.FieldAst));

--- a/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
@@ -55,20 +55,18 @@ public sealed class FieldArgumentsAreValidRule : ValidationRuleBase, INodeVisito
             {
                 await func(ctx).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) when (ctx.CancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
             catch (ValidationError ex)
             {
                 ex.AddNode(ctx.ValidationContext.Document.Source, ctx.FieldAst);
                 ctx.ValidationContext.ReportError(ex);
             }
             // note: ValidationContext can only contain ValidationErrors, not ExecutionErrors
-            catch (Exception ex)
+            catch (ExecutionError ex)
             {
-                ctx.ValidationContext.ReportError(new ValidationError(ctx.ValidationContext.Document.Source, null, ex.Message, ex, ctx.FieldAst));
+                ex.AddLocation(ctx.FieldAst, ctx.ValidationContext.Document);
+                throw;
             }
+            // note: do not catch any other exceptions; let them bubble up to the DocumentExecuter to be handled by the unhandled exception delegate
         }
     }
 

--- a/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
@@ -13,6 +13,10 @@ public sealed class FieldArgumentsAreValidRule : ValidationRuleBase, INodeVisito
     /// </summary>
     public const string HAS_FIELD_ARGUMENT_VALIDATION_KEY = "__GraphQL_Has_Field_Argument_Validation__";
 
+    private FieldArgumentsAreValidRule()
+    {
+    }
+
     /// <summary>
     /// Returns a new instance of the rule.
     /// </summary>

--- a/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
@@ -51,6 +51,10 @@ public sealed class FieldArgumentsAreValidRule : ValidationRuleBase, INodeVisito
             {
                 await func(ctx).ConfigureAwait(false);
             }
+            catch (OperationCanceledException) when (ctx.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 ctx.ValidationContext.ReportError(new ValidationError(ctx.ValidationContext.Document.Source, null, ex.Message, ex, ctx.FieldAst));

--- a/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
@@ -1,0 +1,60 @@
+using GraphQL.Types;
+using GraphQLParser.AST;
+
+namespace GraphQL.Validation.Rules;
+
+/// <summary>
+/// Validates that field arguments are valid.
+/// </summary>
+public sealed class FieldArgumentsAreValidRule : ValidationRuleBase, INodeVisitor
+{
+    /// <summary>
+    /// The key for the metadata that indicates if the schema has field argument validation visitors.
+    /// </summary>
+    public const string HAS_FIELD_ARGUMENT_VALIDATION_KEY = "__GraphQL_Has_Field_Argument_Validation__";
+
+    /// <summary>
+    /// Returns a new instance of the rule.
+    /// </summary>
+    public static FieldArgumentsAreValidRule Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public override ValueTask<INodeVisitor?> GetPostNodeVisitorAsync(ValidationContext context)
+        // only execute this validation rule when there's at least one field with argument validation
+        => context.Schema.GetMetadata<bool>(HAS_FIELD_ARGUMENT_VALIDATION_KEY) ? new(this) : default;
+
+    ValueTask INodeVisitor.EnterAsync(ASTNode node, ValidationContext context)
+    {
+        // only execute for fields of non-input graph types
+        if (node is not GraphQLField fieldNode || context.TypeInfo.GetLastType() is IInputObjectGraphType)
+            return default;
+
+        // only execute when the field has a validation method
+        var field = context.TypeInfo.GetFieldDef();
+        if (field?.ValidateArguments == null)
+            return default;
+
+        var ctx = new FieldArgumentsValidationContext
+        {
+            FieldAst = fieldNode,
+            FieldDefinition = field,
+            ValidationContext = context,
+        };
+
+        return Validate(field.ValidateArguments, ctx);
+
+        static async ValueTask Validate(Func<FieldArgumentsValidationContext, ValueTask> func, FieldArgumentsValidationContext ctx)
+        {
+            try
+            {
+                await func(ctx).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                ctx.ValidationContext.ReportError(new ValidationError(ctx.ValidationContext.Document.Source, null, ex.Message, ex, ctx.FieldAst));
+            }
+        }
+    }
+
+    ValueTask INodeVisitor.LeaveAsync(ASTNode node, ValidationContext context) => default;
+}

--- a/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
@@ -1,6 +1,4 @@
-using System.Reflection.Metadata;
 using GraphQL.Types;
-using GraphQLParser;
 using GraphQLParser.AST;
 
 namespace GraphQL.Validation.Rules;

--- a/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/FieldArgumentsAreValidRule.cs
@@ -21,6 +21,8 @@ public sealed class FieldArgumentsAreValidRule : ValidationRuleBase, INodeVisito
     /// <inheritdoc/>
     public override ValueTask<INodeVisitor?> GetPostNodeVisitorAsync(ValidationContext context)
         // only execute this validation rule when there's at least one field with argument validation
+        // since this triggers the TypeInfo visitor to run during this phase, whereas normally there are
+        // no post-node visitors
         => context.Schema.GetMetadata<bool>(HAS_FIELD_ARGUMENT_VALIDATION_KEY) ? new(this) : default;
 
     ValueTask INodeVisitor.EnterAsync(ASTNode node, ValidationContext context)


### PR DESCRIPTION
Closes #4046 

Provides a way to parse/validate multiple field arguments together, similar to how ParseDictionary can be used to parse/validate multiple input object fields into the returning object.