### PR TITLE
Add NativeAOT support to EnumerationGraphType<TEnum> with DynamicallyAccessedMembers attribute

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -2546,8 +2546,8 @@ namespace GraphQL.Types
         public override object? Serialize(object? value) { }
         public override GraphQLParser.AST.GraphQLValue ToAST(object? value) { }
     }
-    public class EnumerationGraphType<TEnum> : GraphQL.Types.EnumerationGraphType
-        where TEnum : System.Enum
+    public class EnumerationGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  TEnum> : GraphQL.Types.EnumerationGraphType
+        where TEnum :  struct, System.Enum
     {
         public EnumerationGraphType() { }
         public override bool CanParseValue(object? value) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -2553,8 +2553,8 @@ namespace GraphQL.Types
         public override object? Serialize(object? value) { }
         public override GraphQLParser.AST.GraphQLValue ToAST(object? value) { }
     }
-    public class EnumerationGraphType<TEnum> : GraphQL.Types.EnumerationGraphType
-        where TEnum : System.Enum
+    public class EnumerationGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  TEnum> : GraphQL.Types.EnumerationGraphType
+        where TEnum :  struct, System.Enum
     {
         public EnumerationGraphType() { }
         public override bool CanParseValue(object? value) { }

--- a/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
@@ -2562,8 +2562,8 @@ namespace GraphQL.Types
         public override object? Serialize(object? value) { }
         public override GraphQLParser.AST.GraphQLValue ToAST(object? value) { }
     }
-    public class EnumerationGraphType<TEnum> : GraphQL.Types.EnumerationGraphType
-        where TEnum : System.Enum
+    public class EnumerationGraphType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields)]  TEnum> : GraphQL.Types.EnumerationGraphType
+        where TEnum :  struct, System.Enum
     {
         public EnumerationGraphType() { }
         public override bool CanParseValue(object? value) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -2450,7 +2450,7 @@ namespace GraphQL.Types
         public override GraphQLParser.AST.GraphQLValue ToAST(object? value) { }
     }
     public class EnumerationGraphType<TEnum> : GraphQL.Types.EnumerationGraphType
-        where TEnum : System.Enum
+        where TEnum :  struct, System.Enum
     {
         public EnumerationGraphType() { }
         public override bool CanParseValue(object? value) { }


### PR DESCRIPTION
### Changes
- Added `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]` attribute to the `TEnum` generic type parameter in `EnumerationGraphType<TEnum>`
- Changed generic constraint from `where TEnum : Enum` to `where TEnum : struct, Enum` for better type safety
- Optimized enum value retrieval for .NET 6+ using `Enum.GetValues<TEnum>()` instead of reflection-based approach
- Updated API approval tests for all target frameworks (net50, net60, net80, netstandard20+21)

### Reasoning for NativeAOT
NativeAOT (Native Ahead-of-Time compilation) requires explicit annotations to preserve metadata that would normally be available through reflection. The changes address the following NativeAOT requirements:

1. **DynamicallyAccessedMembers Attribute**: The `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]` attribute informs the NativeAOT compiler that the enum's public fields will be accessed via reflection (through `Enum.GetNames()` and field lookups). Without this attribute, the trimmer might remove enum field metadata, causing runtime failures.

2. **Struct Constraint**: Adding `struct` to the constraint (`where TEnum : struct, Enum`) ensures that only value-type enums are used, which is more precise and helps the compiler optimize better for NativeAOT scenarios.

3. **Performance Optimization**: For .NET 6+, the code now uses `Enum.GetValues<TEnum>()` which is more efficient and AOT-friendly than the reflection-based `GetMember()` approach, reducing the reflection surface area while maintaining the same functionality.

These changes ensure that `EnumerationGraphType<TEnum>` works correctly in NativeAOT-compiled applications while maintaining backward compatibility with existing code.
