### PR TITLE
Mark NonNullGraphType<T> and ListGraphType<T> constructors as obsolete

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2871,8 +2871,8 @@ namespace GraphQL.Types
     public sealed class ListGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T> : GraphQL.Types.ListGraphType
         where T : GraphQL.Types.IGraphType
     {
-        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType? type) in" +
-            "stead.")]
+        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType type) ins" +
+            "tead.")]
         public ListGraphType() { }
         public override System.Type Type { get; }
     }
@@ -2894,8 +2894,8 @@ namespace GraphQL.Types
     public sealed class NonNullGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T> : GraphQL.Types.NonNullGraphType
         where T : GraphQL.Types.IGraphType
     {
-        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType? type)" +
-            " instead.")]
+        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType type) " +
+            "instead.")]
         public NonNullGraphType() { }
         public override System.Type Type { get; }
     }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2863,7 +2863,7 @@ namespace GraphQL.Types
     }
     public class ListGraphType : GraphQL.Types.GraphType, GraphQL.Types.IProvideResolvedType
     {
-        public ListGraphType(GraphQL.Types.IGraphType? type) { }
+        public ListGraphType(GraphQL.Types.IGraphType type) { }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
         public virtual System.Type? Type { get; }
         public override string ToString() { }
@@ -2871,6 +2871,8 @@ namespace GraphQL.Types
     public sealed class ListGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T> : GraphQL.Types.ListGraphType
         where T : GraphQL.Types.IGraphType
     {
+        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType? type) in" +
+            "stead.")]
         public ListGraphType() { }
         public override System.Type Type { get; }
     }
@@ -2884,7 +2886,7 @@ namespace GraphQL.Types
     }
     public class NonNullGraphType : GraphQL.Types.GraphType, GraphQL.Types.IProvideResolvedType
     {
-        public NonNullGraphType(GraphQL.Types.IGraphType? type) { }
+        public NonNullGraphType(GraphQL.Types.IGraphType type) { }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
         public virtual System.Type? Type { get; }
         public override string ToString() { }
@@ -2892,6 +2894,8 @@ namespace GraphQL.Types
     public sealed class NonNullGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T> : GraphQL.Types.NonNullGraphType
         where T : GraphQL.Types.IGraphType
     {
+        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType? type)" +
+            " instead.")]
         public NonNullGraphType() { }
         public override System.Type Type { get; }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2878,8 +2878,8 @@ namespace GraphQL.Types
     public sealed class ListGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T> : GraphQL.Types.ListGraphType
         where T : GraphQL.Types.IGraphType
     {
-        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType? type) in" +
-            "stead.")]
+        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType type) ins" +
+            "tead.")]
         public ListGraphType() { }
         public override System.Type Type { get; }
     }
@@ -2901,8 +2901,8 @@ namespace GraphQL.Types
     public sealed class NonNullGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T> : GraphQL.Types.NonNullGraphType
         where T : GraphQL.Types.IGraphType
     {
-        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType? type)" +
-            " instead.")]
+        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType type) " +
+            "instead.")]
         public NonNullGraphType() { }
         public override System.Type Type { get; }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2870,7 +2870,7 @@ namespace GraphQL.Types
     }
     public class ListGraphType : GraphQL.Types.GraphType, GraphQL.Types.IProvideResolvedType
     {
-        public ListGraphType(GraphQL.Types.IGraphType? type) { }
+        public ListGraphType(GraphQL.Types.IGraphType type) { }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
         public virtual System.Type? Type { get; }
         public override string ToString() { }
@@ -2878,6 +2878,8 @@ namespace GraphQL.Types
     public sealed class ListGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T> : GraphQL.Types.ListGraphType
         where T : GraphQL.Types.IGraphType
     {
+        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType? type) in" +
+            "stead.")]
         public ListGraphType() { }
         public override System.Type Type { get; }
     }
@@ -2891,7 +2893,7 @@ namespace GraphQL.Types
     }
     public class NonNullGraphType : GraphQL.Types.GraphType, GraphQL.Types.IProvideResolvedType
     {
-        public NonNullGraphType(GraphQL.Types.IGraphType? type) { }
+        public NonNullGraphType(GraphQL.Types.IGraphType type) { }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
         public virtual System.Type? Type { get; }
         public override string ToString() { }
@@ -2899,6 +2901,8 @@ namespace GraphQL.Types
     public sealed class NonNullGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  T> : GraphQL.Types.NonNullGraphType
         where T : GraphQL.Types.IGraphType
     {
+        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType? type)" +
+            " instead.")]
         public NonNullGraphType() { }
         public override System.Type Type { get; }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2791,8 +2791,8 @@ namespace GraphQL.Types
     public sealed class ListGraphType<T> : GraphQL.Types.ListGraphType
         where T : GraphQL.Types.IGraphType
     {
-        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType? type) in" +
-            "stead.")]
+        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType type) ins" +
+            "tead.")]
         public ListGraphType() { }
         public override System.Type Type { get; }
     }
