### PR TITLE
Add schema-first sample and samples docs

### DIFF
--- a/GraphQL.slnx
+++ b/GraphQL.slnx
@@ -85,6 +85,7 @@
     <File Path="docs2/site/docs/getting-started/query-organization.md" />
     <File Path="docs2/site/docs/getting-started/query-validation.md" />
     <File Path="docs2/site/docs/getting-started/relay.md" />
+    <File Path="docs2/site/docs/getting-started/samples.md" />
     <File Path="docs2/site/docs/getting-started/schema-types.md" />
     <File Path="docs2/site/docs/getting-started/subscriptions.md" />
     <File Path="docs2/site/docs/getting-started/unions.md" />
@@ -121,6 +122,7 @@
     <Project Path="samples/GraphQL.Federation.SchemaFirst.Sample2/GraphQL.Federation.SchemaFirst.Sample2.csproj" />
     <Project Path="samples/GraphQL.Federation.TypeFirst.Sample4/GraphQL.Federation.TypeFirst.Sample4.csproj" />
     <Project Path="samples/GraphQL.Harness/GraphQL.Harness.csproj" />
+    <Project Path="samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj" />
     <Project Path="samples/GraphQL.Server.Polyfill/GraphQL.Server.Polyfill.csproj" />
     <Project Path="src/GraphQL.StarWars.TypeFirst/GraphQL.StarWars.TypeFirst.csproj" />
     <Project Path="src/GraphQL.StarWars/GraphQL.StarWars.csproj" />

--- a/docs2/site/docs/getting-started/samples.md
+++ b/docs2/site/docs/getting-started/samples.md
@@ -1,0 +1,26 @@
+# Samples
+
+The repository includes runnable samples that demonstrate common GraphQL.NET configurations. They are useful starting points when you want to compare schema styles, dependency injection setup, serialization, or server integration without creating a new project from scratch.
+
+## Schema-first
+
+The `samples/GraphQL.SchemaFirst.Sample` project demonstrates a non-federation schema-first application. It keeps the GraphQL schema in `Schema.gql`, builds an `ISchema` with `SchemaBuilder`, registers CLR resolver methods with `schemaBuilder.Types.Include<Query>()`, and executes a small query from a console app.
+
+Run it with:
+
+```bash
+dotnet run --project samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+```
+
+Schema-first works well when the SDL is the source of truth, when a team wants to design the contract before implementing resolvers, or when an existing schema needs to be hosted by GraphQL.NET. Resolver methods still live in CLR types, so you can continue to use dependency injection with attributes such as `[FromServices]`.
+
+Code-first or type-first can be easier when most of the schema should follow the shape of existing CLR models, when you want stronger compile-time feedback for schema changes, or when you rely heavily on GraphQL.NET graph type classes.
+
+## Other sample projects
+
+- `samples/GraphQL.AotCompilationSample.CodeFirst` and `samples/GraphQL.AotCompilationSample.TypeFirst` show AOT-friendly schema configuration.
+- `samples/GraphQL.DataLoader.Sample.Default` and `samples/GraphQL.DataLoader.Sample.DI` show DataLoader usage with and without dependency injection.
+- `samples/GraphQL.Federation.SchemaFirst.Sample1` and `samples/GraphQL.Federation.SchemaFirst.Sample2` show schema-first federation scenarios.
+- `samples/GraphQL.Federation.CodeFirst.Sample3` and `samples/GraphQL.Federation.TypeFirst.Sample4` show federation with code-first and type-first schemas.
+- `samples/GraphQL.Harness` is a runnable ASP.NET Core harness for experimenting with requests.
+- `src/GraphQL.StarWars` and `src/GraphQL.StarWars.TypeFirst` provide the Star Wars example schemas used by tests and samples.

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -72,6 +72,8 @@
             file: relay.md
           - title: Global Switches
             file: global-switches.md
+          - title: Samples
+            file: samples.md
       - title: Guides
         dir: guides
         items:

