### PR TITLE
Use GraphiQL instead of Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ It supports the popular IDEs for managing GraphQL requests and exploring GraphQL
 - [Altair](https://github.com/imolorhe/altair)
 - [Firecamp](https://firecamp.io/graphql/)
 - [GraphiQL](https://github.com/graphql/graphiql)
-- [GraphQL Playground](https://github.com/prisma-labs/graphql-playground)
 - [Voyager](https://github.com/APIs-guru/graphql-voyager)
 
 ## Ahead-of-time compilation

--- a/samples/GraphQL.DataLoader.Sample.DI/GraphQL.DataLoader.Sample.DI.csproj
+++ b/samples/GraphQL.DataLoader.Sample.DI/GraphQL.DataLoader.Sample.DI.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Ui.Altair" Version="8.1.0" />
+    <PackageReference Include="GraphQL.Server.Ui.Altair" Version="8.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.*">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/GraphQL.DataLoader.Sample.Default/GraphQL.DataLoader.Sample.Default.csproj
+++ b/samples/GraphQL.DataLoader.Sample.Default/GraphQL.DataLoader.Sample.Default.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Ui.Altair" Version="8.1.0" />
+    <PackageReference Include="GraphQL.Server.Ui.Altair" Version="8.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.*">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/GraphQL.Federation.CodeFirst.Sample3/GraphQL.Federation.CodeFirst.Sample3.csproj
+++ b/samples/GraphQL.Federation.CodeFirst.Sample3/GraphQL.Federation.CodeFirst.Sample3.csproj
@@ -10,9 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="7.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.Federation.CodeFirst.Sample3/Program.cs
+++ b/samples/GraphQL.Federation.CodeFirst.Sample3/Program.cs
@@ -25,7 +25,7 @@ public class Program
         app.MapPost("/graphql", GraphQLHttpMiddlewareAsync);
 
         // Add a UI package for testing
-        app.UseGraphQLPlayground("/");
+        app.UseGraphQLGraphiQL("/");
 
         // Optional: ensure that the schema builds and initializes
         {

--- a/samples/GraphQL.Federation.SchemaFirst.Sample1/GraphQL.Federation.SchemaFirst.Sample1.csproj
+++ b/samples/GraphQL.Federation.SchemaFirst.Sample1/GraphQL.Federation.SchemaFirst.Sample1.csproj
@@ -18,9 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="7.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.Federation.SchemaFirst.Sample1/Program.cs
+++ b/samples/GraphQL.Federation.SchemaFirst.Sample1/Program.cs
@@ -26,7 +26,7 @@ public class Program
         app.MapPost("/graphql", GraphQLHttpMiddlewareAsync);
 
         // Add a UI package for testing
-        app.UseGraphQLPlayground("/");
+        app.UseGraphQLGraphiQL("/");
 
         // Optional: ensure that the schema builds and initializes
         {

--- a/samples/GraphQL.Federation.SchemaFirst.Sample2/GraphQL.Federation.SchemaFirst.Sample2.csproj
+++ b/samples/GraphQL.Federation.SchemaFirst.Sample2/GraphQL.Federation.SchemaFirst.Sample2.csproj
@@ -18,9 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="7.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.Federation.SchemaFirst.Sample2/Program.cs
+++ b/samples/GraphQL.Federation.SchemaFirst.Sample2/Program.cs
@@ -25,7 +25,7 @@ public class Program
         app.MapPost("/graphql", GraphQLHttpMiddlewareAsync);
 
         // Add a UI package for testing
-        app.UseGraphQLPlayground("/");
+        app.UseGraphQLGraphiQL("/");
 
         // Optional: ensure that the schema builds and initializes
         {

--- a/samples/GraphQL.Federation.TypeFirst.Sample4/GraphQL.Federation.TypeFirst.Sample4.csproj
+++ b/samples/GraphQL.Federation.TypeFirst.Sample4/GraphQL.Federation.TypeFirst.Sample4.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="7.*" />
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
   </ItemGroup>

--- a/samples/GraphQL.Federation.TypeFirst.Sample4/Program.cs
+++ b/samples/GraphQL.Federation.TypeFirst.Sample4/Program.cs
@@ -24,7 +24,7 @@ public class Program
         app.MapPost("/graphql", GraphQLHttpMiddlewareAsync);
 
         // Add a UI package for testing
-        app.UseGraphQLPlayground("/");
+        app.UseGraphQLGraphiQL("/");
 
         // Optional: ensure that the schema builds and initializes
         {

--- a/samples/GraphQL.Harness/GraphQL.Harness.csproj
+++ b/samples/GraphQL.Harness/GraphQL.Harness.csproj
@@ -8,10 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Ui.Altair" Version="7.*" />
-    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="7.*" />
-    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="7.*" />
-    <PackageReference Include="GraphQL.Server.Ui.Voyager" Version="7.*" />
+    <PackageReference Include="GraphQL.Server.Ui.Altair" Version="8.*" />
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="8.*" />
+    <PackageReference Include="GraphQL.Server.Ui.Voyager" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GraphQL.Harness/Properties/launchSettings.json
+++ b/samples/GraphQL.Harness/Properties/launchSettings.json
@@ -1,14 +1,5 @@
 {
   "profiles": {
-    "Playground": {
-      "commandName": "Project",
-      "launchBrowser": false,
-      "launchUrl": "ui/playground",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:62248/"
-    },
     "GraphiQL": {
       "commandName": "Project",
       "launchBrowser": true,

--- a/samples/GraphQL.Harness/Startup.cs
+++ b/samples/GraphQL.Harness/Startup.cs
@@ -41,7 +41,6 @@ public class Startup
             app.UseDeveloperExceptionPage();
 
         app.UseGraphQL();
-        app.UseGraphQLPlayground();
         app.UseGraphQLGraphiQL();
         app.UseGraphQLAltair();
         app.UseGraphQLVoyager();


### PR DESCRIPTION
Playground has been marked as deprecated in the server repo; this PR changes the sample projects to use GraphiQL instead of Playground.