### PR TITLE
Remove SchemaWithNotFullSpecifiedResolvedType test

### DIFF
--- a/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
+++ b/src/GraphQL.Tests/Initialization/SchemaInitializationTests.cs
@@ -280,37 +280,6 @@ public class SchemaWithArgumentsOnInputField : Schema
     }
 }
 
-// https://github.com/graphql-dotnet/graphql-dotnet/issues/2675
-public class SchemaWithNotFullSpecifiedResolvedType : Schema
-{
-    public SchemaWithNotFullSpecifiedResolvedType()
-    {
-        var stringFilterInputType = new InputObjectGraphType { Name = "InputString" };
-
-        stringFilterInputType.AddField(new FieldType
-        {
-            Name = "eq",
-            ResolvedType = new StringGraphType()
-        });
-        stringFilterInputType.AddField(new FieldType
-        {
-            Name = "in",
-            ResolvedType = new ListGraphType(new StringGraphType())
-        });
-        stringFilterInputType.AddField(new FieldType
-        {
-            Name = "not",
-            ResolvedType = new NonNullGraphType(new StringGraphType())
-        });
-
-        var query = new ObjectGraphType();
-        query.Field("test", new StringGraphType())
-            .Arguments(new QueryArgument(stringFilterInputType) { Name = "a" })
-            .Resolve(_ => "ok");
-        Query = query;
-    }
-}
-
 public class SchemaWithInvalidDefault1 : Schema
 {
     public SchemaWithInvalidDefault1()


### PR DESCRIPTION
This test serves no purpose after #4235 as the intended test conditions (using the removed obsolete constructors) no longer exists.  The test should have been removed with #4235 instead of modified to pass.