### PR TITLE
Add DefaultFieldResolver property to ISchema and Schema

### DIFF
--- a/docs2/site/docs/migrations/migration9.md
+++ b/docs2/site/docs/migrations/migration9.md
@@ -317,3 +317,7 @@ These providers are automatically prepended to the list of custom mapping provid
 Most users will not need to make any changes, as the schema initialization process automatically includes these providers. However, if you have custom schema initialization logic or override `CreateSchemaTypes()`, be aware that the built-in providers are now prepended automatically via the `PrependBuiltInProviders` method.
 
 Please note that since the built-in providers are prepended to the list of custom providers, custom mapping providers will receive the suggested mapping from the built-in providers in the `preferredType` parameter of their `GetGraphTypeFromClrType` method. If your custom provider should override built-in mappings, ensure it ignores the `preferredType` parameter for those specific CLR types. Otherwise, return `preferredType` if it's not null to respect the built-in mappings. If you are using the `LegacySchemaTypes` class as described above, it will continue to function as it did in v8 with no changes to your mapping providers.
+
+### 16. `ISchema.DefaultFieldResolver` property and `SchemaTypesExtensions.ApplyMiddleware` parameter added
+
+The `DefaultFieldResolver` property has been added to `ISchema` and `Schema`, which defaults to `NameFieldResolver.Instance`. The `ApplyMiddleware` extension methods on `SchemaTypesBase` now require an `ISchema` parameter. Custom implementations of `ISchema` must implement the new property, and any direct calls to `ApplyMiddleware` must include the schema parameter.

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -885,8 +885,8 @@ namespace GraphQL
     }
     public static class SchemaTypesExtensions
     {
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder, GraphQL.Types.ISchema schema) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform, GraphQL.Types.ISchema schema) { }
     }
     public static class StringExtensions
     {
@@ -2154,13 +2154,15 @@ namespace GraphQL.Resolvers
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         public virtual System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
-    public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver
+    public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver, GraphQL.Resolvers.IRequiresResolveFieldContextAccessor
     {
+        public bool RequiresResolveFieldContextAccessor { get; }
         public static GraphQL.Resolvers.NameFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
-    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver
+    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver, GraphQL.Resolvers.IRequiresResolveFieldContextAccessor
     {
+        public bool RequiresResolveFieldContextAccessor { get; }
         public static GraphQL.Resolvers.SourceFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
@@ -2721,6 +2723,7 @@ namespace GraphQL.Types
                 "graphType"})]
         System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
+        GraphQL.Resolvers.IFieldResolver? DefaultFieldResolver { get; set; }
         GraphQL.Types.SchemaDirectives Directives { get; }
         GraphQL.ExperimentalFeatures Features { get; set; }
         GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; }
@@ -2975,6 +2978,7 @@ namespace GraphQL.Types
                 "graphType"})]
         public System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         public GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
+        public GraphQL.Resolvers.IFieldResolver? DefaultFieldResolver { get; set; }
         public string? Description { get; set; }
         public GraphQL.Types.SchemaDirectives Directives { get; }
         public GraphQL.ExperimentalFeatures Features { get; set; }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -885,8 +885,8 @@ namespace GraphQL
     }
     public static class SchemaTypesExtensions
     {
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder, GraphQL.Types.ISchema schema) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform, GraphQL.Types.ISchema schema) { }
     }
     public static class StringExtensions
     {
@@ -2154,13 +2154,15 @@ namespace GraphQL.Resolvers
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         public virtual System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
-    public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver
+    public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver, GraphQL.Resolvers.IRequiresResolveFieldContextAccessor
     {
+        public bool RequiresResolveFieldContextAccessor { get; }
         public static GraphQL.Resolvers.NameFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
-    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver
+    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver, GraphQL.Resolvers.IRequiresResolveFieldContextAccessor
     {
+        public bool RequiresResolveFieldContextAccessor { get; }
         public static GraphQL.Resolvers.SourceFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
@@ -2728,6 +2730,7 @@ namespace GraphQL.Types
                 "graphType"})]
         System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
