### PR TITLE
Fix argument parsing for merged selection sets

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug4083.cs
+++ b/src/GraphQL.Tests/Bugs/Bug4083.cs
@@ -1,0 +1,62 @@
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Tests.Bugs;
+
+public class Bug4083
+{
+    [Fact]
+    public async Task FragmentsCombineCorrectlyWithVariables()
+    {
+        var services = new ServiceCollection();
+        services.AddGraphQL(b => b
+            .AddAutoSchema<Query>()
+        );
+        var provider = services.BuildServiceProvider();
+        var schema = provider.GetRequiredService<ISchema>();
+        schema.Initialize();
+        var ret = await schema.ExecuteAsync(o =>
+        {
+            o.Query = """
+                query heroQuery($id: Int!) {
+                    ...fragment1
+                    ...fragment2
+                }
+
+                fragment fragment1 on Query {
+                  hero(id: $id) {
+                    id
+                  }
+                }
+
+                fragment fragment2 on Query {
+                  hero(id: $id) {
+                    name
+                  }
+                }
+                """;
+            o.Variables = """{"id":1}""".ToInputs();
+        });
+        ret.ShouldBeCrossPlatJson("""
+            {
+                "data": {
+                    "hero": {
+                        "id": 1,
+                        "name": "John Doe"
+                    }
+                }
+            }
+            """);
+    }
+
+    public class Query
+    {
+        public static Class1 Hero(int id) => new Class1 { Id = id, Name = "John Doe" };
+    }
+
+    public class Class1
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/GraphQL.Tests/Bugs/Issue4060.cs
+++ b/src/GraphQL.Tests/Bugs/Issue4060.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using GraphQL.Execution;
 using GraphQL.SystemTextJson;
@@ -58,6 +59,60 @@ public class Issue4060
             """);
     }
 
+    [Fact]
+    public async Task SampleCodeWorksWhenMergingSelectionSets()
+    {
+        var heroType = new ObjectGraphType() { Name = "Hero" };
+        heroType.Field<IntGraphType>("id");
+        heroType.Field<StringGraphType>("name");
+        var query = new ObjectGraphType() { Name = "Query" };
+        query.Field("hero", heroType)
+            .Argument<IntGraphType>("id")
+            .Resolve(context => new { id = context.GetArgument<int>("id"), name = "John Doe" });
+        var schema = new Schema { Query = query };
+        schema.Initialize();
+        var options = new ExecutionOptions
+        {
+            Schema = schema,
+            Query = """
+                query heroQuery($id: Int!) {
+                    ...fragment1
+                    ...fragment2
+                }
+                fragment fragment1 on Query {
+                    hero(id: $id) {
+                        id
+                    }
+                }
+                fragment fragment2 on Query {
+                    hero(id: $id) {
+                        name
+                    }
+                }
+                """,
+            Variables = new Inputs(new Dictionary<string, object?>
+                {
+                    { "id", 123 }
+                }),
+            ValidationRules = DocumentValidator.CoreRules.Append(new FieldMappingValidationRule()),
+        };
+        options.Listeners.Add(new DynamicVariableExecutionListener());
+
+        var result = await new DocumentExecuter().ExecuteAsync(options);
+        var resultJson = new GraphQLSerializer().Serialize(result);
+
+        resultJson.ShouldBeCrossPlatJson("""
+            {
+                "data": {
+                    "hero": {
+                        "id": 123,
+                        "name": "John Doe"
+                    }
+                }
+            }
+            """);
+    }
+
     public class FieldMappingValidationRule : ValidationRuleBase
     {
         public override ValueTask<INodeVisitor?> GetPostNodeVisitorAsync(ValidationContext context) => new(new MyVisitor());
@@ -97,13 +152,14 @@ public class Issue4060
             return Task.CompletedTask;
         }
 
-        private class FieldArgumentDictionary : IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>
+        private class FieldArgumentDictionary : IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>, IDictionary<GraphQLField, IDictionary<string, ArgumentValue>>
         {
             private readonly IExecutionContext _executionContext;
             private readonly IDictionary<GraphQLField, FieldType> _fieldMappings;
             private GraphQLField? _lastField;
             private IDictionary<string, ArgumentValue>? _lastArgs;
             private readonly object _lastFieldLock = new();
+            private ConcurrentDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? _overrideDictionary;
 
             public FieldArgumentDictionary(IExecutionContext executionContext, IDictionary<GraphQLField, FieldType> fieldMappings)
             {
@@ -119,11 +175,18 @@ public class Issue4060
                         return value;
                     throw new ArgumentOutOfRangeException(nameof(key));
                 }
+                set => (_overrideDictionary ??= new())[key] = value;
             }
 
             public IEnumerable<GraphQLField> Keys => throw new NotImplementedException();
             public IEnumerable<IDictionary<string, ArgumentValue>> Values => throw new NotImplementedException();
             public int Count => throw new NotImplementedException();
+
+            ICollection<GraphQLField> IDictionary<GraphQLField, IDictionary<string, ArgumentValue>>.Keys => throw new NotImplementedException();
+
+            ICollection<IDictionary<string, ArgumentValue>> IDictionary<GraphQLField, IDictionary<string, ArgumentValue>>.Values => throw new NotImplementedException();
+
+            bool ICollection<KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>>>.IsReadOnly => throw new NotImplementedException();
 
             public bool ContainsKey(GraphQLField key) => _fieldMappings.ContainsKey(key);
 
@@ -131,6 +194,9 @@ public class Issue4060
 
             public bool TryGetValue(GraphQLField key, out IDictionary<string, ArgumentValue> value)
             {
+                if (_overrideDictionary?.TryGetValue(key, out value!) == true)
+                    return true;
+
                 lock (_lastFieldLock)
                 {
                     if (key == _lastField)
@@ -163,6 +229,13 @@ public class Issue4060
             }
 
             IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+            void IDictionary<GraphQLField, IDictionary<string, ArgumentValue>>.Add(GraphQLField key, IDictionary<string, ArgumentValue> value) => throw new NotImplementedException();
+            bool IDictionary<GraphQLField, IDictionary<string, ArgumentValue>>.Remove(GraphQLField key) => throw new NotImplementedException();
+            void ICollection<KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>>>.Add(KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>> item) => throw new NotImplementedException();
+            void ICollection<KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>>>.Clear() => throw new NotImplementedException();
+            bool ICollection<KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>>>.Contains(KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>> item) => throw new NotImplementedException();
+            void ICollection<KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>>>.CopyTo(KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>>[] array, int arrayIndex) => throw new NotImplementedException();
+            bool ICollection<KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>>>.Remove(KeyValuePair<GraphQLField, IDictionary<string, ArgumentValue>> item) => throw new NotImplementedException();
         }
     }
 }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -313,6 +313,7 @@ public class DocumentExecuter : IDocumentExecuter
 
         if (context.ExecutionStrategy is not SerialExecutionStrategy)
         {
+            // TODO: remove for v9 after ValidationContext has been changed to use concurrent dictionaries
             context.ArgumentValues = context.ArgumentValues == null ? null : new ConcurrentDictionary<GraphQLField, IDictionary<string, ArgumentValue>>(context.ArgumentValues);
             context.DirectiveValues = context.DirectiveValues == null ? null : new ConcurrentDictionary<ASTNode, IDictionary<string, DirectiveInfo>>(context.DirectiveValues);
         }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -293,8 +293,8 @@ public class DocumentExecuter : IDocumentExecuter
 
             Operation = operation,
             Variables = validationResult.Variables ?? Variables.None,
-            ArgumentValues = validationResult.ArgumentValues == null ? null : new ConcurrentDictionary<GraphQLField, IDictionary<string, ArgumentValue>>(validationResult.ArgumentValues),
-            DirectiveValues = validationResult.DirectiveValues == null ? null : new ConcurrentDictionary<ASTNode, IDictionary<string, DirectiveInfo>>(validationResult.DirectiveValues),
+            ArgumentValues = validationResult.ArgumentValues,
+            DirectiveValues = validationResult.DirectiveValues,
             Errors = new ExecutionErrors(),
             InputExtensions = options.Extensions ?? Inputs.Empty,
             OutputExtensions = new Dictionary<string, object?>(),
@@ -310,6 +310,12 @@ public class DocumentExecuter : IDocumentExecuter
         };
 
         context.ExecutionStrategy = SelectExecutionStrategy(context);
+
+        if (context.ExecutionStrategy is not SerialExecutionStrategy)
+        {
+            context.ArgumentValues = context.ArgumentValues == null ? null : new ConcurrentDictionary<GraphQLField, IDictionary<string, ArgumentValue>>(context.ArgumentValues);
+            context.DirectiveValues = context.DirectiveValues == null ? null : new ConcurrentDictionary<ASTNode, IDictionary<string, DirectiveInfo>>(context.DirectiveValues);
+        }
 
         return context;
     }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -313,7 +313,7 @@ public class DocumentExecuter : IDocumentExecuter
 
         if (context.ExecutionStrategy is not SerialExecutionStrategy)
         {
-            // TODO: remove for v9 after ValidationContext has been changed to use concurrent dictionaries
+            // TODO: remove for v9 after ValidationContext has been changed to use concurrent dictionaries -- see issue #4085
             context.ArgumentValues = context.ArgumentValues == null ? null : new ConcurrentDictionary<GraphQLField, IDictionary<string, ArgumentValue>>(context.ArgumentValues);
             context.DirectiveValues = context.DirectiveValues == null ? null : new ConcurrentDictionary<ASTNode, IDictionary<string, DirectiveInfo>>(context.DirectiveValues);
         }

--- a/src/GraphQL/Execution/DocumentExecuter.cs
+++ b/src/GraphQL/Execution/DocumentExecuter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using GraphQL.DI;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
@@ -292,8 +293,8 @@ public class DocumentExecuter : IDocumentExecuter
 
             Operation = operation,
             Variables = validationResult.Variables ?? Variables.None,
-            ArgumentValues = validationResult.ArgumentValues,
-            DirectiveValues = validationResult.DirectiveValues,
+            ArgumentValues = validationResult.ArgumentValues == null ? null : new ConcurrentDictionary<GraphQLField, IDictionary<string, ArgumentValue>>(validationResult.ArgumentValues),
+            DirectiveValues = validationResult.DirectiveValues == null ? null : new ConcurrentDictionary<ASTNode, IDictionary<string, DirectiveInfo>>(validationResult.DirectiveValues),
             Errors = new ExecutionErrors(),
             InputExtensions = options.Extensions ?? Inputs.Empty,
             OutputExtensions = new Dictionary<string, object?>(),

--- a/src/GraphQL/Execution/ExecutionContext.cs
+++ b/src/GraphQL/Execution/ExecutionContext.cs
@@ -69,10 +69,10 @@ public class ExecutionContext : IExecutionContext, IExecutionArrayPool, IDisposa
     public Variables Variables { get; set; }
 
     /// <inheritdoc/>
-    public IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; }
+    public IReadOnlyDictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; } // TODO: change to IDictionary for v9 - see #4085
 
     /// <inheritdoc/>
-    public IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; }
+    public IReadOnlyDictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; } // TODO: change to IDictionary for v9 - see #4085
 
     /// <inheritdoc/>
     public ExecutionErrors Errors { get; set; }

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -336,11 +336,13 @@ public abstract class ExecutionStrategy : IExecutionStrategy
                 var argumentValues = context.ArgumentValues;
                 if (argumentValues != null && argumentValues.TryGetValue(original.Field, out var arguments))
                 {
+                    // TODO: remove cast for v9 - see #4085
                     ((IDictionary<GraphQLField, IDictionary<string, ArgumentValue>>)argumentValues)[newField] = arguments;
                 }
                 var directiveValues = context.DirectiveValues;
                 if (directiveValues != null && directiveValues.TryGetValue(original.Field, out var directives))
                 {
+                    // TODO: remove cast for v9 - see #4085
                     ((IDictionary<ASTNode, IDictionary<string, DirectiveInfo>>)directiveValues)[newField] = directives;
                 }
                 fields[name] = (newField, original.FieldType);

--- a/src/GraphQL/Execution/ExecutionStrategy.cs
+++ b/src/GraphQL/Execution/ExecutionStrategy.cs
@@ -293,7 +293,7 @@ public abstract class ExecutionStrategy : IExecutionStrategy
                             var fieldType = GetFieldDefinition(context.Schema, (specificType as IComplexGraphType)!, field)
                                 ?? throw new InvalidOperationException($"Schema is not configured correctly to fetch field '{field.Name}' from type '{specificType.Name}'.");
 
-                            Add(fields, field, fieldType);
+                            Add(context, fields, field, fieldType);
                         }
                     }
                     else if (selection is GraphQLFragmentSpread spread)
@@ -319,20 +319,36 @@ public abstract class ExecutionStrategy : IExecutionStrategy
             }
         }
 
-        static void Add(Dictionary<string, (GraphQLField Field, FieldType FieldType)> fields, GraphQLField field, FieldType fieldType)
+        static void Add(ExecutionContext context, Dictionary<string, (GraphQLField Field, FieldType FieldType)> fields, GraphQLField field, FieldType fieldType)
         {
             string name = field.Alias != null ? field.Alias.Name.StringValue : fieldType.Name; //ISSUE:allocation in case of alias
 
-            fields[name] = fields.TryGetValue(name, out var original)
-                ? (new GraphQLField(original.Field.Name) // Sets a new field selection node with the child field selection nodes merged with another field's child field selection nodes.
+            if (fields.TryGetValue(name, out var original))
+            {
+                var newField = new GraphQLField(original.Field.Name) // Sets a new field selection node with the child field selection nodes merged with another field's child field selection nodes.
                 {
                     Alias = original.Field.Alias,
                     Arguments = original.Field.Arguments,
                     SelectionSet = Merge(original.Field.SelectionSet, field.SelectionSet),
                     Directives = original.Field.Directives,
                     Location = original.Field.Location,
-                }, original.FieldType)
-                : (field, fieldType);
+                };
+                var argumentValues = context.ArgumentValues;
+                if (argumentValues != null && argumentValues.TryGetValue(original.Field, out var arguments))
+                {
+                    ((IDictionary<GraphQLField, IDictionary<string, ArgumentValue>>)argumentValues)[newField] = arguments;
+                }
+                var directiveValues = context.DirectiveValues;
+                if (directiveValues != null && directiveValues.TryGetValue(original.Field, out var directives))
+                {
+                    ((IDictionary<ASTNode, IDictionary<string, DirectiveInfo>>)directiveValues)[newField] = directives;
+                }
+                fields[name] = (newField, original.FieldType);
+            }
+            else
+            {
+                fields[name] = (field, fieldType);
+            }
         }
 
         // Returns a new selection set node with the contents merged with another selection set node's contents.

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -97,7 +97,7 @@ public partial class ValidationContext : IProvideUserContext
     /// unless no field arguments were found, in which case the value will be <see langword="null"/>.
     /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
     /// </summary>
-    public Dictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; } // TODO: use a concurrent dictionary -- see PR #4083
+    public Dictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; } // TODO: use a concurrent dictionary -- see #4085
 
     /// <summary>
     /// A dictionary of fields, and for each field, a dictionary of directives defined for the field with their values.
@@ -107,7 +107,7 @@ public partial class ValidationContext : IProvideUserContext
     /// unless no field arguments were found, in which case the value will be <see langword="null"/>.
     /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
     /// </summary>
-    public Dictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; } // TODO: use a concurrent dictionary -- see PR #4083
+    public Dictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; } // TODO: use a concurrent dictionary -- see #4085
 
     /// <summary>
     /// Adds a validation error to the list of validation errors.

--- a/src/GraphQL/Validation/ValidationContext.cs
+++ b/src/GraphQL/Validation/ValidationContext.cs
@@ -97,7 +97,7 @@ public partial class ValidationContext : IProvideUserContext
     /// unless no field arguments were found, in which case the value will be <see langword="null"/>.
     /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
     /// </summary>
-    public Dictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; }
+    public Dictionary<GraphQLField, IDictionary<string, ArgumentValue>>? ArgumentValues { get; set; } // TODO: use a concurrent dictionary -- see PR #4083
 
     /// <summary>
     /// A dictionary of fields, and for each field, a dictionary of directives defined for the field with their values.
@@ -107,7 +107,7 @@ public partial class ValidationContext : IProvideUserContext
     /// unless no field arguments were found, in which case the value will be <see langword="null"/>.
     /// Note that fields will not be present in this dictionary if they would only contain arguments with default values.
     /// </summary>
-    public Dictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; }
+    public Dictionary<ASTNode, IDictionary<string, DirectiveInfo>>? DirectiveValues { get; set; } // TODO: use a concurrent dictionary -- see PR #4083
 
     /// <summary>
     /// Adds a validation error to the list of validation errors.


### PR DESCRIPTION
Fixes queries such as these:

```graphql
query heroQuery($id: Int!) {
    ...fragment1
    ...fragment2
}

fragment fragment1 on Query {
  hero(id: $id) {
    id
  }
}

fragment fragment2 on Query {
  hero(id: $id) {
    name
  }
}
```

Unfortunately this fix is not compatible with the patch described in #4060 - but it makes it no worse either.  See changes to `Issue4060.cs` tests and below notes.
