### PR TITLE
Implement reflection caching for source-generated output GraphQL types

### DIFF
--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForMultipleAttributes.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForMultipleAttributes.approved.txt
@@ -98,12 +98,9 @@ public partial class MySchema
     {
         private static QueryGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Query> _getMemberInstance;
 
         static QueryGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::Sample.Query).GetProperty(nameof(global::Sample.Query.Hello))!, ConstructField0_Hello },
@@ -138,7 +135,7 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::Sample.Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForMultipleAttributes.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForMultipleAttributes.approved.txt
@@ -96,16 +96,39 @@ public partial class MySchema
 {
     private class QueryGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Query>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public QueryGraphType()
+        private static QueryGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Query> _getMemberInstance;
+
+        static QueryGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::Sample.Query).GetProperty(nameof(global::Sample.Query.Hello))!, ConstructField0_Hello },
             };
+        }
+
+        public QueryGraphType() : this(_cache)
+        {
+        }
+
+        private QueryGraphType(QueryGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new QueryGraphType(this);
             }
         }
 
@@ -115,7 +138,9 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::Sample.Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Hello, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForMutationType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForMutationType.approved.txt
@@ -13,12 +13,9 @@ public partial class MySchema
     {
         private static MutationGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Mutation> _getMemberInstance;
 
         static MutationGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::Sample.Mutation).GetMethod(nameof(global::Sample.Mutation.DoSomething), [typeof(string)])!, ConstructField0_DoSomething },
@@ -53,7 +50,7 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::Sample.Mutation GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Mutation GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_DoSomething(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForMutationType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForMutationType.approved.txt
@@ -11,16 +11,39 @@ public partial class MySchema
 {
     private class MutationGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Mutation>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public MutationGraphType()
+        private static MutationGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Mutation> _getMemberInstance;
+
+        static MutationGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::Sample.Mutation).GetMethod(nameof(global::Sample.Mutation.DoSomething), [typeof(string)])!, ConstructField0_DoSomething },
             };
+        }
+
+        public MutationGraphType() : this(_cache)
+        {
+        }
+
+        private MutationGraphType(MutationGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new MutationGraphType(this);
             }
         }
 
@@ -30,7 +53,9 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_DoSomething(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::Sample.Mutation GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_DoSomething(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<string>(fieldType, parameters[0]);

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForOutputType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForOutputType.approved.txt
@@ -11,16 +11,39 @@ public partial class MySchema
 {
     private class MyOutputGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.MyOutput>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public MyOutputGraphType()
+        private static MyOutputGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.MyOutput> _getMemberInstance;
+
+        static MyOutputGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::Sample.MyOutput).GetProperty(nameof(global::Sample.MyOutput.Name))!, ConstructField0_Name },
             };
+        }
+
+        public MyOutputGraphType() : this(_cache)
+        {
+        }
+
+        private MyOutputGraphType(MyOutputGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new MyOutputGraphType(this);
             }
         }
 
@@ -30,7 +53,9 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::Sample.MyOutput GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForOutputType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForOutputType.approved.txt
@@ -13,12 +13,9 @@ public partial class MySchema
     {
         private static MyOutputGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.MyOutput> _getMemberInstance;
 
         static MyOutputGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::Sample.MyOutput).GetProperty(nameof(global::Sample.MyOutput.Name))!, ConstructField0_Name },
@@ -53,7 +50,7 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::Sample.MyOutput GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.MyOutput GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForQueryType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForQueryType.approved.txt
@@ -13,12 +13,9 @@ public partial class MySchema
     {
         private static QueryGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Query> _getMemberInstance;
 
         static QueryGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::Sample.Query).GetProperty(nameof(global::Sample.Query.Hello))!, ConstructField0_Hello },
@@ -53,7 +50,7 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::Sample.Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForQueryType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForQueryType.approved.txt
@@ -11,16 +11,39 @@ public partial class MySchema
 {
     private class QueryGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Query>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public QueryGraphType()
+        private static QueryGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Query> _getMemberInstance;
+
+        static QueryGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::Sample.Query).GetProperty(nameof(global::Sample.Query.Hello))!, ConstructField0_Hello },
             };
+        }
+
+        public QueryGraphType() : this(_cache)
+        {
+        }
+
+        private QueryGraphType(QueryGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new QueryGraphType(this);
             }
         }
 
@@ -30,7 +53,9 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::Sample.Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Hello, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForSubscriptionType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForSubscriptionType.approved.txt
@@ -11,16 +11,39 @@ public partial class MySchema
 {
     private class SubscriptionGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Subscription>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public SubscriptionGraphType()
+        private static SubscriptionGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Subscription> _getMemberInstance;
+
+        static SubscriptionGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::Sample.Subscription).GetMethod(nameof(global::Sample.Subscription.OnMessage), [])!, ConstructField0_OnMessage },
             };
+        }
+
+        public SubscriptionGraphType() : this(_cache)
+        {
+        }
+
+        private SubscriptionGraphType(SubscriptionGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new SubscriptionGraphType(this);
             }
         }
 
@@ -30,7 +53,9 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_OnMessage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::Sample.Subscription GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_OnMessage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = global::GraphQL.Resolvers.SourceFieldResolver.Instance;
             fieldType.StreamResolver = BuildSourceStreamResolver(context =>

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForSubscriptionType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_ForSubscriptionType.approved.txt
@@ -13,12 +13,9 @@ public partial class MySchema
     {
         private static SubscriptionGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Subscription> _getMemberInstance;
 
         static SubscriptionGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::Sample.Subscription).GetMethod(nameof(global::Sample.Subscription.OnMessage), [])!, ConstructField0_OnMessage },
@@ -53,7 +50,7 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::Sample.Subscription GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Subscription GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_OnMessage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_WithoutNamespace.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_WithoutNamespace.approved.txt
@@ -11,12 +11,9 @@ public partial class MySchema
     {
         private static QueryGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Query> _getMemberInstance;
 
         static QueryGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::Query).GetProperty(nameof(global::Query.Hello))!, ConstructField0_Hello },
@@ -51,7 +48,7 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_WithoutNamespace.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.GeneratesPartialClass_WithoutNamespace.approved.txt
@@ -9,16 +9,39 @@ public partial class MySchema
 {
     private class QueryGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Query>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public QueryGraphType()
+        private static QueryGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Query> _getMemberInstance;
+
+        static QueryGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::Query).GetProperty(nameof(global::Query.Hello))!, ConstructField0_Hello },
             };
+        }
+
+        public QueryGraphType() : this(_cache)
+        {
+        }
+
+        private QueryGraphType(QueryGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new QueryGraphType(this);
             }
         }
 
@@ -28,7 +51,9 @@ public partial class MySchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::Query GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_Hello(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Hello, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.Generates_StarWarsSchema.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.Generates_StarWarsSchema.approved.txt
@@ -11,12 +11,9 @@ internal partial class StarWarsSchema
     {
         private static ConnectionGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>> _getMemberInstance;
 
         static ConnectionGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>.TotalCount))!, ConstructField0_TotalCount },
