### PR TITLE
Add automatic nullable value type detection for FieldBuilder.Argument<T>

### DIFF
--- a/docs2/site/docs/migrations/migration9.md
+++ b/docs2/site/docs/migrations/migration9.md
@@ -40,6 +40,24 @@ schema.Features.DeprecationOfInputValues = false;
 
 Note that these properties must be set before schema initialization.
 
+### 2. Automatic Nullable Value Type Detection in Field Arguments
+
+The `Argument<T>` method on field builders now supports automatic nullable value type detection. When the `nullable` parameter is not specified (defaults to `null`), nullable value types like `int?`, `DateTime?`, etc. will automatically be treated as nullable fields in the GraphQL schema.
+
+```csharp
+// Before v9 - explicit nullable parameter required
+Field<StringGraphType>("myField")
+    .Argument<int?>("nullableArg", nullable: true)  // Had to explicitly set nullable: true
+    .Argument<int>("requiredArg", nullable: false); // Explicitly non-null
+
+// v9 - automatic detection when nullable parameter is omitted
+Field<StringGraphType>("myField")
+    .Argument<int?>("nullableArg")     // Automatically nullable (nullable value type)
+    .Argument<int>("requiredArg");     // Automatically non-null (non-nullable value type)
+```
+
+This feature makes it easier to work with nullable value types without having to explicitly specify the `nullable` parameter. Note that reference types like `string` still default to non-null and require explicitly setting `nullable: true` to make them optional. You can always explicitly set `nullable: true` or `nullable: false` to override the automatic behavior if needed.
+
 ## Breaking Changes
 
 ### 1. Removal of Obsolete Members
@@ -186,3 +204,7 @@ protected override SchemaTypesBase CreateSchemaTypes()
 The `AllTypes` property on both `ISchema` and `Schema` now returns `SchemaTypesBase` instead of `SchemaTypes`. `SchemaTypesBase` is now the base class, and a new `SchemaTypes` class now inherits from `SchemaTypesBase`.
 
 This change allows for better extensibility and provides a clearer separation between the base functionality and the concrete implementation. The `SchemaTypesBase` class exposes the same public API as `SchemaTypes` did before, so most code should continue to work without changes.
+
+### 10. `FieldBuilder.Argument<T>` nullable parameter changed to `bool?`
+
+The `nullable` parameter in the `Argument<T>` method has changed from `bool` (default `false`) to `bool?` (default `null`) to support automatic nullable value type detection. This change is generally source-compatible and should not require changes to user code. See the New Features section above for more details.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1055,10 +1055,10 @@ namespace GraphQL.Builders
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable = false, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool? nullable = default, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TArgumentGraphType>(string name, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool? nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(params GraphQL.Types.QueryArgument[] arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Configure(System.Action<GraphQL.Types.FieldType> configure) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1055,10 +1055,10 @@ namespace GraphQL.Builders
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable = false, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool? nullable = default, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TArgumentGraphType>(string name, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool? nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(params GraphQL.Types.QueryArgument[] arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Configure(System.Action<GraphQL.Types.FieldType> configure) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -1014,10 +1014,10 @@ namespace GraphQL.Builders
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable = false, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool? nullable = default, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentGraphType>(string name, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null)
             where TArgumentGraphType : GraphQL.Types.IGraphType { }
-        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
+        public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Argument<TArgumentClrType>(string name, bool? nullable, string? description, System.Action<GraphQL.Types.QueryArgument>? configure = null) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(params GraphQL.Types.QueryArgument[] arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Arguments(System.Collections.Generic.IEnumerable<GraphQL.Types.QueryArgument> arguments) { }
         public virtual GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> Configure(System.Action<GraphQL.Types.FieldType> configure) { }

--- a/src/GraphQL/Builders/FieldBuilder.cs
+++ b/src/GraphQL/Builders/FieldBuilder.cs
@@ -240,16 +240,17 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// </summary>
     /// <typeparam name="TArgumentClrType">The clr type of the argument.</typeparam>
     /// <param name="name">The name of the argument.</param>
-    /// <param name="nullable">Indicates if the argument is optional or not.</param>
+    /// <param name="nullable">Indicates if the argument is optional or not. When <see langword="null"/>, nullable value types will be nullable fields.</param>
     /// <param name="configure">A delegate to further configure the argument.</param>
     [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-    public virtual FieldBuilder<TSourceType, TReturnType> Argument<[NotAGraphType] TArgumentClrType>(string name, bool nullable = false, Action<QueryArgument>? configure = null)
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument<[NotAGraphType] TArgumentClrType>(string name, bool? nullable = null, Action<QueryArgument>? configure = null)
     {
         Type type;
 
         try
         {
-            type = typeof(TArgumentClrType).GetGraphTypeFromType(nullable, TypeMappingMode.InputType);
+            var isNullable = nullable ?? (Nullable.GetUnderlyingType(typeof(TArgumentClrType)) != null);
+            type = typeof(TArgumentClrType).GetGraphTypeFromType(isNullable, TypeMappingMode.InputType);
         }
         catch (ArgumentOutOfRangeException exp)
         {
@@ -264,11 +265,11 @@ public class FieldBuilder<[NotAGraphType] TSourceType, [NotAGraphType] TReturnTy
     /// </summary>
     /// <typeparam name="TArgumentClrType">The clr type of the argument.</typeparam>
     /// <param name="name">The name of the argument.</param>
-    /// <param name="nullable">Indicates if the argument is optional or not.</param>
+    /// <param name="nullable">Indicates if the argument is optional or not. When <see langword="null"/>, nullable value types will be nullable fields.</param>
     /// <param name="description">The description of the argument.</param>
     /// <param name="configure">A delegate to further configure the argument.</param>
     [AllowedOn<IObjectGraphType, IInterfaceGraphType>]
-    public virtual FieldBuilder<TSourceType, TReturnType> Argument<[NotAGraphType] TArgumentClrType>(string name, bool nullable, string? description, Action<QueryArgument>? configure = null)
+    public virtual FieldBuilder<TSourceType, TReturnType> Argument<[NotAGraphType] TArgumentClrType>(string name, bool? nullable, string? description, Action<QueryArgument>? configure = null)
         => Argument<TArgumentClrType>(name, nullable, b =>
         {
             b.Description = description;


### PR DESCRIPTION
### Summary
This PR enhances the `FieldBuilder.Argument<T>` method to automatically detect nullable value types, making it easier to work with nullable value types like `int?`, `DateTime?`, etc. without explicitly specifying the `nullable` parameter.

### Changes
- Changed the `nullable` parameter from `bool` (default `false`) to `bool?` (default `null`)
- When `nullable` is `null` (default), the method automatically detects if `T` is a nullable value type:
  - Nullable value types (`int?`, `DateTime?`, etc.) → automatically nullable fields
  - Non-nullable value types (`int`, `DateTime`, etc.) → non-null fields
  - Reference types (`string`, etc.) → non-null by default (must explicitly set `nullable: true` for optional)
- Updated both `Argument<T>` method overloads for consistency
- Added comprehensive migration documentation

### Example Usage
```csharp
// Before - had to explicitly specify nullable: true for nullable value types
Field<StringGraphType>("myField")
    .Argument<int?>("nullableArg", nullable: true)
    .Argument<int>("requiredArg", nullable: false);

// After - automatic detection when nullable parameter is omitted
Field<StringGraphType>("myField")
    .Argument<int?>("nullableArg")     // Automatically nullable
    .Argument<int>("requiredArg");     // Automatically non-null
