### PR TITLE
Add custom validation rule sample

### DIFF
--- a/GraphQL.slnx
+++ b/GraphQL.slnx
@@ -85,6 +85,7 @@
     <File Path="docs2/site/docs/getting-started/query-organization.md" />
     <File Path="docs2/site/docs/getting-started/query-validation.md" />
     <File Path="docs2/site/docs/getting-started/relay.md" />
+    <File Path="docs2/site/docs/getting-started/samples.md" />
     <File Path="docs2/site/docs/getting-started/schema-types.md" />
     <File Path="docs2/site/docs/getting-started/subscriptions.md" />
     <File Path="docs2/site/docs/getting-started/unions.md" />
@@ -114,6 +115,7 @@
   <Folder Name="/Samples/">
     <Project Path="samples/GraphQL.AotCompilationSample.CodeFirst/GraphQL.AotCompilationSample.CodeFirst.csproj" />
     <Project Path="samples/GraphQL.AotCompilationSample.TypeFirst/GraphQL.AotCompilationSample.TypeFirst.csproj" />
+    <Project Path="samples/GraphQL.CustomValidationRule.Sample/GraphQL.CustomValidationRule.Sample.csproj" />
     <Project Path="samples/GraphQL.DataLoader.Sample.Default/GraphQL.DataLoader.Sample.Default.csproj" />
     <Project Path="samples/GraphQL.DataLoader.Sample.DI/GraphQL.DataLoader.Sample.DI.csproj" />
     <Project Path="samples/GraphQL.Federation.CodeFirst.Sample3/GraphQL.Federation.CodeFirst.Sample3.csproj" />

