### PR TITLE
Add schema-first sample

### DIFF
--- a/GraphQL.slnx
+++ b/GraphQL.slnx
@@ -116,6 +116,7 @@
     <Project Path="samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj" />
     <Project Path="samples/GraphQL.DataLoader.Sample.Default/GraphQL.DataLoader.Sample.Default.csproj" />
     <Project Path="samples/GraphQL.DataLoader.Sample.DI/GraphQL.DataLoader.Sample.DI.csproj" />
+    <Project Path="samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj" />
     <Project Path="samples/GraphQL.Federation.CodeFirst.Sample3/GraphQL.Federation.CodeFirst.Sample3.csproj" />
     <Project Path="samples/GraphQL.Federation.SchemaFirst.Sample1/GraphQL.Federation.SchemaFirst.Sample1.csproj" />
     <Project Path="samples/GraphQL.Federation.SchemaFirst.Sample2/GraphQL.Federation.SchemaFirst.Sample2.csproj" />

--- a/docs2/site/docs/guides/samples.md
+++ b/docs2/site/docs/guides/samples.md
@@ -1,0 +1,31 @@
+# Samples
+
+The repository includes runnable samples that demonstrate common GraphQL.NET application styles. Each sample is under the `samples` directory and references the local source projects, so you can run them while developing changes in this repository.
+
+## Schema-first
+
+`samples/GraphQL.SchemaFirst.Sample` demonstrates the schema-first approach requested by issue #1025. It embeds the GraphQL schema language file as `Schema.gql`, registers CLR resolver classes with `Schema.For`, and executes both a query and a mutation from a console application.
+
+Run it with:
+
+```bash
+dotnet run --project samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+```
+
+Use this sample when you want to see how schema fields map to resolver methods with `GraphQLMetadata`, how GraphQL input objects map to CLR classes, and how a schema-first app can be smoke-tested without hosting ASP.NET Core.
+
+## AOT compilation samples
+
+`samples/GraphQL.AotCompilationSample.CodeFirst` and `samples/GraphQL.AotCompilationSample.TypeFirst` show how to prepare code-first and type-first schemas for ahead-of-time compilation. These samples are useful when trimming and native publishing are part of the deployment target.
+
+## DataLoader samples
+
+`samples/GraphQL.DataLoader.Sample.Default` and `samples/GraphQL.DataLoader.Sample.DI` show two DataLoader integration styles. Use them when you need batched data access and want to compare default registration with dependency-injection-driven graph types.
+
+## Federation samples
+
+The federation samples cover code-first, schema-first, and type-first configurations. `samples/GraphQL.Federation.SchemaFirst.Sample1` and `samples/GraphQL.Federation.SchemaFirst.Sample2` are useful references when you need schema-first SDL plus Apollo Federation directives and resolvers.
+
+## Harness sample
+
+`samples/GraphQL.Harness` is a broader ASP.NET Core sample that exercises middleware, serialization, and transport behavior. It is a useful manual testing target when changing request execution behavior.

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -85,6 +85,8 @@
             file: complexity-analyzer.md
           - title: Schema Generation
             file: schema-generation.md
+          - title: Samples
+            file: samples.md
           - title: Known Issues & FAQ
             file: known-issues.md
           - title: Links

