### PR TITLE
Add custom validation sample project and sample index docs

### DIFF
--- a/GraphQL.slnx
+++ b/GraphQL.slnx
@@ -85,6 +85,7 @@
     <File Path="docs2/site/docs/getting-started/query-organization.md" />
     <File Path="docs2/site/docs/getting-started/query-validation.md" />
     <File Path="docs2/site/docs/getting-started/relay.md" />
+    <File Path="docs2/site/docs/getting-started/samples.md" />
     <File Path="docs2/site/docs/getting-started/schema-types.md" />
     <File Path="docs2/site/docs/getting-started/subscriptions.md" />
     <File Path="docs2/site/docs/getting-started/unions.md" />
@@ -122,6 +123,7 @@
     <Project Path="samples/GraphQL.Federation.TypeFirst.Sample4/GraphQL.Federation.TypeFirst.Sample4.csproj" />
     <Project Path="samples/GraphQL.Harness/GraphQL.Harness.csproj" />
     <Project Path="samples/GraphQL.Server.Polyfill/GraphQL.Server.Polyfill.csproj" />
+    <Project Path="samples/GraphQL.ValidationRules.Sample/GraphQL.ValidationRules.Sample.csproj" />
     <Project Path="src/GraphQL.StarWars.TypeFirst/GraphQL.StarWars.TypeFirst.csproj" />
     <Project Path="src/GraphQL.StarWars/GraphQL.StarWars.csproj" />
   </Folder>