+        GraphQL.Resolvers.IFieldResolver? DefaultFieldResolver { get; set; }
         GraphQL.Types.SchemaDirectives Directives { get; }
         GraphQL.ExperimentalFeatures Features { get; set; }
         GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; }
@@ -2982,6 +2985,7 @@ namespace GraphQL.Types
                 "graphType"})]
         public System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         public GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
+        public GraphQL.Resolvers.IFieldResolver? DefaultFieldResolver { get; set; }
         public string? Description { get; set; }
         public GraphQL.Types.SchemaDirectives Directives { get; }
         public GraphQL.ExperimentalFeatures Features { get; set; }

--- a/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
@@ -885,8 +885,8 @@ namespace GraphQL
     }
     public static class SchemaTypesExtensions
     {
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder, GraphQL.Types.ISchema schema) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform, GraphQL.Types.ISchema schema) { }
     }
     public static class StringExtensions
     {
@@ -2157,13 +2157,15 @@ namespace GraphQL.Resolvers
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         public virtual System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
-    public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver
+    public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver, GraphQL.Resolvers.IRequiresResolveFieldContextAccessor
     {
+        public bool RequiresResolveFieldContextAccessor { get; }
         public static GraphQL.Resolvers.NameFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
-    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver
+    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver, GraphQL.Resolvers.IRequiresResolveFieldContextAccessor
     {
+        public bool RequiresResolveFieldContextAccessor { get; }
         public static GraphQL.Resolvers.SourceFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
@@ -2737,6 +2739,7 @@ namespace GraphQL.Types
                 "graphType"})]
         System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
+        GraphQL.Resolvers.IFieldResolver? DefaultFieldResolver { get; set; }
         GraphQL.Types.SchemaDirectives Directives { get; }
         GraphQL.ExperimentalFeatures Features { get; set; }
         GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; }
@@ -2991,6 +2994,7 @@ namespace GraphQL.Types
                 "graphType"})]
         public System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         public GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
+        public GraphQL.Resolvers.IFieldResolver? DefaultFieldResolver { get; set; }
         public string? Description { get; set; }
         public GraphQL.Types.SchemaDirectives Directives { get; }
         public GraphQL.ExperimentalFeatures Features { get; set; }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -846,8 +846,8 @@ namespace GraphQL
     }
     public static class SchemaTypesExtensions
     {
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder) { }
-        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, GraphQL.Instrumentation.IFieldMiddlewareBuilder fieldMiddlewareBuilder, GraphQL.Types.ISchema schema) { }
+        public static void ApplyMiddleware(this GraphQL.Types.SchemaTypesBase schemaTypes, System.Func<GraphQL.Instrumentation.FieldMiddlewareDelegate, GraphQL.Instrumentation.FieldMiddlewareDelegate> transform, GraphQL.Types.ISchema schema) { }
     }
     public static class StringExtensions
     {
@@ -2090,13 +2090,15 @@ namespace GraphQL.Resolvers
         protected virtual System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<object?>> BuildFieldResolver(System.Linq.Expressions.ParameterExpression resolveFieldContextParameter, System.Linq.Expressions.Expression bodyExpression) { }
         public virtual System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
-    public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver
+    public class NameFieldResolver : GraphQL.Resolvers.IFieldResolver, GraphQL.Resolvers.IRequiresResolveFieldContextAccessor
     {
+        public bool RequiresResolveFieldContextAccessor { get; }
         public static GraphQL.Resolvers.NameFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
-    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver
+    public sealed class SourceFieldResolver : GraphQL.Resolvers.IFieldResolver, GraphQL.Resolvers.IRequiresResolveFieldContextAccessor
     {
+        public bool RequiresResolveFieldContextAccessor { get; }
         public static GraphQL.Resolvers.SourceFieldResolver Instance { get; }
         public System.Threading.Tasks.ValueTask<object?> ResolveAsync(GraphQL.IResolveFieldContext context) { }
     }
@@ -2616,6 +2618,7 @@ namespace GraphQL.Types
                 "graphType"})]
         System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
