### PR TITLE
Auto-add transitively implemented interfaces to object and interface types

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3539,6 +3539,12 @@ namespace GraphQL.Utilities
         public static string QuotedOrList(System.Collections.Generic.IEnumerable<string> items, int maxLength = 5) { }
         public static string[] SuggestionList(string input, System.Collections.Generic.IEnumerable<string>? options) { }
     }
+    public sealed class TransitiveInterfaceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public static GraphQL.Utilities.TransitiveInterfaceVisitor Instance { get; }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
     public class TypeConfig : GraphQL.Utilities.MetadataProvider
     {
         public TypeConfig(string name) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3553,6 +3553,12 @@ namespace GraphQL.Utilities
         public static string QuotedOrList(System.Collections.Generic.IEnumerable<string> items, int maxLength = 5) { }
         public static string[] SuggestionList(string input, System.Collections.Generic.IEnumerable<string>? options) { }
     }
+    public sealed class TransitiveInterfaceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public static GraphQL.Utilities.TransitiveInterfaceVisitor Instance { get; }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
     public class TypeConfig : GraphQL.Utilities.MetadataProvider
     {
         public TypeConfig(string name) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3459,6 +3459,12 @@ namespace GraphQL.Utilities
         public static string QuotedOrList(System.Collections.Generic.IEnumerable<string> items, int maxLength = 5) { }
         public static string[] SuggestionList(string input, System.Collections.Generic.IEnumerable<string>? options) { }
     }
