### PR TITLE
Fix analyzers packing

### DIFF
--- a/src/GraphQL.Analyzers.Package/GraphQL.Analyzers.Package.csproj
+++ b/src/GraphQL.Analyzers.Package/GraphQL.Analyzers.Package.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild Condition="'$(NoBuild)' != 'true'">true</GeneratePackageOnBuild>
+    <BuildProjectReferences Condition="'$(NoBuild)' == 'true'">false</BuildProjectReferences>
     <Authors>Joe McBride</Authors>
     <Copyright>Copyright (c) 2015-2023 Joseph T. McBride, Ivan Maximov, Shane Krueger, et al. All rights reserved.</Copyright>
   </PropertyGroup>


### PR DESCRIPTION
In the previous PR https://github.com/graphql-dotnet/graphql-dotnet/pull/4269 I have [added](https://github.com/graphql-dotnet/graphql-dotnet/pull/4269/changes#diff-62606b9953bc6259ec6f56ad3faa86b747b9efdf7df3233328ce8e0ac95cd4d9R37) `DependsOnTargets="ResolveProjectReferences"` to the `_AddAnalyzersToOutput` to allow packing the `GraphQLParser.dll` in the analyzers nuget package. This dependency target triggers the build target, which conflicts with the `--no-build` in packing command
```bash
dotnet pack --no-restore --no-build -c Release -p:VersionSuffix=$GITHUB_RUN_NUMBER -o src/out
```

> Error: /usr/share/dotnet/sdk/10.0.101/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(262,5): error NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked. [/home/runner/work/graphql-dotnet/graphql-dotnet/src/GraphQL.Analyzers/GraphQL.Analyzers.csproj]

Disabling `BuildProjectReferences` when `--no-build` is provided solves the issue.