### PR TITLE
Incorrect ResolvedType property initialization

### DIFF
--- a/src/GraphQL/Types/Composite/NonNullGraphType.cs
+++ b/src/GraphQL/Types/Composite/NonNullGraphType.cs
@@ -57,7 +57,7 @@ public sealed class NonNullGraphType<[DynamicallyAccessedMembers(DynamicallyAcce
     /// Initializes a new instance for the specified inner graph type.
     /// </summary>
     public NonNullGraphType()
-        : base(null)
+        : base(typeof(T) as IGraphType)
     {
         if (typeof(NonNullGraphType).IsAssignableFrom(typeof(T)))
         {


### PR DESCRIPTION
If you use: new NonNullGraphType<< StringGraphType >>, the ResolvedType property is set to null.
It will cause the HasFullSpecifiedResolvedType method to return false.

But if you use new NonNullGraphType(new StringGraphType()), the method returns true.