### PR TITLE
Allow implicit struct constructors

### DIFF
--- a/src/GraphQL/Extensions/ObjectExtensions.Compiled.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.Compiled.cs
@@ -50,7 +50,9 @@ public static partial class ObjectExtensions
             Expression.Assign(
                 objParam,
                 Expression.MemberInit(
-                    Expression.New(bestConstructor, ctorFields.Select(GetExpressionForCtorParameter)),
+                    bestConstructor == null
+                        ? Expression.New(info.Type) // implicit public parameterless constructor of structs
+                        : Expression.New(bestConstructor, ctorFields.Select(GetExpressionForCtorParameter)),
                     members.Where(x => x.IsRequired || x.IsInitOnly).Select(GetBindingForMember)))
         };
 

--- a/src/GraphQL/Extensions/ObjectExtensions.cs
+++ b/src/GraphQL/Extensions/ObjectExtensions.cs
@@ -13,7 +13,7 @@ namespace GraphQL;
 /// </summary>
 public static partial class ObjectExtensions
 {
-    private static readonly ConcurrentDictionary<Type, (ConstructorInfo Constructor, ParameterInfo[] ConstructorParameters)> _types = new();
+    private static readonly ConcurrentDictionary<Type, (ConstructorInfo? Constructor, ParameterInfo[] ConstructorParameters)> _types = new();
     private static readonly ConcurrentDictionary<(Type Type, string PropertyName), (MemberInfo MemberInfo, bool IsInitOnly, bool IsRequired)> _members = new();
 
     /// <summary>
@@ -76,7 +76,7 @@ public static partial class ObjectExtensions
         {
             obj = reflectionInfo.CtorFields.Length == 0
                 ? Activator.CreateInstance(reflectionInfo.Type)!
-                : reflectionInfo.Constructor.Invoke(ctorArguments);
+                : reflectionInfo.Constructor!.Invoke(ctorArguments);
         }
         catch (TargetInvocationException ex)
         {
@@ -121,14 +121,14 @@ public static partial class ObjectExtensions
     {
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
         public readonly Type Type;
-        public readonly ConstructorInfo Constructor;
+        public readonly ConstructorInfo? Constructor; // can be null for implicit public parameterless constructors of structs
         public readonly CtorParameterInfo[] CtorFields;
         public readonly MemberFieldInfo[] MemberFields;
 
         public ReflectionInfo(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
             Type type,
-            ConstructorInfo constructor,
+            ConstructorInfo? constructor,
             CtorParameterInfo[] ctorFields,
             MemberFieldInfo[] memberFields)
         {
@@ -215,7 +215,7 @@ public static partial class ObjectExtensions
 #pragma warning disable IL2067 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
                 var constructor = AutoRegisteringHelper.GetConstructor(clrType);
 #pragma warning restore IL2067 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
-                var parameters = constructor.GetParameters();
+                var parameters = constructor?.GetParameters() ?? Array.Empty<ParameterInfo>();
                 return (constructor, parameters);
             });
 

--- a/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringHelper.cs
@@ -352,17 +352,27 @@ public static class AutoRegisteringHelper
     /// Identifies the constructor to use when constructing instances of <paramref name="sourceType"/>.
     /// Selects any public constructor marked with <see cref="GraphQLConstructorAttribute"/>, or the public
     /// parameterless constructor, or the only public contructor, or throws an exception otherwise.
+    /// May return <see langword="null"/> for the implicit public parameterless constructor for structs.
     /// </summary>
-    internal static ConstructorInfo GetConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type sourceType)
+    internal static ConstructorInfo? GetConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type sourceType)
     {
         var ret = GetConstructorOrDefault(sourceType);
         // if there are no valid constructors, throw the proper exception
         if (ret == null)
         {
             if (sourceType.GetConstructors().Length == 0)
+            {
+                if (sourceType.IsValueType)
+                {
+                    // structs have an implicit parameterless constructor
+                    return null;
+                }
                 throw new InvalidOperationException($"No public constructors found on CLR type '{sourceType.GetFriendlyName()}'.");
+            }
             else
+            {
                 throw new InvalidOperationException($"CLR type '{sourceType.GetFriendlyName()}' must have a public parameterless constructor, a single constructor, or a public constructor marked with " + nameof(GraphQLConstructorAttribute) + ".");
+            }
         }
         return ret;
     }


### PR DESCRIPTION
Currently `AutoRegisteringInputObjectGraphType` cannot deserialize to a struct that has no explicit constructor.  This patch fixes the logic so if no explicitly defined constructors are found, the deserialization logic will use the implicit constructor.  This would be natural for code such as this, which was previously unsupported due to no explicitly defined constructors:

```cs
public struct MyStruct
{
    public int Id { get; set; }
    public string Name { get; set; }
}
```

This change does not affect any existing schemas, and as such is considered a bugfix.

See:
- #4129 