### PR TITLE
Support federation interface resolution

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>8.0.1-preview</VersionPrefix>
+    <VersionPrefix>8.5.0-preview</VersionPrefix>
     <NextVersion>9.0.0</NextVersion>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/samples/GraphQL.Federation.SchemaFirst.Sample1/MyFederatedResolver.cs
+++ b/samples/GraphQL.Federation.SchemaFirst.Sample1/MyFederatedResolver.cs
@@ -20,10 +20,10 @@ public class MyFederatedResolver<T> : IFederationResolver
 
     public bool MatchKeys(IDictionary<string, object?> representation) => true;
 
-    public object ParseRepresentation(IObjectGraphType graphType, IDictionary<string, object?> representation)
+    public object ParseRepresentation(IComplexGraphType graphType, IDictionary<string, object?> representation)
         => (int)Convert.ChangeType(representation["id"], typeof(int), CultureInfo.InvariantCulture)!;
 
-    public async ValueTask<object?> ResolveAsync(IResolveFieldContext context, IObjectGraphType graphType, object parsedRepresentation)
+    public async ValueTask<object?> ResolveAsync(IResolveFieldContext context, IComplexGraphType graphType, object parsedRepresentation)
     {
         int id = (int)parsedRepresentation;
         var data = context.RequestServices!.GetRequiredService<Data>();

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1742,7 +1742,7 @@ namespace GraphQL.Federation
         public System.Threading.Tasks.ValueTask<GraphQL.Validation.IVariableVisitor?> GetVariableVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         public System.Threading.Tasks.ValueTask LeaveAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true)]
     public class KeyAttribute : GraphQL.GraphQLAttribute
     {
         public KeyAttribute(string fields) { }
@@ -2173,9 +2173,9 @@ namespace GraphQL.Resolvers
     }
     public class MemberResolver : GraphQL.Resolvers.IFieldResolver
     {
-        public MemberResolver(System.Reflection.FieldInfo fieldInfo, System.Linq.Expressions.LambdaExpression instanceExpression) { }
-        public MemberResolver(System.Reflection.PropertyInfo propertyInfo, System.Linq.Expressions.LambdaExpression instanceExpression) { }
-        public MemberResolver(System.Reflection.MethodInfo methodInfo, System.Linq.Expressions.LambdaExpression instanceExpression, System.Collections.Generic.IList<System.Linq.Expressions.LambdaExpression> methodArgumentExpressions) { }
+        public MemberResolver(System.Reflection.FieldInfo fieldInfo, System.Linq.Expressions.LambdaExpression? instanceExpression) { }
+        public MemberResolver(System.Reflection.PropertyInfo propertyInfo, System.Linq.Expressions.LambdaExpression? instanceExpression) { }
+        public MemberResolver(System.Reflection.MethodInfo methodInfo, System.Linq.Expressions.LambdaExpression? instanceExpression, System.Collections.Generic.IList<System.Linq.Expressions.LambdaExpression> methodArgumentExpressions) { }
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         public virtual System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1673,10 +1673,23 @@ namespace GraphQL.Federation
     }
     public static class FederationGraphTypeExtensions
     {
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, GraphQL.Federation.Resolvers.IFederationResolver resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TSourceType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TSourceType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TSourceType?> resolver)
+            where TSourceType : new() { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, GraphQL.Federation.Resolvers.IFederationResolver resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TSourceType?>> resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TSourceType?>> resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TSourceType?> resolver) { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TReturnType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolver)
+            where TSourceType : new() { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TReturnType?>> resolver) { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolver) { }
@@ -1789,15 +1802,15 @@ namespace GraphQL.Federation.Resolvers
         protected FederationResolverBase() { }
         public abstract System.Type SourceType { get; }
         public virtual bool MatchKeys(System.Collections.Generic.IDictionary<string, object?> representation) { }
-        public object ParseRepresentation(GraphQL.Types.IObjectGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation) { }
-        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation);
+        public object ParseRepresentation(GraphQL.Types.IComplexGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation) { }
+        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation);
     }
     public abstract class FederationResolverBase<TParsedType> : GraphQL.Federation.Resolvers.FederationResolverBase
     {
         protected FederationResolverBase() { }
         public override System.Type SourceType { get; }
-        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation) { }
-        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, TParsedType parsedRepresentation);
+        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation) { }
+        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, TParsedType parsedRepresentation);
     }
     public class FederationResolver<TClrType> : GraphQL.Federation.Resolvers.FederationResolver<TClrType, TClrType>
     {
@@ -1811,18 +1824,18 @@ namespace GraphQL.Federation.Resolvers
         public FederationResolver(System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolveFunc) { }
         public FederationResolver(System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolveFunc) { }
         public override System.Type SourceType { get; }
-        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, TSourceType source) { }
+        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, TSourceType source) { }
     }
     public interface IFederationResolver
     {
         bool MatchKeys(System.Collections.Generic.IDictionary<string, object?> representation);
-        object ParseRepresentation(GraphQL.Types.IObjectGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation);
-        System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation);
+        object ParseRepresentation(GraphQL.Types.IComplexGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation);
+        System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation);
     }
     public class Representation : System.IEquatable<GraphQL.Federation.Resolvers.Representation>
     {
-        public Representation(GraphQL.Types.IObjectGraphType GraphType, GraphQL.Federation.Resolvers.IFederationResolver Resolver, object Value) { }
-        public GraphQL.Types.IObjectGraphType GraphType { get; init; }
+        public Representation(GraphQL.Types.IComplexGraphType GraphType, GraphQL.Federation.Resolvers.IFederationResolver Resolver, object Value) { }
+        public GraphQL.Types.IComplexGraphType GraphType { get; init; }
         public GraphQL.Federation.Resolvers.IFederationResolver Resolver { get; init; }
         public object Value { get; init; }
     }
@@ -2745,6 +2758,7 @@ namespace GraphQL.Types
         GraphQLParser.AST.GraphQLValue ToAST(object value);
     }
     public interface IInterfaceGraphType : GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata { }
+    public interface IInterfaceGraphType<in TObject> : GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata { }
     public interface IMetadataReader : GraphQL.Types.IProvideMetadata { }
     public interface IMetadataWriter : GraphQL.Types.IProvideMetadata
     {
@@ -2850,7 +2864,7 @@ namespace GraphQL.Types
     {
         public InterfaceGraphType() { }
     }
-    public class InterfaceGraphType<TSource> : GraphQL.Types.ComplexGraphType<TSource>, GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
+    public class InterfaceGraphType<TSource> : GraphQL.Types.ComplexGraphType<TSource>, GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IInterfaceGraphType<TSource>, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         public InterfaceGraphType() { }
         public GraphQL.Types.Interfaces Interfaces { get; }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1742,7 +1742,7 @@ namespace GraphQL.Federation
         public System.Threading.Tasks.ValueTask<GraphQL.Validation.IVariableVisitor?> GetVariableVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         public System.Threading.Tasks.ValueTask LeaveAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true)]
     public class KeyAttribute : GraphQL.GraphQLAttribute
     {
         public KeyAttribute(string fields) { }
@@ -2173,9 +2173,9 @@ namespace GraphQL.Resolvers
     }
     public class MemberResolver : GraphQL.Resolvers.IFieldResolver
     {
-        public MemberResolver(System.Reflection.FieldInfo fieldInfo, System.Linq.Expressions.LambdaExpression instanceExpression) { }
-        public MemberResolver(System.Reflection.PropertyInfo propertyInfo, System.Linq.Expressions.LambdaExpression instanceExpression) { }
-        public MemberResolver(System.Reflection.MethodInfo methodInfo, System.Linq.Expressions.LambdaExpression instanceExpression, System.Collections.Generic.IList<System.Linq.Expressions.LambdaExpression> methodArgumentExpressions) { }
+        public MemberResolver(System.Reflection.FieldInfo fieldInfo, System.Linq.Expressions.LambdaExpression? instanceExpression) { }
+        public MemberResolver(System.Reflection.PropertyInfo propertyInfo, System.Linq.Expressions.LambdaExpression? instanceExpression) { }
+        public MemberResolver(System.Reflection.MethodInfo methodInfo, System.Linq.Expressions.LambdaExpression? instanceExpression, System.Collections.Generic.IList<System.Linq.Expressions.LambdaExpression> methodArgumentExpressions) { }
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         public virtual System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1673,10 +1673,23 @@ namespace GraphQL.Federation
     }
     public static class FederationGraphTypeExtensions
     {
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, GraphQL.Federation.Resolvers.IFederationResolver resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TSourceType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TSourceType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TSourceType?> resolver)
+            where TSourceType : new() { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, GraphQL.Federation.Resolvers.IFederationResolver resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TSourceType?>> resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TSourceType?>> resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TSourceType?> resolver) { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TReturnType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolver)
+            where TSourceType : new() { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TReturnType?>> resolver) { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolver) { }
@@ -1789,15 +1802,15 @@ namespace GraphQL.Federation.Resolvers
         protected FederationResolverBase() { }
         public abstract System.Type SourceType { get; }
         public virtual bool MatchKeys(System.Collections.Generic.IDictionary<string, object?> representation) { }
