### PR TITLE
Suppress trimming warnings for MakeGenericType calls with known reference types

### DIFF
--- a/src/GraphQL/Extensions/TypeExtensions.cs
+++ b/src/GraphQL/Extensions/TypeExtensions.cs
@@ -220,12 +220,12 @@ public static class TypeExtensions
         {
             var clrElementType = type.GetElementType()!;
             var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent array
-            graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
+            graphType = MakeListType(elementType);
         }
         else if (TryGetEnumerableElementType(type, out var clrElementType))
         {
             var elementType = GetGraphTypeFromType(clrElementType, IsNullableType(clrElementType), mode); // isNullable from elementType, not from parent container
-            graphType = typeof(ListGraphType<>).MakeGenericType(elementType);
+            graphType = MakeListType(elementType);
         }
         else
         {
@@ -267,7 +267,7 @@ public static class TypeExtensions
 
         if (!isNullable)
         {
-            graphType = typeof(NonNullGraphType<>).MakeGenericType(graphType);
+            graphType = MakeNonNullType(graphType);
         }
 
         return graphType;
@@ -275,6 +275,16 @@ public static class TypeExtensions
         //TODO: rewrite nullability condition in v5
         static bool IsNullableType(Type type) => !type.IsValueType || type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
     }
+
+    [SuppressMessage("Trimming", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.",
+        Justification = "The supplied type is expected to be a reference type. NonNullGraphType<T> constrains T to IGraphType, and all supported implementations are classes, so MakeGenericType(type) should be valid.")]
+    private static Type MakeNonNullType(Type type)
+        => typeof(NonNullGraphType<>).MakeGenericType(type);
+
+    [SuppressMessage("Trimming", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.",
+        Justification = "The supplied type is expected to be a reference type. NonNullGraphType<T> constrains T to IGraphType, and all supported implementations are classes, so MakeGenericType(type) should be valid.")]
+    private static Type MakeListType(Type type)
+        => typeof(ListGraphType<>).MakeGenericType(type);
 
     /// <summary>
     /// Returns the friendly name of a type, using C# angle-bracket syntax for generics.


### PR DESCRIPTION
## Summary
This PR addresses IL2055 and IL2070 trimming analyzer warnings related to `MakeGenericType` calls by extracting them into dedicated helper methods with appropriate suppression attributes and detailed justifications.

## Changes Made

### [`TypeExtensions.cs`](src/GraphQL/Extensions/TypeExtensions.cs)
- Extracted `MakeGenericType` calls into two new private helper methods:
  - `MakeNonNullType(Type type)` - Creates `NonNullGraphType<>` instances
  - `MakeListType(Type type)` - Creates `ListGraphType<>` instances
- Added `[SuppressMessage("Trimming", "IL2070:...")]` attributes with justification explaining that the supplied types are expected to be reference types implementing `IGraphType`
- Updated 3 call sites to use the new helper methods

### [`SchemaTypes.cs`](src/GraphQL/Types/Collections/SchemaTypes.cs)
- Extracted `MakeGenericType` call in `ResolveClrTypeReferences` into a new private helper method `MakeGenericTypeNoWarn`
- Added `[SuppressMessage("Trimming", "IL2055:...")]` attribute with detailed justification explaining why the generic type construction is safe (CLR type references and graph types are both reference types)
- Added inline comment explaining the type safety reasoning with a concrete example

## Justification
The trimming analyzer cannot statically determine that these `MakeGenericType` calls are safe, but they are guaranteed to be valid because:
1. `NonNullGraphType<T>` and `ListGraphType<T>` constrain `T` to `IGraphType`, and all supported implementations are reference types (classes)
2. In `SchemaTypes.cs`, the generic arguments being replaced are CLR type references (reference types) being substituted with graph types (also reference types), maintaining type compatibility

These suppressions are safe and necessary to eliminate false positive warnings from the trimming analyzer.