### PR TITLE
Add Schema-First sample project and samples catalog documentation (fixes #1025)

### DIFF
--- a/GraphQL.slnx
+++ b/GraphQL.slnx
@@ -73,6 +73,7 @@
     <File Path="docs2/site/docs/getting-started/fragments.md" />
     <File Path="docs2/site/docs/getting-started/global-switches.md" />
     <File Path="docs2/site/docs/getting-started/graphiql.md" />
+    <File Path="docs2/site/docs/getting-started/samples.md" />
     <File Path="docs2/site/docs/getting-started/installation.md" />
     <File Path="docs2/site/docs/getting-started/interfaces.md" />
     <File Path="docs2/site/docs/getting-started/introduction.md" />
@@ -121,6 +122,7 @@
     <Project Path="samples/GraphQL.Federation.SchemaFirst.Sample2/GraphQL.Federation.SchemaFirst.Sample2.csproj" />
     <Project Path="samples/GraphQL.Federation.TypeFirst.Sample4/GraphQL.Federation.TypeFirst.Sample4.csproj" />
     <Project Path="samples/GraphQL.Harness/GraphQL.Harness.csproj" />
+    <Project Path="samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj" />
     <Project Path="samples/GraphQL.Server.Polyfill/GraphQL.Server.Polyfill.csproj" />
     <Project Path="src/GraphQL.StarWars.TypeFirst/GraphQL.StarWars.TypeFirst.csproj" />
     <Project Path="src/GraphQL.StarWars/GraphQL.StarWars.csproj" />

--- a/docs2/site/docs/getting-started/samples.md
+++ b/docs2/site/docs/getting-started/samples.md
@@ -1,0 +1,107 @@
+# Samples
+
+The GraphQL.NET repository includes a number of sample projects that demonstrate various features and usage patterns.
+All samples can be found in the [`samples/`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples) directory.
+
+## Schema-First Sample
+
+[`samples/GraphQL.SchemaFirst.Sample`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.SchemaFirst.Sample)
+
+Demonstrates the **Schema-First** (SDL-First) approach to building a GraphQL API with GraphQL.NET.
+In the Schema-First approach, you write the schema in the [GraphQL Schema Definition Language (SDL)](https://graphql.org/learn/schema/#type-language)
+and map it to C# resolver classes using `SchemaBuilder`.
+
+Key features demonstrated:
+- Defining the schema in a `.gql` SDL file embedded as a resource
+- Using `SchemaBuilder` to map SDL types to C# classes
+- Injecting services into resolvers via `[FromServices]`
+- Setting up a minimal ASP.NET Core web application with GraphiQL
+
+## GraphQL.Harness
+
+[`samples/GraphQL.Harness`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.Harness)
+
+A full-featured sample ASP.NET Core web application that demonstrates many GraphQL.NET features.
+It supports multiple UI clients including [GraphiQL](https://github.com/graphql/graphiql), [Altair](https://altairgraphql.dev/),
+[Voyager](https://github.com/graphql-kit/graphql-voyager), and [Firecamp](https://firecamp.dev/).
+
+Key features demonstrated:
+- Code-First schema definition using `ObjectGraphType<T>`
+- ASP.NET Core integration
+- Subscriptions via WebSockets
+- Multiple serialization options
+- DataLoader usage
+
+## AOT Compilation Samples
+
+### Code-First AOT Sample
+
+[`samples/GraphQL.AotCompilationSample.CodeFirst`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.AotCompilationSample.CodeFirst)
+
+Demonstrates running GraphQL.NET with **Ahead-of-Time (AOT) compilation** using the **Code-First** approach.
+
+Key features demonstrated:
+- Publishing with `PublishAot=true`
+- Manual service registration required for AOT
+- Limitations and workarounds for AOT scenarios
+
+### Type-First AOT Sample
+
+[`samples/GraphQL.AotCompilationSample.TypeFirst`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.AotCompilationSample.TypeFirst)
+
+Demonstrates running GraphQL.NET with **AOT compilation** using the **Type-First** (CLR-First) approach,
+where the schema is inferred from plain C# classes via attributes.
+
+## DataLoader Samples
+
+### DataLoader with Default Configuration
+
+[`samples/GraphQL.DataLoader.Sample.Default`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.DataLoader.Sample.Default)
+
+Demonstrates using **DataLoader** to batch and cache data-fetching operations.
+
+### DataLoader with Dependency Injection
+
+[`samples/GraphQL.DataLoader.Sample.DI`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.DataLoader.Sample.DI)
+
+Demonstrates using **DataLoader** together with ASP.NET Core **Dependency Injection** and Entity Framework Core.
+
+Key features demonstrated:
+- `IDataLoaderContextAccessor` usage
+- Scoped DataLoader registration with DI
+
+## Federation Samples
+
+These samples demonstrate [Apollo Federation](https://www.apollographql.com/docs/federation/) support in GraphQL.NET.
+
+### Federation Schema-First Sample 1
+
+[`samples/GraphQL.Federation.SchemaFirst.Sample1`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.Federation.SchemaFirst.Sample1)
+
+Federation subgraph using the **Schema-First** approach with Federation v1.
+
+### Federation Schema-First Sample 2
+
+[`samples/GraphQL.Federation.SchemaFirst.Sample2`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.Federation.SchemaFirst.Sample2)
+
+Federation subgraph using the **Schema-First** approach with Federation v2.
+
+### Federation Code-First Sample 3
+
+[`samples/GraphQL.Federation.CodeFirst.Sample3`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.Federation.CodeFirst.Sample3)
+
+Federation subgraph using the **Code-First** approach.
+
+### Federation Type-First Sample 4
+
+[`samples/GraphQL.Federation.TypeFirst.Sample4`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.Federation.TypeFirst.Sample4)
+
+Federation subgraph using the **Type-First** approach.
+
+## StarWars Projects
+
+The [`src/`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/src) directory also contains StarWars-themed
+reference implementations used as the basis for many tests:
+
+- [`src/GraphQL.StarWars`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/src/GraphQL.StarWars) — Code-First StarWars schema
+- [`src/GraphQL.StarWars.TypeFirst`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/src/GraphQL.StarWars.TypeFirst) — Type-First StarWars schema

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -72,6 +72,8 @@
             file: relay.md
           - title: Global Switches
             file: global-switches.md
+          - title: Samples
+            file: samples.md
       - title: Guides
         dir: guides
         items:

--- a/samples/GraphQL.SchemaFirst.Sample/DroidRepository.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/DroidRepository.cs
@@ -1,0 +1,18 @@
+using GraphQL.SchemaFirst.Sample.Schema;
+
+namespace GraphQL.SchemaFirst.Sample;
+
+public class DroidRepository
+{
+    private readonly List<Droid> _droids =
+    [
+        new Droid { Id = "1", Name = "R2-D2", PrimaryFunction = "Astromech" },
+        new Droid { Id = "2", Name = "C-3PO", PrimaryFunction = "Protocol" },
+    ];
+
+    public Droid? GetHero() => _droids.FirstOrDefault();
+
+    public IEnumerable<Droid> GetAllDroids() => _droids;
+
+    public Droid? GetDroidById(string id) => _droids.SingleOrDefault(d => d.Id == id);
+}

--- a/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+++ b/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Schema.gql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Schema.gql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="8.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GraphQL.MicrosoftDI\GraphQL.MicrosoftDI.csproj" />
+    <ProjectReference Include="..\..\src\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GraphQL.SchemaFirst.Sample/Program.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/Program.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using GraphQL.SchemaFirst.Sample.Schema;
+using GraphQL.Transport;
+using GraphQL.Types;
+using GraphQL.Utilities;
+
+namespace GraphQL.SchemaFirst.Sample;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        // Configure services
+        var builder = WebApplication.CreateBuilder(args);
+        builder.Services.AddSingleton<DroidRepository>();
+        builder.Services.AddSingleton<Query>();
+        builder.Services.AddGraphQL(b => b
+            .AddSchema(BuildSchema)
+            .AddSystemTextJson());
+
+        // Build the web application
+        var app = builder.Build();
+
+        // Some simple GraphQL middleware (NOTE: it is suggested to use the GraphQL.Server.Transports.AspNetCore package instead)
+        app.MapPost("/graphql", GraphQLHttpMiddlewareAsync);
+
+        // Add a UI package for testing
+        app.UseGraphQLGraphiQL("/");
+
+        // Optional: ensure that the schema builds and initializes
+        {
+            var schema = app.Services.GetRequiredService<ISchema>();
+            schema.Initialize();
+        }
+
+        // Start the application
+        await app.RunAsync().ConfigureAwait(false);
+    }
+
+    private static ISchema BuildSchema(IServiceProvider serviceProvider)
+    {
+        // load the schema-first SDL from an embedded resource
+        var filename = "GraphQL.SchemaFirst.Sample.Schema.gql";
+        var assembly = Assembly.GetExecutingAssembly();
+        var stream = assembly.GetManifestResourceStream(filename)
+            ?? throw new InvalidOperationException("Could not read schema definitions from embedded resource.");
+        var reader = new StreamReader(stream);
+        var schemaString = reader.ReadToEnd();
+
+        // define the known types and their resolvers using SchemaBuilder
+        var schemaBuilder = new SchemaBuilder
+        {
+            ServiceProvider = serviceProvider,
+        };
+        schemaBuilder.Types.Include<Query>();
+
+        // build the schema from the SDL string
+        return schemaBuilder.Build(schemaString);
+    }
+
+    private static async Task GraphQLHttpMiddlewareAsync(HttpContext context)
+    {
+        // NOTE: it is suggested to use the GraphQL.Server.Transports.AspNetCore package instead
+
+        // pull the serializer and executer from the DI container
+        var serializer = context.RequestServices.GetRequiredService<IGraphQLSerializer>();
+        var executer = context.RequestServices.GetRequiredService<IDocumentExecuter>();
+
+        // read the request (ignores the content-type header)
+        var request = await serializer.ReadAsync<GraphQLRequest>(context.Request.Body, context.RequestAborted).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Could not read request");
+
+        // execute the request
+        var result = await executer.ExecuteAsync(options =>
+        {
+            options.Query = request.Query;
+            options.OperationName = request.OperationName;
+            options.Variables = request.Variables;
+            options.RequestServices = context.RequestServices;
+            options.CancellationToken = context.RequestAborted;
+        }).ConfigureAwait(false);
+
+        // write the response
+        context.Response.StatusCode = 200; // always OK even for errors
+        context.Response.ContentType = "application/json";
+        await serializer.WriteAsync(context.Response.Body, result, context.RequestAborted).ConfigureAwait(false);
+    }
+}

--- a/samples/GraphQL.SchemaFirst.Sample/Properties/launchSettings.json
+++ b/samples/GraphQL.SchemaFirst.Sample/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "GraphQL.SchemaFirst.Sample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:57100;http://localhost:57101"
+    }
+  }
+}

