### PR TITLE
Allow private methods in Parser/Validator/ValidateArguments attributes 

### DIFF
--- a/src/GraphQL.Tests/Attributes/ParserAttributeTests.cs
+++ b/src/GraphQL.Tests/Attributes/ParserAttributeTests.cs
@@ -143,6 +143,7 @@ public class ParserAttributeTests
               hello1(value: "abc")
               hello2(value: "def")
               hello3(value: "ghi")
+              hello4(value: "jkl")
             }
             """;
         var expected = """
@@ -150,7 +151,8 @@ public class ParserAttributeTests
               "data": {
                 "hello1": "abctest1",
                 "hello2": "deftest2",
-                "hello3": "ghitest3"
+                "hello3": "ghitest3",
+                "hello4": "jkltest1"
               }
             }
             """;
@@ -168,6 +170,7 @@ public class ParserAttributeTests
         public static string Hello1([Parser(nameof(ParseHelloArgument))] string value) => value;
         public static string Hello2([Parser(typeof(ParserClass))] string value) => value;
         public static string Hello3([Parser(typeof(HelperClass), nameof(HelperClass.ParseHelloArgument))] string value) => value;
+        public static string Hello4([Parser(typeof(ArgTests), nameof(ParseHelloArgument))] string value) => value;
 
         private static object ParseHelloArgument(object value) => (string)value + "test1";
     }
@@ -185,6 +188,9 @@ public class ParserAttributeTests
         queryType.Field<StringGraphType>("hello3")
             .Argument<AutoRegisteringInputObjectGraphType<FieldTests>>("value")
             .Resolve(ctx => ctx.GetArgument<FieldTests>("value").Field3);
+        queryType.Field<StringGraphType>("hello4")
+            .Argument<AutoRegisteringInputObjectGraphType<FieldTests>>("value")
+            .Resolve(ctx => ctx.GetArgument<FieldTests>("value").Field4);
         var schema = new Schema { Query = queryType };
         schema.Initialize();
         var query = """
@@ -192,6 +198,7 @@ public class ParserAttributeTests
               hello1(value: { field1: "abc" })
               hello2(value: { field2: "def" })
               hello3(value: { field3: "ghi" })
+              hello4(value: { field4: "jkl" })
             }
             """;
         var expected = """
@@ -199,7 +206,8 @@ public class ParserAttributeTests
               "data": {
                 "hello1": "abctest1",
                 "hello2": "deftest2",
-                "hello3": "ghitest3"
+                "hello3": "ghitest3",
+                "hello4": "jkltest1"
               }
             }
             """;
@@ -220,6 +228,8 @@ public class ParserAttributeTests
         public string? Field2 { get; set; }
         [Parser(typeof(HelperClass), nameof(HelperClass.ParseHelloArgument))]
         public string? Field3 { get; set; }
+        [Parser(typeof(FieldTests), nameof(ParseHelloArgument))]
+        public string? Field4 { get; set; }
 
         private static object ParseHelloArgument(object value) => (string)value + "test1";
     }

--- a/src/GraphQL.Tests/Attributes/ValidateArgumentsAttributeTests.cs
+++ b/src/GraphQL.Tests/Attributes/ValidateArgumentsAttributeTests.cs
@@ -95,6 +95,7 @@ public class ValidateArgumentsAttributeTests
               hello1(value: "abc")
               hello2(value: "def")
               hello3(value: "ghi")
+              hello4(value: "jkl")
             }
             """;
         var expected = """
@@ -144,6 +145,21 @@ public class ValidateArgumentsAttributeTests
                       "VALIDATION_ERROR"
                     ]
                   }
+                },
+                {
+                  "message": "jklpass1",
+                  "locations": [
+                    {
+                      "line": 5,
+                      "column": 3
+                    }
+                  ],
+                  "extensions": {
+                    "code": "VALIDATION_ERROR",
+                    "codes": [
+                      "VALIDATION_ERROR"
+                    ]
+                  }
                 }
               ]
             }
@@ -165,6 +181,8 @@ public class ValidateArgumentsAttributeTests
         public static string Hello2(string value) => value;
         [ValidateArguments(typeof(HelperClass), nameof(HelperClass.ValidateHelloArgument))]
         public static string Hello3(string value) => value;
+        [ValidateArguments(typeof(ArgTests), nameof(ValidateHelloArgument))]
+        public static string Hello4(string value) => value;
 
         private static ValueTask ValidateHelloArgument(FieldArgumentsValidationContext context) => throw new ValidationError(context.GetArgument<string>("value") + "pass1");
     }

--- a/src/GraphQL.Tests/Attributes/ValidatorAttributeTests.cs
+++ b/src/GraphQL.Tests/Attributes/ValidatorAttributeTests.cs
@@ -143,6 +143,7 @@ public class ValidatorAttributeTests
               hello1(value: "abc")
               hello2(value: "def")
               hello3(value: "ghi")
+              hello4(value: "jkl")
             }
             """;
         var expected = """
@@ -187,6 +188,23 @@ public class ValidatorAttributeTests
                   "locations": [
                     {
                       "line": 4,
+                      "column": 17
+                    }
+                  ],
+                  "extensions": {
+                    "code": "INVALID_VALUE",
+                    "codes": [
+                      "INVALID_VALUE",
+                      "INVALID_OPERATION"
+                    ],
+                    "number": "5.6"
+                  }
+                },
+                {
+                  "message": "Invalid value for argument 'value' of field 'hello4'. jklpass1",
+                  "locations": [
+                    {
+                      "line": 5,
                       "column": 17
                     }
                   ],
@@ -216,6 +234,7 @@ public class ValidatorAttributeTests
         public static string Hello1([Validator(nameof(ValidateHelloArgument))] string value) => value;
         public static string Hello2([Validator(typeof(ValidatorClass))] string value) => value;
         public static string Hello3([Validator(typeof(HelperClass), nameof(HelperClass.ValidateHelloArgument))] string value) => value;
+        public static string Hello4([Validator(typeof(ArgTests), nameof(ValidateHelloArgument))] string value) => value;
 
         private static void ValidateHelloArgument(object value) => throw new InvalidOperationException((string)value + "pass1");
     }
@@ -233,6 +252,9 @@ public class ValidatorAttributeTests
         queryType.Field<StringGraphType>("hello3")
             .Argument<AutoRegisteringInputObjectGraphType<FieldTests>>("value")
             .Resolve(ctx => ctx.GetArgument<FieldTests>("value").Field3);
+        queryType.Field<StringGraphType>("hello4")
+            .Argument<AutoRegisteringInputObjectGraphType<FieldTests>>("value")
+            .Resolve(ctx => ctx.GetArgument<FieldTests>("value").Field3);
         var schema = new Schema { Query = queryType };
         schema.Initialize();
         var query = """
