### PR TITLE
Bump NativeAOT samples to .NET 8; fix more attributes

### DIFF
--- a/samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj
@@ -7,7 +7,11 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <IsPackable>false</IsPackable>
+    
+    <!-- GraphQL.NET currently requires this option for serialization to work properly -->
+    <!-- Serialization and deserialization takes place primarily within dedicated JsonConverters and so little reflection is used in practice -->
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <IsPackable>false</IsPackable>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.AotCompilationSample.CodeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.CodeFirst/Program.cs
@@ -16,7 +16,7 @@ IServiceCollection serviceCollection = new ServiceCollection();
 serviceCollection.AddGraphQL(b => b
     .AddSystemTextJson()
     //.AddSchema<StarWarsSchema>()
-    //.AddGraphTypes(typeof(StarWarsSchema).Assembly)
+    .AddGraphTypes(typeof(StarWarsSchema).Assembly)
     .AddSelfActivatingSchema<StarWarsSchema>()
 );
 

--- a/samples/GraphQL.AotCompilationSample.CodeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.CodeFirst/Program.cs
@@ -12,12 +12,10 @@ IServiceCollection serviceCollection = new ServiceCollection();
 //   - AddClrTypeMappings
 //   - AddAutoClrMappings
 //   - AddAutoSchema
-//   - AddGraphTypes
 serviceCollection.AddGraphQL(b => b
     .AddSystemTextJson()
-    //.AddSchema<StarWarsSchema>()
-    .AddGraphTypes(typeof(StarWarsSchema).Assembly)
-    .AddSelfActivatingSchema<StarWarsSchema>()
+    .AddSchema<StarWarsSchema>()
+    .AddGraphTypes(typeof(StarWarsSchema).Assembly) //.AddSelfActivatingSchema<StarWarsSchema>()
 );
 
 serviceCollection.AddSingleton<StarWarsData>();

--- a/samples/GraphQL.AotCompilationSample.CodeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.CodeFirst/Program.cs
@@ -14,8 +14,9 @@ IServiceCollection serviceCollection = new ServiceCollection();
 //   - AddAutoSchema
 serviceCollection.AddGraphQL(b => b
     .AddSystemTextJson()
-    .AddSchema<StarWarsSchema>()
-    .AddGraphTypes(typeof(StarWarsSchema).Assembly) //.AddSelfActivatingSchema<StarWarsSchema>()
+    //.AddSchema<StarWarsSchema>()
+    //.AddGraphTypes(typeof(StarWarsSchema).Assembly)
+    .AddSelfActivatingSchema<StarWarsSchema>()
 );
 
 serviceCollection.AddSingleton<StarWarsData>();

--- a/samples/GraphQL.AotCompilationSample.CodeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.CodeFirst/Program.cs
@@ -12,6 +12,7 @@ IServiceCollection serviceCollection = new ServiceCollection();
 //   - AddClrTypeMappings
 //   - AddAutoClrMappings
 //   - AddAutoSchema