--- a/samples/GraphQL.SchemaFirst.Sample/Schema.gql
+++ b/samples/GraphQL.SchemaFirst.Sample/Schema.gql
@@ -1,0 +1,11 @@
+type Query {
+  hero: Droid
+  droids: [Droid!]!
+  droid(id: ID!): Droid
+}
+
+type Droid {
+  id: ID!
+  name: String!
+  primaryFunction: String
+}

--- a/samples/GraphQL.SchemaFirst.Sample/Schema/Droid.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/Schema/Droid.cs
@@ -1,0 +1,8 @@
+namespace GraphQL.SchemaFirst.Sample.Schema;
+
+public class Droid
+{
+    public string Id { get; set; } = null!;
+    public string Name { get; set; } = null!;
+    public string? PrimaryFunction { get; set; }
+}

--- a/samples/GraphQL.SchemaFirst.Sample/Schema/Query.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/Schema/Query.cs
@@ -1,0 +1,13 @@
+namespace GraphQL.SchemaFirst.Sample.Schema;
+
+public class Query
+{
+    public Droid? Hero([FromServices] DroidRepository repository)
+        => repository.GetHero();
+
+    public IEnumerable<Droid> Droids([FromServices] DroidRepository repository)
+        => repository.GetAllDroids();
+
+    public Droid? Droid([FromServices] DroidRepository repository, string id)
+        => repository.GetDroidById(id);
+}

