### PR TITLE
Introducing GraphQL.NET Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub Release Date](https://img.shields.io/github/release-date/graphql-dotnet/graphql-dotnet?label=released)](https://github.com/graphql-dotnet/graphql-dotnet/releases)
 [![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/graphql-dotnet/graphql-dotnet/latest?label=new+commits)](https://github.com/graphql-dotnet/graphql-dotnet/commits/master)
 ![Size](https://img.shields.io/github/repo-size/graphql-dotnet/graphql-dotnet)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20GraphQL.NET%20Guru-006BFF)](https://gurubase.io/g/graphql-net)
 
 [![GitHub contributors](https://img.shields.io/github/contributors/graphql-dotnet/graphql-dotnet)](https://github.com/graphql-dotnet/graphql-dotnet/graphs/contributors)
 ![Activity](https://img.shields.io/github/commit-activity/w/graphql-dotnet/graphql-dotnet)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [GraphQL.NET Guru](https://gurubase.io/g/graphql-net) to Gurubase. GraphQL.NET Guru uses the data from this repo and data from the [docs](http://graphql-dotnet.github.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "GraphQL.NET Guru", which highlights that GraphQL.NET now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable GraphQL.NET Guru in Gurubase, just let me know that's totally fine.
