### PR TITLE
Fix handling of directive arguments with default values

### DIFF
--- a/src/GraphQL.Tests/Execution/Directives/DirectivesTests.cs
+++ b/src/GraphQL.Tests/Execution/Directives/DirectivesTests.cs
@@ -12,6 +12,10 @@ public class DirectiveSchema : Schema
         {
             Arguments = new QueryArguments([new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "value" }])
         });
+        Directives.Register(new Directive("test3", GraphQLParser.AST.DirectiveLocation.Field)
+        {
+            Arguments = new QueryArguments([new QueryArgument<NonNullGraphType<BooleanGraphType>> { Name = "flag", DefaultValue = true }])
+        });
     }
 }
 
@@ -27,6 +31,8 @@ public class DirectiveTestType : ObjectGraphType
             .Resolve(context => context.GetDirective("test1") != null);
         Field<StringGraphType>("d")
             .Resolve(context => context.GetDirective("test2")?.GetArgument<string>("value"));
+        Field<BooleanGraphType>("e")
+            .Resolve(context => context.GetDirective("test3")?.GetArgument<bool>("flag"));
     }
 }
 
@@ -380,6 +386,25 @@ public class DirectiveParsingTests : QueryTestBase<DirectiveSchema>
               "d": "hello"
             }
             """,
+            null, null);
+    }
+}
+
+public class DirectiveDefaultArgumentTests : QueryTestBase<DirectiveSchema>
+{
+    [Theory]
+    [InlineData(null, true)]   // omitted → default value true
+    [InlineData(true, true)]   // explicit true
+    [InlineData(false, false)]   // explicit false
+    public void directive_non_null_arg_with_default_value(bool? providedFlag, bool expectedResult)
+    {
+        string directive = providedFlag.HasValue
+            ? $"@test3(flag: {providedFlag.Value.ToString().ToLower()})"
+            : "@test3";
+
+        AssertQuerySuccess(
+            $"query {{ e {directive} }}",
+            $$$"""{ "e": {{{expectedResult.ToString().ToLower()}}} }""",
             null, null);
     }
 }

--- a/src/GraphQL.Tests/Validation/ProvidedNonNullArgumentsTests.cs
+++ b/src/GraphQL.Tests/Validation/ProvidedNonNullArgumentsTests.cs
@@ -219,12 +219,7 @@ public class ProvidedNonNullArgumentsTests : ValidationTestBase<ProvidedNonNullA
     {
         ShouldPassRule("""
             {
-              dog {
-                ...DogFields @defer(label: "r")
-              }
-            }
-            fragment DogFields on Dog {
-              name
+              ... @defer { __typename }
             }
             """);
     }

--- a/src/GraphQL.Tests/Validation/ProvidedNonNullArgumentsTests.cs
+++ b/src/GraphQL.Tests/Validation/ProvidedNonNullArgumentsTests.cs
@@ -215,6 +215,21 @@ public class ProvidedNonNullArgumentsTests : ValidationTestBase<ProvidedNonNullA
     }
 
     [Fact]
+    public void directive_with_non_null_arg_and_default_value_omitted()
+    {
+        ShouldPassRule("""
+            {
+              dog {
+                ...DogFields @defer(label: "r")
+              }
+            }
+            fragment DogFields on Dog {
+              name
+            }
+            """);
+    }
+
+    [Fact]
     public void directive_with_missing_types()
     {
         ShouldFailRule(_ =>

--- a/src/GraphQL.Tests/Validation/ValidationSchema.cs
+++ b/src/GraphQL.Tests/Validation/ValidationSchema.cs
@@ -291,6 +291,12 @@ public class ValidationSchema : Schema
             new Directive("directiveB", DirectiveLocation.Field),
             new Directive("directive", DirectiveLocation.Field),
             new Directive("rep", DirectiveLocation.Field) { Repeatable = true },
+            new Directive("defer", DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment)
+            {
+                Arguments = new QueryArguments(
+                    new QueryArgument<NonNullGraphType<BooleanGraphType>> { Name = "if", DefaultValue = true },
+                    new QueryArgument<StringGraphType> { Name = "label" })
+            },
 
             new LengthDirective()
         );

--- a/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
+++ b/src/GraphQL/Validation/Rules/ProvidedNonNullArguments.cs
@@ -59,7 +59,7 @@ public class ProvidedNonNullArguments : ValidationRuleBase
                     var argAst = node.Arguments?.ValueFor(arg.Name);
                     var type = arg.ResolvedType;
 
-                    if (argAst == null && type is NonNullGraphType)
+                    if (arg.DefaultValue == null && argAst == null && type is NonNullGraphType)
                     {
                         context.ReportError(new ProvidedNonNullArgumentsError(context, node, arg));
                     }


### PR DESCRIPTION
Hi there! I'm the maintainer of [graphql-conformance](https://jbellenger.github.io/graphql-conformance/#), which verifies spec conformance across the graphql ecosystem. 

I noticed that graphql-dotnet had some spec [test failures](https://jbellenger.github.io/graphql-conformance/#/impl/graphql-dotnet/failures/08c504e7%2F01330b7e%2F44136fa3) and I thought I might be able to contribute a fix for one of the easy ones (more at [graphql-dotnet's conformance page](https://jbellenger.github.io/graphql-conformance/#/impl/graphql-dotnet)).

The issue addressed by this PR is that graphql-dotnet will reject some directive uses that omit arguments, such as when the argument is defined as non-null type with a default value.

For example, in this configuration:
```graphql
# schema
directive @defer(if: Boolean! = true, label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT

# query
{
  ... @defer { __typename }
}
```

graphql-dotnet returns this error:
```json
{
  "errors": [
    {
      "message": "Argument 'if' of type 'Boolean!' is required for directive 'defer' but not provided.",
      "extensions": {
        "code": "PROVIDED_NON_NULL_ARGUMENTS",
        "number": "5.4.2.1"
      }
    }
  ]
}
```

This kind of usage is explicitly allowed by section [5.4.3](https://spec.graphql.org/draft/#sel-IALTJDBBFCAAFFFFBA0wa) of the graphql-spec:
> An argument is required if the argument type is non-null and does not have a default value. Otherwise, the argument is optional.

The existing logic in ProvidedNonNullArguments already handled the general case of field arguments, but the directive case was missing a default value check.

Thank you for considering this PR! I'm not familiar with this code-base or its conventions, so please feel free to point out any issue no matter how small.