### PR TITLE
Fix IsSubtypeOf

### DIFF
--- a/src/GraphQL/Extensions/GraphQLExtensions.cs
+++ b/src/GraphQL/Extensions/GraphQLExtensions.cs
@@ -327,7 +327,7 @@ public static class GraphQLExtensions
         //superType = locationType
 
         // >> - Return {true} if {variableType} and {locationType} are identical, otherwise {false}.
-        if (maybeSubType.Equals(superType))
+        if (ReferenceEquals(maybeSubType, superType))
         {
             return true;
         }


### PR DESCRIPTION
Using `.Equals` simply compared the name of the two graph types, not the actual instance.  This caused a test to fail when rewriting SchemaTypes in #4234 

(I think the existing SchemaTypes implementation does not expose this method to the bug or something.)