### PR TITLE
Fix issue with UseMemoryCache returning documents from the wrong schema

### DIFF
--- a/src/GraphQL.MemoryCache/MemoryDocumentCache.cs
+++ b/src/GraphQL.MemoryCache/MemoryDocumentCache.cs
@@ -1,5 +1,6 @@
 using GraphQL.DI;
 using GraphQL.PersistedDocuments;
+using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQLParser.AST;
 using Microsoft.Extensions.Caching.Memory;
@@ -170,11 +171,13 @@ public class MemoryDocumentCache : IConfigureExecution, IDisposable
 
     private record class CacheItem
     {
+        public ISchema? Schema { get; }
         public string? Query { get; }
         public string? DocumentId { get; }
 
         public CacheItem(ExecutionOptions options)
         {
+            Schema = options.Schema;
             // cache based on the document id if present, or the query if not, but not both
             Query = options.DocumentId != null ? null : options.Query;
             DocumentId = options.DocumentId;


### PR DESCRIPTION
When multiple schemas are used in combination with UseMemoryCache documents which have passed validation in one schema will skip validation when used against another schema.

These queries then result in InvalidOperationExceptions from the ExecutionStrategy.

This PR adds Schema to the CacheItem which appears to fix it.


