### PR TITLE
Add server docs section with basic ASP.NET Core example

### DIFF
--- a/docs2/site/docs/server/overview.md
+++ b/docs2/site/docs/server/overview.md
@@ -1,0 +1,56 @@
+# Server Project (ASP.NET Core)
+
+GraphQL.NET provides the core execution engine. The `graphql-dotnet/server` project adds HTTP and WebSocket transport middleware for ASP.NET Core.
+
+## Installation
+
+Install either the all-in-one package:
+
+```bash
+dotnet add package GraphQL.Server.All
+```
+
+Or install transport + selected UI packages explicitly:
+
+```bash
+dotnet add package GraphQL.Server.Transports.AspNetCore
+dotnet add package GraphQL.Server.Ui.GraphiQL
+dotnet add package GraphQL.SystemTextJson
+```
+
+## Basic ASP.NET Core example
+
+```csharp
+using GraphQL;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddGraphQL(b => b
+    .AddAutoSchema<Query>()
+    .AddSystemTextJson());
+
+var app = builder.Build();
+
+app.UseWebSockets();
+app.MapGraphQL("/graphql");
+app.MapGraphQLGraphiQL("/ui/graphiql");
+
+app.Run();
+
+public class Query
+{
+    public static string Hero() => "Luke Skywalker";
+}
+```
+
+After startup, you can test with:
+
+- GraphQL endpoint: `/graphql`
+- GraphiQL UI: `/ui/graphiql`
+
+## Next steps
+
+- For full server configuration options, see the server README:
+  - https://github.com/graphql-dotnet/server
+- For working reference projects, see server samples:
+  - https://github.com/graphql-dotnet/server/tree/master/samples

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -72,6 +72,11 @@
             file: relay.md
           - title: Global Switches
             file: global-switches.md
+      - title: Server
+        dir: server
+        items:
+          - title: Overview
+            file: overview.md
       - title: Guides
         dir: guides
         items:


### PR DESCRIPTION
## Summary
Adds a dedicated server documentation section to the docs site with a basic ASP.NET Core setup example.

## What changed
- Added a new docs page:
  - `docs2/site/docs/server/overview.md`
- Added a new **Server** section in `docs2/site/sitemap.yml` and linked the page into the sidebar.
- Included a minimal setup covering package installation, service registration, middleware mapping, and quick test URLs.
- Added links to `graphql-dotnet/server` README and samples for deeper configuration.

## Related issue
Refs #2817.
