### PR TITLE
Add IGraphQLBuilder.VerifyServices extension method

### DIFF
--- a/docs2/site/docs/getting-started/dependency-injection.md
+++ b/docs2/site/docs/getting-started/dependency-injection.md
@@ -113,6 +113,7 @@ A list of the available extension methods is below:
 | `UseMiddleware<>`       | Registers the specified middleware and configures it to be installed during schema initialization | |
 | `UsePersistedDocuments` | Registers the persisted document handler and configures its options | |
 | `UseTelemetry`          | Creates telemetry events based on the System.Diagnostics.Activity API, primarily for use with OpenTelemetry | .NET 5+ |
+| `ValidateServices`      | Verifies that all injected services can be created during GraphQL field execution | |
 | `WithTimeout`           | Configures the execution timeout | |
 
 The above methods will register the specified services typically as singletons unless otherwise specified. Graph types and middleware are registered

--- a/samples/GraphQL.Harness/Startup.cs
+++ b/samples/GraphQL.Harness/Startup.cs
@@ -23,6 +23,7 @@ public class Startup
             .AddGraphTypes(typeof(StarWarsQuery).Assembly)
             .UseMiddleware<CountFieldMiddleware>(false) // do not auto-install middleware
             .UseMiddleware<InstrumentFieldsMiddleware>(false) // do not auto-install middleware
+            .ValidateServices()
         );
 
         // add something like repository

--- a/src/GraphQL.ApiTests/net50/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.MicrosoftDI.approved.txt
@@ -182,6 +182,7 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddScopedSubscriptionExecutionStrategy(this GraphQL.DI.IGraphQLBuilder builder, bool serialExecution = true) { }
         public static GraphQL.DI.IGraphQLBuilder AddSelfActivatingSchema<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
+        public static GraphQL.DI.IGraphQLBuilder ValidateServices(this GraphQL.DI.IGraphQLBuilder builder) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method)]
     public class ScopedAttribute : GraphQL.GraphQLAttribute

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -257,12 +257,15 @@ namespace GraphQL
     }
     public static class FieldExtensions
     {
-        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter graphType)
+        public static TMetadataWriter DependsOn<TMetadataWriter>(this TMetadataWriter fieldType, System.Type serviceType)
+            where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
+        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter fieldType)
             where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
     }
     [System.AttributeUsage(System.AttributeTargets.Parameter)]
     public class FromServicesAttribute : GraphQL.GraphQLAttribute
     {
+        public const string REQUIRED_SERVICES_METADATA = "__RequiredServices__";
         public FromServicesAttribute() { }
         public override void Modify(GraphQL.Types.ArgumentInformation argumentInformation) { }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -257,12 +257,15 @@ namespace GraphQL
     }
     public static class FieldExtensions
     {
-        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter graphType)
+        public static TMetadataWriter DependsOn<TMetadataWriter>(this TMetadataWriter fieldType, System.Type serviceType)
+            where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
+        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter fieldType)
             where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
     }
     [System.AttributeUsage(System.AttributeTargets.Parameter)]
     public class FromServicesAttribute : GraphQL.GraphQLAttribute
     {
+        public const string REQUIRED_SERVICES_METADATA = "__RequiredServices__";
         public FromServicesAttribute() { }
         public override void Modify(GraphQL.Types.ArgumentInformation argumentInformation) { }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -254,12 +254,15 @@ namespace GraphQL
     }
     public static class FieldExtensions
     {
-        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter graphType)
+        public static TMetadataWriter DependsOn<TMetadataWriter>(this TMetadataWriter fieldType, System.Type serviceType)
+            where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
+        public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter fieldType)
             where TMetadataWriter : GraphQL.Types.IFieldMetadataWriter { }
     }
     [System.AttributeUsage(System.AttributeTargets.Parameter)]
     public class FromServicesAttribute : GraphQL.GraphQLAttribute
     {
+        public const string REQUIRED_SERVICES_METADATA = "__RequiredServices__";
         public FromServicesAttribute() { }
         public override void Modify(GraphQL.Types.ArgumentInformation argumentInformation) { }
     }

--- a/src/GraphQL.ApiTests/netstandard20/GraphQL.MicrosoftDI.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20/GraphQL.MicrosoftDI.approved.txt
@@ -182,6 +182,7 @@ namespace GraphQL
         public static GraphQL.DI.IGraphQLBuilder AddScopedSubscriptionExecutionStrategy(this GraphQL.DI.IGraphQLBuilder builder, bool serialExecution = true) { }
         public static GraphQL.DI.IGraphQLBuilder AddSelfActivatingSchema<TSchema>(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.DI.ServiceLifetime serviceLifetime = 0)
             where TSchema :  class, GraphQL.Types.ISchema { }
