### PR TITLE
Add DefaultAstValueAttribute to set default values of complex objects in type-first schemas

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1215,7 +1215,7 @@ public class MyInputObject2
     public MyInputObject1 Json { get; set; }
 }
 
-// demonstrates setting a default value for an output field arguments
+// output type
 public class MyOutputObject
 {
     // typical way to set a default value of an output field argument

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1194,6 +1194,38 @@ The `ExecutionContext` property has been added to the `IResolveFieldContext` int
 underlying execution context. This is useful for accessing the parsed arguments and directives from the operation
 via `IExecutionContext.GetArguments` and `GetDirectives`.
 
+### 29. `[DefaultAstValue]` attribute added (v8.1 and newer) to set default values for complex types with type-first schemas
+
+When defining an input object or output field argument in a type-first schema, you may now use the `[DefaultAstValue]`
+attribute to specify a default value for the argument. This is useful when the argument is a complex type that cannot
+be represented as a constant via `[DefaultValue]` or in the method signature.
+
+```csharp
+// typical way to set a default value of an input field, which is not possible for complex types
+public class MyInputObject1
+{
+    [DefaultValue("value")]
+    public required string Field1 { get; set; }
+}
+
+// demonstrates setting a default value for an input field that has a complex type
+public class MyInputObject2
+{
+    [DefaultAstValue("{ field1: \"value\" }")]
+    public MyInputObject1 Json { get; set; }
+}
+
+// demonstrates setting a default value for an output field arguments
+public class MyOutputObject
+{
+    // typical way to set a default value of an output field argument
+    public string Field1(string arg = "abc") => arg;
+
+    // demonstrates setting a default value for an output field argument that has a complex type
+    public string Field2([DefaultAstValue("{ field1: \"sample2\" }")] MyInputObject1 arg) => arg.Field1;
+}
+```
+
 ## Breaking Changes
 
 ### 1. Query type is required

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -91,6 +91,14 @@ namespace GraphQL
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter)]
+    public class DefaultAstValueAttribute : GraphQL.GraphQLAttribute
+    {
+        public DefaultAstValueAttribute(string astValue) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
         public DefaultServiceProvider() { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -91,6 +91,14 @@ namespace GraphQL
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter)]
+    public class DefaultAstValueAttribute : GraphQL.GraphQLAttribute
+    {
+        public DefaultAstValueAttribute(string astValue) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
         public DefaultServiceProvider() { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -90,6 +90,14 @@ namespace GraphQL
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter)]
+    public class DefaultAstValueAttribute : GraphQL.GraphQLAttribute
+    {
+        public DefaultAstValueAttribute(string astValue) { }
+        public override void Modify(GraphQL.Types.QueryArgument queryArgument) { }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
+    }
     public sealed class DefaultServiceProvider : System.IServiceProvider
     {
         public DefaultServiceProvider() { }

--- a/src/GraphQL.Tests/Attributes/DefaultAstValueAttributeTests.cs
+++ b/src/GraphQL.Tests/Attributes/DefaultAstValueAttributeTests.cs
@@ -1,0 +1,111 @@
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Tests.Attributes;
+
+public class DefaultAstValueAttributeTests
+{
+    [Fact]
+    public void TestDefaultArgumentsAndDefaultFields()
+    {
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddAutoSchema<QueryType>());
+        var provider = services.BuildServiceProvider();
+        var schema = provider.GetRequiredService<ISchema>();
+        schema.Initialize();
+        var sdl = schema.Print();
+        sdl.ShouldBe("""
+            type Query {
+              testString(value: String! = "str"): String!
+              testStringArray(value: [String]! = ["str1", "str2", null]): String!
+              testNumber(value: Int! = 123): String!
+              testNumberArray(value: [Int]! = [123, 456, null]): String!
+              testObject(value: TestObject!): String!
+              testObject2(value: TestObject2! = {field1: "str"}): String!
+              testObject2Array(value: [TestObject2!]! = [{field1: "str1"}, {field1: "str2"}]): String!
+            }
+
+            input TestObject {
+              field1: String!
+              testString: String! = "str"
+              testStringArray: [String!]! = ["str1", "str2"]
+              testNumber: Int! = 123
+              testNumberArray: [Int!]! = [123, 456]
+              testObject2: TestObject2! = {field1: "str"}
+              testObject2Array: [TestObject2!]! = [{field1: "str1"}, {field1: "str2"}]
+            }
+
+            input TestObject2 {
+              field1: String!
+            }
+
+            """);
+    }
+
+    public class QueryType
+    {
+        public string TestString([DefaultAstValue("\"str\"")] string value)
+        {
+            return value;
+        }
+
+        public string TestStringArray([DefaultAstValue("[\"str1\", \"str2\", null]")] string?[] value)
+        {
+            return string.Join(", ", value);
+        }
+
+        public string TestNumber([DefaultAstValue("123")] int value)
+        {
+            return value.ToString();
+        }
+
+        public string TestNumberArray([DefaultAstValue("[123, 456, null]")] int?[] value)
+        {
+            return string.Join(", ", value);
+        }
+
+        public string TestObject(TestObject value)
+        {
+            return value.Field1;
+        }
+
+        public string TestObject2([DefaultAstValue("{ field1: \"str\" }")] TestObject2 value)
+        {
+            return value.Field1;
+        }
+
+        public string TestObject2Array([DefaultAstValue("[{ field1: \"str1\" }, { field1: \"str2\" }]")] TestObject2[] value)
+        {
+            return string.Join(", ", value.Select(x => x.Field1));
+        }
+    }
+
+    public class TestObject
+    {
+        public required string Field1 { get; set; }
+
+        [DefaultAstValue("\"str\"")]
+        public required string TestString { get; set; }
+
+        [DefaultAstValue("[\"str1\", \"str2\"]")]
+        public required string[] TestStringArray { get; set; }
+
+        [DefaultAstValue("123")]
+        public required int TestNumber { get; set; }
+
+        [DefaultAstValue("[123, 456]")]
+        public required int[] TestNumberArray { get; set; }
+
+        [DefaultAstValue("{ field1: \"str\" }")]
+        public required TestObject2 TestObject2 { get; set; }
+
+        [DefaultAstValue("[{ field1: \"str1\" }, { field1: \"str2\" }]")]
+        public required TestObject2[] TestObject2Array { get; set; }
+    }
+
+    public class TestObject2
+    {
+        public required string Field1 { get; set; }
+    }
+}