--- a/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+++ b/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Schema.gql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Schema.gql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GraphQL.MicrosoftDI\GraphQL.MicrosoftDI.csproj" />
+    <ProjectReference Include="..\..\src\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GraphQL.SchemaFirst.Sample/Program.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/Program.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using GraphQL;
+using GraphQL.Types;
+using GraphQL.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+Console.WriteLine("Schema-first sample");
+Console.WriteLine();
+
+var services = new ServiceCollection();
+services.AddSingleton<DroidRepository>();
+services.AddSingleton<Query>();
+services.AddGraphQL(builder => builder
+    .AddSchema(BuildSchema)
+    .AddSystemTextJson());
+
+using var provider = services.BuildServiceProvider();
+
+var executer = provider.GetRequiredService<IDocumentExecuter>();
+var serializer = provider.GetRequiredService<IGraphQLTextSerializer>();
+var schema = provider.GetRequiredService<ISchema>();
+
+const string query = """
+{
+  hero {
+    id
+    name
+    primaryFunction
+    appearsIn
+  }
+}
+""";
+
+Console.WriteLine("Executing request:");
+Console.WriteLine(query);
+Console.WriteLine();
+
+var result = await executer.ExecuteAsync(new ExecutionOptions
+{
+    Schema = schema,
+    Query = query,
+    RequestServices = provider,
+    ThrowOnUnhandledException = true,
+}).ConfigureAwait(false);
+
+var response = serializer.Serialize(result);
+Console.WriteLine(response);
+
+const string expected = """{"data":{"hero":{"id":"3","name":"R2-D2","primaryFunction":"Astromech","appearsIn":["NEWHOPE","EMPIRE","JEDI"]}}}""";
+if (response != expected)
+{
+    Console.WriteLine("Unexpected response; exiting.");
+    return 1;
+}
+
+return result.Errors?.Count ?? 0;
+
+static ISchema BuildSchema(IServiceProvider serviceProvider)
+{
+    var schemaBuilder = new SchemaBuilder
+    {
+        ServiceProvider = serviceProvider,
+    };
+    schemaBuilder.Types.Include<Query>();
+
+    return schemaBuilder.Build(LoadResource("Schema.gql"));
+}
+
+static string LoadResource(string resourceName)
+{
+    using var stream = Assembly.GetExecutingAssembly()
+        .GetManifestResourceStream("GraphQL.SchemaFirst.Sample." + resourceName)
+        ?? throw new InvalidOperationException("Could not read schema definitions from embedded resource.");
+    using var reader = new StreamReader(stream);
+    return reader.ReadToEnd();
+}
+
+public class Query
+{
+    public Droid Hero([FromServices] DroidRepository repository)
+        => repository.GetHero();
+
+    public Droid? Droid(string id, [FromServices] DroidRepository repository)
+        => repository.GetDroid(id);
+}
+
+public class DroidRepository
+{
+    private readonly IReadOnlyList<Droid> _droids =
+    [
+        new("3", "R2-D2", "Astromech", ["NEWHOPE", "EMPIRE", "JEDI"]),
+        new("4", "C-3PO", "Protocol", ["NEWHOPE", "EMPIRE", "JEDI"]),
+    ];
+
+    public Droid GetHero()
+        => _droids[0];
+
+    public Droid? GetDroid(string id)
+        => _droids.FirstOrDefault(droid => droid.Id == id);
+}
+
+public record Droid(string Id, string Name, string PrimaryFunction, IReadOnlyList<string> AppearsIn);

--- a/samples/GraphQL.SchemaFirst.Sample/Schema.gql
+++ b/samples/GraphQL.SchemaFirst.Sample/Schema.gql
@@ -1,0 +1,11 @@
+type Droid {
+  id: ID!
+  name: String!
+  primaryFunction: String!
+  appearsIn: [String!]!
+}
+
+type Query {
+  hero: Droid!
+  droid(id: ID!): Droid
+}


### PR DESCRIPTION
Related to #1025
/claim #1025

This adds a small schema-first sample and a samples documentation page.

What changed:
- Added `samples/GraphQL.SchemaFirst.Sample`, a non-federation console sample that loads SDL from `Schema.gql`, builds the schema with `SchemaBuilder`, wires CLR resolvers through `schemaBuilder.Types.Include<Query>()`, and uses dependency injection via `[FromServices]`.
- Added `docs2/site/docs/getting-started/samples.md` to list the repository samples and explain when schema-first is a good fit.
- Updated `docs2/site/sitemap.yml` and `GraphQL.slnx` so the new docs page and sample appear in the navigation / solution tree.

This is intentionally a minimal runnable sample instead of a larger web app. Compared with older open PRs for this issue, this version keeps the sample non-federation, uses the current `SchemaBuilder` path directly, and makes `dotnet run` self-verify the expected response.

Verified locally:

```bash
dotnet run --project samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
dotnet build samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj --no-restore
git diff --check
```