+        public static GraphQL.DI.IGraphQLBuilder ValidateServices(this GraphQL.DI.IGraphQLBuilder builder) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method)]
     public class ScopedAttribute : GraphQL.GraphQLAttribute

--- a/src/GraphQL.MicrosoftDI.Tests/GraphQL.MicrosoftDI.Tests.csproj
+++ b/src/GraphQL.MicrosoftDI.Tests/GraphQL.MicrosoftDI.Tests.csproj
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
     <PackageReference Include="System.Reactive" Version="6.*" />
   </ItemGroup>
 

--- a/src/GraphQL.MicrosoftDI.Tests/GraphQLBuilderExtensionTests.cs
+++ b/src/GraphQL.MicrosoftDI.Tests/GraphQLBuilderExtensionTests.cs
@@ -1,5 +1,6 @@
 using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
+using GraphQL.Utilities;
 
 namespace GraphQL.MicrosoftDI.Tests;
 
@@ -51,6 +52,201 @@ public class GraphQLBuilderExtensionTests
         services.AddGraphQL(builder => Should.Throw<InvalidOperationException>(() => builder.AddSelfActivatingSchema<MySchema>(DI.ServiceLifetime.Transient)));
     }
 
+    [Fact]
+    public void VerifyServices_PassesWhenAllServicesRegistered()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<TestService1>();
+        services.AddSingleton<TestService2>();
+
+        // Act
+        services.AddGraphQL(builder => builder
+            .AddSchema<VerifyServicesTestSchema>()
+            .ValidateServices());
+
+        var serviceProvider = services.BuildServiceProvider();
+        var schema = serviceProvider.GetRequiredService<ISchema>();
+
+        // Assert - should not throw
+        schema.Initialize();
+    }
+
+    [Fact]
+    public void VerifyServices_ThrowsWhenOnlyOneServiceRegistered()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<TestService1>(); // Only register TestService1, not TestService2
+
+        // Act & Assert
+        services.AddGraphQL(builder => builder
+            .AddSchema<VerifyServicesTestSchema>()
+            .ValidateServices());
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        // This should throw because TestService2 is not registered
+        Should.Throw<InvalidOperationException>(() =>
+        {
+            var schema = serviceProvider.GetRequiredService<ISchema>();
+            schema.Initialize();
+        }).Message.ShouldBe("""
+            The service 'GraphQL.MicrosoftDI.Tests.GraphQLBuilderExtensionTests+TestService2' required by 'Class3.getData' is not registered.
+            """, StringCompareShould.IgnoreLineEndings);
+    }
+
+    [Fact]
+    public void VerifyServices_ThrowsWhenBothServicesAreMissing()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        services.AddGraphQL(builder => builder
+            .AddSchema<VerifyServicesTestSchema>()
+            .ValidateServices());
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        // This should throw because TestService is not registered
+        Should.Throw<InvalidOperationException>(() =>
+        {
+            var schema = serviceProvider.GetRequiredService<ISchema>();
+            schema.Initialize();
+        }).Message.ShouldBe("""
+            The following service validation errors were found:
+            The service 'GraphQL.MicrosoftDI.Tests.GraphQLBuilderExtensionTests+TestService1' required by 'Class3.getData' is not registered.
+            The service 'GraphQL.MicrosoftDI.Tests.GraphQLBuilderExtensionTests+TestService2' required by 'Class3.getData' is not registered.
+            """, StringCompareShould.IgnoreLineEndings);
+    }
+
+    [Fact]
+    public void VerifyServices_RegularObjectGraphType_PassesWhenAllServicesRegistered()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        // Register all 15 services
+        services.AddSingleton<Service1>();
+        services.AddSingleton<Service2>();
+        services.AddSingleton<Service3>();
+        services.AddSingleton<Service4>();
+        services.AddSingleton<Service5>();
+        services.AddSingleton<Service6>();
+        services.AddSingleton<Service7>();
+        services.AddSingleton<Service8>();
+        services.AddSingleton<Service9>();
+        services.AddSingleton<Service10>();
+        services.AddSingleton<Service11>();
+        services.AddSingleton<Service12>();
+        services.AddSingleton<Service13>();
+        services.AddSingleton<Service14>();
+        services.AddSingleton<Service15>();
+
+        // Act
+        services.AddGraphQL(builder => builder
+            .AddSchema<RegularObjectGraphTypeSchema>()
+            .ValidateServices());
+
+        var serviceProvider = services.BuildServiceProvider();
+        var schema = serviceProvider.GetRequiredService<ISchema>();
+
+        // Assert - should not throw
+        schema.Initialize();
+    }
+
+    [Fact]
+    public void VerifyServices_RegularObjectGraphType_ThrowsWhenAllServicesMissing()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        // Don't register any services
+
+        // Act & Assert
+        services.AddGraphQL(builder => builder
+            .AddSchema<RegularObjectGraphTypeSchema>()
+            .ValidateServices());
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        // This should throw because all services are missing
+        var exception = Should.Throw<InvalidOperationException>(() =>
+        {
+            var schema = serviceProvider.GetRequiredService<ISchema>();
+            schema.Initialize();
+        });
+
+        // Verify that the error message contains all 15 missing services
+        exception.Message.ShouldContain("The following service validation errors were found:");
+        for (int i = 1; i <= 15; i++)
+        {
+            exception.Message.ShouldContain($"The service 'GraphQL.MicrosoftDI.Tests.GraphQLBuilderExtensionTests+Service{i}' required by ");
+        }
+    }
+
+    [Fact]
+    public void VerifyServices_AsyncRegularObjectGraphType_PassesWhenAllServicesRegistered()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        // Register all 15 services
+        services.AddSingleton<Service1>();
+        services.AddSingleton<Service2>();
+        services.AddSingleton<Service3>();
+        services.AddSingleton<Service4>();
+        services.AddSingleton<Service5>();
+        services.AddSingleton<Service6>();
+        services.AddSingleton<Service7>();
+        services.AddSingleton<Service8>();
+        services.AddSingleton<Service9>();
+        services.AddSingleton<Service10>();
+        services.AddSingleton<Service11>();
+        services.AddSingleton<Service12>();
+        services.AddSingleton<Service13>();
+        services.AddSingleton<Service14>();
+        services.AddSingleton<Service15>();
+
+        // Act
+        services.AddGraphQL(builder => builder
+            .AddSchema<AsyncRegularObjectGraphTypeSchema>()
+            .ValidateServices());
+
+        var serviceProvider = services.BuildServiceProvider();
+        var schema = serviceProvider.GetRequiredService<ISchema>();
+
+        // Assert - should not throw
+        schema.Initialize();
+    }
+
+    [Fact]
+    public void VerifyServices_AsyncRegularObjectGraphType_ThrowsWhenAllServicesMissing()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        // Don't register any services
+
+        // Act & Assert
+        services.AddGraphQL(builder => builder
+            .AddSchema<AsyncRegularObjectGraphTypeSchema>()
+            .ValidateServices());
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        // This should throw because all services are missing
+        var exception = Should.Throw<InvalidOperationException>(() =>
+        {
+            var schema = serviceProvider.GetRequiredService<ISchema>();
+            schema.Initialize();
+        });
+
+        // Verify that the error message contains all 15 missing services
+        exception.Message.ShouldContain("The following service validation errors were found:");
+        for (int i = 1; i <= 15; i++)
+        {
+            exception.Message.ShouldContain($"The service 'GraphQL.MicrosoftDI.Tests.GraphQLBuilderExtensionTests+Service{i}' required by ");
+        }
+    }
+
     private class MySchema : Schema
     {
         public MySchema(IServiceProvider serviceProvider) : base(serviceProvider)
@@ -73,6 +269,165 @@ public class GraphQLBuilderExtensionTests
 
         private Class2()
         {
+        }
+    }
+
+    private class TestService1
+    {
+        public string GetData1() => "Test Data 1";
+    }
+
+    private class TestService2
+    {
+        public string GetData2() => "Test Data 2";
+    }
+
+    private class VerifyServicesTestSchema : Schema
+    {
+        public VerifyServicesTestSchema(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+            Query = new AutoRegisteringObjectGraphType<Class3>();
+        }
+    }
+
+    private class Class3
+    {
+        public string GetData(string input, [FromServices] TestService1 service1, [FromServices] TestService2 service2)
+        {
+            return service1.GetData1() + " & " + service2.GetData2() + ": " + input;
+        }
+    }
+
+    // 15 different service classes for the new tests
+    private class Service1 { }
+    private class Service2 { }
+    private class Service3 { }
+    private class Service4 { }
+    private class Service5 { }
+    private class Service6 { }
+    private class Service7 { }
+    private class Service8 { }
+    private class Service9 { }
+    private class Service10 { }
+    private class Service11 { }
+    private class Service12 { }
+    private class Service13 { }
+    private class Service14 { }
+    private class Service15 { }
+
+    // Regular ObjectGraphType for the query
+    private class RegularQueryType : ObjectGraphType
+    {
+        public RegularQueryType()
+        {
+            Name = "Query";
+
+            // Field with 1 service
+            Field<StringGraphType>("field1")
+                .Resolve()
+                .WithService<Service1>()
+                .Resolve((context, service1) => "");
+
+            // Field with 2 services
+            Field<StringGraphType>("field2")
+                .Resolve()
+                .WithService<Service2>()
+                .WithService<Service3>()
+                .Resolve((context, service2, service3) => "");
+
+            // Field with 3 services
+            Field<StringGraphType>("field3")
+                .Resolve()
+                .WithService<Service4>()
+                .WithService<Service5>()
+                .WithService<Service6>()
+                .Resolve((context, service4, service5, service6) => "");
+
+            // Field with 4 services
+            Field<StringGraphType>("field4")
+                .Resolve()
+                .WithService<Service7>()
+                .WithService<Service8>()
+                .WithService<Service9>()
+                .WithService<Service10>()
+                .Resolve((context, service7, service8, service9, service10) => "");
+
+            // Field with 5 services
+            Field<StringGraphType>("field5")
+                .Resolve()
+                .WithService<Service11>()
+                .WithService<Service12>()
+                .WithService<Service13>()
+                .WithService<Service14>()
+                .WithService<Service15>()
+                .Resolve((context, service11, service12, service13, service14, service15) => "");
+        }
+    }
+
+    // Schema using the regular ObjectGraphType
+    private class RegularObjectGraphTypeSchema : Schema
+    {
+        public RegularObjectGraphTypeSchema(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+            Query = new RegularQueryType();
+        }
+    }
+
+    // Regular ObjectGraphType for the query with async resolvers
+    private class AsyncRegularQueryType : ObjectGraphType
+    {
+        public AsyncRegularQueryType()
+        {
+            Name = "Query";
+
+            // Field with 1 service
+            Field<StringGraphType>("field1")
+                .Resolve()
+                .WithService<Service1>()
+                .ResolveAsync((context, service1) => Task.FromResult<object?>(null));
+
+            // Field with 2 services
+            Field<StringGraphType>("field2")
+                .Resolve()
+                .WithService<Service2>()
+                .WithService<Service3>()
+                .ResolveAsync((context, service2, service3) => Task.FromResult<object?>(null));
+
+            // Field with 3 services
+            Field<StringGraphType>("field3")
+                .Resolve()
+                .WithService<Service4>()
+                .WithService<Service5>()
+                .WithService<Service6>()
+                .ResolveAsync((context, service4, service5, service6) => Task.FromResult<object?>(null));
+
+            // Field with 4 services
+            Field<StringGraphType>("field4")
+                .Resolve()
+                .WithService<Service7>()
+                .WithService<Service8>()
+                .WithService<Service9>()
+                .WithService<Service10>()
+                .ResolveAsync((context, service7, service8, service9, service10) => Task.FromResult<object?>(null));
+
+            // Field with 5 services
+            Field<StringGraphType>("field5")
+                .Resolve()
+                .WithService<Service11>()
+                .WithService<Service12>()
+                .WithService<Service13>()
+                .WithService<Service14>()
+                .WithService<Service15>()
+                .ResolveAsync((context, service11, service12, service13, service14, service15) => Task.FromResult<object?>(null));
+        }
+    }
+
+    // Schema using the regular ObjectGraphType with async resolvers
+    private class AsyncRegularObjectGraphTypeSchema : Schema
+    {
+        public AsyncRegularObjectGraphTypeSchema(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+            Query = new AsyncRegularQueryType();
         }
     }
 }