+        GraphQL.Resolvers.IFieldResolver? DefaultFieldResolver { get; set; }
         GraphQL.Types.SchemaDirectives Directives { get; }
         GraphQL.ExperimentalFeatures Features { get; set; }
         GraphQL.Instrumentation.IFieldMiddlewareBuilder FieldMiddleware { get; }
@@ -2868,6 +2871,7 @@ namespace GraphQL.Types
                 "graphType"})]
         public System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         public GraphQL.Introspection.ISchemaComparer Comparer { get; set; }
+        public GraphQL.Resolvers.IFieldResolver? DefaultFieldResolver { get; set; }
         public string? Description { get; set; }
         public GraphQL.Types.SchemaDirectives Directives { get; }
         public GraphQL.ExperimentalFeatures Features { get; set; }

--- a/src/GraphQL/Extensions/SchemaTypesExtensions.cs
+++ b/src/GraphQL/Extensions/SchemaTypesExtensions.cs
@@ -17,14 +17,15 @@ public static class SchemaTypesExtensions
     /// </summary>
     /// <param name="schemaTypes">The schema types collection to apply middleware to.</param>
     /// <param name="fieldMiddlewareBuilder">The middleware builder containing the middleware to apply.</param>
-    public static void ApplyMiddleware(this SchemaTypesBase schemaTypes, IFieldMiddlewareBuilder fieldMiddlewareBuilder)
+    /// <param name="schema">The schema instance to retrieve the default field resolver from.</param>
+    public static void ApplyMiddleware(this SchemaTypesBase schemaTypes, IFieldMiddlewareBuilder fieldMiddlewareBuilder, ISchema schema)
     {
         var transform = (fieldMiddlewareBuilder ?? throw new ArgumentNullException(nameof(fieldMiddlewareBuilder))).Build();
 
         // allocation free optimization if no middlewares are defined
         if (transform != null)
         {
-            schemaTypes.ApplyMiddleware(transform);
+            schemaTypes.ApplyMiddleware(transform, schema);
         }
     }
 
@@ -36,12 +37,15 @@ public static class SchemaTypesExtensions
     /// </summary>
     /// <param name="schemaTypes">The schema types collection to apply middleware to.</param>
     /// <param name="transform">The middleware transform delegate to apply.</param>