+    public sealed class TransitiveInterfaceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public static GraphQL.Utilities.TransitiveInterfaceVisitor Instance { get; }
+        public override void VisitInterface(GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObject(GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
     public class TypeConfig : GraphQL.Utilities.MetadataProvider
     {
         public TypeConfig(string name) { }

--- a/src/GraphQL.Tests/Utilities/Visitors/TransitiveInterfaceVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/TransitiveInterfaceVisitorTests.cs
@@ -1,0 +1,114 @@
+using GraphQL.Types;
+using GraphQL.Utilities;
+
+namespace GraphQL.Tests.Utilities.Visitors;
+
+public class TransitiveInterfaceVisitorTests
+{
+    [Fact]
+    public void Should_Add_Transitive_Interfaces_To_Object_Type()
+    {
+        // Arrange
+        var schema = new Schema();
+
+        var interfaceC = new InterfaceGraphType { Name = "C" };
+        var interfaceB = new InterfaceGraphType { Name = "B" };
+        interfaceB.AddResolvedInterface(interfaceC);
+        var interfaceA = new InterfaceGraphType { Name = "A" };
+        interfaceA.AddResolvedInterface(interfaceB);
+
+        var objectType = new ObjectGraphType { Name = "TestObject" };
+        objectType.AddResolvedInterface(interfaceA);
+
+        // Act
+        TransitiveInterfaceVisitor.Instance.VisitObject(objectType, schema);
+
+        // Assert
+        objectType.ResolvedInterfaces.Count.ShouldBe(3);
+        objectType.ResolvedInterfaces.ShouldContain(interfaceA);
+        objectType.ResolvedInterfaces.ShouldContain(interfaceB);
+        objectType.ResolvedInterfaces.ShouldContain(interfaceC);
+    }
+
+    [Fact]
+    public void Should_Add_Transitive_Interfaces_To_Interface_Type()
+    {
+        // Arrange
+        var schema = new Schema();
+
+        var interfaceC = new InterfaceGraphType { Name = "C" };
+        var interfaceB = new InterfaceGraphType { Name = "B" };
+        interfaceB.AddResolvedInterface(interfaceC);
+        var interfaceA = new InterfaceGraphType { Name = "A" };
+        interfaceA.AddResolvedInterface(interfaceB);
+
+        // Act
+        TransitiveInterfaceVisitor.Instance.VisitInterface(interfaceA, schema);
+
+        // Assert
+        interfaceA.ResolvedInterfaces.Count.ShouldBe(2);
+        interfaceA.ResolvedInterfaces.ShouldContain(interfaceB);
+        interfaceA.ResolvedInterfaces.ShouldContain(interfaceC);
+    }
+
+    [Fact]
+    public void Should_Handle_No_Interfaces()
+    {
+        // Arrange
+        var schema = new Schema();
+        var objectType = new ObjectGraphType { Name = "TestObject" };
+
+        // Act
+        TransitiveInterfaceVisitor.Instance.VisitObject(objectType, schema);
+
+        // Assert
+        objectType.ResolvedInterfaces.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Should_Detect_Circular_References()
+    {
+        // Arrange
+        var schema = new Schema();
+
+        var interfaceA = new InterfaceGraphType { Name = "A" };
+        var interfaceB = new InterfaceGraphType { Name = "B" };
+
+        interfaceA.AddResolvedInterface(interfaceB);
+        interfaceB.AddResolvedInterface(interfaceA);
+
+        var objectType = new ObjectGraphType { Name = "TestObject" };
+        objectType.AddResolvedInterface(interfaceA);
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() =>
+            TransitiveInterfaceVisitor.Instance.VisitInterface(interfaceA, schema))
+            .Message.ShouldBe("'A' cannot implement interface 'B' because it creates a circular reference.");
+    }
+
+    [Fact]
+    public void Should_Not_Add_Already_Implemented_Interfaces()
+    {
+        // Arrange
+        var schema = new Schema();
+
+        var interfaceC = new InterfaceGraphType { Name = "C" };
+        var interfaceB = new InterfaceGraphType { Name = "B" };
+        interfaceB.AddResolvedInterface(interfaceC);
+        var interfaceA = new InterfaceGraphType { Name = "A" };
+        interfaceA.AddResolvedInterface(interfaceB);
+
+        var objectType = new ObjectGraphType { Name = "TestObject" };
+        objectType.AddResolvedInterface(interfaceA);
+        objectType.AddResolvedInterface(interfaceC); // Already directly implementing C
+
+        // Act
+        TransitiveInterfaceVisitor.Instance.VisitObject(objectType, schema);
+
+        // Assert
+        objectType.ResolvedInterfaces.Count.ShouldBe(3);
+        objectType.ResolvedInterfaces.ShouldContain(interfaceA);
+        objectType.ResolvedInterfaces.ShouldContain(interfaceB);
+        objectType.ResolvedInterfaces.ShouldContain(interfaceC);
+    }
+}

--- a/src/GraphQL.Tests/Utilities/Visitors/TransitiveInterfaceVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/TransitiveInterfaceVisitorTests.cs
@@ -66,7 +66,7 @@ public class TransitiveInterfaceVisitorTests
     }
 
     [Fact]
-    public void Should_Detect_Circular_References()
+    public void Should_Ignore_Circular_References()
     {
         // Arrange
         var schema = new Schema();
@@ -77,13 +77,10 @@ public class TransitiveInterfaceVisitorTests
         interfaceA.AddResolvedInterface(interfaceB);
         interfaceB.AddResolvedInterface(interfaceA);
 
-        var objectType = new ObjectGraphType { Name = "TestObject" };
-        objectType.AddResolvedInterface(interfaceA);
-
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() =>
-            TransitiveInterfaceVisitor.Instance.VisitInterface(interfaceA, schema))
-            .Message.ShouldBe("'A' cannot implement interface 'B' because it creates a circular reference.");
+        TransitiveInterfaceVisitor.Instance.VisitInterface(interfaceA, schema);
+        interfaceA.ResolvedInterfaces.Count.ShouldBe(1);
+        interfaceA.ResolvedInterfaces.ShouldContain(interfaceB);
     }
 
     [Fact]

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -493,6 +493,8 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
         ParseLinkVisitor.Instance.Run(this);
         // rename any applied directives that were imported from another schema to use the alias defined in the @link directive or the proper namespace
         RenameImportedDirectivesVisitor.Run(this);
+        // add direct references to transitively implemented interfaces
+        TransitiveInterfaceVisitor.Instance.Run(this);
         // run general schema validation code
         SchemaValidationVisitor.Run(this);
         // validate that all applied directives are valid

--- a/src/GraphQL/Utilities/Visitors/TransitiveInterfaceVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/TransitiveInterfaceVisitor.cs
@@ -54,8 +54,9 @@ public sealed class TransitiveInterfaceVisitor : BaseSchemaNodeVisitor
             {
                 foreach (var transitiveInterface in iface.ResolvedInterfaces.List)
                 {
+                    // Ignore circular references (will be caught in SchemaValidationVisitor)
                     if (transitiveInterface == baseType)
-                        throw new InvalidOperationException($"'{baseType.Name}' cannot implement interface '{iface.Name}' because it creates a circular reference.");
+                        continue;
 
                     transitiveInterfaces.Add(transitiveInterface);
                 }

--- a/src/GraphQL/Utilities/Visitors/TransitiveInterfaceVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/TransitiveInterfaceVisitor.cs
@@ -1,0 +1,66 @@
+using GraphQL.Types;
+
+namespace GraphQL.Utilities;
+
+/// <summary>
+/// A schema visitor that adds direct references to any transitively implemented interfaces
+/// that are not already directly implemented.
+/// </summary>
+public sealed class TransitiveInterfaceVisitor : BaseSchemaNodeVisitor
+{
+    private TransitiveInterfaceVisitor()
+    {
+    }
+
+    /// <inheritdoc cref="TransitiveInterfaceVisitor"/>
+    public static TransitiveInterfaceVisitor Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public override void VisitObject(IObjectGraphType type, ISchema schema)
+    {
+        AddTransitiveInterfaces(type);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInterface(IInterfaceGraphType type, ISchema schema)
+    {
+        AddTransitiveInterfaces(type);
+    }
+
+    private void AddTransitiveInterfaces(IImplementInterfaces type)
+    {
+        if (type.ResolvedInterfaces.Count == 0)
+            return;
+
+        var checkedInterfaces = new HashSet<IInterfaceGraphType>();
+        var transitiveInterfaces = new HashSet<IInterfaceGraphType>();
+        FindTransitiveInterfaces(type, type, transitiveInterfaces, checkedInterfaces);
+
+        // Add any transitive interfaces that aren't already directly implemented
+        foreach (var iface in transitiveInterfaces)
+        {
+            if (!type.ResolvedInterfaces.Contains(iface))
+            {
+                type.AddResolvedInterface(iface);
+            }
+        }
+    }
+
+    private void FindTransitiveInterfaces(IImplementInterfaces baseType, IImplementInterfaces type, HashSet<IInterfaceGraphType> transitiveInterfaces, HashSet<IInterfaceGraphType> checkedInterfaces)
+    {
+        foreach (var iface in type.ResolvedInterfaces.List)
+        {
+            if (checkedInterfaces.Add(iface))
+            {
+                foreach (var transitiveInterface in iface.ResolvedInterfaces.List)
+                {
+                    if (transitiveInterface == baseType)
+                        throw new InvalidOperationException($"'{baseType.Name}' cannot implement interface '{iface.Name}' because it creates a circular reference.");
+
+                    transitiveInterfaces.Add(transitiveInterface);
+                }
+                FindTransitiveInterfaces(baseType, iface, transitiveInterfaces, checkedInterfaces);
+            }
+        }
+    }
+}


### PR DESCRIPTION
There is no schema validation rule to validate that transitively implemented interfaces are directly implemented by all implementing types.  There are two approaches to fix the problem, both of which are available to us in version 8:

### Auto-adding transitively implemented interfaces (this PR)
  - This would be considered a new feature, widening the supported requests, not narrowing
  - Easier to use / more C#-like interface implementation pattern
  - Resolvers can only execute against a concrete object type, so no problems there
  - Would change the introspection query (for affected schemas)

### Add schema validation to prevent an invalid schema from being initialized
  - Within minor version bumps, we allow changes that better enforce the graphql specification, even if doing so "breaks" an existing schema
  - Requires the developer to directly reference all transitively-referenced interfaces
  - This would break any implementation that uses an invalidly-configured schema in this manner

This PR represents the former option, being that it is likely what was desired by the developer in the first place, and prevents a minor version bump from breaking code.

See:
- https://github.com/graphql-dotnet/graphql-dotnet/issues/4105#issuecomment-2548601842
- #4106 