--- a/src/GraphQL.MicrosoftDI.Tests/GraphQLBuilderTests.cs
+++ b/src/GraphQL.MicrosoftDI.Tests/GraphQLBuilderTests.cs
@@ -47,9 +47,15 @@ public class GraphQLBuilderTests
         {
             var toRemove = new ServiceDescriptor(serviceType, implementationType, ServiceLifetime.Transient);
             descriptorList.Add(toRemove);
-            mockServiceCollection.Setup(x => x.Remove(toRemove)).Returns<ServiceDescriptor>(d => descriptorList.Remove(d)).Verifiable();
+            mockServiceCollection.Setup(x => x.RemoveAt(It.IsAny<int>())).Callback<int>(i =>
+            {
+                descriptorList[i].ShouldBe(toRemove);
+                descriptorList.RemoveAt(i);
+            });
         }
         mockServiceCollection.Setup(x => x.GetEnumerator()).Returns(() => descriptorList.GetEnumerator());
+        mockServiceCollection.Setup(x => x.Count).Returns(() => descriptorList.Count);
+        mockServiceCollection.As<IList<ServiceDescriptor>>().Setup(x => x[It.IsAny<int>()]).Returns<int>(i => descriptorList[i]);
         var services = mockServiceCollection.Object;
         var builder = new GraphQLBuilder(services, b => b.Services.Register(serviceType, implementationType, serviceLifetime, replace));
         mockServiceCollection.Verify();
