### PR TITLE
Update federation printing

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3440,6 +3440,7 @@ namespace GraphQL.Utilities
         public PrintOptions() { }
         public bool IncludeDeprecationReasons { get; set; }
         public bool IncludeDescriptions { get; set; }
+        public bool IncludeFederationDefinitions { get; set; }
         public bool IncludeFederationTypes { get; set; }
         public bool IncludeImportedDefinitions { get; set; }
         public System.StringComparison? StringComparison { get; set; }
@@ -3731,6 +3732,7 @@ namespace GraphQL.Utilities.Visitors
     {
         protected override System.Threading.Tasks.ValueTask VisitDocumentAsync(GraphQLParser.AST.GraphQLDocument document, GraphQL.Utilities.Visitors.RemoveImportedTypesVisitor.Context context) { }
         public static void Visit(GraphQLParser.AST.ASTNode node, GraphQL.Types.ISchema schema) { }
+        public static void Visit(GraphQLParser.AST.ASTNode node, GraphQL.Types.ISchema schema, params string[] urlPrefixes) { }
         public struct Context : GraphQLParser.Visitors.IASTVisitorContext
         {
             public System.Threading.CancellationToken CancellationToken { get; }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3454,6 +3454,7 @@ namespace GraphQL.Utilities
         public PrintOptions() { }
         public bool IncludeDeprecationReasons { get; set; }
         public bool IncludeDescriptions { get; set; }
+        public bool IncludeFederationDefinitions { get; set; }
         public bool IncludeFederationTypes { get; set; }
         public bool IncludeImportedDefinitions { get; set; }
         public System.StringComparison? StringComparison { get; set; }
@@ -3745,6 +3746,7 @@ namespace GraphQL.Utilities.Visitors
     {
         protected override System.Threading.Tasks.ValueTask VisitDocumentAsync(GraphQLParser.AST.GraphQLDocument document, GraphQL.Utilities.Visitors.RemoveImportedTypesVisitor.Context context) { }
         public static void Visit(GraphQLParser.AST.ASTNode node, GraphQL.Types.ISchema schema) { }
+        public static void Visit(GraphQLParser.AST.ASTNode node, GraphQL.Types.ISchema schema, params string[] urlPrefixes) { }
         public struct Context : GraphQLParser.Visitors.IASTVisitorContext
         {
             public System.Threading.CancellationToken CancellationToken { get; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3357,6 +3357,7 @@ namespace GraphQL.Utilities
         public PrintOptions() { }
         public bool IncludeDeprecationReasons { get; set; }
         public bool IncludeDescriptions { get; set; }
+        public bool IncludeFederationDefinitions { get; set; }
         public bool IncludeFederationTypes { get; set; }
         public bool IncludeImportedDefinitions { get; set; }
         public System.StringComparison? StringComparison { get; set; }
@@ -3648,6 +3649,7 @@ namespace GraphQL.Utilities.Visitors
     {
         protected override System.Threading.Tasks.ValueTask VisitDocumentAsync(GraphQLParser.AST.GraphQLDocument document, GraphQL.Utilities.Visitors.RemoveImportedTypesVisitor.Context context) { }
         public static void Visit(GraphQLParser.AST.ASTNode node, GraphQL.Types.ISchema schema) { }
+        public static void Visit(GraphQLParser.AST.ASTNode node, GraphQL.Types.ISchema schema, params string[] urlPrefixes) { }
         public struct Context : GraphQLParser.Visitors.IASTVisitorContext
         {
             public System.Threading.CancellationToken CancellationToken { get; }

--- a/src/GraphQL/Extensions/SchemaExtensions.cs
+++ b/src/GraphQL/Extensions/SchemaExtensions.cs
@@ -136,6 +136,10 @@ public static class SchemaExtensions
         {
             RemoveImportedTypesVisitor.Visit(sdl, schema);
         }
+        if (!options.IncludeFederationDefinitions)
+        {
+            RemoveImportedTypesVisitor.Visit(sdl, schema, "https://specs.apollo.dev/federation/", "https://specs.apollo.dev/link/");
+        }
         if (options.StringComparison != null)
         {
             SDLSorter.Sort(sdl, new(options.StringComparison.Value));

--- a/src/GraphQL/Federation/Types/FederationPrintOptions.cs
+++ b/src/GraphQL/Federation/Types/FederationPrintOptions.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Federation.Types;
 /// returned by '<c>services { sdl }</c>' in a GraphQL federation subgraph.
 /// </summary>
 /// <remarks>
-/// By default this does not include Federation directives imported by '@link'.
+/// By default this does not include Federation types or directives imported by '@link'.
 /// Please disable <see cref="PrintOptions.IncludeFederationTypes"/> for
 /// Federation v1 compatibility.
 /// </remarks>

--- a/src/GraphQL/Federation/Types/FederationPrintOptions.cs
+++ b/src/GraphQL/Federation/Types/FederationPrintOptions.cs
@@ -7,15 +7,17 @@ namespace GraphQL.Federation.Types;
 /// returned by '<c>services { sdl }</c>' in a GraphQL federation subgraph.
 /// </summary>
 /// <remarks>
-/// By default this does not include types or directives imported by '@link'.
+/// By default this does not include Federation directives imported by '@link'.
 /// Please disable <see cref="PrintOptions.IncludeFederationTypes"/> for
 /// Federation v1 compatibility.
 /// </remarks>
 public class FederationPrintOptions : PrintOptions
 {
-    /// <inheritdoc cref="FederationPrintOptions"/>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FederationPrintOptions"/> class.
+    /// </summary>
     public FederationPrintOptions()
     {
-        IncludeImportedDefinitions = false;
+        IncludeFederationDefinitions = false;
     }
 }

--- a/src/GraphQL/Utilities/PrintOptions.cs
+++ b/src/GraphQL/Utilities/PrintOptions.cs
@@ -25,13 +25,18 @@ public class PrintOptions : SDLPrinterOptions
 
     /// <summary>
     /// Indicates whether to print Apollo Federation v1 types.
-    /// Do not use this flag with Federation v2 or newer; see <see cref="IncludeImportedDefinitions"/>.
+    /// Do not use this flag with Federation v2 or newer; see <see cref="IncludeFederationDefinitions"/>.
     /// </summary>
     public bool IncludeFederationTypes { get; set; } = true;
 
     /// <summary>
     /// Indicates whether to print type/directive definitions imported from another schema via the @link directive.
-    /// Typically disabled with Federation v2 to exclude imported definitions from the printed schema.
     /// </summary>
     public bool IncludeImportedDefinitions { get; set; } = true;
+
+    /// <summary>
+    /// Indicates whether to print type/directive definitions that are linked via @link from federation URLs (https://specs.apollo.dev/federation/ or https://specs.apollo.dev/link/).
+    /// Typically disabled with Federation v2.
+    /// </summary>
+    public bool IncludeFederationDefinitions { get; set; } = true;
 }


### PR DESCRIPTION
Changes `{ _service { sdl } }` printing to only exclude federation types and directives.

This is a behavioral change, but considered a bug fix.