### PR TITLE
Add AOT and trimming compatibility annotations to SchemaBuilder and ReflectionHelper

### DIFF
--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3486,15 +3486,23 @@ namespace GraphQL.Utilities
     public class SchemaBuilder
     {
         protected readonly System.Collections.Generic.Dictionary<string, GraphQL.Types.IGraphType> _types;
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses DefaultServiceProvider which does not statically reference graph type constr" +
+            "uctors.")]
         public SchemaBuilder() { }
         public bool AllowUnknownFields { get; set; }
         public bool AllowUnknownTypes { get; set; }
         public bool IgnoreComments { get; set; }
         public bool IgnoreLocations { get; set; }
         public bool RunConfigurations { get; set; }
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
         public System.IServiceProvider ServiceProvider { get; set; }
         public GraphQL.Utilities.TypeSettings Types { get; }
         public virtual GraphQL.Types.Schema Build(string typeDefinitions) { }
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCodeAttribute.")]
         protected virtual GraphQL.Types.Schema CreateSchema() { }
         protected virtual GraphQL.Types.IGraphType? GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3500,15 +3500,23 @@ namespace GraphQL.Utilities
     public class SchemaBuilder
     {
         protected readonly System.Collections.Generic.Dictionary<string, GraphQL.Types.IGraphType> _types;
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses DefaultServiceProvider which does not statically reference graph type constr" +
+            "uctors.")]
         public SchemaBuilder() { }
         public bool AllowUnknownFields { get; set; }
         public bool AllowUnknownTypes { get; set; }
         public bool IgnoreComments { get; set; }
         public bool IgnoreLocations { get; set; }
         public bool RunConfigurations { get; set; }
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
         public System.IServiceProvider ServiceProvider { get; set; }
         public GraphQL.Utilities.TypeSettings Types { get; }
         public virtual GraphQL.Types.Schema Build(string typeDefinitions) { }
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCodeAttribute.")]
         protected virtual GraphQL.Types.Schema CreateSchema() { }
         protected virtual GraphQL.Types.IGraphType? GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }

--- a/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
@@ -3508,15 +3508,24 @@ namespace GraphQL.Utilities
     public class SchemaBuilder
     {
         protected readonly System.Collections.Generic.Dictionary<string, GraphQL.Types.IGraphType> _types;
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Builds resolvers at runtime, requiring dynamic code generation.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses DefaultServiceProvider which does not statically reference graph type constr" +
+            "uctors.")]
         public SchemaBuilder() { }
         public bool AllowUnknownFields { get; set; }
         public bool AllowUnknownTypes { get; set; }
         public bool IgnoreComments { get; set; }
         public bool IgnoreLocations { get; set; }
         public bool RunConfigurations { get; set; }
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
         public System.IServiceProvider ServiceProvider { get; set; }
         public GraphQL.Utilities.TypeSettings Types { get; }
         public virtual GraphQL.Types.Schema Build(string typeDefinitions) { }
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with \'RequiresUnreferencedCodeAttribute\' may bre" +
+            "ak functionality when trimming application code.", Justification="The constructor is marked with RequiresUnreferencedCodeAttribute.")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with \'RequiresDynamicCodeAttribute\' may break fu" +
+            "nctionality when AOT compiling.", Justification="The constructor is marked with RequiresDynamicCodeAttribute.")]
         protected virtual GraphQL.Types.Schema CreateSchema() { }
         protected virtual GraphQL.Types.IGraphType? GetType(string name) { }
         protected virtual void PreConfigure(GraphQL.Types.Schema schema) { }

--- a/src/GraphQL/Reflection/ReflectionHelper.cs
+++ b/src/GraphQL/Reflection/ReflectionHelper.cs
@@ -10,7 +10,9 @@ internal static class ReflectionHelper
     /// <param name="type">The type to check.</param>
     /// <param name="field">The desired field.</param>
     /// <param name="resolverType">defaults to Resolver</param>
