### PR TITLE
Fix recursively referenced input object not initializing all field default values

### DIFF
--- a/src/GraphQL.Tests/Bugs/Bug4447.cs
+++ b/src/GraphQL.Tests/Bugs/Bug4447.cs
@@ -13,7 +13,7 @@ namespace GraphQL.Tests.Bugs;
 /// InputB.value's default hasn't been coerced yet (still a GraphQLIntValue AST node), causing
 /// schema validation to throw "The default value of Input Object type field 'InputB.a' is invalid."
 /// </summary>
-public class Bug4448
+public class Bug4447
 {
     private const string Sdl = """
         schema {

--- a/src/GraphQL.Tests/Bugs/Bug4448.cs
+++ b/src/GraphQL.Tests/Bugs/Bug4448.cs
@@ -1,0 +1,57 @@
+using GraphQL.Types;
+
+namespace GraphQL.Tests.Bugs;
+
+/// <summary>
+/// Regression test for: a recursively referenced input object doesn't initialize all its fields properly.
+///
+/// InputB is processed first by CoerceInputTypeDefaultValues. Field 'a' has a GraphQLValue default
+/// { b: { a: null } }, so ExamineType(InputA) is called recursively. Inside InputA, field 'b' has
+/// NO default value, so the old code hit an early 'continue' that skipped the recursive
+/// ExamineType(InputB) call for that field. Control returns to InputB, which then calls CoerceValue
+/// on InputB.a's default. CoerceValue expands the object using InputB's field defaults — but
+/// InputB.value's default hasn't been coerced yet (still a GraphQLIntValue AST node), causing
+/// schema validation to throw "The default value of Input Object type field 'InputB.a' is invalid."
+/// </summary>
+public class Bug4448
+{
+    private const string Sdl = """
+        schema {
+          query: Query
+        }
+
+        type Query {
+          ping: String
+        }
+
+        input InputB {
+          a: InputA = { b: { a: null } }
+          value: Int = 42
+        }
+
+        input InputA {
+          b: InputB!
+        }
+        """;
+
+    [Fact]
+    public void Recursive_Input_Type_Initializes_All_Field_Default_Values()
+    {
+        // Schema.Initialize() -> Validate() -> CoerceInputTypeDefaultValues() must fully coerce
+        // all nested default values, including those reached through recursive input type references.
+        var schema = Schema.For(Sdl);
+        schema.Initialize();
+
+        var inputB = schema.AllTypes["InputB"] as InputObjectGraphType;
+        inputB.ShouldNotBeNull();
+
+        var aField = inputB.Fields.Find("a");
+        aField.ShouldNotBeNull();
+
+        // InputB.a's coerced default should be a Dictionary containing 'b' -> Dictionary containing
+        // 'value' -> 42 (int). Before the fix, 'value' would be a raw GraphQLIntValue AST node.
+        var aDefault = aField.DefaultValue.ShouldBeOfType<Dictionary<string, object?>>();
+        var bDefault = aDefault["b"].ShouldBeOfType<Dictionary<string, object?>>();
+        bDefault["value"].ShouldBeOfType<int>().ShouldBe(42);
+    }
+}

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -571,9 +571,6 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
 
             foreach (var field in inputType.Fields)
             {
-                if (field.DefaultValue is not GraphQLValue defaultValue)
-                    continue;
-
                 var baseType = field.ResolvedType!.GetNamedType();
                 if (baseType is IInputObjectGraphType inputFieldType)
                 {
@@ -598,7 +595,9 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
                     ExamineType(inputFieldType, completed, inProcess, ref inputTypesCheckedForCycles);
                     inProcess.Pop();
                 }
-                field.DefaultValue = Execution.ExecutionHelper.CoerceValue(field.ResolvedType!, defaultValue).Value;
+
+                if (field.DefaultValue is GraphQLValue defaultValue)
+                    field.DefaultValue = Execution.ExecutionHelper.CoerceValue(field.ResolvedType!, defaultValue).Value;
             }
 
             completed.Add(inputType);

--- a/src/GraphQL/Types/Schema.cs
+++ b/src/GraphQL/Types/Schema.cs
@@ -564,6 +564,16 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
                 ExamineType(inputType, completed, inProcess, ref inputTypesCheckedForCycles);
         }
 
+        static IGraphType? GetNamedTypeNoError(IGraphType? graphType)
+        {
+            return graphType switch
+            {
+                NonNullGraphType nonNull => GetNamedTypeNoError(nonNull.ResolvedType),
+                ListGraphType list => GetNamedTypeNoError(list.ResolvedType),
+                _ => graphType
+            };
+        }
+
         static void ExamineType(IInputObjectGraphType inputType, HashSet<IInputObjectGraphType> completed, Stack<FieldType> inProcess, ref HashSet<IInputObjectGraphType>? inputTypesCheckedForCycles)
         {
             if (completed.Contains(inputType))
@@ -571,7 +581,10 @@ public class Schema : MetadataProvider, ISchema, IServiceProvider, IDisposable
 
             foreach (var field in inputType.Fields)
             {
-                var baseType = field.ResolvedType!.GetNamedType();
+                var baseType = GetNamedTypeNoError(field.ResolvedType);
+                if (baseType == null)
+                    continue; // Schema validation will catch this at a later point
+
                 if (baseType is IInputObjectGraphType inputFieldType)
                 {
                     if (inProcess.Contains(field))


### PR DESCRIPTION
## Problem

When a schema contains mutually recursive input object types where one field has no default value, `CoerceInputTypeDefaultValues` would skip the recursive `ExamineType` call for that field's nested input type. This left any `GraphQLValue` AST default values in that nested type un-coerced, causing schema validation to throw:

> `InvalidOperationException: The default value of Input Object type field 'InputB.a' is invalid.`

**Root cause:** The old code had an early `continue` for fields without a default value, placed *before* the recursive `ExamineType` call:

```csharp
if (field.DefaultValue is not GraphQLValue defaultValue)
    continue;  // skipped ExamineType for this field's nested input type

var baseType = field.ResolvedType!.GetNamedType();
if (baseType is IInputObjectGraphType inputFieldType)
{
    // ... recursive call — never reached for fields without defaults
}
field.DefaultValue = CoerceValue(...);
```

## Fix

Move the `continue` guard to *after* the recursive `ExamineType` call, so all fields' nested input types are always examined regardless of whether the current field has a default value:

```csharp
var baseType = field.ResolvedType!.GetNamedType();
if (baseType is IInputObjectGraphType inputFieldType)
{
    // ... recursive call — always reached
}

if (field.DefaultValue is GraphQLValue defaultValue)
    field.DefaultValue = CoerceValue(...);
```

## Test

Added `Bug4447.cs` with a minimal reproduction: `InputB.a` has a default `{ b: { a: null } }` and `InputA.b` has no default. Without the fix the schema fails to initialize; with the fix `InputB.a`'s coerced default correctly contains `value = 42` (an `int`, not a raw `GraphQLIntValue` AST node).