--- a/docs2/site/docs/getting-started/query-validation.md
+++ b/docs2/site/docs/getting-started/query-validation.md
@@ -27,6 +27,10 @@ await schema.ExecuteAsync(_ =>
 });
 ```
 
+For a runnable custom validation rule sample, see
+[`GraphQL.CustomValidationRule.Sample`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples/GraphQL.CustomValidationRule.Sample).
+The sample demonstrates a rule that reads field metadata and request user context before execution.
+
 ## Setting validation rules on input arguments or input object fields
 
 When defining a schema, you can set validation rules on input arguments or input object fields.

--- a/docs2/site/docs/getting-started/samples.md
+++ b/docs2/site/docs/getting-started/samples.md
@@ -1,0 +1,33 @@
+# Samples
+
+GraphQL.NET includes small sample projects that show supported setup patterns for the core library. Use these projects when you want runnable code in addition to the documentation pages.
+
+## Core Library Samples
+
+| Sample | Focus | Path |
+| --- | --- | --- |
+| Custom validation rule | Field metadata and request-context based validation with `ValidationRuleBase` | `samples/GraphQL.CustomValidationRule.Sample` |
+| AOT compilation, code-first | Native AOT setup with a code-first schema | `samples/GraphQL.AotCompilationSample.CodeFirst` |
+| AOT compilation, type-first | Native AOT setup with a type-first schema | `samples/GraphQL.AotCompilationSample.TypeFirst` |
+| DataLoader, default access | DataLoader usage through `IDataLoaderContextAccessor` | `samples/GraphQL.DataLoader.Sample.Default` |
+| DataLoader, DI access | DataLoader usage with dependency injection | `samples/GraphQL.DataLoader.Sample.DI` |
+| Federation, code-first | Apollo Federation with a code-first schema | `samples/GraphQL.Federation.CodeFirst.Sample3` |
+| Federation, schema-first | Apollo Federation with schema-first setup | `samples/GraphQL.Federation.SchemaFirst.Sample1` and `samples/GraphQL.Federation.SchemaFirst.Sample2` |
+| Federation, type-first | Apollo Federation with a type-first schema | `samples/GraphQL.Federation.TypeFirst.Sample4` |
+| Harness | ASP.NET Core host that exercises multiple GraphQL.NET features | `samples/GraphQL.Harness` |
+| StarWars, code-first | Introductory code-first schema | `src/GraphQL.StarWars` |
+| StarWars, type-first | Introductory type-first schema | `src/GraphQL.StarWars.TypeFirst` |
+
+## Running Samples
+
+Run a sample project from the repository root:
+
+```bash
+dotnet run --project samples/GraphQL.CustomValidationRule.Sample/GraphQL.CustomValidationRule.Sample.csproj
+```
+
+Replace the project path with any sample listed above.
+
+## Server Samples
+
+The main repository focuses on the core GraphQL library. For ASP.NET Core server integration samples, see the [GraphQL.NET Server samples](https://github.com/graphql-dotnet/server/tree/master/samples).

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -14,6 +14,8 @@
             file: introduction.md
           - title: Installation
             file: installation.md
+          - title: Samples
+            file: samples.md
           - title: GraphiQL
             file: graphiql.md
           - title: Altair GraphQL

--- a/samples/GraphQL.CustomValidationRule.Sample/GraphQL.CustomValidationRule.Sample.csproj
+++ b/samples/GraphQL.CustomValidationRule.Sample/GraphQL.CustomValidationRule.Sample.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net10.0;net8.0;net6.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GraphQL\GraphQL.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GraphQL.CustomValidationRule.Sample/Program.cs
+++ b/samples/GraphQL.CustomValidationRule.Sample/Program.cs
@@ -1,0 +1,105 @@
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQLParser;
+using GraphQLParser.AST;
+
+namespace GraphQL.CustomValidationRule.Sample;
+
+internal static class Program
+{
+    private const string RequiredScope = "reports:read";
+
+    private static async Task Main()
+    {
+        await ExecuteAndPrintAsync("{ publicReport }", []);
+        await ExecuteAndPrintAsync("{ adminReport }", []);
+        await ExecuteAndPrintAsync("{ adminReport }", [RequiredScope]);
+    }
+
+    private static async Task ExecuteAndPrintAsync(string query, IReadOnlyCollection<string> scopes)
+    {
+        var result = await new DocumentExecuter().ExecuteAsync(new ExecutionOptions
+        {
+            Schema = new ReportsSchema(),
+            Query = query,
+            UserContext = new Dictionary<string, object?>
+            {
+                [AdminFieldsRequireScopeRule.ScopeContextKey] = scopes,
+            },
+            ValidationRules = DocumentValidator.CoreRules.Append(AdminFieldsRequireScopeRule.Instance),
+        }).ConfigureAwait(false);
+
+        Console.WriteLine($"Query: {query}");
+        Console.WriteLine($"Scopes: {string.Join(", ", scopes.DefaultIfEmpty("(none)"))}");
+
+        if (result.Errors?.Count > 0)
+        {
+            foreach (var error in result.Errors)
+                Console.WriteLine($"Validation error: {error.Message}");
+        }
+        else
+        {
+            Console.WriteLine("Validation passed.");
+        }
+
+        Console.WriteLine();
+    }
+}
+
+public sealed class ReportsSchema : Schema
+{
+    public ReportsSchema()
+    {
+        Query = new ReportsQuery();
+    }
+}
+
+public sealed class ReportsQuery : ObjectGraphType
+{
+    public ReportsQuery()
+    {
+        Field<StringGraphType>("publicReport")
+            .Resolve(_ => "Public report");
+
+        Field<StringGraphType>("adminReport")
+            .Resolve(_ => "Admin report")
+            .WithMetadata(AdminFieldsRequireScopeRule.RequiredScopeMetadataKey, "reports:read");
+    }
+}
+
+public sealed class AdminFieldsRequireScopeRule : ValidationRuleBase
+{
+    public const string RequiredScopeMetadataKey = "requiredScope";
+    public const string ScopeContextKey = "scopes";
+
+    public static readonly AdminFieldsRequireScopeRule Instance = new();
+
+    private static readonly MatchingNodeVisitor<GraphQLField> _visitor = new((field, context) =>
+    {
+        var requiredScope = context.TypeInfo.GetFieldDef()?.GetMetadata<string>(RequiredScopeMetadataKey);
+        if (string.IsNullOrEmpty(requiredScope))
+            return;
+
+        var hasScope =
+            context.UserContext.TryGetValue(ScopeContextKey, out var value) &&
+            value is IEnumerable<string> scopes &&
+            scopes.Contains(requiredScope, StringComparer.Ordinal);
+
+        if (!hasScope)
+            context.ReportError(new MissingScopeError(context.Document.Source, field, requiredScope));
+    });
+
+    private AdminFieldsRequireScopeRule()
+    {
+    }
+
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_visitor);
+}
+
+public sealed class MissingScopeError : ValidationError
+{
+    public MissingScopeError(ROM source, GraphQLField field, string requiredScope)
+        : base(source, null, $"Field '{field.Name.Value}' requires the '{requiredScope}' scope.", field)
+    {
+    }
+}

--- a/samples/GraphQL.CustomValidationRule.Sample/README.md
+++ b/samples/GraphQL.CustomValidationRule.Sample/README.md
@@ -1,0 +1,22 @@
+# GraphQL.CustomValidationRule.Sample
+
+This sample shows how to add a custom validation rule that reads field metadata and request user context before execution.
+
+The sample schema exposes two fields:
+
+| Field | Behavior |
+| --- | --- |
+| `publicReport` | Always passes validation. |
+| `adminReport` | Requires the `reports:read` scope in `ExecutionOptions.UserContext`. |
+
+Run the sample from the repository root:
+
+```bash
+dotnet run --project samples/GraphQL.CustomValidationRule.Sample/GraphQL.CustomValidationRule.Sample.csproj
+```
+
+Expected behavior:
+
+- `{ publicReport }` passes validation without scopes.
+- `{ adminReport }` returns a validation error without the `reports:read` scope.
+- `{ adminReport }` passes validation when `reports:read` is supplied.

--- a/src/GraphQL.Tests/Validation/CustomValidationRuleSampleTests.cs
+++ b/src/GraphQL.Tests/Validation/CustomValidationRuleSampleTests.cs
@@ -1,0 +1,109 @@
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQLParser;
+using GraphQLParser.AST;
+
+namespace GraphQL.Tests.Validation;
+
+public class CustomValidationRuleSampleTests
+{
+    [Fact]
+    public async Task Allows_field_without_required_scope_metadata()
+    {
+        var result = await ExecuteAsync("{ publicReport }");
+
+        result.Errors.ShouldBeNull();
+        result.Executed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Blocks_field_when_required_scope_is_missing()
+    {
+        var result = await ExecuteAsync("{ adminReport }");
+
+        result.Executed.ShouldBeFalse();
+
+        var error = result.Errors.ShouldHaveSingleItem();
+        error.Code.ShouldBe("MISSING_SCOPE");
+        error.Message.ShouldBe("Field 'adminReport' requires the 'reports:read' scope.");
+    }
+
+    [Fact]
+    public async Task Allows_field_when_required_scope_is_present()
+    {
+        var result = await ExecuteAsync("{ adminReport }", "reports:read");
+
+        result.Errors.ShouldBeNull();
+        result.Executed.ShouldBeTrue();
+    }
+
+    private static Task<ExecutionResult> ExecuteAsync(string query, params string[] scopes)
+        => new DocumentExecuter().ExecuteAsync(new ExecutionOptions
+        {
+            Schema = new ReportsSchema(),
+            Query = query,
+            UserContext = new Dictionary<string, object?>
+            {
+                [AdminFieldsRequireScopeRule.ScopeContextKey] = scopes,
+            },
+            ValidationRules = DocumentValidator.CoreRules.Append(AdminFieldsRequireScopeRule.Instance),
+        });
+
+    private sealed class ReportsSchema : Schema
+    {
+        public ReportsSchema()
+        {
+            Query = new ReportsQuery();
+        }
+    }
+
+    private sealed class ReportsQuery : ObjectGraphType
+    {
+        public ReportsQuery()
+        {
+            Field<StringGraphType>("publicReport")
+                .Resolve(_ => "Public report");
+
+            Field<StringGraphType>("adminReport")
+                .Resolve(_ => "Admin report")
+                .WithMetadata(AdminFieldsRequireScopeRule.RequiredScopeMetadataKey, "reports:read");
+        }
+    }
+
+    private sealed class AdminFieldsRequireScopeRule : ValidationRuleBase
+    {
+        public const string RequiredScopeMetadataKey = "requiredScope";
+        public const string ScopeContextKey = "scopes";
+
+        public static readonly AdminFieldsRequireScopeRule Instance = new();
+
+        private static readonly MatchingNodeVisitor<GraphQLField> _visitor = new((field, context) =>
+        {
+            var requiredScope = context.TypeInfo.GetFieldDef()?.GetMetadata<string>(RequiredScopeMetadataKey);
+            if (string.IsNullOrEmpty(requiredScope))
+                return;
+
+            var hasScope =
+                context.UserContext.TryGetValue(ScopeContextKey, out var value) &&
+                value is IEnumerable<string> scopes &&
+                scopes.Contains(requiredScope, StringComparer.Ordinal);
+
+            if (!hasScope)
+                context.ReportError(new MissingScopeError(context.Document.Source, field, requiredScope));
+        });
+
+        private AdminFieldsRequireScopeRule()
+        {
+        }
+
+        public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context) => new(_visitor);
+    }
+
+    private sealed class MissingScopeError : ValidationError
+    {
+        public MissingScopeError(ROM source, GraphQLField field, string requiredScope)
+            : base(source, null, $"Field '{field.Name.Value}' requires the '{requiredScope}' scope.", field)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2406.\n\n## Summary\n- add a runnable GraphQL.CustomValidationRule.Sample project that demonstrates a ValidationRuleBase rule using field metadata and ExecutionOptions.UserContext\n- add a Samples docs page and wire it into sitemap.yml and GraphQL.slnx\n- link query-validation docs to the runnable sample\n- add tests covering the same custom validation rule behavior\n\n## Validation\n- dotnet test src/GraphQL.Tests/GraphQL.Tests.csproj -f net10.0 --filter FullyQualifiedName~CustomValidationRuleSampleTests\n- dotnet run --project samples/GraphQL.CustomValidationRule.Sample/GraphQL.CustomValidationRule.Sample.csproj -f net10.0