+//   - AddGraphTypes
 serviceCollection.AddGraphQL(b => b
     .AddSystemTextJson()
     //.AddSchema<StarWarsSchema>()
@@ -33,9 +34,7 @@ serviceCollection.AddTransient<StarWarsMutation>();
 // - field builders that do not include a resolver such as Field<StringGraphType>("Name") are not supported
 // - strongly recommend each field has the explicit graph type specified and a resolver specified
 
-#pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
 using var services = serviceCollection.BuildServiceProvider();
-#pragma warning restore IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
 
 var executer = services.GetRequiredService<IDocumentExecuter>();
 

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
@@ -8,6 +8,7 @@
     <PublishAot>true</PublishAot>
     <IsPackable>false</IsPackable>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <VerifyOpenGenericServiceTrimmability>false</VerifyOpenGenericServiceTrimmability>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
@@ -12,18 +12,8 @@
     <!-- Serialization and deserialization takes place primarily within dedicated JsonConverters and so little reflection is used in practice -->
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     
-    <DummyVerifyDependencyInjectionOpenGenericServiceTrimmability>false</DummyVerifyDependencyInjectionOpenGenericServiceTrimmability>
-    
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Open generic types of value types cannot be constructed even if they are rooted unless the following non-public option is configured -->
-    <!-- This is necessary for EnumerationGraphType<T> as T is always a value type -->
-    <!-- https://github.com/dotnet/runtime/blob/v8.0.0/docs/workflow/trimming/feature-switches.md -->
-    <!-- https://github.com/dotnet/runtime/blob/v9.0.0/docs/workflow/trimming/feature-switches.md -->
-    <RuntimeHostConfigurationOption Include="Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability" Value="false" Trim="true" />
-  </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.*" />

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
@@ -8,7 +8,7 @@
     <PublishAot>true</PublishAot>
     <IsPackable>false</IsPackable>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
-    <VerifyOpenGenericServiceTrimmability>false</VerifyOpenGenericServiceTrimmability>
+    <VerifyDependencyInjectionOpenGenericServiceTrimmability>false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
@@ -12,14 +12,18 @@
     <!-- Serialization and deserialization takes place primarily within dedicated JsonConverters and so little reflection is used in practice -->
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     
+    <DummyVerifyDependencyInjectionOpenGenericServiceTrimmability>false</DummyVerifyDependencyInjectionOpenGenericServiceTrimmability>
+    
+  </PropertyGroup>
+
+  <ItemGroup>
     <!-- Open generic types of value types cannot be constructed even if they are rooted unless the following non-public option is configured -->
     <!-- This is necessary for EnumerationGraphType<T> as T is always a value type -->
     <!-- https://github.com/dotnet/runtime/blob/v8.0.0/docs/workflow/trimming/feature-switches.md -->
     <!-- https://github.com/dotnet/runtime/blob/v9.0.0/docs/workflow/trimming/feature-switches.md -->
-    <VerifyDependencyInjectionOpenGenericServiceTrimmability>false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
-    
-  </PropertyGroup>
-
+    <RuntimeHostConfigurationOption Include="Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability" Value="false" Trim="true" />
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.*" />

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
@@ -7,8 +7,17 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <IsPackable>false</IsPackable>
+
+    <!-- GraphQL.NET currently requires this option for serialization to work properly -->
+    <!-- Serialization and deserialization takes place primarily within dedicated JsonConverters and so little reflection is used in practice -->
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    
+    <!-- Open generic types of value types cannot be constructed even if they are rooted unless the following non-public option is configured -->
+    <!-- This is necessary for EnumerationGraphType<T> as T is always a value type -->
+    <!-- https://github.com/dotnet/runtime/blob/v8.0.0/docs/workflow/trimming/feature-switches.md -->
+    <!-- https://github.com/dotnet/runtime/blob/v9.0.0/docs/workflow/trimming/feature-switches.md -->
     <VerifyDependencyInjectionOpenGenericServiceTrimmability>false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
+    
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <IsPackable>false</IsPackable>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
@@ -36,7 +36,7 @@ serviceCollection.AddGraphQL(b => b
 serviceCollection.AddSingleton<StarWarsData>();
 // for enumeration types, although the EnumerationGraphType<Episodes> type has been properly rooted, the
 // .NET 8 DI provider will refuse to create open generic types of value types, so they must be registered manually
-serviceCollection.AddTransient<EnumerationGraphType<Episodes>>();
+//serviceCollection.AddTransient<EnumerationGraphType<Episodes>>();
 
 using var services = serviceCollection.BuildServiceProvider();
 

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
@@ -26,17 +26,18 @@ serviceCollection.AddGraphQL(b => b
         // For enumeration types, and types not in the GraphQL.StarWars.TypeFirst assembly, manually calling
         // RegisterTypeMapping or AutoRegister will root the proper classes necessary for the schema to work.
         s.RegisterTypeMapping<Episodes, EnumerationGraphType<Episodes>>();
-        s.AutoRegister<Connection<IStarWarsCharacter>>();
+        //s.AutoRegister<Connection<IStarWarsCharacter>>();
         s.AutoRegister<Edge<IStarWarsCharacter>>();
-        s.AutoRegister<PageInfo>();
+        //s.AutoRegister<PageInfo>();
     })
 );
 #pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 
 serviceCollection.AddSingleton<StarWarsData>();
+
 // for enumeration types, although the EnumerationGraphType<Episodes> type has been properly rooted, the
 // .NET 8 DI provider will refuse to create open generic types of value types, so they must be registered manually
