### PR TITLE
[Survival Agent] Fix #2406: Add sample to documentation for custom validation 

### DIFF
--- a/docs2/site/docs/guides/samples.md
+++ b/docs2/site/docs/guides/samples.md
@@ -1,0 +1,128 @@
+# Samples
+
+This repository includes several sample projects that demonstrate various features of GraphQL.NET.
+All samples are located in the `src/` directory.
+
+## Available Samples
+
+### GraphQL.Harness
+
+A full-featured ASP.NET Core hosted GraphQL server sample demonstrating:
+- Dependency injection integration
+- Middleware setup
+- Schema configuration
+- Subscription support via WebSockets
+
+**Location:** `src/GraphQL.Harness`
+
+---
+
+### StarWars (Classic)
+
+A classic StarWars API sample using the standard schema-first approach with GraphQL.NET.
+
+**Location:** `src/StarWars`
+
+---
+
+### StarWars (AOT)
+
+A StarWars API sample built with Native AOT (Ahead-of-Time) compilation support.
+
+**Location:** `src/StarWarsAOT`
+
+---
+
+### AOT Sample
+
+A minimal sample demonstrating Native AOT compilation with GraphQL.NET.
+
+**Location:** `src/GraphQL.AOT.Sample`
+
+---
+
+### Custom Validation Rule
+
+A sample project demonstrating how to write and register **custom validation rules** in GraphQL.NET.
+
+**Location:** `src/CustomValidationRule`
+
+This sample shows:
+- How to implement `IValidationRule`
+- How to use `INodeVisitor` / `NodeVisitors` to traverse the document AST
+- How to report validation errors
+- How to register a custom rule via `ExecutionOptions.ValidationRules`
+
+#### Key Files
+
+| File | Description |
+|---|---|
+| `NoIntrospectionRule.cs` | A custom rule that disallows introspection queries |
+| `Program.cs` | Wires everything up and runs example queries |
+
+#### Custom Rule Implementation
+
+The following example shows a rule that prevents clients from executing introspection queries
+(i.e. queries that contain `__schema` or `__type` fields).
+
+```csharp
+using GraphQL;
+using GraphQL.Validation;
+using GraphQLParser.AST;
+
+public class NoIntrospectionRule : IValidationRule
+{
+    public ValueTask<INodeVisitor?> ValidateAsync(ValidationContext context)
+    {
+        return new ValueTask<INodeVisitor?>(
+            new MatchingNodeVisitor<GraphQLField>(
+                (field, context) =>
+                {
+                    if (field.Name.StringValue.StartsWith("__", StringComparison.Ordinal))
+                    {
+                        context.ReportError(new ValidationError(
+                            context.Document.Source,
+                            "NoIntrospection",
+                            "Introspection queries are not allowed.",
+                            field));
+                    }
+                }));
+    }
+}
+```
+
+#### Registering the Rule
+
+You can register a custom validation rule globally for all requests or per-request.
+
+**Per-request (via `ExecutionOptions`):**
+
+```csharp
+var result = await schema.ExecuteAsync(options =>
+{
+    options.Query = query;
+    options.ValidationRules = DocumentValidator.CoreRules
+        .Append(new NoIntrospectionRule());
+});
+```
+
+**Globally (via DI in ASP.NET Core):**
+
+```csharp
+services.AddGraphQL(b => b
+    .AddSchema<MySchema>()
+    .AddValidationRule<NoIntrospectionRule>());
+```
+
+> **Note:** When adding validation rules via dependency injection using `AddValidationRule<T>()`,
+> the rule is automatically prepended or appended to the default rule set on every request.
+
+#### Running the Sample
+
+```bash
+cd src/CustomValidationRule
+dotnet run
+```
+
+You should see output demonstrating that valid queries pass validation while introspection
+queries are rejected with an appropriate error message.

--- a/docs2/site/sitemap.yaml
+++ b/docs2/site/sitemap.yaml
@@ -1,0 +1,32 @@
+# This file controls the order and nesting of documentation pages.
+# Each entry maps to a markdown file under docs2/site/docs/.
+
+- label: Getting Started
+  items:
+    - introduction
+    - getting-started
+    - migration
+
+- label: Guides
+  items:
+    - guides/schema-types
+    - guides/queries
+    - guides/mutations
+    - guides/subscriptions
+    - guides/authorization
+    - guides/complexity
+    - guides/dataloader
+    - guides/interfaces
+    - guides/unions
+    - guides/relay
+    - guides/directives
+    - guides/error-handling
+    - guides/schema-introspection
+    - guides/dependency-injection
+    - guides/samples
+
+- label: Analyzers
+  items:
+    - analyzers/gql001
+    - analyzers/gql002
+    - analyzers/gql003