--- a/samples/GraphQL.SchemaFirst.Sample/appsettings.json
+++ b/samples/GraphQL.SchemaFirst.Sample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary

Closes #1025 - Adds a Schema-First sample project and a samples catalog documentation page.

- **New sample**: `samples/GraphQL.SchemaFirst.Sample` — a standalone ASP.NET Core web application demonstrating the Schema-First (SDL-First) approach using `SchemaBuilder`. The schema is defined in a `.gql` SDL file embedded as a resource, mapped to C# resolver classes with `[FromServices]` injection, and served with a GraphiQL UI.
- **New docs page**: `docs2/site/docs/getting-started/samples.md` — a catalog page describing all existing sample projects (Schema-First, Harness, AOT, DataLoader, Federation, StarWars) with links and key features.
- **Updated `sitemap.yml`**: adds the new Samples page under the Getting Started section.
- **Updated `GraphQL.slnx`**: includes the new sample project in the solution.

## Test plan

- [ ] Run `samples/GraphQL.SchemaFirst.Sample`: navigate to `http://localhost:57101`, execute `{ hero { id name primaryFunction } }` and verify expected response
- [ ] Run `samples/GraphQL.SchemaFirst.Sample`: execute `{ droids { id name } }` and verify both droids are returned
- [ ] Run `samples/GraphQL.SchemaFirst.Sample`: execute `{ droid(id: "1") { name } }` and verify single droid returned
- [ ] Review the new Samples documentation page for accuracy and completeness
- [ ] Verify the Samples page appears correctly in the docs site navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)