### PR TITLE
Prevent nullable value types in graph type mappings

### DIFF
--- a/src/GraphQL/Types/Collections/SchemaTypes.cs
+++ b/src/GraphQL/Types/Collections/SchemaTypes.cs
@@ -870,6 +870,9 @@ public sealed partial class SchemaTypes : SchemaTypesBase
         /// </summary>
         private Type GetGraphTypeFromClrType(Type clrType, bool isInputType)
         {
+            if (Nullable.GetUnderlyingType(clrType) != null)
+                throw new InvalidOperationException("Graph type mappings cannot be nullable value types.");
+
             // Check cache first, which includes mappings within schema.TypeMappings
             var cache = isInputType ? _inputClrTypeMappingCache : _outputClrTypeMappingCache;
             if (cache.TryGetValue(clrType, out var cachedType))


### PR DESCRIPTION
### Summary
This PR adds a defensive validation check to detect if `GetGraphTypeFromClrType` is called with a nullable value type, which should never happen under normal operation.

### Changes
- Added a check in `GetGraphTypeFromClrType` method within [`SchemaTypes.cs`](src/GraphQL/Types/Collections/SchemaTypes.cs:873) to detect nullable value types
- Throws `InvalidOperationException` with a clear error message when a nullable value type is encountered

### Reasoning
The `SchemaTypes` class is designed to unwrap nullability from value types before calling `GetGraphTypeFromClrType`. If this method receives a nullable value type (e.g., `int?`, `bool?`, `DateTime?`), it indicates a bug in the `SchemaTypes` implementation logic.

This defensive check serves as:
- An assertion to catch potential bugs during development and testing
- A safeguard to prevent undefined behavior if the unwrapping logic is bypassed
- Clear documentation that nullable value types are not expected at this point in the code path

In GraphQL.NET, nullability is defined via the presence of `NonNullGraphType` wrapper, and the type mapping system expects non-nullable CLR types as input after the unwrapping phase.