-//serviceCollection.AddTransient<EnumerationGraphType<Episodes>>();
+serviceCollection.AddTransient<EnumerationGraphType<Episodes>>();
 
 using var services = serviceCollection.BuildServiceProvider();
 

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
@@ -26,9 +26,9 @@ serviceCollection.AddGraphQL(b => b
         // For enumeration types, and types not in the GraphQL.StarWars.TypeFirst assembly, manually calling
         // RegisterTypeMapping or AutoRegister will root the proper classes necessary for the schema to work.
         s.RegisterTypeMapping<Episodes, EnumerationGraphType<Episodes>>();
-        //s.AutoRegister<Connection<IStarWarsCharacter>>();
+        s.AutoRegister<Connection<IStarWarsCharacter>>();
         s.AutoRegister<Edge<IStarWarsCharacter>>();
-        //s.AutoRegister<PageInfo>();
+        s.AutoRegister<PageInfo>();
     })
 );
 #pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
@@ -35,9 +35,7 @@ serviceCollection.AddGraphQL(b => b
 
 serviceCollection.AddSingleton<StarWarsData>();
 
-#pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
 using var services = serviceCollection.BuildServiceProvider();
-#pragma warning restore IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
 
 var executer = services.GetRequiredService<IDocumentExecuter>();
 

--- a/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
+++ b/samples/GraphQL.AotCompilationSample.TypeFirst/Program.cs
@@ -34,6 +34,9 @@ serviceCollection.AddGraphQL(b => b
 #pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 
 serviceCollection.AddSingleton<StarWarsData>();
+// for enumeration types, although the EnumerationGraphType<Episodes> type has been properly rooted, the
+// .NET 8 DI provider will refuse to create open generic types of value types, so they must be registered manually
+serviceCollection.AddTransient<EnumerationGraphType<Episodes>>();
 
 using var services = serviceCollection.BuildServiceProvider();
 

--- a/src/GraphQL.ApiTests/net50/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.MicrosoftDI.approved.txt
@@ -180,7 +180,7 @@ namespace GraphQL
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddGraphQL(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<GraphQL.DI.IGraphQLBuilder>? configure) { }
         public static GraphQL.DI.IGraphQLBuilder AddScopedSubscriptionExecutionStrategy(this GraphQL.DI.IGraphQLBuilder builder, bool serialExecution = true) { }
-        public static GraphQL.DI.IGraphQLBuilder AddSelfActivatingSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
+        public static GraphQL.DI.IGraphQLBuilder AddSelfActivatingSchema<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method)]

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -372,7 +372,6 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypeMappingProvider<TGraphTypeMappingProvider>(this GraphQL.DI.IGraphQLBuilder builder, TGraphTypeMappingProvider instance)
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
-        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(GraphQL.Types.EnumerationGraphType<System.DayOfWeek>))]
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
         [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
             "d in v9.")]

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -845,7 +845,7 @@ namespace GraphQL
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Please ensure that the CLR type and the related auto-registering graph type are n" +
             "ot trimmed by the compiler.")]
         public static void AutoRegister(this GraphQL.Types.ISchema schema, System.Type clrType, GraphQL.AutoRegisteringMode mode = 3) { }
-        public static void AutoRegister<TClrType>(this GraphQL.Types.ISchema schema, GraphQL.AutoRegisteringMode mode = 3) { }
+        public static void AutoRegister<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TClrType>(this GraphQL.Types.ISchema schema, GraphQL.AutoRegisteringMode mode = 3) { }
         public static TSchema EnableExperimentalIntrospectionFeatures<TSchema>(this TSchema schema, GraphQL.ExperimentalIntrospectionFeaturesMode mode = 0)
             where TSchema : GraphQL.Types.ISchema { }
         public static System.Threading.Tasks.Task<string> ExecuteAsync(this GraphQL.Types.ISchema schema, GraphQL.IGraphQLTextSerializer serializer, System.Action<GraphQL.ExecutionOptions> configure) { }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -372,6 +372,7 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypeMappingProvider<TGraphTypeMappingProvider>(this GraphQL.DI.IGraphQLBuilder builder, TGraphTypeMappingProvider instance)
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(GraphQL.Types.EnumerationGraphType<System.DayOfWeek>))]
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
         [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
             "d in v9.")]

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -372,7 +372,6 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypeMappingProvider<TGraphTypeMappingProvider>(this GraphQL.DI.IGraphQLBuilder builder, TGraphTypeMappingProvider instance)
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
-        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(GraphQL.Types.EnumerationGraphType<System.DayOfWeek>))]
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
         [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
             "d in v9.")]

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -845,7 +845,7 @@ namespace GraphQL
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Please ensure that the CLR type and the related auto-registering graph type are n" +
             "ot trimmed by the compiler.")]
         public static void AutoRegister(this GraphQL.Types.ISchema schema, System.Type clrType, GraphQL.AutoRegisteringMode mode = 3) { }