--- a/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
+++ b/samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Schema.gql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GraphQL\GraphQL.csproj" />
+    <ProjectReference Include="..\..\src\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GraphQL.SchemaFirst.Sample/Program.cs
+++ b/samples/GraphQL.SchemaFirst.Sample/Program.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+using GraphQL;
+using GraphQL.SystemTextJson;
+using GraphQL.Types;
+
+var schemaText = LoadResource("Schema.gql");
+
+var schema = Schema.For(schemaText, builder =>
+{
+    builder.Types.Include<Query>();
+    builder.Types.Include<Mutation>();
+});
+
+var listResult = await schema.ExecuteAsync(options =>
+{
+    options.Query = """
+    {
+      books {
+        id
+        title
+        author { name }
+        tags
+      }
+    }
+    """;
+    options.ThrowOnUnhandledException = true;
+}).ConfigureAwait(false);
+
+Console.WriteLine("Query result:");
+Console.WriteLine(listResult);
+Console.WriteLine();
+
+var mutationResult = await schema.ExecuteAsync(options =>
+{
+    options.Query = """
+    mutation AddBook($book: AddBookInput!) {
+      addBook(input: $book) {
+        id
+        title
+        pages
+        author { name }
+        tags
+      }
+    }
+    """;
+    options.Variables = new Inputs(new Dictionary<string, object?>
+    {
+        ["book"] = new Dictionary<string, object?>
+        {
+            ["title"] = "Schema-first GraphQL.NET",
+            ["authorId"] = "2",
+            ["pages"] = 248,
+            ["tags"] = new[] { "schema-first", "sample" },
+        },
+    });
+    options.ThrowOnUnhandledException = true;
+}).ConfigureAwait(false);
+
+Console.WriteLine("Mutation result:");
+Console.WriteLine(mutationResult);
+
+return listResult.Contains("\"books\"") && mutationResult.Contains("Schema-first GraphQL.NET") ? 0 : 1;
+
+static string LoadResource(string resourceName)
+{
+    var assembly = Assembly.GetExecutingAssembly();
+    var fullName = assembly.GetManifestResourceNames().SingleOrDefault(name => name.EndsWith($".{resourceName}", StringComparison.Ordinal))
+        ?? throw new InvalidOperationException($"Could not find embedded resource ending with '{resourceName}'.");
+    using var stream = assembly.GetManifestResourceStream(fullName)
+        ?? throw new InvalidOperationException($"Could not read embedded resource '{fullName}'.");
+    using var reader = new StreamReader(stream);
+    return reader.ReadToEnd();
+}
+
+public class Query
+{
+    [GraphQLMetadata("authors")]
+    public IEnumerable<Author> GetAuthors() => SampleData.Authors;
+
+    [GraphQLMetadata("books")]
+    public IEnumerable<Book> GetBooks() => SampleData.Books;
+
+    [GraphQLMetadata("book")]
+    public Book? GetBook(string id) => SampleData.Books.SingleOrDefault(book => book.Id == id);
+}
+
+public class Mutation
+{
+    [GraphQLMetadata("addBook")]
+    public Book AddBook(AddBookInput input)
+    {
+        var author = SampleData.Authors.SingleOrDefault(author => author.Id == input.AuthorId)
+            ?? throw new ExecutionError($"Author '{input.AuthorId}' was not found.");
+
+        var book = new Book
+        {
+            Id = (SampleData.Books.Count + 1).ToString(),
+            Title = input.Title,
+            Author = author,
+            Pages = input.Pages,
+            Tags = input.Tags ?? [],
+        };
+        SampleData.Books.Add(book);
+        return book;
+    }
+}
+
+public sealed class AddBookInput
+{
+    public string Title { get; set; } = null!;
+    public string AuthorId { get; set; } = null!;
+    public int Pages { get; set; }
+    public string[]? Tags { get; set; }
+}
+
+public sealed class Author
+{
+    public string Id { get; init; } = null!;
+    public string Name { get; init; } = null!;
+}
+
+public sealed class Book
+{
+    public string Id { get; init; } = null!;
+    public string Title { get; init; } = null!;
+    public Author Author { get; init; } = null!;
+    public int Pages { get; init; }
+    public IReadOnlyList<string> Tags { get; init; } = [];
+}
+
+internal static class SampleData
+{
+    public static readonly IReadOnlyList<Author> Authors =
+    [
+        new() { Id = "1", Name = "Octavia Butler" },
+        new() { Id = "2", Name = "Ursula K. Le Guin" },
+    ];
+
+    public static readonly List<Book> Books =
+    [
+        new()
+        {
+            Id = "1",
+            Title = "Parable of the Sower",
+            Author = Authors[0],
+            Pages = 345,
+            Tags = ["dystopian", "classic"],
+        },
+        new()
+        {
+            Id = "2",
+            Title = "The Left Hand of Darkness",
+            Author = Authors[1],
+            Pages = 304,
+            Tags = ["science-fiction", "classic"],
+        },
+    ];
+}

--- a/samples/GraphQL.SchemaFirst.Sample/Schema.gql
+++ b/samples/GraphQL.SchemaFirst.Sample/Schema.gql
@@ -1,0 +1,29 @@
+type Author {
+  id: ID!
+  name: String!
+}
+
+type Book {
+  id: ID!
+  title: String!
+  author: Author!
+  pages: Int!
+  tags: [String!]!
+}
+
+input AddBookInput {
+  title: String!
+  authorId: ID!
+  pages: Int!
+  tags: [String!]
+}
+
+type Query {
+  authors: [Author!]!
+  books: [Book!]!
+  book(id: ID!): Book
+}
+
+type Mutation {
+  addBook(input: AddBookInput!): Book!
+}


### PR DESCRIPTION
Closes #1025.

## Summary

- Adds `samples/GraphQL.SchemaFirst.Sample`, a runnable console sample using SDL from an embedded `Schema.gql` file.
- Demonstrates schema-first resolver mapping with `Schema.For(...)` and `GraphQLMetadata`.
- Covers both query execution and mutation/input-object mapping in the sample smoke path.
- Adds a samples guide page and sitemap entry so the sample is discoverable from the docs.
- Adds the sample project to `GraphQL.slnx`.

## Verification

```bash
dotnet run --project samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj
dotnet build samples/GraphQL.SchemaFirst.Sample/GraphQL.SchemaFirst.Sample.csproj --no-restore