### PR TITLE
Mark UniqueDirectivesPerLocation ctor as obsolete

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -4380,6 +4380,8 @@ namespace GraphQL.Validation.Rules
     public class UniqueDirectivesPerLocation : GraphQL.Validation.ValidationRuleBase
     {
         public static readonly GraphQL.Validation.Rules.UniqueDirectivesPerLocation Instance;
+        [System.Obsolete("Please use the Instance property to retrieve a static instance. This constructor " +
+            "will be removed in v9.")]
         public UniqueDirectivesPerLocation() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -4394,6 +4394,8 @@ namespace GraphQL.Validation.Rules
     public class UniqueDirectivesPerLocation : GraphQL.Validation.ValidationRuleBase
     {
         public static readonly GraphQL.Validation.Rules.UniqueDirectivesPerLocation Instance;
+        [System.Obsolete("Please use the Instance property to retrieve a static instance. This constructor " +
+            "will be removed in v9.")]
         public UniqueDirectivesPerLocation() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -4297,6 +4297,8 @@ namespace GraphQL.Validation.Rules
     public class UniqueDirectivesPerLocation : GraphQL.Validation.ValidationRuleBase
     {
         public static readonly GraphQL.Validation.Rules.UniqueDirectivesPerLocation Instance;
+        [System.Obsolete("Please use the Instance property to retrieve a static instance. This constructor " +
+            "will be removed in v9.")]
         public UniqueDirectivesPerLocation() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
     }

--- a/src/GraphQL/Validation/Rules/5.7 - Directives/3. UniqueDirectivesPerLocation.cs
+++ b/src/GraphQL/Validation/Rules/5.7 - Directives/3. UniqueDirectivesPerLocation.cs
@@ -15,7 +15,15 @@ public class UniqueDirectivesPerLocation : ValidationRuleBase
     /// <summary>
     /// Returns a static instance of this validation rule.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
     public static readonly UniqueDirectivesPerLocation Instance = new();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    /// <inheritdoc cref="UniqueDirectivesPerLocation"/>
+    [Obsolete("Please use the Instance property to retrieve a static instance. This constructor will be removed in v9.")]
+    public UniqueDirectivesPerLocation()
+    {
+    }
 
     /// <inheritdoc/>
     /// <exception cref="UniqueDirectivesPerLocationError"/>


### PR DESCRIPTION
Same as all other validation rules.