### PR TITLE
Don't allocate dictionary for empty Inputs

### DIFF
--- a/src/GraphQL/Execution/Inputs.cs
+++ b/src/GraphQL/Execution/Inputs.cs
@@ -4,7 +4,7 @@ using GraphQL.Validation;
 namespace GraphQL;
 
 /// <summary>
-/// Represents a readonly dictionary of variable inputs to a document. Typically this
+/// Represents a readonly dictionary of variable inputs to a document. Typically, this
 /// contains the deserialized 'variables' property from the GraphQL request. During document execution,
 /// these inputs will be validated and coerced into a <see cref="Variables"/> dictionary.
 /// </summary>
@@ -13,7 +13,13 @@ public class Inputs : ReadOnlyDictionary<string, object?>
     /// <summary>
     /// Returns an empty set of inputs.
     /// </summary>
-    public static readonly Inputs Empty = new(new Dictionary<string, object?>());
+    public static readonly Inputs Empty = new(
+#if NET5_0_OR_GREATER
+        System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty
+#else
+        new Dictionary<string, object?>()
+#endif
+    );
 
     /// <summary>
     /// Initializes a new instance that is a wrapper for the specified dictionary of elements.


### PR DESCRIPTION
Not a big change. It's only one object allocation during the application lifetime.