@@ -89,9 +95,15 @@ public class GraphQLBuilderTests
         {
             var toRemove = new ServiceDescriptor(typeof(Interface1), typeof(Class1), ServiceLifetime.Transient);
             descriptorList.Add(toRemove);
-            mockServiceCollection.Setup(x => x.Remove(toRemove)).Returns<ServiceDescriptor>(d => descriptorList.Remove(d)).Verifiable();
+            mockServiceCollection.Setup(x => x.RemoveAt(It.IsAny<int>())).Callback<int>(i =>
+            {
+                descriptorList[i].ShouldBe(toRemove);
+                descriptorList.RemoveAt(i);
+            }).Verifiable();
         }
         mockServiceCollection.Setup(x => x.GetEnumerator()).Returns(() => descriptorList.GetEnumerator());
+        mockServiceCollection.Setup(x => x.Count).Returns(() => descriptorList.Count);
+        mockServiceCollection.As<IList<ServiceDescriptor>>().Setup(x => x[It.IsAny<int>()]).Returns<int>(i => descriptorList[i]);
         var services = mockServiceCollection.Object;
         var builder = new GraphQLBuilder(services, b => b.Services.Register<Interface1>(factory, serviceLifetime, replace));
         mockServiceCollection.Verify();
@@ -123,9 +135,15 @@ public class GraphQLBuilderTests
         {
             var toRemove = new ServiceDescriptor(typeof(Interface1), typeof(Class1), ServiceLifetime.Transient);
             descriptorList.Add(toRemove);
-            mockServiceCollection.Setup(x => x.Remove(toRemove)).Returns<ServiceDescriptor>(d => descriptorList.Remove(d)).Verifiable();
+            mockServiceCollection.Setup(x => x.RemoveAt(It.IsAny<int>())).Callback<int>(i =>
+            {
+                descriptorList[i].ShouldBe(toRemove);
+                descriptorList.RemoveAt(i);
+            }).Verifiable();
         }
         mockServiceCollection.Setup(x => x.GetEnumerator()).Returns(() => descriptorList.GetEnumerator());