-        public object ParseRepresentation(GraphQL.Types.IObjectGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation) { }
-        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation);
+        public object ParseRepresentation(GraphQL.Types.IComplexGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation) { }
+        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation);
     }
     public abstract class FederationResolverBase<TParsedType> : GraphQL.Federation.Resolvers.FederationResolverBase
     {
         protected FederationResolverBase() { }
         public override System.Type SourceType { get; }
-        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation) { }
-        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, TParsedType parsedRepresentation);
+        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation) { }
+        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, TParsedType parsedRepresentation);
     }
     public class FederationResolver<TClrType> : GraphQL.Federation.Resolvers.FederationResolver<TClrType, TClrType>
     {
@@ -1811,18 +1824,18 @@ namespace GraphQL.Federation.Resolvers
         public FederationResolver(System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolveFunc) { }
         public FederationResolver(System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolveFunc) { }
         public override System.Type SourceType { get; }
-        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, TSourceType source) { }
+        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, TSourceType source) { }
     }
     public interface IFederationResolver
     {
         bool MatchKeys(System.Collections.Generic.IDictionary<string, object?> representation);
-        object ParseRepresentation(GraphQL.Types.IObjectGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation);
-        System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation);
+        object ParseRepresentation(GraphQL.Types.IComplexGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation);
+        System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation);
     }
     public class Representation : System.IEquatable<GraphQL.Federation.Resolvers.Representation>
     {
-        public Representation(GraphQL.Types.IObjectGraphType GraphType, GraphQL.Federation.Resolvers.IFederationResolver Resolver, object Value) { }
-        public GraphQL.Types.IObjectGraphType GraphType { get; init; }
+        public Representation(GraphQL.Types.IComplexGraphType GraphType, GraphQL.Federation.Resolvers.IFederationResolver Resolver, object Value) { }
+        public GraphQL.Types.IComplexGraphType GraphType { get; init; }
         public GraphQL.Federation.Resolvers.IFederationResolver Resolver { get; init; }
         public object Value { get; init; }
     }
@@ -2752,6 +2765,7 @@ namespace GraphQL.Types
         GraphQLParser.AST.GraphQLValue ToAST(object value);
     }
     public interface IInterfaceGraphType : GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata { }
+    public interface IInterfaceGraphType<in TObject> : GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata { }
     public interface IMetadataReader : GraphQL.Types.IProvideMetadata { }
     public interface IMetadataWriter : GraphQL.Types.IProvideMetadata
     {
@@ -2857,7 +2871,7 @@ namespace GraphQL.Types
     {
         public InterfaceGraphType() { }
     }
-    public class InterfaceGraphType<TSource> : GraphQL.Types.ComplexGraphType<TSource>, GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
+    public class InterfaceGraphType<TSource> : GraphQL.Types.ComplexGraphType<TSource>, GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IInterfaceGraphType<TSource>, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         public InterfaceGraphType() { }
         public GraphQL.Types.Interfaces Interfaces { get; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1630,10 +1630,23 @@ namespace GraphQL.Federation
     }
     public static class FederationGraphTypeExtensions
     {
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, GraphQL.Federation.Resolvers.IFederationResolver resolver) { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TSourceType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TSourceType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType>(this GraphQL.Types.IInterfaceGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TSourceType?> resolver)
+            where TSourceType : new() { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, GraphQL.Federation.Resolvers.IFederationResolver resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TSourceType?>> resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TSourceType?>> resolver) { }
         public static void ResolveReference<TSourceType>(this GraphQL.Types.ObjectGraphType<TSourceType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TSourceType?> resolver) { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TReturnType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolver)
+            where TSourceType : new() { }
+        public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.IInterfaceGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolver)
+            where TSourceType : new() { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, GraphQL.DataLoader.IDataLoaderResult<TReturnType?>> resolver) { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolver) { }
         public static void ResolveReference<TSourceType, TReturnType>(this GraphQL.Types.ObjectGraphType<TReturnType> graphType, System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolver) { }
@@ -1746,15 +1759,15 @@ namespace GraphQL.Federation.Resolvers
         protected FederationResolverBase() { }
         public abstract System.Type SourceType { get; }
         public virtual bool MatchKeys(System.Collections.Generic.IDictionary<string, object?> representation) { }
-        public object ParseRepresentation(GraphQL.Types.IObjectGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation) { }
-        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation);
+        public object ParseRepresentation(GraphQL.Types.IComplexGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation) { }
+        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation);
     }
     public abstract class FederationResolverBase<TParsedType> : GraphQL.Federation.Resolvers.FederationResolverBase
     {
         protected FederationResolverBase() { }
         public override System.Type SourceType { get; }
-        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation) { }
-        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, TParsedType parsedRepresentation);
+        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation) { }
+        public abstract System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, TParsedType parsedRepresentation);
     }
     public class FederationResolver<TClrType> : GraphQL.Federation.Resolvers.FederationResolver<TClrType, TClrType>
     {
@@ -1768,18 +1781,18 @@ namespace GraphQL.Federation.Resolvers
         public FederationResolver(System.Func<GraphQL.IResolveFieldContext, TSourceType, System.Threading.Tasks.Task<TReturnType?>> resolveFunc) { }
         public FederationResolver(System.Func<GraphQL.IResolveFieldContext, TSourceType, TReturnType?> resolveFunc) { }
         public override System.Type SourceType { get; }
-        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, TSourceType source) { }
+        public override System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, TSourceType source) { }
     }
     public interface IFederationResolver
     {
         bool MatchKeys(System.Collections.Generic.IDictionary<string, object?> representation);
-        object ParseRepresentation(GraphQL.Types.IObjectGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation);
-        System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IObjectGraphType graphType, object parsedRepresentation);
+        object ParseRepresentation(GraphQL.Types.IComplexGraphType graphType, System.Collections.Generic.IDictionary<string, object?> representation);
+        System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context, GraphQL.Types.IComplexGraphType graphType, object parsedRepresentation);
     }
     public class Representation : System.IEquatable<GraphQL.Federation.Resolvers.Representation>
     {
-        public Representation(GraphQL.Types.IObjectGraphType GraphType, GraphQL.Federation.Resolvers.IFederationResolver Resolver, object Value) { }
-        public GraphQL.Types.IObjectGraphType GraphType { get; init; }
+        public Representation(GraphQL.Types.IComplexGraphType GraphType, GraphQL.Federation.Resolvers.IFederationResolver Resolver, object Value) { }
+        public GraphQL.Types.IComplexGraphType GraphType { get; init; }
         public GraphQL.Federation.Resolvers.IFederationResolver Resolver { get; init; }
         public object Value { get; init; }
     }
@@ -2663,6 +2676,7 @@ namespace GraphQL.Types
         GraphQLParser.AST.GraphQLValue ToAST(object value);
     }
     public interface IInterfaceGraphType : GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata { }
