### PR TITLE
Clone SkipTypeCheck property in ObjectGraphType

### DIFF
--- a/src/GraphQL/Types/Composite/ObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/ObjectGraphType.cs
@@ -45,6 +45,7 @@ public class ObjectGraphType<[NotAGraphType] TSourceType> : ComplexGraphType<TSo
             return;
         }
         IsTypeOf = cloneFrom.IsTypeOf;
+        SkipTypeCheck = cloneFrom.SkipTypeCheck;
         Interfaces = cloneFrom.Interfaces;
         if (cloneFrom.ResolvedInterfaces.Count > 0)
             throw new InvalidOperationException("Cannot clone ObjectGraphType when ResolvedInterfaces contains items.");


### PR DESCRIPTION
I doubt this is used except for schema-first, which doesn't do type caching.  But the field should have been cloned.