### PR TITLE
Add schema-first sample project and sample catalog docs

### DIFF
--- a/GraphQL.slnx
+++ b/GraphQL.slnx
@@ -85,6 +85,7 @@
     <File Path="docs2/site/docs/getting-started/query-organization.md" />
     <File Path="docs2/site/docs/getting-started/query-validation.md" />
     <File Path="docs2/site/docs/getting-started/relay.md" />
+    <File Path="docs2/site/docs/getting-started/samples.md" />
     <File Path="docs2/site/docs/getting-started/schema-types.md" />
     <File Path="docs2/site/docs/getting-started/subscriptions.md" />
     <File Path="docs2/site/docs/getting-started/unions.md" />
@@ -121,6 +122,7 @@
     <Project Path="samples/GraphQL.Federation.SchemaFirst.Sample2/GraphQL.Federation.SchemaFirst.Sample2.csproj" />
     <Project Path="samples/GraphQL.Federation.TypeFirst.Sample4/GraphQL.Federation.TypeFirst.Sample4.csproj" />
     <Project Path="samples/GraphQL.Harness/GraphQL.Harness.csproj" />
+    <Project Path="samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj" />
     <Project Path="samples/GraphQL.Server.Polyfill/GraphQL.Server.Polyfill.csproj" />
     <Project Path="src/GraphQL.StarWars.TypeFirst/GraphQL.StarWars.TypeFirst.csproj" />
     <Project Path="src/GraphQL.StarWars/GraphQL.StarWars.csproj" />

--- a/docs2/site/docs/getting-started/samples.md
+++ b/docs2/site/docs/getting-started/samples.md
@@ -1,0 +1,30 @@
+# Samples
+
+This page tracks runnable examples in the repository.
+
+## Core samples
+
+| Sample | Approach | Path |
+| --- | --- | --- |
+| GraphQL.SchemaFirst.Sample | Schema-first (`Schema.For`) | `samples/GraphQL.SchemaFirst.Sample` |
+| GraphQL.AotCompilationSample.CodeFirst | Code-first AOT | `samples/GraphQL.AotCompilationSample.CodeFirst` |
+| GraphQL.AotCompilationSample.TypeFirst | Type-first AOT | `samples/GraphQL.AotCompilationSample.TypeFirst` |
+| GraphQL.StarWars | Code-first | `src/GraphQL.StarWars` |
+| GraphQL.StarWars.TypeFirst | Type-first | `src/GraphQL.StarWars.TypeFirst` |
+| GraphQL.Harness | Full server sample | `samples/GraphQL.Harness` |
+
+## Running samples
+
+From repository root:
+
+```bash
+dotnet run --project <path-to-csproj>
+```
+
+Examples:
+
+```bash
+dotnet run --project samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+dotnet run --project samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj
+dotnet run --project samples/GraphQL.Harness/GraphQL.Harness.csproj
+```

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -14,6 +14,8 @@
             file: introduction.md
           - title: Installation
             file: installation.md
+          - title: Samples
+            file: samples.md
           - title: GraphiQL
             file: graphiql.md
           - title: Altair GraphQL

--- a/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+++ b/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GraphQL.SchemaFirst.Sample/Program.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/Program.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using GraphQL;
+using GraphQL.SystemTextJson;
 using GraphQL.Types;
 
 Console.WriteLine("GraphQL.NET Schema-First sample");

--- a/samples/GraphQL.SchemaFirst.Sample/Program.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/Program.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using GraphQL;
+using GraphQL.Types;
+
+Console.WriteLine("GraphQL.NET Schema-First sample");
+Console.WriteLine();
+
+var schema = Schema.For(
+    """
+    type Droid {
+      id: String!
+      name: String!
+    }
+
+    type Query {
+      hero: Droid
+    }
+    """,
+    builder => builder.Types.Include<Query>());
+
+var json = await schema.ExecuteAsync(options =>
+{
+    options.Query = "{ hero { id name } }";
+}).ConfigureAwait(false);
+
+Console.WriteLine(json);
+
+using var document = JsonDocument.Parse(json);
+var hero = document.RootElement.GetProperty("data").GetProperty("hero");
+
+if (hero.GetProperty("id").GetString() != "1" ||
+    hero.GetProperty("name").GetString() != "R2-D2")
+{
+    Console.WriteLine("Unexpected schema-first sample result.");
+    return 1;
+}
+
+return 0;
+
+public sealed class Query
+{
+    [GraphQLMetadata("hero")]
+    public Droid GetHero() => new() { Id = "1", Name = "R2-D2" };
+}
+
+public sealed class Droid
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+}

--- a/samples/GraphQL.SchemaFirst.Sample/README.md
+++ b/samples/GraphQL.SchemaFirst.Sample/README.md
@@ -1,0 +1,21 @@
+# GraphQL.SchemaFirst.Sample
+
+This sample demonstrates the schema-first approach with `Schema.For(...)` and SDL.
+
+## What it demonstrates
+
+- Defining schema types with SDL
+- Mapping resolver methods via `GraphQLMetadata`
+- Executing a query and printing JSON output
+
+## Run
+
+```bash
+dotnet run --project samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+```
+
+Expected output includes:
+
+```json
+{"data":{"hero":{"id":"1","name":"R2-D2"}}}
+```


### PR DESCRIPTION
Related to #1025

This PR adds a concrete schema-first sample and updates sample documentation/navigation.

What is included:
1. New runnable sample project using `Schema.For(...)`:
   - `samples/GraphQL.SchemaFirst.Sample`
2. New samples catalog page that lists key repository samples, including AOT, StarWars, Harness, and the new schema-first sample:
   - `docs2/site/docs/getting-started/samples.md`
3. Docs navigation update:
   - `docs2/site/sitemap.yml`
4. Solution tree updates:
   - `GraphQL.slnx`

The new sample executes a query and validates that the result contains `hero { id, name }` from schema-first resolver mappings.