+        mockServiceCollection.Setup(x => x.Count).Returns(() => descriptorList.Count);
+        mockServiceCollection.As<IList<ServiceDescriptor>>().Setup(x => x[It.IsAny<int>()]).Returns<int>(i => descriptorList[i]);
         var services = mockServiceCollection.Object;
         var builder = new GraphQLBuilder(services, b => b.Services.Register<Interface1>(instance, replace));
         mockServiceCollection.Verify();
@@ -162,6 +180,8 @@ public class GraphQLBuilderTests
             descriptorList.Add(d);
         }).Verifiable();
         mockServiceCollection.Setup(x => x.GetEnumerator()).Returns(() => descriptorList.GetEnumerator());
+        mockServiceCollection.Setup(x => x.Count).Returns(() => descriptorList.Count);
+        mockServiceCollection.As<IList<ServiceDescriptor>>().Setup(x => x[It.IsAny<int>()]).Returns<int>(i => descriptorList[i]);
         var services = mockServiceCollection.Object;
         var builder = new GraphQLBuilder(services, b => b.Services.TryRegister(serviceType, implementationType, serviceLifetime));
         mockServiceCollection.Verify();
@@ -193,8 +213,10 @@ public class GraphQLBuilderTests
             descriptorList.Add(d);
         }).Verifiable();
         mockServiceCollection.Setup(x => x.GetEnumerator()).Returns(() => descriptorList.GetEnumerator());
+        mockServiceCollection.Setup(x => x.Count).Returns(() => descriptorList.Count);
+        mockServiceCollection.As<IList<ServiceDescriptor>>().Setup(x => x[It.IsAny<int>()]).Returns<int>(i => descriptorList[i]);
         var services = mockServiceCollection.Object;
-        services.AddTransient(serviceType, _ => null);
+        services.AddTransient(serviceType, _ => null!);
         var builder = new GraphQLBuilder(services, b => b.Services.TryRegister(serviceType, implementationType, serviceLifetime));
         mockServiceCollection.Verify();
         match.ShouldBeTrue();
@@ -228,6 +250,8 @@ public class GraphQLBuilderTests
             descriptorList.Add(d);
         }).Verifiable();
         mockServiceCollection.Setup(x => x.GetEnumerator()).Returns(() => descriptorList.GetEnumerator());
+        mockServiceCollection.Setup(x => x.Count).Returns(() => descriptorList.Count);
+        mockServiceCollection.As<IList<ServiceDescriptor>>().Setup(x => x[It.IsAny<int>()]).Returns<int>(i => descriptorList[i]);
         var services = mockServiceCollection.Object;
         var builder = new GraphQLBuilder(services, b => b.Services.TryRegister<Interface1>(factory, serviceLifetime));
         mockServiceCollection.Verify();