@@ -240,6 +262,7 @@ public class ValidatorAttributeTests
               hello1(value: { field1: "abc" })
               hello2(value: { field2: "def" })
               hello3(value: { field3: "ghi" })
+              hello4(value: { field4: "jkl" })
             }
             """;
         var expected = """
@@ -284,6 +307,23 @@ public class ValidatorAttributeTests
                   "locations": [
                     {
                       "line": 4,
+                      "column": 27
+                    }
+                  ],
+                  "extensions": {
+                    "code": "INVALID_VALUE",
+                    "codes": [
+                      "INVALID_VALUE",
+                      "INVALID_OPERATION"
+                    ],
+                    "number": "5.6"
+                  }
+                },
+                {
+                  "message": "Invalid value for argument 'value' of field 'hello4'. jklpass1",
+                  "locations": [
+                    {
+                      "line": 5,
                       "column": 27
                     }
                   ],
@@ -316,6 +356,8 @@ public class ValidatorAttributeTests
         public string? Field2 { get; set; }
         [Validator(typeof(HelperClass), nameof(HelperClass.ValidateHelloArgument))]
         public string? Field3 { get; set; }
+        [Validator(typeof(FieldTests), nameof(ValidateHelloArgument))]
+        public string? Field4 { get; set; }
 
         private static void ValidateHelloArgument(object value) => throw new InvalidOperationException((string)value + "pass1");
     }

--- a/src/GraphQL/Attributes/ParserAttribute.cs
+++ b/src/GraphQL/Attributes/ParserAttribute.cs
@@ -12,7 +12,6 @@ public sealed class ParserAttribute : GraphQLAttribute
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
     private readonly Type? _parserType;
     private readonly string _parserMethodName;
-    private readonly bool _includePrivate;
 
     /// <summary>
     /// Specifies a custom parser method for a field of an input object in a GraphQL schema using the specified parser method name.
@@ -25,7 +24,6 @@ public sealed class ParserAttribute : GraphQLAttribute
     {
         _parserMethodName = parserMethodName
             ?? throw new ArgumentNullException(nameof(parserMethodName));
-        _includePrivate = true;
     }
 
     /// <summary>
@@ -62,7 +60,7 @@ public sealed class ParserAttribute : GraphQLAttribute
             return;
         var parserType = _parserType ?? memberInfo.DeclaringType!;
         var bindingFlags = BindingFlags.Public | BindingFlags.Static;
