### PR TITLE
Improve AOT compatibility for ValueConverter with proper attribute annotations

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -1020,9 +1020,15 @@ namespace GraphQL
     }
     public class ValueConverter : GraphQL.ValueConverterBase
     {
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with \'RequiresUnreferencedCodeAttribute\' require dynamic" +
-            " access otherwise can break functionality when trimming application code")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creates list and array types dynamically as needed.")]
         public ValueConverter() { }
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCode.")]
+        protected override GraphQL.Conversion.IListConverterFactory? ArrayListConverterFactory { get; }
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCodeAttribute.")]
         protected override GraphQL.Conversion.IListConverterFactory? DefaultListConverterFactory { get; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"For generic list types, the constructed implementation type (e.g. List<T>) must be rooted for trimming. If the closed generic type is only referenced via reflection, the trimmer may remove its required constructors or other members, which can cause runtime failures.")]
         public override void RegisterListConverterFactory(System.Type listType, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] System.Type implementationType) { }
@@ -1038,6 +1044,7 @@ namespace GraphQL
     public abstract class ValueConverterBase : GraphQL.IValueConverter
     {
         protected ValueConverterBase() { }
+        protected virtual GraphQL.Conversion.IListConverterFactory? ArrayListConverterFactory { get; }
         protected virtual GraphQL.Conversion.IListConverterFactory? DefaultListConverterFactory { get; }
         protected System.Collections.Generic.Dictionary<System.Type, GraphQL.Conversion.IListConverterFactory> ListConverterFactories { get; }
         protected System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, System.Type>, System.Func<object, object>> ValueConversions { get; }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -1020,9 +1020,15 @@ namespace GraphQL
     }
     public class ValueConverter : GraphQL.ValueConverterBase
     {
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with \'RequiresUnreferencedCodeAttribute\' require dynamic" +
-            " access otherwise can break functionality when trimming application code")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creates list and array types dynamically as needed.")]
         public ValueConverter() { }
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCode.")]
+        protected override GraphQL.Conversion.IListConverterFactory? ArrayListConverterFactory { get; }
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCodeAttribute.")]
         protected override GraphQL.Conversion.IListConverterFactory? DefaultListConverterFactory { get; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"For generic list types, the constructed implementation type (e.g. List<T>) must be rooted for trimming. If the closed generic type is only referenced via reflection, the trimmer may remove its required constructors or other members, which can cause runtime failures.")]
         public override void RegisterListConverterFactory(System.Type listType, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] System.Type implementationType) { }
@@ -1038,6 +1044,7 @@ namespace GraphQL
     public abstract class ValueConverterBase : GraphQL.IValueConverter
     {
         protected ValueConverterBase() { }
+        protected virtual GraphQL.Conversion.IListConverterFactory? ArrayListConverterFactory { get; }
         protected virtual GraphQL.Conversion.IListConverterFactory? DefaultListConverterFactory { get; }
         protected System.Collections.Generic.Dictionary<System.Type, GraphQL.Conversion.IListConverterFactory> ListConverterFactories { get; }
         protected System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, System.Type>, System.Func<object, object>> ValueConversions { get; }

--- a/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
@@ -1023,10 +1023,18 @@ namespace GraphQL
     }
     public class ValueConverter : GraphQL.ValueConverterBase
     {
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with \'RequiresUnreferencedCodeAttribute\' require dynamic" +
-            " access otherwise can break functionality when trimming application code")]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates list and array types dynamically as needed.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creates list and array types dynamically as needed.")]
         public ValueConverter() { }
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCode.")]
+        protected override GraphQL.Conversion.IListConverterFactory? ArrayListConverterFactory { get; }
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
+        [get: System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCodeAttribute.")]
         protected override GraphQL.Conversion.IListConverterFactory? DefaultListConverterFactory { get; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Compiles code at runtime to populate the specified type.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"For generic list types, the constructed implementation type (e.g. List<T>) must be rooted for trimming. If the closed generic type is only referenced via reflection, the trimmer may remove its required constructors or other members, which can cause runtime failures.")]
         public override void RegisterListConverterFactory(System.Type listType, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] System.Type implementationType) { }
         public override object ToObject(System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IInputObjectGraphType inputGraphType) { }
