### PR TITLE
Add parser options in IDocumentBuilder

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1394,10 +1394,15 @@ namespace GraphQL.Execution
         public bool IgnoreLocations { get; set; }
         public int? MaxDepth { get; set; }
         public GraphQLParser.AST.GraphQLDocument Build(string body) { }
+        public GraphQLParser.AST.GraphQLDocument Build(string body, GraphQLParser.ParserOptions options) { }
     }
     public interface IDocumentBuilder
     {
+        bool IgnoreComments { get; set; }
+        bool IgnoreLocations { get; set; }
+        int? MaxDepth { get; set; }
         GraphQLParser.AST.GraphQLDocument Build(string body);
+        GraphQLParser.AST.GraphQLDocument Build(string body, GraphQLParser.ParserOptions options);
     }
     public interface IDocumentExecutionListener
     {

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1394,10 +1394,15 @@ namespace GraphQL.Execution
         public bool IgnoreLocations { get; set; }
         public int? MaxDepth { get; set; }
         public GraphQLParser.AST.GraphQLDocument Build(string body) { }
+        public GraphQLParser.AST.GraphQLDocument Build(string body, GraphQLParser.ParserOptions options) { }
     }
     public interface IDocumentBuilder
     {
+        bool IgnoreComments { get; set; }
+        bool IgnoreLocations { get; set; }
+        int? MaxDepth { get; set; }
         GraphQLParser.AST.GraphQLDocument Build(string body);
+        GraphQLParser.AST.GraphQLDocument Build(string body, GraphQLParser.ParserOptions options);
     }
     public interface IDocumentExecutionListener
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1359,10 +1359,15 @@ namespace GraphQL.Execution
         public bool IgnoreLocations { get; set; }
         public int? MaxDepth { get; set; }
         public GraphQLParser.AST.GraphQLDocument Build(string body) { }
+        public GraphQLParser.AST.GraphQLDocument Build(string body, GraphQLParser.ParserOptions options) { }
     }
     public interface IDocumentBuilder
     {
+        bool IgnoreComments { get; set; }
+        bool IgnoreLocations { get; set; }
+        int? MaxDepth { get; set; }
         GraphQLParser.AST.GraphQLDocument Build(string body);
+        GraphQLParser.AST.GraphQLDocument Build(string body, GraphQLParser.ParserOptions options);
     }
     public interface IDocumentExecutionListener
     {

--- a/src/GraphQL.Tests/Language/CommentTests.cs
+++ b/src/GraphQL.Tests/Language/CommentTests.cs
@@ -39,6 +39,23 @@ public class CommentTests
     }
 
     [Fact]
+    public void operation_comment_should_not_be_null_using_options()
+    {
+        const string query = """
+            #comment
+            query _ {
+                person {
+                    name
+                }
+            }
+            """;
+
+        GraphQLDocumentBuilder builder = new();
+        var document = builder.Build(query, new GraphQLParser.ParserOptions { Ignore = GraphQLParser.IgnoreOptions.None });
+        document.Operation().Comments![0].Value.ShouldBe("comment");
+    }
+
+    [Fact]
     public void field_comment_should_be_null()
     {
         const string query = """

--- a/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
+++ b/src/GraphQL/Execution/GraphQLDocumentBuilder.cs
@@ -11,25 +11,13 @@ namespace GraphQL.Execution;
 /// </summary>
 public class GraphQLDocumentBuilder : IDocumentBuilder
 {
-    /// <summary>
-    /// Specifies whether to ignore comments when parsing GraphQL document.
-    /// By default, all comments are ignored.
-    /// </summary>
+    /// <inheritdoc/>
     public bool IgnoreComments { get; set; } = true;
 
-    /// <summary>
-    /// Specifies whether to ignore token locations when parsing GraphQL document.
-    /// By default, all token locations are taken into account.
-    /// </summary>
+    /// <inheritdoc/>
     public bool IgnoreLocations { get; set; }
 
-    /// <summary>
-    /// Maximum allowed recursion depth during parsing.
-    /// Depth is calculated in terms of AST nodes.
-    /// <br/>
-    /// Defaults to 128 if not set.
-    /// Minimum value is 1.
-    /// </summary>
+    /// <inheritdoc/>
     public int? MaxDepth { get; set; }
 
     /// <inheritdoc/>
@@ -38,6 +26,19 @@ public class GraphQLDocumentBuilder : IDocumentBuilder
         try
         {
             return Parser.Parse(body, new ParserOptions { Ignore = CreateIgnoreOptions(), MaxDepth = MaxDepth });
+        }
+        catch (GraphQLSyntaxErrorException ex)
+        {
+            throw new SyntaxError(ex);
+        }
+    }
+
+    /// <inheritdoc/>
+    public GraphQLDocument Build(string body, ParserOptions options)
+    {
+        try
+        {
+            return Parser.Parse(body, options);
         }
         catch (GraphQLSyntaxErrorException ex)
         {

--- a/src/GraphQL/Execution/IDocumentBuilder.cs
+++ b/src/GraphQL/Execution/IDocumentBuilder.cs
@@ -1,3 +1,4 @@
+using GraphQLParser;
 using GraphQLParser.AST;
 
 namespace GraphQL.Execution;
@@ -8,7 +9,33 @@ namespace GraphQL.Execution;
 public interface IDocumentBuilder
 {
     /// <summary>
+    /// Specifies whether to ignore comments when parsing GraphQL document.
+    /// By default, all comments are ignored.
+    /// </summary>
+    public bool IgnoreComments { get; set; }
+
+    /// <summary>
+    /// Specifies whether to ignore token locations when parsing GraphQL document.
+    /// By default, all token locations are taken into account.
+    /// </summary>
+    public bool IgnoreLocations { get; set; }
+
+    /// <summary>
+    /// Maximum allowed recursion depth during parsing.
+    /// Depth is calculated in terms of AST nodes.
+    /// <br/>
+    /// Defaults to 128 if not set.
+    /// Minimum value is 1.
+    /// </summary>
+    public int? MaxDepth { get; set; }
+
+    /// <summary>
     /// Parse a GraphQL request and return a <see cref="GraphQLDocument">Document</see> representing the GraphQL request AST
     /// </summary>
     GraphQLDocument Build(string body);
+
+    /// <summary>
+    /// Parse a GraphQL request using the specified parser options and return a <see cref="GraphQLDocument">Document</see> representing the GraphQL request AST
+    /// </summary>
+    GraphQLDocument Build(string body, ParserOptions options);
 }


### PR DESCRIPTION
When using DI, it might be useful to be able to set the options using the interface directly without having to cast it to GraphQLDocumentBuilder.

Also in some scenarii, it might be convenient to be able to pass the parser options to the Build method.