### PR TITLE
2-Rename SchemaTypes to SchemaTypesBase

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -879,8 +879,8 @@ namespace GraphQL
     }
     public static class SchemaTypesExtensions
     {
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypes schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypes schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
     }
     public static class StringExtensions
     {
@@ -2669,7 +2669,7 @@ namespace GraphQL.Types
     {
         System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AdditionalTypeInstances { get; }
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
-        GraphQL.Types.SchemaTypes AllTypes { get; }
+        GraphQL.Types.SchemaTypesBase AllTypes { get; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "clrType",
                 "graphType"})]
@@ -2765,7 +2765,7 @@ namespace GraphQL.Types
         public bool Contains(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
     }
-    public class LegacySchemaTypes : GraphQL.Types.SchemaTypes
+    public class LegacySchemaTypes : GraphQL.Types.SchemaTypesBase
     {
         protected LegacySchemaTypes() { }
         public LegacySchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
@@ -2931,7 +2931,7 @@ namespace GraphQL.Types
         public Schema(System.IServiceProvider services, bool runConfigurations = true) { }
         public System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AdditionalTypeInstances { get; }
         public System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
-        public GraphQL.Types.SchemaTypes AllTypes { get; }
+        public GraphQL.Types.SchemaTypesBase AllTypes { get; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "clrType",
                 "graphType"})]
@@ -2956,7 +2956,7 @@ namespace GraphQL.Types
         public GraphQL.Types.FieldType TypeMetaFieldType { get; }
         public GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
         protected virtual void CoerceInputTypeDefaultValues() { }
-        protected virtual GraphQL.Types.SchemaTypes CreateSchemaTypes() { }
+        protected virtual GraphQL.Types.SchemaTypesBase CreateSchemaTypes() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void Initialize() { }
@@ -2984,12 +2984,12 @@ namespace GraphQL.Types
         public void Register(GraphQL.Types.Directive directive) { }
         public void Register(params GraphQL.Types.Directive[] directives) { }
     }
-    public abstract class SchemaTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
+    public abstract class SchemaTypesBase : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
     {
         protected static readonly System.Collections.ObjectModel.ReadOnlyDictionary<System.Type, GraphQL.Types.ScalarGraphType> BuiltInScalars;
         protected static readonly System.Collections.ObjectModel.ReadOnlyDictionary<string, GraphQL.Types.ScalarGraphType> BuiltInScalarsByName;
-        protected SchemaTypes() { }
-        protected SchemaTypes(System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> dictionary) { }
+        protected SchemaTypesBase() { }
+        protected SchemaTypesBase(System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> dictionary) { }
         public int Count { get; }
         protected System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> Dictionary { get; set; }
         public GraphQL.Types.IGraphType? this[GraphQLParser.ROM typeName] { get; }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -879,8 +879,8 @@ namespace GraphQL
     }
     public static class SchemaTypesExtensions
     {
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypes schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypes schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
     }
     public static class StringExtensions
     {
@@ -2676,7 +2676,7 @@ namespace GraphQL.Types
     {
         System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AdditionalTypeInstances { get; }
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
-        GraphQL.Types.SchemaTypes AllTypes { get; }
+        GraphQL.Types.SchemaTypesBase AllTypes { get; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "clrType",
                 "graphType"})]
@@ -2772,7 +2772,7 @@ namespace GraphQL.Types
         public bool Contains(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
     }
-    public class LegacySchemaTypes : GraphQL.Types.SchemaTypes
+    public class LegacySchemaTypes : GraphQL.Types.SchemaTypesBase
     {
         protected LegacySchemaTypes() { }
         public LegacySchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
@@ -2938,7 +2938,7 @@ namespace GraphQL.Types
         public Schema(System.IServiceProvider services, bool runConfigurations = true) { }
         public System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AdditionalTypeInstances { get; }
         public System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
-        public GraphQL.Types.SchemaTypes AllTypes { get; }
+        public GraphQL.Types.SchemaTypesBase AllTypes { get; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "clrType",
                 "graphType"})]
