### PR TITLE
Add initialization migration note

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1630,7 +1630,7 @@ public class MyGraphType : ObjectGraphType
     public override void Initialize(ISchema schema)
     {
         AddField(new FieldType {
-            Name = "field",
+            Name = "field", // name converter is not applied here, so the name must be exactly as desired
             ResolvedType = new StringGraphType()
         });
     }

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1602,6 +1602,41 @@ for reference.
 
 If you directly implement `IResolveFieldContext`, you must now also implement the `ExecutionContext` property.
 
+### 30. `GraphType.Initialize` method is now called after initialization is complete
+
+The `Initialize` method on each `GraphType` is now called after the schema has been fully initialized. As such,
+you cannot add fields to the graph type expecting `SchemaTypes` to resolve types and apply name converters.
+If it is necessary for your graph type to add fields dynamically, you should do so in the constructor or else
+set the `ResolvedType` property for the new fields. Failing to do so will result in a schema validation exception.
+
+Please note that the constructor is the preferred place to add fields to a graph type.
+
+```csharp
+// v7
+public class MyGraphType : ObjectGraphType
+{
+    public override void Initialize(ISchema schema)
+    {
+        AddField(new FieldType {
+            Name = "Field",
+            Type = typeof(StringGraphType)
+        });
+    }
+}
+
+// v8
+public class MyGraphType : ObjectGraphType
+{
+    public override void Initialize(ISchema schema)
+    {
+        AddField(new FieldType {
+            Name = "field",
+            ResolvedType = new StringGraphType()
+        });
+    }
+}
+```
+
 ## Appendix
 
 ### Schema verification test example


### PR DESCRIPTION
Changed in https://github.com/graphql-dotnet/graphql-dotnet/pull/3761 ; I can't remember why.

We can consider reverting behavior, or altering behavior so that `SchemaTypes` inspects all types a second time to ensure that `ResolvedType` is set properly, or some such thing.  It's not a bad thing to have `Initialize` occur prior to initialization, but for certain scenarios, such as perhaps the `_Entity` type of GraphQL Federation, one would want the schema fully initialized prior to `Initialize` being called.  Just depends on the use case.