### PR TITLE
Add AOT schema attributes and GQL022 analyzer

### DIFF
--- a/GraphQL.slnx
+++ b/GraphQL.slnx
@@ -57,6 +57,8 @@
     <File Path="docs2/site/docs/analyzers/gql018.md" />
     <File Path="docs2/site/docs/analyzers/gql019.md" />
     <File Path="docs2/site/docs/analyzers/gql020.md" />
+    <File Path="docs2/site/docs/analyzers/gql021.md" />
+    <File Path="docs2/site/docs/analyzers/gql022.md" />
     <File Path="docs2/site/docs/analyzers/gqlfed001.md" />
     <File Path="docs2/site/docs/analyzers/gqlfed002.md" />
     <File Path="docs2/site/docs/analyzers/gqlfed003.md" />

--- a/docs2/site/docs/analyzers/gql022.md
+++ b/docs2/site/docs/analyzers/gql022.md
@@ -1,0 +1,123 @@
+# GQL022: AOT schema attributes must be applied to classes deriving from AotSchema
+
+|                        | Value   |
+| ---------------------- | ------- |
+| **Rule ID**            | GQL022  |
+| **Category**           | Usage   |
+| **Default severity**   | Error   |
+| **Enabled by default** | Yes     |
+| **Code fix provided**  | No      |
+| **Introduced in**      | v9.0    |
+
+## Cause
+
+This rule is triggered when an attribute derived from `AotSchemaAttribute` (such as
+`AotInputType`, `AotOutputType`, `AotGraphType`, `AotTypeMapping`, `AotQueryType`,
+`AotMutationType`, or `AotSubscriptionType`) is applied to a class that does not
+derive from `AotSchema`.
+
+## Rule description
+
+AOT (Ahead-of-Time) schema attributes are designed to configure schema generation
+for classes that derive from `AotSchema`. These attributes provide metadata to a
+source generator that produces GraphQL type definitions at compile time. Applying
+these attributes to classes that don't derive from `AotSchema` serves no purpose
+and indicates a configuration error.
+
+## How to fix violations
+
+Ensure the class with AOT schema attributes derives from `AotSchema`, or remove
+the AOT schema attributes if they were applied incorrectly.
+
+## Example of a violation
+
+### Applying attribute to a regular class
+
+```c#
+using GraphQL;
+
+namespace Sample;
+
+[AotInputType(typeof(MyModel))]  // Error: MyClass doesn't derive from AotSchema
+public class MyClass
+{
+}
+```
+
+### Applying attribute to a Schema class
+
+```c#
+using GraphQL;
+using GraphQL.Types;
+
+namespace Sample;
+
+[AotQueryType(typeof(Query))]  // Error: MySchema derives from Schema, not AotSchema
+public class MySchema : Schema
+{
+}
+```
+
+## Example of how to fix
+
+### Change base class to AotSchema
+
+```c#
+using GraphQL;
+using GraphQL.Types;
+
+namespace Sample;
+
+[AotInputType(typeof(MyModel))]
+public partial class MySchema : AotSchema  // Fixed: Now derives from AotSchema
+{
+}
+```
+
+### Remove attribute if applied incorrectly
+
+```c#
+using GraphQL;
+
+namespace Sample;
+
+// Fixed: Removed the attribute since this is not a schema class
+public class MyClass
+{
+}
+```
+
+## Related attributes
+
+All of the following attributes derive from `AotSchemaAttribute` and must be
+applied only to classes deriving from `AotSchema`:
+
+- `AotInputTypeAttribute` - Specifies CLR types to generate InputObjectGraphType for
+- `AotOutputTypeAttribute` - Specifies CLR types to generate ObjectGraphType for
+- `AotGraphTypeAttribute` - Registers hand-written graph types
+- `AotTypeMappingAttribute` - Maps CLR types to specific GraphQL types
+- `AotQueryTypeAttribute` - Configures the query root type
+- `AotMutationTypeAttribute` - Configures the mutation root type
+- `AotSubscriptionTypeAttribute` - Configures the subscription root type
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable GQL022
+// The code that's violating the rule is on this line.
+#pragma warning restore GQL022
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.cs]
+dotnet_diagnostic.GQL022.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs2/site/docs/analyzers/overview.md
+++ b/docs2/site/docs/analyzers/overview.md
@@ -61,6 +61,7 @@ For more information about analyzers configuration see
 | [GQL019](../gql019) | `Validator` method must be valid                                                                  |
 | [GQL020](../gql020) | `ValidateArguments` method must be valid                                                          |
 | [GQL021](../gql021) | Nullable reference type argument should specify nullable parameter                                |