-    public static IAccessor? ToAccessor(this Type? type, string field, ResolverType resolverType)
+    public static IAccessor? ToAccessor(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+        this Type? type, string field, ResolverType resolverType)
     {
         if (type == null)
             return null;
@@ -41,7 +43,7 @@ internal static class ReflectionHelper
     /// <param name="type">The type to check.</param>
     /// <param name="field">The desired field.</param>
     /// <param name="resolverType">Indicates if a resolver or stream resolver method is requested.</param>
-    public static MethodInfo? MethodForField(this Type type, string field, ResolverType resolverType)
+    public static MethodInfo? MethodForField([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] this Type type, string field, ResolverType resolverType)
     {
         var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
 
@@ -60,7 +62,7 @@ internal static class ReflectionHelper
     /// </summary>
     /// <param name="type">The type to check.</param>
     /// <param name="field">The desired field.</param>
-    public static PropertyInfo? PropertyForField(this Type type, string field)
+    public static PropertyInfo? PropertyForField([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this Type type, string field)
     {
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 

--- a/src/GraphQL/Utilities/SchemaBuilder.cs
+++ b/src/GraphQL/Utilities/SchemaBuilder.cs
@@ -17,6 +17,13 @@ public class SchemaBuilder
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     private GraphQLSchemaDefinition? _schemaDef;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="SchemaBuilder"/>.
+    /// </summary>
+    [RequiresUnreferencedCode("Uses DefaultServiceProvider which does not statically reference graph type constructors.")]
+    [RequiresDynamicCode("Builds resolvers at runtime, requiring dynamic code generation.")]
+    public SchemaBuilder() { }
+
     private IgnoreOptions CreateIgnoreOptions()
     {
         var options = IgnoreOptions.None;
@@ -32,6 +39,8 @@ public class SchemaBuilder
     /// <br/><br/>
     /// By default equals to <see cref="DefaultServiceProvider"/>.
     /// </summary>
+    [UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with 'RequiresUnreferencedCodeAttribute' may break functionality when trimming application code.",
+        Justification = "The constructor is marked with RequiresUnreferencedCodeAttribute.")]
     public IServiceProvider ServiceProvider { get; set; } = new DefaultServiceProvider();
 
     /// <summary>
@@ -101,6 +110,10 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
     /// <summary>
     /// Returns a new <see cref="Schema"/> instance.
     /// </summary>
+    [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.",
+        Justification = "The constructor is marked with RequiresDynamicCodeAttribute.")]
+    [UnconditionalSuppressMessage("AOT", "IL2026:Calling members annotated with 'RequiresUnreferencedCodeAttribute' may break functionality when trimming application code.",
+        Justification = "The constructor is marked with RequiresUnreferencedCodeAttribute.")]
     protected virtual Schema CreateSchema() => new(ServiceProvider, runConfigurations: RunConfigurations);
 
     private Schema BuildSchemaFrom(GraphQLDocument document)
@@ -310,6 +323,10 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
         return type;
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL2067:Calling members with arguments having 'DynamicallyAccessedMembersAttribute' may break functionality when trimming application code.",
+        Justification = "The constructor is marked with RequiresUnreferencedCodeAttribute.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.",
+        Justification = "The constructor is marked with RequiresUnreferencedCodeAttribute.")]
     private void InitializeField(FieldConfig config, Type? parentType)
     {
         config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);
@@ -331,6 +348,10 @@ Schema contains a redefinition of these types: {string.Join(", ", duplicates.Sel
         }
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL2067:Calling members with arguments having 'DynamicallyAccessedMembersAttribute' may break functionality when trimming application code.",
+        Justification = "The constructor is marked with RequiresUnreferencedCodeAttribute.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.",
+        Justification = "The constructor is marked with RequiresUnreferencedCodeAttribute.")]
     private void InitializeSubscriptionField(FieldConfig config, Type? parentType)
     {
         config.ResolverAccessor ??= parentType.ToAccessor(config.Name, ResolverType.Resolver);


### PR DESCRIPTION
## Changes

This PR adds .NET Native AOT and trimming compatibility annotations to improve support for ahead-of-time compilation scenarios.

### Modified Files

- **src/GraphQL/Utilities/SchemaBuilder.cs**
  - Added `RequiresUnreferencedCode` and `RequiresDynamicCode` attributes to constructor
  - Added `UnconditionalSuppressMessage` attributes to suppress AOT warnings (IL2026, IL3050, IL2067) in methods where the constructor is already properly marked
  - Suppressions added to: `ServiceProvider` property setter, `CreateSchema()`, and field initialization methods

- **src/GraphQL/Reflection/ReflectionHelper.cs**
  - Added `DynamicallyAccessedMembers` attributes to type parameters in:
    - `ToAccessor()` - marks PublicProperties and PublicMethods as accessed
    - `MethodForField()` - marks PublicMethods as accessed
    - `PropertyForField()` - marks PublicProperties as accessed

- **API approval tests updated** for .NET 5.0, 6.0, and 8.0 to reflect the new attributes on public API surface

### Impact

These annotations inform the .NET trimmer and AOT compiler about:
- The use of reflection to access properties and methods dynamically
- The use of DefaultServiceProvider which doesn't statically reference graph type constructors
- Runtime resolver building that requires dynamic code generation

This allows developers using Native AOT to make informed decisions about using these APIs and helps the trimmer preserve necessary metadata.