@@ -2963,7 +2963,7 @@ namespace GraphQL.Types
         public GraphQL.Types.FieldType TypeMetaFieldType { get; }
         public GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
         protected virtual void CoerceInputTypeDefaultValues() { }
-        protected virtual GraphQL.Types.SchemaTypes CreateSchemaTypes() { }
+        protected virtual GraphQL.Types.SchemaTypesBase CreateSchemaTypes() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void Initialize() { }
@@ -2991,12 +2991,12 @@ namespace GraphQL.Types
         public void Register(GraphQL.Types.Directive directive) { }
         public void Register(params GraphQL.Types.Directive[] directives) { }
     }
-    public abstract class SchemaTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
+    public abstract class SchemaTypesBase : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
     {
         protected static readonly System.Collections.ObjectModel.ReadOnlyDictionary<System.Type, GraphQL.Types.ScalarGraphType> BuiltInScalars;
         protected static readonly System.Collections.ObjectModel.ReadOnlyDictionary<string, GraphQL.Types.ScalarGraphType> BuiltInScalarsByName;
-        protected SchemaTypes() { }
-        protected SchemaTypes(System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> dictionary) { }
+        protected SchemaTypesBase() { }
+        protected SchemaTypesBase(System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> dictionary) { }
         public int Count { get; }
         protected System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> Dictionary { get; set; }
         public GraphQL.Types.IGraphType? this[GraphQLParser.ROM typeName] { get; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -842,8 +842,8 @@ namespace GraphQL
     }
     public static class SchemaTypesExtensions
     {
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypes schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypes schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
     }
     public static class StringExtensions
     {
@@ -2588,7 +2588,7 @@ namespace GraphQL.Types
     {
         System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AdditionalTypeInstances { get; }
         System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
-        GraphQL.Types.SchemaTypes AllTypes { get; }
+        GraphQL.Types.SchemaTypesBase AllTypes { get; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "clrType",
                 "graphType"})]
@@ -2684,7 +2684,7 @@ namespace GraphQL.Types
         public bool Contains(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
     }
-    public class LegacySchemaTypes : GraphQL.Types.SchemaTypes
+    public class LegacySchemaTypes : GraphQL.Types.SchemaTypesBase
     {
         protected LegacySchemaTypes() { }
         public LegacySchemaTypes(GraphQL.Types.ISchema schema, System.IServiceProvider serviceProvider) { }
@@ -2848,7 +2848,7 @@ namespace GraphQL.Types
         public Schema(System.IServiceProvider services, bool runConfigurations = true) { }
         public System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType> AdditionalTypeInstances { get; }
         public System.Collections.Generic.IEnumerable<System.Type> AdditionalTypes { get; }
-        public GraphQL.Types.SchemaTypes AllTypes { get; }
+        public GraphQL.Types.SchemaTypesBase AllTypes { get; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "clrType",
                 "graphType"})]
@@ -2873,7 +2873,7 @@ namespace GraphQL.Types
         public GraphQL.Types.FieldType TypeMetaFieldType { get; }
         public GraphQL.Types.FieldType TypeNameMetaFieldType { get; }
         protected virtual void CoerceInputTypeDefaultValues() { }
-        protected virtual GraphQL.Types.SchemaTypes CreateSchemaTypes() { }
+        protected virtual GraphQL.Types.SchemaTypesBase CreateSchemaTypes() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void Initialize() { }
@@ -2901,12 +2901,12 @@ namespace GraphQL.Types
         public void Register(GraphQL.Types.Directive directive) { }
         public void Register(params GraphQL.Types.Directive[] directives) { }
     }