@@ -253,6 +277,8 @@ public class GraphQLBuilderTests
             descriptorList.Add(d);
         }).Verifiable();
         mockServiceCollection.Setup(x => x.GetEnumerator()).Returns(() => descriptorList.GetEnumerator());
+        mockServiceCollection.Setup(x => x.Count).Returns(() => descriptorList.Count);
+        mockServiceCollection.As<IList<ServiceDescriptor>>().Setup(x => x[It.IsAny<int>()]).Returns<int>(i => descriptorList[i]);
         var services = mockServiceCollection.Object;
         var builder = new GraphQLBuilder(services, b => b.Services.TryRegister<Interface1>(instance));
         mockServiceCollection.Verify();

--- a/src/GraphQL.MicrosoftDI/MicrosoftDIGraphQLBuilderExtensions.cs
+++ b/src/GraphQL.MicrosoftDI/MicrosoftDIGraphQLBuilderExtensions.cs
@@ -88,4 +88,14 @@ public static class MicrosoftDIGraphQLBuilderExtensions
             GraphQLParser.AST.OperationType.Subscription);
         return builder;
     }
+
+    /// <summary>
+    /// Verifies that all injected services can be created during GraphQL field execution.
+    /// Requires support for IServiceProviderIsService by the dependency injection framework.
+    /// </summary>
+    public static IGraphQLBuilder ValidateServices(this IGraphQLBuilder builder)
+    {
+        builder.Services.TryRegister<IConfigureSchema, ValidateServicesSchemaConfigurator>(ServiceLifetime.Singleton);
+        return builder;
+    }
 }

--- a/src/GraphQL.MicrosoftDI/ResolverBuilder.cs
+++ b/src/GraphQL.MicrosoftDI/ResolverBuilder.cs
@@ -123,6 +123,7 @@ public class ResolverBuilder<TSourceType, TReturnType, T1>
                 context,
                 context.RequestServices.GetRequiredService<T1>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
         return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
@@ -134,6 +135,7 @@ public class ResolverBuilder<TSourceType, TReturnType, T1>
                 context,
                 context.RequestServices.GetRequiredService<T1>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
         return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 
@@ -197,6 +199,8 @@ public class ResolverBuilder<TSourceType, TReturnType, T1, T2>
                 context.RequestServices.GetRequiredService<T1>(),
                 context.RequestServices.GetRequiredService<T2>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
+        _builder.FieldType.DependsOn(typeof(T2));
         return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
@@ -209,6 +213,8 @@ public class ResolverBuilder<TSourceType, TReturnType, T1, T2>
                 context.RequestServices.GetRequiredService<T1>(),
                 context.RequestServices.GetRequiredService<T2>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
+        _builder.FieldType.DependsOn(typeof(T2));
         return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 
@@ -273,6 +279,9 @@ public class ResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
                 context.RequestServices.GetRequiredService<T2>(),
                 context.RequestServices.GetRequiredService<T3>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
+        _builder.FieldType.DependsOn(typeof(T2));
+        _builder.FieldType.DependsOn(typeof(T3));
         return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
@@ -286,6 +295,9 @@ public class ResolverBuilder<TSourceType, TReturnType, T1, T2, T3>
                 context.RequestServices.GetRequiredService<T2>(),
                 context.RequestServices.GetRequiredService<T3>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
+        _builder.FieldType.DependsOn(typeof(T2));
+        _builder.FieldType.DependsOn(typeof(T3));
         return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 
@@ -351,6 +363,10 @@ public class ResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
                 context.RequestServices.GetRequiredService<T3>(),
                 context.RequestServices.GetRequiredService<T4>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
+        _builder.FieldType.DependsOn(typeof(T2));
+        _builder.FieldType.DependsOn(typeof(T3));
+        _builder.FieldType.DependsOn(typeof(T4));
         return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
@@ -365,6 +381,10 @@ public class ResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4>
                 context.RequestServices.GetRequiredService<T3>(),
                 context.RequestServices.GetRequiredService<T4>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
+        _builder.FieldType.DependsOn(typeof(T2));
+        _builder.FieldType.DependsOn(typeof(T3));
+        _builder.FieldType.DependsOn(typeof(T4));
         return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 
@@ -427,6 +447,11 @@ public class ResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5>
                 context.RequestServices.GetRequiredService<T4>(),
                 context.RequestServices.GetRequiredService<T5>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