+    public interface IInterfaceGraphType<in TObject> : GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata { }
     public interface IMetadataReader : GraphQL.Types.IProvideMetadata { }
     public interface IMetadataWriter : GraphQL.Types.IProvideMetadata
     {
@@ -2768,7 +2782,7 @@ namespace GraphQL.Types
     {
         public InterfaceGraphType() { }
     }
-    public class InterfaceGraphType<TSource> : GraphQL.Types.ComplexGraphType<TSource>, GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
+    public class InterfaceGraphType<TSource> : GraphQL.Types.ComplexGraphType<TSource>, GraphQL.Types.IAbstractGraphType, GraphQL.Types.IComplexGraphType, GraphQL.Types.IGraphType, GraphQL.Types.IImplementInterfaces, GraphQL.Types.IInterfaceGraphType, GraphQL.Types.IInterfaceGraphType<TSource>, GraphQL.Types.IMetadataReader, GraphQL.Types.IMetadataWriter, GraphQL.Types.INamedType, GraphQL.Types.IProvideDeprecationReason, GraphQL.Types.IProvideDescription, GraphQL.Types.IProvideMetadata
     {
         public InterfaceGraphType() { }
         public GraphQL.Types.Interfaces Interfaces { get; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1699,7 +1699,7 @@ namespace GraphQL.Federation
         public System.Threading.Tasks.ValueTask<GraphQL.Validation.IVariableVisitor?> GetVariableVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         public System.Threading.Tasks.ValueTask LeaveAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true)]
     public class KeyAttribute : GraphQL.GraphQLAttribute
     {
         public KeyAttribute(string fields) { }
@@ -2130,9 +2130,9 @@ namespace GraphQL.Resolvers
     }
     public class MemberResolver : GraphQL.Resolvers.IFieldResolver
     {
-        public MemberResolver(System.Reflection.FieldInfo fieldInfo, System.Linq.Expressions.LambdaExpression instanceExpression) { }
-        public MemberResolver(System.Reflection.PropertyInfo propertyInfo, System.Linq.Expressions.LambdaExpression instanceExpression) { }
-        public MemberResolver(System.Reflection.MethodInfo methodInfo, System.Linq.Expressions.LambdaExpression instanceExpression, System.Collections.Generic.IList<System.Linq.Expressions.LambdaExpression> methodArgumentExpressions) { }
+        public MemberResolver(System.Reflection.FieldInfo fieldInfo, System.Linq.Expressions.LambdaExpression? instanceExpression) { }
+        public MemberResolver(System.Reflection.PropertyInfo propertyInfo, System.Linq.Expressions.LambdaExpression? instanceExpression) { }
+        public MemberResolver(System.Reflection.MethodInfo methodInfo, System.Linq.Expressions.LambdaExpression? instanceExpression, System.Collections.Generic.IList<System.Linq.Expressions.LambdaExpression> methodArgumentExpressions) { }
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         public virtual System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }

--- a/src/GraphQL.Tests/Federation/EntityResolverTests.cs
+++ b/src/GraphQL.Tests/Federation/EntityResolverTests.cs
@@ -167,7 +167,7 @@ public class EntityResolverTests
         var schema = CreateSchema<TestObject>("id");
         var representations = new List<object> { new Dictionary<string, object>() { { "__typename", "TestInput" }, { "id", "1" } } };
         Should.Throw<InvalidOperationException>(() => _resolver.ConvertRepresentations(schema, representations))
-            .Message.ShouldBe("The type 'TestInput' is not an object graph type.");
+            .Message.ShouldBe("The type 'TestInput' is not an object or interface graph type.");
     }
 
     [Fact]