@@ -54,7 +51,7 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter> GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter> GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_TotalCount(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
@@ -91,12 +88,9 @@ internal partial class StarWarsSchema
     {
         private static DroidGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.Droid> _getMemberInstance;
 
         static DroidGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.PrimaryFunction))!, ConstructField0_PrimaryFunction },
@@ -136,7 +130,7 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_PrimaryFunction(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
@@ -197,12 +191,9 @@ internal partial class StarWarsSchema
     {
         private static EdgeGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>> _getMemberInstance;
 
         static EdgeGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>.Cursor))!, ConstructField0_Cursor },
@@ -238,7 +229,7 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter> GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter> GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_Cursor(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
@@ -265,12 +256,9 @@ internal partial class StarWarsSchema
     {
         private static HumanGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.Human> _getMemberInstance;
 
         static HumanGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Human).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Human.HomePlanet))!, ConstructField0_HomePlanet },
@@ -310,7 +298,7 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.StarWars.TypeFirst.Types.Human GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.StarWars.TypeFirst.Types.Human GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_HomePlanet(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
@@ -520,12 +508,9 @@ internal partial class StarWarsSchema
     {
         private static PageInfoGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.Types.Relay.DataObjects.PageInfo> _getMemberInstance;
 
         static PageInfoGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.Types.Relay.DataObjects.PageInfo).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.PageInfo.HasNextPage))!, ConstructField0_HasNextPage },
@@ -563,7 +548,7 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.Types.Relay.DataObjects.PageInfo GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.Types.Relay.DataObjects.PageInfo GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_HasNextPage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
@@ -600,12 +585,9 @@ internal partial class StarWarsSchema
     {
         private static StarWarsMutationGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation> _getMemberInstance;
 
         static StarWarsMutationGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation.CreateHuman), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData), typeof(global::GraphQL.StarWars.TypeFirst.Types.HumanInput)])!, ConstructField0_CreateHuman },
@@ -640,7 +622,7 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_CreateHuman(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
@@ -670,12 +652,9 @@ internal partial class StarWarsSchema
     {
         private static StarWarsQueryGraphType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery> _getMemberInstance;
 
         static StarWarsQueryGraphType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery.HeroAsync), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData)])!, ConstructField0_HeroAsync },
@@ -712,7 +691,7 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_HeroAsync(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.Generates_StarWarsSchema.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/AotSchemaGeneratorTests.Generates_StarWarsSchema.approved.txt
@@ -9,9 +9,14 @@ internal partial class StarWarsSchema
 {
     private class ConnectionGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public ConnectionGraphType()
+        private static ConnectionGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>> _getMemberInstance;
+
+        static ConnectionGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>.TotalCount))!, ConstructField0_TotalCount },
@@ -19,9 +24,27 @@ internal partial class StarWarsSchema
                 { typeof(global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>.Edges))!, ConstructField2_Edges },
                 { typeof(global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>.Items))!, ConstructField3_Items },
             };
+        }
+
+        public ConnectionGraphType() : this(_cache)
+        {
+        }
+
+        private ConnectionGraphType(ConnectionGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new ConnectionGraphType(this);
             }
         }
 
@@ -31,22 +54,24 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_TotalCount(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.Types.Relay.DataObjects.Connection<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter> GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_TotalCount(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).TotalCount, false);
         }
 
-        public void ConstructField1_PageInfo(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_PageInfo(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).PageInfo, false);
         }
 
-        public void ConstructField2_Edges(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField2_Edges(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Edges, false);
         }
 
-        public void ConstructField3_Items(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField3_Items(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Items, false);
         }
@@ -64,9 +89,14 @@ internal partial class StarWarsSchema
 {
     private class DroidGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.StarWars.TypeFirst.Types.Droid>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public DroidGraphType()
+        private static DroidGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.Droid> _getMemberInstance;
+
+        static DroidGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.PrimaryFunction))!, ConstructField0_PrimaryFunction },
@@ -76,9 +106,27 @@ internal partial class StarWarsSchema
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsCharacter).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsCharacter.GetFriends), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData)])!, ConstructField4_GetFriends },
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsCharacter).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsCharacter.GetFriendsConnection), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData)])!, ConstructField5_GetFriendsConnection },
             };
+        }
+
+        public DroidGraphType() : this(_cache)
+        {
+        }
+
+        private DroidGraphType(DroidGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new DroidGraphType(this);
             }
         }
 
@@ -88,27 +136,29 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_PrimaryFunction(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_PrimaryFunction(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).PrimaryFunction, false);
         }
 
-        public void ConstructField1_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Id, false);
         }
 
-        public void ConstructField2_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField2_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }
 
-        public void ConstructField3_AppearsIn(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField3_AppearsIn(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).AppearsIn, false);
         }
 
-        public void ConstructField4_GetFriends(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField4_GetFriends(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -120,7 +170,7 @@ internal partial class StarWarsSchema
             }, true);
         }
 
-        public void ConstructField5_GetFriendsConnection(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField5_GetFriendsConnection(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -145,17 +195,40 @@ internal partial class StarWarsSchema
 {
     private class EdgeGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public EdgeGraphType()
+        private static EdgeGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>> _getMemberInstance;
+
+        static EdgeGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>.Cursor))!, ConstructField0_Cursor },
                 { typeof(global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>.Node))!, ConstructField1_Node },
             };
+        }
+
+        public EdgeGraphType() : this(_cache)
+        {
+        }
+
+        private EdgeGraphType(EdgeGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new EdgeGraphType(this);
             }
         }
 
@@ -165,12 +238,14 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_Cursor(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.Types.Relay.DataObjects.Edge<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter> GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_Cursor(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Cursor, false);
         }
 
-        public void ConstructField1_Node(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_Node(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Node, false);
         }
@@ -188,9 +263,14 @@ internal partial class StarWarsSchema
 {
     private class HumanGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.StarWars.TypeFirst.Types.Human>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public HumanGraphType()
+        private static HumanGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.Human> _getMemberInstance;
+
+        static HumanGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Human).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Human.HomePlanet))!, ConstructField0_HomePlanet },
@@ -200,9 +280,27 @@ internal partial class StarWarsSchema
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsCharacter).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsCharacter.GetFriends), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData)])!, ConstructField4_GetFriends },
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsCharacter).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsCharacter.GetFriendsConnection), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData)])!, ConstructField5_GetFriendsConnection },
             };
+        }
+
+        public HumanGraphType() : this(_cache)
+        {
+        }
+
+        private HumanGraphType(HumanGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new HumanGraphType(this);
             }
         }
 
@@ -212,27 +310,29 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_HomePlanet(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.StarWars.TypeFirst.Types.Human GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_HomePlanet(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).HomePlanet, false);
         }
 
-        public void ConstructField1_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Id, false);
         }
 
-        public void ConstructField2_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField2_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }
 
-        public void ConstructField3_AppearsIn(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField3_AppearsIn(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).AppearsIn, false);
         }
 