+        _builder.FieldType.DependsOn(typeof(T2));
+        _builder.FieldType.DependsOn(typeof(T3));
+        _builder.FieldType.DependsOn(typeof(T4));
+        _builder.FieldType.DependsOn(typeof(T5));
         return _scoped ? _builder.ResolveScoped(resolver2) : _builder.Resolve(resolver2);
     }
 
@@ -442,6 +467,11 @@ public class ResolverBuilder<TSourceType, TReturnType, T1, T2, T3, T4, T5>
                 context.RequestServices.GetRequiredService<T4>(),
                 context.RequestServices.GetRequiredService<T5>());
 
+        _builder.FieldType.DependsOn(typeof(T1));
+        _builder.FieldType.DependsOn(typeof(T2));
+        _builder.FieldType.DependsOn(typeof(T3));
+        _builder.FieldType.DependsOn(typeof(T4));
+        _builder.FieldType.DependsOn(typeof(T5));
         return _scoped ? _builder.ResolveScopedAsync(resolver2) : _builder.ResolveAsync(resolver2);
     }
 

--- a/src/GraphQL.MicrosoftDI/ValidateServicesSchemaConfigurator.cs
+++ b/src/GraphQL.MicrosoftDI/ValidateServicesSchemaConfigurator.cs
@@ -1,0 +1,21 @@
+using GraphQL.DI;
+using GraphQL.MicrosoftDI;
+using GraphQL.Types;
+
+namespace GraphQL;
+
+/// <summary>
+/// Adds a schema validator to the schema that ensures all services required by <see cref="FromServicesAttribute"/> are registered.
+/// </summary>
+internal sealed class ValidateServicesSchemaConfigurator : IConfigureSchema
+{
+    /// <inheritdoc/>
+    public void Configure(ISchema schema, IServiceProvider serviceProvider)
+    {
+        var serviceValidator = ValidateServicesSchemaValidator.TryCreate(serviceProvider);
+        if (serviceValidator != null)
+            schema.RegisterVisitor(serviceValidator);
+        else
+            throw new InvalidOperationException("Could not create a service validator. Ensure that the dependency injection framework supports IServiceProviderIsService.");
+    }
+}