+| [GQL022](../gql022) | AOT schema attributes must be applied to classes deriving from `AotSchema`                        |
 
 ## Federation Analyzers
 

--- a/src/GraphQL.Analyzers.Tests/AotSchemaAttributeAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/AotSchemaAttributeAnalyzerTests.cs
@@ -1,0 +1,249 @@
+using VerifyCS = GraphQL.Analyzers.Tests.VerifiersExtensions.CSharpAnalyzerVerifier<
+    GraphQL.Analyzers.AotSchemaAttributeAnalyzer>;
+
+namespace GraphQL.Analyzers.Tests;
+
+public class AotSchemaAttributeAnalyzerTests
+{
+    [Fact]
+    public async Task Sanity_NoDiagnostics()
+    {
+        const string source = "";
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Theory]
+    [InlineData("AotInputType<MyModel>", "public class MyModel { public string Name { get; set; } }")]
+    [InlineData("AotOutputType<MyModel>", "public class MyModel { public string Name { get; set; } }")]
+    [InlineData("AotGraphType<MyGraphType>", "public class MyGraphType : ObjectGraphType { }")]
+    [InlineData("AotTypeMapping<DateTime, DateTimeGraphType>", "")]
+    [InlineData("AotQueryType<Query>", "public class Query { public string Hello => \"World\"; }")]
+    [InlineData("AotMutationType<Mutation>", "public class Mutation { public string DoSomething(string input) => input; }")]
+    [InlineData("AotSubscriptionType<Subscription>", "public class Subscription { }")]
+    public async Task AotAttribute_OnAotSchema_NoDiagnostic(string attributeUsage, string supportingClasses)
+    {
+        var source =
+            $$"""
+            using System;
+            using GraphQL;
+            using GraphQL.Types;
+
+            namespace Sample;
+
+            {{supportingClasses}}
+
+            [{{attributeUsage}}]
+            public partial class MySchema : AotSchema
+            {
+                public MySchema() : base(null!, null!) { }
+                protected override void Configure(IServiceProvider services) { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task MultipleAotAttributes_OnAotSchema_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System;
+            using GraphQL;
+            using GraphQL.Types;
+
+            namespace Sample;
+
+            public class MyModel
+            {
+                public string Name { get; set; }
+            }
+
+            public class Query
+            {
+                public string Hello => "World";
+            }
+
+            [AotInputType<MyModel>]
+            [AotOutputType<MyModel>]
+            [AotTypeMapping<DateTime, DateTimeGraphType>]
+            [AotQueryType<Query>]
+            public partial class MySchema : AotSchema
+            {
+                public MySchema() : base(null!, null!) { }
+                protected override void Configure(IServiceProvider services) { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Theory]
+    [InlineData("AotInputTypeAttribute", "AotInputType<MyModel>", "public class MyModel { public string Name { get; set; } }")]
+    [InlineData("AotOutputTypeAttribute", "AotOutputType<MyModel>", "public class MyModel { public string Name { get; set; } }")]
+    [InlineData("AotGraphTypeAttribute", "AotGraphType<MyGraphType>", "public class MyGraphType : ObjectGraphType { }")]
+    [InlineData("AotTypeMappingAttribute", "AotTypeMapping<DateTime, DateTimeGraphType>", "")]
+    [InlineData("AotQueryTypeAttribute", "AotQueryType<Query>", "public class Query { public string Hello => \"World\"; }")]
+    [InlineData("AotMutationTypeAttribute", "AotMutationType<Mutation>", "public class Mutation { public string DoSomething(string input) => input; }")]
+    [InlineData("AotSubscriptionTypeAttribute", "AotSubscriptionType<Subscription>", "public class Subscription { }")]
+    public async Task AotAttribute_OnRegularClass_Diagnostic(string attributeName, string attributeUsage, string supportingClasses)
+    {
+        var source =
+            $$"""
+            using System;
+            using GraphQL;
+            using GraphQL.Types;
+
+            namespace Sample;
+
+            {{supportingClasses}}
+
+            [{|#0:{{attributeUsage}}|}]
+            public class MyClass
+            {
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(AotSchemaAttributeAnalyzer.AotSchemaAttributeMustBeOnAotSchema)
+            .WithLocation(0)
+            .WithArguments(attributeName);
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task MultipleAotAttributes_OnRegularClass_MultipleDiagnostics()
+    {
+        const string source =
+            """
+            using System;
+            using GraphQL;
+            using GraphQL.Types;
+
+            namespace Sample;
+
+            public class MyModel
+            {
+                public string Name { get; set; }
+            }
+
+            public class Query
+            {
+                public string Hello => "World";
+            }
+
+            [{|#0:AotInputType<MyModel>|}]
+            [{|#1:AotOutputType<MyModel>|}]
+            [{|#2:AotTypeMapping<DateTime, DateTimeGraphType>|}]
+            [{|#3:AotQueryType<Query>|}]
+            public class MyClass
+            {
+            }
+            """;
+
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic(AotSchemaAttributeAnalyzer.AotSchemaAttributeMustBeOnAotSchema)
+                .WithLocation(0)
+                .WithArguments("AotInputTypeAttribute"),
+            VerifyCS.Diagnostic(AotSchemaAttributeAnalyzer.AotSchemaAttributeMustBeOnAotSchema)
+                .WithLocation(1)
+                .WithArguments("AotOutputTypeAttribute"),
+            VerifyCS.Diagnostic(AotSchemaAttributeAnalyzer.AotSchemaAttributeMustBeOnAotSchema)
+                .WithLocation(2)
+                .WithArguments("AotTypeMappingAttribute"),
+            VerifyCS.Diagnostic(AotSchemaAttributeAnalyzer.AotSchemaAttributeMustBeOnAotSchema)
+                .WithLocation(3)
+                .WithArguments("AotQueryTypeAttribute"),
+        };
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task AotAttribute_OnClassDerivingFromSchema_Diagnostic()
+    {
+        const string source =
+            """
+            using System;
+            using GraphQL;
+            using GraphQL.Types;
+
+            namespace Sample;
+
+            public class MyModel
+            {
+                public string Name { get; set; }
+            }
+
+            [{|#0:AotInputType<MyModel>|}]
+            public class MySchema : Schema
+            {
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic(AotSchemaAttributeAnalyzer.AotSchemaAttributeMustBeOnAotSchema)
+            .WithLocation(0)
+            .WithArguments("AotInputTypeAttribute");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task AotAttribute_OnAbstractClassDerivingFromAotSchema_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System;
+            using GraphQL;
+            using GraphQL.Types;
+
+            namespace Sample;
+
+            public class MyModel
+            {
+                public string Name { get; set; }
+            }
+
+            [AotInputType<MyModel>]
+            public abstract partial class MyBaseSchema : AotSchema
+            {
+                protected MyBaseSchema() : base(null!, null!) { }
+                protected override void Configure(IServiceProvider services) { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AotAttribute_OnDerivedAotSchema_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System;
+            using GraphQL;
+            using GraphQL.Types;
+
+            namespace Sample;
+
+            public class MyModel
+            {
+                public string Name { get; set; }
+            }
+
+            public abstract partial class MyBaseSchema : AotSchema
+            {
+                protected MyBaseSchema() : base(null!, null!) { }
+                protected override void Configure(IServiceProvider services) { }
+            }
+
+            [AotInputType<MyModel>]
+            public partial class MyDerivedSchema : MyBaseSchema
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+}

--- a/src/GraphQL.Analyzers.Tests/NotAGraphTypeAnalyzerTests.cs
+++ b/src/GraphQL.Analyzers.Tests/NotAGraphTypeAnalyzerTests.cs
@@ -298,4 +298,28 @@ public class NotAGraphTypeAnalyzerTests
             : DiagnosticResult.EmptyDiagnosticResults;
         await VerifyCS.VerifyAnalyzerAsync(source, expected);
     }
+
+    [Fact]
+    public async Task AotInputTypeAttribute_GraphTypeArgument_GQL011()
+    {
+        const string source =
+            """
+            using System;
+            using GraphQL;
+            using GraphQL.Types;
+
+            namespace Sample.Server;
+
+            [AotInputType<{|#0:StringGraphType|}>]
+            public partial class MySchema : AotSchema
+            {
+                public MySchema() : base(null!, null!) { }
+                protected override void Configure(IServiceProvider services) { }
+            }
+            """;
+
+        var expected = VerifyCS.Diagnostic().WithLocation(0)
+            .WithArguments("StringGraphType", "T", "AotInputType<T>");
+        await VerifyCS.VerifyAnalyzerAsync(source, expected);
+    }
 }

--- a/src/GraphQL.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/GraphQL.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,7 +5,8 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-GQL021 | Usage | Warning | NullableReferenceTypeArgumentAnalyzer
+GQL021 | Usage | Warning | NullableReferenceTypeArgumentAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/gql021)
+GQL022 | Usage | Error | AotSchemaAttributeAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/gql022)
 GQLFED001 | Federation | Error | KeyAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/gqlfed001)
 GQLFED002 | Federation | Error | KeyAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/gqlfed002)
 GQLFED003 | Federation | Warning | KeyAnalyzer, [Documentation](https://graphql-dotnet.github.io/docs/analyzers/gqlfed003)

--- a/src/GraphQL.Analyzers/AotSchemaAttributeAnalyzer.cs
+++ b/src/GraphQL.Analyzers/AotSchemaAttributeAnalyzer.cs
@@ -1,0 +1,132 @@
+using System.Collections.Immutable;
+using GraphQL.Analyzers.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace GraphQL.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AotSchemaAttributeAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor AotSchemaAttributeMustBeOnAotSchema = new(
+        id: DiagnosticIds.AOT_SCHEMA_ATTRIBUTE_MUST_BE_ON_AOT_SCHEMA,
+        title: "AOT schema attributes must be applied to classes deriving from AotSchema",
+        messageFormat: "The '{0}' attribute can only be applied to classes that derive from 'AotSchema'",
+        category: DiagnosticCategories.USAGE,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: HelpLinks.AOT_SCHEMA_ATTRIBUTE_MUST_BE_ON_AOT_SCHEMA);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(AotSchemaAttributeMustBeOnAotSchema);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeClassDeclaration, SyntaxKind.ClassDeclaration);
+    }
+
+    private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var classDeclaration = (ClassDeclarationSyntax)context.Node;
+
+        // Get the class symbol
+        var classSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration);
+        if (classSymbol == null)
+            return;
+
+        // Check if the class has any attributes
+        var attributes = classSymbol.GetAttributes();
+        if (attributes.IsEmpty)
+            return;
+
+        // Get the AotSchemaAttribute symbol
+        var aotSchemaAttributeSymbol = context.Compilation.GetTypeByMetadataName(Constants.MetadataNames.AotSchemaAttribute);
+        if (aotSchemaAttributeSymbol == null)
+            return;
+
+        // Check if any attribute derives from or is AotSchemaAttribute
+        foreach (var attribute in attributes)
+        {
+            if (attribute.AttributeClass == null)
+                continue;
+
+            // Check if the attribute is AotSchemaAttribute or derives from it
+            if (IsAotSchemaAttribute(attribute.AttributeClass, aotSchemaAttributeSymbol))
+            {
+                // Check if the class derives from AotSchema
+                if (!DerivesFromAotSchema(classSymbol, context.Compilation))
+                {
+                    // Find the attribute syntax
+                    var attributeSyntax = FindAttributeSyntax(classDeclaration, attribute, context.SemanticModel);
+                    if (attributeSyntax != null)
+                    {
+                        var diagnostic = Diagnostic.Create(
+                            AotSchemaAttributeMustBeOnAotSchema,
+                            attributeSyntax.GetLocation(),
+                            attribute.AttributeClass.Name);
+
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+    }
+
+    private static bool IsAotSchemaAttribute(INamedTypeSymbol attributeClass, INamedTypeSymbol aotSchemaAttributeSymbol)
+    {
+        var current = attributeClass;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, aotSchemaAttributeSymbol))
+                return true;
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool DerivesFromAotSchema(INamedTypeSymbol classSymbol, Compilation compilation)
+    {
+        var aotSchemaSymbol = compilation.GetTypeByMetadataName(Constants.MetadataNames.AotSchema);
+        if (aotSchemaSymbol == null)
+            return false;
+
+        var current = classSymbol;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, aotSchemaSymbol))
+                return true;
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static AttributeSyntax? FindAttributeSyntax(
+        ClassDeclarationSyntax classDeclaration,
+        AttributeData attribute,
+        SemanticModel semanticModel)
+    {
+        foreach (var attributeList in classDeclaration.AttributeLists)
+        {
+            foreach (var attributeSyntax in attributeList.Attributes)
+            {
+                var symbolInfo = semanticModel.GetSymbolInfo(attributeSyntax);
+                if (symbolInfo.Symbol is IMethodSymbol methodSymbol &&
+                    SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, attribute.AttributeClass))
+                {
+                    return attributeSyntax;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/GraphQL.Analyzers/Helpers/Constants.cs
+++ b/src/GraphQL.Analyzers/Helpers/Constants.cs
@@ -81,6 +81,8 @@ public static class Constants
     public static class MetadataNames
     {
         public const string AllowedOnAttribute = "AllowedOnAttribute";
+        public const string AotSchemaAttribute = "GraphQL.AotSchemaAttribute";
+        public const string AotSchema = "GraphQL.Types.AotSchema";
         public const string GraphQLConstructorAttribute = "GraphQL.GraphQLConstructorAttribute";
         public const string IGraphType = "GraphQL.Types.IGraphType";
         public const string InputObjectGraphType = "GraphQL.Types.InputObjectGraphType`1";

--- a/src/GraphQL.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/GraphQL.Analyzers/Helpers/DiagnosticIds.cs
@@ -23,6 +23,7 @@ public static class DiagnosticIds
     public const string VALIDATOR_METHOD_MUST_BE_VALID = "GQL019";
     public const string VALIDATE_ARGUMENTS_METHOD_MUST_BE_VALID = "GQL020";
     public const string NULLABLE_REFERENCE_TYPE_ARGUMENT_SHOULD_SPECIFY_NULLABLE = "GQL021";
+    public const string AOT_SCHEMA_ATTRIBUTE_MUST_BE_ON_AOT_SCHEMA = "GQL022";
 
     public const string KEY_FIELD_DOES_NOT_EXIST = "GQLFED001";
     public const string KEY_MUST_NOT_BE_NULL_OR_EMPTY = "GQLFED002";

--- a/src/GraphQL.Analyzers/Helpers/HelpLinks.cs
+++ b/src/GraphQL.Analyzers/Helpers/HelpLinks.cs
@@ -23,6 +23,7 @@ public static class HelpLinks
     public const string VALIDATOR_METHOD_MUST_BE_VALID = $"{DOCS_URL}/gql019";
     public const string VALIDATE_ARGUMENTS_METHOD_MUST_BE_VALID = $"{DOCS_URL}/gql020";
     public const string NULLABLE_REFERENCE_TYPE_ARGUMENT_SHOULD_SPECIFY_NULLABLE = $"{DOCS_URL}/gql021";
+    public const string AOT_SCHEMA_ATTRIBUTE_MUST_BE_ON_AOT_SCHEMA = $"{DOCS_URL}/gql022";
 
     public const string KEY_FIELD_DOES_NOT_EXIST = $"{DOCS_URL}/gqlfed001";
     public const string KEY_MUST_NOT_BE_NULL_OR_EMPTY = $"{DOCS_URL}/gqlfed002";

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -7,6 +7,56 @@ namespace GraphQL
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
+    public sealed class AotGraphTypeAttribute<TGraphType> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+    {
+        public AotGraphTypeAttribute() { }
+        public bool AutoRegisterClrMapping { get; set; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotInputTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotInputTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotMutationTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotMutationTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotOutputTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotOutputTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotQueryTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotQueryTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotRemapTypeAttribute<TGraphType, TGraphTypeImplementation> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+        where TGraphTypeImplementation : GraphQL.Types.IGraphType
+    {
+        public AotRemapTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public abstract class AotSchemaAttribute : System.Attribute
+    {
+        protected AotSchemaAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotSubscriptionTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotSubscriptionTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotTypeMappingAttribute<TClrType, TGraphType> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+    {
+        public AotTypeMappingAttribute() { }
+    }
     public static class AuthorizationExtensions
     {
         public const string ANONYMOUS_KEY = "Authorization__AllowAnonymous";
@@ -2280,6 +2330,9 @@ namespace GraphQL.Types
         public override System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         protected void AddAotType<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType, new () { }
+        protected void AddAotType<TGraphType, TGraphTypeImplementation>()
+            where TGraphType : GraphQL.Types.IGraphType, new ()
+            where TGraphTypeImplementation : GraphQL.Types.IGraphType, new () { }
         protected abstract void Configure(System.IServiceProvider services);
         protected virtual void OnPostConfigure(System.IServiceProvider services) { }
         protected virtual void OnPreConfigure(System.IServiceProvider services) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -7,6 +7,56 @@ namespace GraphQL
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
+    public sealed class AotGraphTypeAttribute<TGraphType> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+    {
+        public AotGraphTypeAttribute() { }
+        public bool AutoRegisterClrMapping { get; set; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotInputTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotInputTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotMutationTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotMutationTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotOutputTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotOutputTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotQueryTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotQueryTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotRemapTypeAttribute<TGraphType, TGraphTypeImplementation> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+        where TGraphTypeImplementation : GraphQL.Types.IGraphType
+    {
+        public AotRemapTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public abstract class AotSchemaAttribute : System.Attribute
+    {
+        protected AotSchemaAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotSubscriptionTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotSubscriptionTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotTypeMappingAttribute<TClrType, TGraphType> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+    {
+        public AotTypeMappingAttribute() { }
+    }
     public static class AuthorizationExtensions
     {
         public const string ANONYMOUS_KEY = "Authorization__AllowAnonymous";
@@ -2280,6 +2330,9 @@ namespace GraphQL.Types
         public override System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         protected void AddAotType<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType, new () { }
+        protected void AddAotType<TGraphType, TGraphTypeImplementation>()
+            where TGraphType : GraphQL.Types.IGraphType, new ()
+            where TGraphTypeImplementation : GraphQL.Types.IGraphType, new () { }
         protected abstract void Configure(System.IServiceProvider services);
         protected virtual void OnPostConfigure(System.IServiceProvider services) { }
         protected virtual void OnPreConfigure(System.IServiceProvider services) { }

--- a/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
@@ -7,6 +7,56 @@ namespace GraphQL
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
+    public sealed class AotGraphTypeAttribute<TGraphType> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+    {
+        public AotGraphTypeAttribute() { }
+        public bool AutoRegisterClrMapping { get; set; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotInputTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotInputTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotMutationTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotMutationTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotOutputTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotOutputTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotQueryTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotQueryTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotRemapTypeAttribute<TGraphType, TGraphTypeImplementation> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+        where TGraphTypeImplementation : GraphQL.Types.IGraphType
+    {
+        public AotRemapTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public abstract class AotSchemaAttribute : System.Attribute
+    {
+        protected AotSchemaAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotSubscriptionTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotSubscriptionTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotTypeMappingAttribute<TClrType, TGraphType> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+    {
+        public AotTypeMappingAttribute() { }
+    }
     public static class AuthorizationExtensions
     {
         public const string ANONYMOUS_KEY = "Authorization__AllowAnonymous";
@@ -2284,6 +2334,9 @@ namespace GraphQL.Types
         public override System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         protected void AddAotType<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType, new () { }
+        protected void AddAotType<TGraphType, TGraphTypeImplementation>()
+            where TGraphType : GraphQL.Types.IGraphType, new ()
+            where TGraphTypeImplementation : GraphQL.Types.IGraphType, new () { }
         protected abstract void Configure(System.IServiceProvider services);
         protected virtual void OnPostConfigure(System.IServiceProvider services) { }
         protected virtual void OnPreConfigure(System.IServiceProvider services) { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -7,6 +7,56 @@ namespace GraphQL
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Types.FieldType fieldType, bool isInputType) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
+    public sealed class AotGraphTypeAttribute<TGraphType> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+    {
+        public AotGraphTypeAttribute() { }
+        public bool AutoRegisterClrMapping { get; set; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotInputTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotInputTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotMutationTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotMutationTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotOutputTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotOutputTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotQueryTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotQueryTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotRemapTypeAttribute<TGraphType, TGraphTypeImplementation> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+        where TGraphTypeImplementation : GraphQL.Types.IGraphType
+    {
+        public AotRemapTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public abstract class AotSchemaAttribute : System.Attribute
+    {
+        protected AotSchemaAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed class AotSubscriptionTypeAttribute<T> : GraphQL.AotSchemaAttribute
+    {
+        public AotSubscriptionTypeAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public sealed class AotTypeMappingAttribute<TClrType, TGraphType> : GraphQL.AotSchemaAttribute
+        where TGraphType : GraphQL.Types.IGraphType
+    {
+        public AotTypeMappingAttribute() { }
+    }
     public static class AuthorizationExtensions
     {
         public const string ANONYMOUS_KEY = "Authorization__AllowAnonymous";
@@ -2186,6 +2236,9 @@ namespace GraphQL.Types
         public override System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, System.Type>> BuiltInTypeMappings { get; }
         protected void AddAotType<TGraphType>()
             where TGraphType : GraphQL.Types.IGraphType, new () { }
+        protected void AddAotType<TGraphType, TGraphTypeImplementation>()
+            where TGraphType : GraphQL.Types.IGraphType, new ()
+            where TGraphTypeImplementation : GraphQL.Types.IGraphType, new () { }
         protected abstract void Configure(System.IServiceProvider services);
         protected virtual void OnPostConfigure(System.IServiceProvider services) { }
         protected virtual void OnPreConfigure(System.IServiceProvider services) { }

--- a/src/GraphQL/Attributes/AotGraphTypeAttribute.cs
+++ b/src/GraphQL/Attributes/AotGraphTypeAttribute.cs
@@ -1,0 +1,24 @@
+namespace GraphQL;
+
+/// <summary>
+/// Registers a hand-written GraphQL graph type for inclusion in the AOT-compiled schema.
+/// This attribute can be applied multiple times to register multiple graph types.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class AotGraphTypeAttribute<TGraphType> : AotSchemaAttribute
+    where TGraphType : Types.IGraphType
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically register the CLR type mapping for this graph type.
+    /// When <see langword="true"/> (default), the generator will create a mapping from the graph type's
+    /// generic type parameter to the graph type itself. Set to <see langword="false"/> to skip automatic
+    /// CLR type mapping registration when you want to handle the mapping manually.
+    /// <para>Mapping is automatically skipped when any of the following are true:</para>
+    /// <list type="bullet">
+    /// <item>The graph type does not inherit from <see cref="GraphQL.Types.ComplexGraphType{TSourceType}"/> or <see cref="GraphQL.Types.EnumerationGraphType{TEnum}"/>.</item>
+    /// <item>The generic type is <see cref="object"/>.</item>
+    /// <item>The CLR type is marked with <see cref="GraphQL.DoNotMapClrTypeAttribute"/>.</item>
+    /// </list>
+    /// </summary>
+    public bool AutoRegisterClrMapping { get; set; } = true;
+}

--- a/src/GraphQL/Attributes/AotInputTypeAttribute.cs
+++ b/src/GraphQL/Attributes/AotInputTypeAttribute.cs
@@ -1,0 +1,10 @@
+namespace GraphQL;
+
+/// <summary>
+/// Specifies a CLR type that should be used to generate an <see cref="Types.InputObjectGraphType{TSourceType}"/> during AOT schema compilation.
+/// This attribute can be applied multiple times to specify multiple input types.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class AotInputTypeAttribute<[NotAGraphType] T> : AotSchemaAttribute
+{
+}

--- a/src/GraphQL/Attributes/AotMutationTypeAttribute.cs
+++ b/src/GraphQL/Attributes/AotMutationTypeAttribute.cs
@@ -1,0 +1,12 @@
+namespace GraphQL;
+
+/// <summary>
+/// Configures the mutation root type for the schema. Accepts either a CLR type (for automatic generation)
+/// or a graph type (for explicit registration). The generator determines which based on whether the type
+/// implements <see cref="Types.IGraphType"/>.
+/// This attribute is applied to the schema class that derives from <see cref="Types.AotSchema"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class AotMutationTypeAttribute<T> : AotSchemaAttribute
+{
+}

--- a/src/GraphQL/Attributes/AotOutputTypeAttribute.cs
+++ b/src/GraphQL/Attributes/AotOutputTypeAttribute.cs
@@ -1,0 +1,10 @@
+namespace GraphQL;
+
+/// <summary>
+/// Specifies a CLR type that should be used to generate an <see cref="Types.ObjectGraphType{TSourceType}"/> during AOT schema compilation.
+/// This attribute can be applied multiple times to specify multiple output types.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class AotOutputTypeAttribute<[NotAGraphType] T> : AotSchemaAttribute
+{
+}

--- a/src/GraphQL/Attributes/AotQueryTypeAttribute.cs
+++ b/src/GraphQL/Attributes/AotQueryTypeAttribute.cs
@@ -1,0 +1,12 @@
+namespace GraphQL;
+
+/// <summary>
+/// Configures the query root type for the schema. Accepts either a CLR type (for automatic generation)
+/// or a graph type (for explicit registration). The generator determines which based on whether the type
+/// implements <see cref="Types.IGraphType"/>.
+/// This attribute is applied to the schema class that derives from <see cref="Types.AotSchema"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class AotQueryTypeAttribute<T> : AotSchemaAttribute
+{
+}

--- a/src/GraphQL/Attributes/AotRemapTypeAttribute.cs
+++ b/src/GraphQL/Attributes/AotRemapTypeAttribute.cs
@@ -1,0 +1,15 @@
+namespace GraphQL;
+
+/// <summary>
+/// Remaps a base graph type to use a derived implementation when requested by the schema.
+/// This allows you to substitute a specialized graph type implementation in place of a base type.
+/// For example, use <c>[AotRemapType&lt;IdGraphType, GuidGraphType&gt;]</c> to ensure
+/// that whenever <c>IdGraphType</c> is requested, <c>GuidGraphType</c> is used instead.
+/// This attribute can be applied multiple times to remap multiple graph types.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class AotRemapTypeAttribute<TGraphType, TGraphTypeImplementation> : AotSchemaAttribute
+    where TGraphType : Types.IGraphType
+    where TGraphTypeImplementation : Types.IGraphType
+{
+}

--- a/src/GraphQL/Attributes/AotSchemaAttribute.cs
+++ b/src/GraphQL/Attributes/AotSchemaAttribute.cs
@@ -1,0 +1,10 @@
+namespace GraphQL;
+
+/// <summary>
+/// Base class for attributes that configure AOT schema generation.
+/// All AOT schema attributes must be applied to a class that derives from <see cref="Types.AotSchema"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public abstract class AotSchemaAttribute : Attribute
+{
+}

--- a/src/GraphQL/Attributes/AotSubscriptionTypeAttribute.cs
+++ b/src/GraphQL/Attributes/AotSubscriptionTypeAttribute.cs
@@ -1,0 +1,12 @@
+namespace GraphQL;
+
+/// <summary>
+/// Configures the subscription root type for the schema. Accepts either a CLR type (for automatic generation)
+/// or a graph type (for explicit registration). The generator determines which based on whether the type
+/// implements <see cref="Types.IGraphType"/>.
+/// This attribute is applied to the schema class that derives from <see cref="Types.AotSchema"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class AotSubscriptionTypeAttribute<T> : AotSchemaAttribute
+{
+}

--- a/src/GraphQL/Attributes/AotTypeMappingAttribute.cs
+++ b/src/GraphQL/Attributes/AotTypeMappingAttribute.cs
@@ -1,0 +1,11 @@
+namespace GraphQL;
+
+/// <summary>
+/// Specifies a mapping between a CLR type and its corresponding GraphQL type for AOT schema compilation.
+/// This attribute can be applied multiple times to specify multiple type mappings.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class AotTypeMappingAttribute<[NotAGraphType] TClrType, TGraphType> : AotSchemaAttribute
+    where TGraphType : Types.IGraphType
+{
+}

--- a/src/GraphQL/Types/AotSchema.cs
+++ b/src/GraphQL/Types/AotSchema.cs
@@ -38,6 +38,16 @@ public abstract class AotSchema : Schema, IServiceProvider
         AotTypes.Add(typeof(TGraphType), () => new TGraphType());
     }
 
+    /// <summary>
+    /// Registers an AOT graph type.
+    /// </summary>
+    protected void AddAotType<TGraphType, TGraphTypeImplementation>()
+        where TGraphType : IGraphType, new()
+        where TGraphTypeImplementation : IGraphType, new()
+    {
+        AotTypes.Add(typeof(TGraphType), () => new TGraphTypeImplementation());
+    }
+
     object? IServiceProvider.GetService(Type serviceType)
     {
         if (AotTypes.TryGetValue(serviceType, out var factory))


### PR DESCRIPTION
## Summary

Adds a comprehensive set of attributes for declaring AOT (Ahead-of-Time) compiled schemas, along with analyzer support to ensure correct usage.

## Changes

### New Attributes
- **`AotSchemaAttribute`** - Base class for all AOT schema configuration attributes
- **`AotInputTypeAttribute<T>`** - Declares CLR types for InputObjectGraphType generation
- **`AotOutputTypeAttribute<T>`** - Declares CLR types for ObjectGraphType generation  
- **`AotGraphTypeAttribute<TGraphType>`** - Registers hand-written graph types
- **`AotTypeMappingAttribute<TClrType, TGraphType>`** - Maps CLR types to GraphQL types
- **`AotRemapTypeAttribute<TGraphType, TGraphTypeImplementation>`** - Substitutes base types with derived implementations
- **`AotQueryTypeAttribute<T>`** - Configures query root type
- **`AotMutationTypeAttribute<T>`** - Configures mutation root type
- **`AotSubscriptionTypeAttribute<T>`** - Configures subscription root type

### New Analyzer (GQL022)
- **Rule**: AOT schema attributes must be applied to classes deriving from `AotSchema`
- **Severity**: Error
- Validates that AOT attributes are only used on appropriate base classes
- Includes comprehensive test coverage

### Analyzer Enhancements
- Extended `NotAGraphTypeAnalyzer` to validate attribute usage
- Now detects graph types passed to `[NotAGraphType]` parameters in attributes

### API Changes
- Added `AddAotType<TGraphType, TGraphTypeImplementation>()` to `AotSchema` for type remapping
- Updated API approval tests for all target frameworks (net50, net60, net80, netstandard20/21)

### Documentation
- Added GQL022 analyzer documentation with examples
- Updated analyzer overview with new rule

### Other
- Updated solution file to include new analyzer documentation
- Updated `AnalyzerReleases.Unshipped.md`