-        public void ConstructField4_GetFriends(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField4_GetFriends(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -244,7 +344,7 @@ internal partial class StarWarsSchema
             }, true);
         }
 
-        public void ConstructField5_GetFriendsConnection(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField5_GetFriendsConnection(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -357,8 +457,10 @@ internal partial class StarWarsSchema
 {
     private class IStarWarsCharacterGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringInterfaceGraphType<global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>?> _members;
-        public IStarWarsCharacterGraphType()
+        private static IStarWarsCharacterGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>?> _members;
+
+        static IStarWarsCharacterGraphType()
         {
             _members = new()
             {
@@ -368,9 +470,27 @@ internal partial class StarWarsSchema
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter.GetFriends), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData)])!, null },
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.IStarWarsCharacter.GetFriendsConnection), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData)])!, null },
             };
+        }
+
+        public IStarWarsCharacterGraphType() : this(_cache)
+        {
+        }
+
+        private IStarWarsCharacterGraphType(IStarWarsCharacterGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new IStarWarsCharacterGraphType(this);
             }
         }
 
@@ -398,9 +518,14 @@ internal partial class StarWarsSchema
 {
     private class PageInfoGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.Types.Relay.DataObjects.PageInfo>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public PageInfoGraphType()
+        private static PageInfoGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.Types.Relay.DataObjects.PageInfo> _getMemberInstance;
+
+        static PageInfoGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.Types.Relay.DataObjects.PageInfo).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.PageInfo.HasNextPage))!, ConstructField0_HasNextPage },
@@ -408,9 +533,27 @@ internal partial class StarWarsSchema
                 { typeof(global::GraphQL.Types.Relay.DataObjects.PageInfo).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.PageInfo.StartCursor))!, ConstructField2_StartCursor },
                 { typeof(global::GraphQL.Types.Relay.DataObjects.PageInfo).GetProperty(nameof(global::GraphQL.Types.Relay.DataObjects.PageInfo.EndCursor))!, ConstructField3_EndCursor },
             };
+        }
+
+        public PageInfoGraphType() : this(_cache)
+        {
+        }
+
+        private PageInfoGraphType(PageInfoGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new PageInfoGraphType(this);
             }
         }
 
@@ -420,22 +563,24 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_HasNextPage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.Types.Relay.DataObjects.PageInfo GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_HasNextPage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).HasNextPage, false);
         }
 
-        public void ConstructField1_HasPreviousPage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_HasPreviousPage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).HasPreviousPage, false);
         }
 
-        public void ConstructField2_StartCursor(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField2_StartCursor(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).StartCursor, false);
         }
 
-        public void ConstructField3_EndCursor(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField3_EndCursor(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).EndCursor, false);
         }
@@ -453,16 +598,39 @@ internal partial class StarWarsSchema
 {
     private class StarWarsMutationGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public StarWarsMutationGraphType()
+        private static StarWarsMutationGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation> _getMemberInstance;
+
+        static StarWarsMutationGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation.CreateHuman), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData), typeof(global::GraphQL.StarWars.TypeFirst.Types.HumanInput)])!, ConstructField0_CreateHuman },
             };
+        }
+
+        public StarWarsMutationGraphType() : this(_cache)
+        {
+        }
+
+        private StarWarsMutationGraphType(StarWarsMutationGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new StarWarsMutationGraphType(this);
             }
         }
 
@@ -472,7 +640,9 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_CreateHuman(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.StarWars.TypeFirst.Types.StarWarsMutation GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_CreateHuman(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -498,18 +668,41 @@ internal partial class StarWarsSchema
 {
     private class StarWarsQueryGraphType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public StarWarsQueryGraphType()
+        private static StarWarsQueryGraphType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery> _getMemberInstance;
+
+        static StarWarsQueryGraphType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery.HeroAsync), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData)])!, ConstructField0_HeroAsync },
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery.HumanAsync), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData), typeof(string)])!, ConstructField1_HumanAsync },
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery.DroidAsync), [typeof(global::GraphQL.StarWars.TypeFirst.StarWarsData), typeof(string)])!, ConstructField2_DroidAsync },
             };
+        }
+
+        public StarWarsQueryGraphType() : this(_cache)
+        {
+        }
+
+        private StarWarsQueryGraphType(StarWarsQueryGraphType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new StarWarsQueryGraphType(this);
             }
         }
 
@@ -519,7 +712,9 @@ internal partial class StarWarsSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_HeroAsync(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.StarWars.TypeFirst.Types.StarWarsQuery GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_HeroAsync(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -530,7 +725,7 @@ internal partial class StarWarsSchema
             }, true);
         }
 
-        public void ConstructField1_HumanAsync(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_HumanAsync(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -543,7 +738,7 @@ internal partial class StarWarsSchema
             }, true);
         }
 
-        public void ConstructField2_DroidAsync(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField2_DroidAsync(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesComprehensiveOutputGraphTypes.Interface.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesComprehensiveOutputGraphTypes.Interface.approved.txt
@@ -7,8 +7,10 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_IStarWarsCharacter : global::GraphQL.Types.Aot.AotAutoRegisteringInterfaceGraphType<global::GraphQL.StarWars.TypeFirst.IStarWarsCharacter>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>?> _members;
-        public AutoOutputGraphType_IStarWarsCharacter()
+        private static AutoOutputGraphType_IStarWarsCharacter? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>?> _members;
+
+        static AutoOutputGraphType_IStarWarsCharacter()
         {
             _members = new()
             {
@@ -20,9 +22,27 @@ public partial class SampleAotSchema
                 { typeof(global::GraphQL.StarWars.TypeFirst.IStarWarsCharacter).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.IStarWarsCharacter.Version))!, ConstructField5_Version },
                 { typeof(global::GraphQL.StarWars.TypeFirst.IStarWarsCharacter).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.IStarWarsCharacter.GetAllCharacterTypes), [])!, ConstructField6_GetAllCharacterTypes },
             };
+        }
+
+        public AutoOutputGraphType_IStarWarsCharacter() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_IStarWarsCharacter(AutoOutputGraphType_IStarWarsCharacter? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_IStarWarsCharacter(this);
             }
         }
 
@@ -37,12 +57,12 @@ public partial class SampleAotSchema
             }
         }
 
-        public void ConstructField5_Version(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField5_Version(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => global::GraphQL.StarWars.TypeFirst.IStarWarsCharacter.Version, false);
         }
 
-        public void ConstructField6_GetAllCharacterTypes(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField6_GetAllCharacterTypes(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context =>
             {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesComprehensiveOutputGraphTypes.Object.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesComprehensiveOutputGraphTypes.Object.approved.txt
@@ -9,12 +9,9 @@ public partial class SampleAotSchema
     {
         private static AutoOutputGraphType_Droid? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.Droid> _getMemberInstance;
 
         static AutoOutputGraphType_Droid()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.Id))!, ConstructField0_Id },
@@ -58,7 +55,7 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesComprehensiveOutputGraphTypes.Object.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesComprehensiveOutputGraphTypes.Object.approved.txt
@@ -7,9 +7,14 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_Droid : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.StarWars.TypeFirst.Types.Droid>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public AutoOutputGraphType_Droid()
+        private static AutoOutputGraphType_Droid? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.Droid> _getMemberInstance;
+
+        static AutoOutputGraphType_Droid()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.Id))!, ConstructField0_Id },
@@ -23,9 +28,27 @@ public partial class SampleAotSchema
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.CreateDroid), [typeof(string), typeof(string)])!, ConstructField8_CreateDroid },
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetMethod(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.GetSerialNumber), [])!, ConstructField9_GetSerialNumber },
             };
