### PR TITLE
Fix xml comment on InferFieldNullabilityFromNRTAnnotations

### DIFF
--- a/src/GraphQL/GlobalSwitches.cs
+++ b/src/GraphQL/GlobalSwitches.cs
@@ -128,7 +128,7 @@ public static class GlobalSwitches
 
     /// <summary>
     /// Infer the field's graph type nullability from the Null Reference Type annotations of
-    /// the field or property represented by the expression argument. <see langword="false"/> by default.
+    /// the field or property represented by the expression argument. <see langword="true"/> by default.
     /// </summary>
     public static bool InferFieldNullabilityFromNRTAnnotations { get; set; } = true;
 }


### PR DESCRIPTION
This default value was changed for v8 but the comment not updated.  (See [migration notes.](https://graphql-dotnet.github.io/docs/migrations/migration8/))