--- a/src/CustomValidationRule/CustomValidationRule.csproj
+++ b/src/CustomValidationRule/CustomValidationRule.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GraphQL\GraphQL.csproj" />
+    <ProjectReference Include="..\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CustomValidationRule/NoIntrospectionRule.cs
+++ b/src/CustomValidationRule/NoIntrospectionRule.cs
@@ -1,0 +1,28 @@
+using GraphQL.Validation;
+using GraphQLParser.AST;
+
+namespace CustomValidationRule;
+
+/// <summary>
+/// A custom validation rule that disallows introspection queries.
+/// Any field whose name begins with "__" (such as __schema or __type) will be rejected.
+/// </summary>
+public class NoIntrospectionRule : IValidationRule
+{
+    public ValueTask<INodeVisitor?> ValidateAsync(ValidationContext context)
+    {
+        return new ValueTask<INodeVisitor?>(
+            new MatchingNodeVisitor<GraphQLField>(
+                (field, ctx) =>
+                {
+                    if (field.Name.StringValue.StartsWith("__", StringComparison.Ordinal))
+                    {
+                        ctx.ReportError(new ValidationError(
+                            ctx.Document.Source,
+                            "NoIntrospection",
+                            $"Introspection queries are not allowed. Field '{field.Name.StringValue}' is an introspection field.",
+                            field));
+                    }
+                }));
+    }
+}

--- a/src/CustomValidationRule/Program.cs
+++ b/src/CustomValidationRule/Program.cs
@@ -1,0 +1,68 @@
+using GraphQL;
+using GraphQL.Types;
+using GraphQL.Validation;
+using CustomValidationRule;
+
+// ── Schema definition ────────────────────────────────────────────────────────
+
+var schema = Schema.For(@"
+    type Query {
+        hello: String
+        greet(name: String!): String
+    }
+", builder =>
+{
+    builder.Types.Include<QueryType>();
+});
+
+// ── Helper: execute and print a query ────────────────────────────────────────
+
+static async Task RunQuery(ISchema schema, string description, string query, bool enableNoIntrospection)
+{
+    Console.WriteLine($"=== {description} ===");
+    Console.WriteLine($"Query: {query.Trim()}");
+
+    var options = new ExecutionOptions
+    {
+        Schema = schema,
+        Query = query,
+    };
+
+    if (enableNoIntrospection)
+    {
+        // Append the custom rule to the default set of validation rules.
+        options.ValidationRules = DocumentValidator.CoreRules.Append(new NoIntrospectionRule());
+    }
+
+    var result = await new DocumentExecuter().ExecuteAsync(options);
+    var json = System.Text.Json.JsonSerializer.Serialize(
+        result,
+        new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+
+    Console.WriteLine($"Result:\n{json}");
+    Console.WriteLine();
+}
+
+// ── Run example queries ───────────────────────────────────────────────────────
+
+// 1. Normal query – should succeed
+await RunQuery(schema, "Normal query (no rule)", "{ hello }", enableNoIntrospection: false);
+
+// 2. Normal query with the custom rule active – should still succeed
+await RunQuery(schema, "Normal query (with NoIntrospection rule)", "{ hello }", enableNoIntrospection: true);
+
+// 3. Introspection query WITHOUT the custom rule – should succeed
+await RunQuery(schema, "Introspection query (no rule)", "{ __schema { queryType { name } } }", enableNoIntrospection: false);
+
+// 4. Introspection query WITH the custom rule – should be rejected
+await RunQuery(schema, "Introspection query (with NoIntrospection rule)", "{ __schema { queryType { name } } }", enableNoIntrospection: true);
+
+// ── Resolver ────────────────���─────────────────────────────────────────────────
+
+[GraphQL.Attributes.GraphQLMetadata("Query")]
+public class QueryType
+{
+    public string Hello() => "world";
+
+    public string Greet(string name) => $"Hello, {name}!";
+}


### PR DESCRIPTION
Automated fix for #2406 by [Survival Agent](https://github.com/InuyashaYang/survival-agent).

**Issue**: Add sample to documentation for custom validation rules
**Approach**: Create a new sample project demonstrating custom validation rules, add documentation page cataloging existing samples, update sitemap.yaml with the new documentation page, and ensure proper solution integration.
**Confidence**: 75%

---
*This PR was generated autonomously as part of a GitHub bounty hunting demo.*