+        }
+
+        public AutoOutputGraphType_Droid() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_Droid(AutoOutputGraphType_Droid? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_Droid(this);
             }
         }
 
@@ -35,17 +58,19 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Id, false);
         }
 
-        public void ConstructField1_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }
 
-        public void ConstructField2_GetFriends(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField2_GetFriends(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -57,7 +82,7 @@ public partial class SampleAotSchema
             }, true);
         }
 
-        public void ConstructField3_GetFriendsConnection(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField3_GetFriendsConnection(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -73,27 +98,27 @@ public partial class SampleAotSchema
             }, true);
         }
 
-        public void ConstructField4_AppearsIn(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField4_AppearsIn(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).AppearsIn, false);
         }
 
-        public void ConstructField5_PrimaryFunction(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField5_PrimaryFunction(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).PrimaryFunction, false);
         }
 
-        public void ConstructField6__manufacturer(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField6__manufacturer(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context)._manufacturer, false);
         }
 
-        public void ConstructField7_DefaultModel(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField7_DefaultModel(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => global::GraphQL.StarWars.TypeFirst.Types.Droid.DefaultModel, false);
         }
 
-        public void ConstructField8_CreateDroid(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField8_CreateDroid(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<string>(fieldType, parameters[0]);
@@ -106,7 +131,7 @@ public partial class SampleAotSchema
             }, true);
         }
 
-        public void ConstructField9_GetSerialNumber(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField9_GetSerialNumber(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context =>
             {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesDroidObjectType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesDroidObjectType.approved.txt
@@ -9,12 +9,9 @@ public partial class SampleAotSchema
     {
         private static AutoOutputGraphType_Droid? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.Droid> _getMemberInstance;
 
         static AutoOutputGraphType_Droid()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.Id))!, ConstructField0_Id },
@@ -54,7 +51,7 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesDroidObjectType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesDroidObjectType.approved.txt
@@ -7,9 +7,14 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_Droid : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::GraphQL.StarWars.TypeFirst.Types.Droid>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public AutoOutputGraphType_Droid()
+        private static AutoOutputGraphType_Droid? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::GraphQL.StarWars.TypeFirst.Types.Droid> _getMemberInstance;
+
+        static AutoOutputGraphType_Droid()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.Id))!, ConstructField0_Id },
@@ -19,9 +24,27 @@ public partial class SampleAotSchema
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.AppearsIn))!, ConstructField4_AppearsIn },
                 { typeof(global::GraphQL.StarWars.TypeFirst.Types.Droid).GetProperty(nameof(global::GraphQL.StarWars.TypeFirst.Types.Droid.PrimaryFunction))!, ConstructField5_PrimaryFunction },
             };
+        }
+
+        public AutoOutputGraphType_Droid() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_Droid(AutoOutputGraphType_Droid? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_Droid(this);
             }
         }
 
@@ -31,17 +54,19 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::GraphQL.StarWars.TypeFirst.Types.Droid GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_Id(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Id, false);
         }
 
-        public void ConstructField1_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }
 
-        public void ConstructField2_GetFriends(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField2_GetFriends(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -53,7 +78,7 @@ public partial class SampleAotSchema
             }, true);
         }
 
-        public void ConstructField3_GetFriendsConnection(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField3_GetFriendsConnection(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<global::GraphQL.StarWars.TypeFirst.StarWarsData>(fieldType, parameters[0]);
@@ -65,12 +90,12 @@ public partial class SampleAotSchema
             }, true);
         }
 
-        public void ConstructField4_AppearsIn(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField4_AppearsIn(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).AppearsIn, false);
         }
 
-        public void ConstructField5_PrimaryFunction(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField5_PrimaryFunction(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).PrimaryFunction, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesEmptyOutputGraphType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesEmptyOutputGraphType.approved.txt
@@ -9,12 +9,9 @@ public partial class SampleAotSchema
     {
         private static AutoOutputGraphType_EmptyType? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.EmptyType> _getMemberInstance;
 
         static AutoOutputGraphType_EmptyType()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
             };
@@ -48,7 +45,7 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::Sample.EmptyType GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.EmptyType GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
     }
 }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesEmptyOutputGraphType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesEmptyOutputGraphType.approved.txt
@@ -7,15 +7,38 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_EmptyType : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.EmptyType>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public AutoOutputGraphType_EmptyType()
+        private static AutoOutputGraphType_EmptyType? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.EmptyType> _getMemberInstance;
+
+        static AutoOutputGraphType_EmptyType()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
             };
+        }
+
+        public AutoOutputGraphType_EmptyType() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_EmptyType(AutoOutputGraphType_EmptyType? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_EmptyType(this);
             }
         }
 
@@ -24,6 +47,8 @@ public partial class SampleAotSchema
         {
             _members[memberInfo](fieldType, memberInfo);
         }
+
+        protected static global::Sample.EmptyType GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
 
     }
 }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesGetRequiredServiceInstance.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesGetRequiredServiceInstance.approved.txt
@@ -7,9 +7,11 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_Person : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Person>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
-        public AutoOutputGraphType_Person()
+        private static AutoOutputGraphType_Person? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
+
+        static AutoOutputGraphType_Person()
         {
             _getMemberInstance = BuildConstructorParameter<global::Sample.Person>();
 
@@ -17,9 +19,27 @@ public partial class SampleAotSchema
             {
                 { typeof(global::Sample.Person).GetProperty(nameof(global::Sample.Person.Name))!, ConstructField0_Name },
             };
+        }
+
+        public AutoOutputGraphType_Person() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_Person(AutoOutputGraphType_Person? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_Person(this);
             }
         }
 
@@ -29,9 +49,9 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected override global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
 
-        public void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesGetServiceOrCreateInstance.WithRequiredProperties.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesGetServiceOrCreateInstance.WithRequiredProperties.approved.txt
@@ -7,9 +7,11 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_Person : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Person>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
-        public AutoOutputGraphType_Person()
+        private static AutoOutputGraphType_Person? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
+
+        static AutoOutputGraphType_Person()
         {
             var ctorParam0 = BuildConstructorParameter<global::System.String>();
             var ctorParam1 = BuildConstructorParameter<global::System.Int32>();
@@ -34,9 +36,27 @@ public partial class SampleAotSchema
             {
                 { typeof(global::Sample.Person).GetProperty(nameof(global::Sample.Person.Name))!, ConstructField0_Name },
             };
+        }
+
+        public AutoOutputGraphType_Person() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_Person(AutoOutputGraphType_Person? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_Person(this);
             }
         }
 
