### PR TITLE
Lock federation 1 supergraph testing to Apollo Router 1.59

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -210,7 +210,12 @@ jobs:
       - name: Print supergraph
         working-directory: samples/Federation
         run: cat supergraph.graphql
-      - name: Download router
+      - name: Download router for federation 1
+        if: matrix.federationversion == 1
+        working-directory: samples/Federation
+        run: curl -sSL https://router.apollo.dev/download/nix/1.59.0 | sh
+      - name: Download router for federation 2
+        if: matrix.federationversion == 2
         working-directory: samples/Federation
         run: curl -sSL https://router.apollo.dev/download/nix/latest | sh
       - name: Start router

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Download router for federation 1
         if: matrix.federationversion == 1
         working-directory: samples/Federation
-        run: curl -sSL https://router.apollo.dev/download/nix/1.59.0 | sh
+        run: curl -sSL https://router.apollo.dev/download/nix/v1.59.0 | sh
       - name: Download router for federation 2
         if: matrix.federationversion == 2
         working-directory: samples/Federation


### PR DESCRIPTION
Apollo Router 1.60 does not support federation v1 supergraphs