### PR TITLE
Add schema-first sample docs

### DIFF
--- a/GraphQL.slnx
+++ b/GraphQL.slnx
@@ -85,6 +85,7 @@
     <File Path="docs2/site/docs/getting-started/query-organization.md" />
     <File Path="docs2/site/docs/getting-started/query-validation.md" />
     <File Path="docs2/site/docs/getting-started/relay.md" />
+    <File Path="docs2/site/docs/getting-started/samples.md" />
     <File Path="docs2/site/docs/getting-started/schema-types.md" />
     <File Path="docs2/site/docs/getting-started/subscriptions.md" />
     <File Path="docs2/site/docs/getting-started/unions.md" />
@@ -121,6 +122,7 @@
     <Project Path="samples/GraphQL.Federation.SchemaFirst.Sample2/GraphQL.Federation.SchemaFirst.Sample2.csproj" />
     <Project Path="samples/GraphQL.Federation.TypeFirst.Sample4/GraphQL.Federation.TypeFirst.Sample4.csproj" />
     <Project Path="samples/GraphQL.Harness/GraphQL.Harness.csproj" />
+    <Project Path="samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj" />
     <Project Path="samples/GraphQL.Server.Polyfill/GraphQL.Server.Polyfill.csproj" />
     <Project Path="src/GraphQL.StarWars.TypeFirst/GraphQL.StarWars.TypeFirst.csproj" />
     <Project Path="src/GraphQL.StarWars/GraphQL.StarWars.csproj" />

--- a/docs2/site/docs/getting-started/samples.md
+++ b/docs2/site/docs/getting-started/samples.md
@@ -1,0 +1,53 @@
+# Samples
+
+The repository includes sample projects for common GraphQL.NET setup styles. Use them when you want to compare complete projects rather than isolated documentation snippets.
+
+| Sample | Approach | Use when |
+| --- | --- | --- |
+| [`GraphQL.SchemaFirst.Sample`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.SchemaFirst.Sample) | Schema first | You want to start with GraphQL SDL and map fields to .NET resolver classes. |
+| [`GraphQL.Harness`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.Harness) | GraphType first with ASP.NET Core | You want a web-hosted sample with common GraphQL UI middleware. |
+| [`GraphQL.StarWars`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/src/GraphQL.StarWars) | GraphType first | You want a reusable in-memory schema used by tests and the harness sample. |
+| [`GraphQL.StarWars.TypeFirst`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/src/GraphQL.StarWars.TypeFirst) | Type first | You want GraphQL.NET to infer schema metadata from CLR types and attributes. |
+| [`GraphQL.AotCompilationSample.CodeFirst`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.AotCompilationSample.CodeFirst) | GraphType first with AOT | You want to see the extra registrations needed for native AOT. |
+| [`GraphQL.AotCompilationSample.TypeFirst`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.AotCompilationSample.TypeFirst) | Type first with AOT | You want type-first schema generation in a trimmed/AOT application. |
+| Federation samples | Federation | You are building Apollo Federation-compatible schemas. |
+
+## Schema-first sample
+
+`GraphQL.SchemaFirst.Sample` demonstrates the schema-first flow:
+
+1. Define the schema using GraphQL SDL.
+2. Build the schema with `Schema.For`.
+3. Register resolver classes with `builder.Types.Include<T>()`.
+4. Execute a query against the schema.
+
+The sample keeps the model small so the schema-to-resolver mapping is easy to inspect:
+
+```csharp
+using var schema = Schema.For(schemaDefinition, builder =>
+{
+    builder.Types.Include<Query>();
+    builder.Types.Include<Droid>();
+});
+```
+
+Use `[GraphQLMetadata]` when the CLR method or type name should map to a specific GraphQL name. For example, the sample maps `GetHero` to the `hero` field and `GetDroid` to the `droid` field.
+
+Schema-first is a good fit when your team wants the GraphQL schema language to be the source of truth. It is less flexible than GraphType-first configuration for advanced runtime customization, so switch to GraphType-first when you need direct access to all `GraphType`, field, or schema configuration APIs.
+
+## Schema-first support notes
+
+Schema-first projects can:
+
+- Define object, input object, enum, interface, union, query, mutation, and subscription types in SDL.
+- Resolve fields from CLR properties and methods on registered resolver classes.
+- Use `[GraphQLMetadata]` to map CLR names to GraphQL names or add metadata.
+- Register additional types with `builder.Types.Include<T>()`.
+- Use custom scalars and type mappings when they are registered on the schema.
+
+Schema-first projects are not the best fit when:
+
+- You need to configure many fields through `GraphType` APIs.
+- You want compile-time discovery from CLR types instead of SDL as the source of truth.
+- You are targeting native AOT or aggressive trimming and cannot root the resolver and model types used by reflection.
+- You need extensive per-field customization that is clearer in `ObjectGraphType` classes.

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -56,6 +56,8 @@
             file: errors.md
           - title: Dependency Injection
             file: dependency-injection.md
+          - title: Samples
+            file: samples.md
           - title: Databases
             file: databases.md
           - title: Malicious Queries

--- a/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+++ b/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GraphQL\GraphQL.csproj" />
+    <ProjectReference Include="..\..\src\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GraphQL.SchemaFirst.Sample/Program.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/Program.cs
@@ -1,0 +1,70 @@
+using GraphQL;
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+
+namespace GraphQL.SchemaFirst.Sample;
+
+public static class Program
+{
+    public static async Task Main()
+    {
+        using var schema = Schema.For(SchemaDefinition, builder =>
+        {
+            builder.Types.Include<Query>();
+            builder.Types.Include<Droid>();
+        });
+
+        var json = await schema.ExecuteAsync(options =>
+        {
+            options.Query = """
+                {
+                  hero {
+                    id
+                    name
+                    primaryFunction
+                  }
+                  droid(id: "2") {
+                    name
+                  }
+                }
+                """;
+        });
+
+        Console.WriteLine(json);
+    }
+
+    private const string SchemaDefinition = """
+        type Droid {
+          id: ID!
+          name: String!
+          primaryFunction: String!
+        }
+
+        type Query {
+          hero: Droid!
+          droid(id: ID!): Droid
+        }
+        """;
+}
+
+[GraphQLMetadata("Query")]
+public sealed class Query
+{
+    private readonly IReadOnlyDictionary<string, Droid> _droids = new Dictionary<string, Droid>
+    {
+        ["1"] = new("1", "C-3PO", "Protocol"),
+        ["2"] = new("2", "R2-D2", "Astromech"),
+    };
+
+    [GraphQLMetadata("hero")]
+    public Droid GetHero() => _droids["2"];
+
+    [GraphQLMetadata("droid")]
+    public Droid? GetDroid(string id) => _droids.GetValueOrDefault(id);
+}
+
+[GraphQLMetadata("Droid")]
+public sealed record Droid(
+    string Id,
+    string Name,
+    string PrimaryFunction);


### PR DESCRIPTION
## Summary

- Adds a small `GraphQL.SchemaFirst.Sample` console sample that builds a schema from SDL with `Schema.For`, maps SDL fields to CLR resolver classes, and executes a query.
- Adds a `Samples` documentation page explaining the repository's sample projects and when to use the schema-first sample.
- Adds the new docs page and sample project to `sitemap.yml` and `GraphQL.slnx`.

## Bounty

This is an implementation draft for #1025. I also posted a proposal on the issue and can adjust the shape of this PR if the maintainers prefer a different sample layout.

## Verification

- `git diff --check`

I could not run `dotnet build` locally because the current environment does not have the .NET SDK installed.