-        public static void AutoRegister<TClrType>(this GraphQL.Types.ISchema schema, GraphQL.AutoRegisteringMode mode = 3) { }
+        public static void AutoRegister<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  TClrType>(this GraphQL.Types.ISchema schema, GraphQL.AutoRegisteringMode mode = 3) { }
         public static TSchema EnableExperimentalIntrospectionFeatures<TSchema>(this TSchema schema, GraphQL.ExperimentalIntrospectionFeaturesMode mode = 0)
             where TSchema : GraphQL.Types.ISchema { }
         public static System.Threading.Tasks.Task<string> ExecuteAsync(this GraphQL.Types.ISchema schema, GraphQL.IGraphQLTextSerializer serializer, System.Action<GraphQL.ExecutionOptions> configure) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -372,6 +372,7 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypeMappingProvider<TGraphTypeMappingProvider>(this GraphQL.DI.IGraphQLBuilder builder, TGraphTypeMappingProvider instance)
             where TGraphTypeMappingProvider :  class, GraphQL.Types.IGraphTypeMappingProvider { }
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder) { }
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(GraphQL.Types.EnumerationGraphType<System.DayOfWeek>))]
         public static GraphQL.DI.IGraphQLBuilder AddGraphTypes(this GraphQL.DI.IGraphQLBuilder builder, System.Reflection.Assembly assembly) { }
         [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
             "d in v9.")]

--- a/src/GraphQL.MicrosoftDI/MicrosoftDIGraphQLBuilderExtensions.cs
+++ b/src/GraphQL.MicrosoftDI/MicrosoftDIGraphQLBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class MicrosoftDIGraphQLBuilderExtensions
     /// Schemas that implement <see cref="IDisposable"/> of a transient lifetime are not supported, as this will cause a
     /// memory leak if requested from the root service provider.
     /// </remarks>
