### PR TITLE
Add .git-blame-ignore-revs to improve git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# .git-blame-ignore-revs
+
+# Change solution to use file-scoped namespaces (#3864)
+12d4361b49e7ee77549176573dbd599c1572a08f


### PR DESCRIPTION
The `.git-blame-ignore-revs` file is used in Git to specify a list of commits that should be ignored when running the `git blame` command. 

