### PR TITLE
Make memory cache unique per schema

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1298,6 +1298,42 @@ the `Age` field is processed via the standard mapping mechanism by calling `base
 This approach allows you to seamlessly mix automatic and custom binding, providing greater
 flexibility in how your input objects are processed and mapped.
 
+### 31. Unique Cache Keys for Multi-Schema Environments (from version 8.4.0)
+
+Document caching now supports unique cache keys for applications using multiple or dynamic
+schemas. The cache key has been enhanced to include an extra property computed by the new
+`AdditionalCacheKeySelector` delegate. By default, this delegate distinguishes between
+schema-first and code-first implementations by returning the schema instance for
+schema-first and dynamic schemas (those that are direct implementations of
+`Schema`), and the schema type for code-first and type-first schemas (schemas that derive
+from `Schema`). This change ensures that cached documents are uniquely identified even
+when multiple schemas are configured in the same application, while still supporting
+caching for scoped code-first and type-first schemas.
+
+To migrate, you may continue using the default behavior. However, if you need further
+customization -- such as incorporating additional context to identify unique dynamic schemas
+-- you can override the default selector as shown in the example below:
+
+```csharp
+services.AddGraphQL(b => b
+    .UseMemoryCache(options =>
+    {
+        options.AdditionalCacheKeySelector = execOptions =>
+        {
+            if (execOptions.UserContext is IDictionary<string, object> context &&
+                context.TryGetValue("CustomHeader", out var header))
+            {
+                return header;
+            }
+            return null;
+        };
+    })
+);
+```
+
+These changes help ensure that cached documents are correctly associated with the appropriate
+schema when multiple schemas are in use.
+
 ## Breaking Changes
 
 ### 1. Query type is required

--- a/src/GraphQL.ApiTests/GraphQL.MemoryCache.approved.txt
+++ b/src/GraphQL.ApiTests/GraphQL.MemoryCache.approved.txt
@@ -48,6 +48,7 @@ namespace GraphQL.Caching
     public class MemoryDocumentCacheOptions : Microsoft.Extensions.Caching.Memory.MemoryCacheOptions, Microsoft.Extensions.Options.IOptions<GraphQL.Caching.MemoryDocumentCacheOptions>
     {
         public MemoryDocumentCacheOptions() { }
+        public System.Func<GraphQL.ExecutionOptions, object?>? AdditionalCacheKeySelector { get; set; }
         public System.TimeSpan? SlidingExpiration { get; set; }
     }
     public class PersistedQueryBadHashError : GraphQL.Execution.RequestError

--- a/src/GraphQL.MemoryCache/MemoryDocumentCache.cs
+++ b/src/GraphQL.MemoryCache/MemoryDocumentCache.cs
@@ -1,5 +1,6 @@
 using GraphQL.DI;
 using GraphQL.PersistedDocuments;
+using GraphQL.Types;
 using GraphQL.Validation;
 using GraphQLParser.AST;
 using Microsoft.Extensions.Caching.Memory;
@@ -170,11 +171,13 @@ public class MemoryDocumentCache : IConfigureExecution, IDisposable
 
     private record class CacheItem
     {
+        public ISchema? Schema { get; }
         public string? Query { get; }
         public string? DocumentId { get; }
 
         public CacheItem(ExecutionOptions options)
         {
+            Schema = options.Schema;
             // cache based on the document id if present, or the query if not, but not both
             Query = options.DocumentId != null ? null : options.Query;
             DocumentId = options.DocumentId;

--- a/src/GraphQL.MemoryCache/MemoryDocumentCacheOptions.cs
+++ b/src/GraphQL.MemoryCache/MemoryDocumentCacheOptions.cs
@@ -24,8 +24,9 @@ public class MemoryDocumentCacheOptions : MemoryCacheOptions, IOptions<MemoryDoc
 
     /// <summary>
     /// A delegate that supplies an extra value to be included in the cache key.
-    /// By default, this returns the <see cref="ExecutionOptions.Schema"/>. You can override
-    /// this behavior to incorporate additional uniqueness.
+    /// When not configured, the extra value is computed from <see cref="ExecutionOptions.Schema"/> as follows:
+    /// The schema instance is used for schema-first and dynamic schemas (when the type <see cref="Types.Schema"/>),
+    /// and the schema type is used for type-first and code-first schemas (when the type is derived from <see cref="Types.Schema"/>).
     /// </summary>
     public Func<ExecutionOptions, object?>? AdditionalCacheKeySelector { get; set; }
 

--- a/src/GraphQL.MemoryCache/MemoryDocumentCacheOptions.cs
+++ b/src/GraphQL.MemoryCache/MemoryDocumentCacheOptions.cs
@@ -22,5 +22,12 @@ public class MemoryDocumentCacheOptions : MemoryCacheOptions, IOptions<MemoryDoc
     /// </summary>
     public TimeSpan? SlidingExpiration { get; set; }
 
+    /// <summary>
+    /// A delegate that supplies an extra value to be included in the cache key.
+    /// By default, this returns the <see cref="ExecutionOptions.Schema"/>. You can override
+    /// this behavior to incorporate additional uniqueness.
+    /// </summary>
+    public Func<ExecutionOptions, object?>? AdditionalCacheKeySelector { get; set; }
+
     MemoryDocumentCacheOptions IOptions<MemoryDocumentCacheOptions>.Value => this;
 }

--- a/src/GraphQL.MemoryCache/MemoryDocumentCacheOptions.cs
+++ b/src/GraphQL.MemoryCache/MemoryDocumentCacheOptions.cs
@@ -25,7 +25,7 @@ public class MemoryDocumentCacheOptions : MemoryCacheOptions, IOptions<MemoryDoc
     /// <summary>
     /// A delegate that supplies an extra value to be included in the cache key.
     /// When not configured, the extra value is computed from <see cref="ExecutionOptions.Schema"/> as follows:
-    /// The schema instance is used for schema-first and dynamic schemas (when the type <see cref="Types.Schema"/>),
+    /// The schema instance is used for schema-first and dynamic schemas (when the type is <see cref="Types.Schema"/>),
     /// and the schema type is used for type-first and code-first schemas (when the type is derived from <see cref="Types.Schema"/>).
     /// </summary>
     public Func<ExecutionOptions, object?>? AdditionalCacheKeySelector { get; set; }


### PR DESCRIPTION
This fix/change prevents the document cache from matching on a query previously cached for one schema when the same query is requested for another schema.

See:
- #4121

Added docs:

---


### 31. Unique Cache Keys for Multi-Schema Environments (from version 8.4.0)

Document caching now supports unique cache keys for applications using multiple or dynamic schemas. The cache key has been enhanced to include an extra property computed by the new `AdditionalCacheKeySelector` delegate. By default, this delegate distinguishes between schema-first and code-first implementations by returning the schema instance for schema-first and dynamic schemas (those that are direct implementations of `Schema`), and the schema type for code-first and type-first schemas (schemas that derive from `Schema`). This change ensures that cached documents are uniquely identified even when multiple schemas are configured in the same application, while still supporting caching for scoped code-first and type-first schemas.

To migrate, you may continue using the default behavior. However, if you need further customization -- such as incorporating additional context to identify unique dynamic schemas -- you can override the default selector as shown in the example below:

```csharp
services.AddGraphQL(b => b
    .UseMemoryCache(options =>
    {
        options.AdditionalCacheKeySelector = execOptions =>
        {
            if (execOptions.UserContext is IDictionary<string, object> context &&
                context.TryGetValue("CustomHeader", out var header))
            {
                return header;
            }
            return null;
        };
    })
);
```

These changes help ensure that cached documents are correctly associated with the appropriate schema when multiple schemas are in use.