@@ -46,9 +66,9 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected override global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
 
-        public void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesGetServiceOrCreateInstance.WithoutRequiredProperties.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesGetServiceOrCreateInstance.WithoutRequiredProperties.approved.txt
@@ -7,9 +7,11 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_Person : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Person>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
-        public AutoOutputGraphType_Person()
+        private static AutoOutputGraphType_Person? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
+
+        static AutoOutputGraphType_Person()
         {
             var ctorParam0 = BuildConstructorParameter<global::System.String>();
             var ctorParam1 = BuildConstructorParameter<global::System.Int32>();
@@ -28,9 +30,27 @@ public partial class SampleAotSchema
             {
                 { typeof(global::Sample.Person).GetProperty(nameof(global::Sample.Person.Name))!, ConstructField0_Name },
             };
+        }
+
+        public AutoOutputGraphType_Person() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_Person(AutoOutputGraphType_Person? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_Person(this);
             }
         }
 
@@ -40,9 +60,9 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected override global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
 
-        public void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesNestedPartialClasses.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesNestedPartialClasses.approved.txt
@@ -11,16 +11,39 @@ public partial class OuterClass
         {
             private class AutoOutputGraphType_Person : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Person>
             {
-                private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-                public AutoOutputGraphType_Person()
+                private static AutoOutputGraphType_Person? _cache;
+                private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+                private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
+
+                static AutoOutputGraphType_Person()
                 {
+                    _getMemberInstance = GetMemberInstanceFromSource;
+
                     _members = new()
                     {
                         { typeof(global::Sample.Person).GetProperty(nameof(global::Sample.Person.Name))!, ConstructField0_Name },
                     };
+                }
+
+                public AutoOutputGraphType_Person() : this(_cache)
+                {
+                }
+
+                private AutoOutputGraphType_Person(AutoOutputGraphType_Person? cloneFrom) : base(cloneFrom)
+                {
+                    if (cloneFrom != null)
+                    {
+                        return;
+                    }
+
                     foreach (var fieldType in ProvideFields())
                     {
                         AddField(fieldType);
+                    }
+
+                    if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+                    {
+                        _cache = new AutoOutputGraphType_Person(this);
                     }
                 }
 
@@ -30,7 +53,9 @@ public partial class OuterClass
                     _members[memberInfo](fieldType, memberInfo);
                 }
 
-                public void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+                protected static global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+                public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
                 {
                     fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
                 }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesNestedPartialClasses.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesNestedPartialClasses.approved.txt
@@ -13,12 +13,9 @@ public partial class OuterClass
             {
                 private static AutoOutputGraphType_Person? _cache;
                 private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-                private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
 
                 static AutoOutputGraphType_Person()
                 {
-                    _getMemberInstance = GetMemberInstanceFromSource;
-
                     _members = new()
                     {
                         { typeof(global::Sample.Person).GetProperty(nameof(global::Sample.Person.Name))!, ConstructField0_Name },
@@ -53,7 +50,7 @@ public partial class OuterClass
                     _members[memberInfo](fieldType, memberInfo);
                 }
 
-                protected static global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+                protected static global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
                 public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
                 {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesNewInstanceWithConstructor.WithRequiredProperties.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesNewInstanceWithConstructor.WithRequiredProperties.approved.txt
@@ -7,9 +7,11 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_Person : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Person>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
-        public AutoOutputGraphType_Person()
+        private static AutoOutputGraphType_Person? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
+
+        static AutoOutputGraphType_Person()
         {
             var ctorParam0 = BuildConstructorParameter<global::System.String>();
             var ctorParam1 = BuildConstructorParameter<global::System.Int32>();
@@ -28,9 +30,27 @@ public partial class SampleAotSchema
             {
                 { typeof(global::Sample.Person).GetProperty(nameof(global::Sample.Person.Name))!, ConstructField0_Name },
             };
+        }
+
+        public AutoOutputGraphType_Person() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_Person(AutoOutputGraphType_Person? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_Person(this);
             }
         }
 
@@ -40,9 +60,9 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected override global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
 
-        public void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesNewInstanceWithConstructor.WithoutRequiredProperties.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesNewInstanceWithConstructor.WithoutRequiredProperties.approved.txt
@@ -7,9 +7,11 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_Person : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Person>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
-        public AutoOutputGraphType_Person()
+        private static AutoOutputGraphType_Person? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Person> _getMemberInstance;
+
+        static AutoOutputGraphType_Person()
         {
             var ctorParam0 = BuildConstructorParameter<global::System.String>();
             var ctorParam1 = BuildConstructorParameter<global::System.Int32>();
@@ -22,9 +24,27 @@ public partial class SampleAotSchema
             {
                 { typeof(global::Sample.Person).GetProperty(nameof(global::Sample.Person.Name))!, ConstructField0_Name },
             };
+        }
+
+        public AutoOutputGraphType_Person() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_Person(AutoOutputGraphType_Person? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_Person(this);
             }
         }
 
@@ -34,9 +54,9 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected override global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Person GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
 
-        public void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField0_Name(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context => GetMemberInstance(context).Name, false);
         }

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesSubscriptionGraphType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesSubscriptionGraphType.approved.txt
@@ -9,12 +9,9 @@ public partial class SampleAotSchema
     {
         private static AutoOutputGraphType_Subscription? _cache;
         private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Subscription> _getMemberInstance;
 
         static AutoOutputGraphType_Subscription()
         {
-            _getMemberInstance = GetMemberInstanceFromSource;
-
             _members = new()
             {
                 { typeof(global::Sample.Subscription).GetMethod(nameof(global::Sample.Subscription.OnMessage), [])!, ConstructField0_OnMessage },
@@ -52,7 +49,7 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        protected static global::Sample.Subscription GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+        protected static global::Sample.Subscription GetMemberInstance(global::GraphQL.IResolveFieldContext context) => GetMemberInstanceFromSource(context);
 
         public static void ConstructField0_OnMessage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {

--- a/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesSubscriptionGraphType.approved.txt
+++ b/src/GraphQL.Analyzers.Tests/SourceGenerators/Generators/OutputGraphTypeGeneratorTests.GeneratesSubscriptionGraphType.approved.txt
@@ -7,9 +7,14 @@ public partial class SampleAotSchema
 {
     private class AutoOutputGraphType_Subscription : global::GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<global::Sample.Subscription>
     {
-        private readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
-        public AutoOutputGraphType_Subscription()
+        private static AutoOutputGraphType_Subscription? _cache;
+        private static readonly global::System.Collections.Generic.Dictionary<global::System.Reflection.MemberInfo, global::System.Action<global::GraphQL.Types.FieldType, global::System.Reflection.MemberInfo>> _members;
+        private static readonly global::System.Func<global::GraphQL.IResolveFieldContext, global::Sample.Subscription> _getMemberInstance;
+
+        static AutoOutputGraphType_Subscription()
         {
+            _getMemberInstance = GetMemberInstanceFromSource;
+
             _members = new()
             {
                 { typeof(global::Sample.Subscription).GetMethod(nameof(global::Sample.Subscription.OnMessage), [])!, ConstructField0_OnMessage },
@@ -17,9 +22,27 @@ public partial class SampleAotSchema
                 { typeof(global::Sample.Subscription).GetMethod(nameof(global::Sample.Subscription.OnEvent), [typeof(int)])!, ConstructField2_OnEvent },
                 { typeof(global::Sample.Subscription).GetMethod(nameof(global::Sample.Subscription.GetStatus), [])!, ConstructField3_GetStatus },
             };
+        }
+
+        public AutoOutputGraphType_Subscription() : this(_cache)
+        {
+        }
+
+        private AutoOutputGraphType_Subscription(AutoOutputGraphType_Subscription? cloneFrom) : base(cloneFrom)
+        {
+            if (cloneFrom != null)
+            {
+                return;
+            }
+
             foreach (var fieldType in ProvideFields())
             {
                 AddField(fieldType);
+            }
+
+            if (global::GraphQL.GlobalSwitches.EnableReflectionCaching)
+            {
+                _cache = new AutoOutputGraphType_Subscription(this);
             }
         }
 
@@ -29,7 +52,9 @@ public partial class SampleAotSchema
             _members[memberInfo](fieldType, memberInfo);
         }
 
-        public void ConstructField0_OnMessage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        protected static global::Sample.Subscription GetMemberInstance(global::GraphQL.IResolveFieldContext context) => _getMemberInstance(context);
+
+        public static void ConstructField0_OnMessage(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = global::GraphQL.Resolvers.SourceFieldResolver.Instance;
             fieldType.StreamResolver = BuildSourceStreamResolver(context =>
@@ -39,7 +64,7 @@ public partial class SampleAotSchema
             });
         }
 
-        public void ConstructField1_OnNotification(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField1_OnNotification(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<string>(fieldType, parameters[0]);
@@ -52,7 +77,7 @@ public partial class SampleAotSchema
             });
         }
 
-        public void ConstructField2_OnEvent(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField2_OnEvent(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             var parameters = ((global::System.Reflection.MethodInfo)memberInfo).GetParameters();
             var param0 = BuildArgument<int>(fieldType, parameters[0]);
@@ -65,7 +90,7 @@ public partial class SampleAotSchema
             });
         }
 
-        public void ConstructField3_GetStatus(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
+        public static void ConstructField3_GetStatus(global::GraphQL.Types.FieldType fieldType, global::System.Reflection.MemberInfo memberInfo)
         {
             fieldType.Resolver = BuildFieldResolver(context =>
             {

--- a/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net50/GraphQL.approved.txt
@@ -3482,38 +3482,38 @@ namespace GraphQL.Types.Aot
     }
     public abstract class AotAutoRegisteringInterfaceGraphType<TSource> : GraphQL.Types.AutoRegisteringInterfaceGraphType<TSource>
     {
-        public AotAutoRegisteringInterfaceGraphType() { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        public AotAutoRegisteringInterfaceGraphType(GraphQL.Types.Aot.AotAutoRegisteringInterfaceGraphType<TSource>? cloneFrom) { }
         protected override void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
         protected override System.Collections.Generic.IEnumerable<System.Reflection.MemberInfo> GetRegisteredMembers() { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
     }
     public abstract class AotAutoRegisteringObjectGraphType<TSource> : GraphQL.Types.AutoRegisteringObjectGraphType<TSource>
     {
-        public AotAutoRegisteringObjectGraphType() { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>() { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        public AotAutoRegisteringObjectGraphType(GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<TSource>? cloneFrom) { }
         protected override void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
         protected override sealed System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
-        protected virtual TSource GetMemberInstance(GraphQL.IResolveFieldContext context) { }
         protected override System.Collections.Generic.IEnumerable<System.Reflection.MemberInfo> GetRegisteredMembers() { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>() { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
+        protected static TSource GetMemberInstanceFromSource(GraphQL.IResolveFieldContext context) { }
     }
 }
 namespace GraphQL.Types.Relay

--- a/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net60/GraphQL.approved.txt
@@ -3496,38 +3496,38 @@ namespace GraphQL.Types.Aot
     }
     public abstract class AotAutoRegisteringInterfaceGraphType<TSource> : GraphQL.Types.AutoRegisteringInterfaceGraphType<TSource>
     {
-        public AotAutoRegisteringInterfaceGraphType() { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        public AotAutoRegisteringInterfaceGraphType(GraphQL.Types.Aot.AotAutoRegisteringInterfaceGraphType<TSource>? cloneFrom) { }
         protected override void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
         protected override System.Collections.Generic.IEnumerable<System.Reflection.MemberInfo> GetRegisteredMembers() { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
     }
     public abstract class AotAutoRegisteringObjectGraphType<TSource> : GraphQL.Types.AutoRegisteringObjectGraphType<TSource>
     {
-        public AotAutoRegisteringObjectGraphType() { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>() { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        public AotAutoRegisteringObjectGraphType(GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<TSource>? cloneFrom) { }
         protected override void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
         protected override sealed System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
-        protected virtual TSource GetMemberInstance(GraphQL.IResolveFieldContext context) { }
         protected override System.Collections.Generic.IEnumerable<System.Reflection.MemberInfo> GetRegisteredMembers() { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>() { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
+        protected static TSource GetMemberInstanceFromSource(GraphQL.IResolveFieldContext context) { }
     }
 }
 namespace GraphQL.Types.Relay

--- a/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/net80/GraphQL.approved.txt
@@ -3554,38 +3554,38 @@ namespace GraphQL.Types.Aot
     }
     public abstract class AotAutoRegisteringInterfaceGraphType<TSource> : GraphQL.Types.AutoRegisteringInterfaceGraphType<TSource>
     {
-        public AotAutoRegisteringInterfaceGraphType() { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        public AotAutoRegisteringInterfaceGraphType(GraphQL.Types.Aot.AotAutoRegisteringInterfaceGraphType<TSource>? cloneFrom) { }
         protected override void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
         protected override System.Collections.Generic.IEnumerable<System.Reflection.MemberInfo> GetRegisteredMembers() { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
     }
     public abstract class AotAutoRegisteringObjectGraphType<TSource> : GraphQL.Types.AutoRegisteringObjectGraphType<TSource>
     {
-        public AotAutoRegisteringObjectGraphType() { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>() { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        public AotAutoRegisteringObjectGraphType(GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<TSource>? cloneFrom) { }
         protected override void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
         protected override sealed System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
-        protected virtual TSource GetMemberInstance(GraphQL.IResolveFieldContext context) { }
         protected override System.Collections.Generic.IEnumerable<System.Reflection.MemberInfo> GetRegisteredMembers() { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>() { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
+        protected static TSource GetMemberInstanceFromSource(GraphQL.IResolveFieldContext context) { }
     }
 }
 namespace GraphQL.Types.Relay

--- a/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
+++ b/src/GraphQL.ApiTests/netstandard20+netstandard21/GraphQL.approved.txt
@@ -3263,38 +3263,38 @@ namespace GraphQL.Types.Aot
     }
     public abstract class AotAutoRegisteringInterfaceGraphType<TSource> : GraphQL.Types.AutoRegisteringInterfaceGraphType<TSource>
     {
-        public AotAutoRegisteringInterfaceGraphType() { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        public AotAutoRegisteringInterfaceGraphType(GraphQL.Types.Aot.AotAutoRegisteringInterfaceGraphType<TSource>? cloneFrom) { }
         protected override void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
         protected override System.Collections.Generic.IEnumerable<System.Reflection.MemberInfo> GetRegisteredMembers() { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
     }
     public abstract class AotAutoRegisteringObjectGraphType<TSource> : GraphQL.Types.AutoRegisteringObjectGraphType<TSource>
     {
-        public AotAutoRegisteringObjectGraphType() { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
-        protected virtual System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>() { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
-        protected GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        public AotAutoRegisteringObjectGraphType(GraphQL.Types.Aot.AotAutoRegisteringObjectGraphType<TSource>? cloneFrom) { }
         protected override void BuildFieldType(GraphQL.Types.FieldType fieldType, System.Reflection.MemberInfo memberInfo) { }
         protected override sealed System.Linq.Expressions.LambdaExpression BuildMemberInstanceExpression(System.Reflection.MemberInfo memberInfo) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
-        protected GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
-        protected virtual TSource GetMemberInstance(GraphQL.IResolveFieldContext context) { }
         protected override System.Collections.Generic.IEnumerable<System.Reflection.MemberInfo> GetRegisteredMembers() { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(GraphQL.Types.FieldType fieldType, System.Reflection.ParameterInfo parameterInfo) { }
+        protected static System.Func<GraphQL.IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>() { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<T>> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.IFieldResolver BuildFieldResolver<T>(System.Func<GraphQL.IResolveFieldContext, T> fn, bool requiresAccessor) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Collections.Generic.IAsyncEnumerable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.IObservable<T>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.Task<System.IObservable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.Collections.Generic.IAsyncEnumerable<T>>> fn) { }
+        protected static GraphQL.Resolvers.ISourceStreamResolver BuildSourceStreamResolver<T>(System.Func<GraphQL.IResolveFieldContext, System.Threading.Tasks.ValueTask<System.IObservable<T>>> fn) { }
+        protected static TSource GetMemberInstanceFromSource(GraphQL.IResolveFieldContext context) { }
     }
 }
 namespace GraphQL.Types.Relay

--- a/src/GraphQL/Types/Aot/AotAutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Aot/AotAutoRegisteringObjectGraphType.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Types.Aot;
 public abstract class AotAutoRegisteringObjectGraphType<TSource> : AutoRegisteringObjectGraphType<TSource>
 {
     /// <inheritdoc/>
-    public AotAutoRegisteringObjectGraphType() : base(true)
+    public AotAutoRegisteringObjectGraphType(AotAutoRegisteringObjectGraphType<TSource>? cloneFrom) : base(true, cloneFrom)
     {
     }
 
@@ -23,19 +23,19 @@ public abstract class AotAutoRegisteringObjectGraphType<TSource> : AutoRegisteri
     /// <summary>
     /// Returns the instance of <typeparamref name="TSource"/> for a given field resolution.
     /// </summary>
-    protected virtual TSource GetMemberInstance(IResolveFieldContext context) => (TSource)(context.Source ?? AutoRegisteringOutputHelper.ThrowSourceNullException());
+    protected static TSource GetMemberInstanceFromSource(IResolveFieldContext context) => (TSource)(context.Source ?? AutoRegisteringOutputHelper.ThrowSourceNullException());
     /// <inheritdoc/>
     protected sealed override LambdaExpression BuildMemberInstanceExpression(MemberInfo memberInfo) => throw new NotSupportedException();
 
     /// <summary>
     /// Builds a field argument and returns a resolver.
     /// </summary>
-    protected virtual Func<IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)
+    protected static Func<IResolveFieldContext, TParameterType> BuildArgument<TParameterType>(FieldType fieldType, ParameterInfo parameterInfo)
     {
-        var argumentInfo = GetArgumentInformation(fieldType, parameterInfo);
+        var argumentInfo = AutoRegisteringOutputHelper.GetArgumentInformation(typeof(TSource), AutoRegisteringHelper.GetTypeInformation(parameterInfo), fieldType, parameterInfo);
         var queryArgument = argumentInfo.ConstructQueryArgument();
-        ApplyArgumentAttributes(parameterInfo, queryArgument);
-        var resolver = GetParameterResolver<TParameterType>(argumentInfo);
+        AutoRegisteringOutputHelper.ApplyArgumentAttributes(parameterInfo, queryArgument);
+        var resolver = AutoRegisteringHelper.GetParameterResolver<TParameterType>(argumentInfo);
         if (resolver == null)
         {
             (fieldType.Arguments ??= new()).Add(queryArgument);
@@ -48,7 +48,7 @@ public abstract class AotAutoRegisteringObjectGraphType<TSource> : AutoRegisteri
     /// <summary>
     /// Gets a parameter resolver for a given source constructor parameter type.
     /// </summary>
-    protected virtual Func<IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>()
+    protected static Func<IResolveFieldContext, TParameterType> BuildConstructorParameter<TParameterType>()
     {
         if (typeof(TParameterType) == typeof(IResolveFieldContext))
         {
@@ -60,19 +60,19 @@ public abstract class AotAutoRegisteringObjectGraphType<TSource> : AutoRegisteri
     /// <summary>
     /// Builds a field resolver using the provided function.
     /// </summary>
-    protected IFieldResolver BuildFieldResolver<T>(Func<IResolveFieldContext, T> fn, bool requiresAccessor)
+    protected static IFieldResolver BuildFieldResolver<T>(Func<IResolveFieldContext, T> fn, bool requiresAccessor)
         => requiresAccessor
         ? new FuncFieldResolver<T>(context => fn(context))
         : new FuncFieldResolverNoAccessor<T>(context => fn(context));
 
     /// <inheritdoc cref="BuildFieldResolver{T}(Func{IResolveFieldContext, T}, bool)"/>
-    protected IFieldResolver BuildFieldResolver<T>(Func<IResolveFieldContext, Task<T>> fn, bool requiresAccessor)
+    protected static IFieldResolver BuildFieldResolver<T>(Func<IResolveFieldContext, Task<T>> fn, bool requiresAccessor)
         => requiresAccessor
         ? new FuncFieldResolver<T>(context => new ValueTask<T>(fn(context))!)
         : new FuncFieldResolverNoAccessor<T>(context => new ValueTask<T>(fn(context))!);
 
     /// <inheritdoc cref="BuildFieldResolver{T}(Func{IResolveFieldContext, T}, bool)"/>
-    protected IFieldResolver BuildFieldResolver<T>(Func<IResolveFieldContext, ValueTask<T>> fn, bool requiresAccessor)
+    protected static IFieldResolver BuildFieldResolver<T>(Func<IResolveFieldContext, ValueTask<T>> fn, bool requiresAccessor)
         => requiresAccessor
         ? new FuncFieldResolver<T>(fn!)
         : new FuncFieldResolverNoAccessor<T>(fn!);
@@ -80,26 +80,26 @@ public abstract class AotAutoRegisteringObjectGraphType<TSource> : AutoRegisteri
     /// <summary>
     /// Builds a source stream resolver using the provided function.
     /// </summary>
-    protected ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, IObservable<T>> fn)
+    protected static ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, IObservable<T>> fn)
         => new SourceStreamResolver<T>(fn);
 
     /// <inheritdoc cref="BuildSourceStreamResolver{T}(Func{IResolveFieldContext, IObservable{T}})"/>
-    protected ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, Task<IObservable<T>>> fn)
+    protected static ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, Task<IObservable<T>>> fn)
         => new SourceStreamResolver<T>(context => new ValueTask<IObservable<T>>(fn(context))!);
 
     /// <inheritdoc cref="BuildSourceStreamResolver{T}(Func{IResolveFieldContext, IObservable{T}})"/>
-    protected ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, ValueTask<IObservable<T>>> fn)
+    protected static ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, ValueTask<IObservable<T>>> fn)
         => new SourceStreamResolver<T>(fn!);
 
     /// <inheritdoc cref="BuildSourceStreamResolver{T}(Func{IResolveFieldContext, IObservable{T}})"/>
-    protected ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, IAsyncEnumerable<T>> fn)
+    protected static ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, IAsyncEnumerable<T>> fn)
         => new SourceStreamResolver<object?>(ObservableFromAsyncEnumerable<T>.Create(fn));
 
     /// <inheritdoc cref="BuildSourceStreamResolver{T}(Func{IResolveFieldContext, IObservable{T}})"/>
-    protected ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, Task<IAsyncEnumerable<T>>> fn)
+    protected static ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, Task<IAsyncEnumerable<T>>> fn)
         => new SourceStreamResolver<object?>(ObservableFromAsyncEnumerable<T>.Create(fn));
 
     /// <inheritdoc cref="BuildSourceStreamResolver{T}(Func{IResolveFieldContext, IObservable{T}})"/>
-    protected ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, ValueTask<IAsyncEnumerable<T>>> fn)
+    protected static ISourceStreamResolver BuildSourceStreamResolver<T>(Func<IResolveFieldContext, ValueTask<IAsyncEnumerable<T>>> fn)
         => new SourceStreamResolver<object?>(ObservableFromAsyncEnumerable<T>.Create(fn));
 }

--- a/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs
@@ -24,9 +24,10 @@ public class AutoRegisteringInterfaceGraphType<[NotAGraphType] TSourceType> : In
     /// Initializes a new instance of the <see cref="AutoRegisteringInterfaceGraphType{TSourceType}"/> class without adding any fields.
     /// </summary>
     /// <param name="configureGraph">When true, sets the name and processes all attributes defined for the source type.</param>
-    internal AutoRegisteringInterfaceGraphType(bool configureGraph)
+    /// <param name="cloneFrom">When not null, clones fields the specified instance. This is used internally for caching instances when <see cref="GlobalSwitches.EnableReflectionCaching"/> is enabled.</param>
+    internal AutoRegisteringInterfaceGraphType(bool configureGraph, AutoRegisteringInterfaceGraphType<TSourceType>? cloneFrom) : base(cloneFrom)
     {
-        if (configureGraph)
+        if (configureGraph && cloneFrom == null)
         {
             Name = typeof(TSourceType).GraphQLName();
             ConfigureGraph();

--- a/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
+++ b/src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs
@@ -24,9 +24,10 @@ public class AutoRegisteringObjectGraphType<[NotAGraphType] TSourceType> : Objec
     /// Initializes a new instance of the <see cref="AutoRegisteringObjectGraphType{TSourceType}"/> class without adding any fields.
     /// </summary>
     /// <param name="configureGraph">When true, sets the name and processes all attributes defined for the source type.</param>
-    internal AutoRegisteringObjectGraphType(bool configureGraph)
+    /// <param name="cloneFrom">When not null, clones fields the specified instance. This is used internally for caching instances when <see cref="GlobalSwitches.EnableReflectionCaching"/> is enabled.</param>
+    internal AutoRegisteringObjectGraphType(bool configureGraph, AutoRegisteringObjectGraphType<TSourceType>? cloneFrom)
     {
-        if (configureGraph)
+        if (configureGraph && cloneFrom == null)
         {
             Name = typeof(TSourceType).GraphQLName();
             ConfigureGraph();


### PR DESCRIPTION
This PR implements a caching mechanism for source-generated GraphQL types to improve performance when [`GlobalSwitches.EnableReflectionCaching`](src/GraphQL/GlobalSwitches.cs) is enabled.

## Key Changes

### Source Generator Changes ([`OutputGraphTypeGenerator.cs`](src/GraphQL.Analyzers.SourceGenerators/Generators/OutputGraphTypeGenerator.cs))

- **Static field architecture**: Converted instance fields (`_members`, `_getMemberInstance`) to `static readonly` fields to enable sharing across instances
- **Three-constructor pattern**: 
  - Static constructor: Initializes shared static fields (`_members` dictionary and `_getMemberInstance` resolver)
  - Public constructor: Delegates to private constructor with cached instance
  - Private constructor: Implements copy-on-write caching logic with `cloneFrom` parameter
- **Caching logic**: First instance populates fields normally, then creates and caches a clone of itself when `EnableReflectionCaching` is true. Subsequent instances use the cached clone via the copy constructor
- **Static helper methods**: Converted `ConstructField*`, `GetMemberInstance`, and `Build*` methods to `static` to work with the new architecture

### Runtime Base Class Changes

- [`AotAutoRegisteringObjectGraphType<TSource>`](src/GraphQL/Types/Aot/AotAutoRegisteringObjectGraphType.cs): Updated constructor signature to accept `cloneFrom` parameter, made helper methods static, renamed `GetMemberInstance` to `GetMemberInstanceFromSource`
- [`AotAutoRegisteringInterfaceGraphType<TSource>`](src/GraphQL/Types/Aot/AotAutoRegisteringInterfaceGraphType.cs): Similar changes for interface types
- [`AutoRegisteringObjectGraphType<TSource>`](src/GraphQL/Types/Composite/AutoRegisteringObjectGraphType.cs): Updated internal constructor to support cloning
- [`AutoRegisteringInterfaceGraphType<TSource>`](src/GraphQL/Types/Composite/AutoRegisteringInterfaceGraphType.cs): Updated internal constructor to support cloning

## Benefits

- **Performance improvement**: Eliminates redundant reflection operations when creating multiple instances of the same graph type
- **Memory efficiency**: Shares static field metadata across all instances of a type
- **Backward compatible**: Only activates when `GlobalSwitches.EnableReflectionCaching` is enabled
- **Thread-safe**: Static initialization ensures thread-safe lazy initialization

## Test Updates

All approved test snapshots have been updated to reflect the new generated code structure with static constructors, caching fields, and the three-constructor pattern.