-    public abstract class SchemaTypes : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
+    public abstract class SchemaTypesBase : System.Collections.Generic.IEnumerable<GraphQL.Types.IGraphType>, System.Collections.IEnumerable
     {
         protected static readonly System.Collections.ObjectModel.ReadOnlyDictionary<System.Type, GraphQL.Types.ScalarGraphType> BuiltInScalars;
         protected static readonly System.Collections.ObjectModel.ReadOnlyDictionary<string, GraphQL.Types.ScalarGraphType> BuiltInScalarsByName;
-        protected SchemaTypes() { }
-        protected SchemaTypes(System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> dictionary) { }
+        protected SchemaTypesBase() { }
+        protected SchemaTypesBase(System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> dictionary) { }
         public int Count { get; }
         protected System.Collections.Generic.Dictionary<GraphQLParser.ROM, GraphQL.Types.IGraphType> Dictionary { get; set; }
         public GraphQL.Types.IGraphType? this[GraphQLParser.ROM typeName] { get; }

--- a/src/GraphQL.Tests/Federation/FederationResolverTests.cs
+++ b/src/GraphQL.Tests/Federation/FederationResolverTests.cs
@@ -464,7 +464,7 @@ public class FederationResolverTests
         return ret.ShouldNotBeNull().ShouldBeAssignableTo<T>()!;
     }
 
