### PR TITLE
Update NuGet.Frameworks package version to 7.0.3

### DIFF
--- a/src/GraphQL.Analyzers.Tests/GraphQL.Analyzers.Tests.csproj
+++ b/src/GraphQL.Analyzers.Tests/GraphQL.Analyzers.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing" Version="1.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="1.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="1.*" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.9.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes dependency resolution problem:

```
/home/runner/work/graphql-dotnet/graphql-dotnet/src/GraphQL.Analyzers.Tests/GraphQL.Analyzers.Tests.csproj : error NU1605: Warning As Error: Detected package downgrade: NuGet.Frameworks from 7.0.3 to 6.9.1. Reference the package directly from the project to select a different version.  [/home/runner/work/graphql-dotnet/graphql-dotnet/GraphQL.slnx]
```