--- a/docs2/site/docs/getting-started/query-validation.md
+++ b/docs2/site/docs/getting-started/query-validation.md
@@ -27,6 +27,8 @@ await schema.ExecuteAsync(_ =>
 });
 ```
 
+For a runnable end-to-end example, see `samples/GraphQL.ValidationRules.Sample`.
+
 ## Setting validation rules on input arguments or input object fields
 
 When defining a schema, you can set validation rules on input arguments or input object fields.

--- a/docs2/site/docs/getting-started/samples.md
+++ b/docs2/site/docs/getting-started/samples.md
@@ -1,0 +1,36 @@
+# Samples
+
+This repository includes multiple runnable examples. Use them as reference implementations for setup patterns, schema styles, and project structure.
+
+## Sample index
+
+| Sample | Focus | Path |
+| --- | --- | --- |
+| GraphQL.ValidationRules.Sample | Custom validation rule with `ValidationRuleBase` and `DocumentValidator.CoreRules` | `samples/GraphQL.ValidationRules.Sample` |
+| GraphQL.AotCompilationSample.CodeFirst | Native AOT setup with code-first schema | `samples/GraphQL.AotCompilationSample.CodeFirst` |
+| GraphQL.AotCompilationSample.TypeFirst | Native AOT setup with type-first schema | `samples/GraphQL.AotCompilationSample.TypeFirst` |
+| GraphQL.StarWars | Code-first StarWars API sample | `src/GraphQL.StarWars` |
+| GraphQL.StarWars.TypeFirst | Type-first StarWars API sample | `src/GraphQL.StarWars.TypeFirst` |
+| GraphQL.Harness | Full-featured ASP.NET Core host with auth, subscriptions, and tooling | `samples/GraphQL.Harness` |
+| GraphQL.DataLoader.Sample.Default | DataLoader usage without DI container integration | `samples/GraphQL.DataLoader.Sample.Default` |
+| GraphQL.DataLoader.Sample.DI | DataLoader usage with DI container integration | `samples/GraphQL.DataLoader.Sample.DI` |
+| GraphQL.Federation.SchemaFirst.Sample1 | Federation sample using schema-first approach | `samples/GraphQL.Federation.SchemaFirst.Sample1` |
+| GraphQL.Federation.SchemaFirst.Sample2 | Federation sample using schema-first approach (alternate setup) | `samples/GraphQL.Federation.SchemaFirst.Sample2` |
+| GraphQL.Federation.CodeFirst.Sample3 | Federation sample using code-first approach | `samples/GraphQL.Federation.CodeFirst.Sample3` |
+| GraphQL.Federation.TypeFirst.Sample4 | Federation sample using type-first approach | `samples/GraphQL.Federation.TypeFirst.Sample4` |
+
+## Running a sample
+
+Run any sample from the repository root:
+
+```bash
+dotnet run --project <path-to-sample-csproj>
+```
+
+Examples:
+
+```bash
+dotnet run --project samples/GraphQL.ValidationRules.Sample/GraphQL.ValidationRules.Sample.csproj
+dotnet run --project samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj
+dotnet run --project samples/GraphQL.Harness/GraphQL.Harness.csproj
+```

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -14,6 +14,8 @@
             file: introduction.md
           - title: Installation
             file: installation.md
+          - title: Samples
+            file: samples.md
           - title: GraphiQL
             file: graphiql.md
           - title: Altair GraphQL

--- a/samples/GraphQL.ValidationRules.Sample/GraphQL.ValidationRules.Sample.csproj
+++ b/samples/GraphQL.ValidationRules.Sample/GraphQL.ValidationRules.Sample.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GraphQL\GraphQL.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GraphQL.ValidationRules.Sample/Program.cs
+++ b/samples/GraphQL.ValidationRules.Sample/Program.cs
@@ -1,0 +1,81 @@
+using GraphQL;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQLParser.AST;
+
+Console.WriteLine("GraphQL.NET custom validation rule sample");
+Console.WriteLine();
+
+var schema = new ValidationSampleSchema();
+var executer = new DocumentExecuter();
+
+await ExecuteAndPrintAsync("{ publicMessage }");
+await ExecuteAndPrintAsync("{ secretMessage }");
+
+return;
+
+async Task ExecuteAndPrintAsync(string query)
+{
+    var result = await executer.ExecuteAsync(options =>
+    {
+        options.Schema = schema;
+        options.Query = query;
+        options.ValidationRules = DocumentValidator.CoreRules.Append(BlockSecretFieldValidationRule.Instance);
+        options.ThrowOnUnhandledException = true;
+    }).ConfigureAwait(false);
+
+    Console.WriteLine($"Query: {query}");
+    if (result.Errors?.Count > 0)
+    {
+        foreach (var error in result.Errors)
+            Console.WriteLine($"Validation error: {error.Message}");
+    }
+    else
+    {
+        Console.WriteLine("Validation passed.");
+    }
+    Console.WriteLine();
+}
+
+public sealed class ValidationSampleSchema : Schema
+{
+    public ValidationSampleSchema()
+    {
+        Query = new ValidationSampleQuery();
+    }
+}
+
+public sealed class ValidationSampleQuery : ObjectGraphType
+{
+    public ValidationSampleQuery()
+    {
+        Field<StringGraphType>("publicMessage")
+            .Resolve(_ => "This field is always allowed.");
+
+        Field<StringGraphType>("secretMessage")
+            .Resolve(_ => "This field is blocked by custom validation.");
+    }
+}
+
+public sealed class BlockSecretFieldValidationRule : ValidationRuleBase
+{
+    public static readonly BlockSecretFieldValidationRule Instance = new();
+
+    private BlockSecretFieldValidationRule()
+    {
+    }
+
+    private static readonly MatchingNodeVisitor<GraphQLField> _visitor = new((field, context) =>
+    {
+        if (field.Name.Value == "secretMessage")
+        {
+            context.ReportError(new ValidationError(
+                context.Document.Source,
+                "BLOCKED_FIELD",
+                "Field 'secretMessage' is blocked by BlockSecretFieldValidationRule.",
+                field));
+        }
+    });
+
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_visitor);
+}

--- a/samples/GraphQL.ValidationRules.Sample/README.md
+++ b/samples/GraphQL.ValidationRules.Sample/README.md
@@ -1,0 +1,21 @@
+# GraphQL.ValidationRules.Sample
+
+This sample demonstrates how to register and run a custom validation rule that blocks access to a specific field.
+
+## What it shows
+
+- Building a schema with two query fields
+- Implementing a custom `ValidationRuleBase`
+- Running GraphQL execution with `DocumentValidator.CoreRules` plus a custom rule
+- Returning a validation error when the blocked field is requested
+
+## Run
+
+```bash
+dotnet run --project samples/GraphQL.ValidationRules.Sample/GraphQL.ValidationRules.Sample.csproj
+```
+
+Expected behavior:
+
+- Query `{ publicMessage }` passes validation
+- Query `{ secretMessage }` returns a validation error from the custom rule


### PR DESCRIPTION
Related to #2406

This PR delivers the remaining docs/sample work from the bounty issue:

1. Adds a new runnable sample project for custom validation rules:
   - `samples/GraphQL.ValidationRules.Sample`
   - demonstrates `ValidationRuleBase` + `DocumentValidator.CoreRules` composition
2. Adds a dedicated sample index page documenting available repository examples:
   - `docs2/site/docs/getting-started/samples.md`
3. Wires the new docs page into docs navigation:
   - `docs2/site/sitemap.yml`
4. Adds the docs file and sample project to solution tree:
   - `GraphQL.slnx`
5. Adds a cross-link from query validation docs to the runnable sample:
   - `docs2/site/docs/getting-started/query-validation.md`

I noticed #4319 appears to be a stale draft from Jan 2026 with overlapping scope. This PR keeps scope focused on issue requirements and includes the explicit sample project requested by the issue.