-    public static IGraphQLBuilder AddSelfActivatingSchema<TSchema>(this IGraphQLBuilder builder, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    public static IGraphQLBuilder AddSelfActivatingSchema<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSchema>(this IGraphQLBuilder builder, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         where TSchema : class, ISchema
     {
         if (serviceLifetime == ServiceLifetime.Transient && typeof(IDisposable).IsAssignableFrom(typeof(TSchema)))

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -315,7 +315,6 @@ public static class GraphQLBuilderExtensions // TODO: split
         builder.AddSchema(provider => new AutoSchema<TQueryClrType>(provider), ServiceLifetime.Singleton);
         builder.Services.TryRegister<IGraphTypeMappingProvider, AutoRegisteringGraphTypeMappingProvider>(ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
         configure?.Invoke(new ConfigureAutoSchema<TQueryClrType>(builder));
-        builder.AddGenericGraphTypes();
         return builder;
     }
 
@@ -526,13 +525,6 @@ public static class GraphQLBuilderExtensions // TODO: split
             builder.Services.TryRegister(type, type, ServiceLifetime.Transient);
         }
 
-        builder.AddGenericGraphTypes();
-
-        return builder;
-    }
-
-    private static IGraphQLBuilder AddGenericGraphTypes(this IGraphQLBuilder builder)
-    {
         builder.Services.TryRegister(typeof(EnumerationGraphType<>), typeof(EnumerationGraphType<>), ServiceLifetime.Transient);
         builder.Services.TryRegister(typeof(ConnectionType<>), typeof(ConnectionType<>), ServiceLifetime.Transient);
         builder.Services.TryRegister(typeof(ConnectionType<,>), typeof(ConnectionType<,>), ServiceLifetime.Transient);

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -509,7 +509,6 @@ public static class GraphQLBuilderExtensions // TODO: split
     /// <see cref="InputObjectGraphType{TSourceType}"/>, <see cref="AutoRegisteringInputObjectGraphType{TSourceType}"/>, and
     /// <see cref="AutoRegisteringObjectGraphType{TSourceType}"/> as generic types.
     /// </summary>
-    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(EnumerationGraphType<DayOfWeek>))]
     public static IGraphQLBuilder AddGraphTypes(this IGraphQLBuilder builder, Assembly assembly)
     {
         // Graph types are always created with the transient lifetime, since they are only instantiated once

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -509,6 +509,7 @@ public static class GraphQLBuilderExtensions // TODO: split
     /// <see cref="InputObjectGraphType{TSourceType}"/>, <see cref="AutoRegisteringInputObjectGraphType{TSourceType}"/>, and
     /// <see cref="AutoRegisteringObjectGraphType{TSourceType}"/> as generic types.
     /// </summary>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(EnumerationGraphType<DayOfWeek>))]
     public static IGraphQLBuilder AddGraphTypes(this IGraphQLBuilder builder, Assembly assembly)
     {
         // Graph types are always created with the transient lifetime, since they are only instantiated once

--- a/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLBuilderExtensions.cs
@@ -315,6 +315,7 @@ public static class GraphQLBuilderExtensions // TODO: split
         builder.AddSchema(provider => new AutoSchema<TQueryClrType>(provider), ServiceLifetime.Singleton);
         builder.Services.TryRegister<IGraphTypeMappingProvider, AutoRegisteringGraphTypeMappingProvider>(ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
         configure?.Invoke(new ConfigureAutoSchema<TQueryClrType>(builder));
+        builder.AddGenericGraphTypes();
         return builder;
     }
 
@@ -525,6 +526,13 @@ public static class GraphQLBuilderExtensions // TODO: split
             builder.Services.TryRegister(type, type, ServiceLifetime.Transient);
         }
 
+        builder.AddGenericGraphTypes();
+
+        return builder;
+    }
+
+    private static IGraphQLBuilder AddGenericGraphTypes(this IGraphQLBuilder builder)
+    {
         builder.Services.TryRegister(typeof(EnumerationGraphType<>), typeof(EnumerationGraphType<>), ServiceLifetime.Transient);
         builder.Services.TryRegister(typeof(ConnectionType<>), typeof(ConnectionType<>), ServiceLifetime.Transient);
         builder.Services.TryRegister(typeof(ConnectionType<,>), typeof(ConnectionType<,>), ServiceLifetime.Transient);

--- a/src/GraphQL/Extensions/SchemaExtensions.cs
+++ b/src/GraphQL/Extensions/SchemaExtensions.cs
@@ -177,7 +177,7 @@ public static class SchemaExtensions
     /// <param name="schema">The schema for which the mapping is registered.</param>
     /// <typeparam name="TClrType">The CLR property type from which to infer the GraphType.</typeparam>
     /// <param name="mode">Which registering mode to use - input only, output only or both.</param>
-    public static void AutoRegister<TClrType>(this ISchema schema, AutoRegisteringMode mode = AutoRegisteringMode.Both)
+    public static void AutoRegister<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] TClrType>(this ISchema schema, AutoRegisteringMode mode = AutoRegisteringMode.Both)
     {
         if (mode.HasFlag(AutoRegisteringMode.Output))
             schema.RegisterTypeMapping<TClrType, AutoRegisteringObjectGraphType<TClrType>>();


### PR DESCRIPTION
The AOT samples previously written for .NET 7 do not work properly for .NET 8 due to changes in the NativeAOT compiler and trim analysis.  .NET 8 also places additional restrictions on the MS DI service provider and JSON serializer, requiring additional changes.  This PR implements the necessary changes and updates the samples to work under .NET 8.

Note that implementation of the `Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability` runtime configuration switch would provide for a better experience, but I cannot figure out how to get it to work via the csproj, either with a MSBuild property or via `RuntimeHostConfigurationOption`.

See:
- https://github.com/dotnet/runtime/blob/v8.0.0/docs/workflow/trimming/feature-switches.md