--- a/src/GraphQL.MicrosoftDI/ValidateServicesSchemaValidator.cs
+++ b/src/GraphQL.MicrosoftDI/ValidateServicesSchemaValidator.cs
@@ -1,0 +1,92 @@
+using System.Reflection;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.MicrosoftDI;
+
+/// <summary>
+/// A schema validator that ensures all services required by <see cref="FromServicesAttribute"/> are registered.
+/// </summary>
+internal sealed class ValidateServicesSchemaValidator : BaseSchemaNodeVisitor
+{
+    private readonly Func<Type, bool> _isValidService;
+    private List<string>? _errors;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidateServicesSchemaValidator"/> class.
+    /// </summary>
+    private ValidateServicesSchemaValidator(Func<Type, bool> isValidService)
+    {
+        _isValidService = isValidService;
+    }
+
+    /// <inheritdoc/>
+    public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
+    {
+        var serviceTypes = field.GetMetadata<List<Type>>(FromServicesAttribute.REQUIRED_SERVICES_METADATA);
+        if (serviceTypes != null)
+        {
+            foreach (var serviceType in serviceTypes)
+            {
+                if (!_isValidService(serviceType))
+                {
+                    _errors ??= new();
+                    _errors.Add($"The service '{serviceType.FullName}' required by '{type.Name}.{field.Name}' is not registered.");
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void PostVisitSchema(ISchema schema)
+    {
+        if (_errors != null)
+        {
+            if (_errors.Count == 1)
+                throw new InvalidOperationException(_errors[0]);
+            else
+                throw new InvalidOperationException($"The following service validation errors were found:{Environment.NewLine}{string.Join(Environment.NewLine, _errors)}");
+        }
+    }
+
+    /// <summary>
+    /// Attempts to create a new instance of <see cref="ValidateServicesSchemaValidator"/> for the specified service provider.
+    /// If the service provider implements IServiceProviderIsService, then a new instance will be returned.
+    /// </summary>
+    internal static ValidateServicesSchemaValidator? TryCreate(IServiceProvider serviceProvider)
+    {
+        try
+        {
+            var diProvider = serviceProvider.GetService<IServiceProvider>();
+            if (diProvider == null)
+                return null;
+
+            var providerType = diProvider.GetType();
+
+            // Get the assembly that contains IServiceCollection
+            var assembly = typeof(IServiceCollection).Assembly;
+
+            // Find the IServiceProviderIsService type in that assembly
+            var isServiceType = assembly.GetType("Microsoft.Extensions.DependencyInjection.IServiceProviderIsService");
+            if (isServiceType == null)
+                return null;
+
+            // Check if the provider implements the interface
+            var serviceProviderIsService = diProvider.GetService(isServiceType);
+            if (serviceProviderIsService == null)
+                return null;
+
+            var isValidServiceMethod = isServiceType.GetMethod("IsService", BindingFlags.Instance | BindingFlags.Public, null, [typeof(Type)], null);
+            if (isValidServiceMethod == null || isValidServiceMethod.ReturnType != typeof(bool))
+                return null;
+
+            var fn = (Func<Type, bool>)isValidServiceMethod.CreateDelegate(typeof(Func<Type, bool>), serviceProviderIsService);
+            return new ValidateServicesSchemaValidator(fn);
+        }
+        catch (AmbiguousMatchException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/GraphQL/Attributes/FromServicesAttribute.cs
+++ b/src/GraphQL/Attributes/FromServicesAttribute.cs
@@ -9,6 +9,12 @@ namespace GraphQL;
 [AttributeUsage(AttributeTargets.Parameter)]
 public class FromServicesAttribute : GraphQLAttribute
 {
+    /// <summary>
+    /// The metadata key used to store a list of the required DI-injected services for a given <see cref="QueryArgument"/>.
+    /// This information can be used during schema validation to ensure that all required services have been registered.
+    /// </summary>
+    public const string REQUIRED_SERVICES_METADATA = "__RequiredServices__";
+
     /* This is a typed copy of the below code, but does not work in AOT compilation scenarios.
      * However, this is the recommended pattern for user-defined attributes.
      * 
@@ -19,5 +25,8 @@ public class FromServicesAttribute : GraphQLAttribute
 
     /// <inheritdoc/>
     public override void Modify(ArgumentInformation argumentInformation)
-        => argumentInformation.SetDelegateWithCast(context => context.RequestServicesOrThrow().GetRequiredService(argumentInformation.ParameterInfo.ParameterType));
+    {
+        argumentInformation.SetDelegateWithCast(context => context.RequestServicesOrThrow().GetRequiredService(argumentInformation.ParameterInfo.ParameterType));
+        argumentInformation.FieldType?.DependsOn(argumentInformation.ParameterInfo.ParameterType);
+    }
 }

--- a/src/GraphQL/Extensions/FieldExtensions.cs
+++ b/src/GraphQL/Extensions/FieldExtensions.cs
@@ -18,7 +18,24 @@ public static class FieldExtensions
     /// to handle the conversion between the input and CLR object.
     /// </remarks>
     [AllowedOn<IInputObjectGraphType>]
-    public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter graphType)
+    public static TMetadataWriter NoClrMapping<TMetadataWriter>(this TMetadataWriter fieldType)
         where TMetadataWriter : IFieldMetadataWriter
-        => graphType.WithMetadata(InputObjectGraphType.ORIGINAL_EXPRESSION_PROPERTY_NAME, InputObjectGraphType.SKIP_EXPRESSION_VALUE_NAME);
+        => fieldType.WithMetadata(InputObjectGraphType.ORIGINAL_EXPRESSION_PROPERTY_NAME, InputObjectGraphType.SKIP_EXPRESSION_VALUE_NAME);
+
+    /// <summary>
+    /// Specifies that the field depends on a specific service type provided by the dependency injection provider.
+    /// </summary>
+    [AllowedOn<IObjectGraphType>]
+    public static TMetadataWriter DependsOn<TMetadataWriter>(this TMetadataWriter fieldType, Type serviceType)
+        where TMetadataWriter : IFieldMetadataWriter
+    {
+        var keys = fieldType.GetMetadata<List<Type>>(FromServicesAttribute.REQUIRED_SERVICES_METADATA);
+        if (keys == null)
+        {
+            keys = new List<Type>();
+            fieldType.Metadata[FromServicesAttribute.REQUIRED_SERVICES_METADATA] = keys;
+        }
+        keys.Add(serviceType);
+        return fieldType;
+    }
 }


### PR DESCRIPTION
The PR modifies `[FromServices]` and the resolver builder code to mark `FieldType` instances with metadata indicating which DI services are necessary to execute the resolver.  Then by adding `.ValidateServices()` to the startup, all those services can be validated that they can be serviced by the DI provider, reducing runtime errors due to missing services.

`.ValidateServices()` uses reflection to obtain a handle to `IServiceProviderIsService` as this type does not exist in the current dependency on Microsoft.Extensions.DependencyInjection.Abstractions 2.0.0.  Perhaps in v9 we should bump the dependency.

`.ValidateServices()` is opt-in and throws an exception when used with older versions of MSDI which do not contain this functionality.  This mimics the functionality of MSDI's BuildServiceProvider, where it is opt-in to verify the service chain.  It is also important to help reduce initialization time for scoped schemas.