-        if (_includePrivate)
+        if (parserType == memberInfo.DeclaringType!)
             bindingFlags |= BindingFlags.NonPublic;
 #pragma warning disable IL2075 // UnrecognizedReflectionPattern
         var method = parserType.GetMethod(_parserMethodName, bindingFlags, null, [typeof(object)], null)
@@ -78,7 +76,7 @@ public sealed class ParserAttribute : GraphQLAttribute
     {
         var parserType = _parserType ?? parameterInfo.Member.DeclaringType!;
         var bindingFlags = BindingFlags.Public | BindingFlags.Static;
-        if (_includePrivate)
+        if (parserType == parameterInfo.Member.DeclaringType)
             bindingFlags |= BindingFlags.NonPublic;
 #pragma warning disable IL2075 // UnrecognizedReflectionPattern
         var method = parserType.GetMethod(_parserMethodName, bindingFlags, null, [typeof(object)], null)

--- a/src/GraphQL/Attributes/ValidateArgumentsAttribute.cs
+++ b/src/GraphQL/Attributes/ValidateArgumentsAttribute.cs
@@ -13,7 +13,6 @@ public sealed class ValidateArgumentsAttribute : GraphQLAttribute
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
     private readonly Type? _validationType;
     private readonly string _validationMethodName;
-    private readonly bool _includePrivate;
 
     /// <summary>
     /// Specifies a custom argument validation method for a field in a GraphQL schema using the specified validation method name.
@@ -25,7 +24,6 @@ public sealed class ValidateArgumentsAttribute : GraphQLAttribute
     {
         _validationMethodName = validationMethodName
             ?? throw new ArgumentNullException(nameof(validationMethodName));
-        _includePrivate = true;
     }
 
     /// <summary>
@@ -62,7 +60,7 @@ public sealed class ValidateArgumentsAttribute : GraphQLAttribute
             return;
         var validationType = _validationType ?? memberInfo.DeclaringType!;
         var bindingFlags = BindingFlags.Public | BindingFlags.Static;
-        if (_includePrivate)
+        if (validationType == memberInfo.DeclaringType!)
             bindingFlags |= BindingFlags.NonPublic;
 #pragma warning disable IL2075 // UnrecognizedReflectionPattern
         var method = validationType.GetMethod(_validationMethodName, bindingFlags, null, [typeof(FieldArgumentsValidationContext)], null)

--- a/src/GraphQL/Attributes/ValidatorAttribute.cs
+++ b/src/GraphQL/Attributes/ValidatorAttribute.cs
@@ -12,7 +12,6 @@ public sealed class ValidatorAttribute : GraphQLAttribute
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
     private readonly Type? _validatorType;
     private readonly string _validatorMethodName;
-    private readonly bool _includePrivate;
 
     /// <summary>
     /// Specifies a custom validator method for a field of an input object in a GraphQL schema using the specified validator method name.
@@ -25,7 +24,6 @@ public sealed class ValidatorAttribute : GraphQLAttribute
     {
         _validatorMethodName = validatorMethodName
             ?? throw new ArgumentNullException(nameof(validatorMethodName));
-        _includePrivate = true;
     }
 
     /// <summary>
@@ -62,7 +60,7 @@ public sealed class ValidatorAttribute : GraphQLAttribute
             return;
         var validatorType = _validatorType ?? memberInfo.DeclaringType!;
         var bindingFlags = BindingFlags.Public | BindingFlags.Static;
-        if (_includePrivate)
+        if (validatorType == memberInfo.DeclaringType!)
             bindingFlags |= BindingFlags.NonPublic;
 #pragma warning disable IL2075 // UnrecognizedReflectionPattern
         var method = validatorType.GetMethod(_validatorMethodName, bindingFlags, null, [typeof(object)], null)
@@ -78,7 +76,7 @@ public sealed class ValidatorAttribute : GraphQLAttribute
     {
         var validatorType = _validatorType ?? parameterInfo.Member.DeclaringType!;
         var bindingFlags = BindingFlags.Public | BindingFlags.Static;
-        if (_includePrivate)
+        if (validatorType == parameterInfo.Member.DeclaringType!)
             bindingFlags |= BindingFlags.NonPublic;
 #pragma warning disable IL2075 // UnrecognizedReflectionPattern
         var method = validatorType.GetMethod(_validatorMethodName, bindingFlags, null, [typeof(object)], null)


### PR DESCRIPTION
Allow Parser, Validator and ValidateArguments attributes to define private method names when the type argument is the same as the type where the attribute is applied.