### PR TITLE
Add QOL validation rule and schema visitor to detect use of deprecated elements

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1399,6 +1399,65 @@ public interface IMyInterface
 }
 ```
 
+### 34. Deprecated element detection and validation support (v8.6+)
+
+Two new classes have been added to help manage deprecated schema elements more effectively:
+[`DeprecatedTypeReferenceVisitor`](src/GraphQL/Utilities/Visitors/Custom/DeprecatedTypeReferenceVisitor.cs) and
+[`DeprecatedElementsValidationRule`](src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs).
+These classes work together to provide comprehensive deprecation management at both the schema and query validation levels.
+
+The [`DeprecatedTypeReferenceVisitor`](src/GraphQL/Utilities/Visitors/Custom/DeprecatedTypeReferenceVisitor.cs) is a schema visitor that identifies non-deprecated fields that directly reference deprecated types during schema initialization. This helps maintain schema consistency by flagging potential issues where deprecated types are still being referenced by active fields.
+
+The [`DeprecatedElementsValidationRule`](src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs) is an abstract validation rule that identifies deprecated fields, arguments, and types referenced in GraphQL documents during query validation. It provides abstract methods that can be overridden to implement custom handling of deprecated element usage, such as logging warnings or collecting metrics.
+
+```csharp
+// Create a custom validation rule to handle deprecated element usage during query validation
+public class LoggingDeprecatedElementsRule : DeprecatedElementsValidationRule
+{
+    private readonly ILogger<LoggingDeprecatedElementsRule> _logger;
+
+    public LoggingDeprecatedElementsRule(ILogger<LoggingDeprecatedElementsRule> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask OnDeprecatedFieldReferenced(ValidationContext context, GraphQLField fieldNode, FieldType fieldDefinition, IGraphType parentType)
+    {
+        _logger.LogWarning("Deprecated field '{ParentType}.{FieldName}' was used: {DeprecationReason}",
+            parentType.Name, fieldDefinition.Name, fieldDefinition.DeprecationReason);
+        return default;
+    }
+
+    protected override ValueTask OnDeprecatedFieldArgumentReferenced(ValidationContext context, GraphQLArgument argumentNode, QueryArgument argumentDefinition, FieldType fieldDefinition, IGraphType parentType)
+    {
+        _logger.LogWarning("Deprecated argument '{ParentType}.{FieldName}.{ArgumentName}' was used: {DeprecationReason}",
+            parentType.Name, fieldDefinition.Name, argumentDefinition.Name, argumentDefinition.DeprecationReason);
+        return default;
+    }
+
+    protected override ValueTask OnDeprecatedDirectiveArgumentReferenced(ValidationContext context, GraphQLArgument argumentNode, QueryArgument argumentDefinition, Directive directiveDefinition)
+    {
+        _logger.LogWarning("Deprecated directive argument '@{DirectiveName}.{ArgumentName}' was used: {DeprecationReason}",
+            directiveDefinition.Name, argumentDefinition.Name, argumentDefinition.DeprecationReason);
+        return default;
+    }
+
+    protected override ValueTask OnDeprecatedTypeReferenced(ValidationContext context, GraphQLNamedType typeConditionNode, IGraphType typeDefinition)
+    {
+        _logger.LogWarning("Deprecated type '{TypeName}' was used: {DeprecationReason}",
+            typeDefinition.Name, typeDefinition.DeprecationReason);
+        return default;
+    }
+}
+
+// Register the schema visitor and validation rule
+services.AddGraphQL(b => b
+    .AddSchema<MySchema>()
+    .AddSchemaVisitor<DeprecatedTypeReferenceVisitor>()
+    .AddValidationRule<LoggingDeprecatedElementsRule>()
+);
+```
+
 ## Breaking Changes
 
 ### 1. Query type is required

--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1421,28 +1421,28 @@ public class LoggingDeprecatedElementsRule : DeprecatedElementsValidationRule
         _logger = logger;
     }
 
-    protected override ValueTask OnDeprecatedFieldReferenced(ValidationContext context, GraphQLField fieldNode, FieldType fieldDefinition, IGraphType parentType)
+    protected override ValueTask OnDeprecatedFieldReferencedAsync(ValidationContext context, GraphQLField fieldNode, FieldType fieldDefinition, IGraphType parentType)
     {
         _logger.LogWarning("Deprecated field '{ParentType}.{FieldName}' was used: {DeprecationReason}",
             parentType.Name, fieldDefinition.Name, fieldDefinition.DeprecationReason);
         return default;
     }
 
-    protected override ValueTask OnDeprecatedFieldArgumentReferenced(ValidationContext context, GraphQLArgument argumentNode, QueryArgument argumentDefinition, FieldType fieldDefinition, IGraphType parentType)
+    protected override ValueTask OnDeprecatedFieldArgumentReferencedAsync(ValidationContext context, GraphQLArgument argumentNode, QueryArgument argumentDefinition, FieldType fieldDefinition, IGraphType parentType)
     {
         _logger.LogWarning("Deprecated argument '{ParentType}.{FieldName}.{ArgumentName}' was used: {DeprecationReason}",
             parentType.Name, fieldDefinition.Name, argumentDefinition.Name, argumentDefinition.DeprecationReason);
         return default;
     }
 
-    protected override ValueTask OnDeprecatedDirectiveArgumentReferenced(ValidationContext context, GraphQLArgument argumentNode, QueryArgument argumentDefinition, Directive directiveDefinition)
+    protected override ValueTask OnDeprecatedDirectiveArgumentReferencedAsync(ValidationContext context, GraphQLArgument argumentNode, QueryArgument argumentDefinition, Directive directiveDefinition)
     {
         _logger.LogWarning("Deprecated directive argument '@{DirectiveName}.{ArgumentName}' was used: {DeprecationReason}",
             directiveDefinition.Name, argumentDefinition.Name, argumentDefinition.DeprecationReason);
         return default;
     }
 
-    protected override ValueTask OnDeprecatedTypeReferenced(ValidationContext context, GraphQLNamedType typeConditionNode, IGraphType typeDefinition)
+    protected override ValueTask OnDeprecatedTypeReferencedAsync(ValidationContext context, GraphQLNamedType typeConditionNode, IGraphType typeDefinition)
     {
         _logger.LogWarning("Deprecated type '{TypeName}' was used: {DeprecationReason}",
             typeDefinition.Name, typeDefinition.DeprecationReason);

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3673,6 +3673,19 @@ namespace GraphQL.Utilities.Federation
         public static void ResolveReferenceAsync<T>(this GraphQL.Utilities.TypeConfig config, System.Func<GraphQL.Utilities.Federation.FederatedResolveContext, System.Threading.Tasks.Task<T?>> resolver) { }
     }
 }
+namespace GraphQL.Utilities.Visitors.Custom
+{
+    public class DeprecatedTypeReferenceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public DeprecatedTypeReferenceVisitor() { }
+        public override void PostVisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
+}
 namespace GraphQL.Utilities.Visitors
 {
     public sealed class ParseLinkVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
@@ -4446,6 +4459,15 @@ namespace GraphQL.Validation.Rules.Custom
         protected virtual System.Threading.Tasks.ValueTask<System.ValueTuple<double, int>> CalculateComplexityAsync(GraphQL.Validation.ValidationContext context) { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         protected virtual System.Threading.Tasks.ValueTask ValidateComplexityAsync(GraphQL.Validation.ValidationContext context, double totalComplexity, int maxDepth) { }
+    }
+    public abstract class DeprecatedElementsValidationRule : GraphQL.Validation.ValidationRuleBase
+    {
+        protected DeprecatedElementsValidationRule() { }
+        public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
     }
     [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
         "d in v9.")]

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -4465,10 +4465,10 @@ namespace GraphQL.Validation.Rules.Custom
     {
         protected DeprecatedElementsValidationRule() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
     }
     [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
         "d in v9.")]

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3677,6 +3677,7 @@ namespace GraphQL.Utilities.Visitors.Custom
 {
     public class DeprecatedTypeReferenceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
+        protected readonly System.Collections.Generic.List<string> Violations;
         public DeprecatedTypeReferenceVisitor() { }
         public override void PostVisitSchema(GraphQL.Types.ISchema schema) { }
         public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -4479,10 +4479,10 @@ namespace GraphQL.Validation.Rules.Custom
     {
         protected DeprecatedElementsValidationRule() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
     }
     [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
         "d in v9.")]

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3687,6 +3687,19 @@ namespace GraphQL.Utilities.Federation
         public static void ResolveReferenceAsync<T>(this GraphQL.Utilities.TypeConfig config, System.Func<GraphQL.Utilities.Federation.FederatedResolveContext, System.Threading.Tasks.Task<T?>> resolver) { }
     }
 }
+namespace GraphQL.Utilities.Visitors.Custom
+{
+    public class DeprecatedTypeReferenceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public DeprecatedTypeReferenceVisitor() { }
+        public override void PostVisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
+}
 namespace GraphQL.Utilities.Visitors
 {
     public sealed class ParseLinkVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
@@ -4460,6 +4473,15 @@ namespace GraphQL.Validation.Rules.Custom
         protected virtual System.Threading.Tasks.ValueTask<System.ValueTuple<double, int>> CalculateComplexityAsync(GraphQL.Validation.ValidationContext context) { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         protected virtual System.Threading.Tasks.ValueTask ValidateComplexityAsync(GraphQL.Validation.ValidationContext context, double totalComplexity, int maxDepth) { }
+    }
+    public abstract class DeprecatedElementsValidationRule : GraphQL.Validation.ValidationRuleBase
+    {
+        protected DeprecatedElementsValidationRule() { }
+        public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
     }
     [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
         "d in v9.")]

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3691,6 +3691,7 @@ namespace GraphQL.Utilities.Visitors.Custom
 {
     public class DeprecatedTypeReferenceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
+        protected readonly System.Collections.Generic.List<string> Violations;
         public DeprecatedTypeReferenceVisitor() { }
         public override void PostVisitSchema(GraphQL.Types.ISchema schema) { }
         public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3590,6 +3590,19 @@ namespace GraphQL.Utilities.Federation
         public static void ResolveReferenceAsync<T>(this GraphQL.Utilities.TypeConfig config, System.Func<GraphQL.Utilities.Federation.FederatedResolveContext, System.Threading.Tasks.Task<T?>> resolver) { }
     }
 }
+namespace GraphQL.Utilities.Visitors.Custom
+{
+    public class DeprecatedTypeReferenceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
+    {
+        public DeprecatedTypeReferenceVisitor() { }
+        public override void PostVisitSchema(GraphQL.Types.ISchema schema) { }
+        public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitInterfaceFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInterfaceGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldArgumentDefinition(GraphQL.Types.QueryArgument argument, GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+        public override void VisitObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IObjectGraphType type, GraphQL.Types.ISchema schema) { }
+    }
+}
 namespace GraphQL.Utilities.Visitors
 {
     public sealed class ParseLinkVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
@@ -4363,6 +4376,15 @@ namespace GraphQL.Validation.Rules.Custom
         protected virtual System.Threading.Tasks.ValueTask<System.ValueTuple<double, int>> CalculateComplexityAsync(GraphQL.Validation.ValidationContext context) { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPostNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
         protected virtual System.Threading.Tasks.ValueTask ValidateComplexityAsync(GraphQL.Validation.ValidationContext context, double totalComplexity, int maxDepth) { }
+    }
+    public abstract class DeprecatedElementsValidationRule : GraphQL.Validation.ValidationRuleBase
+    {
+        protected DeprecatedElementsValidationRule() { }
+        public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
     }
     [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
         "d in v9.")]

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -4382,10 +4382,10 @@ namespace GraphQL.Validation.Rules.Custom
     {
         protected DeprecatedElementsValidationRule() { }
         public override System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> GetPreNodeVisitorAsync(GraphQL.Validation.ValidationContext context) { }
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
-        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferenced(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedDirectiveArgumentReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.Directive directiveDefinition);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldArgumentReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLArgument argumentNode, GraphQL.Types.QueryArgument argumentDefinition, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedFieldReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLField fieldNode, GraphQL.Types.FieldType fieldDefinition, GraphQL.Types.IGraphType parentType);
+        protected abstract System.Threading.Tasks.ValueTask OnDeprecatedTypeReferencedAsync(GraphQL.Validation.ValidationContext context, GraphQLParser.AST.GraphQLNamedType typeConditionNode, GraphQL.Types.IGraphType typeDefinition);
     }
     [System.Obsolete("Please use the new complexity analyzer. The v7 complexity analyzer will be remove" +
         "d in v9.")]

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3594,6 +3594,7 @@ namespace GraphQL.Utilities.Visitors.Custom
 {
     public class DeprecatedTypeReferenceVisitor : GraphQL.Utilities.BaseSchemaNodeVisitor
     {
+        protected readonly System.Collections.Generic.List<string> Violations;
         public DeprecatedTypeReferenceVisitor() { }
         public override void PostVisitSchema(GraphQL.Types.ISchema schema) { }
         public override void VisitInputObjectFieldDefinition(GraphQL.Types.FieldType field, GraphQL.Types.IInputObjectGraphType type, GraphQL.Types.ISchema schema) { }

--- a/src/GraphQL.Tests/Utilities/Visitors/DeprecatedTypeReferenceVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/DeprecatedTypeReferenceVisitorTests.cs
@@ -1,0 +1,273 @@
+using GraphQL.Types;
+using GraphQL.Utilities.Visitors.Custom;
+
+namespace GraphQL.Tests.Utilities.Visitors;
+
+public class DeprecatedTypeReferenceVisitorTests
+{
+    [Fact]
+    public void Should_Throw_When_NonDeprecated_Field_References_Deprecated_Type()
+    {
+        // Arrange
+        var deprecatedType = new ObjectGraphType
+        {
+            Name = "DeprecatedUser",
+            DeprecationReason = "Use NewUser instead"
+        };
+        deprecatedType.Field<StringGraphType>("id");
+
+        var activeType = new ObjectGraphType { Name = "Post" };
+        activeType.Field<StringGraphType>("title");
+        // Non-deprecated field referencing deprecated type
+        activeType.Field<ObjectGraphType>("author").Type(deprecatedType);
+
+        var schema = new Schema
+        {
+            Query = activeType
+        };
+        schema.RegisterType(deprecatedType);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => schema.Initialize());
+        exception.Message.ShouldBe("Non-deprecated field 'Post.author' references deprecated type 'DeprecatedUser'.");
+    }
+
+    [Fact]
+    public void Should_Not_Throw_When_Deprecated_Field_References_Deprecated_Type()
+    {
+        // Arrange
+        var deprecatedType = new ObjectGraphType
+        {
+            Name = "DeprecatedUser",
+            DeprecationReason = "Use NewUser instead"
+        };
+        deprecatedType.Field<StringGraphType>("id");
+
+        var activeType = new ObjectGraphType { Name = "Post" };
+        activeType.Field<StringGraphType>("title");
+        // Deprecated field referencing deprecated type - this should be allowed
+        activeType.Field<ObjectGraphType>("author")
+            .Type(deprecatedType)
+            .DeprecationReason("Use newAuthor field instead");
+
+        var schema = new Schema
+        {
+            Query = activeType
+        };
+        schema.RegisterType(deprecatedType);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        schema.Initialize();
+    }
+
+    [Fact]
+    public void Should_Throw_AggregateException_When_Multiple_Violations()
+    {
+        // Arrange
+        var deprecatedType1 = new ObjectGraphType
+        {
+            Name = "DeprecatedUser",
+            DeprecationReason = "Use NewUser instead"
+        };
+        deprecatedType1.Field<StringGraphType>("id");
+
+        var deprecatedType2 = new ObjectGraphType
+        {
+            Name = "DeprecatedCategory",
+            DeprecationReason = "Use NewCategory instead"
+        };
+        deprecatedType2.Field<StringGraphType>("name");
+
+        var activeType = new ObjectGraphType { Name = "Post" };
+        activeType.Field<StringGraphType>("title");
+        activeType.Field<ObjectGraphType>("author").Type(deprecatedType1);
+        activeType.Field<ObjectGraphType>("category").Type(deprecatedType2);
+
+        var schema = new Schema
+        {
+            Query = activeType
+        };
+        schema.RegisterType(deprecatedType1);
+        schema.RegisterType(deprecatedType2);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        var exception = Should.Throw<AggregateException>(() => schema.Initialize());
+        exception.Message.ShouldContain("Schema validation failed. Found multiple non-deprecated fields referencing deprecated types.");
+        exception.InnerExceptions.Count.ShouldBe(2);
+
+        var innerMessages = exception.InnerExceptions.Select(ex => ex.Message).ToArray();
+        innerMessages.ShouldContain("Non-deprecated field 'Post.author' references deprecated type 'DeprecatedUser'.");
+        innerMessages.ShouldContain("Non-deprecated field 'Post.category' references deprecated type 'DeprecatedCategory'.");
+    }
+
+    [Fact]
+    public void Should_Not_Throw_When_NonDeprecated_Field_References_NonDeprecated_Type()
+    {
+        // Arrange
+        var activeUserType = new ObjectGraphType { Name = "User" };
+        activeUserType.Field<StringGraphType>("id");
+
+        var activePostType = new ObjectGraphType { Name = "Post" };
+        activePostType.Field<StringGraphType>("title");
+        activePostType.Field<ObjectGraphType>("author").Type(activeUserType);
+
+        var schema = new Schema
+        {
+            Query = activePostType
+        };
+        schema.RegisterType(activeUserType);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        schema.Initialize();
+    }
+
+    [Fact]
+    public void Should_Throw_When_ObjectField_References_Deprecated_Type()
+    {
+        // Arrange
+        var deprecatedType = new ObjectGraphType
+        {
+            Name = "DeprecatedUser",
+            DeprecationReason = "Use NewUser instead"
+        };
+        deprecatedType.Field<StringGraphType>("id");
+
+        var activeType = new ObjectGraphType { Name = "Post" };
+        activeType.Field<ObjectGraphType>("author").Type(deprecatedType);
+
+        var schema = new Schema { Query = activeType };
+        schema.RegisterType(deprecatedType);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => schema.Initialize());
+        exception.Message.ShouldBe("Non-deprecated field 'Post.author' references deprecated type 'DeprecatedUser'.");
+    }
+
+    [Fact]
+    public void Should_Throw_When_InterfaceField_References_Deprecated_Type()
+    {
+        // Arrange
+        var deprecatedType = new ObjectGraphType
+        {
+            Name = "DeprecatedUser",
+            DeprecationReason = "Use NewUser instead"
+        };
+        deprecatedType.Field<StringGraphType>("id");
+
+        var activeInterface = new InterfaceGraphType { Name = "IPost" };
+        activeInterface.Field<ObjectGraphType>("author").Type(deprecatedType);
+
+        var schema = new Schema { Query = new ObjectGraphType { Name = "Query" } };
+        schema.RegisterType(deprecatedType);
+        schema.RegisterType(activeInterface);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => schema.Initialize());
+        exception.Message.ShouldBe("Non-deprecated field 'IPost.author' references deprecated type 'DeprecatedUser'.");
+    }
+
+    [Fact]
+    public void Should_Throw_When_InputObjectField_References_Deprecated_Type()
+    {
+        // Arrange
+        var deprecatedInputType = new InputObjectGraphType
+        {
+            Name = "DeprecatedUserInput",
+            DeprecationReason = "Use NewUserInput instead"
+        };
+        deprecatedInputType.Field<StringGraphType>("name");
+
+        var activeInputType = new InputObjectGraphType { Name = "PostInput" };
+        activeInputType.Field<InputObjectGraphType>("author").Type(deprecatedInputType);
+
+        var schema = new Schema { Query = new ObjectGraphType { Name = "Query" } };
+        schema.RegisterType(deprecatedInputType);
+        schema.RegisterType(activeInputType);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => schema.Initialize());
+        exception.Message.ShouldBe("Non-deprecated field 'PostInput.author' references deprecated type 'DeprecatedUserInput'.");
+    }
+
+    [Fact]
+    public void Should_Throw_When_ObjectFieldArgument_References_Deprecated_Type()
+    {
+        // Arrange
+        var deprecatedInputType = new InputObjectGraphType
+        {
+            Name = "DeprecatedFilterInput",
+            DeprecationReason = "Use NewFilterInput instead"
+        };
+        deprecatedInputType.Field<StringGraphType>("term");
+
+        var queryType = new ObjectGraphType { Name = "Query" };
+        queryType.Field<StringGraphType>("search")
+            .Argument(deprecatedInputType, "filter")
+            .Resolve(ctx => "result");
+
+        var schema = new Schema { Query = queryType };
+        schema.RegisterType(deprecatedInputType);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => schema.Initialize());
+        exception.Message.ShouldBe("Non-deprecated argument 'Query.search.filter' references deprecated type 'DeprecatedFilterInput'.");
+    }
+
+    [Fact]
+    public void Should_Throw_When_InterfaceFieldArgument_References_Deprecated_Type()
+    {
+        // Arrange
+        var deprecatedInputType = new InputObjectGraphType
+        {
+            Name = "DeprecatedSortInput",
+            DeprecationReason = "Use NewSortInput instead"
+        };
+        deprecatedInputType.Field<StringGraphType>("field");
+
+        var activeInterface = new InterfaceGraphType { Name = "ISearchable" };
+        activeInterface.Field<StringGraphType>("find")
+            .Argument(deprecatedInputType, "sort")
+            .Resolve(ctx => "result");
+
+        var schema = new Schema { Query = new ObjectGraphType { Name = "Query" } };
+        schema.RegisterType(deprecatedInputType);
+        schema.RegisterType(activeInterface);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => schema.Initialize());
+        exception.Message.ShouldBe("Non-deprecated argument 'ISearchable.find.sort' references deprecated type 'DeprecatedSortInput'.");
+    }
+
+    [Fact]
+    public void Should_Handle_Wrapped_Deprecated_Types_In_ObjectFields()
+    {
+        // Arrange
+        var deprecatedType = new ObjectGraphType
+        {
+            Name = "DeprecatedUser",
+            DeprecationReason = "Use NewUser instead"
+        };
+        deprecatedType.Field<StringGraphType>("id");
+
+        var activeType = new ObjectGraphType { Name = "Post" };
+        activeType.Field<NonNullGraphType<ListGraphType<NonNullGraphType<ObjectGraphType>>>>("authors")
+            .Type(new NonNullGraphType(new ListGraphType(new NonNullGraphType(deprecatedType))));
+
+        var schema = new Schema { Query = activeType };
+        schema.RegisterType(deprecatedType);
+        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => schema.Initialize());
+        exception.Message.ShouldBe("Non-deprecated field 'Post.authors' references deprecated type 'DeprecatedUser'.");
+    }
+}

--- a/src/GraphQL.Tests/Utilities/Visitors/DeprecatedTypeReferenceVisitorTests.cs
+++ b/src/GraphQL.Tests/Utilities/Visitors/DeprecatedTypeReferenceVisitorTests.cs
@@ -6,34 +6,6 @@ namespace GraphQL.Tests.Utilities.Visitors;
 public class DeprecatedTypeReferenceVisitorTests
 {
     [Fact]
-    public void Should_Throw_When_NonDeprecated_Field_References_Deprecated_Type()
-    {
-        // Arrange
-        var deprecatedType = new ObjectGraphType
-        {
-            Name = "DeprecatedUser",
-            DeprecationReason = "Use NewUser instead"
-        };
-        deprecatedType.Field<StringGraphType>("id");
-
-        var activeType = new ObjectGraphType { Name = "Post" };
-        activeType.Field<StringGraphType>("title");
-        // Non-deprecated field referencing deprecated type
-        activeType.Field<ObjectGraphType>("author").Type(deprecatedType);
-
-        var schema = new Schema
-        {
-            Query = activeType
-        };
-        schema.RegisterType(deprecatedType);
-        schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
-
-        // Act & Assert
-        var exception = Should.Throw<InvalidOperationException>(() => schema.Initialize());
-        exception.Message.ShouldBe("Non-deprecated field 'Post.author' references deprecated type 'DeprecatedUser'.");
-    }
-
-    [Fact]
     public void Should_Not_Throw_When_Deprecated_Field_References_Deprecated_Type()
     {
         // Arrange

--- a/src/GraphQL.Tests/Validation/DeprecatedElementsValidationRuleTests.cs
+++ b/src/GraphQL.Tests/Validation/DeprecatedElementsValidationRuleTests.cs
@@ -377,7 +377,7 @@ public class DeprecatedElementsValidationRuleTests : ValidationTestBase<Deprecat
         public List<DeprecatedDirectiveArgumentCall> DeprecatedDirectiveArgumentCalls { get; } = new();
         public List<DeprecatedTypeCall> DeprecatedTypeCalls { get; } = new();
 
-        protected override ValueTask OnDeprecatedFieldReferenced(
+        protected override ValueTask OnDeprecatedFieldReferencedAsync(
             ValidationContext context,
             GraphQLField fieldNode,
             FieldType fieldDefinition,
@@ -387,7 +387,7 @@ public class DeprecatedElementsValidationRuleTests : ValidationTestBase<Deprecat
             return default;
         }
 
-        protected override ValueTask OnDeprecatedFieldArgumentReferenced(
+        protected override ValueTask OnDeprecatedFieldArgumentReferencedAsync(
             ValidationContext context,
             GraphQLArgument argumentNode,
             QueryArgument argumentDefinition,
@@ -398,7 +398,7 @@ public class DeprecatedElementsValidationRuleTests : ValidationTestBase<Deprecat
             return default;
         }
 
-        protected override ValueTask OnDeprecatedDirectiveArgumentReferenced(
+        protected override ValueTask OnDeprecatedDirectiveArgumentReferencedAsync(
             ValidationContext context,
             GraphQLArgument argumentNode,
             QueryArgument argumentDefinition,
@@ -408,7 +408,7 @@ public class DeprecatedElementsValidationRuleTests : ValidationTestBase<Deprecat
             return default;
         }
 
-        protected override ValueTask OnDeprecatedTypeReferenced(
+        protected override ValueTask OnDeprecatedTypeReferencedAsync(
             ValidationContext context,
             GraphQLNamedType typeConditionNode,
             IGraphType typeDefinition)

--- a/src/GraphQL.Tests/Validation/DeprecatedElementsValidationRuleTests.cs
+++ b/src/GraphQL.Tests/Validation/DeprecatedElementsValidationRuleTests.cs
@@ -1,0 +1,522 @@
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Rules.Custom;
+using GraphQLParser.AST;
+
+namespace GraphQL.Tests.Validation;
+
+public class DeprecatedElementsValidationRuleTests : ValidationTestBase<DeprecatedElementsValidationRuleTests.TestDeprecatedElementsValidationRule, DeprecatedElementsValidationRuleTests.DeprecatedElementsTestSchema>
+{
+    [Fact]
+    public void should_detect_deprecated_field()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    name
+                    deprecatedField
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedFieldCalls.Count.ShouldBe(1);
+        var call = rule.DeprecatedFieldCalls[0];
+        call.FieldNode.Name.StringValue.ShouldBe("deprecatedField");
+        call.FieldDefinition.Name.ShouldBe("deprecatedField");
+        call.FieldDefinition.DeprecationReason.ShouldBe("This field is deprecated");
+        call.ParentType.Name.ShouldBe("Human");
+    }
+
+    [Fact]
+    public void should_detect_multiple_deprecated_fields()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    deprecatedField
+                    anotherDeprecatedField
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedFieldCalls.Count.ShouldBe(2);
+        rule.DeprecatedFieldCalls[0].FieldNode.Name.StringValue.ShouldBe("deprecatedField");
+        rule.DeprecatedFieldCalls[1].FieldNode.Name.StringValue.ShouldBe("anotherDeprecatedField");
+    }
+
+    [Fact]
+    public void should_not_detect_non_deprecated_fields()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    name
+                    id
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedFieldCalls.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void should_detect_deprecated_field_argument()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    fieldWithDeprecatedArg(deprecatedArg: "test")
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedFieldArgumentCalls.Count.ShouldBe(1);
+        var call = rule.DeprecatedFieldArgumentCalls[0];
+        call.ArgumentNode.Name.StringValue.ShouldBe("deprecatedArg");
+        call.ArgumentDefinition.Name.ShouldBe("deprecatedArg");
+        call.ArgumentDefinition.DeprecationReason.ShouldBe("This argument is deprecated");
+        call.FieldDefinition.Name.ShouldBe("fieldWithDeprecatedArg");
+        call.ParentType.Name.ShouldBe("Human");
+    }
+
+    [Fact]
+    public void should_detect_multiple_deprecated_field_arguments()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    fieldWithMultipleDeprecatedArgs(deprecatedArg: "test", anotherDeprecatedArg: 42)
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedFieldArgumentCalls.Count.ShouldBe(2);
+        rule.DeprecatedFieldArgumentCalls[0].ArgumentNode.Name.StringValue.ShouldBe("deprecatedArg");
+        rule.DeprecatedFieldArgumentCalls[1].ArgumentNode.Name.StringValue.ShouldBe("anotherDeprecatedArg");
+    }
+
+    [Fact]
+    public void should_not_detect_non_deprecated_field_arguments()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    fieldWithDeprecatedArg(normalArg: "test")
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedFieldArgumentCalls.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void should_detect_deprecated_directive_argument()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    name @testDirective(deprecatedDirectiveArg: "test")
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedDirectiveArgumentCalls.Count.ShouldBe(1);
+        var call = rule.DeprecatedDirectiveArgumentCalls[0];
+        call.ArgumentNode.Name.StringValue.ShouldBe("deprecatedDirectiveArg");
+        call.ArgumentDefinition.Name.ShouldBe("deprecatedDirectiveArg");
+        call.ArgumentDefinition.DeprecationReason.ShouldBe("This directive argument is deprecated");
+        call.DirectiveDefinition.Name.ShouldBe("testDirective");
+    }
+
+    [Fact]
+    public void should_not_detect_non_deprecated_directive_arguments()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    name @testDirective(normalDirectiveArg: "test")
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedDirectiveArgumentCalls.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void should_detect_deprecated_type_in_fragment_definition()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                fragment TestFragment on DeprecatedType {
+                  name
+                }
+                
+                {
+                  human {
+                    name
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedTypeCalls.Count.ShouldBe(1);
+        var call = rule.DeprecatedTypeCalls[0];
+        call.TypeConditionNode.Name.StringValue.ShouldBe("DeprecatedType");
+        call.TypeDefinition.Name.ShouldBe("DeprecatedType");
+        call.TypeDefinition.DeprecationReason.ShouldBe("This type is deprecated");
+    }
+
+    [Fact]
+    public void should_detect_deprecated_type_in_inline_fragment()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    name
+                    ... on DeprecatedType {
+                      name
+                    }
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedTypeCalls.Count.ShouldBe(1);
+        var call = rule.DeprecatedTypeCalls[0];
+        call.TypeConditionNode.Name.StringValue.ShouldBe("DeprecatedType");
+        call.TypeDefinition.Name.ShouldBe("DeprecatedType");
+        call.TypeDefinition.DeprecationReason.ShouldBe("This type is deprecated");
+    }
+
+    [Fact]
+    public void should_not_detect_deprecated_type_in_inline_fragment_without_type_condition()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    name
+                    ... {
+                      id
+                    }
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedTypeCalls.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void should_not_detect_non_deprecated_types()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                fragment TestFragment on Human {
+                  name
+                }
+                
+                {
+                  human {
+                    name
+                    ... on Human {
+                      id
+                    }
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedTypeCalls.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void should_detect_multiple_deprecated_elements_in_single_query()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                fragment TestFragment on DeprecatedType {
+                  name
+                }
+                
+                {
+                  human {
+                    deprecatedField
+                    fieldWithDeprecatedArg(deprecatedArg: "test")
+                    name @testDirective(deprecatedDirectiveArg: "test")
+                    ... on DeprecatedType {
+                      name
+                    }
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedFieldCalls.Count.ShouldBe(1);
+        rule.DeprecatedFieldCalls[0].FieldNode.Name.StringValue.ShouldBe("deprecatedField");
+        rule.DeprecatedFieldCalls[0].FieldDefinition.DeprecationReason.ShouldBe("This field is deprecated");
+        rule.DeprecatedFieldCalls[0].ParentType.Name.ShouldBe("Human");
+
+        rule.DeprecatedFieldArgumentCalls.Count.ShouldBe(1);
+        rule.DeprecatedFieldArgumentCalls[0].ArgumentNode.Name.StringValue.ShouldBe("deprecatedArg");
+        rule.DeprecatedFieldArgumentCalls[0].ArgumentDefinition.DeprecationReason.ShouldBe("This argument is deprecated");
+        rule.DeprecatedFieldArgumentCalls[0].FieldDefinition.Name.ShouldBe("fieldWithDeprecatedArg");
+
+        rule.DeprecatedDirectiveArgumentCalls.Count.ShouldBe(1);
+        rule.DeprecatedDirectiveArgumentCalls[0].ArgumentNode.Name.StringValue.ShouldBe("deprecatedDirectiveArg");
+        rule.DeprecatedDirectiveArgumentCalls[0].ArgumentDefinition.DeprecationReason.ShouldBe("This directive argument is deprecated");
+        rule.DeprecatedDirectiveArgumentCalls[0].DirectiveDefinition.Name.ShouldBe("testDirective");
+
+        rule.DeprecatedTypeCalls.Count.ShouldBe(2); // One from fragment definition, one from inline fragment
+        rule.DeprecatedTypeCalls[0].TypeConditionNode.Name.StringValue.ShouldBe("DeprecatedType");
+        rule.DeprecatedTypeCalls[0].TypeDefinition.DeprecationReason.ShouldBe("This type is deprecated");
+        rule.DeprecatedTypeCalls[1].TypeConditionNode.Name.StringValue.ShouldBe("DeprecatedType");
+        rule.DeprecatedTypeCalls[1].TypeDefinition.DeprecationReason.ShouldBe("This type is deprecated");
+    }
+
+    [Fact]
+    public void should_handle_nested_deprecated_fields()
+    {
+        var rule = new TestDeprecatedElementsValidationRule();
+
+        ShouldPassRule(config =>
+        {
+            config.Query = """
+                {
+                  human {
+                    deprecatedField {
+                      nestedDeprecatedField
+                    }
+                  }
+                }
+                """;
+            config.Rule(rule);
+        });
+
+        rule.DeprecatedFieldCalls.Count.ShouldBe(2);
+        rule.DeprecatedFieldCalls[0].FieldNode.Name.StringValue.ShouldBe("deprecatedField");
+        rule.DeprecatedFieldCalls[1].FieldNode.Name.StringValue.ShouldBe("nestedDeprecatedField");
+    }
+
+
+
+
+    public class TestDeprecatedElementsValidationRule : DeprecatedElementsValidationRule
+    {
+        public List<DeprecatedFieldCall> DeprecatedFieldCalls { get; } = new();
+        public List<DeprecatedFieldArgumentCall> DeprecatedFieldArgumentCalls { get; } = new();
+        public List<DeprecatedDirectiveArgumentCall> DeprecatedDirectiveArgumentCalls { get; } = new();
+        public List<DeprecatedTypeCall> DeprecatedTypeCalls { get; } = new();
+
+        protected override ValueTask OnDeprecatedFieldReferenced(
+            ValidationContext context,
+            GraphQLField fieldNode,
+            FieldType fieldDefinition,
+            IGraphType parentType)
+        {
+            DeprecatedFieldCalls.Add(new DeprecatedFieldCall(fieldNode, fieldDefinition, parentType));
+            return default;
+        }
+
+        protected override ValueTask OnDeprecatedFieldArgumentReferenced(
+            ValidationContext context,
+            GraphQLArgument argumentNode,
+            QueryArgument argumentDefinition,
+            FieldType fieldDefinition,
+            IGraphType parentType)
+        {
+            DeprecatedFieldArgumentCalls.Add(new DeprecatedFieldArgumentCall(argumentNode, argumentDefinition, fieldDefinition, parentType));
+            return default;
+        }
+
+        protected override ValueTask OnDeprecatedDirectiveArgumentReferenced(
+            ValidationContext context,
+            GraphQLArgument argumentNode,
+            QueryArgument argumentDefinition,
+            Directive directiveDefinition)
+        {
+            DeprecatedDirectiveArgumentCalls.Add(new DeprecatedDirectiveArgumentCall(argumentNode, argumentDefinition, directiveDefinition));
+            return default;
+        }
+
+        protected override ValueTask OnDeprecatedTypeReferenced(
+            ValidationContext context,
+            GraphQLNamedType typeConditionNode,
+            IGraphType typeDefinition)
+        {
+            DeprecatedTypeCalls.Add(new DeprecatedTypeCall(typeConditionNode, typeDefinition));
+            return default;
+        }
+    }
+
+    public record DeprecatedFieldCall(GraphQLField FieldNode, FieldType FieldDefinition, IGraphType ParentType);
+    public record DeprecatedFieldArgumentCall(GraphQLArgument ArgumentNode, QueryArgument ArgumentDefinition, FieldType FieldDefinition, IGraphType ParentType);
+    public record DeprecatedDirectiveArgumentCall(GraphQLArgument ArgumentNode, QueryArgument ArgumentDefinition, Directive DirectiveDefinition);
+    public record DeprecatedTypeCall(GraphQLNamedType TypeConditionNode, IGraphType TypeDefinition);
+
+    public class DeprecatedElementsTestSchema : Schema
+    {
+        public DeprecatedElementsTestSchema()
+        {
+            Query = new DeprecatedElementsQueryRoot();
+            this.RegisterType<DeprecatedType>();
+            this.RegisterType<NestedDeprecatedType>();
+
+            Directives.Register(new TestDirective());
+        }
+    }
+
+    public class DeprecatedElementsQueryRoot : ObjectGraphType
+    {
+        public DeprecatedElementsQueryRoot()
+        {
+            Name = "Query";
+            Field<HumanWithDeprecatedElements>("human");
+        }
+    }
+
+    public class HumanWithDeprecatedElements : ObjectGraphType
+    {
+        public HumanWithDeprecatedElements()
+        {
+            Name = "Human";
+            Field<StringGraphType>("name");
+            Field<IntGraphType>("id");
+
+            // Deprecated field
+            Field<NestedDeprecatedType>("deprecatedField")
+                .DeprecationReason("This field is deprecated");
+
+            // Another deprecated field
+            Field<StringGraphType>("anotherDeprecatedField")
+                .DeprecationReason("Another deprecated field");
+
+            // Field with deprecated argument
+            Field<StringGraphType>("fieldWithDeprecatedArg")
+                .Argument<StringGraphType>("deprecatedArg", arg => arg.DeprecationReason = "This argument is deprecated")
+                .Argument<StringGraphType>("normalArg");
+
+            // Field with multiple deprecated arguments
+            Field<StringGraphType>("fieldWithMultipleDeprecatedArgs")
+                .Argument<StringGraphType>("deprecatedArg", arg => arg.DeprecationReason = "This argument is deprecated")
+                .Argument<IntGraphType>("anotherDeprecatedArg", arg => arg.DeprecationReason = "Another deprecated argument")
+                .Argument<StringGraphType>("normalArg");
+
+            IsTypeOf = _ => true;
+        }
+    }
+
+    public class NestedDeprecatedType : ObjectGraphType
+    {
+        public NestedDeprecatedType()
+        {
+            Name = "NestedDeprecatedType";
+            Field<StringGraphType>("name");
+
+            // Nested deprecated field
+            Field<StringGraphType>("nestedDeprecatedField")
+                .DeprecationReason("This nested field is deprecated");
+
+            IsTypeOf = _ => true;
+        }
+    }
+
+    public class DeprecatedType : ObjectGraphType
+    {
+        public DeprecatedType()
+        {
+            Name = "DeprecatedType";
+            DeprecationReason = "This type is deprecated";
+            Field<StringGraphType>("name");
+
+            IsTypeOf = _ => true;
+        }
+    }
+
+    public class TestDirective : Directive
+    {
+        public TestDirective() : base("testDirective", DirectiveLocation.Field)
+        {
+            Arguments = new QueryArguments(
+                new QueryArgument<StringGraphType>
+                {
+                    Name = "deprecatedDirectiveArg",
+                    DeprecationReason = "This directive argument is deprecated"
+                },
+                new QueryArgument<StringGraphType>
+                {
+                    Name = "normalDirectiveArg"
+                }
+            );
+        }
+    }
+}

--- a/src/GraphQL/Utilities/Visitors/Custom/DeprecatedTypeReferenceVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/Custom/DeprecatedTypeReferenceVisitor.cs
@@ -1,0 +1,113 @@
+using GraphQL.Types;
+
+namespace GraphQL.Utilities.Visitors.Custom;
+
+/// <summary>
+/// A schema visitor that identifies non-deprecated fields that directly reference deprecated types.
+/// This visitor helps maintain schema consistency by flagging potential issues where deprecated
+/// types are still being referenced by active fields.
+/// </summary>
+/// <remarks>
+/// Use this visitor to scan your schema for fields that may need attention when deprecating types.
+/// The visitor will throw exceptions during schema initialization if violations are found.
+///
+/// Example usage:
+/// <code>
+/// schema.RegisterVisitor(new DeprecatedTypeReferenceVisitor());
+/// schema.Initialize(); // Will throw if violations are found
+/// </code>
+/// </remarks>
+public class DeprecatedTypeReferenceVisitor : BaseSchemaNodeVisitor
+{
+    /// <summary>
+    /// Internal list of violations found during schema traversal.
+    /// Each violation represents a non-deprecated field that references a deprecated type.
+    /// </summary>
+    private readonly List<string> _violations = new List<string>();
+
+    /// <inheritdoc/>
+    public override void PostVisitSchema(ISchema schema)
+    {
+        if (_violations.Count == 1)
+        {
+            throw new InvalidOperationException(_violations[0]);
+        }
+        else if (_violations.Count > 1)
+        {
+            var exceptions = _violations.Select(violation => new InvalidOperationException(violation)).ToArray();
+            throw new AggregateException("Schema validation failed. Found multiple non-deprecated fields referencing deprecated types.", exceptions);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void VisitObjectFieldDefinition(FieldType field, IObjectGraphType type, ISchema schema)
+    {
+        CheckFieldForDeprecatedTypeReference(field, type.Name);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInterfaceFieldDefinition(FieldType field, IInterfaceGraphType type, ISchema schema)
+    {
+        CheckFieldForDeprecatedTypeReference(field, type.Name);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInputObjectFieldDefinition(FieldType field, IInputObjectGraphType type, ISchema schema)
+    {
+        CheckFieldForDeprecatedTypeReference(field, type.Name);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitObjectFieldArgumentDefinition(QueryArgument argument, FieldType field, IObjectGraphType type, ISchema schema)
+    {
+        CheckArgumentForDeprecatedTypeReference(argument, field, type.Name);
+    }
+
+    /// <inheritdoc/>
+    public override void VisitInterfaceFieldArgumentDefinition(QueryArgument argument, FieldType field, IInterfaceGraphType type, ISchema schema)
+    {
+        CheckArgumentForDeprecatedTypeReference(argument, field, type.Name);
+    }
+
+    private void CheckFieldForDeprecatedTypeReference(FieldType field, string parentTypeName)
+    {
+        // Skip if the field itself is deprecated
+        if (IsDeprecated(field))
+            return;
+
+        var fieldType = field.ResolvedType?.GetNamedType();
+        if (fieldType != null && IsDeprecated(fieldType))
+        {
+            var violation = $"Non-deprecated field '{parentTypeName}.{field.Name}' references deprecated type '{fieldType.Name}'.";
+            _violations.Add(violation);
+        }
+    }
+
+    private void CheckArgumentForDeprecatedTypeReference(QueryArgument argument, FieldType field, string parentTypeName)
+    {
+        // Skip if the argument itself is deprecated
+        if (IsDeprecated(argument))
+            return;
+
+        // Skip if the parent field is deprecated
+        if (IsDeprecated(field))
+            return;
+
+        var argumentType = argument.ResolvedType?.GetNamedType();
+        if (argumentType != null && IsDeprecated(argumentType))
+        {
+            var violation = $"Non-deprecated argument '{parentTypeName}.{field.Name}.{argument.Name}' references deprecated type '{argumentType.Name}'.";
+            _violations.Add(violation);
+        }
+    }
+
+    /// <summary>
+    /// Determines if a schema element is deprecated by checking its DeprecationReason property.
+    /// </summary>
+    /// <param name="element">The schema element to check.</param>
+    /// <returns>True if the element is deprecated, false otherwise.</returns>
+    private static bool IsDeprecated(IProvideDeprecationReason element)
+    {
+        return !string.IsNullOrEmpty(element.DeprecationReason);
+    }
+}

--- a/src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs
@@ -28,7 +28,7 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
                     var parentType = context.TypeInfo.GetParentType()!.GetNamedType();
 
                     // Call the abstract method for handling deprecated field usage
-                    await OnDeprecatedFieldReferenced(context, node, fieldDef, parentType).ConfigureAwait(false);
+                    await OnDeprecatedFieldReferencedAsync(context, node, fieldDef, parentType).ConfigureAwait(false);
                 }
             }),
             new MatchingNodeVisitor<GraphQLArgument>(async (node, context) =>
@@ -44,13 +44,13 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
                     if (directiveDef != null)
                     {
                         // This is a directive argument
-                        await OnDeprecatedDirectiveArgumentReferenced(context, node, argumentDef, directiveDef).ConfigureAwait(false);
+                        await OnDeprecatedDirectiveArgumentReferencedAsync(context, node, argumentDef, directiveDef).ConfigureAwait(false);
                     }
                     else if (fieldDef != null) // note: when a directive is applied to a field, both fieldDef and directiveDef are non-null
                     {
                         // This is a field argument
                         var parentType = context.TypeInfo.GetParentType()!.GetNamedType();
-                        await OnDeprecatedFieldArgumentReferenced(context, node, argumentDef, fieldDef, parentType).ConfigureAwait(false);
+                        await OnDeprecatedFieldArgumentReferencedAsync(context, node, argumentDef, fieldDef, parentType).ConfigureAwait(false);
                     }
                 }
             }),
@@ -62,7 +62,7 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
                 if (type?.DeprecationReason != null)
                 {
                     // Call the abstract method for handling deprecated type usage
-                    await OnDeprecatedTypeReferenced(context, node.TypeCondition.Type, type).ConfigureAwait(false);
+                    await OnDeprecatedTypeReferencedAsync(context, node.TypeCondition.Type, type).ConfigureAwait(false);
                 }
             }),
             new MatchingNodeVisitor<GraphQLInlineFragment>(async (node, context) =>
@@ -75,7 +75,7 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
                     if (type?.DeprecationReason != null)
                     {
                         // Call the abstract method for handling deprecated type usage
-                        await OnDeprecatedTypeReferenced(context, node.TypeCondition.Type, type).ConfigureAwait(false);
+                        await OnDeprecatedTypeReferencedAsync(context, node.TypeCondition.Type, type).ConfigureAwait(false);
                     }
                 }
             })
@@ -93,7 +93,7 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
     /// <param name="fieldNode">The GraphQL field node that references the deprecated field.</param>
     /// <param name="fieldDefinition">The field definition that is deprecated.</param>
     /// <param name="parentType">The parent type containing the deprecated field.</param>
-    protected abstract ValueTask OnDeprecatedFieldReferenced(
+    protected abstract ValueTask OnDeprecatedFieldReferencedAsync(
         ValidationContext context,
         GraphQLField fieldNode,
         FieldType fieldDefinition,
@@ -108,7 +108,7 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
     /// <param name="argumentDefinition">The argument definition that is deprecated.</param>
     /// <param name="fieldDefinition">The field definition containing the deprecated argument.</param>
     /// <param name="parentType">The parent type containing the field with the deprecated argument.</param>
-    protected abstract ValueTask OnDeprecatedFieldArgumentReferenced(
+    protected abstract ValueTask OnDeprecatedFieldArgumentReferencedAsync(
         ValidationContext context,
         GraphQLArgument argumentNode,
         QueryArgument argumentDefinition,
@@ -123,7 +123,7 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
     /// <param name="argumentNode">The GraphQL argument node that references the deprecated argument.</param>
     /// <param name="argumentDefinition">The argument definition that is deprecated.</param>
     /// <param name="directiveDefinition">The directive definition containing the deprecated argument.</param>
-    protected abstract ValueTask OnDeprecatedDirectiveArgumentReferenced(
+    protected abstract ValueTask OnDeprecatedDirectiveArgumentReferencedAsync(
         ValidationContext context,
         GraphQLArgument argumentNode,
         QueryArgument argumentDefinition,
@@ -136,7 +136,7 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
     /// <param name="context">The validation context.</param>
     /// <param name="typeConditionNode">The GraphQL type condition node that references the deprecated type.</param>
     /// <param name="typeDefinition">The type definition that is deprecated.</param>
-    protected abstract ValueTask OnDeprecatedTypeReferenced(
+    protected abstract ValueTask OnDeprecatedTypeReferencedAsync(
         ValidationContext context,
         GraphQLNamedType typeConditionNode,
         IGraphType typeDefinition);

--- a/src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs
@@ -41,16 +41,16 @@ public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
                     var fieldDef = context.TypeInfo.GetFieldDef();
                     var directiveDef = context.TypeInfo.GetDirective();
 
-                    if (fieldDef != null)
+                    if (directiveDef != null)
+                    {
+                        // This is a directive argument
+                        await OnDeprecatedDirectiveArgumentReferenced(context, node, argumentDef, directiveDef).ConfigureAwait(false);
+                    }
+                    else if (fieldDef != null) // note: when a directive is applied to a field, both fieldDef and directiveDef are non-null
                     {
                         // This is a field argument
                         var parentType = context.TypeInfo.GetParentType()!.GetNamedType();
                         await OnDeprecatedFieldArgumentReferenced(context, node, argumentDef, fieldDef, parentType).ConfigureAwait(false);
-                    }
-                    else if (directiveDef != null)
-                    {
-                        // This is a directive argument
-                        await OnDeprecatedDirectiveArgumentReferenced(context, node, argumentDef, directiveDef).ConfigureAwait(false);
                     }
                 }
             }),

--- a/src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs
+++ b/src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs
@@ -1,0 +1,143 @@
+using GraphQL.Types;
+using GraphQLParser.AST;
+
+namespace GraphQL.Validation.Rules.Custom;
+
+/// <summary>
+/// A GraphQL validation rule that identifies deprecated fields, arguments, and types referenced in the document
+/// and calls abstract methods for each deprecated element found. This allows custom
+/// handling of deprecated element usage, such as logging warnings or collecting metrics.
+/// </summary>
+public abstract class DeprecatedElementsValidationRule : ValidationRuleBase
+{
+    private readonly INodeVisitor _nodeVisitor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeprecatedElementsValidationRule"/> class.
+    /// </summary>
+    protected DeprecatedElementsValidationRule()
+    {
+        _nodeVisitor = new NodeVisitors(
+            new MatchingNodeVisitor<GraphQLField>(async (node, context) =>
+            {
+                var fieldDef = context.TypeInfo.GetFieldDef();
+
+                if (fieldDef?.DeprecationReason != null)
+                {
+                    // Get the parent type for context
+                    var parentType = context.TypeInfo.GetParentType()!.GetNamedType();
+
+                    // Call the abstract method for handling deprecated field usage
+                    await OnDeprecatedFieldReferenced(context, node, fieldDef, parentType).ConfigureAwait(false);
+                }
+            }),
+            new MatchingNodeVisitor<GraphQLArgument>(async (node, context) =>
+            {
+                var argumentDef = context.TypeInfo.GetArgument();
+
+                if (argumentDef?.DeprecationReason != null)
+                {
+                    // Get the field definition and directive for context
+                    var fieldDef = context.TypeInfo.GetFieldDef();
+                    var directiveDef = context.TypeInfo.GetDirective();
+
+                    if (fieldDef != null)
+                    {
+                        // This is a field argument
+                        var parentType = context.TypeInfo.GetParentType()!.GetNamedType();
+                        await OnDeprecatedFieldArgumentReferenced(context, node, argumentDef, fieldDef, parentType).ConfigureAwait(false);
+                    }
+                    else if (directiveDef != null)
+                    {
+                        // This is a directive argument
+                        await OnDeprecatedDirectiveArgumentReferenced(context, node, argumentDef, directiveDef).ConfigureAwait(false);
+                    }
+                }
+            }),
+            new MatchingNodeVisitor<GraphQLFragmentDefinition>(async (node, context) =>
+            {
+                var typeName = node.TypeCondition.Type.Name;
+                var type = context.Schema.AllTypes[typeName];
+
+                if (type?.DeprecationReason != null)
+                {
+                    // Call the abstract method for handling deprecated type usage
+                    await OnDeprecatedTypeReferenced(context, node.TypeCondition.Type, type).ConfigureAwait(false);
+                }
+            }),
+            new MatchingNodeVisitor<GraphQLInlineFragment>(async (node, context) =>
+            {
+                if (node.TypeCondition != null)
+                {
+                    var typeName = node.TypeCondition.Type.Name;
+                    var type = context.Schema.AllTypes[typeName];
+
+                    if (type?.DeprecationReason != null)
+                    {
+                        // Call the abstract method for handling deprecated type usage
+                        await OnDeprecatedTypeReferenced(context, node.TypeCondition.Type, type).ConfigureAwait(false);
+                    }
+                }
+            })
+        );
+    }
+
+    /// <inheritdoc/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_nodeVisitor);
+
+    /// <summary>
+    /// Called when a deprecated field is referenced in the document.
+    /// Implement this method to define custom behavior for deprecated field usage.
+    /// </summary>
+    /// <param name="context">The validation context.</param>
+    /// <param name="fieldNode">The GraphQL field node that references the deprecated field.</param>
+    /// <param name="fieldDefinition">The field definition that is deprecated.</param>
+    /// <param name="parentType">The parent type containing the deprecated field.</param>
+    protected abstract ValueTask OnDeprecatedFieldReferenced(
+        ValidationContext context,
+        GraphQLField fieldNode,
+        FieldType fieldDefinition,
+        IGraphType parentType);
+
+    /// <summary>
+    /// Called when a deprecated field argument is referenced in the document.
+    /// Implement this method to define custom behavior for deprecated field argument usage.
+    /// </summary>
+    /// <param name="context">The validation context.</param>
+    /// <param name="argumentNode">The GraphQL argument node that references the deprecated argument.</param>
+    /// <param name="argumentDefinition">The argument definition that is deprecated.</param>
+    /// <param name="fieldDefinition">The field definition containing the deprecated argument.</param>
+    /// <param name="parentType">The parent type containing the field with the deprecated argument.</param>
+    protected abstract ValueTask OnDeprecatedFieldArgumentReferenced(
+        ValidationContext context,
+        GraphQLArgument argumentNode,
+        QueryArgument argumentDefinition,
+        FieldType fieldDefinition,
+        IGraphType parentType);
+
+    /// <summary>
+    /// Called when a deprecated directive argument is referenced in the document.
+    /// Implement this method to define custom behavior for deprecated directive argument usage.
+    /// </summary>
+    /// <param name="context">The validation context.</param>
+    /// <param name="argumentNode">The GraphQL argument node that references the deprecated argument.</param>
+    /// <param name="argumentDefinition">The argument definition that is deprecated.</param>
+    /// <param name="directiveDefinition">The directive definition containing the deprecated argument.</param>
+    protected abstract ValueTask OnDeprecatedDirectiveArgumentReferenced(
+        ValidationContext context,
+        GraphQLArgument argumentNode,
+        QueryArgument argumentDefinition,
+        Directive directiveDefinition);
+
+    /// <summary>
+    /// Called when a deprecated type is referenced in the document.
+    /// Implement this method to define custom behavior for deprecated type usage.
+    /// </summary>
+    /// <param name="context">The validation context.</param>
+    /// <param name="typeConditionNode">The GraphQL type condition node that references the deprecated type.</param>
+    /// <param name="typeDefinition">The type definition that is deprecated.</param>
+    protected abstract ValueTask OnDeprecatedTypeReferenced(
+        ValidationContext context,
+        GraphQLNamedType typeConditionNode,
+        IGraphType typeDefinition);
+}


### PR DESCRIPTION
Two new classes have been added to help manage deprecated schema elements more effectively:
[`DeprecatedTypeReferenceVisitor`](src/GraphQL/Utilities/Visitors/Custom/DeprecatedTypeReferenceVisitor.cs) and
[`DeprecatedElementsValidationRule`](src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs).
These classes work together to provide comprehensive deprecation management at both the schema and query validation levels.

The [`DeprecatedTypeReferenceVisitor`](src/GraphQL/Utilities/Visitors/Custom/DeprecatedTypeReferenceVisitor.cs) is a schema visitor that identifies non-deprecated fields that directly reference deprecated types during schema initialization. This helps maintain schema consistency by flagging potential issues where deprecated types are still being referenced by active fields.

The [`DeprecatedElementsValidationRule`](src/GraphQL/Validation/Rules.Custom/DeprecatedElementsValidationRule.cs) is an abstract validation rule that identifies deprecated fields, arguments, and types referenced in GraphQL documents during query validation. It provides abstract methods that can be overridden to implement custom handling of deprecated element usage, such as logging warnings or collecting metrics.

```csharp
// Create a custom validation rule to handle deprecated element usage during query validation
public class LoggingDeprecatedElementsRule : DeprecatedElementsValidationRule
{
    private readonly ILogger<LoggingDeprecatedElementsRule> _logger;

    public LoggingDeprecatedElementsRule(ILogger<LoggingDeprecatedElementsRule> logger)
    {
        _logger = logger;
    }

    protected override ValueTask OnDeprecatedFieldReferencedAsync(ValidationContext context, GraphQLField fieldNode, FieldType fieldDefinition, IGraphType parentType)
    {
        _logger.LogWarning("Deprecated field '{ParentType}.{FieldName}' was used: {DeprecationReason}",
            parentType.Name, fieldDefinition.Name, fieldDefinition.DeprecationReason);
        return default;
    }

    protected override ValueTask OnDeprecatedFieldArgumentReferencedAsync(ValidationContext context, GraphQLArgument argumentNode, QueryArgument argumentDefinition, FieldType fieldDefinition, IGraphType parentType)
    {
        _logger.LogWarning("Deprecated argument '{ParentType}.{FieldName}.{ArgumentName}' was used: {DeprecationReason}",
            parentType.Name, fieldDefinition.Name, argumentDefinition.Name, argumentDefinition.DeprecationReason);
        return default;
    }

    protected override ValueTask OnDeprecatedDirectiveArgumentReferencedAsync(ValidationContext context, GraphQLArgument argumentNode, QueryArgument argumentDefinition, Directive directiveDefinition)
    {
        _logger.LogWarning("Deprecated directive argument '@{DirectiveName}.{ArgumentName}' was used: {DeprecationReason}",
            directiveDefinition.Name, argumentDefinition.Name, argumentDefinition.DeprecationReason);
        return default;
    }

    protected override ValueTask OnDeprecatedTypeReferencedAsync(ValidationContext context, GraphQLNamedType typeConditionNode, IGraphType typeDefinition)
    {
        _logger.LogWarning("Deprecated type '{TypeName}' was used: {DeprecationReason}",
            typeDefinition.Name, typeDefinition.DeprecationReason);
        return default;
    }
}

// Register the schema visitor and validation rule
services.AddGraphQL(b => b
    .AddSchema<MySchema>()
    .AddSchemaVisitor<DeprecatedTypeReferenceVisitor>()
    .AddValidationRule<LoggingDeprecatedElementsRule>()
);
```