-    public static void ApplyMiddleware(this SchemaTypesBase schemaTypes, Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform)
+    /// <param name="schema">The schema instance to retrieve the default field resolver from.</param>
+    public static void ApplyMiddleware(this SchemaTypesBase schemaTypes, Func<FieldMiddlewareDelegate, FieldMiddlewareDelegate> transform, ISchema schema)
     {
         if (schemaTypes == null)
             throw new ArgumentNullException(nameof(schemaTypes));
         if (transform == null)
             throw new ArgumentNullException(nameof(transform));
+        if (schema == null)
+            throw new ArgumentNullException(nameof(schema));
 
         foreach (var graphType in schemaTypes.Dictionary.Values)
         {
@@ -49,7 +53,9 @@ public static class SchemaTypesExtensions
             {
                 foreach (var field in obj.Fields.List)
                 {
-                    var inner = field.Resolver ?? (field.StreamResolver == null ? NameFieldResolver.Instance : SourceFieldResolver.Instance);
+                    var inner = field.Resolver ?? (field.StreamResolver == null
+                        ? (schema.DefaultFieldResolver ?? throw new InvalidOperationException($"Schema.DefaultFieldResolver is null for field '{field.Name}' on type '{obj.Name}'."))
+                        : SourceFieldResolver.Instance);
 
                     var fieldMiddlewareDelegate = transform(inner.ResolveAsync);
 

--- a/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
+++ b/src/GraphQL/Instrumentation/FieldMiddlewareBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Instrumentation;
 public static class FieldMiddlewareBuilderExtensions
 {
     /// <summary>
-    /// Adds middleware to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypesExtensions.ApplyMiddleware(SchemaTypesBase, IFieldMiddlewareBuilder)"/>.
+    /// Adds middleware to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypesExtensions.ApplyMiddleware(SchemaTypesBase, IFieldMiddlewareBuilder, ISchema)"/>.
     /// </summary>
     /// <param name="builder">Interface for connecting middlewares to a schema.</param>
     /// <param name="middleware">Middleware instance.</param>

--- a/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
+++ b/src/GraphQL/Instrumentation/IFieldMiddlewareBuilder.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Instrumentation;
 public interface IFieldMiddlewareBuilder
 {
     /// <summary>
-    /// Adds the specified delegate to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypesExtensions.ApplyMiddleware(SchemaTypesBase, IFieldMiddlewareBuilder)"/>.
+    /// Adds the specified delegate to the list of delegates that will be applied to all field resolvers when invoking <see cref="SchemaTypesExtensions.ApplyMiddleware(SchemaTypesBase, IFieldMiddlewareBuilder, ISchema)"/>.
     /// <br/><br/>
     /// The delegate is used to unify the different ways of specifying middleware. See additional methods in <see cref="FieldMiddlewareBuilderExtensions"/>.
     /// </summary>

--- a/src/GraphQL/Resolvers/NameFieldResolver.cs
+++ b/src/GraphQL/Resolvers/NameFieldResolver.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Resolvers;
 /// Call <see cref="Instance"/> to retrieve an instance of this class.
 /// </para>
 /// </summary>
-public class NameFieldResolver : IFieldResolver
+public class NameFieldResolver : IFieldResolver, IRequiresResolveFieldContextAccessor
 {
     private static readonly ConcurrentDictionary<(Type targetType, string name), IFieldResolver> _resolvers = new();
 
@@ -23,6 +23,9 @@ public class NameFieldResolver : IFieldResolver
     /// Returns the static instance of the <see cref="NameFieldResolver"/> class.
     /// </summary>
     public static NameFieldResolver Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public bool RequiresResolveFieldContextAccessor => false;
 
     /// <inheritdoc/>
     public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => Resolve(context, context.FieldDefinition.Name);

--- a/src/GraphQL/Resolvers/SourceFieldResolver.cs
+++ b/src/GraphQL/Resolvers/SourceFieldResolver.cs
@@ -3,7 +3,7 @@ namespace GraphQL.Resolvers;
 /// <summary>
 /// Returns value of <see cref="IResolveFieldContext.Source"/>.
 /// </summary>
-public sealed class SourceFieldResolver : IFieldResolver
+public sealed class SourceFieldResolver : IFieldResolver, IRequiresResolveFieldContextAccessor
 {
     private SourceFieldResolver() { }
 
@@ -11,6 +11,9 @@ public sealed class SourceFieldResolver : IFieldResolver
     /// Returns the static instance of the <see cref="SourceFieldResolver"/> class.
     /// </summary>
     public static SourceFieldResolver Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public bool RequiresResolveFieldContextAccessor => false;
 
     /// <inheritdoc/>
     public ValueTask<object?> ResolveAsync(IResolveFieldContext context) => new(context.Source);

--- a/src/GraphQL/Types/ISchema.cs
+++ b/src/GraphQL/Types/ISchema.cs
@@ -2,6 +2,7 @@ using GraphQL.Conversion;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Introspection;
+using GraphQL.Resolvers;
 using GraphQL.Utilities;
 
 namespace GraphQL.Types;
@@ -171,4 +172,10 @@ public interface ISchema : IMetadataReader, IMetadataWriter, IProvideDescription
     /// to all fields to populate the accessor.
     /// </summary>
     public IResolveFieldContextAccessor? ResolveFieldContextAccessor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default field resolver to use when a field does not have a resolver explicitly set.
+    /// Typically defaults to <see cref="NameFieldResolver.Instance"/>.
+    /// </summary>
+    public IFieldResolver? DefaultFieldResolver { get; set; }
 }

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -5,6 +5,7 @@ using GraphQL.DI;
 using GraphQL.Execution;
 using GraphQL.Instrumentation;
 using GraphQL.Introspection;
+using GraphQL.Resolvers;
 using GraphQL.Utilities;
 using GraphQL.Utilities.Visitors;
 using GraphQLParser.AST;
@@ -174,6 +175,9 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
 
     /// <inheritdoc/>
     public IResolveFieldContextAccessor? ResolveFieldContextAccessor { get; set; }
+
+    /// <inheritdoc/>
+    public IFieldResolver? DefaultFieldResolver { get; set; } = NameFieldResolver.Instance;
 
     /// <inheritdoc/>
     public bool Initialized { get; private set; }
@@ -483,7 +487,7 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
             new FieldMiddlewareVisitor(_services).Run(this);
 
             // Apply schema-wide middleware
-            _allTypes.ApplyMiddleware(FieldMiddleware);
+            _allTypes.ApplyMiddleware(FieldMiddleware, this);
 
             foreach (var visitor in GetVisitors())
                 visitor.Run(this);

--- a/src/GraphQL/Utilities/Visitors/FieldMiddlewareVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/FieldMiddlewareVisitor.cs
@@ -28,7 +28,9 @@ internal sealed class FieldMiddlewareVisitor : BaseSchemaNodeVisitor
         var middlewareTransform = field.Middleware;
         if (middlewareTransform != null)
         {
-            var inner = field.Resolver ?? (field.StreamResolver == null ? NameFieldResolver.Instance : SourceFieldResolver.Instance);
+            var inner = field.Resolver ?? (field.StreamResolver == null
+                ? (schema.DefaultFieldResolver ?? throw new InvalidOperationException($"Schema.DefaultFieldResolver is null for field '{field.Name}' on type '{type.Name}'."))
+                : SourceFieldResolver.Instance);
 
             // Apply the middleware transform to wrap the resolver
             FieldMiddlewareDelegate wrappedDelegate = middlewareTransform(_serviceProvider, inner.ResolveAsync);

--- a/src/GraphQL/Utilities/Visitors/ResolveFieldContextAccessorVisitor.cs
+++ b/src/GraphQL/Utilities/Visitors/ResolveFieldContextAccessorVisitor.cs
@@ -27,8 +27,6 @@ internal sealed class ResolveFieldContextAccessorVisitor : BaseSchemaNodeVisitor
         // only wrap fields that have a custom resolver, as default resolvers do not need the context accessor
         // also, do not wrap fields that explicitly indicate they do not need the context accessor
         if (field.Resolver != null &&
-            field.Resolver != NameFieldResolver.Instance &&
-            field.Resolver != SourceFieldResolver.Instance &&
             (field.Resolver is not IRequiresResolveFieldContextAccessor requiresAccessor || requiresAccessor.RequiresResolveFieldContextAccessor))
         {
             field.Resolver = new ResolveFieldContextAccessorResolver(_accessor, field.Resolver);


### PR DESCRIPTION
## Summary

Adds a `DefaultFieldResolver` property to `ISchema` and `Schema` to allow customization of the default field resolver used when a field doesn't have an explicit resolver set. This property defaults to `NameFieldResolver.Instance`.

## Changes

- Added `ISchema.DefaultFieldResolver` property (nullable `IFieldResolver`)
- Added `Schema.DefaultFieldResolver` property with default value of `NameFieldResolver.Instance`
- Updated `FieldMiddlewareVisitor` to use schema's `DefaultFieldResolver` with appropriate error handling
- Updated `ResolveFieldContextAccessorVisitor` to check `IRequiresResolveFieldContextAccessor` interface instead of comparing specific resolver instances
- Implemented `IRequiresResolveFieldContextAccessor` on `NameFieldResolver` and `SourceFieldResolver` (both return `false`)
- Updated `SchemaTypesExtensions.ApplyMiddleware` methods to require `ISchema` parameter
- Updated schema initialization to pass schema to `ApplyMiddleware`
- Updated migration documentation

## Breaking Changes

- `ISchema` now includes a `DefaultFieldResolver` property that custom implementations must implement
- `SchemaTypesExtensions.ApplyMiddleware` methods now require an `ISchema` parameter

See migration9.md for details.