@@ -1034,6 +1042,7 @@ namespace GraphQL
     public class ValueConverterAot : GraphQL.ValueConverterBase
     {
         public ValueConverterAot() { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Compiles code at runtime to populate the specified type.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"For generic list types, the constructed implementation type (e.g. List<T>) must be rooted for trimming. If the closed generic type is only referenced via reflection, the trimmer may remove its required constructors or other members, which can cause runtime failures.")]
         public override void RegisterListConverterFactory(System.Type listType, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] System.Type implementationType) { }
         public override object ToObject(System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IInputObjectGraphType inputGraphType) { }
@@ -1041,6 +1050,7 @@ namespace GraphQL
     public abstract class ValueConverterBase : GraphQL.IValueConverter
     {
         protected ValueConverterBase() { }
+        protected virtual GraphQL.Conversion.IListConverterFactory? ArrayListConverterFactory { get; }
         protected virtual GraphQL.Conversion.IListConverterFactory? DefaultListConverterFactory { get; }
         protected System.Collections.Generic.Dictionary<System.Type, GraphQL.Conversion.IListConverterFactory> ListConverterFactories { get; }
         protected System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, System.Type>, System.Func<object, object>> ValueConversions { get; }
@@ -1052,6 +1062,7 @@ namespace GraphQL
         public virtual void RegisterListConverter<TListType, TElementType>(System.Func<System.Collections.Generic.IEnumerable<TElementType>, TListType>? conversion)
             where TListType : System.Collections.Generic.IEnumerable<TElementType> { }
         public virtual void RegisterListConverterFactory(System.Type listType, GraphQL.Conversion.IListConverterFactory? converter) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Compiles code at runtime to populate the specified type.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"For generic list types, the constructed implementation type (e.g. List<T>) must be rooted for trimming. If the closed generic type is only referenced via reflection, the trimmer may remove its required constructors or other members, which can cause runtime failures.")]
         public abstract void RegisterListConverterFactory(System.Type listType, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] System.Type implementationType);
         protected void RegisterScalarConversions() { }

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -976,6 +976,7 @@ namespace GraphQL
     public class ValueConverter : GraphQL.ValueConverterBase
     {
         public ValueConverter() { }
+        protected override GraphQL.Conversion.IListConverterFactory? ArrayListConverterFactory { get; }
         protected override GraphQL.Conversion.IListConverterFactory? DefaultListConverterFactory { get; }
         public override void RegisterListConverterFactory(System.Type listType, System.Type implementationType) { }
         public override object ToObject(System.Collections.Generic.IDictionary<string, object?> source, System.Type type, GraphQL.Types.IInputObjectGraphType inputGraphType) { }
@@ -989,6 +990,7 @@ namespace GraphQL
     public abstract class ValueConverterBase : GraphQL.IValueConverter
     {
         protected ValueConverterBase() { }
+        protected virtual GraphQL.Conversion.IListConverterFactory? ArrayListConverterFactory { get; }
         protected virtual GraphQL.Conversion.IListConverterFactory? DefaultListConverterFactory { get; }
         protected System.Collections.Generic.Dictionary<System.Type, GraphQL.Conversion.IListConverterFactory> ListConverterFactories { get; }
         protected System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, System.Type>, System.Func<object, object>> ValueConversions { get; }

--- a/src/GraphQL/Conversion/ValueConverterAot.cs
+++ b/src/GraphQL/Conversion/ValueConverterAot.cs
@@ -24,6 +24,7 @@ public class ValueConverterAot : ValueConverterBase
         "For generic list types, the constructed implementation type (e.g. List<T>) must be rooted for trimming. " +
         "If the closed generic type is only referenced via reflection, the trimmer may remove its required constructors " +
         "or other members, which can cause runtime failures.")]