--- a/src/GraphQL.Tests/Federation/InterfaceEntityTests.cs
+++ b/src/GraphQL.Tests/Federation/InterfaceEntityTests.cs
@@ -7,6 +7,161 @@ namespace GraphQL.Tests.Federation;
 
 public class InterfaceEntityTests
 {
+    [Fact]
+    public async Task SchemaFirst_Test()
+    {
+        // Define the schema with Media interface and Book type
+        var sdlInput = """
+            interface Media @key(fields: "id") {
+              id: ID!
+              title: String!
+            }
+
+            type Book implements Media @key(fields: "id") {
+              id: ID!
+              title: String!
+            }
+            """;
+
+        // Create and initialize the schema
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddGraphQL(x => x
+            .AddSchema(provider =>
+            {
+                var schema = Schema.For(sdlInput, c =>
+                {
+                    c.ServiceProvider = provider;
+                    c.Types.For("Book").IsTypeOf<Book>();
+                    c.Types.For("Book").ResolveReference<Book>((ctx, rep) =>
+                        new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
+                    c.Types.For("Media").ResolveReference<Media>((ctx, rep) =>
+                        new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
+                });
+                schema.Query = new ObjectGraphType() { Name = "Query" };
+                return schema;
+            })
+            .AddFederation("2.3", c => c.Imports["@interfaceObject"] = "@interfaceObject"));
+
+        var schema = serviceCollection.BuildServiceProvider().GetRequiredService<ISchema>();
+        await ValidateAsync(schema);
+    }
+
+    [Fact]
+    public async Task CodeFirst_Test()
+    {
+        // Create interface type
+        var mediaInterface = new InterfaceGraphType<IMedia>
+        {
+            Name = "Media"
+        };
+        var idField = mediaInterface.Field(m => m.Id, typeof(NonNullGraphType<IdGraphType>));
+        var titleField = mediaInterface.Field(m => m.Title, typeof(NonNullGraphType<StringGraphType>));
+        mediaInterface.Key("id");
+        mediaInterface.ResolveReference<Media>((ctx, rep) => new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
+
+        // Create Book type implementing the interface
+        var bookType = new ObjectGraphType<Book>
+        {
+            Name = "Book"
+        };
+        var bookIdField = bookType.Field(b => b.Id, typeof(NonNullGraphType<IdGraphType>));
+        var bookTitleField = bookType.Field(b => b.Title, typeof(NonNullGraphType<StringGraphType>));
+        bookType.Key("id");
+        bookType.ResolveReference((ctx, rep) => new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
+        bookType.AddResolvedInterface(mediaInterface);
+
+        // Create query type
+        var queryType = new ObjectGraphType { Name = "Query" };
+
+        // Create and initialize the schema
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddGraphQL(x => x
+            .AddSchema(provider => new Schema(provider) { Query = queryType })
+            .AddFederation("2.3", c => c.Imports["@interfaceObject"] = "@interfaceObject")
+            .ConfigureSchema(s =>
+            {
+                s.RegisterType(mediaInterface);
+                s.RegisterType(bookType);
+            }));
+
+        var schema = serviceCollection.BuildServiceProvider().GetRequiredService<ISchema>();
+        await ValidateAsync(schema);
+    }
+
+#if NET6_0_OR_GREATER // Default interface implementations (required for [FederationResolver] on an interface) require .NET 6.0 or greater
+    [Fact]
+    public async Task TypeFirst_Test()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddGraphQL(b => b
+            .AddAutoSchema<Query>()
+            .AddFederation("2.3", c => c.Imports["@interfaceObject"] = "@interfaceObject")
+            .ConfigureSchema(s => s.RegisterType(typeof(AutoRegisteringObjectGraphType<Book>))));
+        var schema = serviceCollection.BuildServiceProvider().GetRequiredService<ISchema>();
+        await ValidateAsync(schema);
+    }
+#endif
+
+    private async Task ValidateAsync(ISchema schema)
+    {
+        schema.Initialize();
+
+        // Verify the schema was created correctly
+        var sdl = schema.Print(new() { StringComparison = StringComparison.OrdinalIgnoreCase });
+        sdl.ShouldBe(approvedSdl);
+
+        // Execute the query
+        var query = """
+            query {
+              _entities(representations: [{ __typename: "Book", id: "1" }]) {
+                ... on Media {
+                  __typename
+                  id
+                  title
+                }
+              }
+            }
+            """;
+
+        var executor = new DocumentExecuter();
+        var result = await executor.ExecuteAsync(new ExecutionOptions
+        {
+            Schema = schema,
+            Query = query
+        });
+
+        // Verify the result
+        var resultJson = new GraphQLSerializer().Serialize(result);
+        resultJson.ShouldBe("""
+            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
+            """);
+
+        // Execute the query with Media interface
+        var interfaceQuery = """
+            query {
+              _entities(representations: [{ __typename: "Media", id: "1" }]) {
+                ... on Media {
+                  __typename
+                  id
+                  title
+                }
+              }
+            }
+            """;
+
+        var interfaceResult = await executor.ExecuteAsync(new ExecutionOptions
+        {
+            Schema = schema,
+            Query = interfaceQuery
+        });
+
+        // Verify the result - this should return null for the entity since Media is an interface
+        var interfaceResultJson = new GraphQLSerializer().Serialize(interfaceResult);
+        interfaceResultJson.ShouldBe("""
+            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
+            """);
+    }
+
     private const string approvedSdl = """
         schema @link(import: ["@link"], url: "https://specs.apollo.dev/link/v1.0") @link(import: ["@key", "@external", "@requires", "@provides", "@shareable", "@inaccessible", "@override", "@tag", "@interfaceObject"], url: "https://specs.apollo.dev/federation/v2.3") {
           query: Query
@@ -72,211 +227,43 @@ public class InterfaceEntityTests
 
         """;
 
-    [Fact]
-    public async Task SchemaFirst_Test()
+    public class Query
     {
-        // Define the schema with Media interface and Book type
-        var sdlInput = """
-            interface Media @key(fields: "id") {
-              id: ID!
-              title: String!
-            }
-
-            type Book implements Media @key(fields: "id") {
-              id: ID!
-              title: String!
-            }
-            """;
-
-        // Create and initialize the schema
-        var serviceCollection = new ServiceCollection();
-        serviceCollection.AddGraphQL(x => x
-            .AddSchema(provider =>
-            {
-                var schema = Schema.For(sdlInput, c =>
-                {
-                    c.ServiceProvider = provider;
-                    c.Types.For("Book").IsTypeOf<Book>();
-                    c.Types.For("Book").ResolveReference<Book>((ctx, rep) =>
-                        new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
-                    c.Types.For("Media").ResolveReference<Media>((ctx, rep) =>
-                        new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
-                });
-                schema.Query = new ObjectGraphType() { Name = "Query" };
-                return schema;
-            })
-            .AddFederation("2.3", c => c.Imports["@interfaceObject"] = "@interfaceObject"));
-
-        var schema = serviceCollection.BuildServiceProvider().GetRequiredService<ISchema>();
-        schema.Initialize();
-
-        // Verify the schema was created correctly
-        var sdl = schema.Print(new() { StringComparison = StringComparison.OrdinalIgnoreCase });
-        sdl.ShouldBe(approvedSdl);
-
-        // Execute the query
-        var query = """
-            query {
-              _entities(representations: [{ __typename: "Book", id: "1" }]) {
-                ... on Media {
-                  __typename
-                  id
-                  title
-                }
-              }
-            }
-            """;
-
-        var executor = new DocumentExecuter();
-        var result = await executor.ExecuteAsync(new ExecutionOptions
-        {
-            Schema = schema,
-            Query = query
-        });
-
-        // Verify the result
-        var resultJson = new GraphQLSerializer().Serialize(result);
-        resultJson.ShouldBe("""
-            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
-            """);
-
-        // Execute the query with Media interface
-        var interfaceQuery = """
-            query {
-              _entities(representations: [{ __typename: "Media", id: "1" }]) {
-                ... on Media {
-                  __typename
-                  id
-                  title
-                }
-              }
-            }
-            """;
-
-        var interfaceResult = await executor.ExecuteAsync(new ExecutionOptions
-        {
-            Schema = schema,
-            Query = interfaceQuery
-        });
-
-        // Verify the result - this should return null for the entity since Media is an interface
-        var interfaceResultJson = new GraphQLSerializer().Serialize(interfaceResult);
-        interfaceResultJson.ShouldBe("""
-            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
-            """);
-    }
-
-    [Fact]
-    public async Task CodeFirst_Test()
-    {
-        // Create interface type
-        var mediaInterface = new InterfaceGraphType<IMedia>
-        {
-            Name = "Media"
-        };
-        var idField = mediaInterface.Field(m => m.Id, typeof(NonNullGraphType<IdGraphType>));
-        var titleField = mediaInterface.Field(m => m.Title, typeof(NonNullGraphType<StringGraphType>));
-        mediaInterface.Key("id");
-        mediaInterface.ResolveReference<Media>((ctx, rep) => new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
-
-        // Create Book type implementing the interface
-        var bookType = new ObjectGraphType<Book>
-        {
-            Name = "Book"
-        };
-        var bookIdField = bookType.Field(b => b.Id, typeof(NonNullGraphType<IdGraphType>));
-        var bookTitleField = bookType.Field(b => b.Title, typeof(NonNullGraphType<StringGraphType>));
-        bookType.Key("id");
-        bookType.ResolveReference((ctx, rep) => new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
-        bookType.AddResolvedInterface(mediaInterface);
-
-        // Create query type
-        var queryType = new ObjectGraphType { Name = "Query" };
-
-        // Create and initialize the schema
-        var serviceCollection = new ServiceCollection();
-        serviceCollection.AddGraphQL(x => x
-            .AddSchema(provider => new Schema(provider) { Query = queryType })
-            .AddFederation("2.3", c => c.Imports["@interfaceObject"] = "@interfaceObject")
-            .ConfigureSchema(s =>
-            {
-                s.RegisterType(mediaInterface);
-                s.RegisterType(bookType);
-            }));
-
-        var schema = serviceCollection.BuildServiceProvider().GetRequiredService<ISchema>();
-        schema.Initialize();
-
-        // Verify the schema was created correctly
-        var sdl = schema.Print(new() { StringComparison = StringComparison.OrdinalIgnoreCase });
-        sdl.ShouldBe(approvedSdl, StringCompareShould.IgnoreLineEndings);
-
-        // Execute the query
-        var query = """
-            query {
-              _entities(representations: [{ __typename: "Book", id: "1" }]) {
-                ... on Media {
-                  __typename
-                  id
-                  title
-                }
-              }
-            }
-            """;
-
-        var executor = new DocumentExecuter();
-        var result = await executor.ExecuteAsync(new ExecutionOptions
-        {
-            Schema = schema,
-            Query = query
-        });
-
-        // Verify the result
-        var resultJson = new GraphQLSerializer().Serialize(result);
-        resultJson.ShouldBe("""
-            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
-            """);
-
-        // Execute the query with Media interface
-        var interfaceQuery = """
-            query {
-              _entities(representations: [{ __typename: "Media", id: "1" }]) {
-                ... on Media {
-                  __typename
-                  id
-                  title
-                }
-              }
-            }
-            """;
-
-        var interfaceResult = await executor.ExecuteAsync(new ExecutionOptions
-        {
-            Schema = schema,
-            Query = interfaceQuery
-        });
-
-        // Verify the result - this should return null for the entity since Media is an interface
-        var interfaceResultJson = new GraphQLSerializer().Serialize(interfaceResult);
-        interfaceResultJson.ShouldBe("""
-            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
-            """);
     }
 
     // Model classes
+    [Name("Media")] // used for type-first only
+    [Key("id")] // used for type-first only
     public interface IMedia
     {
+        [Id] // used for type-first only
         public string Id { get; set; }
         public string Title { get; set; }
+
+#if NET6_0_OR_GREATER // Default interface implementations (required for [FederationResolver] on an interface) require .NET 6.0 or greater
+        [FederationResolver]
+        public static IMedia ResolveReference(string id) // used for type-first only
+        {
+            return new Book { Id = id, Title = $"Book {id}" };
+        }
+#endif
     }
 
     public class Media : IMedia
     {
+        [Id] // used for type-first only
         public string Id { get; set; }
         public string Title { get; set; }
     }
 
+    [Implements(typeof(IMedia))] // used for type-first only
+    [Key("id")] // used for type-first only
     public class Book : Media
     {
+        [FederationResolver]
+        public static Book ResolveReference(string id) // used for type-first only
+        {
+            return new Book { Id = id, Title = $"Book {id}" };
+        }
     }
 }

--- a/src/GraphQL.Tests/Federation/InterfaceEntityTests.cs
+++ b/src/GraphQL.Tests/Federation/InterfaceEntityTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.Tests.Federation;
 
-public class MediaEntityTests
+public class InterfaceEntityTests
 {
     private const string approvedSdl = """
         schema @link(import: ["@link"], url: "https://specs.apollo.dev/link/v1.0") @link(import: ["@key", "@external", "@requires", "@provides", "@shareable", "@inaccessible", "@override", "@tag", "@interfaceObject"], url: "https://specs.apollo.dev/federation/v2.3") {

--- a/src/GraphQL.Tests/Federation/MediaEntityTests.cs
+++ b/src/GraphQL.Tests/Federation/MediaEntityTests.cs
@@ -1,0 +1,282 @@
+using GraphQL.Federation;
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Tests.Federation;
+
+public class MediaEntityTests
+{
+    private const string approvedSdl = """
+        schema @link(import: ["@link"], url: "https://specs.apollo.dev/link/v1.0") @link(import: ["@key", "@external", "@requires", "@provides", "@shareable", "@inaccessible", "@override", "@tag", "@interfaceObject"], url: "https://specs.apollo.dev/federation/v2.3") {
+          query: Query
+        }
+
+        directive @external on FIELD_DEFINITION | OBJECT
+
+        directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+
+        directive @federation__extends on INTERFACE | OBJECT
+
+        directive @inaccessible on ARGUMENT_DEFINITION | ENUM | ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+        directive @interfaceObject on OBJECT
+
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT
+
+        directive @link(as: String, import: [link__Import], purpose: link__Purpose, url: String!) repeatable on SCHEMA
+
+        directive @override(from: String!) on FIELD_DEFINITION
+
+        directive @provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @shareable repeatable on FIELD_DEFINITION | OBJECT
+
+        directive @tag(name: String!) repeatable on ARGUMENT_DEFINITION | ENUM | ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | SCHEMA | UNION
+
+        type Book implements Media @key(fields: "id") {
+          id: ID!
+          title: String!
+        }
+
+        scalar federation__FieldSet
+
+        scalar link__Import
+
+        enum link__Purpose {
+          "`EXECUTION` features provide metadata necessary for operation execution."
+          EXECUTION
+          "`SECURITY` features provide metadata necessary to securely resolve fields."
+          SECURITY
+        }
+
+        interface Media @key(fields: "id") {
+          id: ID!
+          title: String!
+        }
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+        }
+
+        scalar _Any
+
+        union _Entity = Book
+
+        type _Service {
+          sdl: String
+        }
+
+        """;
+
+    [Fact]
+    public async Task SchemaFirst_Test()
+    {
+        // Define the schema with Media interface and Book type
+        var sdlInput = """
+            interface Media @key(fields: "id") {
+              id: ID!
+              title: String!
+            }
+
+            type Book implements Media @key(fields: "id") {
+              id: ID!
+              title: String!
+            }
+            """;
+
+        // Create and initialize the schema
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddGraphQL(x => x
+            .AddSchema(provider =>
+            {
+                var schema = Schema.For(sdlInput, c =>
+                {
+                    c.ServiceProvider = provider;
+                    c.Types.For("Book").IsTypeOf<Book>();
+                    c.Types.For("Book").ResolveReference<Book>((ctx, rep) =>
+                        new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
+                    c.Types.For("Media").ResolveReference<Media>((ctx, rep) =>
+                        new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
+                });
+                schema.Query = new ObjectGraphType() { Name = "Query" };
+                return schema;
+            })
+            .AddFederation("2.3", c => c.Imports["@interfaceObject"] = "@interfaceObject"));
+
+        var schema = serviceCollection.BuildServiceProvider().GetRequiredService<ISchema>();
+        schema.Initialize();
+
+        // Verify the schema was created correctly
+        var sdl = schema.Print(new() { StringComparison = StringComparison.OrdinalIgnoreCase });
+        sdl.ShouldBe(approvedSdl);
+
+        // Execute the query
+        var query = """
+            query {
+              _entities(representations: [{ __typename: "Book", id: "1" }]) {
+                ... on Media {
+                  __typename
+                  id
+                  title
+                }
+              }
+            }
+            """;
+
+        var executor = new DocumentExecuter();
+        var result = await executor.ExecuteAsync(new ExecutionOptions
+        {
+            Schema = schema,
+            Query = query
+        });
+
+        // Verify the result
+        var resultJson = new GraphQLSerializer().Serialize(result);
+        resultJson.ShouldBe("""
+            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
+            """);
+
+        // Execute the query with Media interface
+        var interfaceQuery = """
+            query {
+              _entities(representations: [{ __typename: "Media", id: "1" }]) {
+                ... on Media {
+                  __typename
+                  id
+                  title
+                }
+              }
+            }
+            """;
+
+        var interfaceResult = await executor.ExecuteAsync(new ExecutionOptions
+        {
+            Schema = schema,
+            Query = interfaceQuery
+        });
+
+        // Verify the result - this should return null for the entity since Media is an interface
+        var interfaceResultJson = new GraphQLSerializer().Serialize(interfaceResult);
+        interfaceResultJson.ShouldBe("""
+            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
+            """);
+    }
+
+    [Fact]
+    public async Task CodeFirst_Test()
+    {
+        // Create interface type
+        var mediaInterface = new InterfaceGraphType<IMedia>
+        {
+            Name = "Media"
+        };
+        var idField = mediaInterface.Field(m => m.Id, typeof(NonNullGraphType<IdGraphType>));
+        var titleField = mediaInterface.Field(m => m.Title, typeof(NonNullGraphType<StringGraphType>));
+        mediaInterface.Key("id");
+        mediaInterface.ResolveReference<Media>((ctx, rep) => new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
+
+        // Create Book type implementing the interface
+        var bookType = new ObjectGraphType<Book>
+        {
+            Name = "Book"
+        };
+        var bookIdField = bookType.Field(b => b.Id, typeof(NonNullGraphType<IdGraphType>));
+        var bookTitleField = bookType.Field(b => b.Title, typeof(NonNullGraphType<StringGraphType>));
+        bookType.Key("id");
+        bookType.ResolveReference((ctx, rep) => new Book { Id = rep.Id, Title = $"Book {rep.Id}" });
+        bookType.AddResolvedInterface(mediaInterface);
+
+        // Create query type
+        var queryType = new ObjectGraphType { Name = "Query" };
+
+        // Create and initialize the schema
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddGraphQL(x => x
+            .AddSchema(provider => new Schema(provider) { Query = queryType })
+            .AddFederation("2.3", c => c.Imports["@interfaceObject"] = "@interfaceObject")
+            .ConfigureSchema(s =>
+            {
+                s.RegisterType(mediaInterface);
+                s.RegisterType(bookType);
+            }));
+
+        var schema = serviceCollection.BuildServiceProvider().GetRequiredService<ISchema>();
+        schema.Initialize();
+
+        // Verify the schema was created correctly
+        var sdl = schema.Print(new() { StringComparison = StringComparison.OrdinalIgnoreCase });
+        sdl.ShouldBe(approvedSdl, StringCompareShould.IgnoreLineEndings);
+
+        // Execute the query
+        var query = """
+            query {
+              _entities(representations: [{ __typename: "Book", id: "1" }]) {
+                ... on Media {
+                  __typename
+                  id
+                  title
+                }
+              }
+            }
+            """;
+
+        var executor = new DocumentExecuter();
+        var result = await executor.ExecuteAsync(new ExecutionOptions
+        {
+            Schema = schema,
+            Query = query
+        });
+
+        // Verify the result
+        var resultJson = new GraphQLSerializer().Serialize(result);
+        resultJson.ShouldBe("""
+            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
+            """);
+
+        // Execute the query with Media interface
+        var interfaceQuery = """
+            query {
+              _entities(representations: [{ __typename: "Media", id: "1" }]) {
+                ... on Media {
+                  __typename
+                  id
+                  title
+                }
+              }
+            }
+            """;
+
+        var interfaceResult = await executor.ExecuteAsync(new ExecutionOptions
+        {
+            Schema = schema,
+            Query = interfaceQuery
+        });
+
+        // Verify the result - this should return null for the entity since Media is an interface
+        var interfaceResultJson = new GraphQLSerializer().Serialize(interfaceResult);
+        interfaceResultJson.ShouldBe("""
+            {"data":{"_entities":[{"__typename":"Book","id":"1","title":"Book 1"}]}}
+            """);
+    }
+
+    // Model classes
+    public interface IMedia
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+    }
+
+    public class Media : IMedia
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+    }
+
+    public class Book : Media
+    {
+    }
+}

--- a/src/GraphQL/Extensions/GraphQLExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLExtensions.cs
@@ -184,6 +184,9 @@ public static class GraphQLExtensions
         // loop through all fields defined in the interface
         foreach (var implementedField in implementedType.Fields)
         {
+            if (implementedField.IsPrivate)
+                continue;
+
             // find the field on the object type that implements the interface field
             // note: "object type" may refer to an object or interface type that implements the interface
             var field = type.GetField(implementedField.Name);

--- a/src/GraphQL/Federation/Attributes/FederationResolverAttribute.FederationNonStaticResolver.cs
+++ b/src/GraphQL/Federation/Attributes/FederationResolverAttribute.FederationNonStaticResolver.cs
@@ -35,7 +35,7 @@ public partial class FederationResolverAttribute
 
         public override Type SourceType { get; }
 
-        public override ValueTask<object?> ResolveAsync(IResolveFieldContext context, IObjectGraphType graphType, object source)
+        public override ValueTask<object?> ResolveAsync(IResolveFieldContext context, IComplexGraphType graphType, object source)
         {
             var context2 = new Context(context, source);
             var resolver = _fieldType.Resolver ?? ThrowForNoResolver();

--- a/src/GraphQL/Federation/Attributes/FederationResolverAttribute.FederationStaticResolver.cs
+++ b/src/GraphQL/Federation/Attributes/FederationResolverAttribute.FederationStaticResolver.cs
@@ -52,7 +52,7 @@ public partial class FederationResolverAttribute
             return true;
         }
 
-        public object ParseRepresentation(IObjectGraphType graphType, IDictionary<string, object?> representation)
+        public object ParseRepresentation(IComplexGraphType graphType, IDictionary<string, object?> representation)
         {
             // Creates a dictionary of arguments for the field type based on the entity representation properties.
             // The argument dictionary is returned as the parsed representation, to be used by the synthesized IResolveFieldContext.
@@ -84,7 +84,7 @@ public partial class FederationResolverAttribute
             return arguments;
         }
 
-        public ValueTask<object?> ResolveAsync(IResolveFieldContext context, IObjectGraphType graphType, object parsedRepresentation)
+        public ValueTask<object?> ResolveAsync(IResolveFieldContext context, IComplexGraphType graphType, object parsedRepresentation)
         {
             // create a synthesized IResolveFieldContext with the arguments and a null source
             var context2 = new Context(context, _fieldType, (Dictionary<string, ArgumentValue>?)parsedRepresentation);

--- a/src/GraphQL/Federation/Attributes/KeyAttribute.cs
+++ b/src/GraphQL/Federation/Attributes/KeyAttribute.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Federation;
 /// <remarks>
 /// See <see href="https://www.apollographql.com/docs/federation/federated-types/federated-directives#key"/>.
 /// </remarks>
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
 public class KeyAttribute : GraphQLAttribute
 {
     private readonly string _fields;
@@ -52,8 +52,17 @@ public class KeyAttribute : GraphQLAttribute
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="graphType"/> is not an <see cref="IObjectGraphType"/>.</exception>
     public override void Modify(IGraphType graphType)
     {
-        if (graphType is not IObjectGraphType objectGraphType)
-            throw new ArgumentOutOfRangeException(nameof(graphType), graphType, "Only ObjectGraphType is supported.");
-        objectGraphType.Key(_fields, Resolvable);
+        if (graphType is IObjectGraphType objectGraphType)
+        {
+            objectGraphType.Key(_fields, Resolvable);
+        }
+        else if (graphType is IInterfaceGraphType interfaceGraphType)
+        {
+            interfaceGraphType.Key(_fields, Resolvable);
+        }
+        else
+        {
+            throw new ArgumentOutOfRangeException(nameof(graphType), graphType, "Only object and interface graph types are supported.");
+        }
     }
 }

--- a/src/GraphQL/Federation/Extensions/FederationGraphTypeExtensions.cs
+++ b/src/GraphQL/Federation/Extensions/FederationGraphTypeExtensions.cs
@@ -58,18 +58,6 @@ public static class FederationGraphTypeExtensions
     }
 
     /// <summary>
-    /// Configures synchronous resolution of a reference using a resolver function with a return type.
-    /// </summary>
-    /// <typeparam name="TSourceType">The CLR type of the entity type, populated by the representation.</typeparam>
-    /// <param name="graphType">The graph type to apply the resolver to.</param>
-    /// <param name="resolver">The function used to resolve the source representation.</param>
-    public static void ResolveReference<TSourceType>(this IInterfaceGraphType<TSourceType> graphType, Func<IResolveFieldContext, TSourceType, TSourceType?> resolver)
-        where TSourceType : new()
-    {
-        graphType.Metadata[RESOLVER_METADATA] = new FederationResolver<TSourceType>(resolver);
-    }
-
-    /// <summary>
     /// Configures asynchronous resolution of a reference using a task-based resolver function with a return type.
     /// </summary>
     /// <typeparam name="TSourceType">The CLR type of the entity type, populated by the representation.</typeparam>
@@ -98,6 +86,92 @@ public static class FederationGraphTypeExtensions
     /// <param name="graphType">The graph type to apply the resolver to.</param>
     /// <param name="resolver">The federation resolver used to resolve the source representation.</param>
     public static void ResolveReference<TSourceType>(this ObjectGraphType<TSourceType> graphType, IFederationResolver resolver)
+    {
+        graphType.Metadata[RESOLVER_METADATA] = resolver;
+    }
+
+    /// <summary>
+    /// Configures synchronous resolution of a reference using a resolver function with a return type.
+    /// </summary>
+    /// <typeparam name="TSourceType">The CLR type of the source representation that the resolver handles.</typeparam>
+    /// <typeparam name="TReturnType">The CLR type of the resolved object returned by the resolver.</typeparam>
+    /// <param name="graphType">The graph type to apply the resolver to.</param>
+    /// <param name="resolver">The function used to resolve the source representation.</param>
+    public static void ResolveReference<TSourceType, TReturnType>(this IInterfaceGraphType<TReturnType> graphType, Func<IResolveFieldContext, TSourceType, TReturnType?> resolver)
+        where TSourceType : new()
+    {
+        graphType.Metadata[RESOLVER_METADATA] = new FederationResolver<TSourceType, TReturnType>(resolver);
+    }
+
+    /// <summary>
+    /// Configures asynchronous resolution of a reference using a task-based resolver function with a return type.
+    /// </summary>
+    /// <typeparam name="TSourceType">The CLR type of the source representation that the resolver handles.</typeparam>
+    /// <typeparam name="TReturnType">The CLR type of the resolved object returned by the resolver.</typeparam>
+    /// <param name="graphType">The graph type to apply the resolver to.</param>
+    /// <param name="resolver">The asynchronous function used to resolve the source representation.</param>
+    public static void ResolveReference<TSourceType, TReturnType>(this IInterfaceGraphType<TReturnType> graphType, Func<IResolveFieldContext, TSourceType, Task<TReturnType?>> resolver)
+        where TSourceType : new()
+    {
+        graphType.Metadata[RESOLVER_METADATA] = new FederationResolver<TSourceType, TReturnType>(resolver);
+    }
+
+    /// <summary>
+    /// Configures resolution of a reference using a data loader-based resolver function with a return type.
+    /// </summary>
+    /// <typeparam name="TSourceType">The CLR type of the source representation that the resolver handles.</typeparam>
+    /// <typeparam name="TReturnType">The CLR type of the resolved object returned by the resolver.</typeparam>
+    /// <param name="graphType">The graph type to apply the resolver to.</param>
+    /// <param name="resolver">The data loader function used to resolve the source representation.</param>
+    public static void ResolveReference<TSourceType, TReturnType>(this IInterfaceGraphType<TReturnType> graphType, Func<IResolveFieldContext, TSourceType, IDataLoaderResult<TReturnType?>> resolver)
+        where TSourceType : new()
+    {
+        graphType.Metadata[RESOLVER_METADATA] = new FederationResolver<TSourceType, TReturnType>(resolver);
+    }
+
+    /// <summary>
+    /// Configures synchronous resolution of a reference using a resolver function with a return type.
+    /// </summary>
+    /// <typeparam name="TSourceType">The CLR type of the entity type, populated by the representation.</typeparam>
+    /// <param name="graphType">The graph type to apply the resolver to.</param>
+    /// <param name="resolver">The function used to resolve the source representation.</param>
+    public static void ResolveReference<TSourceType>(this IInterfaceGraphType<TSourceType> graphType, Func<IResolveFieldContext, TSourceType, TSourceType?> resolver)
+        where TSourceType : new()
+    {
+        graphType.Metadata[RESOLVER_METADATA] = new FederationResolver<TSourceType>(resolver);
+    }
+
+    /// <summary>
+    /// Configures asynchronous resolution of a reference using a task-based resolver function with a return type.
+    /// </summary>
+    /// <typeparam name="TSourceType">The CLR type of the entity type, populated by the representation.</typeparam>
+    /// <param name="graphType">The graph type to apply the resolver to.</param>
+    /// <param name="resolver">The asynchronous function used to resolve the source representation.</param>
+    public static void ResolveReference<TSourceType>(this IInterfaceGraphType<TSourceType> graphType, Func<IResolveFieldContext, TSourceType, Task<TSourceType?>> resolver)
+        where TSourceType : new()
+    {
+        graphType.Metadata[RESOLVER_METADATA] = new FederationResolver<TSourceType>(resolver);
+    }
+
+    /// <summary>
+    /// Configures resolution of a reference using a data loader-based resolver function with a return type.
+    /// </summary>
+    /// <typeparam name="TSourceType">The CLR type of the entity type, populated by the representation.</typeparam>
+    /// <param name="graphType">The graph type to apply the resolver to.</param>
+    /// <param name="resolver">The data loader function used to resolve the source representation.</param>
+    public static void ResolveReference<TSourceType>(this IInterfaceGraphType<TSourceType> graphType, Func<IResolveFieldContext, TSourceType, IDataLoaderResult<TSourceType?>> resolver)
+        where TSourceType : new()
+    {
+        graphType.Metadata[RESOLVER_METADATA] = new FederationResolver<TSourceType>(resolver);
+    }
+
+    /// <summary>
+    /// Configures resolution of a reference using a specified federation resolver.
+    /// </summary>
+    /// <typeparam name="TSourceType">The CLR type of the entity type.</typeparam>
+    /// <param name="graphType">The graph type to apply the resolver to.</param>
+    /// <param name="resolver">The federation resolver used to resolve the source representation.</param>
+    public static void ResolveReference<TSourceType>(this IInterfaceGraphType<TSourceType> graphType, IFederationResolver resolver)
     {
         graphType.Metadata[RESOLVER_METADATA] = resolver;
     }

--- a/src/GraphQL/Federation/Extensions/FederationGraphTypeExtensions.cs
+++ b/src/GraphQL/Federation/Extensions/FederationGraphTypeExtensions.cs
@@ -58,6 +58,18 @@ public static class FederationGraphTypeExtensions
     }
 
     /// <summary>
+    /// Configures synchronous resolution of a reference using a resolver function with a return type.
+    /// </summary>
+    /// <typeparam name="TSourceType">The CLR type of the entity type, populated by the representation.</typeparam>
+    /// <param name="graphType">The graph type to apply the resolver to.</param>
+    /// <param name="resolver">The function used to resolve the source representation.</param>
+    public static void ResolveReference<TSourceType>(this IInterfaceGraphType<TSourceType> graphType, Func<IResolveFieldContext, TSourceType, TSourceType?> resolver)
+        where TSourceType : new()
+    {
+        graphType.Metadata[RESOLVER_METADATA] = new FederationResolver<TSourceType>(resolver);
+    }
+
+    /// <summary>
     /// Configures asynchronous resolution of a reference using a task-based resolver function with a return type.
     /// </summary>
     /// <typeparam name="TSourceType">The CLR type of the entity type, populated by the representation.</typeparam>

--- a/src/GraphQL/Federation/Resolvers/EntityResolver.cs
+++ b/src/GraphQL/Federation/Resolvers/EntityResolver.cs
@@ -63,7 +63,7 @@ public sealed class EntityResolver : IFieldResolver
             // now find the graph type instance for the type name, ensuring it is an object type
             var graphTypeInstance = schema.AllTypes[typeName]
                 ?? throw new InvalidOperationException($"The type '{typeName}' could not be found.");
-            if (graphTypeInstance is not IComplexGraphType complexGraphType)
+            if (graphTypeInstance is not IComplexGraphType complexGraphType || graphTypeInstance is IInputObjectGraphType)
                 throw new InvalidOperationException($"The type '{typeName}' is not an object or interface graph type.");
 
             // find the federation resolver to use based on the representation

--- a/src/GraphQL/Federation/Resolvers/EntityResolver.cs
+++ b/src/GraphQL/Federation/Resolvers/EntityResolver.cs
@@ -63,8 +63,8 @@ public sealed class EntityResolver : IFieldResolver
             // now find the graph type instance for the type name, ensuring it is an object type
             var graphTypeInstance = schema.AllTypes[typeName]
                 ?? throw new InvalidOperationException($"The type '{typeName}' could not be found.");
-            if (graphTypeInstance is not IObjectGraphType objectGraphType)
-                throw new InvalidOperationException($"The type '{typeName}' is not an object graph type.");
+            if (graphTypeInstance is not IComplexGraphType complexGraphType)
+                throw new InvalidOperationException($"The type '{typeName}' is not an object or interface graph type.");
 
             // find the federation resolver to use based on the representation
             var resolver = SelectFederationResolver(graphTypeInstance.GetMetadata<object>(RESOLVER_METADATA), typeName, rep);
@@ -75,7 +75,7 @@ public sealed class EntityResolver : IFieldResolver
             object value;
             try
             {
-                value = resolver.ParseRepresentation(objectGraphType, rep);
+                value = resolver.ParseRepresentation(complexGraphType, rep);
             }
             catch (Exception ex)
             {
@@ -84,7 +84,7 @@ public sealed class EntityResolver : IFieldResolver
                 throw new InvalidOperationException($"Error converting representation for type '{typeName}'. Please verify your supergraph is up to date.", ex);
             }
 
-            ret.Add(new Representation(objectGraphType, resolver, value));
+            ret.Add(new Representation(complexGraphType, resolver, value));
         }
         return ret;
     }

--- a/src/GraphQL/Federation/Resolvers/FederationResolver.cs
+++ b/src/GraphQL/Federation/Resolvers/FederationResolver.cs
@@ -85,6 +85,6 @@ public class FederationResolver<TSourceType, TReturnType> : FederationResolverBa
     }
 
     /// <inheritdoc/>
-    public override ValueTask<object?> ResolveAsync(IResolveFieldContext context, IObjectGraphType graphType, TSourceType source)
+    public override ValueTask<object?> ResolveAsync(IResolveFieldContext context, IComplexGraphType graphType, TSourceType source)
         => _resolveFunc(context, source)!;
 }

--- a/src/GraphQL/Federation/Resolvers/FederationResolverBase.cs
+++ b/src/GraphQL/Federation/Resolvers/FederationResolverBase.cs
@@ -10,11 +10,11 @@ public abstract class FederationResolverBase<TParsedType> : FederationResolverBa
     public override Type SourceType => typeof(TParsedType);
 
     /// <inheritdoc/>
-    public override ValueTask<object?> ResolveAsync(IResolveFieldContext context, IObjectGraphType graphType, object parsedRepresentation)
+    public override ValueTask<object?> ResolveAsync(IResolveFieldContext context, IComplexGraphType graphType, object parsedRepresentation)
         => ResolveAsync(context, graphType, (TParsedType)parsedRepresentation);
 
-    /// <inheritdoc cref="IFederationResolver.ResolveAsync(IResolveFieldContext, IObjectGraphType, object)"/>
-    public abstract ValueTask<object?> ResolveAsync(IResolveFieldContext context, IObjectGraphType graphType, TParsedType parsedRepresentation);
+    /// <inheritdoc cref="IFederationResolver.ResolveAsync(IResolveFieldContext, IComplexGraphType, object)"/>
+    public abstract ValueTask<object?> ResolveAsync(IResolveFieldContext context, IComplexGraphType graphType, TParsedType parsedRepresentation);
 }
 
 /// <summary>
@@ -26,7 +26,7 @@ public abstract class FederationResolverBase : IFederationResolver
     /// <summary>
     /// Gets the CLR type of the representation that this resolver is responsible for.
     /// This property indicates the type to which the 'parsedRepresentation' parameter's representation
-    /// will be converted before being passed to the <see cref="ResolveAsync(IResolveFieldContext, IObjectGraphType, object)"/> method.
+    /// will be converted before being passed to the <see cref="ResolveAsync(IResolveFieldContext, IComplexGraphType, object)"/> method.
     /// </summary>
     public abstract Type SourceType { get; }
 
@@ -34,10 +34,10 @@ public abstract class FederationResolverBase : IFederationResolver
     public virtual bool MatchKeys(IDictionary<string, object?> representation) => true;
 
     /// <inheritdoc/>
-    public abstract ValueTask<object?> ResolveAsync(IResolveFieldContext context, IObjectGraphType graphType, object parsedRepresentation);
+    public abstract ValueTask<object?> ResolveAsync(IResolveFieldContext context, IComplexGraphType graphType, object parsedRepresentation);
 
     /// <inheritdoc/>
-    public object ParseRepresentation(IObjectGraphType graphType, IDictionary<string, object?> representation)
+    public object ParseRepresentation(IComplexGraphType graphType, IDictionary<string, object?> representation)
     {
         // entity resolvers that derive from FederationResolverBase define a source CLR type (stored in SourceType)
         //   that the representation should be converted to (for convenience).
@@ -60,7 +60,7 @@ public abstract class FederationResolverBase : IFederationResolver
     /// Deserializes an object based on properties provided in a dictionary, using graph type information from
     /// an output graph type. Requires that the object type has a parameterless constructor.
     /// </summary>
-    private static object ToObject(Type objectType, IObjectGraphType objectGraphType, IDictionary<string, object?> map)
+    private static object ToObject(Type objectType, IComplexGraphType objectGraphType, IDictionary<string, object?> map)
     {
         // create an instance of the target CLR type
         var obj = Activator.CreateInstance(objectType)!;

--- a/src/GraphQL/Federation/Resolvers/IFederationResolver.cs
+++ b/src/GraphQL/Federation/Resolvers/IFederationResolver.cs
@@ -17,18 +17,18 @@ public interface IFederationResolver
     /// <summary>
     /// Parses the source representation into a CLR type that can be used by the resolver.
     /// </summary>
-    /// <param name="graphType">The object graph type associated with the entity being resolved.</param>
+    /// <param name="graphType">The object or interface graph type associated with the entity being resolved.</param>
     /// <param name="representation">The source representation provided by the Apollo Router.</param>
-    object ParseRepresentation(IObjectGraphType graphType, IDictionary<string, object?> representation);
+    object ParseRepresentation(IComplexGraphType graphType, IDictionary<string, object?> representation);
 
     /// <summary>
     /// Asynchronously resolves an object based on the given context and source representation.
-    /// The source representation is parsed by <see cref="ParseRepresentation(IObjectGraphType, IDictionary{string, object?})"/>
+    /// The source representation is parsed by <see cref="ParseRepresentation(IComplexGraphType, IDictionary{string, object?})"/>
     /// during the validation phase before being passed to this method's <paramref name="parsedRepresentation"/> argument.
     /// </summary>
     /// <param name="context">The context of the field being resolved, providing access to various aspects of the GraphQL execution.</param>
     /// <param name="graphType">The object graph type associated with the entity being resolved.</param>
-    /// <param name="parsedRepresentation">The source representation, parsed by <see cref="ParseRepresentation(IObjectGraphType, IDictionary{string, object?})"/>.</param>
+    /// <param name="parsedRepresentation">The source representation, parsed by <see cref="ParseRepresentation(IComplexGraphType, IDictionary{string, object?})"/>.</param>
     /// <returns>A task that represents the asynchronous resolve operation. The task result contains the resolved object.</returns>
-    ValueTask<object?> ResolveAsync(IResolveFieldContext context, IObjectGraphType graphType, object parsedRepresentation);
+    ValueTask<object?> ResolveAsync(IResolveFieldContext context, IComplexGraphType graphType, object parsedRepresentation);
 }

--- a/src/GraphQL/Federation/Resolvers/Representation.cs
+++ b/src/GraphQL/Federation/Resolvers/Representation.cs
@@ -4,15 +4,15 @@ namespace GraphQL.Federation.Resolvers;
 
 /// <summary>
 /// Represents a record class for holding the necessary components to resolve an entity
-/// in a GraphQL federation setup. This includes the GraphQL object type, the resolver,
+/// in a GraphQL federation setup. This includes the GraphQL object or interface type, the resolver,
 /// and the converted representation of the entity.
 /// </summary>
-/// <param name="GraphType">The GraphQL object graph type associated with the entity being resolved.
+/// <param name="GraphType">The GraphQL object or interface graph type associated with the entity being resolved.
 /// This defines the shape of the output data for the GraphQL query.</param>
 /// <param name="Resolver">The federation resolver responsible for resolving the entity.
 /// Each entity type has its specific implementation of <see cref="IFederationResolver"/>
 /// to handle its resolution logic.</param>
 /// <param name="Value">The representation of the entity, parsed to an object by
-/// <see cref="IFederationResolver.ParseRepresentation(IObjectGraphType, IDictionary{string, object?})"/>.
+/// <see cref="IFederationResolver.ParseRepresentation(IComplexGraphType, IDictionary{string, object?})"/>.
 /// This is the actual data passed to the resolver for processing and fetching the corresponding entity.</param>
-public record class Representation(IObjectGraphType GraphType, IFederationResolver Resolver, object Value);
+public record class Representation(IComplexGraphType GraphType, IFederationResolver Resolver, object Value);

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -98,7 +98,17 @@ public class AutoRegisteringInterfaceGraphType<[DynamicallyAccessedMembers(Dynam
 
     /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.CreateField(MemberInfo)"/>
     protected virtual FieldType? CreateField(MemberInfo memberInfo)
-        => AutoRegisteringHelper.CreateField(this, memberInfo, GetTypeInformation, BuildFieldType, false);
+    {
+        var field = AutoRegisteringHelper.CreateField(this, memberInfo, GetTypeInformation, BuildFieldType, false);
+        // clear the field resolver after the attributes are applied, which may set IsPrivate
+        // private fields are ignored, as [FederationResolver] uses a private field and requires the resolver to execute
+        if (field != null && !field.IsPrivate)
+        {
+            field.Resolver = null;
+            field.StreamResolver = null;
+        }
+        return field;
+    }
 
     /// <inheritdoc cref="AutoRegisteringObjectGraphType{TSourceType}.BuildFieldType(FieldType, MemberInfo)"/>
     protected void BuildFieldType(FieldType fieldType, MemberInfo memberInfo)

--- a/src/GraphQL/Types/Composite/InterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/InterfaceGraphType.cs
@@ -7,6 +7,11 @@ public interface IInterfaceGraphType : IAbstractGraphType, IComplexGraphType, II
 {
 }
 
+/// <inheritdoc cref="IInterfaceGraphType"/>
+public interface IInterfaceGraphType<in TObject> : IInterfaceGraphType
+{
+}
+
 // todo: merge these members into IAbstractGraphType for v9 (which already match the members in UnionGraphType)
 internal interface IInterfaceGraphType2 : IInterfaceGraphType
 {
@@ -16,7 +21,7 @@ internal interface IInterfaceGraphType2 : IInterfaceGraphType
 }
 
 /// <inheritdoc cref="InterfaceGraphType"/>
-public class InterfaceGraphType<[NotAGraphType] TSource> : ComplexGraphType<TSource>, IInterfaceGraphType2
+public class InterfaceGraphType<[NotAGraphType] TSource> : ComplexGraphType<TSource>, IInterfaceGraphType2, IInterfaceGraphType<TSource>
 {
     /// <summary>
     /// Initializes a new instance.

--- a/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/SchemaValidationVisitor.cs
@@ -258,7 +258,7 @@ public sealed class SchemaValidationVisitor : BaseSchemaNodeVisitor
         if (field.StreamResolver != null && type != schema.Subscription)
             ReportError(new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have StreamResolver set. You should set StreamResolver only for the root fields of subscriptions."));
 
-        if (field.Resolver != null)
+        if (field.Resolver != null && !field.IsPrivate)
             ReportError(new InvalidOperationException($"The field '{field.Name}' of an Interface type '{type.Name}' must not have Resolver set. Each interface is translated to a concrete type during request execution. You should set Resolver only for fields of object output types."));
 
         if (field.Parser != null)


### PR DESCRIPTION
This allows for resolving interfaces within GraphQL federation.  Unfortunately it requires breaking changes.  While possible, it does not seem practical to implement the required functionality as non-breaking changes.

The biggest breaking change is to `IFederationResolver` which now uses `IComplexGraphType` instead of `IObjectGraphType`.  This will break custom implementations of the resolver as seen in Sample1, either if the interface is directly implemented, or if they derive from `FederationResolverBase`.

Extension methods to configure the schema have not changed, so it is possible or even likely that most federation schemas will not break with these changes.