### PR TITLE
Update .git-blame-ignore-revs to exclude #1776

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,6 @@
 
 # Change solution to use file-scoped namespaces (#3864)
 12d4361b49e7ee77549176573dbd599c1572a08f
+
+# Clean and sort usings (#1776) 
+1047a9d80ee4a82f570898db148f139437751cf2


### PR DESCRIPTION
As I am looking at the history changes, I also noticed this hash that should also be ignore.