@@ -2814,8 +2814,8 @@ namespace GraphQL.Types
     public sealed class NonNullGraphType<T> : GraphQL.Types.NonNullGraphType
         where T : GraphQL.Types.IGraphType
     {
-        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType? type)" +
-            " instead.")]
+        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType type) " +
+            "instead.")]
         public NonNullGraphType() { }
         public override System.Type Type { get; }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2783,7 +2783,7 @@ namespace GraphQL.Types
     }
     public class ListGraphType : GraphQL.Types.GraphType, GraphQL.Types.IProvideResolvedType
     {
-        public ListGraphType(GraphQL.Types.IGraphType? type) { }
+        public ListGraphType(GraphQL.Types.IGraphType type) { }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
         public virtual System.Type? Type { get; }
         public override string ToString() { }
@@ -2791,6 +2791,8 @@ namespace GraphQL.Types
     public sealed class ListGraphType<T> : GraphQL.Types.ListGraphType
         where T : GraphQL.Types.IGraphType
     {
+        [System.Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType? type) in" +
+            "stead.")]
         public ListGraphType() { }
         public override System.Type Type { get; }
     }
@@ -2804,7 +2806,7 @@ namespace GraphQL.Types
     }
     public class NonNullGraphType : GraphQL.Types.GraphType, GraphQL.Types.IProvideResolvedType
     {
-        public NonNullGraphType(GraphQL.Types.IGraphType? type) { }
+        public NonNullGraphType(GraphQL.Types.IGraphType type) { }
         public GraphQL.Types.IGraphType? ResolvedType { get; set; }
         public virtual System.Type? Type { get; }
         public override string ToString() { }
@@ -2812,6 +2814,8 @@ namespace GraphQL.Types
     public sealed class NonNullGraphType<T> : GraphQL.Types.NonNullGraphType
         where T : GraphQL.Types.IGraphType
     {
+        [System.Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType? type)" +
+            " instead.")]
         public NonNullGraphType() { }
         public override System.Type Type { get; }
     }

--- a/src/GraphQL/Types/Composite/ListGraphType.cs
+++ b/src/GraphQL/Types/Composite/ListGraphType.cs
@@ -9,7 +9,7 @@ public class ListGraphType : GraphType, IProvideResolvedType
     /// <summary>
     /// Initializes a new instance for the specified inner graph type.
     /// </summary>
-    public ListGraphType(IGraphType? type)
+    public ListGraphType(IGraphType type)
     {
         ResolvedType = type;
     }
@@ -50,8 +50,9 @@ public sealed class ListGraphType<[DynamicallyAccessedMembers(DynamicallyAccesse
     /// <summary>
     /// Initializes a new instance for the specified inner graph type.
     /// </summary>
+    [Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType? type) instead.")]
     public ListGraphType()
-        : base(null)
+        : base(null!)
     {
     }
 

--- a/src/GraphQL/Types/Composite/ListGraphType.cs
+++ b/src/GraphQL/Types/Composite/ListGraphType.cs
@@ -50,7 +50,7 @@ public sealed class ListGraphType<[DynamicallyAccessedMembers(DynamicallyAccesse
     /// <summary>
     /// Initializes a new instance for the specified inner graph type.
     /// </summary>
-    [Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType? type) instead.")]
+    [Obsolete("This constructor is for internal use only; use ListGraphType(IGraphType type) instead.")]
     public ListGraphType()
         : base(null!)
     {

--- a/src/GraphQL/Types/Composite/NonNullGraphType.cs
+++ b/src/GraphQL/Types/Composite/NonNullGraphType.cs
@@ -9,7 +9,7 @@ public class NonNullGraphType : GraphType, IProvideResolvedType
     /// <summary>
     /// Initializes a new instance for the specified inner graph type.
     /// </summary>
-    public NonNullGraphType(IGraphType? type)
+    public NonNullGraphType(IGraphType type)
     {
         ResolvedType = type;
     }
@@ -56,8 +56,9 @@ public sealed class NonNullGraphType<[DynamicallyAccessedMembers(DynamicallyAcce
     /// <summary>
     /// Initializes a new instance for the specified inner graph type.
     /// </summary>
+    [Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType? type) instead.")]
     public NonNullGraphType()
-        : base(null)
+        : base(null!)
     {
         if (typeof(NonNullGraphType).IsAssignableFrom(typeof(T)))
         {

--- a/src/GraphQL/Types/Composite/NonNullGraphType.cs
+++ b/src/GraphQL/Types/Composite/NonNullGraphType.cs
@@ -56,7 +56,7 @@ public sealed class NonNullGraphType<[DynamicallyAccessedMembers(DynamicallyAcce
     /// <summary>
     /// Initializes a new instance for the specified inner graph type.
     /// </summary>
-    [Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType? type) instead.")]
+    [Obsolete("This constructor is for internal use only; use NonNullGraphType(IGraphType type) instead.")]
     public NonNullGraphType()
         : base(null!)
     {


### PR DESCRIPTION
See:
- #4080 