### PR TITLE
Remove async suffix from ValueTask and IAsyncEnumerable

### DIFF
--- a/docs2/site/docs/migrations/migration9.md
+++ b/docs2/site/docs/migrations/migration9.md
@@ -25,3 +25,11 @@ To address both concerns:
   - `ExecutionContext.ArgumentValues` and `ExecutionContext.DirectiveValues`
   - `IValidationResult.ArgumentValues` and `IValidationResult.DirectiveValues`
   - `ValidationResult.ArgumentValues` and `ValidationResult.DirectiveValues`
+
+### 2. Async suffix removal for type-first field names
+
+In type-first GraphQL schemas, field names ending with "Async" are now automatically removed for methods returning `ValueTask<T>` and `IAsyncEnumerable<T>`, consistent with the existing behavior for `Task<T>`.
+
+For example, previously only `Task<string> GetDataAsync()` would become field `"GetData"`, while `ValueTask<string> GetDataAsync()` and `IAsyncEnumerable<int> GetItemsAsync()` would keep their "Async" suffix. Now all three async return types have consistent field naming.
+
+If you have type-first schemas with `ValueTask<T>` or `IAsyncEnumerable<T>` methods ending in "Async", update your GraphQL queries to use the new field names without the "Async" suffix, or use the `[Name]` attribute to explicitly specify the desired field name.