+    [RequiresDynamicCode("Compiles code at runtime to populate the specified type.")]
     public override void RegisterListConverterFactory(Type listType,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type implementationType)

--- a/src/GraphQL/Conversion/ValueConverterBase.cs
+++ b/src/GraphQL/Conversion/ValueConverterBase.cs
@@ -171,8 +171,8 @@ public abstract class ValueConverterBase : IValueConverter
     /// </summary>
     public virtual IListConverterFactory GetListConverterFactory(Type listType)
     {
-        if (listType.IsArray)
-            return ArrayListConverterFactory.Instance;
+        if (listType.IsArray && ArrayListConverterFactory != null)
+            return ArrayListConverterFactory;
 
         // if the list type is not explicitly registered
         if (!ListConverterFactories.TryGetValue(listType, out var converter)
@@ -195,6 +195,11 @@ public abstract class ValueConverterBase : IValueConverter
     /// when attempting to convert a list type that is not explicitly registered.
     /// </summary>
     protected virtual IListConverterFactory? DefaultListConverterFactory => null;
+
+    /// <summary>
+    /// Gets the array list converter factory for array types.
+    /// </summary>
+    protected virtual IListConverterFactory? ArrayListConverterFactory => null;
 
     /// <summary>
     /// Allows you to register your own conversion delegate from one type to another.
@@ -268,6 +273,7 @@ public abstract class ValueConverterBase : IValueConverter
         "For generic list types, the constructed implementation type (e.g. List<T>) must be rooted for trimming. " +
         "If the closed generic type is only referenced via reflection, the trimmer may remove its required constructors " +
         "or other members, which can cause runtime failures.")]
+    [RequiresDynamicCode("Compiles code at runtime to populate the specified type.")]
     public abstract void RegisterListConverterFactory(Type listType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type implementationType);
 


### PR DESCRIPTION
## Description

Refactors the value converter system to improve AOT (Ahead-Of-Time) compilation compatibility and trimming behavior by adding proper diagnostic attributes and restructuring list converter factory handling.

## Changes

### Core Refactoring
- **Separated array list converter handling**: Added `ArrayListConverterFactory` as a virtual property in `ValueConverterBase` to allow derived classes to control array conversion behavior independently
- **Improved null safety**: Added null check for `ArrayListConverterFactory` in `GetListConverterFactory` method

### AOT Attribute Annotations
- **ValueConverter constructor**: Replaced `UnconditionalSuppressMessage` with explicit `RequiresUnreferencedCode` and `RequiresDynamicCode` attributes to properly indicate the constructor's runtime code generation requirements
- **RegisterListConverterFactory**: Added `RequiresDynamicCode` attribute across `ValueConverter`, `ValueConverterAot`, and `ValueConverterBase` to indicate runtime compilation requirements
- **Property getters**: Added targeted `UnconditionalSuppressMessage` attributes for IL2026, IL3050, and IL2067 warnings with clear justifications referencing the constructor's requirements

### Code Organization
- **Refactored ToObject**: Extracted reflection-based object creation into a private `ToObjectImpl` method with appropriate AOT suppression attributes to isolate warnings
- **Namespace qualification**: Explicitly qualified `ArrayListConverterFactory` references with `Conversion.` namespace to avoid ambiguity

### API Surface Changes
- Updated public API approval tests across all target frameworks (net50, net60, net80, netstandard2.0/2.1) to reflect the new property and attribute changes

## Impact

These changes improve the library's behavior in trimmed and AOT-compiled scenarios by:
1. Providing clearer signals to the AOT analyzer about which code paths require dynamic code generation
2. Allowing developers to better understand trimming implications through proper attributes
3. Enabling more granular control over list converter factories in derived classes
