### PR TITLE
Add Schema.OnBeforeInitializeType

### DIFF
--- a/docs2/site/docs/migrations/migration8.md
+++ b/docs2/site/docs/migrations/migration8.md
@@ -1458,6 +1458,31 @@ services.AddGraphQL(b => b
 );
 ```
 
+### 35. Schema type initialization hooks (v8.6+)
+
+A new protected method `OnBeforeInitializeType` has been added to the `Schema` class that is called before each graph type is initialized during schema creation. This allows for custom logic to be executed before type processing, such as logging, validation, or metadata collection.
+
+```csharp
+public class MySchema : Schema
+{
+    public MySchema(IServiceProvider serviceProvider) : base(serviceProvider)
+    {
+        Query = new MyQuery();
+    }
+
+    protected override void OnBeforeInitializeType(IGraphType graphType)
+    {
+        // Custom logic before each type is initialized
+        Console.WriteLine($"Initializing type: {graphType.Name}");
+        
+        // Example: Add metadata to track initialization order
+        graphType.WithMetadata("InitializationTimestamp", DateTime.UtcNow);
+    }
+}
+```
+
+This method is called exactly once for each graph type during schema initialization, ensuring that duplicate calls are avoided even when types are referenced multiple times or built automatically.
+
 ## Breaking Changes
 
 ### 1. Query type is required

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3085,6 +3085,7 @@ namespace GraphQL.Types
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void Initialize() { }
+        protected virtual void OnBeforeInitializeType(GraphQL.Types.IGraphType graphType) { }
         public void RegisterType(GraphQL.Types.IGraphType type) { }
         public void RegisterType([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         public void RegisterTypeMapping(System.Type clrType, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type graphType) { }
@@ -3113,6 +3114,7 @@ namespace GraphQL.Types
         protected SchemaTypes() { }
         public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
         public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings) { }
+        public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings, System.Action<GraphQL.Types.IGraphType>? onBeforeInitialize) { }
         public int Count { get; }
         protected virtual System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> Dictionary { get; }
         public GraphQL.Types.IGraphType? this[GraphQLParser.ROM typeName] { get; }
@@ -3126,6 +3128,7 @@ namespace GraphQL.Types
         public System.Collections.Generic.IEnumerator<GraphQL.Types.IGraphType> GetEnumerator() { }
         protected virtual System.Type? GetGraphTypeFromClrType(System.Type clrType, bool isInputType, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? typeMappings) { }
         protected void Initialize(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings) { }
+        protected virtual void OnBeforeInitialize(GraphQL.Types.IGraphType graphType) { }
     }
     public class ShortGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3092,6 +3092,7 @@ namespace GraphQL.Types
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void Initialize() { }
+        protected virtual void OnBeforeInitializeType(GraphQL.Types.IGraphType graphType) { }
         public void RegisterType(GraphQL.Types.IGraphType type) { }
         public void RegisterType([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type type) { }
         public void RegisterTypeMapping(System.Type clrType, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type graphType) { }
@@ -3120,6 +3121,7 @@ namespace GraphQL.Types
         protected SchemaTypes() { }
         public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
         public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings) { }
+        public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings, System.Action<GraphQL.Types.IGraphType>? onBeforeInitialize) { }
         public int Count { get; }
         protected virtual System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> Dictionary { get; }
         public GraphQL.Types.IGraphType? this[GraphQLParser.ROM typeName] { get; }
@@ -3133,6 +3135,7 @@ namespace GraphQL.Types
         public System.Collections.Generic.IEnumerator<GraphQL.Types.IGraphType> GetEnumerator() { }
         protected virtual System.Type? GetGraphTypeFromClrType(System.Type clrType, bool isInputType, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? typeMappings) { }
         protected void Initialize(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings) { }
+        protected virtual void OnBeforeInitialize(GraphQL.Types.IGraphType graphType) { }
     }
     public class ShortGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3002,6 +3002,7 @@ namespace GraphQL.Types
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void Initialize() { }
+        protected virtual void OnBeforeInitializeType(GraphQL.Types.IGraphType graphType) { }
         public void RegisterType(GraphQL.Types.IGraphType type) { }
         public void RegisterType(System.Type type) { }
         public void RegisterTypeMapping(System.Type clrType, System.Type graphType) { }
@@ -3030,6 +3031,7 @@ namespace GraphQL.Types
         protected SchemaTypes() { }
         public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
         public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings) { }
+        public SchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings, System.Action<GraphQL.Types.IGraphType>? onBeforeInitialize) { }
         public int Count { get; }
         protected virtual System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> Dictionary { get; }
         public GraphQL.Types.IGraphType? this[GraphQLParser.ROM typeName] { get; }
@@ -3043,6 +3045,7 @@ namespace GraphQL.Types
         public System.Collections.Generic.IEnumerator<GraphQL.Types.IGraphType> GetEnumerator() { }
         protected virtual System.Type? GetGraphTypeFromClrType(System.Type clrType, bool isInputType, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? typeMappings) { }
         protected void Initialize(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider, System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphTypeMappingProvider>? graphTypeMappings) { }
+        protected virtual void OnBeforeInitialize(GraphQL.Types.IGraphType graphType) { }
     }
     public class ShortGraphType : GraphQL.Types.ScalarGraphType
     {

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -230,6 +230,32 @@ public class SchemaTests
         schema.Initialize();
         schema.Query.Fields.Find("test")!.Arguments![0].ResolvedType.ShouldBeOfType<AutoRegisteringInputObjectGraphType<CustomData>>();
     }
+
+    [Fact]
+    public void OnBeforeInitializeType_cannot_access_AllTypes()
+    {
+        var schema = new SchemaWithOnBeforeInitializeTypeAccessingAllTypes();
+
+        // Attempting to initialize should throw an exception when OnBeforeInitializeType tries to access AllTypes
+        Should.Throw<InvalidOperationException>(() => schema.Initialize())
+            .Message.ShouldBe("Cannot access AllTypes while schema types are being created. AllTypes is not available during OnBeforeInitializeType execution.");
+    }
+}
+
+public class SchemaWithOnBeforeInitializeTypeAccessingAllTypes : Schema
+{
+    public SchemaWithOnBeforeInitializeTypeAccessingAllTypes()
+    {
+        var query = new ObjectGraphType { Name = "Query" };
+        query.Field<StringGraphType>("test");
+        Query = query;
+    }
+
+    protected override void OnBeforeInitializeType(IGraphType graphType)
+    {
+        // This should throw an exception because AllTypes is not available during initialization
+        _ = AllTypes.Count;
+    }
 }
 
 public class CustomData

--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -155,6 +155,7 @@ public class SchemaTypes : IEnumerable<IGraphType>
 
     private TypeCollectionContext _context;
     private INameConverter _nameConverter;
+    private readonly Action<IGraphType>? _onBeforeInitialize;
 
     /// <summary>
     /// Initializes a new instance with no types registered.
@@ -182,10 +183,25 @@ public class SchemaTypes : IEnumerable<IGraphType>
     /// <param name="schema">A schema for which this instance is created.</param>
     /// <param name="serviceProvider">A service provider used to resolve graph types.</param>
     /// <param name="graphTypeMappings">A list of <see cref="IGraphTypeMappingProvider"/> instances used to map CLR types to graph types.</param>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     public SchemaTypes(ISchema schema, IServiceProvider serviceProvider, IEnumerable<IGraphTypeMappingProvider>? graphTypeMappings)
+        : this(schema, serviceProvider, graphTypeMappings, null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance for the specified schema, with the specified type resolver,
+    /// with the specified set of <see cref="IGraphTypeMappingProvider"/> instances, and with
+    /// an optional delegate to call before initializing each graph type.
+    /// </summary>
+    /// <param name="schema">A schema for which this instance is created.</param>
+    /// <param name="serviceProvider">A service provider used to resolve graph types.</param>
+    /// <param name="graphTypeMappings">A list of <see cref="IGraphTypeMappingProvider"/> instances used to map CLR types to graph types.</param>
+    /// <param name="onBeforeInitialize">An optional delegate to call before initializing each graph type.</param>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    public SchemaTypes(ISchema schema, IServiceProvider serviceProvider, IEnumerable<IGraphTypeMappingProvider>? graphTypeMappings, Action<IGraphType>? onBeforeInitialize)
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     {
+        _onBeforeInitialize = onBeforeInitialize;
         Initialize(schema, serviceProvider, graphTypeMappings);
     }
 
@@ -541,6 +557,8 @@ public class SchemaTypes : IEnumerable<IGraphType>
         {
             throw new ArgumentOutOfRangeException(nameof(type), "Only add root types.");
         }
+
+        OnBeforeInitialize(type);
 
         if (context.InitializationTrace != null)
             type.WithMetadata(INITIALIZATIION_TRACE_KEY, string.Join(Environment.NewLine, context.InitializationTrace));
@@ -1110,4 +1128,14 @@ Make sure that your ServiceProvider is configured correctly.");
     /// Returns the <see cref="FieldType"/> instance for the <c>__typename</c> meta-field.
     /// </summary>
     protected internal virtual FieldType TypeNameMetaFieldType { get; } = new TypeNameMetaFieldType();
+
+    /// <summary>
+    /// Called before a graph type is initialized. By default, calls the delegate
+    /// specified in the constructor if supplied.
+    /// </summary>
+    /// <param name="graphType">The graph type that is about to be initialized.</param>
+    protected virtual void OnBeforeInitialize(IGraphType graphType)
+    {
+        _onBeforeInitialize?.Invoke(graphType);
+    }
 }


### PR DESCRIPTION
Adds a new `OnBeforeInitializeType` virtual method to the `Schema` class that allows custom logic to be executed before each graph type is initialized during schema creation.

- Adds a protected virtual `OnBeforeInitializeType` method to the Schema class
- Implements thread-safe access controls to prevent accessing `AllTypes` during type creation
- Adds comprehensive test coverage for the new functionality

Notes:
- `OnBeforeInitializeType` does not have access to `AllTypes` since `SchemaTypes` has not finished processing
- `OnBeforeInitializeType` does not have access to `GetGraphTypeFromClrType` either
- Neither of the above matter because any added/modified fields can use type references or similar to access other types, either by CLR type or by name, just the same way defining a field in a graph type's constructor would do.
- Stack overflow prevention code added in case a developer attempts to use `AllTypes` from within `OnBeforeInitializeType`
- The `OnBeforeInitializeType` method is not provided a reference to `ISchema` because of course `this` is available
- The `OnBeforeInitializeType` method is not provided a reference to `IServiceProvider` because a developer may capture this from the `Schema` constructor
- No `IGraphQLBuilder` methods are provided to configure this, as this is considered an advanced requirement, and developers can derive from `Schema` when needed.  They can also write their own `IGraphQLBuilder` extension methods if desired. A subsequent PR could add this feature however....