--- a/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
@@ -198,7 +198,7 @@ public class AutoRegisteringInterfaceGraphTypeTests
     [InlineData(nameof(FieldTests.TaskStringField), typeof(NonNullGraphType<GraphQLClrOutputTypeReference<string>>))]
     [InlineData("TaskIntField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<int>>))]
     [InlineData("ValueTaskStringField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<string>>))]
-    [InlineData("AsyncEnumerableIntField", typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>>))]
+    [InlineData("AsyncEnumerableIntField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<int>>))]
     [InlineData(nameof(FieldTests.DataLoaderNullableStringField), typeof(GraphQLClrOutputTypeReference<string>))]
     [InlineData(nameof(FieldTests.NullableDataLoaderStringField), typeof(GraphQLClrOutputTypeReference<string>))]
     [InlineData(nameof(FieldTests.TaskDataLoaderStringArrayField), typeof(NonNullGraphType<ListGraphType<GraphQLClrOutputTypeReference<string>>>))]

--- a/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringInterfaceGraphTypeTests.cs
@@ -197,6 +197,8 @@ public class AutoRegisteringInterfaceGraphTypeTests
     [InlineData(nameof(FieldTests.ListOfListOfIntsField), typeof(ListGraphType<ListGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(nameof(FieldTests.TaskStringField), typeof(NonNullGraphType<GraphQLClrOutputTypeReference<string>>))]
     [InlineData("TaskIntField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<int>>))]
+    [InlineData("ValueTaskStringField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<string>>))]
+    [InlineData("AsyncEnumerableIntField", typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>>))]
     [InlineData(nameof(FieldTests.DataLoaderNullableStringField), typeof(GraphQLClrOutputTypeReference<string>))]
     [InlineData(nameof(FieldTests.NullableDataLoaderStringField), typeof(GraphQLClrOutputTypeReference<string>))]
     [InlineData(nameof(FieldTests.TaskDataLoaderStringArrayField), typeof(NonNullGraphType<ListGraphType<GraphQLClrOutputTypeReference<string>>>))]
@@ -211,7 +213,9 @@ public class AutoRegisteringInterfaceGraphTypeTests
     public void Field_RemovesAsyncSuffix()
     {
         var graphType = new AutoRegisteringInterfaceGraphType<FieldTests>();
-        var fieldType = graphType.Fields.Find("TaskIntField").ShouldNotBeNull();
+        graphType.Fields.Find("TaskIntField").ShouldNotBeNull();
+        graphType.Fields.Find("ValueTaskStringField").ShouldNotBeNull();
+        graphType.Fields.Find("AsyncEnumerableIntField").ShouldNotBeNull();
     }
 
     [Fact]
@@ -691,6 +695,8 @@ public class AutoRegisteringInterfaceGraphTypeTests
         int?[]?[]? ListOfListOfIntsField { get; set; }
         Task<string> TaskStringField();
         Task<int> TaskIntFieldAsync();
+        ValueTask<string> ValueTaskStringFieldAsync();
+        IAsyncEnumerable<int> AsyncEnumerableIntFieldAsync();
         IDataLoaderResult<string?> DataLoaderNullableStringField();
         IDataLoaderResult<string>? NullableDataLoaderStringField();
         Task<IDataLoaderResult<string?[]>> TaskDataLoaderStringArrayField();

--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -201,7 +201,7 @@ public class AutoRegisteringObjectGraphTypeTests
     [InlineData(nameof(FieldTests.TaskStringField), typeof(NonNullGraphType<GraphQLClrOutputTypeReference<string>>))]
     [InlineData("TaskIntField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<int>>))]
     [InlineData("ValueTaskStringField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<string>>))]
-    [InlineData("AsyncEnumerableIntField", typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>>))]
+    [InlineData("AsyncEnumerableIntField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<int>>))]
     [InlineData(nameof(FieldTests.DataLoaderNullableStringField), typeof(GraphQLClrOutputTypeReference<string>))]
     [InlineData(nameof(FieldTests.NullableDataLoaderStringField), typeof(GraphQLClrOutputTypeReference<string>))]
     [InlineData(nameof(FieldTests.TaskDataLoaderStringArrayField), typeof(NonNullGraphType<ListGraphType<GraphQLClrOutputTypeReference<string>>>))]

--- a/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
+++ b/src/GraphQL.Tests/Types/AutoRegisteringObjectGraphTypeTests.cs
@@ -200,6 +200,8 @@ public class AutoRegisteringObjectGraphTypeTests
     [InlineData(nameof(FieldTests.ListOfListOfIntsField), typeof(ListGraphType<ListGraphType<GraphQLClrOutputTypeReference<int>>>))]
     [InlineData(nameof(FieldTests.TaskStringField), typeof(NonNullGraphType<GraphQLClrOutputTypeReference<string>>))]
     [InlineData("TaskIntField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<int>>))]
+    [InlineData("ValueTaskStringField", typeof(NonNullGraphType<GraphQLClrOutputTypeReference<string>>))]
+    [InlineData("AsyncEnumerableIntField", typeof(NonNullGraphType<ListGraphType<NonNullGraphType<GraphQLClrOutputTypeReference<int>>>>))]
     [InlineData(nameof(FieldTests.DataLoaderNullableStringField), typeof(GraphQLClrOutputTypeReference<string>))]
     [InlineData(nameof(FieldTests.NullableDataLoaderStringField), typeof(GraphQLClrOutputTypeReference<string>))]
     [InlineData(nameof(FieldTests.TaskDataLoaderStringArrayField), typeof(NonNullGraphType<ListGraphType<GraphQLClrOutputTypeReference<string>>>))]
@@ -214,7 +216,9 @@ public class AutoRegisteringObjectGraphTypeTests
     public void Field_RemovesAsyncSuffix()
     {
         var graphType = new AutoRegisteringObjectGraphType<FieldTests>();
-        var fieldType = graphType.Fields.Find("TaskIntField").ShouldNotBeNull();
+        graphType.Fields.Find("TaskIntField").ShouldNotBeNull();
+        graphType.Fields.Find("ValueTaskStringField").ShouldNotBeNull();
+        graphType.Fields.Find("AsyncEnumerableIntField").ShouldNotBeNull();
     }
 
     [Fact]
@@ -766,6 +770,8 @@ public class AutoRegisteringObjectGraphTypeTests
         public int?[]?[]? ListOfListOfIntsField { get; set; }
         public Task<string> TaskStringField() => null!;
         public Task<int> TaskIntFieldAsync() => Task.FromResult(0);
+        public ValueTask<string> ValueTaskStringFieldAsync() => default;
+        public IAsyncEnumerable<int> AsyncEnumerableIntFieldAsync() => null!;
         public IDataLoaderResult<string?> DataLoaderNullableStringField() => null!;
         public IDataLoaderResult<string>? NullableDataLoaderStringField() => null!;
         public Task<IDataLoaderResult<string?[]>> TaskDataLoaderStringArrayField() => null!;


### PR DESCRIPTION
Fixes #4154 