### PR TITLE
Remove ParseLinkVisitor.Run

### DIFF
--- a/docs2/site/docs/migrations/migration9.md
+++ b/docs2/site/docs/migrations/migration9.md
@@ -25,3 +25,7 @@ To address both concerns:
   - `ExecutionContext.ArgumentValues` and `ExecutionContext.DirectiveValues`
   - `IValidationResult.ArgumentValues` and `IValidationResult.DirectiveValues`
   - `ValidationResult.ArgumentValues` and `ValidationResult.DirectiveValues`
+
+### 2. `ParseLinkVisitor.Run` method removed
+
+The `ParseLinkVisitor.Run` method has been removed. However, no changes should be required in your code since an equivalent extension method `Run` already exists for all `ISchemaNodeVisitor` instances, including `ParseLinkVisitor`.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3679,7 +3679,6 @@ namespace GraphQL.Utilities.Visitors
     public sealed class ParseLinkVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
         public static GraphQL.Utilities.Visitors.ParseLinkVisitor Instance { get; }
-        public void Run(GraphQL.Types.ISchema schema) { }
         public override void VisitSchema(GraphQL.Types.ISchema schema) { }
     }
     public class PatternMatchingVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3693,7 +3693,6 @@ namespace GraphQL.Utilities.Visitors
     public sealed class ParseLinkVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
         public static GraphQL.Utilities.Visitors.ParseLinkVisitor Instance { get; }
-        public void Run(GraphQL.Types.ISchema schema) { }
         public override void VisitSchema(GraphQL.Types.ISchema schema) { }
     }
     public class PatternMatchingVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3595,7 +3595,6 @@ namespace GraphQL.Utilities.Visitors
     public sealed class ParseLinkVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
         public static GraphQL.Utilities.Visitors.ParseLinkVisitor Instance { get; }
-        public void Run(GraphQL.Types.ISchema schema) { }
         public override void VisitSchema(GraphQL.Types.ISchema schema) { }
     }
     public class PatternMatchingVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor

--- a/src/GraphQL/Utilities/Visitors/ParseLinkVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/ParseLinkVisitor.cs
@@ -14,12 +14,6 @@ public sealed class ParseLinkVisitor : BaseSchemaNodeVisitor
     /// <inheritdoc cref="ParseLinkVisitor"/>
     public static ParseLinkVisitor Instance { get; } = new();
 
-    /// <inheritdoc cref="SchemaExtensions.Run(ISchemaNodeVisitor, ISchema)"/>
-    public void Run(ISchema schema)
-    {
-        VisitSchema(schema);
-    }
-
     /// <inheritdoc/>
     public override void VisitSchema(ISchema schema)
     {


### PR DESCRIPTION
(Duplicate of extension method in SchemaExtensions)

Fixes #4107 