### PR TITLE
docs: add custom validation rules sample and samples documentation

### DIFF
--- a/docs2/site/docs/guides/samples.md
+++ b/docs2/site/docs/guides/samples.md
@@ -1,0 +1,120 @@
+# Samples
+
+The GraphQL.NET repository includes several sample projects that demonstrate various features and patterns.
+These samples are located in the [`samples`](https://github.com/graphql-dotnet/graphql-dotnet/tree/master/samples)
+folder of the repository.
+
+## GraphQL.Harness
+
+A basic ASP.NET Core project that demonstrates how to set up GraphQL.NET with the StarWars schema.
+It includes GraphiQL, Altair, and Voyager UI integrations for interactive query testing.
+
+**Key concepts demonstrated:**
+- Basic GraphQL.NET setup with ASP.NET Core
+- Schema registration via dependency injection
+- Multiple GraphQL UI tools
+- Field middleware (`CountFieldMiddleware`, `InstrumentFieldsMiddleware`)
+
+## GraphQL.CustomValidationRules.Sample
+
+A sample project that demonstrates how to create and register custom validation rules.
+This is useful when you want to enforce additional constraints on incoming GraphQL queries
+beyond the standard specification validation.
+
+**Key concepts demonstrated:**
+
+### Extending `ValidationRuleBase`
+
+All custom validation rules should extend `ValidationRuleBase` and override one or more
+of the visitor methods:
+
+```csharp
+public class MaxDepthValidationRule : ValidationRuleBase
+{
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
+        => new(new MatchingNodeVisitor<GraphQLOperationDefinition>(
+            enter: (op, ctx) =>
+            {
+                // Validate the operation here
+            }));
+}
+```
+
+### Using `MatchingNodeVisitor<TNode>`
+
+`MatchingNodeVisitor<TNode>` allows you to define callbacks that fire only when the
+validation visitor encounters a specific AST node type. You can provide `enter` (before
+children are visited) and `leave` (after children are visited) delegates:
+
+```csharp
+new MatchingNodeVisitor<GraphQLField>(
+    enter: (field, context) => { /* called when entering a field node */ },
+    leave: (field, context) => { /* called when leaving a field node */ });
+```
+
+### Registering custom rules
+
+Custom validation rules can be registered via the DI builder:
+
+```csharp
+services.AddGraphQL(b => b
+    .AddSchema<MySchema>()
+    .AddSystemTextJson()
+    .AddValidationRule<MaxDepthValidationRule>()
+    .AddValidationRule<MaxFieldsValidationRule>());
+```
+
+Alternatively, you can set them directly on `ExecutionOptions.ValidationRules` when
+calling `IDocumentExecuter.ExecuteAsync`.
+
+### Reporting validation errors
+
+Use `context.ReportError()` with a `ValidationError` to report issues:
+
+```csharp
+context.ReportError(new ValidationError(
+    context.Document.Source,
+    "CUSTOM_CODE",
+    "Human-readable error message.",
+    node));
+```
+
+### Sample rules included
+
+| Rule | Description |
+|------|-------------|
+| `MaxDepthValidationRule` | Rejects queries that nest fields deeper than a configured limit (default: 5 levels). |
+| `MaxFieldsValidationRule` | Rejects selection sets that contain more than a configured number of fields (default: 20). |
+
+## AOT Compilation Samples
+
+Two samples demonstrate ahead-of-time (AOT) compilation support:
+
+- **GraphQL.AotCompilationSample.CodeFirst** — Code-first approach with AOT
+- **GraphQL.AotCompilationSample.TypeFirst** — Type-first approach with AOT
+
+## DataLoader Samples
+
+- **GraphQL.DataLoader.Sample.Default** — Basic DataLoader usage
+- **GraphQL.DataLoader.Sample.DI** — DataLoader with dependency injection
+
+## Federation Samples
+
+Four samples demonstrate Apollo Federation support:
+
+- **GraphQL.Federation.SchemaFirst.Sample1** — Schema-first federation with `@key` directive
+- **GraphQL.Federation.SchemaFirst.Sample2** — Schema-first federation with products/categories
+- **GraphQL.Federation.CodeFirst.Sample3** — Code-first federation approach
+- **GraphQL.Federation.TypeFirst.Sample4** — Type-first federation approach
+
+## Running the Samples
+
+Each sample can be run independently using:
+
+```bash
+cd samples/GraphQL.Harness
+dotnet run
+```
+
+Then navigate to the displayed URL (typically `http://localhost:5000`) to access the
+GraphiQL interface.

--- a/docs2/site/sitemap.yml
+++ b/docs2/site/sitemap.yml
@@ -91,6 +91,8 @@
             file: links.md
           - title: Document Caching
             file: document-caching.md
+          - title: Samples
+            file: samples.md
       - title: Analyzers
         dir: analyzers
         items:

--- a/samples/GraphQL.CustomValidationRules.Sample/GraphQL.CustomValidationRules.Sample.csproj
+++ b/samples/GraphQL.CustomValidationRules.Sample/GraphQL.CustomValidationRules.Sample.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="8.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GraphQL.MicrosoftDI\GraphQL.MicrosoftDI.csproj" />
+    <ProjectReference Include="..\..\src\GraphQL.SystemTextJson\GraphQL.SystemTextJson.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GraphQL.CustomValidationRules.Sample/Program.cs
+++ b/samples/GraphQL.CustomValidationRules.Sample/Program.cs
@@ -1,0 +1,64 @@
+using GraphQL.CustomValidationRules.Sample.Schema;
+using GraphQL.CustomValidationRules.Sample.Validation;
+using GraphQL.Types;
+using GraphQL.Utilities;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Register data source
+builder.Services.AddSingleton<BlogData>();
+
+// Register schema as a factory
+builder.Services.AddSingleton<ISchema>(sp =>
+{
+    var schema = Schema.For("""
+        type Post {
+            id: ID!
+            title: String!
+            content: String!
+            author: String!
+            comments: [Comment!]!
+        }
+
+        type Comment {
+            id: ID!
+            text: String!
+            author: String!
+        }
+
+        type Query {
+            posts: [Post!]!
+            post(id: ID!): Post
+        }
+
+        type Mutation {
+            addPost(title: String!, content: String!, author: String!): Post!
+        }
+        """, opts =>
+    {
+        opts.Types.Include<Query>();
+        opts.Types.Include<Mutation>();
+        opts.ServiceProvider = sp;
+    });
+    return schema;
+});
+
+// Register GraphQL with custom validation rules
+builder.Services.AddGraphQL(b => b
+    .AddSystemTextJson()
+    .AddSchema<ISchema>()
+    // Custom rule: limit query depth to prevent deeply nested queries
+    .AddValidationRule<MaxDepthValidationRule>()
+    // Custom rule: restrict the number of fields in a selection set
+    .AddValidationRule<MaxFieldsValidationRule>()
+);
+
+var app = builder.Build();
+
+app.UseGraphQL<ISchema>();
+app.UseGraphQLGraphiQL("/");
+
+// Ensure schema is initialized
+app.Services.GetRequiredService<ISchema>().Initialize();
+
+await app.RunAsync();

--- a/samples/GraphQL.CustomValidationRules.Sample/Schema/BlogData.cs
+++ b/samples/GraphQL.CustomValidationRules.Sample/Schema/BlogData.cs
@@ -1,0 +1,54 @@
+namespace GraphQL.CustomValidationRules.Sample.Schema;
+
+public class BlogData
+{
+    private readonly List<Post> _posts =
+    [
+        new Post { Id = "1", Title = "Introduction to GraphQL", Content = "GraphQL is a query language for APIs.", Author = "Alice" },
+        new Post { Id = "2", Title = "Advanced GraphQL.NET", Content = "Deep dive into GraphQL.NET validation rules.", Author = "Bob" },
+        new Post { Id = "3", Title = "Schema-First Approach", Content = "Building schemas using SDL definitions.", Author = "Alice" },
+    ];
+
+    private readonly List<Comment> _comments =
+    [
+        new Comment { Id = "101", PostId = "1", Text = "Great introduction!", Author = "Charlie" },
+        new Comment { Id = "102", PostId = "1", Text = "Very helpful, thanks!", Author = "Dave" },
+        new Comment { Id = "103", PostId = "2", Text = "Loved the deep dive.", Author = "Charlie" },
+    ];
+
+    public IEnumerable<Post> GetPosts() => _posts;
+
+    public Post? GetPostById(string id) => _posts.FirstOrDefault(p => p.Id == id);
+
+    public IEnumerable<Comment> GetCommentsForPost(string postId) =>
+        _comments.Where(c => c.PostId == postId);
+
+    public Post AddPost(string title, string content, string author)
+    {
+        var post = new Post
+        {
+            Id = (_posts.Count + 100).ToString(),
+            Title = title,
+            Content = content,
+            Author = author,
+        };
+        _posts.Add(post);
+        return post;
+    }
+}
+
+public class Post
+{
+    public string Id { get; set; } = "";
+    public string Title { get; set; } = "";
+    public string Content { get; set; } = "";
+    public string Author { get; set; } = "";
+}
+
+public class Comment
+{
+    public string Id { get; set; } = "";
+    public string PostId { get; set; } = "";
+    public string Text { get; set; } = "";
+    public string Author { get; set; } = "";
+}

--- a/samples/GraphQL.CustomValidationRules.Sample/Schema/Query.cs
+++ b/samples/GraphQL.CustomValidationRules.Sample/Schema/Query.cs
@@ -1,0 +1,20 @@
+namespace GraphQL.CustomValidationRules.Sample.Schema;
+
+/// <summary>
+/// Query root resolver. Public methods map to SDL fields automatically.
+/// </summary>
+public class Query
+{
+    public IEnumerable<Post> Posts([FromServices] BlogData data) => data.GetPosts();
+
+    public Post? Post([FromServices] BlogData data, string id) => data.GetPostById(id);
+}
+
+/// <summary>
+/// Mutation root resolver.
+/// </summary>
+public class Mutation
+{
+    public Post AddPost([FromServices] BlogData data, string title, string content, string author)
+        => data.AddPost(title, content, author);
+}

--- a/samples/GraphQL.CustomValidationRules.Sample/Validation/MaxDepthValidationRule.cs
+++ b/samples/GraphQL.CustomValidationRules.Sample/Validation/MaxDepthValidationRule.cs
@@ -1,0 +1,51 @@
+using GraphQL.Validation;
+using GraphQLParser.AST;
+
+namespace GraphQL.CustomValidationRules.Sample.Validation;
+
+/// <summary>
+/// A custom validation rule that limits the maximum depth of a GraphQL query.
+/// This helps prevent expensive deeply-nested queries that could overload the server.
+///
+/// This rule demonstrates how to extend <see cref="ValidationRuleBase"/> and use
+/// <see cref="MatchingNodeVisitor{TNode}"/> to inspect AST nodes during validation.
+/// </summary>
+public class MaxDepthValidationRule : ValidationRuleBase
+{
+    private const int MAX_DEPTH = 5;
+
+    /// <inheritdoc/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
+        => new(new MatchingNodeVisitor<GraphQLOperationDefinition>(
+            enter: (op, ctx) =>
+            {
+                var depth = CalculateMaxDepth(op.SelectionSet);
+                if (depth > MAX_DEPTH)
+                {
+                    ctx.ReportError(new ValidationError(
+                        ctx.Document.Source,
+                        "CUSTOM_DEPTH",
+                        $"Query exceeds maximum allowed depth of {MAX_DEPTH} (actual depth: {depth}).",
+                        op));
+                }
+            }));
+
+    private static int CalculateMaxDepth(GraphQLSelectionSet? selectionSet, int currentDepth = 1)
+    {
+        if (selectionSet?.Selections == null || selectionSet.Selections.Count == 0)
+            return currentDepth;
+
+        int maxChildDepth = currentDepth;
+        foreach (var selection in selectionSet.Selections)
+        {
+            if (selection is GraphQLField field && field.SelectionSet != null)
+            {
+                var childDepth = CalculateMaxDepth(field.SelectionSet, currentDepth + 1);
+                if (childDepth > maxChildDepth)
+                    maxChildDepth = childDepth;
+            }
+        }
+
+        return maxChildDepth;
+    }
+}

--- a/samples/GraphQL.CustomValidationRules.Sample/Validation/MaxFieldsValidationRule.cs
+++ b/samples/GraphQL.CustomValidationRules.Sample/Validation/MaxFieldsValidationRule.cs
@@ -1,0 +1,35 @@
+using GraphQL.Validation;
+using GraphQLParser.AST;
+
+namespace GraphQL.CustomValidationRules.Sample.Validation;
+
+/// <summary>
+/// A custom validation rule that limits the maximum number of fields in any
+/// single selection set. This prevents overly broad queries that request too
+/// many fields at once.
+///
+/// This rule demonstrates using <see cref="MatchingNodeVisitor{TNode}"/> with
+/// the leave callback to inspect nodes after their children have been processed.
+/// </summary>
+public class MaxFieldsValidationRule : ValidationRuleBase
+{
+    private const int MAX_FIELDS = 20;
+
+    /// <inheritdoc/>
+    public override ValueTask<INodeVisitor?> GetPreNodeVisitorAsync(ValidationContext context)
+        => new(new MatchingNodeVisitor<GraphQLSelectionSet>(
+            enter: (selectionSet, ctx) =>
+            {
+                int fieldCount = selectionSet.Selections
+                    .Count(s => s is GraphQLField);
+
+                if (fieldCount > MAX_FIELDS)
+                {
+                    ctx.ReportError(new ValidationError(
+                        ctx.Document.Source,
+                        "CUSTOM_MAX_FIELDS",
+                        $"Selection set contains {fieldCount} fields, exceeding the maximum allowed {MAX_FIELDS} fields.",
+                        selectionSet));
+                }
+            }));
+}


### PR DESCRIPTION
## Summary

This PR addresses #2406 by adding:

1. **New sample project** (`GraphQL.CustomValidationRules.Sample`) demonstrating custom validation rules
2. **Documentation page** (`samples.md`) covering all repository samples
3. **Sitemap update** to include the new page in the Guides section

### Custom Validation Rules Sample

The sample project demonstrates:

- **Extending `ValidationRuleBase`** — the base class for all custom validation rules
- **Using `MatchingNodeVisitor<T>`** — targeted AST node inspection with enter/leave callbacks
- **Two practical validation rules:**
  - `MaxDepthValidationRule` — rejects queries nesting deeper than 5 levels
  - `MaxFieldsValidationRule` — rejects selection sets with more than 20 fields
- **DI registration** via `AddValidationRule<T>()`
- **Schema-first approach** using `Schema.For()` with SDL and `Types.Include<T>()` for resolvers

### Samples Documentation

The new `samples.md` page provides an overview of all sample projects in the repository:
- GraphQL.Harness
- GraphQL.CustomValidationRules.Sample
- AOT Compilation Samples
- DataLoader Samples
- Federation Samples

Each sample includes key concepts demonstrated and usage instructions.

Closes #2406