-    private class MySchemaTypes : SchemaTypes
+    private class MySchemaTypes : SchemaTypesBase
     {
         public MySchemaTypes(IEnumerable<IGraphType> types)
         {

--- a/src/GraphQL.Tests/Types/SchemaTests.cs
+++ b/src/GraphQL.Tests/Types/SchemaTests.cs
@@ -265,7 +265,7 @@ public class CustomData
 
 public class CustomTypesSchema : Schema
 {
-    protected override SchemaTypes CreateSchemaTypes()
+    protected override SchemaTypesBase CreateSchemaTypes()
         => new CustomSchemaTypes(this, this);
 }
 

--- a/src/GraphQL/Extensions/SchemaTypesExtensions.cs
+++ b/src/GraphQL/Extensions/SchemaTypesExtensions.cs
@@ -5,7 +5,7 @@ using GraphQL.Types;
 namespace GraphQL;
 
 /// <summary>
-/// Extension methods for <see cref="SchemaTypes"/>.
+/// Extension methods for <see cref="SchemaTypesBase"/>.
 /// </summary>
 public static class SchemaTypesExtensions
 {
@@ -17,7 +17,7 @@ public static class SchemaTypesExtensions
     /// </summary>
     /// <param name="schemaTypes">The schema types collection to apply middleware to.</param>
     /// <param name="fieldMiddlewareBuilder">The middleware builder containing the middleware to apply.</param>
-    public static void ApplyMiddleware(this SchemaTypes schemaTypes, IFieldMiddlewareBuilder fieldMiddlewareBuilder)
+    public static void ApplyMiddleware(this SchemaTypesBase schemaTypes, IFieldMiddlewareBuilder fieldMiddlewareBuilder)
     {
         var transform = (fieldMiddlewareBuilder ?? throw new ArgumentNullException(nameof(fieldMiddlewareBuilder))).Build();
 
@@ -36,7 +36,7 @@ public static class SchemaTypesExtensions
     /// </summary>
     /// <param name="schemaTypes">The schema types collection to apply middleware to.</param>
     /// <param name="transform">The middleware transform delegate to apply.</param>
-    public static void ApplyMiddleware(this SchemaTypes schemaTypes, Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform)
+    public static void ApplyMiddleware(this SchemaTypesBase schemaTypes, Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform)
     {
         if (schemaTypes == null)
             throw new ArgumentNullException(nameof(schemaTypes));

--- a/src/GraphQL/Extensions/TypeExtensions.cs
+++ b/src/GraphQL/Extensions/TypeExtensions.cs
@@ -246,7 +246,7 @@ public static class TypeExtensions
             {
                 if (mode == TypeMappingMode.UseBuiltInScalarMappings)
                 {
-                    if (!SchemaTypes.BuiltInScalarMappings.TryGetValue(type, out graphType))
+                    if (!SchemaTypesBase.BuiltInScalarMappings.TryGetValue(type, out graphType))
                     {
                         if (type.IsEnum)
                         {

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Instrumentation;
 public static class FieldMiddlewareBuilderExtensions
 {
     /// <summary>
-    /// Adds middleware to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypesExtensions.ApplyMiddleware(SchemaTypes, IFieldMiddlewareBuilder)"/>.
+    /// Adds middleware to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypesExtensions.ApplyMiddleware(SchemaTypesBase, IFieldMiddlewareBuilder)"/>.
     /// </summary>
     /// <param name="builder">Interface for connecting middlewares to a schema.</param>
     /// <param name="middleware">Middleware instance.</param>

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Instrumentation;
 public interface IFieldMiddlewareBuilder
 {
     /// <summary>
-    /// Adds the specified delegate to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypesExtensions.ApplyMiddleware(SchemaTypes, IFieldMiddlewareBuilder)"/>.
+    /// Adds the specified delegate to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypesExtensions.ApplyMiddleware(SchemaTypesBase, IFieldMiddlewareBuilder)"/>.
     /// <br/><br/>
     /// The delegate is used to unify the different ways of specifying middleware. See additional methods in <see cref="FieldMiddlewareBuilderExtensions"/>.
     /// </summary>

--- a/src/GraphQL/Types/Collections/AutoRegisteringGraphTypeMappingProvider.cs
+++ b/src/GraphQL/Types/Collections/AutoRegisteringGraphTypeMappingProvider.cs
@@ -45,7 +45,7 @@ public class AutoRegisteringGraphTypeMappingProvider : IGraphTypeMappingProvider
         if (isInputType && !_mapInputTypes && !IsForcedType(clrType) ||
             !isInputType && !_mapOutputTypes && !IsForcedType(clrType) ||
             clrType.IsEnum ||
-            SchemaTypes.BuiltInScalarMappings.ContainsKey(clrType))
+            SchemaTypesBase.BuiltInScalarMappings.ContainsKey(clrType))
             return null;
 
         if (isInputType)

--- a/src/GraphQL/Types/Collections/LegacySchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/LegacySchemaTypes.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Types;
 /// <br/>
 /// NOTE: After creating an instance of this class, its contents cannot be changed.
 /// </summary>
-public class LegacySchemaTypes : SchemaTypes
+public class LegacySchemaTypes : SchemaTypesBase
 {
     private const string INITIALIZATIION_TRACE_KEY = "__INITIALIZATIION_TRACE_KEY__";
 

--- a/src/GraphQL/Types/Collections/SchemaTypesBase.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypesBase.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Types;
 /// An abstract base class that represents a list of all the graph types utilized by a schema.
 /// Also provides lookup for all schema types.
 /// </summary>
-public abstract class SchemaTypes : IEnumerable<IGraphType>
+public abstract class SchemaTypesBase : IEnumerable<IGraphType>
 {
     /// <summary>
     /// Returns a dictionary of default CLR type to graph type mappings for a set of built-in (primitive) types.
@@ -90,7 +90,7 @@ public abstract class SchemaTypes : IEnumerable<IGraphType>
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(GraphQLClrOutputTypeReference<>))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ListGraphType<>))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NonNullGraphType<>))]
-    static SchemaTypes()
+    static SchemaTypesBase()
     {
         // The above attributes preserve those classes when T is a reference type, but not
         // when T is a value type, which is necessary for GraphQL CLR type references.
@@ -144,7 +144,7 @@ public abstract class SchemaTypes : IEnumerable<IGraphType>
     /// <summary>
     /// Initializes a new instance with an empty dictionary.
     /// </summary>
-    protected SchemaTypes() : this([])
+    protected SchemaTypesBase() : this([])
     {
     }
 
@@ -152,7 +152,7 @@ public abstract class SchemaTypes : IEnumerable<IGraphType>
     /// Initializes a new instance with the specified dictionary.
     /// </summary>
     /// <param name="dictionary">The dictionary that relates type names to graph types.</param>
-    protected SchemaTypes(Dictionary<ROM, IGraphType> dictionary)
+    protected SchemaTypesBase(Dictionary<ROM, IGraphType> dictionary)
     {
         Dictionary = dictionary;
     }

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -73,7 +73,7 @@ public interface ISchema : IMetadataReader, IMetadataWriter, IProvideDescription
     /// <summary>
     /// Returns a list of all the graph types utilized by this schema.
     /// </summary>
-    public SchemaTypes AllTypes { get; }
+    public SchemaTypesBase AllTypes { get; }
 
     /// <summary>
     /// A list of additional graph types manually added to the schema by a <see cref="RegisterType(Type)"/> call.

--- a/src/GraphQL/Types/Scalars/BigIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BigIntGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The BigInt scalar graph type represents a signed integer with any number of digits.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="BigInteger"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="BigInteger"/> .NET values to this scalar graph type.
 /// </summary>
 public class BigIntGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/BooleanGraphType.cs
+++ b/src/GraphQL/Types/Scalars/BooleanGraphType.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Boolean scalar graph type represents a boolean value. It is one of the five built-in scalars.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="bool"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="bool"/> .NET values to this scalar graph type.
 /// </summary>
 public class BooleanGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/ByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ByteGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Byte scalar graph type represents an unsigned 8-bit integer value.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="byte"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="byte"/> .NET values to this scalar graph type.
 /// </summary>
 public class ByteGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The DateTime scalar graph type represents a date and time in accordance with the ISO-8601 standard.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="DateTime"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="DateTime"/> .NET values to this scalar graph type.
 /// </summary>
 public class DateTimeGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DateTimeOffsetGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The DateTimeOffset scalar graph type represents a date, time and offset from UTC.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="DateTimeOffset"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="DateTimeOffset"/> .NET values to this scalar graph type.
 /// </summary>
 public class DateTimeOffsetGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/DecimalGraphType.cs
+++ b/src/GraphQL/Types/Scalars/DecimalGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Decimal scalar graph type represents a decimal value.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="decimal"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="decimal"/> .NET values to this scalar graph type.
 /// </summary>
 public class DecimalGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/FloatGraphType.cs
+++ b/src/GraphQL/Types/Scalars/FloatGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Float scalar graph type represents an IEEE 754 double-precision floating point value. It is one of the five built-in scalars.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="double"/> and <see cref="float"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="double"/> and <see cref="float"/> .NET values to this scalar graph type.
 /// </summary>
 public class FloatGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/IdGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IdGraphType.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Types;
 /// <summary>
 /// The ID scalar graph type represents a string identifier, not intended to be human-readable. It is one of the five built-in scalars.
 /// When expected as an input type, any string or integer input value will be accepted as an ID.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="Guid"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="Guid"/> .NET values to this scalar graph type.
 /// </summary>
 public class IdGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/IntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/IntGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Int scalar type represents a signed 32‐bit numeric non‐fractional value. It is one of the five built-in scalars.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="int"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="int"/> .NET values to this scalar graph type.
 /// </summary>
 public class IntGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/LongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/LongGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Long scalar graph type represents a signed 64-bit integer value.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="long"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="long"/> .NET values to this scalar graph type.
 /// </summary>
 public class LongGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/SByteGraphType.cs
+++ b/src/GraphQL/Types/Scalars/SByteGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The SByte scalar graph type represents a signed 8-bit integer value.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="sbyte"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="sbyte"/> .NET values to this scalar graph type.
 /// </summary>
 public class SByteGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/ShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ShortGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Short scalar graph type represents a signed 16-bit integer value.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="short"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="short"/> .NET values to this scalar graph type.
 /// </summary>
 public class ShortGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/StringGraphType.cs
+++ b/src/GraphQL/Types/Scalars/StringGraphType.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The String scalar graph type represents a string value. It is one of the five built-in scalars.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="string"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="string"/> .NET values to this scalar graph type.
 /// </summary>
 public class StringGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
+++ b/src/GraphQL/Types/Scalars/TimeSpanSecondsGraphType.cs
@@ -5,7 +5,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Seconds scalar graph type represents a period of time represented as an integer value of the total number of seconds.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="TimeSpan"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="TimeSpan"/> .NET values to this scalar graph type.
 /// </summary>
 public class TimeSpanSecondsGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/UIntGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UIntGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The UInt scalar graph type represents an unsigned 32-bit integer value.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="uint"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="uint"/> .NET values to this scalar graph type.
 /// </summary>
 public class UIntGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/ULongGraphType.cs
+++ b/src/GraphQL/Types/Scalars/ULongGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The ULong scalar graph type represents an unsigned 64-bit integer value.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="ulong"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="ulong"/> .NET values to this scalar graph type.
 /// </summary>
 public class ULongGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/UShortGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UShortGraphType.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The UShort scalar graph type represents an unsigned 16-bit integer value.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="ushort"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="ushort"/> .NET values to this scalar graph type.
 /// </summary>
 public class UShortGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Scalars/UriGraphType.cs
+++ b/src/GraphQL/Types/Scalars/UriGraphType.cs
@@ -4,7 +4,7 @@ namespace GraphQL.Types;
 
 /// <summary>
 /// The Uri scalar graph type represents a string Uri specified in RFC 2396, RFC 2732, RFC 3986, and RFC 3987.
-/// By default <see cref="SchemaTypes"/> maps all <see cref="Uri"/> .NET values to this scalar graph type.
+/// By default <see cref="SchemaTypesBase"/> maps all <see cref="Uri"/> .NET values to this scalar graph type.
 /// </summary>
 public class UriGraphType : ScalarGraphType
 {

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -51,7 +51,7 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
         public SchemaDirectives Directives => _schema.Directives;
 
         /// <inheritdoc/>
-        public SchemaTypes? AllTypes => _schema._allTypes;
+        public SchemaTypesBase? AllTypes => _schema._allTypes;
 
         public string AllTypesMessage => _schema._allTypes == null ? "AllTypes property too early initialization was suppressed to prevent unforeseen consequences. You may click Raw View in debugger window to evaluate all properties." : string.Empty;
 
@@ -76,7 +76,7 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
 
     private bool _disposed;
     private IServiceProvider _services;
-    private SchemaTypes? _allTypes;
+    private SchemaTypesBase? _allTypes;
     private ExceptionDispatchInfo? _initializationException;
     private readonly object _allTypesInitializationLock = new();
     private bool _creatingSchemaTypes;
@@ -255,7 +255,7 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
     public SchemaDirectives Directives { get; }
 
     /// <inheritdoc/>
-    public SchemaTypes AllTypes
+    public SchemaTypesBase AllTypes
     {
         get
         {
@@ -390,7 +390,7 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
     {
         get
         {
-            foreach (var pair in SchemaTypes.BuiltInScalarMappings)
+            foreach (var pair in SchemaTypesBase.BuiltInScalarMappings)
                 yield return (pair.Key, pair.Value);
         }
     }
@@ -496,13 +496,13 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
     }
 
     /// <summary>
-    /// Creates and returns a new instance of <see cref="SchemaTypes"/> for this schema.
+    /// Creates and returns a new instance of <see cref="SchemaTypesBase"/> for this schema.
     /// Does not apply middleware, apply schema visitors, or validate the schema.
     /// </summary>
     /// <remarks>
     /// This executes within a lock in <see cref="Initialize"/>.
     /// </remarks>
-    protected virtual SchemaTypes CreateSchemaTypes()
+    protected virtual SchemaTypesBase CreateSchemaTypes()
     {
         var graphTypeMappingProviders = (IEnumerable<IGraphTypeMappingProvider>?)_services.GetService(typeof(IEnumerable<IGraphTypeMappingProvider>));
         return new LegacySchemaTypes(this, _services, graphTypeMappingProviders, OnBeforeInitializeType);

--- a/src/GraphQL/Types/TypeCollectionContext.cs
+++ b/src/GraphQL/Types/TypeCollectionContext.cs
@@ -3,7 +3,7 @@ namespace GraphQL.Types;
 /// <summary>
 /// Provides a mechanism to resolve graph type instances from their .NET types,
 /// and also to register new graph type instances with their name in the graph type lookup table.
-/// (See <see cref="SchemaTypes"/>.)
+/// (See <see cref="SchemaTypesBase"/>.)
 /// </summary>
 internal sealed class TypeCollectionContext
 {


### PR DESCRIPTION
No other changes; strictly renaming `SchemaTypes` to `SchemaTypesBase`

Builds on:
- #4233 

To be followed by:
- #4234 