### PR TITLE
Add NoClrMapping option for input fields

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -255,6 +255,11 @@ namespace GraphQL
     {
         public static GraphQL.DI.IGraphQLBuilder AddFederation(this GraphQL.DI.IGraphQLBuilder builder, string version, System.Action<GraphQL.Utilities.LinkConfiguration>? configureLinkDirective = null) { }
     }
+    public static class FieldExtensions
+    {
+        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter graphType)
+            where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Parameter)]
     public class FromServicesAttribute : GraphQL.GraphQLAttribute
     {

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -255,6 +255,11 @@ namespace GraphQL
     {
         public static GraphQL.DI.IGraphQLBuilder AddFederation(this GraphQL.DI.IGraphQLBuilder builder, string version, System.Action<GraphQL.Utilities.LinkConfiguration>? configureLinkDirective = null) { }
     }
+    public static class FieldExtensions
+    {
+        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter graphType)
+            where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Parameter)]
     public class FromServicesAttribute : GraphQL.GraphQLAttribute
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -252,6 +252,11 @@ namespace GraphQL
     {
         public static GraphQL.DI.IGraphQLBuilder AddFederation(this GraphQL.DI.IGraphQLBuilder builder, string version, System.Action<GraphQL.Utilities.LinkConfiguration>? configureLinkDirective = null) { }
     }
+    public static class FieldExtensions
+    {
+        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter graphType)
+            where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Parameter)]
     public class FromServicesAttribute : GraphQL.GraphQLAttribute
     {

--- a/src/GraphQL/Extensions/FieldExtensions.cs
+++ b/src/GraphQL/Extensions/FieldExtensions.cs
@@ -1,0 +1,24 @@
+using GraphQL.Types;
+
+namespace GraphQL;
+
+/// <summary>
+/// Provides extension methods for configuring field metadata.
+/// </summary>
+public static class FieldExtensions
+{
+    /// <summary>
+    /// Instructs the GraphQL input object type to bypass automatic CLR mapping for the field.
+    /// </summary>
+    /// <remarks>
+    /// This extension method sets a specific metadata flag on the field (using the keys defined on <see cref="InputObjectGraphType"/>)
+    /// to indicate that the field should not be automatically bound to a property on the corresponding CLR type.
+    /// This is particularly useful when the input type defines a field that is computed or otherwise does not have a matching
+    /// CLR property. In such cases, developers typically override <see cref="InputObjectGraphType{TSourceType}.ParseDictionary(IDictionary{string, object?})"/>
+    /// to handle the conversion between the input and CLR object.
+    /// </remarks>
+    [AllowedOn<IInputObjectGraphType>]
+    public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter graphType)
+        where TMetadataWriter : IFieldMetadataWriter
+        => graphType.WithMetadata(InputObjectGraphType.ORIGINAL_EXPRESSION_PROPERTY_NAME, InputObjectGraphType.SKIP_EXPRESSION_VALUE_NAME);
+}

--- a/src/GraphQL/Types/Composite/ComplexGraphType.cs
+++ b/src/GraphQL/Types/Composite/ComplexGraphType.cs
@@ -13,6 +13,7 @@ namespace GraphQL.Types;
 public abstract class ComplexGraphType<[NotAGraphType] TSourceType> : GraphType, IComplexGraphType
 {
     internal const string ORIGINAL_EXPRESSION_PROPERTY_NAME = nameof(ORIGINAL_EXPRESSION_PROPERTY_NAME);
+    internal const string SKIP_EXPRESSION_VALUE_NAME = "-- skip --"; // CLR names cannot contain spaces
 
     /// <inheritdoc/>
     protected ComplexGraphType()

--- a/src/GraphQL/Utilities/SchemaPrinter.cs
+++ b/src/GraphQL/Utilities/SchemaPrinter.cs
@@ -391,6 +391,8 @@ public class SchemaPrinter //TODO: rewrite string concatenations to use buffer ?
         foreach (var field in input.Fields.OrderBy(Options.Comparer?.FieldComparer(input)))
         {
             string propertyName = field.GetMetadata<string>(ComplexGraphType<object>.ORIGINAL_EXPRESSION_PROPERTY_NAME) ?? field.Name;
+            if (propertyName == InputObjectGraphType.SKIP_EXPRESSION_VALUE_NAME)
+                continue;
 
             // if 'value' is stored as a dictionary of key/value pairs, pull the field value from the dictionary by the property name
             object? propertyValue;


### PR DESCRIPTION
Allows the developer to exclude specific fields from the graph from being mapped to the CLR type automatically.  The developer must override ParseDictionary to apply the input to the CLR object.  Note that IsValidDefault and ToAST methods also skip these fields, and if necessary, the developer should override those methods as well.

See discussion:
- https://github.com/graphql-dotnet/graphql-dotnet/discussions/4123

Added doc below:

---

### 30. NoClrMapping Extension for Input Fields with Custom CLR Mapping (from version 8.4.0)

A new extension method, `NoClrMapping`, has been introduced to give you fine-grained control over how input object fields are mapped to CLR types. In many scenarios, your input types may include fields that are computed or require custom processing before being set on your CLR model. For example, you might have a CLR type with a single `FullName` property but want your input object to accept separate `firstName` and `lastName` fields. By marking these fields with `NoClrMapping()`, they are excluded from the automatic binding process. You can then override the `ParseDictionary` method to manually combine these values into the CLR's `FullName` property, while letting the base implementation handle any automatically mapped fields (such as `Age`). The following example illustrates this pattern:

```csharp
public class Person
{
    public string FullName { get; set; } = string.Empty;
    public int Age { get; set; }
}

public class PersonInputType : InputObjectGraphType<Person>
{
    public PersonInputType()
    {
        Name = "PersonInput";

        // Define fields for 'firstName' and 'lastName' that are not automatically mapped.
        Field<NonNullGraphType<StringGraphType>>("firstName").NoClrMapping();
        Field<NonNullGraphType<StringGraphType>>("lastName").NoClrMapping();

        // Define the 'age' field which is automatically mapped to Person.Age.
        Field(x => x.Age);
    }

    public override object ParseDictionary(IDictionary<string, object?> value)
    {
        // Use base.ParseDictionary to handle automatic mapping (e.g., Age).
        var person = (Person)base.ParseDictionary(value);

        // Manually combine firstName and lastName into FullName.
        if (value.TryGetValue("firstName", out var firstNameObj) && firstNameObj is string firstName &&
            value.TryGetValue("lastName", out var lastNameObj) && lastNameObj is string lastName)
        {
            person.FullName = $"{firstName} {lastName}";
        }

        return person;
    }
}
```

In this example, the input object defines three fields: `firstName`, `lastName`, and `age`. The `firstName` and `lastName` fields are marked with `NoClrMapping()` so that they are not automatically bound to any CLR properties. Instead, the overridden `ParseDictionary` method combines these two fields into the `FullName` property of the `Person` CLR type. Meanwhile, the `Age` field is processed via the standard mapping mechanism by calling `base.ParseDictionary`. This approach allows you to seamlessly mix automatic and custom binding, providing greater flexibility in how your input objects are processed and mapped.