--- a/src/GraphQL/Attributes/DefaultAstValueAttribute.cs
+++ b/src/GraphQL/Attributes/DefaultAstValueAttribute.cs
@@ -1,0 +1,43 @@
+using GraphQL.Types;
+using GraphQL.Utilities;
+using GraphQLParser;
+using GraphQLParser.AST;
+
+namespace GraphQL;
+
+/// <summary>
+/// Specifies the default value for an argument or a field of an input object.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class DefaultAstValueAttribute : GraphQLAttribute
+{
+    private readonly GraphQLValue _value;
+    private static readonly ParserOptions _options = new() { Ignore = IgnoreOptions.All };
+
+    /// <inheritdoc cref="DefaultAstValueAttribute"/>
+    public DefaultAstValueAttribute(string astValue)
+    {
+        _value = Parser.Parse<GraphQLValue>(astValue, _options);
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldType fieldType, bool isInputType)
+    {
+        if (isInputType)
+        {
+            fieldType.DefaultValue = _value;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(QueryArgument queryArgument)
+    {
+        queryArgument.DefaultValue = _value;
+    }
+
+    /// <inheritdoc/>
+    public override void Modify(FieldConfig field)
+    {
+        field.DefaultValue = _value;
+    }
+}

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -505,7 +505,8 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
 
     /// <summary>
     /// Coerces input types' default values when those values are <see cref="GraphQLValue"/> nodes.
-    /// This is applicable when the <see cref="SchemaBuilder"/> is used to build the schema.
+    /// This is applicable when the <see cref="SchemaBuilder"/> is used to build the schema
+    /// or when <see cref="DefaultAstValueAttribute"/> applies a default value.
     /// </summary>
     protected virtual void CoerceInputTypeDefaultValues()
     {


### PR DESCRIPTION
This attribute sets the default value of an input object's field or an output type's field argument to a `GraphQLValue` instance parsed from the provided string.  Already there is functionality within the schema initialization code to create an instance of the correct object type from the `GraphQLValue` instance and apply it during schema initialization.